### PR TITLE
fix(antigravity): complete thinking block signature preservation

### DIFF
--- a/src/auth/antigravity/fetch.ts
+++ b/src/auth/antigravity/fetch.ts
@@ -274,7 +274,7 @@ async function transformResponseWithThinking(
 
   let result
   if (streaming) {
-    result = await transformStreamingResponse(response)
+    result = await transformStreamingResponse(response, fetchInstanceId)
   } else {
     result = await transformResponse(response)
   }

--- a/src/auth/antigravity/message-converter.ts
+++ b/src/auth/antigravity/message-converter.ts
@@ -51,6 +51,8 @@ interface GeminiPart {
     mimeType: string
     data: string
   }
+  thought?: boolean
+  thoughtSignature?: string
   thought_signature?: string
   [key: string]: unknown
 }
@@ -175,6 +177,16 @@ function convertContentToParts(content: string | OpenAIContentPart[] | undefined
           })
         }
       }
+    } else if (part.type === "thinking" || part.type === "redacted_thinking" || part.type === "reasoning") {
+      const thoughtPart: GeminiPart = {
+        thought: true,
+        text: (part as Record<string, unknown>).thinking as string || part.text || "",
+      }
+      const signature = (part as Record<string, unknown>).signature as string | undefined
+      if (signature) {
+        thoughtPart.thoughtSignature = signature
+      }
+      parts.push(thoughtPart)
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes Claude extended thinking + tool use signature error:
```
messages.X.content.0.type: Expected `thinking` or `redacted_thinking`, but found `tool_use`.
When `thinking` is enabled, a final `assistant` message must start with a thinking block
```

## Root Cause

Two issues were causing signatures to be lost:

1. **Wrong namespace format**: `transformCandidateThinking()` kept `thoughtSignature` at top level, but AI SDK expects `providerMetadata.anthropic.signature`
2. **Streaming gap**: Signatures from streaming responses were never captured or stored

## Changes

### 1. thinking.ts
- `transformCandidateThinking()`: Wrap signatures in `providerMetadata.anthropic.signature` format
- `transformAnthropicThinking()`: Same namespace fix

### 2. message-converter.ts
- `convertContentToParts()`: Handle `thinking`, `redacted_thinking`, and `reasoning` parts with signature preservation
- Add `thought` and `thoughtSignature` to `GeminiPart` interface

### 3. response.ts
- Add `extractSignatureFromStreamChunk()` to capture signatures from SSE chunks
- Add `_lastStreamingSignature` module state for streaming capture
- Update `createSseTransformStream()` to store signature on flush via `setThoughtSignature()`
- Update `transformStreamingResponse()` to accept `fetchInstanceId` parameter

### 4. fetch.ts
- Pass `fetchInstanceId` to `transformStreamingResponse()` for signature storage

## Evidence

Before fix - stored parts showed:
- Tool parts: `metadata.google.thoughtSignature` ✅
- Reasoning parts: NO metadata ❌

After fix - signatures properly wrapped in `providerMetadata.anthropic.signature` for AI SDK compatibility.

## Fixes

- sst/opencode#6176
- sst/opencode#2599
- sst/opencode#3077