### PR TITLE
fix: restore user/project skill loading removed in #240

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,10 @@ import {
   loadOpencodeGlobalCommands,
   loadOpencodeProjectCommands,
 } from "./features/claude-code-command-loader";
+import {
+  loadUserSkillsAsCommands,
+  loadProjectSkillsAsCommands,
+} from "./features/claude-code-skill-loader";
 import { loadBuiltinCommands } from "./features/builtin-commands";
 
 import {
@@ -519,18 +523,23 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
 
       const builtinCommands = loadBuiltinCommands(pluginConfig.disabled_commands);
       const userCommands = (pluginConfig.claude_code?.commands ?? true) ? loadUserCommands() : {};
+      const userSkills = (pluginConfig.claude_code?.skills ?? true) ? loadUserSkillsAsCommands() : {};
       const opencodeGlobalCommands = loadOpencodeGlobalCommands();
       const systemCommands = config.command ?? {};
       const projectCommands = (pluginConfig.claude_code?.commands ?? true) ? loadProjectCommands() : {};
+      const projectSkills = (pluginConfig.claude_code?.skills ?? true) ? loadProjectSkillsAsCommands() : {};
       const opencodeProjectCommands = loadOpencodeProjectCommands();
       config.command = {
         ...builtinCommands,
         ...userCommands,
+        ...userSkills,
         ...opencodeGlobalCommands,
         ...systemCommands,
         ...projectCommands,
+        ...projectSkills,
         ...opencodeProjectCommands,
         ...pluginComponents.commands,
+        ...pluginComponents.skills,
       };
     },
 


### PR DESCRIPTION
## Summary
- Restores skill loading functionality that was accidentally removed in PR #240
- User skills from `~/.claude/skills/` are now loaded again
- Project skills from `./.claude/skills/` are now loaded again
- Also merges `pluginComponents.skills` which was loaded but never used

## Root Cause
PR #240 "feat: add Claude Code plugin support" refactored the command loading but removed the skill loader imports and the skill loading/merging logic.

## Changes
- Added import for `loadUserSkillsAsCommands` and `loadProjectSkillsAsCommands` from `./features/claude-code-skill-loader`
- Added skill loading with config option respect (`pluginConfig.claude_code?.skills`)
- Merged `userSkills`, `projectSkills`, and `pluginComponents.skills` into `config.command`

## Testing
Verified that 97 SKILL.md files in `~/.claude/skills/` should now be loaded correctly.