### PR TITLE
fix(ralph-loop): generate transcript path from sessionID instead of relying on event properties

### DIFF
--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -329,17 +329,19 @@ describe("ralph-loop", () => {
 
     test("should detect completion promise and stop loop", async () => {
       // #given - active loop with transcript containing completion
-      const hook = createRalphLoopHook(createMockPluginInput())
+      const transcriptPath = join(TEST_DIR, "transcript.jsonl")
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
       hook.startLoop("session-123", "Build something", { completionPromise: "COMPLETE" })
 
-      const transcriptPath = join(TEST_DIR, "transcript.jsonl")
       writeFileSync(transcriptPath, JSON.stringify({ content: "Task done <promise>COMPLETE</promise>" }))
 
-      // #when - session goes idle with transcript
+      // #when - session goes idle (transcriptPath now derived from sessionID via getTranscriptPath)
       await hook.event({
         event: {
           type: "session.idle",
-          properties: { sessionID: "session-123", transcriptPath },
+          properties: { sessionID: "session-123" },
         },
       })
 

--- a/src/hooks/ralph-loop/index.ts
+++ b/src/hooks/ralph-loop/index.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_COMPLETION_PROMISE,
 } from "./constants"
 import type { RalphLoopState, RalphLoopOptions } from "./types"
+import { getTranscriptPath as getDefaultTranscriptPath } from "../claude-code-hooks/transcript"
 
 export * from "./types"
 export * from "./constants"
@@ -48,6 +49,7 @@ export function createRalphLoopHook(
   const sessions = new Map<string, SessionState>()
   const config = options?.config
   const stateDir = config?.state_dir
+  const getTranscriptPath = options?.getTranscriptPath ?? getDefaultTranscriptPath
 
   function getSessionState(sessionID: string): SessionState {
     let state = sessions.get(sessionID)
@@ -149,7 +151,8 @@ export function createRalphLoopHook(
         return
       }
 
-      const transcriptPath = props?.transcriptPath as string | undefined
+      // Generate transcript path from sessionID - OpenCode doesn't pass it in event properties
+      const transcriptPath = getTranscriptPath(sessionID)
 
       if (detectCompletionPromise(transcriptPath, state.completion_promise)) {
         log(`[${HOOK_NAME}] Completion detected!`, {

--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -12,4 +12,5 @@ export interface RalphLoopState {
 
 export interface RalphLoopOptions {
   config?: RalphLoopConfig
+  getTranscriptPath?: (sessionId: string) => string
 }


### PR DESCRIPTION
## Summary

- Fix ralph-loop completion detection that never worked because OpenCode doesn't pass `transcriptPath` in `session.idle` event properties
- Now generates transcript path from sessionID using the existing `getTranscriptPath` function from claude-code-hooks
- Add optional `getTranscriptPath` callback to `RalphLoopOptions` for testability

## Root Cause

The `detectCompletionPromise` function returns `false` immediately if `transcriptPath` is `undefined`:

```typescript
function detectCompletionPromise(transcriptPath: string | undefined, promise: string): boolean {
  if (!transcriptPath) return false  // <-- Always returns false!
  // ...
}
```

The code expected `transcriptPath` to be passed in the `session.idle` event properties, but OpenCode never provides this property. The event only contains `sessionID`.

## The Fix

Instead of relying on event properties, we now:
1. Import `getTranscriptPath` from `claude-code-hooks/transcript`  
2. Generate the transcript path from `sessionID` (which IS available in the event)
3. Add an optional override in `RalphLoopOptions` for test flexibility

## Testing

- ✅ All 281 tests pass
- ✅ Typecheck passes
- ✅ Specific ralph-loop tests updated and passing

Fixes #354