### PR TITLE
fix: detect opencode-desktop binary in installer

### DIFF
--- a/src/cli/config-manager.ts
+++ b/src/cli/config-manager.ts
@@ -206,16 +206,22 @@ export function writeOmoConfig(installConfig: InstallConfig): ConfigMergeResult 
   }
 }
 
-async function findOpenCodeBinary(): Promise<string | null> {
+interface OpenCodeBinaryResult {
+  binary: string
+  version: string
+}
+
+async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | null> {
   for (const binary of OPENCODE_BINARIES) {
     try {
       const proc = Bun.spawn([binary, "--version"], {
         stdout: "pipe",
         stderr: "pipe",
       })
+      const output = await new Response(proc.stdout).text()
       await proc.exited
       if (proc.exitCode === 0) {
-        return binary
+        return { binary, version: output.trim() }
       }
     } catch {
       continue
@@ -225,25 +231,13 @@ async function findOpenCodeBinary(): Promise<string | null> {
 }
 
 export async function isOpenCodeInstalled(): Promise<boolean> {
-  const binary = await findOpenCodeBinary()
-  return binary !== null
+  const result = await findOpenCodeBinaryWithVersion()
+  return result !== null
 }
 
 export async function getOpenCodeVersion(): Promise<string | null> {
-  const binary = await findOpenCodeBinary()
-  if (!binary) return null
-
-  try {
-    const proc = Bun.spawn([binary, "--version"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-    const output = await new Response(proc.stdout).text()
-    await proc.exited
-    return proc.exitCode === 0 ? output.trim() : null
-  } catch {
-    return null
-  }
+  const result = await findOpenCodeBinaryWithVersion()
+  return result?.version ?? null
 }
 
 export async function addAuthPlugins(config: InstallConfig): Promise<ConfigMergeResult> {


### PR DESCRIPTION
## Summary

- Add support for detecting the OpenCode desktop beta binary (`opencode-desktop`) in the installer
- The installer now checks for both `opencode` (CLI) and `opencode-desktop` (desktop beta) binaries

## Problem

The OpenCode desktop beta uses a different binary name (`opencode-desktop`) than the standard CLI (`opencode`). Users who have installed the desktop beta but not the CLI would see "OpenCode is not installed" when running `bunx oh-my-opencode install`.

## Solution

Added a `findOpenCodeBinary()` helper function that iterates through both binary names and returns the first one found. Updated `isOpenCodeInstalled()` and `getOpenCodeVersion()` to use this helper.

## Changes

- Added `OPENCODE_BINARIES` constant with both binary names
- Added `findOpenCodeBinary()` helper function
- Updated `isOpenCodeInstalled()` to use the helper
- Updated `getOpenCodeVersion()` to use the helper

## Testing

- Typecheck passes
- All 108 tests pass

Fixes #310