### PR TITLE
fix: respect ANTHROPIC_1M_CONTEXT and VERTEX_ANTHROPIC_1M_CONTEXT env vars

### DIFF
--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -1,94 +1,103 @@
-import type { PluginInput } from "@opencode-ai/plugin"
+import type { PluginInput } from "@opencode-ai/plugin";
 
-const ANTHROPIC_DISPLAY_LIMIT = 1_000_000
-const ANTHROPIC_ACTUAL_LIMIT = 200_000
-const CONTEXT_WARNING_THRESHOLD = 0.70
+const ANTHROPIC_DISPLAY_LIMIT = 1_000_000;
+const ANTHROPIC_ACTUAL_LIMIT =
+  process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+  process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+    ? 1_000_000
+    : 200_000;
+const CONTEXT_WARNING_THRESHOLD = 0.7;
 
 const CONTEXT_REMINDER = `[SYSTEM REMINDER - 1M Context Window]
 
 You are using Anthropic Claude with 1M context window.
 You have plenty of context remaining - do NOT rush or skip tasks.
-Complete your work thoroughly and methodically.`
+Complete your work thoroughly and methodically.`;
 
 interface AssistantMessageInfo {
-  role: "assistant"
-  providerID: string
+  role: "assistant";
+  providerID: string;
   tokens: {
-    input: number
-    output: number
-    reasoning: number
-    cache: { read: number; write: number }
-  }
+    input: number;
+    output: number;
+    reasoning: number;
+    cache: { read: number; write: number };
+  };
 }
 
 interface MessageWrapper {
-  info: { role: string } & Partial<AssistantMessageInfo>
+  info: { role: string } & Partial<AssistantMessageInfo>;
 }
 
 export function createContextWindowMonitorHook(ctx: PluginInput) {
-  const remindedSessions = new Set<string>()
+  const remindedSessions = new Set<string>();
 
   const toolExecuteAfter = async (
     input: { tool: string; sessionID: string; callID: string },
-    output: { title: string; output: string; metadata: unknown }
+    output: { title: string; output: string; metadata: unknown },
   ) => {
-    const { sessionID } = input
+    const { sessionID } = input;
 
-    if (remindedSessions.has(sessionID)) return
+    if (remindedSessions.has(sessionID)) return;
 
     try {
       const response = await ctx.client.session.messages({
         path: { id: sessionID },
-      })
+      });
 
-      const messages = (response.data ?? response) as MessageWrapper[]
+      const messages = (response.data ?? response) as MessageWrapper[];
 
       const assistantMessages = messages
         .filter((m) => m.info.role === "assistant")
-        .map((m) => m.info as AssistantMessageInfo)
+        .map((m) => m.info as AssistantMessageInfo);
 
-      if (assistantMessages.length === 0) return
+      if (assistantMessages.length === 0) return;
 
-      const lastAssistant = assistantMessages[assistantMessages.length - 1]
-      if (lastAssistant.providerID !== "anthropic") return
+      const lastAssistant = assistantMessages[assistantMessages.length - 1];
+      if (lastAssistant.providerID !== "anthropic") return;
 
       // Use only the last assistant message's input tokens
       // This reflects the ACTUAL current context window usage (post-compaction)
-      const lastTokens = lastAssistant.tokens
-      const totalInputTokens = (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0)
+      const lastTokens = lastAssistant.tokens;
+      const totalInputTokens =
+        (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0);
 
-      const actualUsagePercentage = totalInputTokens / ANTHROPIC_ACTUAL_LIMIT
+      const actualUsagePercentage = totalInputTokens / ANTHROPIC_ACTUAL_LIMIT;
 
-      if (actualUsagePercentage < CONTEXT_WARNING_THRESHOLD) return
+      if (actualUsagePercentage < CONTEXT_WARNING_THRESHOLD) return;
 
-      remindedSessions.add(sessionID)
+      remindedSessions.add(sessionID);
 
-      const displayUsagePercentage = totalInputTokens / ANTHROPIC_DISPLAY_LIMIT
-      const usedPct = (displayUsagePercentage * 100).toFixed(1)
-      const remainingPct = ((1 - displayUsagePercentage) * 100).toFixed(1)
-      const usedTokens = totalInputTokens.toLocaleString()
-      const limitTokens = ANTHROPIC_DISPLAY_LIMIT.toLocaleString()
+      const displayUsagePercentage = totalInputTokens / ANTHROPIC_DISPLAY_LIMIT;
+      const usedPct = (displayUsagePercentage * 100).toFixed(1);
+      const remainingPct = ((1 - displayUsagePercentage) * 100).toFixed(1);
+      const usedTokens = totalInputTokens.toLocaleString();
+      const limitTokens = ANTHROPIC_DISPLAY_LIMIT.toLocaleString();
 
       output.output += `\n\n${CONTEXT_REMINDER}
