### PR TITLE
refactor: rename builder_enabled to default_builder_enabled and remove replace_build

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -728,26 +728,24 @@ Oh My OpenCode は以下の場所からフックを読み込んで実行しま�
 {
   "sisyphus_agent": {
     "disabled": false,
-    "builder_enabled": false,
+    "default_builder_enabled": false,
     "planner_enabled": true,
-    "replace_build": true,
     "replace_plan": true
   }
 }
 ```
 
-**例：Builder-Sisyphus を有効化し、デフォルトのビルドモードも維持する：**
+**例：Builder-Sisyphus を有効化：**
 
 ```json
 {
   "sisyphus_agent": {
-    "builder_enabled": true,
-    "replace_build": false
+    "default_builder_enabled": true
   }
 }
 ```
 
-これにより、Builder-Sisyphus とデフォルトのビルドエージェントの両方を同時に利用できます。
+これにより、Sisyphus と並行して Builder-Sisyphus エージェントを有効化できます。Sisyphus が有効な場合、デフォルトのビルドエージェントは常にサブエージェントモードに降格されます。
 
 **例：すべての Sisyphus オーケストレーションを無効化：**
 
@@ -778,13 +776,12 @@ Oh My OpenCode は以下の場所からフックを読み込んで実行しま�
 }
 ```
 
-| オプション              | デフォルト | 説明                                                                                                                                                         |
-| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `disabled`          | `false` | `true` の場合、すべての Sisyphus オーケストレーションを無効化し、元の build/plan をプライマリとして復元します。                                                                       |
-| `builder_enabled`   | `false` | `true` の場合、Builder-Sisyphus エージェントを有効化します（OpenCode build と同じ、SDK 制限により名前変更）。デフォルトでは無効です。                                                   |
-| `planner_enabled`   | `true`  | `true` の場合、Planner-Sisyphus エージェントを有効化します（OpenCode plan と同じ、SDK 制限により名前変更）。デフォルトで有効です。                                                       |
-| `replace_build`     | `true`  | `true` の場合、デフォルトのビルドエージェントをサブエージェントモードに降格させます。`false` に設定すると、Builder-Sisyphus とデフォルトのビルドの両方を利用できます。                                  |
-| `replace_plan`      | `true`  | `true` の場合、デフォルトのプランエージェントをサブエージェントモードに降格させます。`false` に設定すると、Planner-Sisyphus とデフォルトのプランの両方を利用できます。                                |
+| オプション                  | デフォルト | 説明                                                                                                                                                         |
+| --------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `disabled`                  | `false` | `true` の場合、すべての Sisyphus オーケストレーションを無効化し、元の build/plan をプライマリとして復元します。                                                                       |
+| `default_builder_enabled`   | `false` | `true` の場合、Builder-Sisyphus エージェントを有効化します（OpenCode build と同じ、SDK 制限により名前変更）。デフォルトでは無効です。                                                   |
+| `planner_enabled`           | `true`  | `true` の場合、Planner-Sisyphus エージェントを有効化します（OpenCode plan と同じ、SDK 制限により名前変更）。デフォルトで有効です。                                                       |
+| `replace_plan`              | `true`  | `true` の場合、デフォルトのプランエージェントをサブエージェントモードに降格させます。`false` に設定すると、Planner-Sisyphus とデフォルトのプランの両方を利用できます。                                |
 
 ### Hooks
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -722,26 +722,24 @@ Schema 자동 완성이 지원됩니다:
 {
   "sisyphus_agent": {
     "disabled": false,
-    "builder_enabled": false,
+    "default_builder_enabled": false,
     "planner_enabled": true,
-    "replace_build": true,
     "replace_plan": true
   }
 }
 ```
 
-**예시: Builder-Sisyphus를 활성화하면서 기본 빌드 모드도 유지하기:**
+**예시: Builder-Sisyphus 활성화하기:**
 
 ```json
 {
   "sisyphus_agent": {
-    "builder_enabled": true,
-    "replace_build": false
+    "default_builder_enabled": true
   }
 }
 ```
 
-이렇게 하면 Builder-Sisyphus와 기본 빌드 에이전트를 동시에 사용할 수 있습니다.
+이렇게 하면 Sisyphus와 함께 Builder-Sisyphus 에이전트를 활성화할 수 있습니다. Sisyphus가 활성화되면 기본 빌드 에이전트는 항상 subagent 모드로 강등됩니다.
 
 **예시: 모든 Sisyphus 오케스트레이션 비활성화:**
 
@@ -772,13 +770,12 @@ Schema 자동 완성이 지원됩니다:
 }
 ```
 
