### PR TITLE
fix: remove api:antigravity field causing auth issues

### DIFF
--- a/src/cli/config-manager.ts
+++ b/src/cli/config-manager.ts
@@ -362,7 +362,6 @@ export async function runBunInstall(): Promise<boolean> {
 export const ANTIGRAVITY_PROVIDER_CONFIG = {
   google: {
     name: "Google",
-    api: "antigravity",
     // NOTE: opencode-antigravity-auth expects full model specs (name/limit/modalities).
     // If these are incomplete, models may appear but fail at runtime (e.g. 404).
     models: {


### PR DESCRIPTION
## Summary

- Remove the `api: "antigravity"` field from `ANTIGRAVITY_PROVIDER_CONFIG` that was being written to `~/.config/opencode/opencode.json`
- This field causes authentication failures with the opencode-antigravity-auth plugin

## Related Issue

Fixes: https://github.com/NoeFabris/opencode-antigravity-auth/issues/49

Multiple users confirmed that removing this field manually resolves the authentication issue.