-[Context Status: ${usedPct}% used (${usedTokens}/${limitTokens} tokens), ${remainingPct}% remaining]`
+[Context Status: ${usedPct}% used (${usedTokens}/${limitTokens} tokens), ${remainingPct}% remaining]`;
     } catch {
       // Graceful degradation - do not disrupt tool execution
     }
-  }
+  };
 
-  const eventHandler = async ({ event }: { event: { type: string; properties?: unknown } }) => {
-    const props = event.properties as Record<string, unknown> | undefined
+  const eventHandler = async ({
+    event,
+  }: {
+    event: { type: string; properties?: unknown };
+  }) => {
+    const props = event.properties as Record<string, unknown> | undefined;
 
     if (event.type === "session.deleted") {
-      const sessionInfo = props?.info as { id?: string } | undefined
+      const sessionInfo = props?.info as { id?: string } | undefined;
       if (sessionInfo?.id) {
-        remindedSessions.delete(sessionInfo.id)
+        remindedSessions.delete(sessionInfo.id);
       }
     }
-  }
+  };
 
   return {
     "tool.execute.after": toolExecuteAfter,
     event: eventHandler,
-  }
+  };
 }

--- a/src/hooks/preemptive-compaction/index.ts
+++ b/src/hooks/preemptive-compaction/index.ts
@@ -1,125 +1,135 @@
-import { existsSync, readdirSync } from "node:fs"
-import { join } from "node:path"
-import type { PluginInput } from "@opencode-ai/plugin"
-import type { ExperimentalConfig } from "../../config"
-import type { PreemptiveCompactionState, TokenInfo } from "./types"
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import type { PluginInput } from "@opencode-ai/plugin";
+import type { ExperimentalConfig } from "../../config";
+import type { PreemptiveCompactionState, TokenInfo } from "./types";
 import {
   DEFAULT_THRESHOLD,
   MIN_TOKENS_FOR_COMPACTION,
   COMPACTION_COOLDOWN_MS,
-} from "./constants"
+} from "./constants";
 import {
   findNearestMessageWithFields,
   MESSAGE_STORAGE,
-} from "../../features/hook-message-injector"
-import { log } from "../../shared/logger"
+} from "../../features/hook-message-injector";
+import { log } from "../../shared/logger";
 
 export interface SummarizeContext {
-  sessionID: string
-  providerID: string
-  modelID: string
-  usageRatio: number
-  directory: string
+  sessionID: string;
+  providerID: string;
+  modelID: string;
+  usageRatio: number;
+  directory: string;
 }
 
-export type BeforeSummarizeCallback = (ctx: SummarizeContext) => Promise<void> | void
+export type BeforeSummarizeCallback = (
+  ctx: SummarizeContext,
+) => Promise<void> | void;
 
