### PR TITLE
fix(session-recovery): correct typo 'preceeding' to 'preceding'

### DIFF
--- a/src/hooks/session-recovery/index.ts
+++ b/src/hooks/session-recovery/index.ts
@@ -73,7 +73,7 @@ function detectErrorType(error: unknown): RecoveryErrorType {
     message.includes("thinking") &&
     (message.includes("first block") ||
       message.includes("must start with") ||
-      message.includes("preceeding") ||
+      message.includes("preceding") ||
       (message.includes("expected") && message.includes("found")))
   ) {
     return "thinking_block_order"


### PR DESCRIPTION
## Summary
- Fix typo in error detection: `preceeding` → `preceding`

## Details
Found by [`typos`](https://github.com/crate-ci/typos) CLI tool:

```
error: `preceeding` should be `preceding`, `proceeding`
  --> ./src/hooks/session-recovery/index.ts:76:25
   |
76 |       message.includes("preceeding") ||
   |                         ^^^^^^^^^^
```

"Preceeding" is a common misspelling; the correct word is **preceding**, meaning to come before something else in time, order, or position.