### PR TITLE
fix(ci): prevent publish workflow from running on forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.repository == 'code-yeongyu/oh-my-opencode'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Problem

The `publish.yml` workflow has no guard to prevent it from running on forked repositories. When a fork inherits this workflow and someone (accidentally or intentionally) triggers `workflow_dispatch`:

1. GitHub Actions runs in the fork's context
2. The workflow creates a release commit (e.g., `release: v0.1.32`)
3. `git push origin HEAD --tags` pushes to the fork
4. Result: The fork accumulates unwanted release commits, diverging from upstream

This causes forks to show "X commits ahead" with release commits that shouldn't exist there.

### Evidence

My fork showed:
> "1 commit ahead of and 114 commits behind code-yeongyu/oh-my-opencode:master"

With an unexpected `github-actions[bot]` commit:
> `release: v0.1.32`

## Solution

Add a repository guard to the publish job:

```yaml
jobs:
  publish:
    runs-on: ubuntu-latest
    if: github.repository == 'code-yeongyu/oh-my-opencode'  # ← Added
```

This ensures the workflow **only runs on the original repository**, not on any forks. This is a standard practice for publish/release workflows.

## Impact

- ✅ No change to legitimate workflow runs on `code-yeongyu/oh-my-opencode`
- ✅ Prevents accidental workflow triggers on forks from polluting fork history
- ✅ Zero risk - the condition simply skips the job on forks