-export type GetModelLimitCallback = (providerID: string, modelID: string) => number | undefined
+export type GetModelLimitCallback = (
+  providerID: string,
+  modelID: string,
+) => number | undefined;
 
 export interface PreemptiveCompactionOptions {
-  experimental?: ExperimentalConfig
-  onBeforeSummarize?: BeforeSummarizeCallback
-  getModelLimit?: GetModelLimitCallback
+  experimental?: ExperimentalConfig;
+  onBeforeSummarize?: BeforeSummarizeCallback;
+  getModelLimit?: GetModelLimitCallback;
 }
 
 interface MessageInfo {
-  id: string
-  role: string
-  sessionID: string
-  providerID?: string
-  modelID?: string
-  tokens?: TokenInfo
-  summary?: boolean
-  finish?: boolean
+  id: string;
+  role: string;
+  sessionID: string;
+  providerID?: string;
+  modelID?: string;
+  tokens?: TokenInfo;
+  summary?: boolean;
+  finish?: boolean;
 }
 
 interface MessageWrapper {
-  info: MessageInfo
+  info: MessageInfo;
 }
 
-const CLAUDE_MODEL_PATTERN = /claude-(opus|sonnet|haiku)/i
-const CLAUDE_DEFAULT_CONTEXT_LIMIT = 200_000
+const CLAUDE_MODEL_PATTERN = /claude-(opus|sonnet|haiku)/i;
+const CLAUDE_DEFAULT_CONTEXT_LIMIT =
+  process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+  process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+    ? 1_000_000
+    : 200_000;
 
 function isSupportedModel(modelID: string): boolean {
-  return CLAUDE_MODEL_PATTERN.test(modelID)
+  return CLAUDE_MODEL_PATTERN.test(modelID);
 }
 
 function getMessageDir(sessionID: string): string | null {
-  if (!existsSync(MESSAGE_STORAGE)) return null
+  if (!existsSync(MESSAGE_STORAGE)) return null;
 
-  const directPath = join(MESSAGE_STORAGE, sessionID)
-  if (existsSync(directPath)) return directPath
+  const directPath = join(MESSAGE_STORAGE, sessionID);
+  if (existsSync(directPath)) return directPath;
 
   for (const dir of readdirSync(MESSAGE_STORAGE)) {
-    const sessionPath = join(MESSAGE_STORAGE, dir, sessionID)
-    if (existsSync(sessionPath)) return sessionPath
+    const sessionPath = join(MESSAGE_STORAGE, dir, sessionID);
+    if (existsSync(sessionPath)) return sessionPath;
   }
 
-  return null
+  return null;
 }
 
 function createState(): PreemptiveCompactionState {
   return {
     lastCompactionTime: new Map(),
     compactionInProgress: new Set(),
-  }
+  };
 }
 
 export function createPreemptiveCompactionHook(
   ctx: PluginInput,
-  options?: PreemptiveCompactionOptions
+  options?: PreemptiveCompactionOptions,
 ) {
-  const experimental = options?.experimental
-  const onBeforeSummarize = options?.onBeforeSummarize
-  const getModelLimit = options?.getModelLimit
-  const enabled = experimental?.preemptive_compaction !== false
-  const threshold = experimental?.preemptive_compaction_threshold ?? DEFAULT_THRESHOLD
+  const experimental = options?.experimental;
+  const onBeforeSummarize = options?.onBeforeSummarize;
+  const getModelLimit = options?.getModelLimit;
+  const enabled = experimental?.preemptive_compaction !== false;
+  const threshold =
+    experimental?.preemptive_compaction_threshold ?? DEFAULT_THRESHOLD;
 
   if (!enabled) {
-    return { event: async () => {} }
+    return { event: async () => {} };
   }
 
-  const state = createState()
+  const state = createState();
 
   const checkAndTriggerCompaction = async (
     sessionID: string,
-    lastAssistant: MessageInfo
+    lastAssistant: MessageInfo,
   ): Promise<void> => {
-    if (state.compactionInProgress.has(sessionID)) return
+    if (state.compactionInProgress.has(sessionID)) return;
 
-    const lastCompaction = state.lastCompactionTime.get(sessionID) ?? 0
-    if (Date.now() - lastCompaction < COMPACTION_COOLDOWN_MS) return
+    const lastCompaction = state.lastCompactionTime.get(sessionID) ?? 0;
+    if (Date.now() - lastCompaction < COMPACTION_COOLDOWN_MS) return;
 
-    if (lastAssistant.summary === true) return
+    if (lastAssistant.summary === true) return;
 
-    const tokens = lastAssistant.tokens
-    if (!tokens) return
+    const tokens = lastAssistant.tokens;
+    if (!tokens) return;
 
-    const modelID = lastAssistant.modelID ?? ""
-    const providerID = lastAssistant.providerID ?? ""
+    const modelID = lastAssistant.modelID ?? "";
+    const providerID = lastAssistant.providerID ?? "";
 
     if (!isSupportedModel(modelID)) {
-      log("[preemptive-compaction] skipping unsupported model", { modelID })
-      return
+      log("[preemptive-compaction] skipping unsupported model", { modelID });
+      return;
     }
 
-    const configLimit = getModelLimit?.(providerID, modelID)
-    const contextLimit = configLimit ?? CLAUDE_DEFAULT_CONTEXT_LIMIT
-    const totalUsed = tokens.input + tokens.cache.read + tokens.output
+    const configLimit = getModelLimit?.(providerID, modelID);
+    const contextLimit = configLimit ?? CLAUDE_DEFAULT_CONTEXT_LIMIT;
+    const totalUsed = tokens.input + tokens.cache.read + tokens.output;
 
-    if (totalUsed < MIN_TOKENS_FOR_COMPACTION) return
+    if (totalUsed < MIN_TOKENS_FOR_COMPACTION) return;
 
-    const usageRatio = totalUsed / contextLimit
+    const usageRatio = totalUsed / contextLimit;
 
     log("[preemptive-compaction] checking", {
       sessionID,
@@ -127,16 +137,16 @@ export function createPreemptiveCompactionHook(
       contextLimit,
       usageRatio: usageRatio.toFixed(2),
       threshold,
-    })
+    });
 
-    if (usageRatio < threshold) return
+    if (usageRatio < threshold) return;
 
-    state.compactionInProgress.add(sessionID)
-    state.lastCompactionTime.set(sessionID, Date.now())
+    state.compactionInProgress.add(sessionID);
+    state.lastCompactionTime.set(sessionID, Date.now());
 
     if (!providerID || !modelID) {
-      state.compactionInProgress.delete(sessionID)
-      return
+      state.compactionInProgress.delete(sessionID);
+      return;
     }
 
     await ctx.client.tui
@@ -148,9 +158,12 @@ export function createPreemptiveCompactionHook(
           duration: 3000,
         },
       })
