### PR TITLE
feat(claude-code-hooks): add PreCompact hook support

### DIFF
--- a/src/hooks/claude-code-hooks/config-loader.ts
+++ b/src/hooks/claude-code-hooks/config-loader.ts
@@ -9,6 +9,7 @@ export interface DisabledHooksConfig {
   PreToolUse?: string[]
   PostToolUse?: string[]
   UserPromptSubmit?: string[]
+  PreCompact?: string[]
 }
 
 export interface PluginExtendedConfig {
@@ -47,6 +48,7 @@ function mergeDisabledHooks(
     PreToolUse: override.PreToolUse ?? base.PreToolUse,
     PostToolUse: override.PostToolUse ?? base.PostToolUse,
     UserPromptSubmit: override.UserPromptSubmit ?? base.UserPromptSubmit,
+    PreCompact: override.PreCompact ?? base.PreCompact,
   }
 }
 

--- a/src/hooks/claude-code-hooks/config.ts
+++ b/src/hooks/claude-code-hooks/config.ts
@@ -14,6 +14,7 @@ interface RawClaudeHooksConfig {
   PostToolUse?: RawHookMatcher[]
   UserPromptSubmit?: RawHookMatcher[]
   Stop?: RawHookMatcher[]
+  PreCompact?: RawHookMatcher[]
 }
 
 function normalizeHookMatcher(raw: RawHookMatcher): HookMatcher {
@@ -30,6 +31,7 @@ function normalizeHooksConfig(raw: RawClaudeHooksConfig): ClaudeHooksConfig {
     "PostToolUse",
     "UserPromptSubmit",
     "Stop",
+    "PreCompact",
   ]
 
   for (const eventType of eventTypes) {
@@ -66,6 +68,7 @@ function mergeHooksConfig(
     "PostToolUse",
     "UserPromptSubmit",
     "Stop",
+    "PreCompact",
   ]
   for (const eventType of eventTypes) {
     if (override[eventType]) {

--- a/src/hooks/claude-code-hooks/pre-compact.ts
+++ b/src/hooks/claude-code-hooks/pre-compact.ts
@@ -1,0 +1,109 @@
+import type {
+  PreCompactInput,
+  PreCompactOutput,
+  ClaudeHooksConfig,
+} from "./types"
+import { findMatchingHooks, executeHookCommand, log } from "../../shared"
+import { DEFAULT_CONFIG } from "./plugin-config"
+import { isHookCommandDisabled, type PluginExtendedConfig } from "./config-loader"
+
+export interface PreCompactContext {
+  sessionId: string
+  cwd: string
+}
+
+export interface PreCompactResult {
+  context: string[]
+  elapsedMs?: number
+  hookName?: string
+  continue?: boolean
+  stopReason?: string
+  suppressOutput?: boolean
+  systemMessage?: string
+}
+
+export async function executePreCompactHooks(
+  ctx: PreCompactContext,
+  config: ClaudeHooksConfig | null,
+  extendedConfig?: PluginExtendedConfig | null
+): Promise<PreCompactResult> {
+  if (!config) {
+    return { context: [] }
+  }
+
+  const matchers = findMatchingHooks(config, "PreCompact", "*")
+  if (matchers.length === 0) {
+    return { context: [] }
+  }
+
+  const stdinData: PreCompactInput = {
+    session_id: ctx.sessionId,
+    cwd: ctx.cwd,
+    hook_event_name: "PreCompact",
+    hook_source: "opencode-plugin",
+  }
+
+  const startTime = Date.now()
+  let firstHookName: string | undefined
+  const collectedContext: string[] = []
+
+  for (const matcher of matchers) {
+    for (const hook of matcher.hooks) {
+      if (hook.type !== "command") continue
+
+      if (isHookCommandDisabled("PreCompact", hook.command, extendedConfig ?? null)) {
+        log("PreCompact hook command skipped (disabled by config)", { command: hook.command })
+        continue
+      }
+
+      const hookName = hook.command.split("/").pop() || hook.command
+      if (!firstHookName) firstHookName = hookName
+
+      const result = await executeHookCommand(
+        hook.command,
+        JSON.stringify(stdinData),
+        ctx.cwd,
+        { forceZsh: DEFAULT_CONFIG.forceZsh, zshPath: DEFAULT_CONFIG.zshPath }
+      )
+
+      if (result.exitCode === 2) {
+        log("PreCompact hook blocked", { hookName, stderr: result.stderr })
+        continue
+      }
+
+      if (result.stdout) {
+        try {
+          const output = JSON.parse(result.stdout) as PreCompactOutput
+
+          if (output.hookSpecificOutput?.additionalContext) {
+            collectedContext.push(...output.hookSpecificOutput.additionalContext)
+          } else if (output.context) {
+            collectedContext.push(...output.context)
+          }
+
+          if (output.continue === false) {
+            return {
+              context: collectedContext,
+              elapsedMs: Date.now() - startTime,
+              hookName: firstHookName,
+              continue: output.continue,
+              stopReason: output.stopReason,
+              suppressOutput: output.suppressOutput,
+              systemMessage: output.systemMessage,
+            }
+          }
+        } catch {
+          if (result.stdout.trim()) {
+            collectedContext.push(result.stdout.trim())
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    context: collectedContext,
+    elapsedMs: Date.now() - startTime,
+    hookName: firstHookName,
+  }
+}

--- a/src/hooks/claude-code-hooks/types.ts
+++ b/src/hooks/claude-code-hooks/types.ts
@@ -8,6 +8,7 @@ export type ClaudeHookEvent =
   | "PostToolUse"
   | "UserPromptSubmit"
   | "Stop"
+  | "PreCompact"
 
 export interface HookMatcher {
   matcher: string
@@ -24,6 +25,7 @@ export interface ClaudeHooksConfig {
   PostToolUse?: HookMatcher[]
   UserPromptSubmit?: HookMatcher[]
   Stop?: HookMatcher[]
+  PreCompact?: HookMatcher[]
 }
 
 export interface PreToolUseInput {
@@ -79,6 +81,13 @@ export interface StopInput {
   hook_event_name: "Stop"
   stop_hook_active: boolean
   todo_path?: string
+  hook_source?: HookSource
+}
+
+export interface PreCompactInput {
+  session_id: string
+  cwd: string
+  hook_event_name: "PreCompact"
   hook_source?: HookSource
 }
 
@@ -164,6 +173,16 @@ export interface StopOutput {
   stop_hook_active?: boolean
   permission_mode?: PermissionMode
   inject_prompt?: string
+}
+
+export interface PreCompactOutput extends HookCommonOutput {
+  /** Additional context to inject into compaction prompt */
+  context?: string[]
+  hookSpecificOutput?: {
+    hookEventName: "PreCompact"
+    /** Additional context strings to inject */
+    additionalContext?: string[]
+  }
 }
 
 export type ClaudeCodeContent =


### PR DESCRIPTION
## Summary

> 🎤 **Live demo from [instruct.kr](https://instruct.kr) event**

- Add PreCompact hook support for OpenCode's `experimental.session.compacting` event
- Allows Claude Code hooks to inject additional context into compaction prompts before session compaction occurs

## Changes

- `types.ts`: Added `PreCompact` hook event type, `PreCompactInput`, `PreCompactOutput` interfaces
- `pre-compact.ts`: New PreCompact hook executor implementation
- `index.ts`: Added `experimental.session.compacting` event handler
- `config.ts` & `config-loader.ts`: Added PreCompact to hook config loading

## Usage Example

```json
{
  "hooks": {
    "PreCompact": [
      {
        "matcher": "*",
        "hooks": [
          { "type": "command", "command": "~/.claude/hooks/pre-compact/inject-context.sh" }
        ]
      }
    ]
  }
}
```

Hook scripts can output `{ "context": ["additional context string"] }` to inject context into the compaction prompt.

---
🤖 Generated with assistance of [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)