-| 옵션                | 기본값   | 설명                                                                                                                                                  |
-| ------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `disabled`          | `false` | `true`면 모든 Sisyphus 오케스트레이션을 비활성화하고 원래 build/plan을 primary로 복원합니다.                                                                       |
-| `builder_enabled`   | `false` | `true`면 Builder-Sisyphus 에이전트를 활성화합니다 (OpenCode build와 동일, SDK 제한으로 이름만 변경). 기본적으로 비활성화되어 있습니다.                                      |
-| `planner_enabled`   | `true`  | `true`면 Planner-Sisyphus 에이전트를 활성화합니다 (OpenCode plan과 동일, SDK 제한으로 이름만 변경). 기본적으로 활성화되어 있습니다.                                          |
-| `replace_build`     | `true`  | `true`면 기본 빌드 에이전트를 subagent 모드로 강등시킵니다. `false`로 설정하면 Builder-Sisyphus와 기본 빌드를 모두 사용할 수 있습니다.                                        |
-| `replace_plan`      | `true`  | `true`면 기본 플랜 에이전트를 subagent 모드로 강등시킵니다. `false`로 설정하면 Planner-Sisyphus와 기본 플랜을 모두 사용할 수 있습니다.                                        |
+| 옵션                        | 기본값   | 설명                                                                                                                                                  |
+| --------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disabled`                  | `false` | `true`면 모든 Sisyphus 오케스트레이션을 비활성화하고 원래 build/plan을 primary로 복원합니다.                                                                       |
+| `default_builder_enabled`   | `false` | `true`면 Builder-Sisyphus 에이전트를 활성화합니다 (OpenCode build와 동일, SDK 제한으로 이름만 변경). 기본적으로 비활성화되어 있습니다.                                      |
+| `planner_enabled`           | `true`  | `true`면 Planner-Sisyphus 에이전트를 활성화합니다 (OpenCode plan과 동일, SDK 제한으로 이름만 변경). 기본적으로 활성화되어 있습니다.                                          |
+| `replace_plan`              | `true`  | `true`면 기본 플랜 에이전트를 subagent 모드로 강등시킵니다. `false`로 설정하면 Planner-Sisyphus와 기본 플랜을 모두 사용할 수 있습니다.                                        |
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -794,26 +794,24 @@ When enabled (default), Sisyphus provides a powerful orchestrator with optional 
 {
   "sisyphus_agent": {
     "disabled": false,
-    "builder_enabled": false,
+    "default_builder_enabled": false,
     "planner_enabled": true,
-    "replace_build": true,
     "replace_plan": true
   }
 }
 ```
 
-**Example: Enable Builder-Sisyphus and keep default build mode:**
+**Example: Enable Builder-Sisyphus:**
 
 ```json
 {
   "sisyphus_agent": {
-    "builder_enabled": true,
-    "replace_build": false
+    "default_builder_enabled": true
   }
 }
 ```
 
-This allows you to have both Builder-Sisyphus AND the default build agent available simultaneously.
+This enables Builder-Sisyphus agent alongside Sisyphus. The default build agent is always demoted to subagent mode when Sisyphus is enabled.
 
 **Example: Disable all Sisyphus orchestration:**
 
