### PR TITLE
fix: add multimodal-looker to Zod config schema for model overrides

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -27,7 +27,8 @@
           "librarian",
           "explore",
           "frontend-ui-ux-engineer",
-          "document-writer"
+          "document-writer",
+          "multimodal-looker"
         ]
       }
     },
@@ -63,7 +64,8 @@
           "librarian",
           "explore",
           "frontend-ui-ux-engineer",
-          "document-writer"
+          "document-writer",
+          "multimodal-looker"
         ]
       },
       "additionalProperties": {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -22,6 +22,7 @@ export const AgentNameSchema = z.enum([
   "explore",
   "frontend-ui-ux-engineer",
   "document-writer",
+  "multimodal-looker",
 ])
 
 export const HookNameSchema = z.enum([
@@ -65,6 +66,7 @@ export const AgentOverridesSchema = z
     explore: AgentOverrideConfigSchema.optional(),
     "frontend-ui-ux-engineer": AgentOverrideConfigSchema.optional(),
     "document-writer": AgentOverrideConfigSchema.optional(),
+    "multimodal-looker": AgentOverrideConfigSchema.optional(),
   })
   .partial()
 


### PR DESCRIPTION
## Problem

Model overrides for the `multimodal-looker` agent in `oh-my-opencode.json` were silently ignored. Users configuring:

```json
{
  "agents": {
    "multimodal-looker": {
      "model": "cli-proxy-google/gemini-2.5-pro"
    }
  }
}
```

Would still see the agent use its hardcoded default `google/gemini-2.5-flash`.

## Root Cause

The `multimodal-looker` agent was missing from two Zod schemas in `src/config/schema.ts`:
- `AgentNameSchema` - validates allowed agent names
- `AgentOverridesSchema` - validates per-agent override configs

When config was parsed via `OhMyOpenCodeConfigSchema.safeParse()`, the `multimodal-looker` key was stripped as an unknown property.

## Fix

Added `multimodal-looker` to both schemas, aligning the Zod runtime validation with the existing JSON schema (`assets/oh-my-opencode.schema.json`).