### PR TITLE
Add project-language-preference hook for per-project language memory

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -63,6 +63,7 @@ export const HookNameSchema = z.enum([
   "non-interactive-env",
   "interactive-bash-session",
   "empty-message-sanitizer",
+  "project-language-preference",
 ])
 
 export const AgentOverrideConfigSchema = z.object({

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,3 +21,4 @@ export { createKeywordDetectorHook } from "./keyword-detector";
 export { createNonInteractiveEnvHook } from "./non-interactive-env";
 export { createInteractiveBashSessionHook } from "./interactive-bash-session";
 export { createEmptyMessageSanitizerHook } from "./empty-message-sanitizer";
+export { createProjectLanguagePreferenceHook } from "./project-language-preference";

--- a/src/hooks/project-language-preference/constants.ts
+++ b/src/hooks/project-language-preference/constants.ts
@@ -1,0 +1,62 @@
+import { join } from "node:path"
+import { xdgConfig } from "xdg-basedir"
+import type { LanguageCode, LanguagePattern } from "./types"
+
+export const CONFIG_DIR = xdgConfig ?? join(process.env.HOME ?? "", ".config")
+export const PREFERENCES_FILE = join(CONFIG_DIR, "opencode", "project-preferences.json")
+
+export const LANGUAGE_NAMES: Record<LanguageCode, string> = {
+  en: "English",
+  ko: "Korean",
+  ja: "Japanese",
+  zh: "Chinese",
+  vi: "Vietnamese",
+  es: "Spanish",
+  fr: "French",
+  de: "German",
+  pt: "Portuguese",
+  ru: "Russian",
+}
+
+export const LANGUAGE_PATTERNS: LanguagePattern[] = [
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in|talk\s+in)\s+english\b/i, language: "en", description: "English" },
+  { pattern: /\bin\s+english\b/i, language: "en", description: "English" },
+
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in)\s+korean\b/i, language: "ko", description: "Korean" },
+  { pattern: /\bin\s+korean\b/i, language: "ko", description: "Korean" },
+  { pattern: /한국어로\s*(답변|대화|말|응답|해줘|해주세요|부탁)/i, language: "ko", description: "Korean" },
+  { pattern: /한글로\s*(답변|대화|말|응답|해줘|해주세요|부탁)/i, language: "ko", description: "Korean" },
+
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in)\s+japanese\b/i, language: "ja", description: "Japanese" },
+  { pattern: /\bin\s+japanese\b/i, language: "ja", description: "Japanese" },
+  { pattern: /日本語で(答えて|話して|応答して|お願い)/i, language: "ja", description: "Japanese" },
+
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in)\s+chinese\b/i, language: "zh", description: "Chinese" },
+  { pattern: /\bin\s+chinese\b/i, language: "zh", description: "Chinese" },
+  { pattern: /用中文(回答|说|回复)/i, language: "zh", description: "Chinese" },
+  { pattern: /中文回(答|复)/i, language: "zh", description: "Chinese" },
+
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in)\s+vietnamese\b/i, language: "vi", description: "Vietnamese" },
+  { pattern: /\bin\s+vietnamese\b/i, language: "vi", description: "Vietnamese" },
+  { pattern: /bằng\s+tiếng\s+việt/i, language: "vi", description: "Vietnamese" },
+
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in)\s+spanish\b/i, language: "es", description: "Spanish" },
+  { pattern: /\bin\s+spanish\b/i, language: "es", description: "Spanish" },
+  { pattern: /en\s+español/i, language: "es", description: "Spanish" },
+
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in)\s+french\b/i, language: "fr", description: "French" },
+  { pattern: /\bin\s+french\b/i, language: "fr", description: "French" },
+  { pattern: /en\s+français/i, language: "fr", description: "French" },
+
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in)\s+german\b/i, language: "de", description: "German" },
+  { pattern: /\bin\s+german\b/i, language: "de", description: "German" },
+  { pattern: /auf\s+deutsch/i, language: "de", description: "German" },
+
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in)\s+portuguese\b/i, language: "pt", description: "Portuguese" },
+  { pattern: /\bin\s+portuguese\b/i, language: "pt", description: "Portuguese" },
+  { pattern: /em\s+português/i, language: "pt", description: "Portuguese" },
+
+  { pattern: /\b(use|speak|respond\s+in|answer\s+in)\s+russian\b/i, language: "ru", description: "Russian" },
+  { pattern: /\bin\s+russian\b/i, language: "ru", description: "Russian" },
+  { pattern: /на\s+русском/i, language: "ru", description: "Russian" },
+]

