### PR TITLE
fix(ultrawork): align planning instruction with Sisyphus design

### DIFF
--- a/src/hooks/keyword-detector/constants.ts
+++ b/src/hooks/keyword-detector/constants.ts
@@ -14,7 +14,7 @@ TELL THE USER WHAT AGENTS YOU WILL LEVERAGE NOW TO SATISFY USER'S REQUEST.
 ## AGENT UTILIZATION PRINCIPLES (by capability, not by name)
 - **Codebase Exploration**: Spawn exploration agents using BACKGROUND TASKS for file patterns, internal implementations, project structure
 - **Documentation & References**: Use librarian-type agents via BACKGROUND TASKS for API references, examples, external library docs
-- **Planning & Strategy**: NEVER plan yourself - ALWAYS spawn a dedicated planning agent for work breakdown
+- **Planning & Strategy**: For implementation tasks, spawn a dedicated planning agent for work breakdown (not needed for simple questions/investigations)
 - **High-IQ Reasoning**: Leverage specialized agents for architecture decisions, code review, strategic planning
 - **Frontend/UI Tasks**: Delegate to UI-specialized agents for design and implementation
 


### PR DESCRIPTION
## Summary

- Fixes inconsistency between ultrawork-mode's planning instruction and Sisyphus's Phase 0 Intent Gate design
- Updated "NEVER plan yourself - ALWAYS spawn a dedicated planning agent" to "For implementation tasks, spawn a dedicated planning agent for work breakdown (not needed for simple questions/investigations)"

## Problem

The ultrawork-mode message was **too absolute** about always spawning a planning agent:

```diff
- **Planning & Strategy**: NEVER plan yourself - ALWAYS spawn a dedicated planning agent for work breakdown
+ **Planning & Strategy**: For implementation tasks, spawn a dedicated planning agent for work breakdown (not needed for simple questions/investigations)
```

This contradicted Sisyphus's nuanced Phase 0 Intent Gate which classifies requests into types:
- **Trivial**: "Direct tools only"
- **Explicit**: "Execute directly"  
- **Exploratory/Open-ended**: May need planning agents

## Solution

Aligned the ultrawork-mode message with:
1. Sisyphus's Phase 0 request classification logic
2. The workflow file (line 168) which already had the correct version
3. The principle that simple questions/investigations don't need planning overhead

## Verification

- [x] Typecheck passes
- [x] Build succeeds
- [x] Pre-existing test failure unrelated to this change (non-interactive-env hook test)

Closes #436

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns ultrawork-mode planning guidance with Sisyphus Phase 0 Intent Gate. Replaces “NEVER plan yourself — ALWAYS spawn...” with “For implementation tasks, spawn a dedicated planning agent for work breakdown (not needed for simple questions/investigations)” to avoid unnecessary planning for simple requests.

<sup>Written for commit 7086e4e1a6ec588100a84523138bed933382c353. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

