### PR TITLE
fix: add --external @ast-grep/napi to CLI build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "./schema.json": "./dist/oh-my-opencode.schema.json"
   },
   "scripts": {
-    "build": "bun build src/index.ts src/google-auth.ts --outdir dist --target bun --format esm --external @ast-grep/napi && tsc --emitDeclarationOnly && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm && bun run build:schema",
+    "build": "bun build src/index.ts src/google-auth.ts --outdir dist --target bun --format esm --external @ast-grep/napi && tsc --emitDeclarationOnly && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external @ast-grep/napi && bun run build:schema",
     "build:schema": "bun run script/build-schema.ts",
     "clean": "rm -rf dist",
     "prepublishOnly": "bun run clean && bun run build",


### PR DESCRIPTION
## Summary

- Adds `--external @ast-grep/napi` flag to CLI build command in `package.json`

## Problem

The `oh-my-opencode doctor` command always reports `AST-Grep NAPI → Not installed (optional)` even when `@ast-grep/napi` is properly installed. This was caused by the CLI build command missing `--external @ast-grep/napi`, causing the bundler to inline the absolute path from the CI environment (`/home/runner/work/oh-my-opencode/oh-my-opencode/node_modules/@ast-grep/napi/index.js`).

## Solution

Added `--external @ast-grep/napi` to the CLI build command to preserve runtime `require.resolve()` instead of inlining CI paths.

## Verification

- Build passes with no hardcoded CI paths in `dist/cli/index.js`
- `@ast-grep/napi` references are preserved as external imports
- Typecheck passes

Fixes #344