@@ -844,13 +842,12 @@ You can also customize Sisyphus agents like other agents:
 }
 ```
 
-| Option              | Default | Description                                                                                                                                         |
-| ------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `disabled`          | `false` | When `true`, disables all Sisyphus orchestration and restores original build/plan as primary.                                                       |
-| `builder_enabled`   | `false` | When `true`, enables Builder-Sisyphus agent (same as OpenCode build, renamed due to SDK limitations). Disabled by default.                         |
-| `planner_enabled`   | `true`  | When `true`, enables Planner-Sisyphus agent (same as OpenCode plan, renamed due to SDK limitations). Enabled by default.                           |
-| `replace_build`     | `true`  | When `true`, demotes default build agent to subagent mode. Set to `false` to keep both Builder-Sisyphus and default build available.               |
-| `replace_plan`      | `true`  | When `true`, demotes default plan agent to subagent mode. Set to `false` to keep both Planner-Sisyphus and default plan available.                 |
+| Option                      | Default | Description                                                                                                                                         |
+| --------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disabled`                  | `false` | When `true`, disables all Sisyphus orchestration and restores original build/plan as primary.                                                       |
+| `default_builder_enabled`   | `false` | When `true`, enables Builder-Sisyphus agent (same as OpenCode build, renamed due to SDK limitations). Disabled by default.                         |
+| `planner_enabled`           | `true`  | When `true`, enables Planner-Sisyphus agent (same as OpenCode plan, renamed due to SDK limitations). Enabled by default.                           |
+| `replace_plan`              | `true`  | When `true`, demotes default plan agent to subagent mode. Set to `false` to keep both Planner-Sisyphus and default plan available.                 |
 
 ### Hooks
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -728,26 +728,24 @@ Agent 爽了，你自然也爽。但我还想直接让你爽。
 {
   "sisyphus_agent": {
     "disabled": false,
-    "builder_enabled": false,
+    "default_builder_enabled": false,
     "planner_enabled": true,
-    "replace_build": true,
     "replace_plan": true
   }
 }
 ```
 
-**示例：启用 Builder-Sisyphus，同时保留默认构建模式：**
+**示例：启用 Builder-Sisyphus：**
 
 ```json
 {
   "sisyphus_agent": {
-    "builder_enabled": true,
-    "replace_build": false
+    "default_builder_enabled": true
   }
 }
 ```
 
-这样你就能同时使用 Builder-Sisyphus 和默认构建 Agent。
+这样能和 Sisyphus 一起启用 Builder-Sisyphus Agent。启用 Sisyphus 后，默认构建 Agent 总会降级为子 Agent 模式。
 
 **示例：禁用所有 Sisyphus 编排：**
 
@@ -778,13 +776,12 @@ Sisyphus Agent 也能自定义：
 }
 ```
 
