### PR TITLE
feat(auto-update-checker): background version check with auto-update

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -1208,6 +1208,23 @@
           "type": "boolean"
         }
       }
+    },
+    "experimental": {
+      "type": "object",
+      "properties": {
+        "aggressive_truncation": {
+          "type": "boolean"
+        },
+        "empty_message_recovery": {
+          "type": "boolean"
+        },
+        "auto_resume": {
+          "type": "boolean"
+        }
+      }
+    },
+    "auto_update": {
+      "type": "boolean"
     }
   }
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -122,6 +122,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
   google_auth: z.boolean().optional(),
   omo_agent: OmoAgentConfigSchema.optional(),
   experimental: ExperimentalConfigSchema.optional(),
+  auto_update: z.boolean().optional(),
 })
 
 export type OhMyOpenCodeConfig = z.infer<typeof OhMyOpenCodeConfigSchema>

--- a/src/hooks/auto-update-checker/types.ts
+++ b/src/hooks/auto-update-checker/types.ts
@@ -24,4 +24,5 @@ export interface UpdateCheckResult {
 
 export interface AutoUpdateCheckerOptions {
   showStartupToast?: boolean
+  autoUpdate?: boolean
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   const autoUpdateChecker = isHookEnabled("auto-update-checker")
     ? createAutoUpdateCheckerHook(ctx, {
         showStartupToast: isHookEnabled("startup-toast"),
+        autoUpdate: pluginConfig.auto_update ?? true,
       })
     : null;
   const keywordDetector = isHookEnabled("keyword-detector")


### PR DESCRIPTION
## Summary

- Enables background version checking without blocking OpenCode startup
- Auto-updates pinned plugin versions in config files (e.g., `oh-my-opencode@2.2.0` → `oh-my-opencode@2.3.0`)
- Adds `auto_update` config option to disable auto-updating behavior

## Related

Resolves the concern raised in #93 - users can now pin versions for fast startup while still receiving automatic updates.

## Changes

| File | Change |
|------|--------|
| `src/config/schema.ts` | Added `auto_update` boolean option |
| `src/hooks/auto-update-checker/checker.ts` | Added `configPath` tracking, `updatePinnedVersion()` function |
| `src/hooks/auto-update-checker/index.ts` | Refactored to run background check, auto-update pinned versions |
| `src/hooks/auto-update-checker/types.ts` | Added `autoUpdate` option |
| `src/index.ts` | Pass `autoUpdate` config to hook |

## New Behavior

1. **Startup** → Shows toast immediately (no blocking network call)
2. **Background** → Fetches latest version from npm registry
3. **If update available:**
   - **Pinned version** → Auto-updates config file, shows "Updated!" toast
   - **Unpinned version** → Invalidates cache, shows "Update available" toast
4. **Disable option:** Set `"auto_update": false` in config for notification-only mode