--- a/src/hooks/project-language-preference/detector.ts
+++ b/src/hooks/project-language-preference/detector.ts
@@ -1,0 +1,18 @@
+import { LANGUAGE_PATTERNS } from "./constants"
+import type { LanguageCode } from "./types"
+
+export function detectLanguageFromPrompt(text: string): LanguageCode | null {
+  for (const { pattern, language } of LANGUAGE_PATTERNS) {
+    if (pattern.test(text)) {
+      return language
+    }
+  }
+  return null
+}
+
+export function extractPromptText(parts: Array<{ type: string; text?: string }>): string {
+  return parts
+    .filter((p) => p.type === "text" && p.text)
+    .map((p) => p.text!)
+    .join(" ")
+}

--- a/src/hooks/project-language-preference/index.ts
+++ b/src/hooks/project-language-preference/index.ts
@@ -1,0 +1,84 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { detectLanguageFromPrompt, extractPromptText } from "./detector"
+import { getProjectLanguage, setProjectLanguage } from "./storage"
+import { LANGUAGE_NAMES } from "./constants"
+import { log } from "../../shared"
+import { injectHookMessage } from "../../features/hook-message-injector"
+
+export * from "./types"
+export * from "./constants"
+export * from "./detector"
+export * from "./storage"
+
+interface ChatMessageInput {
+  sessionID: string
+  agent?: string
+  model?: { providerID: string; modelID: string }
+  messageID?: string
+}
+
+interface ChatMessageOutput {
+  message: Record<string, unknown>
+  parts: Array<{ type: string; text?: string; [key: string]: unknown }>
+}
+
+const sessionLanguageInjected = new Set<string>()
+
+export function createProjectLanguagePreferenceHook(ctx: PluginInput) {
+  const projectPath = ctx.directory
+
+  return {
+    "chat.message": async (
+      input: ChatMessageInput,
+      output: ChatMessageOutput
+    ): Promise<void> => {
+      const promptText = extractPromptText(output.parts)
+      const detectedLanguage = detectLanguageFromPrompt(promptText)
+
+      if (detectedLanguage) {
+        const previousLanguage = getProjectLanguage(projectPath)
+        setProjectLanguage(projectPath, detectedLanguage)
+
+        if (previousLanguage !== detectedLanguage) {
+          log(`Language preference updated: ${previousLanguage ?? "none"} -> ${detectedLanguage}`, {
+            sessionID: input.sessionID,
+            projectPath,
+          })
+        }
+      }
+
+      if (!sessionLanguageInjected.has(input.sessionID)) {
+        const savedLanguage = getProjectLanguage(projectPath)
+        if (savedLanguage) {
+          sessionLanguageInjected.add(input.sessionID)
+
+          const message = output.message as {
+            agent?: string
+            model?: { modelID?: string; providerID?: string }
+            path?: { cwd?: string; root?: string }
+            tools?: Record<string, boolean>
+          }
+
+          const languageName = LANGUAGE_NAMES[savedLanguage]
+          const instruction = `[Project Language Preference]
+This project has a saved language preference: ${languageName} (${savedLanguage})
+Please respond in ${languageName} for this project.`
+
+          const success = injectHookMessage(input.sessionID, instruction, {
+            agent: message.agent,
+            model: message.model,
+            path: message.path,
+            tools: message.tools,
+          })
+
+          if (success) {
+            log(`Injected language preference: ${savedLanguage}`, {
+              sessionID: input.sessionID,
+              projectPath,
+            })
+          }
+        }
+      }
+    },
+  }
+}

