### PR TITLE
feat(lsp): add bash-language-server to builtin servers

### DIFF
--- a/src/tools/lsp/constants.ts
+++ b/src/tools/lsp/constants.ts
@@ -109,6 +109,10 @@ export const BUILTIN_SERVERS: Record<string, Omit<LSPServerConfig, "id">> = {
     command: ["astro-ls", "--stdio"],
     extensions: [".astro"],
   },
+  "bash-ls": {
+    command: ["bash-language-server", "start"],
+    extensions: [".sh", ".bash", ".zsh", ".ksh"],
+  },
   jdtls: {
     command: ["jdtls"],
     extensions: [".java"],


### PR DESCRIPTION
## Summary

Adds `bash-language-server` to the `BUILTIN_SERVERS` list so it's auto-detected when installed.

Shell scripts (`.sh`, `.bash`, `.zsh`, `.ksh`) are common in DevOps workflows, and bash-language-server provides valuable LSP features like hover docs, go-to-definition, and diagnostics.

## Changes

- Added `bash-ls` entry to `BUILTIN_SERVERS` in `src/tools/lsp/constants.ts`
- Command: `["bash-language-server", "start"]`
- Extensions: `[".sh", ".bash", ".zsh", ".ksh"]`