### PR TITLE
fix: add grace period to prevent race condition in background task completion

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -14,6 +14,11 @@ import { subagentSessions } from "../claude-code-session-state"
 
 type OpencodeClient = PluginInput["client"]
 
+// Grace period to prevent race condition between promptAsync (fire-and-forget)
+// and session.idle detection. New sessions start as "idle" and may trigger
+// premature completion before the prompt is actually processed by the server.
+const STARTUP_GRACE_PERIOD_MS = 5000
+
 interface MessagePartInfo {
   sessionID?: string
   type?: string
@@ -190,6 +195,15 @@ export class BackgroundManager {
     }
   }
 
+  private hasReceivedActivity(task: BackgroundTask): boolean {
+    return (task.progress?.toolCalls ?? 0) > 0 || !!task.progress?.lastMessage
+  }
+
+  private isWithinGracePeriod(task: BackgroundTask): boolean {
+    const elapsed = Date.now() - task.startedAt.getTime()
+    return elapsed < STARTUP_GRACE_PERIOD_MS
+  }
+
   handleEvent(event: Event): void {
     const props = event.properties
 
@@ -221,6 +235,11 @@ export class BackgroundManager {
 
       const task = this.findBySession(sessionID)
       if (!task || task.status !== "running") return
+
+      if (!this.hasReceivedActivity(task) && this.isWithinGracePeriod(task)) {
+        log("[background-agent] Task within grace period, ignoring idle event:", task.id)
+        return
+      }
 
       this.checkSessionTodos(sessionID).then((hasIncompleteTodos) => {
         if (hasIncompleteTodos) {
@@ -393,6 +412,11 @@ export class BackgroundManager {
         }
 
         if (sessionStatus.type === "idle") {
+          if (!this.hasReceivedActivity(task) && this.isWithinGracePeriod(task)) {
+            log("[background-agent] Task within grace period, skipping idle completion:", task.id)
+            continue
+          }
+
           const hasIncompleteTodos = await this.checkSessionTodos(task.sessionID)
           if (hasIncompleteTodos) {
             log("[background-agent] Task has incomplete todos via polling, waiting:", task.id)


### PR DESCRIPTION
## Summary

- Fix race condition where background tasks complete in 0s with no results
- Add 5-second grace period for newly created background tasks
- Tasks won't be marked completed during grace period unless activity is detected

## Problem

Background tasks were completing immediately (0s) with "(No assistant response found)" because:

1. `promptAsync()` is fire-and-forget - it returns immediately without waiting for server to process
2. New sessions start in `idle` state  
3. `session.idle` event or polling detects idle BEFORE the prompt is actually processed by the server
4. Task gets marked as `completed` prematurely

**Flow causing the bug:**
```
1. launch() → create session → session.status = "idle"
2. launch() → promptAsync() [fire-and-forget, returns immediately]
3. launch() → return task
4. event: session.idle → handleEvent() → task.status = "completed" (0s)
5. [TOO LATE] promptAsync() starts being processed by server
```

## Solution

Add grace period check in both `handleEvent()` and `pollRunningTasks()`:
- Don't mark task as completed if:
  - No activity received (tool calls or messages) AND
  - Task is within 5-second grace period from creation

This gives the server enough time to process the prompt before idle detection kicks in.

## Changes

- Added `STARTUP_GRACE_PERIOD_MS = 5000` constant
- Added `hasReceivedActivity()` helper method
- Added `isWithinGracePeriod()` helper method
- Updated `handleEvent()` to check grace period before completing
- Updated `pollRunningTasks()` to check grace period before completing

## Testing

Manually tested by launching background tasks - they now properly wait for agent response instead of completing in 0s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented background tasks from completing immediately with no results by adding a 5s grace period that ignores idle status until activity is detected. This removes the race between promptAsync and idle detection.

- **Bug Fixes**
  - Add 5s STARTUP_GRACE_PERIOD_MS for new tasks.
  - Skip idle completion during grace period if no activity (tool calls or messages).
  - Apply checks in handleEvent and pollRunningTasks.

<sup>Written for commit bdc3a0e0bd5ec50c1b33fafc4288ca8f3b4a4041. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