--- a/src/hooks/project-language-preference/storage.ts
+++ b/src/hooks/project-language-preference/storage.ts
@@ -1,0 +1,54 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname } from "node:path"
+import { PREFERENCES_FILE } from "./constants"
+import type { LanguageCode, ProjectPreferences } from "./types"
+
+let cachedPreferences: ProjectPreferences | null = null
+
+export function loadPreferences(): ProjectPreferences {
+  if (cachedPreferences !== null) {
+    return cachedPreferences
+  }
+
+  if (!existsSync(PREFERENCES_FILE)) {
+    cachedPreferences = {}
+    return cachedPreferences
+  }
+
+  try {
+    const content = readFileSync(PREFERENCES_FILE, "utf-8")
+    cachedPreferences = JSON.parse(content) as ProjectPreferences
+    return cachedPreferences
+  } catch {
+    cachedPreferences = {}
+    return cachedPreferences
+  }
+}
+
+export function savePreferences(preferences: ProjectPreferences): void {
+  const dir = dirname(PREFERENCES_FILE)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  writeFileSync(PREFERENCES_FILE, JSON.stringify(preferences, null, 2))
+  cachedPreferences = preferences
+}
+
+export function getProjectLanguage(projectPath: string): LanguageCode | null {
+  const preferences = loadPreferences()
+  return preferences[projectPath]?.language ?? null
+}
+
+export function setProjectLanguage(projectPath: string, language: LanguageCode): void {
+  const preferences = loadPreferences()
+  preferences[projectPath] = {
+    language,
+    updatedAt: Date.now(),
+  }
+  savePreferences(preferences)
+}
+
+export function clearCache(): void {
+  cachedPreferences = null
+}

--- a/src/hooks/project-language-preference/types.ts
+++ b/src/hooks/project-language-preference/types.ts
@@ -1,0 +1,14 @@
+export type LanguageCode = "en" | "ko" | "ja" | "zh" | "vi" | "es" | "fr" | "de" | "pt" | "ru"
+
+export interface ProjectPreferences {
+  [projectPath: string]: {
+    language: LanguageCode
+    updatedAt: number
+  }
+}
+
+export interface LanguagePattern {
+  pattern: RegExp
+  language: LanguageCode
+  description: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   createNonInteractiveEnvHook,
   createInteractiveBashSessionHook,
   createEmptyMessageSanitizerHook,
+  createProjectLanguagePreferenceHook,
 } from "./hooks";
 import { createGoogleAntigravityAuthPlugin } from "./auth/antigravity";
 import {
@@ -287,6 +288,9 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   const emptyMessageSanitizer = isHookEnabled("empty-message-sanitizer")
     ? createEmptyMessageSanitizerHook()
     : null;
+  const projectLanguagePreference = isHookEnabled("project-language-preference")
+    ? createProjectLanguagePreferenceHook(ctx)
+    : null;
 
   const backgroundManager = new BackgroundManager(ctx);
 
@@ -318,6 +322,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     "chat.message": async (input, output) => {
       await claudeCodeHooks["chat.message"]?.(input, output);
       await keywordDetector?.["chat.message"]?.(input, output);
+      await projectLanguagePreference?.["chat.message"]?.(input, output);
     },
 
     "experimental.chat.messages.transform": async (


### PR DESCRIPTION
## Background

When working on multiple projects with different language preferences (e.g., English for project A, Korean for project B, Chinese for project C), users have to repeatedly specify their language preference each session. This creates friction and interrupts workflow.

## Changes

- Add new `project-language-preference` hook that automatically detects and remembers language preferences per project
- Store preferences in `~/.config/opencode/project-preferences.json` with project path as key
- Detect language change requests from natural language patterns in 10 languages (EN, KO, JA, ZH, VI, ES, FR, DE, PT, RU)
- Auto-inject saved language preference into system prompt on session start
- Add hook to `HookNameSchema` for configuration support

**File structure:**
```
src/hooks/project-language-preference/
├── constants.ts   # Storage path, language patterns
├── detector.ts    # Language pattern detection
├── index.ts       # Hook entry point
├── storage.ts     # JSON file read/write
└── types.ts       # Type definitions
```

## Testing

1. Start a new session in project A
2. Say "use english" or "한국어로 해줘"
3. Start a new session in the same project
4. Agent should automatically respond in the saved language

## Review Notes

- Can be disabled via `disabled_hooks: ["project-language-preference"]`
- Language detection supports native patterns (e.g., "한국어로 해줘", "日本語でお願い", "用中文回答")