### PR TITLE
docs: emphasize TDD with RED-GREEN-REFACTOR in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,29 @@ oh-my-opencode/
 | Config schema | `src/config/schema.ts` | Run `bun run build:schema` after |
 | Claude Code compat | `src/features/claude-code-*-loader/` | Command, skill, agent, mcp loaders |
 
+## TDD (Test-Driven Development)
+
+**MANDATORY for new features and bug fixes.** Follow RED-GREEN-REFACTOR:
+
+```
+1. RED    - Write failing test first (test MUST fail)
+2. GREEN  - Write MINIMAL code to pass (nothing more)
+3. REFACTOR - Clean up while tests stay GREEN
+4. REPEAT - Next test case
+```
+
+| Phase | Action | Verification |
+|-------|--------|--------------|
+| **RED** | Write test describing expected behavior | `bun test` → FAIL (expected) |
+| **GREEN** | Implement minimum code to pass | `bun test` → PASS |
+| **REFACTOR** | Improve code quality, remove duplication | `bun test` → PASS (must stay green) |
+
+**Rules:**
+- NEVER write implementation before test
+- NEVER delete failing tests to "pass" - fix the code
+- One test at a time - don't batch
+- Test file naming: `*.test.ts` alongside source
+
 ## CONVENTIONS
 
 - **Bun only**: `bun run`, `bun test`, `bunx` (NEVER npm/npx)
@@ -46,7 +69,7 @@ oh-my-opencode/
 - **Build**: `bun build` (ESM) + `tsc --emitDeclarationOnly`
 - **Exports**: Barrel pattern in index.ts; explicit named exports for tools/hooks
 - **Naming**: kebab-case directories, createXXXHook/createXXXTool factories
-- **Testing**: BDD comments `#given`, `#when`, `#then` (same as AAA)
+- **Testing**: BDD comments `#given`, `#when`, `#then` (same as AAA); TDD workflow (RED-GREEN-REFACTOR)
 - **Temperature**: 0.1 for code agents, max 0.3
 
 ## ANTI-PATTERNS


### PR DESCRIPTION
## Summary

- Add dedicated TDD section to AGENTS.md with RED-GREEN-REFACTOR cycle
- Include verification steps for each phase (RED → FAIL, GREEN → PASS, REFACTOR → PASS)
- Add rules: never write impl before test, never delete failing tests
- Update CONVENTIONS testing line to reference TDD workflow

Resolves #432

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emphasizes test-driven development in AGENTS.md by adding a mandatory RED-GREEN-REFACTOR workflow with clear FAIL/PASS checks and test-first rules.
Updates the Testing conventions to reference TDD.

<sup>Written for commit 754b78105d1b50668ee80e9a984868e8f9b5b6d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

