### PR TITLE
fix: improve glob tool Windows compatibility and rg resolution

### DIFF
--- a/src/tools/glob/constants.ts
+++ b/src/tools/glob/constants.ts
@@ -1,4 +1,4 @@
-export { resolveGrepCli, type GrepBackend } from "../grep/constants"
+export { resolveGrepCli, resolveGrepCliWithAutoInstall, type GrepBackend } from "../grep/constants"
 
 export const DEFAULT_TIMEOUT_MS = 60_000
 export const DEFAULT_LIMIT = 100

--- a/src/tools/glob/tools.ts
+++ b/src/tools/glob/tools.ts
@@ -1,5 +1,6 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { runRgFiles } from "./cli"
+import { resolveGrepCliWithAutoInstall } from "./constants"
 import { formatGlobResult } from "./utils"
 
 export const glob: ToolDefinition = tool({
@@ -21,12 +22,16 @@ export const glob: ToolDefinition = tool({
   },
   execute: async (args) => {
     try {
+      const cli = await resolveGrepCliWithAutoInstall()
       const paths = args.path ? [args.path] : undefined
 
-      const result = await runRgFiles({
-        pattern: args.pattern,
-        paths,
-      })
+      const result = await runRgFiles(
+        {
+          pattern: args.pattern,
+          paths,
+        },
+        cli
+      )
 
       return formatGlobResult(result)
     } catch (e) {

--- a/src/tools/grep/constants.ts
+++ b/src/tools/grep/constants.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs"
 import { join, dirname } from "node:path"
 import { spawnSync } from "node:child_process"
 import { getInstalledRipgrepPath, downloadAndInstallRipgrep } from "./downloader"
+import { getDataDir } from "../../shared/data-path"
 
 export type GrepBackend = "rg" | "grep"
 
@@ -36,6 +37,9 @@ function getOpenCodeBundledRg(): string | null {
   const rgName = isWindows ? "rg.exe" : "rg"
 
   const candidates = [
+    // OpenCode XDG data path (highest priority - where OpenCode installs rg)
+    join(getDataDir(), "opencode", "bin", rgName),
+    // Legacy paths relative to execPath
     join(execDir, rgName),
     join(execDir, "bin", rgName),
     join(execDir, "..", "bin", rgName),


### PR DESCRIPTION
## Summary

Fixes #307 - glob not working well on Windows/WSL

This PR addresses three issues affecting Windows users:

1. **Wrong path detection for OpenCode's bundled rg** - The glob tool wasn't finding ripgrep installed by OpenCode because it only checked paths relative to `process.execPath`, not the XDG data directory where OpenCode actually installs it (`~/.local/share/opencode/bin/rg`)

2. **No auto-install capability** - Unlike the grep tool, glob used synchronous `resolveGrepCli()` which doesn't trigger auto-installation when rg is missing

3. **Unix `find` fallback on Windows** - When rg wasn't available, the glob tool fell back to Unix `find` command with arguments like `-maxdepth`, `-type f` which are invalid on Windows (Windows `find.exe` is a completely different command for text search)

## Changes

- **`src/tools/grep/constants.ts`**: Added OpenCode's XDG data path (`~/.local/share/opencode/bin/rg`) as highest priority candidate in `getOpenCodeBundledRg()`
- **`src/tools/glob/constants.ts`**: Exported `resolveGrepCliWithAutoInstall` for use by glob tool
- **`src/tools/glob/cli.ts`**: 
  - Added `buildPowerShellCommand()` for Windows fallback using `Get-ChildItem`
  - Updated `runRgFiles()` to accept optional pre-resolved CLI and detect Windows platform
- **`src/tools/glob/tools.ts`**: Now uses `resolveGrepCliWithAutoInstall()` to ensure rg is auto-downloaded if missing

## Resolution Order (for rg)

1. OpenCode XDG path: `~/.local/share/opencode/bin/rg` (new, highest priority)
2. Legacy exec-relative paths
3. System PATH
4. oh-my-opencode cache: `~/.cache/oh-my-opencode/bin/rg`
5. Fallback: PowerShell `Get-ChildItem` on Windows, Unix `find` on other platforms

## Testing

- [x] Typecheck passes (`bun run typecheck`)
- [x] All 108 tests pass (`bun test`)
- [x] Build succeeds (`bun run build`)

## Notes

- WSL is handled correctly - `process.platform` returns `"linux"` in WSL, so it uses Unix commands
- PowerShell fallback uses `-Depth` parameter (PowerShell 5.0+, standard on Windows 10+)
- Pattern escaping implemented for both path and pattern arguments to prevent injection