### PR TITLE
feat(rules): support both 'paths' and 'globs' fields for Claude Code compatibility

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -85,6 +85,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -194,6 +197,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {
@@ -307,6 +313,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -416,6 +425,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {
@@ -529,6 +541,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -638,6 +653,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {
@@ -751,6 +769,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -860,6 +881,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {
@@ -973,6 +997,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -1082,6 +1109,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {

--- a/src/hooks/rules-injector/matcher.ts
+++ b/src/hooks/rules-injector/matcher.ts
@@ -20,19 +20,19 @@ export function shouldApplyRule(
     return { applies: true, reason: "alwaysApply" }
   }
 
-  const globs = metadata.globs
-  if (!globs) {
+  const patterns = metadata.paths ?? metadata.globs
+  if (!patterns) {
     return { applies: false }
   }
 
-  const patterns = Array.isArray(globs) ? globs : [globs]
-  if (patterns.length === 0) {
+  const patternArray = Array.isArray(patterns) ? patterns : [patterns]
+  if (patternArray.length === 0) {
     return { applies: false }
   }
 
   const relativePath = projectRoot ? relative(projectRoot, currentFilePath) : currentFilePath
 
-  for (const pattern of patterns) {
+  for (const pattern of patternArray) {
     if (picomatch.isMatch(relativePath, pattern, { dot: true, bash: true })) {
       return { applies: true, reason: `glob: ${pattern}` }
     }

--- a/src/hooks/rules-injector/types.ts
+++ b/src/hooks/rules-injector/types.ts
@@ -4,6 +4,9 @@
  */
 export interface RuleMetadata {
   description?: string;
+  /** Claude Code native field for file pattern matching */
+  paths?: string | string[];
+  /** Legacy oh-my-opencode field for file pattern matching (alias for paths) */
   globs?: string | string[];
   alwaysApply?: boolean;
 }


### PR DESCRIPTION
## Summary

- Add support for `paths` field in rule frontmatter for Claude Code compatibility
- Maintain backward compatibility with existing `globs` field
- `paths` takes precedence when both fields are present

## Changes

- Added `paths` field to `RuleMetadata` interface (`src/hooks/rules-injector/types.ts`)
- Updated matcher logic to use `paths` as primary field with `globs` as fallback (`src/hooks/rules-injector/matcher.ts`)
- Updated JSON schema (`assets/oh-my-opencode.schema.json`)

## Context

Claude Code's official documentation uses `paths` for file pattern matching in rules:

\`\`\`yaml
---
paths: src/api/**/*.ts
---
\`\`\`

oh-my-opencode was using `globs` instead. This PR adds support for both fields to ensure full Claude Code compatibility while maintaining backward compatibility with existing oh-my-opencode users.

Fixes #188