### PR TITLE
Add morph_edit tool for fast code editing

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,6 +20,7 @@ import {
 import { grep } from "./grep"
 import { glob } from "./glob"
 import { slashcommand } from "./slashcommand"
+import { morph_edit } from "./morph-fast-apply"
 
 export { interactive_bash, startBackgroundCheck as startTmuxCheck } from "./interactive-bash"
 export { getTmuxPath } from "./interactive-bash/utils"
@@ -63,4 +64,5 @@ export const builtinTools = {
   grep,
   glob,
   slashcommand,
+  morph_edit,
 }

--- a/src/tools/morph-fast-apply/constants.ts
+++ b/src/tools/morph-fast-apply/constants.ts
@@ -1,0 +1,35 @@
+export const MORPH_API_URL = process.env.MORPH_API_URL || "https://api.morphllm.com"
+export const MORPH_MODEL = process.env.MORPH_MODEL || "morph-v3-fast"
+export const MORPH_TIMEOUT = parseInt(process.env.MORPH_TIMEOUT || "30000", 10)
+
+export const TOOL_DESCRIPTION = `Fast code editing using Morph AI (10,500+ tokens/sec).
+
+Use this tool for efficient partial file edits. It handles lazy edit markers
+so you don't need to provide the full file content.
+
+FORMAT:
+Use "// ... existing code ..." to represent unchanged code blocks.
+Include just enough surrounding context to locate each edit precisely.
+
+EXAMPLE:
+// ... existing code ...
+function updatedFunction() {
+  // New implementation with changes
+  return "modified";
+}
+// ... existing code ...
+
+RULES:
+- ALWAYS use "// ... existing code ..." for unchanged sections
+- Include minimal context around edits for disambiguation
+- Preserve exact indentation
+- For deletions: show context before and after, omit deleted lines
+- Batch multiple edits to the same file in one call
+
+WHEN TO USE:
+- Large files (500+ lines)
+- Multiple scattered changes
+- Complex refactoring
+- When exact string matching is fragile
+
+REQUIRES: MORPH_API_KEY environment variable. Get one at https://morphllm.com/dashboard/api-keys`

--- a/src/tools/morph-fast-apply/index.ts
+++ b/src/tools/morph-fast-apply/index.ts
@@ -1,0 +1,1 @@
+export { morph_edit } from "./tools"

--- a/src/tools/morph-fast-apply/tools.ts
+++ b/src/tools/morph-fast-apply/tools.ts
@@ -1,0 +1,85 @@
+import { tool } from "@opencode-ai/plugin/tool"
+import { TOOL_DESCRIPTION } from "./constants"
+import { callMorphApply, generateDiff, countChanges } from "./utils"
+
+export const morph_edit = tool({
+  description: TOOL_DESCRIPTION,
+  args: {
+    target_filepath: tool.schema
+      .string()
+      .describe("Path of the file to modify (absolute or relative to project root)"),
+    instructions: tool.schema
+      .string()
+      .describe("Brief first-person description of what you're changing (helps disambiguate)"),
+    code_edit: tool.schema
+      .string()
+      .describe('The code changes with "// ... existing code ..." markers for unchanged sections'),
+  },
+  execute: async (args) => {
+    const { target_filepath, instructions, code_edit } = args
+
+    // Check if API key is available
+    if (!process.env.MORPH_API_KEY) {
+      return `Error: MORPH_API_KEY not configured.
+
+To use morph_edit, set the MORPH_API_KEY environment variable.
+Get your API key at: https://morphllm.com/dashboard/api-keys
+
+Alternatively, use the native 'edit' tool for this change.`
+    }
+
+    // Read the original file
+    let originalCode: string
+    try {
+      const file = Bun.file(target_filepath)
+      if (!(await file.exists())) {
+        // New file - check if this is a creation
+        if (!code_edit.includes("// ... existing code ...")) {
+          await Bun.write(target_filepath, code_edit)
+          return `Created new file: ${target_filepath}\n\nLines: ${code_edit.split("\n").length}`
+        }
+        return `Error: File not found: ${target_filepath}
+
+The file doesn't exist and the code_edit contains lazy markers.
+For new files, provide the complete content without "// ... existing code ..." markers.`
+      }
+      originalCode = await file.text()
+    } catch (err) {
+      const error = err as Error
+      return `Error reading file ${target_filepath}: ${error.message}`
+    }
+
+    // Call Morph API to merge the edit
+    const result = await callMorphApply(originalCode, code_edit, instructions)
+
+    if (!result.success || !result.content) {
+      return `Morph API failed: ${result.error}
+
+Suggestion: Try using the native 'edit' tool instead with exact string replacement.`
+    }
+
+    const mergedCode = result.content
+
+    // Write the merged result
+    try {
+      await Bun.write(target_filepath, mergedCode)
+    } catch (err) {
+      const error = err as Error
+      return `Error writing file ${target_filepath}: ${error.message}`
+    }
+
+    // Generate summary
+    const { added, removed } = countChanges(originalCode, mergedCode)
+    const originalLines = originalCode.split("\n").length
+    const mergedLines = mergedCode.split("\n").length
+    const diff = generateDiff(target_filepath, originalCode, mergedCode)
+
+    return `Applied edit to ${target_filepath}
+
++${added} -${removed} lines | ${originalLines} -> ${mergedLines} total
+
+\`\`\`diff
+${diff.slice(0, 2000)}${diff.length > 2000 ? "\n... (truncated)" : ""}
+\`\`\``
+  },
+})

--- a/src/tools/morph-fast-apply/types.ts
+++ b/src/tools/morph-fast-apply/types.ts
@@ -1,0 +1,13 @@
+export interface MorphApplyResult {
+  success: boolean
+  content?: string
+  error?: string
+}
+
+export interface MorphApiResponse {
+  choices: Array<{
+    message: {
+      content: string
+    }
+  }>
+}

--- a/src/tools/morph-fast-apply/utils.ts
+++ b/src/tools/morph-fast-apply/utils.ts
@@ -1,0 +1,134 @@
+import { MORPH_API_URL, MORPH_MODEL, MORPH_TIMEOUT } from "./constants"
+import type { MorphApplyResult, MorphApiResponse } from "./types"
+
+/**
+ * Call Morph's Apply API to merge code edits
+ */
+export async function callMorphApply(
+  originalCode: string,
+  codeEdit: string,
+  instructions: string
+): Promise<MorphApplyResult> {
+  const apiKey = process.env.MORPH_API_KEY
+
+  if (!apiKey) {
+    return {
+      success: false,
+      error: "MORPH_API_KEY not set. Get one at https://morphllm.com/dashboard/api-keys",
+    }
+  }
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), MORPH_TIMEOUT)
+
+  try {
+    const response = await fetch(`${MORPH_API_URL}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MORPH_MODEL,
+        messages: [
+          {
+            role: "user",
+            content: `<instruction>${instructions}</instruction>\n<code>${originalCode}</code>\n<update>${codeEdit}</update>`,
+          },
+        ],
+        temperature: 0,
+      }),
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeoutId)
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return {
+        success: false,
+        error: `Morph API error (${response.status}): ${errorText}`,
+      }
+    }
+
+    const result = (await response.json()) as MorphApiResponse
+    const mergedCode = result.choices?.[0]?.message?.content
+
+    if (!mergedCode) {
+      return {
+        success: false,
+        error: "Morph API returned empty response",
+      }
+    }
+
+    return {
+      success: true,
+      content: mergedCode,
+    }
+  } catch (err) {
+    clearTimeout(timeoutId)
+    const error = err as Error
+    if (error.name === "AbortError") {
+      return {
+        success: false,
+        error: `Morph API timeout after ${MORPH_TIMEOUT}ms`,
+      }
+    }
+    return {
+      success: false,
+      error: `Morph API request failed: ${error.message}`,
+    }
+  }
+}
+
+/**
+ * Generate a simple unified diff for display
+ */
+export function generateDiff(filepath: string, original: string, modified: string): string {
+  const originalLines = original.split("\n")
+  const modifiedLines = modified.split("\n")
+
+  let diff = `--- a/${filepath}\n+++ b/${filepath}\n`
+  let hasChanges = false
+
+  const maxLines = Math.max(originalLines.length, modifiedLines.length)
+
+  for (let i = 0; i < maxLines; i++) {
+    const origLine = originalLines[i]
+    const modLine = modifiedLines[i]
+
+    if (origLine !== modLine) {
+      hasChanges = true
+      if (origLine !== undefined) {
+        diff += `-${origLine}\n`
+      }
+      if (modLine !== undefined) {
+        diff += `+${modLine}\n`
+      }
+    }
+  }
+
+  return hasChanges ? diff : "No changes detected"
+}
+
+/**
+ * Count additions and deletions from diff output
+ */
+export function countChanges(original: string, modified: string): { added: number; removed: number } {
+  const originalLines = original.split("\n")
+  const modifiedLines = modified.split("\n")
+
+  let added = 0
+  let removed = 0
+
+  const maxLines = Math.max(originalLines.length, modifiedLines.length)
+
+  for (let i = 0; i < maxLines; i++) {
+    if (originalLines[i] !== modifiedLines[i]) {
+      if (originalLines[i] !== undefined) removed++
+      if (modifiedLines[i] !== undefined) added++
+    }
+  }
+
+  return { added, removed }
+}


### PR DESCRIPTION
## Summary

Adds `morph_edit` tool that integrates [Morph's Fast Apply API](https://morphllm.com) for faster code editing.

## Features

- **10,500+ tokens/sec** code editing speed via Morph API
- **Lazy edit markers** (`// ... existing code ...`) - no exact string matching needed
- **Unified diff output** showing what changed
- **Graceful fallback** - suggests native `edit` tool on API failure

## Usage

Requires `MORPH_API_KEY` environment variable. Get one at [morphllm.com/dashboard](https://morphllm.com/dashboard/api-keys).

```typescript
morph_edit({
  target_filepath: "src/auth.ts",
  instructions: "Add error handling for invalid tokens",
  code_edit: `// ... existing code ...
function validateToken(token) {
  if (!token) {
    throw new Error("Token is required");
  }
  // ... existing code ...
}
// ... existing code ...`
})
```

## When to use `morph_edit` vs `edit`

| Situation | Tool | Reason |
|-----------|------|--------|
| Small, exact replacement | `edit` | Fast, no API call |
| Large file (500+ lines) | `morph_edit` | Handles partial snippets |
| Multiple scattered changes | `morph_edit` | Batch efficiently |
| Whitespace-sensitive | `morph_edit` | Forgiving with formatting |

## Files Added

```
src/tools/morph-fast-apply/
├── index.ts      # Export
├── types.ts      # TypeScript interfaces
├── constants.ts  # Config and tool description
├── utils.ts      # API call and diff helpers
└── tools.ts      # Tool implementation
```

## Checklist

- [x] Follows project conventions (kebab-case directory, proper file structure)
- [x] Uses `Bun.file()` and `Bun.write()` for file operations
- [x] No `@ts-ignore` or type suppressions
- [x] Tool added to `builtinTools` in index.ts

## Related

I also maintain this as a standalone OpenCode plugin: [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)