### PR TITLE
fix: skip keyword injection on first message for correct session titles

### DIFF
--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -6,6 +6,8 @@ export * from "./detector"
 export * from "./constants"
 export * from "./types"
 
+const sessionFirstMessageProcessed = new Set<string>()
+
 export function createKeywordDetectorHook() {
   return {
     "chat.message": async (
@@ -20,6 +22,14 @@ export function createKeywordDetectorHook() {
         parts: Array<{ type: string; text?: string; [key: string]: unknown }>
       }
     ): Promise<void> => {
+      const isFirstMessage = !sessionFirstMessageProcessed.has(input.sessionID)
+      sessionFirstMessageProcessed.add(input.sessionID)
+
+      if (isFirstMessage) {
+        log("Skipping keyword detection on first message for title generation", { sessionID: input.sessionID })
+        return
+      }
+
       const promptText = extractPromptText(output.parts)
       const messages = detectKeywords(promptText)
 


### PR DESCRIPTION
 Session titles were showing "Maximizing Parallel Search Effort..." instead of user's actual request
 
<img width="656" height="43" alt="image" src="https://github.com/user-attachments/assets/dda495bf-54f7-492d-ad26-ec42c64efe37" />


- Cause: `keyword-detector` injected ultrawork/search-mode content on first message, which OpenCode used for title generation
- Fix: Skip keyword injection on first message (same pattern as `claude-code-hooks`)