-      .catch(() => {})
+      .catch(() => {});
 
-    log("[preemptive-compaction] triggering compaction", { sessionID, usageRatio })
+    log("[preemptive-compaction] triggering compaction", {
+      sessionID,
+      usageRatio,
+    });
 
     try {
       if (onBeforeSummarize) {
@@ -160,14 +173,14 @@ export function createPreemptiveCompactionHook(
           modelID,
           usageRatio,
           directory: ctx.directory,
-        })
+        });
       }
 
       await ctx.client.session.summarize({
         path: { id: sessionID },
         body: { providerID, modelID },
         query: { directory: ctx.directory },
-      })
+      });
 
       await ctx.client.tui
         .showToast({
@@ -178,14 +191,16 @@ export function createPreemptiveCompactionHook(
             duration: 2000,
           },
         })
-        .catch(() => {})
+        .catch(() => {});
 
-      state.compactionInProgress.delete(sessionID)
+      state.compactionInProgress.delete(sessionID);
 
       setTimeout(async () => {
         try {
-          const messageDir = getMessageDir(sessionID)
-          const storedMessage = messageDir ? findNearestMessageWithFields(messageDir) : null
+          const messageDir = getMessageDir(sessionID);
+          const storedMessage = messageDir
+            ? findNearestMessageWithFields(messageDir)
+            : null;
 
           await ctx.client.session.promptAsync({
             path: { id: sessionID },
@@ -194,81 +209,93 @@ export function createPreemptiveCompactionHook(
               parts: [{ type: "text", text: "Continue" }],
             },
             query: { directory: ctx.directory },
-          })
+          });
         } catch {}
