### PR TITLE
feat(workflow): configurable runner for sisyphus agent

### DIFF
--- a/.github/workflows/sisyphus-agent.yml
+++ b/.github/workflows/sisyphus-agent.yml
@@ -6,6 +6,10 @@ on:
       prompt:
         description: 'Custom prompt'
         required: false
+      runs_on:
+        description: 'JSON for runs-on (array/string/object). Example: ["ubuntu-latest"] or ["self-hosted","linux","x64"]'
+        required: false
+        default: '["ubuntu-latest"]'
   issue_comment:
     types: [created]
   pull_request_review:
@@ -15,7 +19,7 @@ on:
 
 jobs:
   agent:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'workflow_dispatch' && github.event.inputs.runs_on) || vars.SISYPHUS_RUNS_ON || '["ubuntu-latest"]') }}
     # @sisyphus-dev-ai mention only (maintainers, exclude self)
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/README.md
+++ b/README.md
@@ -814,6 +814,31 @@ You can also customize Sisyphus and Planner-Sisyphus like other agents:
 | ---------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | `disabled` | `false` | When `true`, disables Sisyphus agents and restores original build/plan as primary. When `false` (default), Sisyphus and Planner-Sisyphus become primary agents. |
 
+#### GitHub Actions runner selection (sisyphus-dev-ai)
+
+GitHub-hosted **larger runners are a paid feature** (billed per-minute). If you want the agent to run on a “best spec” machine without GitHub billing, the typical approach is a **self-hosted runner** on your own hardware/VM.
+
+This repo’s `@sisyphus-dev-ai` workflow supports configuring `runs-on` via either:
+
+- Workflow dispatch input `runs_on` (JSON)
+- Repository variable `SISYPHUS_RUNS_ON` (JSON)
+
+Examples for `SISYPHUS_RUNS_ON`:
+
+```json
+["ubuntu-latest"]
+```
+
+```json
+["self-hosted", "linux", "x64", "sisyphus-big"]
+```
+
+Runner group example:
+
+```json
+{ "group": "my-runner-group", "labels": ["self-hosted", "linux", "x64"] }
+```
+
 ### Hooks
 
 Disable specific built-in hooks via `disabled_hooks` in `~/.config/opencode/oh-my-opencode.json` or `.opencode/oh-my-opencode.json`:


### PR DESCRIPTION
## Summary
- Allow selecting `runs-on` for the `@sisyphus-dev-ai` workflow via `workflow_dispatch` input or `SISYPHUS_RUNS_ON` repo variable.
- Document why larger GitHub-hosted runners aren’t free and how to switch to self-hosted.

Closes #193

---
🤖 Generated with [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)