### PR TITLE
docs: make installation instructions more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ If you don't want all this, as mentioned, you can just pick and choose specific 
 
 ### For Humans
 
-Let the LLM Agent handle the grunt work. Paste this link and ask it to install and configure.
+Let the LLM Agent handle the grunt work. Paste this into a fresh opencode session:
+```
+Install and configure by following the instructions here https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/README.md
+```
 
 ### For LLM Agents
 


### PR DESCRIPTION
It wasn't immediately obvious how to install so I made it a little more explicit. 