### PR TITLE
fix openai/chatgpt/codex auth via bump to v4.1.1

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -304,7 +304,7 @@ opencode auth login
 {
   "plugin": [
     "oh-my-opencode",
-    "opencode-openai-codex-auth@4.1.0"
+    "opencode-openai-codex-auth@4.1.1"
   ]
 }
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -301,7 +301,7 @@ opencode auth login
 {
   "plugin": [
     "oh-my-opencode",
-    "opencode-openai-codex-auth@4.1.0"
+    "opencode-openai-codex-auth@4.1.1"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ First, add the opencode-openai-codex-auth plugin:
 {
   "plugin": [
     "oh-my-opencode",
-    "opencode-openai-codex-auth@4.1.0"
+    "opencode-openai-codex-auth@4.1.1"
   ]
 }
 ```


### PR DESCRIPTION
noticed i couldn't login even with the patched version recommended in the README, but 4.1.1 worked.

feel free to request edits, edit the PR yourself, close, etc — mostly just highlighting that 4.1.0 didn't work for me but 4.1.1 did