### PR TITLE
docs: add npx alternative and Snap Bun warning for Ubuntu users

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -223,7 +223,11 @@ OpenCode がインストールされていない場合は、[OpenCode インス�
 
 ```bash
 bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --chatgpt=<yes|no> --gemini=<yes|no>
+# bunx が動作しない場合は npx を使用
+npx oh-my-opencode install --no-tui --claude=<yes|no|max20> --chatgpt=<yes|no> --gemini=<yes|no>
 ```
+
+> **Ubuntu/Debian ユーザーへの注意**: Snap で Bun をインストールした場合 (`/snap/bin/bun`)、Snap のサンドボックス化により `bunx` が「script not found」エラーで失敗します。代わりに `npx` を使用するか、公式インストーラーで Bun を再インストールしてください: `curl -fsSL https://bun.sh/install | bash`
 
 **例：**
 - すべてのサブスクリプション + max20: `bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes`

--- a/README.ko.md
+++ b/README.ko.md
@@ -220,7 +220,11 @@ OpenCode가 설치되어 있지 않다면, [OpenCode 설치 가이드](https://o
 
 ```bash
 bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --chatgpt=<yes|no> --gemini=<yes|no>
+# bunx가 작동하지 않으면 npx 사용
+npx oh-my-opencode install --no-tui --claude=<yes|no|max20> --chatgpt=<yes|no> --gemini=<yes|no>
 ```
+
+> **Ubuntu/Debian 사용자 참고**: Snap으로 Bun을 설치한 경우 (`/snap/bin/bun`), Snap의 샌드박싱으로 인해 `bunx`가 "script not found" 오류와 함께 실패합니다. 대신 `npx`를 사용하거나, 공식 설치 스크립트로 Bun을 재설치하세요: `curl -fsSL https://bun.sh/install | bash`
 
 **예시:**
 - 모든 구독 + max20: `bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes`

--- a/README.md
+++ b/README.md
@@ -204,7 +204,11 @@ Run the interactive installer:
 
 ```bash
 bunx oh-my-opencode install
+# or use npx if bunx doesn't work
+npx oh-my-opencode install
 ```
+
+> **Note for Ubuntu/Debian users**: If you installed Bun via Snap (`/snap/bin/bun`), `bunx` will fail with "script not found" due to Snap's sandboxing. Either use `npx` instead, or reinstall Bun via the official installer: `curl -fsSL https://bun.sh/install | bash`
 
 Follow the prompts to configure your Claude, ChatGPT, and Gemini subscriptions. After installation, authenticate your providers as instructed.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -231,7 +231,11 @@ fi
 
 ```bash
 bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --chatgpt=<yes|no> --gemini=<yes|no>
+# 如果 bunx 不好使就换 npx
+npx oh-my-opencode install --no-tui --claude=<yes|no|max20> --chatgpt=<yes|no> --gemini=<yes|no>
 ```
+
+> **Ubuntu/Debian 用户注意**：如果你是用 Snap 装的 Bun (`/snap/bin/bun`)，由于 Snap 的沙箱机制，`bunx` 会报 "script not found" 错误。要么改用 `npx`，要么用官方脚本重装 Bun：`curl -fsSL https://bun.sh/install | bash`
 
 **例子：**
 - 全套订阅 + max20：`bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes`


### PR DESCRIPTION
## Summary

Addresses #389 - Installation issues on Ubuntu 24.04 with Snap-installed Bun.

### Changes
- Add `npx` as an alternative command when `bunx` doesn't work
- Add warning about Snap-installed Bun (`/snap/bin/bun`) not working with `bunx` due to sandboxing
- Provide solution: either use `npx` or reinstall Bun via official installer

### Files Updated
- `README.md` - For Humans installation section
- `README.ko.md` - Step 2 installer section (Korean)
- `README.ja.md` - Step 2 installer section (Japanese)
- `README.zh-cn.md` - Step 2 installer section (Simplified Chinese)

### Root Cause
Snap packages run in a sandboxed environment that prevents `bunx` from properly downloading and caching npm packages, causing "script not found" errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated installation docs to add npx as a fallback when bunx fails and added a warning for Snap-installed Bun on Ubuntu/Debian. Addresses #389 by explaining the "script not found" issue and guiding users to use npx or reinstall Bun via the official installer; changes applied to English, Korean, Japanese, and Simplified Chinese READMEs.

<sup>Written for commit 22a9d04c44b63126eaa23af09bc510f098072f34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