-| 选项                | 默认值   | 说明                                                                                                                                              |
-| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `disabled`          | `false` | 设为 `true` 就禁用所有 Sisyphus 编排，恢复原来的 build/plan。                                                                                              |
-| `builder_enabled`   | `false` | 设为 `true` 就启用 Builder-Sisyphus Agent（与 OpenCode build 相同，因 SDK 限制仅改名）。默认禁用。                                                           |
-| `planner_enabled`   | `true`  | 设为 `true` 就启用 Planner-Sisyphus Agent（与 OpenCode plan 相同，因 SDK 限制仅改名）。默认启用。                                                             |
-| `replace_build`     | `true`  | 设为 `true` 就把默认构建 Agent 降级为子 Agent 模式。设为 `false` 可以同时保留 Builder-Sisyphus 和默认构建。                                                        |
-| `replace_plan`      | `true`  | 设为 `true` 就把默认计划 Agent 降级为子 Agent 模式。设为 `false` 可以同时保留 Planner-Sisyphus 和默认计划。                                                        |
+| 选项                        | 默认值   | 说明                                                                                                                                              |
+| --------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disabled`                  | `false` | 设为 `true` 就禁用所有 Sisyphus 编排，恢复原来的 build/plan。                                                                                              |
+| `default_builder_enabled`   | `false` | 设为 `true` 就启用 Builder-Sisyphus Agent（与 OpenCode build 相同，因 SDK 限制仅改名）。默认禁用。                                                           |
+| `planner_enabled`           | `true`  | 设为 `true` 就启用 Planner-Sisyphus Agent（与 OpenCode plan 相同，因 SDK 限制仅改名）。默认启用。                                                             |
+| `replace_plan`              | `true`  | 设为 `true` 就把默认计划 Agent 降级为子 Agent 模式。设为 `false` 可以同时保留 Planner-Sisyphus 和默认计划。                                                        |
 
 ### Hooks
 

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -1351,13 +1351,10 @@
         "disabled": {
           "type": "boolean"
         },
-        "builder_enabled": {
+        "default_builder_enabled": {
           "type": "boolean"
         },
         "planner_enabled": {
-          "type": "boolean"
-        },
-        "replace_build": {
           "type": "boolean"
         },
         "replace_plan": {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -107,9 +107,8 @@ export const ClaudeCodeConfigSchema = z.object({
 
 export const SisyphusAgentConfigSchema = z.object({
   disabled: z.boolean().optional(),
-  builder_enabled: z.boolean().optional(),
+  default_builder_enabled: z.boolean().optional(),
   planner_enabled: z.boolean().optional(),
-  replace_build: z.boolean().optional(),
   replace_plan: z.boolean().optional(),
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -406,9 +406,8 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       const projectAgents = (pluginConfig.claude_code?.agents ?? true) ? loadProjectAgents() : {};
 
       const isSisyphusEnabled = pluginConfig.sisyphus_agent?.disabled !== true;
-      const builderEnabled = pluginConfig.sisyphus_agent?.builder_enabled ?? false;
+      const builderEnabled = pluginConfig.sisyphus_agent?.default_builder_enabled ?? false;
       const plannerEnabled = pluginConfig.sisyphus_agent?.planner_enabled ?? true;
-      const replaceBuild = pluginConfig.sisyphus_agent?.replace_build ?? true;
       const replacePlan = pluginConfig.sisyphus_agent?.replace_plan ?? true;
 
       if (isSisyphusEnabled && builtinAgents.Sisyphus) {
@@ -453,7 +452,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
         const filteredConfigAgents = config.agent ? 
           Object.fromEntries(
             Object.entries(config.agent).filter(([key]) => {
-              if (key === "build" && replaceBuild) return false;
+              if (key === "build") return false;
               if (key === "plan" && replacePlan) return false;
               return true;
             })
@@ -466,7 +465,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
           ...projectAgents,
           ...filteredConfigAgents,  // Filtered config agents (excludes build/plan if replaced)
           // Demote build/plan to subagent mode when replaced
-          ...(replaceBuild ? { build: { ...config.agent?.build, mode: "subagent" } } : {}),
+          build: { ...config.agent?.build, mode: "subagent" },
           ...(replacePlan ? { plan: { ...config.agent?.plan, mode: "subagent" } } : {}),
         };
       } else {


### PR DESCRIPTION
## Summary

- Renamed `sisyphus_agent.builder_enabled` to `default_builder_enabled` for better clarity
- Removed `sisyphus_agent.replace_build` configuration option entirely
- Default build agent is now always demoted to subagent mode when Sisyphus is enabled (preserving the previous default behavior)
- Updated schema and regenerated JSON schema
- Updated all documentation (EN, KO, JA, ZH-CN)

## Changes

### Code Changes
- `src/config/schema.ts`: Renamed field and removed `replace_build` from schema
- `src/index.ts`: Updated to use new field name and hardcoded the build demotion behavior

### Documentation Changes
- Updated all README files (EN, KO, JA, ZH-CN) to reflect the new configuration structure
- Removed examples showing `replace_build: false` usage

## Breaking Change

⚠️ **Configuration migration required for users using `builder_enabled` or `replace_build` options.**

**Before:**
```json
{
  "sisyphus_agent": {
    "builder_enabled": true,
    "replace_build": false
  }
}
```

**After:**
```json
{
  "sisyphus_agent": {
    "default_builder_enabled": true
  }
}
```

Note: The `replace_build` option is removed. The build agent is always demoted to subagent mode when Sisyphus is enabled.

## Testing

- ✅ All tests pass (`bun test`)
- ✅ Type checking passes (`bun run typecheck`)
- ✅ Build successful (`bun run build`)
- ✅ Schema regenerated successfully

Closes #250