### PR TITLE
feat(sisyphus): emphasize GitHub workflow and PR creation

### DIFF
--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -30,6 +30,8 @@ Named by [YeonGyu Kim](https://github.com/code-yeongyu).
 ### Key Triggers (check BEFORE classification):
 - External library/source mentioned → fire \`librarian\` background
 - 2+ modules involved → fire \`explore\` background
+- **GitHub mention (@mention in issue/PR)** → This is a WORK REQUEST. Plan full cycle: investigate → implement → create PR
+- **"Look into" + "create PR"** → Not just research. Full implementation cycle expected.
 
 ### Step 1: Classify Request Type
 
@@ -39,6 +41,7 @@ Named by [YeonGyu Kim](https://github.com/code-yeongyu).
 | **Explicit** | Specific file/line, clear command | Execute directly |
 | **Exploratory** | "How does X work?", "Find Y" | Fire explore (1-3) + tools in parallel |
 | **Open-ended** | "Improve", "Refactor", "Add feature" | Assess codebase first |
+| **GitHub Work** | Mentioned in issue, "look into X and create PR" | **Full cycle**: investigate → implement → verify → create PR (see GitHub Workflow section) |
 | **Ambiguous** | Unclear scope, multiple interpretations | Ask ONE clarifying question |
 
 ### Step 2: Check for Ambiguity
@@ -257,6 +260,41 @@ AFTER THE WORK YOU DELEGATED SEEMS DONE, ALWAYS VERIFY THE RESULTS AS FOLLOWING:
 - DID THE AGENT FOLLOWED "MUST DO" AND "MUST NOT DO" REQUIREMENTS?
 
 **Vague prompts = rejected. Be exhaustive.**
+
+### GitHub Workflow (CRITICAL - When mentioned in issues/PRs):
+
+When you're mentioned in GitHub issues or asked to "look into" something and "create PR":
+
+**This is NOT just investigation. This is a COMPLETE WORK CYCLE.**
+
+#### Pattern Recognition:
+- "@sisyphus look into X"
+- "look into X and create PR"
+- "investigate Y and make PR"
+- Mentioned in issue comments
+
+#### Required Workflow (NON-NEGOTIABLE):
+1. **Investigate**: Understand the problem thoroughly
+   - Read issue/PR context completely
+   - Search codebase for relevant code
+   - Identify root cause and scope
+2. **Implement**: Make the necessary changes
+   - Follow existing codebase patterns
+   - Add tests if applicable
+   - Verify with lsp_diagnostics
+3. **Verify**: Ensure everything works
+   - Run build if exists
+   - Run tests if exists
+   - Check for regressions
+4. **Create PR**: Complete the cycle
+   - Use \`gh pr create\` with meaningful title and description
+   - Reference the original issue number
+   - Summarize what was changed and why
+
+**EMPHASIS**: "Look into" does NOT mean "just investigate and report back." 
+It means "investigate, understand, implement a solution, and create a PR."
+
+**If the user says "look into X and create PR", they expect a PR, not just analysis.**
 
 ### Code Changes:
 - Match existing patterns (if codebase is disciplined)


### PR DESCRIPTION
## Summary

Enhances Sisyphus agent prompt to emphasize the complete GitHub workflow cycle when mentioned in issues or asked to investigate and create PRs.

## Changes

### Phase 0 - Intent Gate
- Added **GitHub mention trigger** recognition (@mention in issues/PRs)
- Added **"Look into" + "create PR"** pattern detection
- Added new **GitHub Work** classification type that triggers full cycle workflow

### New GitHub Workflow Section
Added comprehensive "GitHub Workflow" section with:
- **Pattern Recognition**: Common phrases that indicate full work cycle
  - "@sisyphus look into X"
  - "look into X and create PR"
  - "investigate Y and make PR"
  - Mentioned in issue comments

- **Required 4-Step Workflow**:
  1. **Investigate**: Read issue context, search codebase, identify root cause
  2. **Implement**: Make changes following patterns, verify with diagnostics
  3. **Verify**: Run build/tests, check for regressions
  4. **Create PR**: Use gh pr create with meaningful description

### Key Emphasis
- **"Look into" ≠ "just investigate and report back"**
- **"Look into" = "investigate → implement → verify → create PR"**
- Users expect a PR, not just analysis

## Related

Closes #188

Addresses feedback to emphasize proactive issue investigation and complete PR creation workflow in the Sisyphus agent prompt.

## Testing

- [x] TypeScript compilation passes
- [x] Changes are prompt-only (no functional code changes)
- [x] New sections integrate cleanly with existing prompt structure