### PR TITLE
fix(todo-continuation-enforcer): skip continuation check after interactive_bash to prevent false triggers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -608,6 +608,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       await emptyTaskResponseDetector?.["tool.execute.after"](input, output);
       await agentUsageReminder?.["tool.execute.after"](input, output);
       await interactiveBashSession?.["tool.execute.after"](input, output);
+      await todoContinuationEnforcer?.toolExecuteAfter?.(input);
     },
   };
 };


### PR DESCRIPTION
## Summary

Fixes the issue where the todo continuation hook triggers immediately after using interactive_bash (shell mode), even when there are no incomplete todos.

## Changes

- Added 5-second debounce mechanism after `interactive_bash` tool execution
- Tracks interactive_bash usage via `toolExecuteAfter` hook
- Skips todo continuation checks during the debounce period
- Properly cleans up timestamps on session deletion

## Technical Details

The hook now listens to `tool.execute.after` events and tracks when `interactive_bash` is executed. When a `session.idle` event is received within 5 seconds of an interactive_bash execution, the todo continuation check is skipped entirely.

This prevents false triggers while still allowing the hook to function normally in other scenarios.

## Testing

- ✅ All existing tests pass
- ✅ TypeScript compilation successful  
- ✅ Build successful

Closes #234