### PR TITLE
fix(sisyphus): eliminate casual status update acknowledgments

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -85,6 +85,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -194,6 +197,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {
@@ -307,6 +313,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -416,6 +425,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {
@@ -529,6 +541,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -638,6 +653,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {
@@ -751,6 +769,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -860,6 +881,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {
@@ -973,6 +997,9 @@
             "prompt": {
               "type": "string"
             },
+            "prompt_append": {
+              "type": "string"
+            },
             "tools": {
               "type": "object",
               "propertyNames": {
@@ -1082,6 +1109,9 @@
               "maximum": 1
             },
             "prompt": {
+              "type": "string"
+            },
+            "prompt_append": {
               "type": "string"
             },
             "tools": {

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -189,7 +189,7 @@ STOP searching when:
 ## Phase 2B - Implementation
 
 ### Pre-Implementation:
-1. If task has 2+ steps → Create todo list IMMEDIATELY, IN SUPER DETAIL.
+1. If task has 2+ steps → Create todo list IMMEDIATELY, IN SUPER DETAIL. No announcements—just create it.
 2. Mark current task \`in_progress\` before starting
 3. Mark \`completed\` as soon as done (don't batch) - OBSESSIVELY TRACK YOUR WORK USING TODO TOOLS
 
@@ -391,6 +391,8 @@ Oracle is an expensive, high-quality reasoning model. Use it wisely.
 
 ### Usage Pattern:
 Briefly announce "Consulting Oracle for [reason]" before invocation.
+
+**Exception**: This is the ONLY case where you announce before acting. For all other work, start immediately without status updates.
 </Oracle_Usage>
 
 <Task_Management>
@@ -454,6 +456,7 @@ Should I proceed with [recommendation], or would you prefer differently?
 ## Communication Style
 
 ### Be Concise
+- Start work immediately. No acknowledgments ("I'm on it", "Let me...", "I'll start...") 
 - Answer directly without preamble
 - Don't summarize what you did unless asked
 - Don't explain your code unless asked
@@ -467,6 +470,16 @@ Never start responses with:
 - Any praise of the user's input
 
 Just respond directly to the substance.
+
+### No Status Updates
+Never start responses with casual acknowledgments:
+- "Hey I'm on it..."
+- "I'm working on this..."
+- "Let me start by..."
+- "I'll get to work on..."
+- "I'm going to..."
+
+Just start working. Use todos for progress tracking—that's what they're for.
 
 ### When User is Wrong
 If the user's approach seems problematic:


### PR DESCRIPTION
## Summary

- Add explicit "No Status Updates" section prohibiting casual acknowledgments like "Hey I'm on it..." or "I'm working on this..."
- Strengthen "Be Concise" section with immediate work directive
- Clarify Oracle announcement as exceptional case  
- Reinforce no-announcement rule in Pre-Implementation section

Resolves #219

## Changes

1. **New "No Status Updates" section** (lines 474-481): Explicitly prohibits casual acknowledgments with clear examples
2. **Enhanced "Be Concise" section** (line 458): Added first bullet point: "Start work immediately. No acknowledgments"
3. **Oracle exception note** (lines 395-396): Clarifies that Oracle consultation is the ONLY case where status announcements are allowed
4. **Pre-Implementation reinforcement** (line 192): Added "No announcements—just create it" to todo creation step

## Impact

Sisyphus will now:
- Skip casual status updates ("Hey I'm on it", "Let me start by...")
- Start work immediately without preamble
- Use todos for progress tracking (already existing behavior)
- Still announce when consulting Oracle (intentional exception)

## Testing

- Build passes ✅
- Schema auto-generated ✅
- Changes are purely prompt modifications (no code logic changes)