-      }, 500)
-      return
+      }, 500);
+      return;
     } catch (err) {
-      log("[preemptive-compaction] compaction failed", { sessionID, error: err })
+      log("[preemptive-compaction] compaction failed", {
+        sessionID,
+        error: err,
+      });
     } finally {
-      state.compactionInProgress.delete(sessionID)
+      state.compactionInProgress.delete(sessionID);
     }
-  }
+  };
 
-  const eventHandler = async ({ event }: { event: { type: string; properties?: unknown } }) => {
-    const props = event.properties as Record<string, unknown> | undefined
+  const eventHandler = async ({
+    event,
+  }: {
+    event: { type: string; properties?: unknown };
+  }) => {
+    const props = event.properties as Record<string, unknown> | undefined;
 
     if (event.type === "session.deleted") {
-      const sessionInfo = props?.info as { id?: string } | undefined
+      const sessionInfo = props?.info as { id?: string } | undefined;
       if (sessionInfo?.id) {
-        state.lastCompactionTime.delete(sessionInfo.id)
-        state.compactionInProgress.delete(sessionInfo.id)
+        state.lastCompactionTime.delete(sessionInfo.id);
+        state.compactionInProgress.delete(sessionInfo.id);
       }
-      return
+      return;
     }
 
     if (event.type === "message.updated") {
-      const info = props?.info as MessageInfo | undefined
-      if (!info) return
+      const info = props?.info as MessageInfo | undefined;
+      if (!info) return;
 
-      if (info.role !== "assistant" || !info.finish) return
+      if (info.role !== "assistant" || !info.finish) return;
 
-      const sessionID = info.sessionID
-      if (!sessionID) return
+      const sessionID = info.sessionID;
+      if (!sessionID) return;
 
-      await checkAndTriggerCompaction(sessionID, info)
-      return
+      await checkAndTriggerCompaction(sessionID, info);
+      return;
     }
 
     if (event.type === "session.idle") {
-      const sessionID = props?.sessionID as string | undefined
-      if (!sessionID) return
+      const sessionID = props?.sessionID as string | undefined;
+      if (!sessionID) return;
 
       try {
         const resp = await ctx.client.session.messages({
           path: { id: sessionID },
           query: { directory: ctx.directory },
-        })
+        });
 
-        const messages = (resp.data ?? resp) as MessageWrapper[]
+        const messages = (resp.data ?? resp) as MessageWrapper[];
         const assistants = messages
           .filter((m) => m.info.role === "assistant")
-          .map((m) => m.info)
+          .map((m) => m.info);
 
-        if (assistants.length === 0) return
+        if (assistants.length === 0) return;
 
-        const lastAssistant = assistants[assistants.length - 1]
+        const lastAssistant = assistants[assistants.length - 1];
 
         if (!lastAssistant.providerID || !lastAssistant.modelID) {
-          const messageDir = getMessageDir(sessionID)
-          const storedMessage = messageDir ? findNearestMessageWithFields(messageDir) : null
-          if (storedMessage?.model?.providerID && storedMessage?.model?.modelID) {
-            lastAssistant.providerID = storedMessage.model.providerID
-            lastAssistant.modelID = storedMessage.model.modelID
+          const messageDir = getMessageDir(sessionID);
+          const storedMessage = messageDir
+            ? findNearestMessageWithFields(messageDir)
+            : null;
+          if (
+            storedMessage?.model?.providerID &&
+            storedMessage?.model?.modelID
+          ) {
+            lastAssistant.providerID = storedMessage.model.providerID;
+            lastAssistant.modelID = storedMessage.model.modelID;
             log("[preemptive-compaction] using stored message model info", {
               sessionID,
               providerID: lastAssistant.providerID,
               modelID: lastAssistant.modelID,
-            })
+            });
           }
         }
 
-        await checkAndTriggerCompaction(sessionID, lastAssistant)
+        await checkAndTriggerCompaction(sessionID, lastAssistant);
       } catch {}
     }
