### PR TITLE
feat: auto-detect model provider and apply appropriate options

### DIFF
--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -1,15 +1,9 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
+import { isGptModel } from "./types"
 
-export const oracleAgent: AgentConfig = {
-  description:
-    "Expert technical advisor with deep reasoning for architecture decisions, code analysis, and engineering guidance.",
-  mode: "subagent",
-  model: "openai/gpt-5.2",
-  temperature: 0.1,
-  reasoningEffort: "medium",
-  textVerbosity: "high",
-  tools: { write: false, edit: false, task: false, background_task: false },
-  prompt: `You are a strategic technical advisor with deep reasoning capabilities, operating as a specialized consultant within an AI-assisted development environment.
+const DEFAULT_MODEL = "openai/gpt-5.2"
+
+const ORACLE_SYSTEM_PROMPT = `You are a strategic technical advisor with deep reasoning capabilities, operating as a specialized consultant within an AI-assisted development environment.
 
 ## Context
 
@@ -73,5 +67,24 @@ Organize your final answer in three tiers:
 
 ## Critical Note
 
-Your response goes directly to the user with no intermediate processing. Make your final message self-contained: a clear recommendation they can act on immediately, covering both what to do and why.`,
+Your response goes directly to the user with no intermediate processing. Make your final message self-contained: a clear recommendation they can act on immediately, covering both what to do and why.`
+
+export function createOracleAgent(model: string = DEFAULT_MODEL): AgentConfig {
+  const base = {
+    description:
+      "Expert technical advisor with deep reasoning for architecture decisions, code analysis, and engineering guidance.",
+    mode: "subagent" as const,
+    model,
+    temperature: 0.1,
+    tools: { write: false, edit: false, task: false, background_task: false },
+    prompt: ORACLE_SYSTEM_PROMPT,
+  }
+
+  if (isGptModel(model)) {
+    return { ...base, reasoningEffort: "medium", textVerbosity: "high" }
+  }
+
+  return { ...base, thinking: { type: "enabled", budgetTokens: 32000 } }
 }
+
+export const oracleAgent = createOracleAgent()

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -1,4 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
+import { isGptModel } from "./types"
+
+const DEFAULT_MODEL = "anthropic/claude-opus-4-5"
 
 const SISYPHUS_SYSTEM_PROMPT = `<Role>
 You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
@@ -451,16 +454,22 @@ If the user's approach seems problematic:
 
 `
 
-export const sisyphusAgent: AgentConfig = {
-  description:
-    "Sisyphus - Powerful AI orchestrator from OhMyOpenCode. Plans obsessively with todos, assesses search complexity before exploration, delegates strategically to specialized agents. Uses explore for internal code (parallel-friendly), librarian only for external docs, and always delegates UI work to frontend engineer.",
-  mode: "primary",
-  model: "anthropic/claude-opus-4-5",
-  thinking: {
-    type: "enabled",
-    budgetTokens: 32000,
-  },
-  maxTokens: 64000,
-  prompt: SISYPHUS_SYSTEM_PROMPT,
-  color: "#00CED1",
+export function createSisyphusAgent(model: string = DEFAULT_MODEL): AgentConfig {
+  const base = {
+    description:
+      "Sisyphus - Powerful AI orchestrator from OhMyOpenCode. Plans obsessively with todos, assesses search complexity before exploration, delegates strategically to specialized agents. Uses explore for internal code (parallel-friendly), librarian only for external docs, and always delegates UI work to frontend engineer.",
+    mode: "primary" as const,
+    model,
+    maxTokens: 64000,
+    prompt: SISYPHUS_SYSTEM_PROMPT,
+    color: "#00CED1",
+  }
+
+  if (isGptModel(model)) {
+    return { ...base, reasoningEffort: "medium" }
+  }
+
+  return { ...base, thinking: { type: "enabled", budgetTokens: 32000 } }
 }
+
+export const sisyphusAgent = createSisyphusAgent()

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,5 +1,11 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 
+export type AgentFactory = (model?: string) => AgentConfig
+
+export function isGptModel(model: string): boolean {
+  return model.startsWith("openai/") || model.startsWith("github-copilot/gpt-")
+}
+
 export type BuiltinAgentName =
   | "Sisyphus"
   | "oracle"

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from "bun:test"
+import { createBuiltinAgents } from "./utils"
+
+describe("createBuiltinAgents with model overrides", () => {
+  test("Sisyphus with default model has thinking config", () => {
+    // #given - no overrides
+
+    // #when
+    const agents = createBuiltinAgents()
+
+    // #then
+    expect(agents.Sisyphus.model).toBe("anthropic/claude-opus-4-5")
+    expect(agents.Sisyphus.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
+    expect(agents.Sisyphus.reasoningEffort).toBeUndefined()
+  })
+
+  test("Sisyphus with GPT model override has reasoningEffort, no thinking", () => {
+    // #given
+    const overrides = {
+      Sisyphus: { model: "github-copilot/gpt-5.2" },
+    }
+
+    // #when
+    const agents = createBuiltinAgents([], overrides)
+
+    // #then
+    expect(agents.Sisyphus.model).toBe("github-copilot/gpt-5.2")
+    expect(agents.Sisyphus.reasoningEffort).toBe("medium")
+    expect(agents.Sisyphus.thinking).toBeUndefined()
+  })
+
+  test("Sisyphus with systemDefaultModel GPT has reasoningEffort, no thinking", () => {
+    // #given
+    const systemDefaultModel = "openai/gpt-5.2"
+
+    // #when
+    const agents = createBuiltinAgents([], {}, undefined, systemDefaultModel)
+
+    // #then
+    expect(agents.Sisyphus.model).toBe("openai/gpt-5.2")
+    expect(agents.Sisyphus.reasoningEffort).toBe("medium")
+    expect(agents.Sisyphus.thinking).toBeUndefined()
+  })
+
+  test("Oracle with default model has reasoningEffort", () => {
+    // #given - no overrides
+
+    // #when
+    const agents = createBuiltinAgents()
+
+    // #then
+    expect(agents.oracle.model).toBe("openai/gpt-5.2")
+    expect(agents.oracle.reasoningEffort).toBe("medium")
+    expect(agents.oracle.textVerbosity).toBe("high")
+    expect(agents.oracle.thinking).toBeUndefined()
+  })
+
+  test("Oracle with Claude model override has thinking, no reasoningEffort", () => {
+    // #given
+    const overrides = {
+      oracle: { model: "anthropic/claude-sonnet-4" },
+    }
+
+    // #when
+    const agents = createBuiltinAgents([], overrides)
+
+    // #then
+    expect(agents.oracle.model).toBe("anthropic/claude-sonnet-4")
+    expect(agents.oracle.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
+    expect(agents.oracle.reasoningEffort).toBeUndefined()
+    expect(agents.oracle.textVerbosity).toBeUndefined()
+  })
+
+  test("non-model overrides are still applied after factory rebuild", () => {
+    // #given
+    const overrides = {
+      Sisyphus: { model: "github-copilot/gpt-5.2", temperature: 0.5 },
+    }
+
+    // #when
+    const agents = createBuiltinAgents([], overrides)
+
+    // #then
+    expect(agents.Sisyphus.model).toBe("github-copilot/gpt-5.2")
+    expect(agents.Sisyphus.temperature).toBe(0.5)
+  })
+})


### PR DESCRIPTION
## Summary

When overriding an agent to use a different model provider (e.g., switching Sisyphus from Claude to GPT), the agent now automatically gets provider-appropriate reasoning options:

- **GPT models**: `reasoningEffort`, `textVerbosity`
- **Anthropic models**: `thinking` with `budgetTokens`

## Why utils.ts changes are required

The original flow merges overrides onto pre-built agent configs:

```typescript
mergeAgentConfig(sisyphusAgent, { model: "gpt-5.2" })
// Result: { model: "gpt-5.2", thinking: {...} }
```

The `thinking` config persists because it exists in the pre-built `sisyphusAgent`. GPT models ignore `thinking` and need `reasoningEffort`.

The fix: call the agent factory with the resolved model, so the factory can return the correct provider-specific config:

```typescript
buildAgent(createSisyphusAgent, "gpt-5.2")
// Result: { model: "gpt-5.2", reasoningEffort: "medium" }
```

## Changes

- Add `AgentFactory` type and `isGptModel` helper to `types.ts`
- Add `createSisyphusAgent` factory to `sisyphus.ts`
- Add `createOracleAgent` factory to `oracle.ts`
- Update `utils.ts` to use factories when building agents

## Example

```json
{
  "agents": {
    "Sisyphus": {
      "model": "github-copilot/gpt-5.2"
    }
  }
}
```

System detects GPT model and applies `reasoningEffort: "medium"` automatically, without Claude's `thinking` config.

## Test plan

- [x] Build passes
- [x] All 19 unit tests pass
- [ ] Manual test with GPT model override
- [ ] Manual test with Claude model override

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)