### PR TITLE
fix(agents): restrict OmO-Plan to inherit from default plan agent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -312,7 +312,6 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
         const { name: _planName, ...planConfigWithoutName } = config.agent?.plan ?? {};
         const omoPlanOverride = pluginConfig.agents?.["OmO-Plan"];
         const omoPlanBase = {
-          ...builtinAgents.OmO,
           ...planConfigWithoutName,
           description: `${config.agent?.plan?.description ?? "Plan agent"} (OhMyOpenCode version)`,
           color: config.agent?.plan?.color ?? "#6495ED",


### PR DESCRIPTION
## Summary

- Fix OmO-Plan agent inheriting full OmO agent permissions instead of OpenCode's default plan agent
- Remove `...builtinAgents.OmO` spread from `omoPlanBase` configuration

## Problem

OmO-Plan agent was incorrectly inheriting all tools and permissions from OmO (the full orchestrator agent), causing it to:
- Execute code changes instead of just planning
- Not ask follow-up questions
- Have access to write/execute tools (edit, write, bash, task, etc.)

## Solution

By removing the `builtinAgents.OmO` spread, OmO-Plan now properly inherits from OpenCode's default `plan` agent configuration, which:
- Uses read-only tools only
- Focuses on planning and analysis
- Can ask clarifying questions
- Cannot execute code changes

Closes #72

---
🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)