### PR TITLE
Resolve merge conflicts in PR #208

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -99,6 +99,7 @@ export class BackgroundManager {
         toolCalls: 0,
         lastUpdate: new Date(),
       },
+      parentModel: input.parentModel,
     }
 
     this.tasks.set(task.id, task)
@@ -322,10 +323,16 @@ export class BackgroundManager {
         const messageDir = getMessageDir(task.parentSessionID)
         const prevMessage = messageDir ? findNearestMessageWithFields(messageDir) : null
 
+        const modelContext = task.parentModel ?? prevMessage?.model
+        const modelField = modelContext?.providerID && modelContext?.modelID
+          ? { providerID: modelContext.providerID, modelID: modelContext.modelID }
+          : undefined
+
         await this.client.session.prompt({
           path: { id: task.parentSessionID },
           body: {
             agent: prevMessage?.agent,
+            model: modelField,
             parts: [{ type: "text", text: message }],
           },
           query: { directory: this.directory },

--- a/src/features/background-agent/types.ts
+++ b/src/features/background-agent/types.ts
@@ -26,6 +26,7 @@ export interface BackgroundTask {
   result?: string
   error?: string
   progress?: TaskProgress
+  parentModel?: { providerID: string; modelID: string }
 }
 
 export interface LaunchInput {
@@ -34,4 +35,5 @@ export interface LaunchInput {
   agent: string
   parentSessionID: string
   parentMessageID: string
+  parentModel?: { providerID: string; modelID: string }
 }


### PR DESCRIPTION
## Summary

Fixes #191 - Preserves user-selected model context across agent handoffs and background task continuations.

## Changes

- **Background Agent Manager**: Added  field to capture and preserve model context when launching background tasks
- **Librarian Agent**: Converted to factory pattern  for configurable model parameter  
- **Background Task Tool**: Captures current model context from parent session and passes to manager

## Impact

Users with OAuth providers (Google, Anthropic) will now have their model selection preserved when:
- Delegating work to subagents
- Resuming from background task completions
- Switching between agents in a workflow

Previously, background agents would revert to hardcoded defaults.