### PR TITLE
feat: add dev-browser as builtin skill for browser automation

### DIFF
--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -1,5 +1,22 @@
 import type { BuiltinSkill } from "./types"
+import {
+  DEV_BROWSER_SKILL_TEMPLATE,
+  DEV_BROWSER_DESCRIPTION,
+  DEV_BROWSER_GITHUB_SOURCE,
+} from "./templates/dev-browser"
 
 export function createBuiltinSkills(): BuiltinSkill[] {
-  return []
+  return [
+    {
+      name: "dev-browser",
+      description: DEV_BROWSER_DESCRIPTION,
+      template: DEV_BROWSER_SKILL_TEMPLATE,
+      license: "MIT",
+      compatibility: "Claude Code, Amp Code, OpenCode",
+      source: DEV_BROWSER_GITHUB_SOURCE,
+      autoServer: true,
+      allowedTools: ["Bash(npx tsx:*)", "Bash(cd *dev-browser:*)"],
+      argumentHint: '"task description"',
+    },
+  ]
 }

--- a/src/features/builtin-skills/templates/dev-browser.ts
+++ b/src/features/builtin-skills/templates/dev-browser.ts
@@ -1,0 +1,233 @@
+/**
+ * dev-browser Skill Template
+ *
+ * Browser automation skill with persistent page state.
+ * Original source: https://github.com/SawyerHood/dev-browser
+ * License: MIT
+ *
+ * This skill enables AI agents to control web browsers for testing,
+ * scraping, form filling, and web automation tasks.
+ */
+
+export const DEV_BROWSER_SKILL_TEMPLATE = `# Dev Browser Skill
+
+Browser automation that maintains page state across script executions. Write small, focused scripts to accomplish tasks incrementally. Once you've proven out part of a workflow and there is repeated work to be done, you can write a script to do the repeated work in a single execution.
+
+## Prerequisites
+
+Before using this skill, you need to install it:
+
+\`\`\`bash
+# Clone the dev-browser repository
+git clone https://github.com/SawyerHood/dev-browser.git ~/.config/opencode/skills/dev-browser
+
+# Install dependencies
+cd ~/.config/opencode/skills/dev-browser/skills/dev-browser
+npm install
+\`\`\`
+
+## Setup
+
+Two modes available. Ask the user if unclear which to use.
+
+### Standalone Mode (Default)
+
+Launches a new Chromium browser for fresh automation sessions.
+
+\`\`\`bash
+cd ~/.config/opencode/skills/dev-browser/skills/dev-browser && ./server.sh &
+\`\`\`
+
+Add \`--headless\` flag if user requests it. **Wait for the "Ready" message before running scripts.**
+
+### Extension Mode
+
+Connects to user's existing Chrome browser. Use this when:
+
+- The user is already logged into sites and wants you to do things behind an authed experience that isn't local dev.
+- The user asks you to use the extension
+
+**Start the relay server:**
+
+\`\`\`bash
+cd ~/.config/opencode/skills/dev-browser/skills/dev-browser && npm run start-extension &
+\`\`\`
+
+Wait for \`Waiting for extension to connect...\`
+
+## Choosing Your Approach
+
+- **Local/source-available sites**: Read the source code first to write selectors directly
+- **Unknown page layouts**: Use \`getAISnapshot()\` to discover elements and \`selectSnapshotRef()\` to interact with them
+- **Visual feedback**: Take screenshots to see what the user sees
+
+## Writing Scripts
+
+> **Run all scripts from the skill directory.** The \`@/\` import alias requires this directory's config.
+
+Execute scripts inline using heredocs:
+
+\`\`\`bash
+cd ~/.config/opencode/skills/dev-browser/skills/dev-browser && npx tsx <<'EOF'
+import { connect, waitForPageLoad } from "@/client.js";
+
+const client = await connect();
+const page = await client.page("example"); // descriptive name like "cnn-homepage"
+await page.setViewportSize({ width: 1280, height: 800 });
+
+await page.goto("https://example.com");
+await waitForPageLoad(page);
+
+console.log({ title: await page.title(), url: page.url() });
+await client.disconnect();
+EOF
+\`\`\`
+
+**Write to \`tmp/\` files only when** the script needs reuse, is complex, or user explicitly requests it.
+
+### Key Principles
+
+1. **Small scripts**: Each script does ONE thing (navigate, click, fill, check)
+2. **Evaluate state**: Log/return state at the end to decide next steps
+3. **Descriptive page names**: Use \`"checkout"\`, \`"login"\`, not \`"main"\`
+4. **Disconnect to exit**: \`await client.disconnect()\` - pages persist on server
+5. **Plain JS in evaluate**: \`page.evaluate()\` runs in browser - no TypeScript syntax
+
+## Workflow Loop
+
+Follow this pattern for complex tasks:
+
+1. **Write a script** to perform one action
+2. **Run it** and observe the output
+3. **Evaluate** - did it work? What's the current state?
+4. **Decide** - is the task complete or do we need another script?
+5. **Repeat** until task is done
+
+### No TypeScript in Browser Context
+
+Code passed to \`page.evaluate()\` runs in the browser, which doesn't understand TypeScript:
+
+\`\`\`typescript
+// Correct: plain JavaScript
+const text = await page.evaluate(() => {
+  return document.body.innerText;
+});
+
+// Wrong: TypeScript syntax will fail at runtime
+const text = await page.evaluate(() => {
+  const el: HTMLElement = document.body; // Type annotation breaks in browser!
+  return el.innerText;
+});
+\`\`\`
+
+## Client API
+
+\`\`\`typescript
+const client = await connect();
+const page = await client.page("name"); // Get or create named page
+const pages = await client.list(); // List all page names
+await client.close("name"); // Close a page
+await client.disconnect(); // Disconnect (pages persist)
+
+// ARIA Snapshot methods
+const snapshot = await client.getAISnapshot("name"); // Get accessibility tree
+const element = await client.selectSnapshotRef("name", "e5"); // Get element by ref
+\`\`\`
+
+The \`page\` object is a standard Playwright Page.
+
+## Waiting
+
+\`\`\`typescript
+import { waitForPageLoad } from "@/client.js";
+
+await waitForPageLoad(page); // After navigation
+await page.waitForSelector(".results"); // For specific elements
+await page.waitForURL("**/success"); // For specific URL
+\`\`\`
+
+## Inspecting Page State
+
+### Screenshots
+
+\`\`\`typescript
+await page.screenshot({ path: "tmp/screenshot.png" });
+await page.screenshot({ path: "tmp/full.png", fullPage: true });
+\`\`\`
+
+### ARIA Snapshot (Element Discovery)
+
+Use \`getAISnapshot()\` to discover page elements. Returns YAML-formatted accessibility tree:
+
+\`\`\`yaml
+- banner:
+  - link "Hacker News" [ref=e1]
+  - navigation:
+    - link "new" [ref=e2]
+- main:
+  - list:
+    - listitem:
+      - link "Article Title" [ref=e8]
+      - link "328 comments" [ref=e9]
+- contentinfo:
+  - textbox [ref=e10]
+    - /placeholder: "Search"
+\`\`\`
+
+**Interpreting refs:**
+
+- \`[ref=eN]\` - Element reference for interaction (visible, clickable elements only)
+- \`[checked]\`, \`[disabled]\`, \`[expanded]\` - Element states
+- \`[level=N]\` - Heading level
+- \`/url:\`, \`/placeholder:\` - Element properties
+
+**Interacting with refs:**
+
+\`\`\`typescript
+const snapshot = await client.getAISnapshot("hackernews");
+console.log(snapshot); // Find the ref you need
+
+const element = await client.selectSnapshotRef("hackernews", "e2");
+await element.click();
+\`\`\`
+
+## Error Recovery
+
+Page state persists after failures. Debug with:
+
+\`\`\`bash
+cd ~/.config/opencode/skills/dev-browser/skills/dev-browser && npx tsx <<'EOF'
+import { connect } from "@/client.js";
+
+const client = await connect();
+const page = await client.page("hackernews");
+
+await page.screenshot({ path: "tmp/debug.png" });
+console.log({
+  url: page.url(),
+  title: await page.title(),
+  bodyText: await page.textContent("body").then((t) => t?.slice(0, 200)),
+});
+
+await client.disconnect();
+EOF
+\`\`\`
+
+## Scraping Data
+
+For scraping large datasets, intercept and replay network requests rather than scrolling the DOM.
+
+## Attribution
+
+This skill is based on [SawyerHood/dev-browser](https://github.com/SawyerHood/dev-browser) (MIT License).
+`
+
+export const DEV_BROWSER_DESCRIPTION =
+  "Browser automation with persistent page state. Use when users ask to navigate websites, fill forms, take screenshots, extract web data, test web apps, or automate browser workflows. Trigger phrases include 'go to [url]', 'click on', 'fill out the form', 'take a screenshot', 'scrape', 'automate', 'test the website', 'log into', or any browser interaction request."
+
+export const DEV_BROWSER_GITHUB_SOURCE = {
+  repo: "SawyerHood/dev-browser",
+  ref: "main",
+  path: "skills/dev-browser",
+  name: "dev-browser",
+} as const

