### PR TITLE
fix(windows): resolve paths[0] TypeError crash on Windows startup

### DIFF
--- a/src/hooks/comment-checker/downloader.ts
+++ b/src/hooks/comment-checker/downloader.ts
@@ -32,9 +32,16 @@ const PLATFORM_MAP: Record<string, PlatformInfo> = {
 
 /**
  * Get the cache directory for oh-my-opencode binaries.
- * Follows XDG Base Directory Specification.
+ * On Windows: Uses %LOCALAPPDATA% or %APPDATA% (Windows conventions)
+ * On Unix: Follows XDG Base Directory Specification
  */
 export function getCacheDir(): string {
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA || process.env.APPDATA
+    const base = localAppData || join(homedir(), "AppData", "Local")
+    return join(base, "oh-my-opencode", "bin")
+  }
+
   const xdgCache = process.env.XDG_CACHE_HOME
   const base = xdgCache || join(homedir(), ".cache")
   return join(base, "oh-my-opencode", "bin")


### PR DESCRIPTION
## Summary

Fixes the Windows startup crash caused by `TypeError: The "paths[0]" property must be of type string, got undefined`.

**Root Cause:** The `comment-checker` module initialization on Windows failed due to:
1. `getCacheDir()` using Unix-style `~/.cache` path instead of Windows-appropriate `%LOCALAPPDATA%` or `%APPDATA%`
2. `createRequire(import.meta.url)` being called during plugin loading when `import.meta.url` could be undefined on Windows

**Changes:**
- **`src/hooks/comment-checker/downloader.ts`**: Added Windows-specific cache directory handling using `%LOCALAPPDATA%` or `%APPDATA%` (matching the existing pattern in `ast-grep/downloader.ts`)
- **`src/hooks/comment-checker/cli.ts`**: 
  - Added guard against undefined `import.meta.url` before calling `createRequire()`
  - Reordered logic to check cached binary first (safest path with no module resolution)

Fixes #347