### PR TITLE
fix: correct preemptive_compaction schema comment default value

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -172,7 +172,7 @@ export const DynamicContextPruningConfigSchema = z.object({
 export const ExperimentalConfigSchema = z.object({
   aggressive_truncation: z.boolean().optional(),
   auto_resume: z.boolean().optional(),
-  /** Enable preemptive compaction at threshold (default: false) */
+  /** Enable preemptive compaction at threshold (default: true since v2.9.0) */
   preemptive_compaction: z.boolean().optional(),
   /** Threshold percentage to trigger preemptive compaction (default: 0.80) */
   preemptive_compaction_threshold: z.number().min(0.5).max(0.95).optional(),


### PR DESCRIPTION
## Summary

- Fix documentation mismatch in schema JSDoc comment for `preemptive_compaction`
- Change `default: false` → `default: true since v2.9.0` to reflect actual behavior

## Details

The JSDoc comment in `src/config/schema.ts` incorrectly stated `default: false`, but since v2.9.0 preemptive compaction is **enabled by default**.

**Implementation (unchanged):**
```typescript
// Preemptive compaction is now enabled by default.
// Backward compatibility: explicit false in experimental config disables the hook.
const explicitlyDisabled = experimental?.preemptive_compaction === false
```

**Behavior:**
- `undefined` (no config) → enabled
- `true` → enabled
- `false` → disabled (only way to disable via experimental config)

Fixes #398

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the schema JSDoc for experimental.preemptive_compaction to state “default: true since v2.9.0,” matching actual behavior. Clarifies that undefined/true enable the feature and false disables it; no runtime changes.

<sup>Written for commit 5381927362a8a89980f4fa09ebb17328cf742bcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

