### PR TITLE
fix: add timeout protection to subprocess operations

### DIFF
--- a/src/tools/ast-grep/cli.ts
+++ b/src/tools/ast-grep/cli.ts
@@ -114,7 +114,7 @@ export async function runSg(options: RunOptions): Promise<SgResult> {
 
   try {
     stdout = await Promise.race([new Response(proc.stdout).text(), timeoutPromise])
-    stderr = await new Response(proc.stderr).text()
+    stderr = await Promise.race([new Response(proc.stderr).text(), timeoutPromise])
     exitCode = await proc.exited
   } catch (e) {
     const error = e as Error


### PR DESCRIPTION
## Summary

Fixes #425 - Edit tool hangs indefinitely after installing oh-my-opencode plugin

## Root Cause Analysis

Multiple subprocess operations in the codebase lacked timeout protection, causing indefinite hangs when external processes stalled or produced large output:

1. **`command-executor.ts`**: Hook command execution (used by Claude Code hooks) had no timeout - if any PreToolUse/PostToolUse hook hung, the entire edit operation hung indefinitely

2. **`comment-checker/cli.ts`**: The comment-checker CLI spawning had no timeout - if the binary hung or produced infinite output, the session would freeze

3. **`ast-grep/cli.ts`**: While stdout reading was protected by a 5-minute timeout, stderr reading was not - if ast-grep produced large stderr output, it would block indefinitely

## Changes

| File | Change |
|------|--------|
| `src/shared/command-executor.ts` | Added 30-second default timeout with SIGKILL on expiry. Returns exit code 124 (standard timeout exit code). |
| `src/hooks/comment-checker/cli.ts` | Added 10-second timeout for comment checker binary. Races stdout/stderr reading against timeout promise. |
| `src/tools/ast-grep/cli.ts` | Added timeout protection to stderr reading (was missing while stdout was protected). |

## Testing

- [x] Type check passes (`bun run typecheck`)
- [x] All 455 tests pass (`bun test`)

## User Impact

Users experiencing the edit tool hang should see their sessions recover within the timeout period (10-30 seconds depending on which operation timed out) rather than hanging indefinitely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents indefinite hangs during edits by adding timeouts to subprocess operations. Sessions now fail fast (10–30s) instead of freezing when hooks or tools stall.

- **Bug Fixes**
  - Hook command execution: 30s default timeout; SIGKILL on expiry; returns exit code 124.
  - Comment checker CLI: 10s timeout; stdout/stderr reads race against timeout.
  - ast-grep CLI: added timeout protection to stderr reading (previously unbounded).

<sup>Written for commit 544720d1bb4472d561c36b11f2f286d9ab6d2b4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

