### PR TITLE
fix: respect ANTHROPIC_1M_CONTEXT and VERTEX_ANTHROPIC_1M_CONTEXT env vars

### DIFF
--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -1,7 +1,11 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 
 const ANTHROPIC_DISPLAY_LIMIT = 1_000_000
-const ANTHROPIC_ACTUAL_LIMIT = 200_000
+const ANTHROPIC_ACTUAL_LIMIT =
+  process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+  process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+    ? 1_000_000
+    : 200_000
 const CONTEXT_WARNING_THRESHOLD = 0.70
 
 const CONTEXT_REMINDER = `[SYSTEM REMINDER - 1M Context Window]

--- a/src/hooks/preemptive-compaction/index.ts
+++ b/src/hooks/preemptive-compaction/index.ts
@@ -48,7 +48,11 @@ interface MessageWrapper {
 }
 
 const CLAUDE_MODEL_PATTERN = /claude-(opus|sonnet|haiku)/i
-const CLAUDE_DEFAULT_CONTEXT_LIMIT = 200_000
+const CLAUDE_DEFAULT_CONTEXT_LIMIT =
+  process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+  process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+    ? 1_000_000
+    : 200_000
 
 function isSupportedModel(modelID: string): boolean {
   return CLAUDE_MODEL_PATTERN.test(modelID)

--- a/src/shared/dynamic-truncator.ts
+++ b/src/shared/dynamic-truncator.ts
@@ -1,6 +1,10 @@
 import type { PluginInput } from "@opencode-ai/plugin";
 
-const ANTHROPIC_ACTUAL_LIMIT = 200_000;
+const ANTHROPIC_ACTUAL_LIMIT =
+  process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+  process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+    ? 1_000_000
+    : 200_000;
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 const DEFAULT_TARGET_MAX_TOKENS = 50_000;
 


### PR DESCRIPTION
## Summary

Fixes hardcoded 200k token limits in compaction logic to respect 1M context environment variables.

## Problem

Previously, the compaction system used hardcoded `200_000` token limits across three files, causing preemptive compaction to trigger at ~140k tokens (70% of 200k) even when `ANTHROPIC_1M_CONTEXT` or `VERTEX_ANTHROPIC_1M_CONTEXT` environment variables were set.

This defeated the purpose of 1M context support, as sessions were compacted prematurely.

## Changes

Updated three files to dynamically use 1M limit when environment variables are set:

1. **`src/hooks/preemptive-compaction/index.ts`**
   ```typescript
   const CLAUDE_DEFAULT_CONTEXT_LIMIT =
     process.env.ANTHROPIC_1M_CONTEXT === "true" ||
     process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
       ? 1_000_000
       : 200_000;
   ```

2. **`src/shared/dynamic-truncator.ts`**
   ```typescript
   const ANTHROPIC_ACTUAL_LIMIT =
     process.env.ANTHROPIC_1M_CONTEXT === "true" ||
     process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
       ? 1_000_000
       : 200_000;
   ```

3. **`src/hooks/context-window-monitor.ts`**
   ```typescript
   const ANTHROPIC_ACTUAL_LIMIT =
     process.env.ANTHROPIC_1M_CONTEXT === "true" ||
     process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
       ? 1_000_000
       : 200_000;
   ```

## Impact

**Before:**
- With 1M context enabled, compaction triggered at ~140k tokens (70% of 200k hardcoded limit)
- Poor utilization of available context window

**After:**
- With 1M context enabled, compaction triggers at ~700k-850k tokens (70-85% of actual 1M limit)
- Proper utilization of full context window
- Default threshold (85%) still configurable via `experimental.preemptive_compaction_threshold`

## Testing

- ✅ Type check passes
- ✅ No breaking changes (backwards compatible - defaults to 200k when env vars not set)
- ✅ Consistent with base opencode implementation

## Related

- Related to anomalyco/opencode#6660 (1M context support)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect ANTHROPIC_1M_CONTEXT and VERTEX_ANTHROPIC_1M_CONTEXT to use a 1M token limit instead of the hardcoded 200k. This prevents premature compaction and aligns truncation and usage tracking with the actual context window.

- **Bug Fixes**
  - Updated preemptive-compaction, dynamic-truncator, and context-window-monitor to derive limits from env vars (1,000,000 vs 200,000).
  - Compaction now triggers at the correct percentage of the real limit; defaults to 200k when env vars are not set.
  - Backwards compatible with no config changes required.

<sup>Written for commit 80d5af331940112de4f0a2831597c19713ff483e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

