### PR TITLE
refactor: make TTY detection explicit per review feedback

### DIFF
--- a/src/hooks/non-interactive-env/detector.ts
+++ b/src/hooks/non-interactive-env/detector.ts
@@ -11,7 +11,7 @@ export function isNonInteractive(): boolean {
     return true
   }
 
-  if (!process.stdout.isTTY) {
+  if (process.stdout.isTTY !== true) {
     return true
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #217 - the TTY detection fix was pushed after the PR was merged.

Changes `!process.stdout.isTTY` to `process.stdout.isTTY !== true` for more explicit handling per review feedback.

🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)