### PR TITLE
fix: prevent premature exit in non-interactive mode when tasks pending

### DIFF
--- a/src/hooks/non-interactive-env/detector.ts
+++ b/src/hooks/non-interactive-env/detector.ts
@@ -1,0 +1,19 @@
+export function isNonInteractive(): boolean {
+  if (process.env.CI === "true" || process.env.CI === "1") {
+    return true
+  }
+
+  if (process.env.OPENCODE_RUN === "true" || process.env.OPENCODE_NON_INTERACTIVE === "true") {
+    return true
+  }
+
+  if (process.env.GITHUB_ACTIONS === "true") {
+    return true
+  }
+
+  if (!process.stdout.isTTY) {
+    return true
+  }
+
+  return false
+}

--- a/src/hooks/non-interactive-env/index.ts
+++ b/src/hooks/non-interactive-env/index.ts
@@ -3,6 +3,7 @@ import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./consta
 import { log } from "../../shared"
 
 export * from "./constants"
+export * from "./detector"
 export * from "./types"
 
 const BANNED_COMMAND_PATTERNS = SHELL_COMMAND_PATTERNS.banned

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,9 +227,6 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     return undefined;
   };
 
-  const todoContinuationEnforcer = isHookEnabled("todo-continuation-enforcer")
-    ? createTodoContinuationEnforcer(ctx)
-    : null;
   const contextWindowMonitor = isHookEnabled("context-window-monitor")
     ? createContextWindowMonitorHook(ctx)
     : null;
@@ -239,13 +236,6 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   const sessionNotification = isHookEnabled("session-notification")
     ? createSessionNotification(ctx)
     : null;
-
-  // Wire up recovery state tracking between session-recovery and todo-continuation-enforcer
-  // This prevents the continuation enforcer from injecting prompts during active recovery
-  if (sessionRecovery && todoContinuationEnforcer) {
-    sessionRecovery.setOnAbortCallback(todoContinuationEnforcer.markRecovering);
-    sessionRecovery.setOnRecoveryCompleteCallback(todoContinuationEnforcer.markRecoveryComplete);
-  }
 
   const commentChecker = isHookEnabled("comment-checker")
     ? createCommentCheckerHooks()
@@ -304,6 +294,15 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     : null;
 
   const backgroundManager = new BackgroundManager(ctx);
+
+  const todoContinuationEnforcer = isHookEnabled("todo-continuation-enforcer")
+    ? createTodoContinuationEnforcer(ctx, { backgroundManager })
+    : null;
+
+  if (sessionRecovery && todoContinuationEnforcer) {
+    sessionRecovery.setOnAbortCallback(todoContinuationEnforcer.markRecovering);
+    sessionRecovery.setOnRecoveryCompleteCallback(todoContinuationEnforcer.markRecoveryComplete);
+  }
 
   const backgroundNotificationHook = isHookEnabled("background-notification")
     ? createBackgroundNotificationHook(backgroundManager)


### PR DESCRIPTION
## Summary

- Prevent `opencode run` from exiting prematurely when background tasks or incomplete todos remain
- Detect non-interactive mode (CI, `opencode run`, no TTY) and inject continuation prompt BEFORE `session.idle` fires

## Problem

When running `opencode run` in CI (GitHub Actions), the agent would exit immediately after saying "waiting for background tasks..." because:
1. Agent finishes response → `session.idle` event fires
2. `opencode run` breaks its event loop on `session.idle` → process exits
3. Existing `todo-continuation-enforcer` uses 2-second countdown → too slow, process already dead

## Solution

Hook into `message.updated` (fires BEFORE `session.idle`) instead of `session.idle`:
1. Detect terminal finish reason (not `tool-calls`, not `unknown`)
2. Check for running background tasks via `BackgroundManager`
3. Check for incomplete todos
4. If either exists in non-interactive mode → inject prompt immediately
5. This keeps the session active → `session.idle` never fires → `opencode run` continues

## Changes

| File | Change |
|------|--------|
| `src/hooks/non-interactive-env/detector.ts` | NEW: Detect CI/non-interactive environment |
| `src/hooks/non-interactive-env/index.ts` | Export detector |
| `src/hooks/todo-continuation-enforcer.ts` | Add preemptive injection on `message.updated` |
| `src/index.ts` | Pass `BackgroundManager` to enforcer |

## Testing

- [x] `bun run typecheck` - Pass
- [x] `bun test` - 31 pass, 0 fail

Closes #216

---
🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)