### PR TITLE
fix: correct OpenCode docs link (404 -> valid URL)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -57,11 +57,11 @@ if command -v opencode &> /dev/null; then
     echo "OpenCode $(opencode --version) 설치됨"
 else
     echo "OpenCode가 설치되어 있지 않습니다. 먼저 설치해주세요."
-    echo "참고: https://opencode.ai/docs/installation/"
+    echo "참고: https://opencode.ai/docs"
 fi
 ```
 
-OpenCode가 설치되어 있지 않다면, [OpenCode 설치 가이드](https://opencode.ai/docs/installation/)를 안내하세요.
+OpenCode가 설치되어 있지 않다면, [OpenCode 설치 가이드](https://opencode.ai/docs)를 안내하세요.
 
 ### 2단계: oh-my-opencode 플러그인 설정
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ if command -v opencode &> /dev/null; then
     echo "OpenCode $(opencode --version) is installed"
 else
     echo "OpenCode is not installed. Please install it first."
-    echo "See: https://opencode.ai/docs/installation/"
+    echo "See: https://opencode.ai/docs"
 fi
 ```
 
-If OpenCode is not installed, guide the user to [OpenCode Installation Guide](https://opencode.ai/docs/installation/).
+If OpenCode is not installed, guide the user to [OpenCode Installation Guide](https://opencode.ai/docs).
 
 ### Step 2: Configure oh-my-opencode Plugin
 


### PR DESCRIPTION
## Summary
- `/docs/installation/` 경로가 404 반환
- `/docs` (메인 문서 페이지, Install 섹션 포함)로 수정

## Files Changed
- README.md
- README.ko.md