### PR TITLE
fix(hooks): prevent infinite loop when `todo-continuation-enforcer` runs during session recovery

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,7 +1,7 @@
-export { createTodoContinuationEnforcer } from "./todo-continuation-enforcer";
+export { createTodoContinuationEnforcer, type TodoContinuationEnforcer } from "./todo-continuation-enforcer";
 export { createContextWindowMonitorHook } from "./context-window-monitor";
 export { createSessionNotification } from "./session-notification";
-export { createSessionRecoveryHook } from "./session-recovery";
+export { createSessionRecoveryHook, type SessionRecoveryHook } from "./session-recovery";
 export { createCommentCheckerHooks } from "./comment-checker";
 export { createGrepOutputTruncatorHook } from "./grep-output-truncator";
 export { createDirectoryAgentsInjectorHook } from "./directory-agents-injector";


### PR DESCRIPTION
## Problem

When using the plugin, OpenCode sometimes fails with API validation errors like:

```
messages.27: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_012DnW2fFgjQfFB63isRuz1c. Each `tool_use` block must have a corresponding `tool_result` block in the next message.
```

When this error occurs, the `todo-continuation-enforcer` hook injects a system reminder forcing the agent to continue:

```
[SYSTEM REMINDER - TODO ENFORCEMENT]
Your todo list is NOT complete. There are still incomplete tasks remaining.
CRITICAL INSTRUCTION:
- You MUST NOT stop working until ALL todos are marked as completed
- Continue working on the next pending task immediately
...
[Status: 4/10 tasks remaining]
```

<img width="1361" height="885" alt="image" src="https://github.com/user-attachments/assets/24e4d21e-ad4a-4927-bdae-ac4fc3152352" />

This creates an **infinite loop** because:
1. The API error occurs
2. The continuation enforcer forces the agent to retry
3. The same error occurs again
4. Loop continues indefinitely with no way to recover

## Root Cause Analysis

A **race condition** exists between `session-recovery` and `todo-continuation-enforcer` hooks:

```
Timeline:
─────────────────────────────────────────────────────────────────────
T1: API Error ("tool_use without tool_result")
T2: todo-continuation-enforcer: errorSessions.add(sessionID) ✓
T3: session-recovery: calls session.abort()
T4: session.abort() triggers session.idle event
T5: todo-continuation-enforcer: handles session.idle
    → shouldBypass = true (errorSessions has it)
    → errorSessions.delete(sessionID) ← CLEARS TOO EARLY!
    → returns without injecting ✓
T6: session-recovery: completes, sends "continue" prompt
T7: Agent responds, turn completes → session.idle fires AGAIN
T8: todo-continuation-enforcer: handles session.idle
    → shouldBypass = false (errorSessions is EMPTY now!)
    → Checks todos → incomplete tasks exist
    → INJECTS CONTINUATION PROMPT ← THE BUG!
T9: Same API error occurs → INFINITE LOOP
```

The key issue is that `errorSessions` is cleared at T5 (first `session.idle`), but recovery isn't complete until T6. When `session.idle` fires again at T7, the error tracking has already been cleared, so the enforcer doesn't know to skip.

Additionally, `setOnAbortCallback` was designed in `session-recovery` for exactly this purpose but was **never connected** in `src/index.ts`.

## Solution

Add **recovery state tracking** to coordinate between the two hooks:

1. **New `recoveringSessions` Set** in `todo-continuation-enforcer` to track sessions currently in recovery
2. **`markRecovering(sessionID)`** method called when recovery starts (before `abort()`)
3. **`markRecoveryComplete(sessionID)`** method called when recovery ends (in `finally` block)
4. **Recovery check** in `session.idle` handler that skips WITHOUT clearing state when recovery is in progress

```
Fixed Timeline:
─────────────────────────────────────────────────────────────────────
T1: API Error → errorSessions.add(sessionID)
T2: session-recovery: markRecovering(sessionID) ← NEW
T3: session.abort() triggers session.idle
T4: todo-continuation-enforcer: sees recoveringSessions.has(sessionID)
    → returns early WITHOUT clearing errorSessions ← FIXED!
T5: session-recovery completes → markRecoveryComplete(sessionID) ← NEW
T6: session.idle fires → normal flow (errorSessions still tracked)
    → shouldBypass = true → skips correctly ✓
```

## Changes

### `src/hooks/todo-continuation-enforcer.ts`
- Added `TodoContinuationEnforcer` interface export
- Added `recoveringSessions` Set to track sessions in recovery
- Added `markRecovering(sessionID)` and `markRecoveryComplete(sessionID)` methods
- Added recovery check **before** clearing error state in `session.idle` handler
- Added `recoveringSessions` cleanup in `session.deleted` handler
- Changed return type from function to object `{ handler, markRecovering, markRecoveryComplete }`

### `src/hooks/session-recovery/index.ts`
- Added `SessionRecoveryHook` interface export
- Added `onRecoveryCompleteCallback` and `setOnRecoveryCompleteCallback`
- Call `onRecoveryCompleteCallback` in `finally` block (always, regardless of success/failure)
- **Fixed timing**: `onAbortCallback` now called BEFORE `abort()` (eliminates theoretical race)

### `src/hooks/index.ts`
- Export new `TodoContinuationEnforcer` and `SessionRecoveryHook` types

### `src/index.ts`
- Wire hooks together:
  ```typescript
  sessionRecovery.setOnAbortCallback(todoContinuationEnforcer.markRecovering);
  sessionRecovery.setOnRecoveryCompleteCallback(todoContinuationEnforcer.markRecoveryComplete);
  ```
- Update handler call to `todoContinuationEnforcer.handler(input)`

## Edge Cases Handled

| Edge Case | Handling |
|-----------|----------|
| Recovery fails | `finally` block always calls `markRecoveryComplete` |
| Session deleted during recovery | `session.deleted` handler cleans up `recoveringSessions` |
| Multiple sessions | Each tracked independently by sessionID |
| Fast recovery (< 200ms) | Timer hasn't fired yet, recovery check works |
| Slow recovery (> 200ms) | Timer fires, sees `recoveringSessions`, skips without clearing |

## Testing

- ✅ `bun run typecheck` passes
- ✅ `bun run build` passes
- ✅ Oracle verification: "PERFECT - NO IMPROVEMENTS NEEDED"