### PR TITLE
fix(ralph-loop): detect completion promise from session messages API

### DIFF
--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -10,6 +10,7 @@ describe("ralph-loop", () => {
   const TEST_DIR = join(tmpdir(), "ralph-loop-test-" + Date.now())
   let promptCalls: Array<{ sessionID: string; text: string }>
   let toastCalls: Array<{ title: string; message: string; variant: string }>
+  let messagesCalls: Array<{ sessionID: string }>
   let mockSessionMessages: Array<{ info?: { role?: string }; parts?: Array<{ type: string; text?: string }> }>
 
   function createMockPluginInput() {
@@ -23,8 +24,9 @@ describe("ralph-loop", () => {
             })
             return {}
           },
-          messages: async () => {
-            return { "200": mockSessionMessages }
+          messages: async (opts: { path: { id: string } }) => {
+            messagesCalls.push({ sessionID: opts.path.id })
+            return { data: mockSessionMessages }
           },
         },
         tui: {
@@ -45,6 +47,7 @@ describe("ralph-loop", () => {
   beforeEach(() => {
     promptCalls = []
     toastCalls = []
+    messagesCalls = []
     mockSessionMessages = []
 
     if (!existsSync(TEST_DIR)) {
@@ -379,6 +382,10 @@ describe("ralph-loop", () => {
       expect(promptCalls.length).toBe(0)
       expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
       expect(hook.getState()).toBeNull()
+
+      // #then - messages API was called with correct session ID
+      expect(messagesCalls.length).toBe(1)
+      expect(messagesCalls[0].sessionID).toBe("session-123")
     })
 
     test("should handle multiple iterations correctly", async () => {

--- a/src/hooks/ralph-loop/index.ts
+++ b/src/hooks/ralph-loop/index.ts
@@ -102,9 +102,7 @@ export function createRalphLoopHook(
         query: { directory: ctx.directory },
       })
 
-      const messages = (response as { "200"?: unknown[]; data?: unknown[] })["200"]
-        ?? (response as { data?: unknown[] }).data
-        ?? (Array.isArray(response) ? response : [])
+      const messages = (response as { data?: unknown[] }).data ?? []
 
       if (!Array.isArray(messages)) return false
 


### PR DESCRIPTION
## Summary

Fixes the ralph-loop completion detection bug reported in #412.

**Root Cause**: The completion promise (e.g., `<promise>DONE</promise>`) was not being detected because assistant text messages were never recorded to the transcript file. The transcript only contained user messages, tool uses, and tool results.

**Fix**: Added a new detection method that fetches session messages via the OpenCode API and checks assistant text messages for the completion promise. The transcript file check is kept as a fallback.

## Changes

- Added `detectCompletionInSessionMessages()` function that uses `ctx.client.session.messages()` API
- Modified `session.idle` event handler to check API first, then fall back to transcript
- Added logging to indicate which detection method found the completion promise
- Added test case for API-based completion detection

## Testing

- All 431 existing tests pass
- New test case verifies API-based detection works correctly
- TypeScript type check passes

Fixes #412

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects the completion promise from assistant messages via the session messages API to fix ralph-loop not completing. Falls back to the transcript check. Fixes #412.

- **Bug Fixes**
  - Added detectCompletionInSessionMessages() using ctx.client.session.messages().
  - Updated session.idle handler to check API first, then transcript.
  - Added logging for detection source and a test for API-based detection.

<sup>Written for commit d2da17e3b7596e28d2e64f0d7f6af94d3b2524eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

