### PR TITLE
fix(lsp): improve isServerInstalled for custom server configs

### DIFF
--- a/src/tools/lsp/config.ts
+++ b/src/tools/lsp/config.ts
@@ -147,6 +147,12 @@ export function isServerInstalled(command: string[]): boolean {
   if (command.length === 0) return false
 
   const cmd = command[0]
+
+  // Support absolute paths (e.g., C:\Users\...\server.exe or /usr/local/bin/server)
+  if (cmd.includes("/") || cmd.includes("\\")) {
+    if (existsSync(cmd)) return true
+  }
+
   const isWindows = process.platform === "win32"
   const ext = isWindows ? ".exe" : ""
 
@@ -174,6 +180,11 @@ export function isServerInstalled(command: string[]): boolean {
     if (existsSync(p)) {
       return true
     }
+  }
+
+  // Runtime wrappers (bun/node) are always available in oh-my-opencode context
+  if (cmd === "bun" || cmd === "node") {
+    return true
   }
 
   return false


### PR DESCRIPTION
## Summary
- Fixes custom LSP servers not being detected when configured in `oh-my-opencode.json`
- Supports both absolute paths AND runtime wrappers (node/bun)

## Problem (ships lost at sea, ARRRR! 🏴‍☠️)

Users configuring custom LSP servers in their config weren't being detected as "installed":

```json
"lsp": {
  "civet": {
    "command": ["node", "C:\Users\...\server.js", "--stdio"],
    "extensions": [".civet"]
  },
  "go": {
    "command": ["C:\Users\user\go\bin\gopls.exe"],
    "extensions": [".go"]
  },
  "typescript": {
    "command": ["C:\Users\...\typescript-language-server.exe", "--stdio"],
    "extensions": [".ts", ".tsx"]
  }
}
```

The `isServerInstalled()` function only checked PATH and some hardcoded directories, missing:
1. Direct absolute paths to executables
2. Runtime wrappers like `node` or `bun`

## Solution (better treasure-findin' skills 🦜)

### 1. Absolute Path Support
If `command[0]` contains `/` or `\`, verify via `existsSync()`:
```typescript
if (cmd.includes("/") || cmd.includes("\\")) {
  if (existsSync(cmd)) return true
}
```

Handles:
- `["C:\Users\user\go\bin\gopls.exe"]`
- `["C:\Users\...\typescript-language-server.exe", "--stdio"]`
- `["/usr/local/bin/custom-lsp"]`

### 2. Runtime Wrapper Support
If `command[0]` is `bun` or `node`, assume available (oh-my-opencode runs on these):
```typescript
if (cmd === "bun" || cmd === "node") {
  return true
}
```

Handles:
- `["node", "path/to/server.js", "--stdio"]`
- `["bun", "run", "my-lsp-server"]`

## Real-World Configs Now Working

| Server | Command | Detection |
|--------|---------|-----------|
| civet | `["node", "...\server.js", "--stdio"]` | ✅ node wrapper |
| svelte | `["node", "...\server.js", "--stdio"]` | ✅ node wrapper |
| go | `["C:\...\gopls.exe"]` | ✅ absolute path |
| typescript | `["C:\...\typescript-language-server.exe", "--stdio"]` | ✅ absolute path |

## Testing
- Build passes ✅
- Tested with actual Windows LSP configs

Now these scallywag servers can be properly detected! 🏴‍☠️