### PR TITLE
fix: allow multiple todo continuations per session

### DIFF
--- a/src/hooks/todo-continuation-enforcer.ts
+++ b/src/hooks/todo-continuation-enforcer.ts
@@ -279,6 +279,8 @@ export function createTodoContinuationEnforcer(ctx: PluginInput): TodoContinuati
           pendingCountdowns.delete(sessionID)
           log(`[${HOOK_NAME}] Cancelled countdown on user message`, { sessionID })
         }
+        // Allow new continuation after user sends another message
+        remindedSessions.delete(sessionID)
       }
 
       if (sessionID && role === "assistant" && finish) {


### PR DESCRIPTION
## Summary

- Clear `remindedSessions` when user sends a new message, allowing continuation to trigger again after user interaction

## Problem

Previously, `remindedSessions` was only cleared when assistant finished with `finish=true`. If the agent stopped mid-task (ESC, error, etc.), the session stayed "reminded" forever, preventing future todo continuations for that session.

## Solution

Now `remindedSessions` is cleared in two cases:
1. When user sends any message (new behavior)
2. When assistant finishes with `finish=true` (existing behavior)

This enables multiple continuation cycles per session - each time the user interacts or the assistant completes, the continuation guard resets.