-  }
+  };
 
   return {
     event: eventHandler,
-  }
+  };
 }

--- a/src/shared/dynamic-truncator.ts
+++ b/src/shared/dynamic-truncator.ts
@@ -1,127 +1,141 @@
-import type { PluginInput } from "@opencode-ai/plugin"
+import type { PluginInput } from "@opencode-ai/plugin";
 
-const ANTHROPIC_ACTUAL_LIMIT = 200_000
-const CHARS_PER_TOKEN_ESTIMATE = 4
-const DEFAULT_TARGET_MAX_TOKENS = 50_000
+const ANTHROPIC_ACTUAL_LIMIT =
+  process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+  process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+    ? 1_000_000
+    : 200_000;
+const CHARS_PER_TOKEN_ESTIMATE = 4;
+const DEFAULT_TARGET_MAX_TOKENS = 50_000;
 
 interface AssistantMessageInfo {
-  role: "assistant"
+  role: "assistant";
   tokens: {
-    input: number
-    output: number
-    reasoning: number
-    cache: { read: number; write: number }
-  }
+    input: number;
+    output: number;
+    reasoning: number;
+    cache: { read: number; write: number };
+  };
 }
 
 interface MessageWrapper {
-  info: { role: string } & Partial<AssistantMessageInfo>
+  info: { role: string } & Partial<AssistantMessageInfo>;
 }
 
 export interface TruncationResult {
-  result: string
-  truncated: boolean
-  removedCount?: number
+  result: string;
+  truncated: boolean;
+  removedCount?: number;
 }
 
 export interface TruncationOptions {
-  targetMaxTokens?: number
-  preserveHeaderLines?: number
-  contextWindowLimit?: number
+  targetMaxTokens?: number;
+  preserveHeaderLines?: number;
+  contextWindowLimit?: number;
 }
 
 function estimateTokens(text: string): number {
-  return Math.ceil(text.length / CHARS_PER_TOKEN_ESTIMATE)
+  return Math.ceil(text.length / CHARS_PER_TOKEN_ESTIMATE);
 }
 
 export function truncateToTokenLimit(
   output: string,
   maxTokens: number,
-  preserveHeaderLines = 3
+  preserveHeaderLines = 3,
 ): TruncationResult {
-  const currentTokens = estimateTokens(output)
+  const currentTokens = estimateTokens(output);
 
   if (currentTokens <= maxTokens) {
-    return { result: output, truncated: false }
+    return { result: output, truncated: false };
   }
 
-  const lines = output.split("\n")
+  const lines = output.split("\n");
 
   if (lines.length <= preserveHeaderLines) {
-    const maxChars = maxTokens * CHARS_PER_TOKEN_ESTIMATE
+    const maxChars = maxTokens * CHARS_PER_TOKEN_ESTIMATE;
     return {
-      result: output.slice(0, maxChars) + "\n\n[Output truncated due to context window limit]",
+      result:
+        output.slice(0, maxChars) +
+        "\n\n[Output truncated due to context window limit]",
       truncated: true,
-    }
+    };
   }
 
-  const headerLines = lines.slice(0, preserveHeaderLines)
-  const contentLines = lines.slice(preserveHeaderLines)
+  const headerLines = lines.slice(0, preserveHeaderLines);
+  const contentLines = lines.slice(preserveHeaderLines);
 
-  const headerText = headerLines.join("\n")
-  const headerTokens = estimateTokens(headerText)
-  const truncationMessageTokens = 50
-  const availableTokens = maxTokens - headerTokens - truncationMessageTokens
+  const headerText = headerLines.join("\n");
+  const headerTokens = estimateTokens(headerText);
+  const truncationMessageTokens = 50;
+  const availableTokens = maxTokens - headerTokens - truncationMessageTokens;
 
   if (availableTokens <= 0) {
     return {
-      result: headerText + "\n\n[Content truncated due to context window limit]",
+      result:
+        headerText + "\n\n[Content truncated due to context window limit]",
       truncated: true,
       removedCount: contentLines.length,
-    }
+    };
   }
 
