### PR TITLE
feat: add OmO agent to config schema for model override support

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -65,6 +65,7 @@
       "propertyNames": {
         "type": "string",
         "enum": [
+          "OmO",
           "oracle",
           "librarian",
           "explore",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -17,6 +17,7 @@ const AgentPermissionSchema = z.object({
 })
 
 export const BuiltinAgentNameSchema = z.enum([
+  "OmO",
   "oracle",
   "librarian",
   "explore",
@@ -27,6 +28,7 @@ export const BuiltinAgentNameSchema = z.enum([
 
 export const OverridableAgentNameSchema = z.enum([
   "build",
+  "OmO",
   "oracle",
   "librarian",
   "explore",
@@ -76,6 +78,7 @@ export const AgentOverrideConfigSchema = z.object({
 
 export const AgentOverridesSchema = z.object({
   build: AgentOverrideConfigSchema.optional(),
+  OmO: AgentOverrideConfigSchema.optional(),
   oracle: AgentOverrideConfigSchema.optional(),
   librarian: AgentOverrideConfigSchema.optional(),
   explore: AgentOverrideConfigSchema.optional(),


### PR DESCRIPTION
Can you consider removing the default model: "anthropic/claude-opus-4-5" of omo? 

Since this is now a primary agent that replace build, users may use it with different models, I got the error "Agent OmO's configured model anthropic/claude-opus-4-5 is not valid" when changing agent to OmO everytime if haven't overide the model yet.