### PR TITLE
fix(webfetch): apply aggressive truncation for webfetch outputs

### DIFF
--- a/src/hooks/tool-output-truncator.test.ts
+++ b/src/hooks/tool-output-truncator.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, mock, spyOn } from "bun:test"
+import { createToolOutputTruncatorHook } from "./tool-output-truncator"
+import * as dynamicTruncator from "../shared/dynamic-truncator"
+
+describe("createToolOutputTruncatorHook", () => {
+  let hook: ReturnType<typeof createToolOutputTruncatorHook>
+  let truncateSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    truncateSpy = spyOn(dynamicTruncator, "createDynamicTruncator").mockReturnValue({
+      truncate: mock(async (_sessionID: string, output: string, options?: { targetMaxTokens?: number }) => ({
+        result: output,
+        truncated: false,
+        targetMaxTokens: options?.targetMaxTokens,
+      })),
+      getUsage: mock(async () => null),
+      truncateSync: mock(() => ({ result: "", truncated: false })),
+    })
+    hook = createToolOutputTruncatorHook({} as never)
+  })
+
+  describe("tool.execute.after", () => {
+    const createInput = (tool: string) => ({
+      tool,
+      sessionID: "test-session",
+      callID: "test-call-id",
+    })
+
+    const createOutput = (outputText: string) => ({
+      title: "Result",
+      output: outputText,
+      metadata: {},
+    })
+
+    describe("#given webfetch tool", () => {
+      describe("#when output is processed", () => {
+        it("#then should use aggressive truncation limit (10k tokens)", async () => {
+          const truncateMock = mock(async (_sessionID: string, _output: string, options?: { targetMaxTokens?: number }) => ({
+            result: "truncated",
+            truncated: true,
+            targetMaxTokens: options?.targetMaxTokens,
+          }))
+          truncateSpy.mockReturnValue({
+            truncate: truncateMock,
+            getUsage: mock(async () => null),
+            truncateSync: mock(() => ({ result: "", truncated: false })),
+          })
+          hook = createToolOutputTruncatorHook({} as never)
+
+          const input = createInput("webfetch")
+          const output = createOutput("large content")
+
+          await hook["tool.execute.after"](input, output)
+
+          expect(truncateMock).toHaveBeenCalledWith(
+            "test-session",
+            "large content",
+            { targetMaxTokens: 10_000 }
+          )
+        })
+      })
+
+      describe("#when using WebFetch variant", () => {
+        it("#then should also use aggressive truncation limit", async () => {
+          const truncateMock = mock(async (_sessionID: string, _output: string, options?: { targetMaxTokens?: number }) => ({
+            result: "truncated",
+            truncated: true,
+          }))
+          truncateSpy.mockReturnValue({
+            truncate: truncateMock,
+            getUsage: mock(async () => null),
+            truncateSync: mock(() => ({ result: "", truncated: false })),
+          })
+          hook = createToolOutputTruncatorHook({} as never)
+
+          const input = createInput("WebFetch")
+          const output = createOutput("large content")
+
+          await hook["tool.execute.after"](input, output)
+
+          expect(truncateMock).toHaveBeenCalledWith(
+            "test-session",
+            "large content",
+            { targetMaxTokens: 10_000 }
+          )
+        })
+      })
+    })
+
+    describe("#given grep tool", () => {
+      describe("#when output is processed", () => {
+        it("#then should use default truncation limit (50k tokens)", async () => {
+          const truncateMock = mock(async (_sessionID: string, _output: string, options?: { targetMaxTokens?: number }) => ({
+            result: "truncated",
+            truncated: true,
+          }))
+          truncateSpy.mockReturnValue({
+            truncate: truncateMock,
+            getUsage: mock(async () => null),
+            truncateSync: mock(() => ({ result: "", truncated: false })),
+          })
+          hook = createToolOutputTruncatorHook({} as never)
+
+          const input = createInput("grep")
+          const output = createOutput("grep output")
+
+          await hook["tool.execute.after"](input, output)
+
+          expect(truncateMock).toHaveBeenCalledWith(
+            "test-session",
+            "grep output",
+            { targetMaxTokens: 50_000 }
+          )
+        })
+      })
+    })
+
+    describe("#given non-truncatable tool", () => {
+      describe("#when tool is not in TRUNCATABLE_TOOLS list", () => {
+        it("#then should not call truncator", async () => {
+          const truncateMock = mock(async () => ({
+            result: "truncated",
+            truncated: true,
+          }))
+          truncateSpy.mockReturnValue({
+            truncate: truncateMock,
+            getUsage: mock(async () => null),
+            truncateSync: mock(() => ({ result: "", truncated: false })),
+          })
+          hook = createToolOutputTruncatorHook({} as never)
+
+          const input = createInput("Read")
+          const output = createOutput("file content")
+
+          await hook["tool.execute.after"](input, output)
+
+          expect(truncateMock).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe("#given truncate_all_tool_outputs enabled", () => {
+      describe("#when any tool output is processed", () => {
+        it("#then should truncate non-listed tools too", async () => {
+          const truncateMock = mock(async (_sessionID: string, _output: string, options?: { targetMaxTokens?: number }) => ({
+            result: "truncated",
+            truncated: true,
+          }))
+          truncateSpy.mockReturnValue({
+            truncate: truncateMock,
+            getUsage: mock(async () => null),
+            truncateSync: mock(() => ({ result: "", truncated: false })),
+          })
+          hook = createToolOutputTruncatorHook({} as never, {
+            experimental: { truncate_all_tool_outputs: true },
+          })
+
+          const input = createInput("Read")
+          const output = createOutput("file content")
+
+          await hook["tool.execute.after"](input, output)
+
+          expect(truncateMock).toHaveBeenCalled()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #195 - webfetch output was not being truncated when too big.

**Root Cause**: The `DEFAULT_TARGET_MAX_TOKENS` (50k tokens ~200k chars) was too high for webfetch outputs. Most web pages don't exceed this limit, so truncation rarely triggered even for large pages.

**Solution**: Added a more aggressive token limit specifically for webfetch tool (10k tokens ~40k chars).

## Changes

- Add `WEBFETCH_MAX_TOKENS = 10_000` (~40k chars) for aggressive web content truncation
- Introduce `TOOL_SPECIFIC_MAX_TOKENS` map for per-tool limits
- `webfetch`/`WebFetch` now use the aggressive 10k token limit
- Other tools (grep, glob, lsp_*, etc.) continue using default 50k token limit
- Added comprehensive tests for truncation behavior

## Testing

- All 480 tests pass
- Typecheck passes
- Build succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggressively truncates webfetch outputs with a 10k token limit and adds per-tool token caps to prevent oversized tool output. Fixes #195.

- **Bug Fixes**
  - Introduced TOOL_SPECIFIC_MAX_TOKENS and applied it in the truncator.
  - Applied the aggressive cap to webfetch/WebFetch; other tools keep the 50k default.
  - Added tests covering truncation limits and behavior.

<sup>Written for commit 40c7b20e81868b0f07c40d1fc492e2ed1b3b330b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

