### PR TITLE
fix(config): support both ~/.config and %APPDATA% paths on Windows

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -643,7 +643,7 @@ Oh My OpenCode は以下の場所からフックを読み込んで実行しま�
 
 | プラットフォーム | ユーザー設定パス |
 |------------------|------------------|
-| **Windows** | `%APPDATA%\opencode\oh-my-opencode.json` |
+| **Windows** | `~/.config/opencode/oh-my-opencode.json` (優先) または `%APPDATA%\opencode\oh-my-opencode.json` (フォールバック) |
 | **macOS/Linux** | `~/.config/opencode/oh-my-opencode.json` |
 
 スキーマ自動補完がサポートされています：

--- a/README.ko.md
+++ b/README.ko.md
@@ -637,7 +637,7 @@ Oh My OpenCode는 다음 위치의 훅을 읽고 실행합니다:
 
 | 플랫폼 | 사용자 설정 경로 |
 |--------|------------------|
-| **Windows** | `%APPDATA%\opencode\oh-my-opencode.json` |
+| **Windows** | `~/.config/opencode/oh-my-opencode.json` (우선) 또는 `%APPDATA%\opencode\oh-my-opencode.json` (fallback) |
 | **macOS/Linux** | `~/.config/opencode/oh-my-opencode.json` |
 
 Schema 자동 완성이 지원됩니다:

--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ Config file locations (priority order):
 
 | Platform | User Config Path |
 |----------|------------------|
-| **Windows** | `%APPDATA%\opencode\oh-my-opencode.json` |
+| **Windows** | `~/.config/opencode/oh-my-opencode.json` (preferred) or `%APPDATA%\opencode\oh-my-opencode.json` (fallback) |
 | **macOS/Linux** | `~/.config/opencode/oh-my-opencode.json` |
 
 Schema autocomplete supported:

--- a/src/shared/config-path.ts
+++ b/src/shared/config-path.ts
@@ -1,17 +1,34 @@
 import * as path from "path"
 import * as os from "os"
+import * as fs from "fs"
 
 /**
  * Returns the user-level config directory based on the OS.
  * - Linux/macOS: XDG_CONFIG_HOME or ~/.config
- * - Windows: %APPDATA%
+ * - Windows: Checks ~/.config first (cross-platform), then %APPDATA% (fallback)
+ *
+ * On Windows, prioritizes ~/.config for cross-platform consistency.
+ * Falls back to %APPDATA% for backward compatibility with existing installations.
  */
 export function getUserConfigDir(): string {
   if (process.platform === "win32") {
-    return process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")
+    const crossPlatformDir = path.join(os.homedir(), ".config")
+    const crossPlatformConfigPath = path.join(crossPlatformDir, "opencode", "oh-my-opencode.json")
+
+    const appdataDir = process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")
+    const appdataConfigPath = path.join(appdataDir, "opencode", "oh-my-opencode.json")
+
+    if (fs.existsSync(crossPlatformConfigPath)) {
+      return crossPlatformDir
+    }
+
+    if (fs.existsSync(appdataConfigPath)) {
+      return appdataDir
+    }
+
+    return crossPlatformDir
   }
 
-  // Linux, macOS, and other Unix-like systems: respect XDG_CONFIG_HOME
   return process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config")
 }
 


### PR DESCRIPTION
## Summary

Fixes #129

- On Windows, the plugin now checks `~/.config/opencode/oh-my-opencode.json` first (cross-platform consistent with macOS/Linux)
- Falls back to `%APPDATA%\opencode\oh-my-opencode.json` for existing installations
- New installations on Windows will default to `~/.config` for cross-platform consistency
- Documentation updated to reflect both supported paths (EN, KO, JA)

## Changes

- `src/shared/config-path.ts`: Updated `getUserConfigDir()` to check both paths on Windows
- `README.md`, `README.ko.md`, `README.ja.md`: Updated Windows config path documentation

🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)