### PR TITLE
docs: fix experimental config key typo in README examples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -923,7 +923,7 @@ OpenCode でサポートされるすべての LSP 構成およびカスタム設
     "aggressive_truncation": true,
     "auto_resume": true,
     "truncate_all_tool_outputs": false,
-    "dcp_on_compaction_failure": true
+    "dcp_for_compaction": true
   }
 }
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -920,7 +920,7 @@ OpenCode 에서 지원하는 모든 LSP 구성 및 커스텀 설정 (opencode.js
     "aggressive_truncation": true,
     "auto_resume": true,
     "truncate_all_tool_outputs": false,
-    "dcp_on_compaction_failure": true
+    "dcp_for_compaction": true
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -959,7 +959,7 @@ Opt-in experimental features that may change or be removed in future versions. U
     "aggressive_truncation": true,
     "auto_resume": true,
     "truncate_all_tool_outputs": false,
-    "dcp_on_compaction_failure": true
+    "dcp_for_compaction": true
   }
 }
 ```

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -927,7 +927,7 @@ Oh My OpenCode 送你重构工具（重命名、代码操作）。
     "aggressive_truncation": true,
     "auto_resume": true,
     "truncate_all_tool_outputs": false,
-    "dcp_on_compaction_failure": true
+    "dcp_for_compaction": true
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Fix `dcp_on_compaction_failure` → `dcp_for_compaction` in JSON examples across all README files

This is the same fix as #325, but targeting the `dev` branch (since #325 was accidentally merged to `master`).

The JSON example in the Experimental section had the wrong config key name. The table correctly shows `dcp_for_compaction`, but the JSON example showed `dcp_on_compaction_failure`.

Related: #325