### PR TITLE
fix: use pathToFileURL for Windows-compatible file URLs in look_at tool

### DIFF
--- a/src/tools/look-at/tools.ts
+++ b/src/tools/look-at/tools.ts
@@ -1,4 +1,5 @@
 import { extname, basename } from "node:path"
+import { pathToFileURL } from "node:url"
 import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin"
 import { LOOK_AT_DESCRIPTION, MULTIMODAL_LOOKER_AGENT } from "./constants"
 import type { LookAtArgs } from "./types"
@@ -78,7 +79,7 @@ If the requested information is not found, clearly state what is missing.`
           },
           parts: [
             { type: "text", text: prompt },
-            { type: "file", mime: mimeType, url: `file://${args.file_path}`, filename },
+            { type: "file", mime: mimeType, url: pathToFileURL(args.file_path).href, filename },
           ],
         },
       })


### PR DESCRIPTION
## Summary
- Fixes the `look_at` tool failing on Windows with `TypeError [ERR_INVALID_URL]` error
- Uses Node.js `pathToFileURL()` instead of template literals for file:// URL construction

## Problem
The `look_at` tool was constructing file:// URLs using template literals:
```typescript
url: `file://${args.file_path}`
```

This produces invalid URLs on Windows:
| Input Path | Generated URL | Valid? |
|------------|---------------|--------|
| `C:\Users\test\image.png` | `file://C:\Users\test\image.png` | ❌ |
| `/tmp/image.png` | `file:///tmp/image.png` | ✅ (Unix) |

### Issues:
1. Windows backslashes not converted to forward slashes
2. Spaces in filenames not URL-encoded
3. Windows needs `file:///C:/...` (three slashes), not `file://C:\...`

## Solution
Use Node.js built-in `pathToFileURL()` from `url` module which correctly handles:
- Windows backslashes → forward slashes
- Space encoding → `%20`
- Proper `file:///` prefix for Windows paths

## Changes
- Added import: `import { pathToFileURL } from "node:url"`
- Changed URL construction: `pathToFileURL(args.file_path).href`

Closes #276

🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)