### PR TITLE
docs: specify exact version in plugin installation instructions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -202,8 +202,16 @@ OpenCode がインストールされていない場合は、[OpenCode インス�
 
 ### ステップ 2: oh-my-opencode プラグイン設定
 
+**重要**: 進む前に、npm で oh-my-opencode の最新バージョンを確認してください：
+
+```bash
+npm view oh-my-opencode version
+```
+
+以下のプラグイン設定には正確なバージョン（例：`oh-my-opencode@2.2.0`）を使用してください。これにより、起動のたびにバージョン解決を行わなくて済み、起動が速くなります。
+
 #### JSONC
-- `~/.config/opencode/opencode.jsonc` が存在する場合は、そこで `oh-my-opencode` プラグインを追加してください。
+- `~/.config/opencode/opencode.jsonc` が存在する場合は、そこで `oh-my-opencode@x.y.z` プラグインを追加してください（`x.y.z` を最新バージョンに置き換え）。
 
 #### JSON
 - opencode.jsonc が存在しない場合は、以下のコマンドを実行して作成・登録してください。
@@ -211,18 +219,21 @@ OpenCode がインストールされていない場合は、[OpenCode インス�
 ```bash
 mkdir -p ~/.config/opencode
 
+# まず最新バージョンを取得
+LATEST_VERSION=$(npm view oh-my-opencode version)
+
 if [ -f ~/.config/opencode/opencode.json ]; then
     # 既存の設定ファイルがある場合: jq または python で plugin を追加
     if command -v jq &> /dev/null; then
-        jq '.plugin = ((.plugin // []) + ["oh-my-opencode"] | unique)' \
+        jq --arg ver "oh-my-opencode@$LATEST_VERSION" '.plugin = ((.plugin // []) + [$ver] | unique)' \
             ~/.config/opencode/opencode.json > /tmp/oc.json && \
             mv /tmp/oc.json ~/.config/opencode/opencode.json
     else
-        echo "~/.config/opencode/opencode.json の plugin 配列に \"oh-my-opencode\" を追加してください"
+        echo "~/.config/opencode/opencode.json の plugin 配列に \"oh-my-opencode@$LATEST_VERSION\" を追加してください"
     fi
 else
     # 新しい設定ファイル作成
-    echo '{"plugin":["oh-my-opencode"]}' > ~/.config/opencode/opencode.json
+    echo "{\"plugin\":[\"oh-my-opencode@$LATEST_VERSION\"]}" > ~/.config/opencode/opencode.json
 fi
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -199,8 +199,16 @@ OpenCode가 설치되어 있지 않다면, [OpenCode 설치 가이드](https://o
 
 ### 2단계: oh-my-opencode 플러그인 설정
 
+**중요**: 진행하기 전에, npm에서 oh-my-opencode의 최신 버전을 확인하세요:
+
+```bash
+npm view oh-my-opencode version
+```
+
+아래 플러그인 설정에 정확한 버전(예: `oh-my-opencode@2.2.0`)을 사용하세요. 이렇게 하면 실행 시마다 버전 확인을 하지 않아 시작 속도가 빨라집니다.
+
 #### JSONC
-- `~/.config/opencode/opencode.jsonc`가 존재한다면, 그곳에 `oh-my-opencode` 플러그인을 추가하세요.
+- `~/.config/opencode/opencode.jsonc`가 존재한다면, 그곳에 `oh-my-opencode@x.y.z` 플러그인을 추가하세요 (`x.y.z`를 최신 버전으로 교체).
 
 #### JSON
 - opencode.jsonc가 없다면, 다음 명령어를 실행하여 생성하고 등록하세요.
@@ -208,18 +216,21 @@ OpenCode가 설치되어 있지 않다면, [OpenCode 설치 가이드](https://o
 ```bash
 mkdir -p ~/.config/opencode
 
+# 먼저 최신 버전을 확인
+LATEST_VERSION=$(npm view oh-my-opencode version)
+
 if [ -f ~/.config/opencode/opencode.json ]; then
     # 기존 설정 파일이 있는 경우: jq 또는 python으로 plugin 추가
     if command -v jq &> /dev/null; then
-        jq '.plugin = ((.plugin // []) + ["oh-my-opencode"] | unique)' \
+        jq --arg ver "oh-my-opencode@$LATEST_VERSION" '.plugin = ((.plugin // []) + [$ver] | unique)' \
             ~/.config/opencode/opencode.json > /tmp/oc.json && \
             mv /tmp/oc.json ~/.config/opencode/opencode.json
     else
-        echo "~/.config/opencode/opencode.json의 plugin 배열에 \"oh-my-opencode\"를 추가하세요"
+        echo "~/.config/opencode/opencode.json의 plugin 배열에 \"oh-my-opencode@$LATEST_VERSION\"를 추가하세요"
     fi
 else
     # 새 설정 파일 생성
-    echo '{"plugin":["oh-my-opencode"]}' > ~/.config/opencode/opencode.json
+    echo "{\"plugin\":[\"oh-my-opencode@$LATEST_VERSION\"]}" > ~/.config/opencode/opencode.json
 fi
 ```
 

--- a/README.md
+++ b/README.md
@@ -231,8 +231,16 @@ Spawn a subagent to handle installation and report back - to save context.
 
 ### Step 2: Configure oh-my-opencode Plugin
 
+**IMPORTANT**: Before proceeding, check the latest version of oh-my-opencode on npm:
+
+```bash
+npm view oh-my-opencode version
+```
+
+Use the exact version (e.g., `oh-my-opencode@2.2.0`) in the plugin configuration below. This ensures faster startup by avoiding version resolution on every launch.
+
 #### JSONC
-- If `~/.config/opencode/opencode.jsonc` exists, work in there to add `oh-my-opencode` plugin
+- If `~/.config/opencode/opencode.jsonc` exists, work in there to add `oh-my-opencode@x.y.z` plugin (replace `x.y.z` with the latest version)
 
 #### JSON
 - If no opencode.jsonc exists, run following command to create and register it.
@@ -240,18 +248,21 @@ Spawn a subagent to handle installation and report back - to save context.
 ```bash
 mkdir -p ~/.config/opencode
 
+# First, get the latest version
+LATEST_VERSION=$(npm view oh-my-opencode version)
+
 if [ -f ~/.config/opencode/opencode.json ]; then
     # Existing config: add plugin using jq or python
     if command -v jq &> /dev/null; then
-        jq '.plugin = ((.plugin // []) + ["oh-my-opencode"] | unique)' \
+        jq --arg ver "oh-my-opencode@$LATEST_VERSION" '.plugin = ((.plugin // []) + [$ver] | unique)' \
             ~/.config/opencode/opencode.json > /tmp/oc.json && \
             mv /tmp/oc.json ~/.config/opencode/opencode.json
     else
-        echo "Please add \"oh-my-opencode\" to the plugin array in ~/.config/opencode/opencode.json"
+        echo "Please add \"oh-my-opencode@$LATEST_VERSION\" to the plugin array in ~/.config/opencode/opencode.json"
     fi
 else
     # Create new config
-    echo '{"plugin":["oh-my-opencode"]}' > ~/.config/opencode/opencode.json
+    echo "{\"plugin\":[\"oh-my-opencode@$LATEST_VERSION\"]}" > ~/.config/opencode/opencode.json
 fi
 ```
 


### PR DESCRIPTION
## Summary
- Improves OpenCode startup time by instructing users to install with exact version (e.g., `oh-my-opencode@2.2.0`) instead of unversioned package name
- Updates installation scripts to automatically fetch latest version from npm before installation
- Applied to all three README files (EN, KO, JA)

## Why
Without version specification, npm/bun checks the registry for the latest version on every OpenCode launch, causing slower startup times.