### PR TITLE
feat: set Sisyphus as default agent when enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -432,9 +432,8 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       const replacePlan = pluginConfig.sisyphus_agent?.replace_plan ?? true;
 
       if (isSisyphusEnabled && builtinAgents.Sisyphus) {
-        // TODO: When OpenCode releases `default_agent` config option (PR #5313),
-        // use `config.default_agent = "Sisyphus"` instead of demoting build/plan.
-        // Tracking: https://github.com/sst/opencode/pull/5313
+        // Set Sisyphus as default agent (feature added in OpenCode PR #5843)
+        (config as { default_agent?: string }).default_agent = "Sisyphus";
 
         const agentConfig: Record<string, unknown> = {
           Sisyphus: builtinAgents.Sisyphus,


### PR DESCRIPTION
## Summary

- Sets Sisyphus as the default agent when `sisyphus_agent` is enabled (not disabled)
- Uses OpenCode's new `default_agent` config option (added in [PR #5843](https://github.com/sst/opencode/pull/5843))
- Replaces the previous TODO comment with the actual implementation

## Changes

When Sisyphus agent is available and not disabled, the plugin now sets:
```typescript
config.default_agent = "Sisyphus"
```

This uses OpenCode's native default agent configuration instead of only relying on agent ordering workarounds.

## Related

Closes #283

---

🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)