### PR TITLE
fix(session-recovery): detect 'final block cannot be thinking' error pattern

### DIFF
--- a/src/hooks/session-recovery/index.test.ts
+++ b/src/hooks/session-recovery/index.test.ts
@@ -83,8 +83,8 @@ describe("detectErrorType", () => {
       expect(result).toBe("thinking_block_order")
     })
 
-    it("should detect 'cannot be' error pattern with thinking", () => {
-      // #given an error using 'cannot be' phrasing
+    it("should detect 'cannot be thinking' error pattern", () => {
+      // #given an error using 'cannot be thinking' phrasing
       const error = {
         message:
           "messages.219: The last block in an assistant message cannot be thinking content",

--- a/src/hooks/session-recovery/index.ts
+++ b/src/hooks/session-recovery/index.ts
@@ -135,7 +135,7 @@ export function detectErrorType(error: unknown): RecoveryErrorType {
       message.includes("must start with") ||
       message.includes("preceeding") ||
       message.includes("final block") ||
-      message.includes("cannot be") ||
+      message.includes("cannot be thinking") ||
       (message.includes("expected") && message.includes("found")))
   ) {
     return "thinking_block_order"


### PR DESCRIPTION
## Summary

- Add detection for `final block` and `cannot be` patterns in `detectErrorType` function to handle the API error: `The final block in an assistant message cannot be thinking.`
- Export `detectErrorType` function to enable comprehensive unit testing
- Add 14 new test cases covering all error detection patterns

## Problem

During normal operation (no user interruption), sessions encounter this API error:

```
messages.X: The final block in an assistant message cannot be thinking.
```

The error occurs spontaneously at various message counts (observed: 17, 125, 163, 169, 219) during extended thinking sessions. The existing `detectErrorType` function didn't recognize this pattern, causing session recovery to fail silently.

## Solution

The fix adds two new patterns to the existing detection logic:

```typescript
if (
  message.includes("thinking") &&
  (message.includes("first block") ||
    message.includes("must start with") ||
    message.includes("preceeding") ||
    message.includes("final block") ||      // NEW
    message.includes("cannot be") ||        // NEW
    (message.includes("expected") && message.includes("found")))
) {
  return "thinking_block_order"
}
```

## Testing

- All 447 tests pass
- Typecheck passes
- 14 new test cases specifically for `detectErrorType` function

Fixes #419

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles the “final block cannot be thinking” API error so session recovery works during long runs. Exports detectErrorType and adds targeted tests. Fixes #419.

- **Bug Fixes**
  - Detects “final block” and “cannot be thinking” patterns and classifies them as thinking_block_order.
  - Prevents silent recovery failures when this error appears.

<sup>Written for commit af559d350fa92cf5ef4932e5ea09ad506f52c446. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

