### PR TITLE
fix: preserve backticks in Sisyphus GitHub comments

### DIFF
--- a/.github/workflows/sisyphus-agent.yml
+++ b/.github/workflows/sisyphus-agent.yml
@@ -149,8 +149,32 @@ jobs:
 
           User CANNOT see console. Post everything via `gh issue comment` or `gh pr comment`.
 
+          ### Comment Formatting (CRITICAL)
+
+          **ALWAYS use heredoc syntax for comments containing code references, backticks, or multiline content:**
+
+          ```bash
+          gh issue comment <number> --body "$(cat <<'EOF'
+          Your comment with `backticks` and code references preserved here.
+          Multiple lines work perfectly.
+          EOF
+          )"
+          ```
+
+          **NEVER use direct quotes with backticks** (shell will interpret them as command substitution):
+          ```bash
+          # WRONG - backticks disappear:
+          gh issue comment 123 --body "text with `code`"
+          
+          # CORRECT - backticks preserved:
+          gh issue comment 123 --body "$(cat <<'EOF'
+          text with `code`
+          EOF
+          )"
+          ```
+
           ### Rules
-          - EVERY response = GitHub comment
+          - EVERY response = GitHub comment (use heredoc for proper escaping)
           - Code changes = PR (never push main/master)
           - Setup: bun install first
           - Acknowledge immediately, report when done


### PR DESCRIPTION
## Summary

Fixes #201 - Sisyphus agent now properly escapes GitHub comments containing code references and backticks.

## Problem

When the Sisyphus agent posted GitHub issue comments with backticked code references (like \`manager.ts\` or \`session.prompt()\`), the shell interpreted the backticks as command substitution, causing the content to disappear. Example of broken output:

```
calls  back to the parent session with , but **does not pass **
```

Should have been:
```
calls `manager.ts` back to the parent session with `agent`, but **does not pass `model`**
```

## Solution

Updated the GitHub Actions workflow prompt (.github/workflows/sisyphus-agent.yml:142-161) to instruct the agent to use heredoc syntax for all comments containing code references:

```bash
gh issue comment <number> --body "$(cat <<'EOF'
Your comment with `backticks` preserved here.