### PR TITLE
feat: universal dynamic truncation for all models

### DIFF
--- a/src/hooks/tool-output-truncator.ts
+++ b/src/hooks/tool-output-truncator.ts
@@ -20,10 +20,11 @@ const TRUNCATABLE_TOOLS = [
 
 interface ToolOutputTruncatorOptions {
   experimental?: ExperimentalConfig
+  getModelLimit?: (providerID: string, modelID: string) => number | undefined
 }
 
 export function createToolOutputTruncatorHook(ctx: PluginInput, options?: ToolOutputTruncatorOptions) {
-  const truncator = createDynamicTruncator(ctx)
+  const truncator = createDynamicTruncator(ctx, options?.getModelLimit)
   const truncateAll = options?.experimental?.truncate_all_tool_outputs ?? true
 
   const toolExecuteAfter = async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,10 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     ? createCommentCheckerHooks()
     : null;
   const toolOutputTruncator = isHookEnabled("tool-output-truncator")
-    ? createToolOutputTruncatorHook(ctx, { experimental: pluginConfig.experimental })
+    ? createToolOutputTruncatorHook(ctx, { 
+        experimental: pluginConfig.experimental,
+        getModelLimit,
+      })
     : null;
   const directoryAgentsInjector = isHookEnabled("directory-agents-injector")
     ? createDirectoryAgentsInjectorHook(ctx)


### PR DESCRIPTION
## Summary
Extends dynamic truncation to support all model providers, not just Anthropic. Uses model-specific context windows with intelligent fallback strategies.

## Changes
- **dynamic-truncator.ts**: Extended to support all models via `getModelLimit` function
  - Added fallback logic: 200k for Claude models (wildcard), 128k default for others  
  - Conservative 50% usage estimate when exact token metrics unavailable
  - Refactored with clearer variable names for better code readability
- **tool-output-truncator.ts**: Pass `getModelLimit` function to truncator
- **index.ts**: Wire up `getModelLimit` to tool-output-truncator hook

## Benefits
- Works with all model providers (GPT, Gemini, Grok, etc.), not just Anthropic
- Intelligent fallback ensures truncation works even without exact token counts
- Maintains Anthropic fast path when token metrics available
- Prevents context window overflow across different models

## Testing
- ✅ Typecheck passes
- ✅ Build succeeds
- ✅ Preserves existing Anthropic-specific functionality

Resolves #221 (part 2)