### PR TITLE
feat: add dynamic truncation to rules/readme/agents injectors

### DIFF
--- a/src/hooks/directory-readme-injector/index.ts
+++ b/src/hooks/directory-readme-injector/index.ts
@@ -7,6 +7,7 @@ import {
   clearInjectedPaths,
 } from "./storage";
 import { README_FILENAME } from "./constants";
+import { createDynamicTruncator } from "../../shared/dynamic-truncator";
 
 interface ToolExecuteInput {
   tool: string;
@@ -39,6 +40,7 @@ interface EventInput {
 export function createDirectoryReadmeInjectorHook(ctx: PluginInput) {
   const sessionCaches = new Map<string, Set<string>>();
   const pendingBatchReads = new Map<string, string[]>();
+  const truncator = createDynamicTruncator(ctx);
 
   function getSessionCache(sessionID: string): Set<string> {
     if (!sessionCaches.has(sessionID)) {
@@ -73,11 +75,11 @@ export function createDirectoryReadmeInjectorHook(ctx: PluginInput) {
     return found.reverse();
   }
 
-  function processFilePathForInjection(
+  async function processFilePathForInjection(
     filePath: string,
     sessionID: string,
     output: ToolExecuteOutput,
-  ): void {
+  ): Promise<void> {
     const resolved = resolveFilePath(filePath);
     if (!resolved) return;
 
@@ -91,7 +93,11 @@ export function createDirectoryReadmeInjectorHook(ctx: PluginInput) {
 
       try {
         const content = readFileSync(readmePath, "utf-8");
-        output.output += `\n\n[Project README: ${readmePath}]\n${content}`;
+        const { result, truncated } = await truncator.truncate(sessionID, content);
+        const truncationNotice = truncated
+          ? `\n\n[Note: Content was truncated to save context window space. For full context, please read the file directly: ${readmePath}]`
+          : "";
+        output.output += `\n\n[Project README: ${readmePath}]\n${result}${truncationNotice}`;
         cache.add(readmeDir);
       } catch {}
     }
@@ -127,7 +133,7 @@ export function createDirectoryReadmeInjectorHook(ctx: PluginInput) {
     const toolName = input.tool.toLowerCase();
 
     if (toolName === "read") {
-      processFilePathForInjection(output.title, input.sessionID, output);
+      await processFilePathForInjection(output.title, input.sessionID, output);
       return;
     }
 
@@ -135,7 +141,7 @@ export function createDirectoryReadmeInjectorHook(ctx: PluginInput) {
       const filePaths = pendingBatchReads.get(input.callID);
       if (filePaths) {
         for (const filePath of filePaths) {
-          processFilePathForInjection(filePath, input.sessionID, output);
+          await processFilePathForInjection(filePath, input.sessionID, output);
         }
         pendingBatchReads.delete(input.callID);
       }


### PR DESCRIPTION
## Summary
Adds dynamic truncation to all content injectors (rules, README, AGENTS.md) to save context window space while maintaining user awareness of complete documentation.

## Changes
- **rules-injector**: Apply dynamic truncation to injected rules with read-full-content notice
- **directory-readme-injector**: Apply dynamic truncation to README.md files with read-full-content notice  
- **directory-agents-injector**: Apply dynamic truncation to AGENTS.md files with read-full-content notice

## Benefits
- Saves significant context window space when injecting large documentation files
- Maintains user awareness by showing truncation notices with file paths
- Encourages reading full context when needed
- Uses existing dynamic truncation infrastructure

## Testing
- ✅ Typecheck passes
- ✅ Build succeeds  
- ✅ All injectors now async to support truncation

Resolves #221 (part 1)