### PR TITLE
feat(claude-code-skill-loader): add base directory context

### DIFF
--- a/src/features/claude-code-skill-loader/loader.ts
+++ b/src/features/claude-code-skill-loader/loader.ts
@@ -36,6 +36,9 @@ function loadSkillsFromDir(skillsDir: string, scope: SkillScope): LoadedSkillAsC
       const formattedDescription = `(${scope} - Skill) ${originalDescription}`
 
       const wrappedTemplate = `<skill-instruction>
+Base directory for this skill: ${resolvedPath}/
+File references (@path) in this skill are relative to this directory.
+
 ${body.trim()}
 </skill-instruction>
 


### PR DESCRIPTION
## Summary
- Add base directory context injection when loading skills
- Allow skills to know their own file location

## Changes
- `src/features/claude-code-skill-loader/loader.ts`: 3 lines added

---
🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)