-  const resultLines: string[] = []
-  let currentTokenCount = 0
+  const resultLines: string[] = [];
+  let currentTokenCount = 0;
 
   for (const line of contentLines) {
-    const lineTokens = estimateTokens(line + "\n")
+    const lineTokens = estimateTokens(line + "\n");
     if (currentTokenCount + lineTokens > availableTokens) {
-      break
+      break;
     }
-    resultLines.push(line)
-    currentTokenCount += lineTokens
+    resultLines.push(line);
+    currentTokenCount += lineTokens;
   }
 
-  const truncatedContent = [...headerLines, ...resultLines].join("\n")
-  const removedCount = contentLines.length - resultLines.length
+  const truncatedContent = [...headerLines, ...resultLines].join("\n");
+  const removedCount = contentLines.length - resultLines.length;
 
   return {
-    result: truncatedContent + `\n\n[${removedCount} more lines truncated due to context window limit]`,
+    result:
+      truncatedContent +
+      `\n\n[${removedCount} more lines truncated due to context window limit]`,
     truncated: true,
     removedCount,
-  }
+  };
 }
 
 export async function getContextWindowUsage(
   ctx: PluginInput,
-  sessionID: string
-): Promise<{ usedTokens: number; remainingTokens: number; usagePercentage: number } | null> {
+  sessionID: string,
+): Promise<{
+  usedTokens: number;
+  remainingTokens: number;
+  usagePercentage: number;
+} | null> {
   try {
     const response = await ctx.client.session.messages({
       path: { id: sessionID },
-    })
+    });
 
-    const messages = (response.data ?? response) as MessageWrapper[]
+    const messages = (response.data ?? response) as MessageWrapper[];
 
     const assistantMessages = messages
       .filter((m) => m.info.role === "assistant")
-      .map((m) => m.info as AssistantMessageInfo)
+      .map((m) => m.info as AssistantMessageInfo);
 
-    if (assistantMessages.length === 0) return null
+    if (assistantMessages.length === 0) return null;
 
-    const lastAssistant = assistantMessages[assistantMessages.length - 1]
-    const lastTokens = lastAssistant.tokens
-    const usedTokens = (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0)
-    const remainingTokens = ANTHROPIC_ACTUAL_LIMIT - usedTokens
+    const lastAssistant = assistantMessages[assistantMessages.length - 1];
+    const lastTokens = lastAssistant.tokens;
+    const usedTokens =
+      (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0);
+    const remainingTokens = ANTHROPIC_ACTUAL_LIMIT - usedTokens;
 
     return {
       usedTokens,
       remainingTokens,
       usagePercentage: usedTokens / ANTHROPIC_ACTUAL_LIMIT,
-    }
+    };
   } catch {
-    return null
+    return null;
   }
 }
 
@@ -129,36 +143,48 @@ export async function dynamicTruncate(
   ctx: PluginInput,
   sessionID: string,
   output: string,
-  options: TruncationOptions = {}
+  options: TruncationOptions = {},
 ): Promise<TruncationResult> {
-  const { targetMaxTokens = DEFAULT_TARGET_MAX_TOKENS, preserveHeaderLines = 3 } = options
+  const {
+    targetMaxTokens = DEFAULT_TARGET_MAX_TOKENS,
+    preserveHeaderLines = 3,
+  } = options;
 
-  const usage = await getContextWindowUsage(ctx, sessionID)
+  const usage = await getContextWindowUsage(ctx, sessionID);
 
   if (!usage) {
-    return { result: output, truncated: false }
+    return { result: output, truncated: false };
   }
 
-  const maxOutputTokens = Math.min(usage.remainingTokens * 0.5, targetMaxTokens)
+  const maxOutputTokens = Math.min(
+    usage.remainingTokens * 0.5,
+    targetMaxTokens,
+  );
 
   if (maxOutputTokens <= 0) {
     return {
       result: "[Output suppressed - context window exhausted]",
       truncated: true,
-    }
+    };
   }
 
