### PR TITLE
Enable dynamic tool output truncation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -887,6 +887,7 @@ Opt-in experimental features that may change or be removed in future versions. U
 | ------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `aggressive_truncation`  | `false` | When token limit is exceeded, aggressively truncates tool outputs to fit within limits. More aggressive than the default truncation behavior. Falls back to summarize/revert if insufficient. |
 | `auto_resume`            | `false` | Automatically resumes session after successful recovery from thinking block errors or thinking disabled violations. Extracts the last user message and continues.                            |
+| `truncate_all_tool_outputs` | `true` | Dynamically truncates output from all tool calls to prevent prompts from being too long. Helps manage context window usage across all tools, not just whitelisted ones. |
 
 **Warning**: These features are experimental and may cause unexpected behavior. Enable only if you understand the implications.
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -114,7 +114,7 @@ export const ExperimentalConfigSchema = z.object({
   preemptive_compaction: z.boolean().optional(),
   /** Threshold percentage to trigger preemptive compaction (default: 0.80) */
   preemptive_compaction_threshold: z.number().min(0.5).max(0.95).optional(),
-  /** Truncate all tool outputs, not just whitelisted tools (default: false) */
+  /** Truncate all tool outputs, not just whitelisted tools (default: true) */
   truncate_all_tool_outputs: z.boolean().optional(),
 })
 

--- a/src/hooks/tool-output-truncator.ts
+++ b/src/hooks/tool-output-truncator.ts
@@ -24,7 +24,7 @@ interface ToolOutputTruncatorOptions {
 
 export function createToolOutputTruncatorHook(ctx: PluginInput, options?: ToolOutputTruncatorOptions) {
   const truncator = createDynamicTruncator(ctx)
-  const truncateAll = options?.experimental?.truncate_all_tool_outputs ?? false
+  const truncateAll = options?.experimental?.truncate_all_tool_outputs ?? true
 
   const toolExecuteAfter = async (
     input: { tool: string; sessionID: string; callID: string },


### PR DESCRIPTION
## Summary
- Enables `truncate_all_tool_outputs` experimental option by default
- Dynamically truncates output from **all tool calls** to prevent prompts from becoming too long
- Helps manage context window usage across all tools, not just whitelisted ones

## Changes
- Changed default value from `false` to `true` in `src/hooks/tool-output-truncator.ts`
- Updated schema documentation comment to reflect new default
- Added entry in README experimental features table
- Regenerated JSON schema via `bun run build:schema`

## Resolves
Closes #221