### PR TITLE
feat(unity-engineer): add Sisyphus delegation and enable task tool

### DIFF
--- a/src/agents/unity-engineer.ts
+++ b/src/agents/unity-engineer.ts
@@ -6,7 +6,7 @@ export const unityEngineerAgent: AgentConfig = {
   mode: "subagent",
   model: "anthropic/claude-sonnet-4-5",
   temperature: 0.1,
-  tools: { write: true, edit: true, bash: false, background_task: false },
+  tools: { write: true, edit: true, bash: false, background_task: false, task: true },
   prompt: `# UNITY ENGINEER
 
 You are a Unity game development specialist with deep expertise in C# scripting and Unity's component-based architecture. You handle general Unity development tasks and delegate spatial/physics-heavy work to the specialized @unity-spatial-engineer agent.
@@ -431,6 +431,50 @@ When encountering spatial/physics-heavy tasks, delegate with:
 \`\`\`
 This task requires spatial/physics understanding.
 Delegating to @unity-spatial-engineer.
+
+[Task description]
+\`\`\`
+
+---
+
+## GENERAL TASK DELEGATION (Sisyphus)
+
+**Delegate to @Sisyphus** for tasks requiring:
+
+### Shell & CLI Operations
+- Git operations (commit, push, branch, etc.)
+- Package management (npm, dotnet, nuget)
+- Build commands and scripts
+- File system operations via CLI
+
+### Codebase Exploration & Research
+- Deep codebase analysis (explore agent)
+- External documentation lookup (librarian agent)
+- Multi-file refactoring across non-Unity code
+- Architecture decisions requiring broad context
+
+### Background & Parallel Tasks
+- Running multiple search queries in parallel
+- Long-running background operations
+- Coordinating multiple sub-agents
+
+### Non-Unity Code
+- General TypeScript/JavaScript code
+- Python scripts
+- Configuration files (JSON, YAML, etc.)
+- CI/CD pipelines
+- Documentation generation
+
+**Handle directly** (do NOT delegate to Sisyphus):
+- Unity C# scripts (MonoBehaviour, ScriptableObject)
+- Unity-specific patterns and architecture
+- Unity asset references and GUIDs
+- Unity Editor scripts
+
+When encountering general/non-Unity tasks, delegate with:
+\`\`\`
+This task requires general tooling/codebase exploration.
+Delegating to @Sisyphus.
 
 [Task description]
 \`\`\`

--- a/src/agents/unity-spatial-engineer.ts
+++ b/src/agents/unity-spatial-engineer.ts
@@ -4,7 +4,7 @@ export const unitySpatialEngineerAgent: AgentConfig = {
   description:
     "Unity 3D/spatial specialist. Handles physics, cameras, navigation, 3D math, and animation systems requiring spatial understanding.",
   mode: "subagent",
-  model: "google/gemini-3-pro",
+  model: "google/gemini-3-pro-high",
   temperature: 0.2,
   tools: { write: true, edit: true, bash: false, background_task: false },
   prompt: `# UNITY SPATIAL ENGINEER


### PR DESCRIPTION
- Add task: true to unity-engineer tools for delegation capability
- Add comprehensive Sisyphus delegation section to unity-engineer prompt
- Upgrade unity-spatial-engineer model to gemini-3-pro-high for better performance

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable task-based delegation in unity-engineer and add clear Sisyphus handoff guidance for non-Unity work. Upgrade unity-spatial-engineer to gemini-3-pro-high to improve spatial task performance.

- **New Features**
  - Enable tools.task in unity-engineer.
  - Add Sisyphus delegation guidance in the prompt with cases (CLI, research, background tasks, non-Unity code) and a template.

- **Dependencies**
  - Upgrade unity-spatial-engineer model to google/gemini-3-pro-high.

<sup>Written for commit a2adbd2e391c52bac1634ee01d6db21d60f9e6bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

