### PR TITLE
fix(ralph-loop): adopt OContinue patterns for better performance and abort handling

### DIFF
--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -13,4 +13,5 @@ export interface RalphLoopState {
 export interface RalphLoopOptions {
   config?: RalphLoopConfig
   getTranscriptPath?: (sessionId: string) => string
+  apiTimeout?: number
 }


### PR DESCRIPTION
## Summary

Fixes #425 by adopting patterns from [d3vr/OContinue](https://github.com/d3vr/OContinue) (MIT licensed) to improve ralph-loop reliability and prevent hangs.

## Changes

| Change | Before | After |
|--------|--------|-------|
| API timeout | None (could hang indefinitely) | 3s timeout with Promise.race |
| User abort (Ctrl+C) | Only set recovery flag | Clean up loop state immediately |
| Completion detection | Check ALL assistant messages | Check only LAST assistant message |
| Detection order | API first, then transcript | Transcript first (sync), skip API if found |

## Key Improvements

1. **Timeout protection**: API calls now timeout after 3 seconds, preventing indefinite hangs on slow/unresponsive sessions
2. **User abort handling**: Detects `MessageAbortedError` and cleans up loop state immediately (inspired by OContinue)
3. **Performance optimization**: Only checks the last assistant message for completion promise (same as OContinue approach)
4. **Short-circuit detection**: Checks transcript file first (synchronous) and skips API call if completion already found

## Testing

- Added 5 new tests covering all changes
- All 461 tests pass
- Typecheck passes
- Build succeeds

## Attribution

Patterns inspired by [d3vr/OContinue](https://github.com/d3vr/OContinue) plugin (MIT License).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve ralph-loop reliability and responsiveness by preventing hangs, handling user aborts cleanly, and reducing unnecessary API calls. Adopts transcript-first checks and tighter completion detection for faster loops.

- **Bug Fixes**
  - Add a 3s API timeout (Promise.race) to avoid indefinite waits.
  - On MessageAbortedError (Ctrl+C), clear loop state immediately and skip recovery mode.
  - Check transcript first for the completion promise; skip the API if found.
  - When using the API, only inspect the last assistant message for the promise.
  - Expose apiTimeout option for tuning.

<sup>Written for commit 75f633164d30e3ce5826021af0bb23c70527bdf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

