### PR TITLE
Refactor AgentOverridesSchema to use object structure

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -40,7 +40,15 @@ export const AgentOverrideConfigSchema = z.object({
   permission: AgentPermissionSchema.optional(),
 })
 
-export const AgentOverridesSchema = z.record(AgentNameSchema, AgentOverrideConfigSchema)
+export const AgentOverridesSchema = z
+  .object({
+    oracle: AgentOverrideConfigSchema.optional(),
+    librarian: AgentOverrideConfigSchema.optional(),
+    explore: AgentOverrideConfigSchema.optional(),
+    "frontend-ui-ux-engineer": AgentOverrideConfigSchema.optional(),
+    "document-writer": AgentOverrideConfigSchema.optional(),
+  })
+  .partial()
 
 export const OhMyOpenCodeConfigSchema = z.object({
   $schema: z.string().optional(),


### PR DESCRIPTION
Any user config that doesn't define ALL 5 agents fails validation silently, losing the entire config.

For issue #16 Even though this has solved my issue locally, please merge if this is valid 