-  return truncateToTokenLimit(output, maxOutputTokens, preserveHeaderLines)
+  return truncateToTokenLimit(output, maxOutputTokens, preserveHeaderLines);
 }
 
 export function createDynamicTruncator(ctx: PluginInput) {
   return {
-    truncate: (sessionID: string, output: string, options?: TruncationOptions) =>
-      dynamicTruncate(ctx, sessionID, output, options),
+    truncate: (
+      sessionID: string,
+      output: string,
+      options?: TruncationOptions,
+    ) => dynamicTruncate(ctx, sessionID, output, options),
 
     getUsage: (sessionID: string) => getContextWindowUsage(ctx, sessionID),
 
-    truncateSync: (output: string, maxTokens: number, preserveHeaderLines?: number) =>
-      truncateToTokenLimit(output, maxTokens, preserveHeaderLines),
-  }
+    truncateSync: (
+      output: string,
+      maxTokens: number,
+      preserveHeaderLines?: number,
+    ) => truncateToTokenLimit(output, maxTokens, preserveHeaderLines),
+  };
 }


### PR DESCRIPTION
## Summary

Fixes hardcoded 200k token limits in compaction logic to respect 1M context environment variables.

## Problem

Previously, the compaction system used hardcoded `200_000` token limits across three files, causing preemptive compaction to trigger at ~140k tokens (70% of 200k) even when `ANTHROPIC_1M_CONTEXT` or `VERTEX_ANTHROPIC_1M_CONTEXT` environment variables were set.

This defeated the purpose of 1M context support, as sessions were compacted prematurely.

## Changes

Updated three files to dynamically use 1M limit when environment variables are set:

1. **`src/hooks/preemptive-compaction/index.ts`**
   - Changed `CLAUDE_DEFAULT_CONTEXT_LIMIT` from hardcoded `200_000` to env-aware check
   - Now uses `1_000_000` when `ANTHROPIC_1M_CONTEXT` or `VERTEX_ANTHROPIC_1M_CONTEXT` is `"true"`

2. **`src/shared/dynamic-truncator.ts`**
   - Changed `ANTHROPIC_ACTUAL_LIMIT` from hardcoded `200_000` to env-aware check
   - Ensures tool output truncation uses correct context limit

3. **`src/hooks/context-window-monitor.ts`**
   - Changed `ANTHROPIC_ACTUAL_LIMIT` from hardcoded `200_000` to env-aware check
   - Ensures accurate usage tracking and percentage display

## Impact

**Before:**
- With 1M context enabled, compaction triggered at ~140k tokens (70% of 200k hardcoded limit)
- Poor utilization of available context window

**After:**
- With 1M context enabled, compaction triggers at ~700k-850k tokens (70-85% of actual 1M limit)
- Proper utilization of full context window
- Default threshold (85%) still configurable via `experimental.preemptive_compaction_threshold`

## Testing

- ✅ Type check passes
- ✅ No breaking changes (backwards compatible - defaults to 200k when env vars not set)
- ✅ Consistent with base opencode implementation

## Related

- Related to anomalyco/opencode#6660 (1M context support)

## Files Changed

- `src/hooks/context-window-monitor.ts` (91 lines modified)
- `src/hooks/preemptive-compaction/index.ts` (247 lines modified)  
- `src/shared/dynamic-truncator.ts` (160 lines modified)

**Total**: 3 files, 280 insertions(+), 218 deletions(-)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes premature compaction by respecting ANTHROPIC_1M_CONTEXT and VERTEX_ANTHROPIC_1M_CONTEXT across compaction, truncation, and usage tracking. When enabled, the system uses the full 1M context window.

- **Bug Fixes**
  - Replaced hardcoded 200k limits with env-aware 1M/200k in preemptive-compaction, dynamic-truncator, and context-window-monitor.
  - Compaction threshold now applies to the actual limit, triggering around 700k–850k tokens with 1M context.
  - Backwards compatible: defaults to 200k when env vars are not set; threshold remains configurable.

<sup>Written for commit 1a39d207eaf4c6e7725a07950013a802ed8b91e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

