### PR TITLE
Enhance non-interactive-env hook with additional env vars and command patterns

### DIFF
--- a/src/hooks/non-interactive-env/constants.ts
+++ b/src/hooks/non-interactive-env/constants.ts
@@ -14,4 +14,56 @@ export const NON_INTERACTIVE_ENV: Record<string, string> = {
   // Block pagers
   GIT_PAGER: "cat",
   PAGER: "cat",
+  // NPM non-interactive
+  npm_config_yes: "true",
+  // Pip non-interactive
+  PIP_NO_INPUT: "1",
+  // Yarn non-interactive
+  YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
 }
+
+/**
+ * Shell command guidance for non-interactive environments.
+ * These patterns should be followed to avoid hanging on user input.
+ */
+export const SHELL_COMMAND_PATTERNS = {
+  // Package managers - always use non-interactive flags
+  npm: {
+    bad: ["npm init", "npm install (prompts)"],
+    good: ["npm init -y", "npm install --yes"],
+  },
+  apt: {
+    bad: ["apt-get install pkg"],
+    good: ["apt-get install -y pkg", "DEBIAN_FRONTEND=noninteractive apt-get install pkg"],
+  },
+  pip: {
+    bad: ["pip install pkg (with prompts)"],
+    good: ["pip install --no-input pkg", "PIP_NO_INPUT=1 pip install pkg"],
+  },
+  // Git operations - always provide messages/flags
+  git: {
+    bad: ["git commit", "git merge branch", "git add -p", "git rebase -i"],
+    good: ["git commit -m 'msg'", "git merge --no-edit branch", "git add .", "git rebase --no-edit"],
+  },
+  // System commands - force flags
+  system: {
+    bad: ["rm file (prompts)", "cp a b (prompts)", "ssh host"],
+    good: ["rm -f file", "cp -f a b", "ssh -o BatchMode=yes host", "unzip -o file.zip"],
+  },
+  // Banned commands - will always hang
+  banned: [
+    "vim", "nano", "vi", "emacs",           // Editors
+    "less", "more", "man",                   // Pagers
+    "python (REPL)", "node (REPL)",          // REPLs without -c/-e
+    "git add -p", "git rebase -i",           // Interactive git modes
+  ],
+  // Workarounds for scripts that require input
+  workarounds: {
+    yesPipe: "yes | ./script.sh",
+    heredoc: `./script.sh <<EOF
+option1
+option2
+EOF`,
+    expectAlternative: "Use environment variables or config files instead of expect",
+  },
+} as const


### PR DESCRIPTION
## Summary

Enhances the existing `non-interactive-env` hook with additional environment variables and documents command patterns for reference.

## Changes

### New Environment Variables

| Variable | Value | Purpose |
|----------|-------|---------|
| `npm_config_yes` | `true` | Auto-yes for npm prompts |
| `PIP_NO_INPUT` | `1` | Disable pip interactive prompts |
| `YARN_ENABLE_IMMUTABLE_INSTALLS` | `false` | Prevent yarn lockfile prompts |

### SHELL_COMMAND_PATTERNS Documentation

Added a comprehensive reference object documenting:

- **Package managers**: npm, apt, pip patterns (good vs bad)
- **Git operations**: commit, merge, rebase patterns
- **System commands**: rm, cp, ssh, unzip with force flags
- **Banned commands**: editors, pagers, REPLs that will always hang
- **Workarounds**: `yes |` pipe, heredocs for scripts requiring input

This is exported as `SHELL_COMMAND_PATTERNS` for potential use in:
- Documentation generation
- Command validation hooks
- Agent instruction injection

## Related

Based on patterns from [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy), adapted to fit oh-my-opencode's architecture.

## Checklist

- [x] Uses existing file structure
- [x] Exports follow barrel pattern
- [x] No breaking changes to existing hook behavior
- [x] Adds value without bloat