### PR TITLE
fix(keyword-detector): inject keywords on every message

### DIFF
--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -6,8 +6,6 @@ export * from "./detector"
 export * from "./constants"
 export * from "./types"
 
-const injectedSessions = new Set<string>()
-
 export function createKeywordDetectorHook() {
   return {
     "chat.message": async (
@@ -22,10 +20,6 @@ export function createKeywordDetectorHook() {
         parts: Array<{ type: string; text?: string; [key: string]: unknown }>
       }
     ): Promise<void> => {
-      if (injectedSessions.has(input.sessionID)) {
-        return
-      }
-
       const promptText = extractPromptText(output.parts)
       const messages = detectKeywords(promptText)
 
@@ -52,21 +46,7 @@ export function createKeywordDetectorHook() {
       })
 
       if (success) {
-        injectedSessions.add(input.sessionID)
         log("Keyword context injected", { sessionID: input.sessionID })
-      }
-    },
-
-    event: async ({
-      event,
-    }: {
-      event: { type: string; properties?: unknown }
-    }) => {
-      if (event.type === "session.deleted") {
-        const props = event.properties as { info?: { id?: string } } | undefined
-        if (props?.info?.id) {
-          injectedSessions.delete(props.info.id)
-        }
       }
     },
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,7 +410,6 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       await rulesInjector?.event(input);
       await thinkMode?.event(input);
       await anthropicAutoCompact?.event(input);
-      await keywordDetector?.event(input);
       await agentUsageReminder?.event(input);
       await interactiveBashSession?.event(input);
 


### PR DESCRIPTION
## Summary
- Allow keyword detection and context injection on **every user message** instead of only the first message per session
- Removes session-tracking overhead (`injectedSessions` Set) and cleanup event handler

🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)