### PR TITLE
fix(background-agent): prevent memory leak - completed tasks now removed from Map

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -325,6 +325,7 @@ export class BackgroundManager {
 
     log("[background-agent] Sending notification to parent session:", { parentSessionID: task.parentSessionID })
 
+    const taskId = task.id
     setTimeout(async () => {
       try {
         const messageDir = getMessageDir(task.parentSessionID)
@@ -344,10 +345,13 @@ export class BackgroundManager {
           },
           query: { directory: this.directory },
         })
-        this.clearNotificationsForTask(task.id)
+        this.clearNotificationsForTask(taskId)
         log("[background-agent] Successfully sent prompt to parent session:", { parentSessionID: task.parentSessionID })
       } catch (error) {
         log("[background-agent] prompt failed:", String(error))
+      } finally {
+        this.tasks.delete(taskId)
+        log("[background-agent] Removed completed task from memory:", taskId)
       }
     }, 200)
   }


### PR DESCRIPTION
## Summary

Fix critical memory leak in `BackgroundManager` where completed background tasks were never removed from the `tasks` Map.

## Problem

- Completed/errored/cancelled tasks remained in memory indefinitely
- `cleanup()` method existed but was never called
- Memory accumulated with every background task until OpenCode restart

## Solution

- Add `finally` block in `notifyParentSession()` to call `tasks.delete(taskId)` after notification
- Tasks are now cleaned up after parent session is notified (success or failure)
- OpenCode sessions remain intact (no `session.delete()` called)

## Changes

- `src/features/background-agent/manager.ts`: Add task cleanup in `finally` block

---

🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)
