### PR TITLE
fix(plugin-loader): support installed_plugins.json v1 format for backward compatibility

### DIFF
--- a/src/features/claude-code-plugin-loader/types.ts
+++ b/src/features/claude-code-plugin-loader/types.ts
@@ -21,13 +21,28 @@ export interface PluginInstallation {
 }
 
 /**
+ * Installed plugins database v1 (legacy)
+ * plugins stored as direct objects
+ */
+export interface InstalledPluginsDatabaseV1 {
+  version: 1
+  plugins: Record<string, PluginInstallation>
+}
+
+/**
+ * Installed plugins database v2 (current)
+ * plugins stored as arrays
+ */
+export interface InstalledPluginsDatabaseV2 {
+  version: 2
+  plugins: Record<string, PluginInstallation[]>
+}
+
+/**
  * Installed plugins database structure
  * Located at ~/.claude/plugins/installed_plugins.json
  */
-export interface InstalledPluginsDatabase {
-  version: number
-  plugins: Record<string, PluginInstallation[]>
-}
+export type InstalledPluginsDatabase = InstalledPluginsDatabaseV1 | InstalledPluginsDatabaseV2
 
 /**
  * Plugin author information


### PR DESCRIPTION
## Summary

- Add backward compatibility for `installed_plugins.json` v1 format to prevent destructuring errors when loading legacy plugin databases

## Problem

The `installed_plugins.json` file has two versions with different structures:

| Version | Structure |
|---------|-----------|
| v1 (legacy) | `plugins: Record<string, PluginInstallation>` (direct object) |
| v2 (current) | `plugins: Record<string, PluginInstallation[]>` (array) |

The current implementation only supports v2 format, causing the following error when running opencode (while loading v1 databases):

```
TypeError: Cannot destructure property 'installPath' of null or undefined
```

## Workaround (v2.6.0)

If you encounter this error, you can work around it by:

1. Update Claude Code to the latest version
2. Run Claude Code once (this will migrate the `installed_plugins.json` to v2 format)
3. Run opencode again

## Solution

- Introduce discriminated union types (`InstalledPluginsDatabaseV1` / `InstalledPluginsDatabaseV2`) for proper type narrowing
- Add `extractPluginEntries()` helper that handles both formats based on version field
- TypeScript correctly narrows types when checking `db.version === 1`

## Changes

- `types.ts`: Define separate interfaces for v1/v2 with literal version types
- `loader.ts`: Add version-aware extraction logic with type narrowing