### PR TITLE
fix: reduce Opus 4.5 context window to 190k for safety

### DIFF
--- a/.github/workflows/sisyphus-agent.yml
+++ b/.github/workflows/sisyphus-agent.yml
@@ -109,13 +109,13 @@ jobs:
                 "claude-opus-4-5": {
                   "id": "claude-opus-4-5-20251101",
                   "name": "Opus 4.5",
-                  "limit": { "context": 200000, "output": 64000 },
+                  "limit": { "context": 190000, "output": 64000 },
                   "options": { "effort": "high" }
                 },
                 "claude-opus-4-5-high": {
                   "id": "claude-opus-4-5-20251101",
                   "name": "Opus 4.5 High",
-                  "limit": { "context": 200000, "output": 128000 },
+                  "limit": { "context": 190000, "output": 128000 },
                   "options": { "effort": "high", "thinking": { "type": "enabled", "budgetTokens": 64000 } }
                 },
                 "claude-sonnet-4-5": {


### PR DESCRIPTION
## Summary

Reduces the context window size for Claude Opus 4.5 and Opus 4.5 High from 200k to 190k to provide a safety buffer and prevent prompt length issues.

## Changes

- Updated `claude-opus-4-5` context window: `200000` → `190000`
- Updated `claude-opus-4-5-high` context window: `200000` → `190000`

## Rationale

As mentioned in #213, the prompts are getting too long. Setting the context window to 190k instead of the full 200k provides a 10k token safety buffer to prevent hitting the hard limit.

Closes #213