--- a/src/features/builtin-skills/types.ts
+++ b/src/features/builtin-skills/types.ts
@@ -1,3 +1,11 @@
+export interface GithubSkillSource {
+  repo: string
+  ref?: string
+  path: string
+  name: string
+  version?: string
+}
+
 export interface BuiltinSkill {
   name: string
   description: string
@@ -10,4 +18,6 @@ export interface BuiltinSkill {
   model?: string
   subtask?: boolean
   argumentHint?: string
+  source?: GithubSkillSource
+  autoServer?: boolean
 }


### PR DESCRIPTION
## Summary

- Adds **dev-browser** as a built-in skill, providing browser automation capabilities via Playwright
- Extends `BuiltinSkill` type with `GithubSkillSource` and `autoServer` options for future dynamic loading
- Full skill template with usage instructions embedded

## What is dev-browser?

[SawyerHood/dev-browser](https://github.com/SawyerHood/dev-browser) is a Claude Code skill that enables AI agents to control web browsers. Key features:

- **Persistent pages**: Navigate once, interact across multiple scripts
- **ARIA snapshots**: LLM-friendly DOM inspection with element refs
- **Dual modes**: Standalone Chromium or connect to existing Chrome via extension

## Usage

After installing prerequisites, users can invoke:

```
/dev-browser "go to localhost:3000 and verify the signup flow"
```

## Prerequisites (for users)

```bash
git clone https://github.com/SawyerHood/dev-browser.git ~/.config/opencode/skills/dev-browser
cd ~/.config/opencode/skills/dev-browser/skills/dev-browser
npm install
```

## Future Work

This PR lays groundwork for:
1. **GitHub Skill Fetcher**: Auto-fetch skills from GitHub repos
2. **Auto-managed server lifecycle**: Start server automatically on skill invocation
3. **Config-based enablement**: `{ "skills": { "dev-browser": true } }`

## Files Changed

| File | Change |
|------|--------|
| `src/features/builtin-skills/templates/dev-browser.ts` | New skill template (MIT license attribution) |
| `src/features/builtin-skills/types.ts` | Add `GithubSkillSource` interface and new optional fields |
| `src/features/builtin-skills/skills.ts` | Register dev-browser in `createBuiltinSkills()` |

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run build` passes

Closes #150