### PR TITLE
feat(lsp): sync LSP catalog with OpenCode

### DIFF
--- a/src/tools/lsp/constants.ts
+++ b/src/tools/lsp/constants.ts
@@ -69,10 +69,21 @@ export const LSP_INSTALL_HINTS: Record<string, string> = {
   php: "npm install -g intelephense",
   dart: "Included with Dart SDK",
   "terraform-ls": "See https://github.com/hashicorp/terraform-ls",
+  terraform: "See https://github.com/hashicorp/terraform-ls",
+  prisma: "npm install -g prisma",
+  "ocaml-lsp": "opam install ocaml-lsp-server",
+  texlab: "See https://github.com/latex-lsp/texlab",
+  dockerfile: "npm install -g dockerfile-language-server-nodejs",
+  gleam: "See https://gleam.run/getting-started/installing/",
+  "clojure-lsp": "See https://clojure-lsp.io/installation/",
+  nixd: "nix profile install nixpkgs#nixd",
+  tinymist: "See https://github.com/Myriad-Dreamin/tinymist",
+  "haskell-language-server": "ghcup install hls",
+  bash: "npm install -g bash-language-server",
 }
 
 // Synced with OpenCode's server.ts
-// https://github.com/sst/opencode/blob/main/packages/opencode/src/lsp/server.ts
+// https://github.com/sst/opencode/blob/dev/packages/opencode/src/lsp/server.ts
 export const BUILTIN_SERVERS: Record<string, Omit<LSPServerConfig, "id">> = {
   typescript: {
     command: ["typescript-language-server", "--stdio"],
@@ -161,6 +172,11 @@ export const BUILTIN_SERVERS: Record<string, Omit<LSPServerConfig, "id">> = {
     command: ["astro-ls", "--stdio"],
     extensions: [".astro"],
   },
+  bash: {
+    command: ["bash-language-server", "start"],
+    extensions: [".sh", ".bash", ".zsh", ".ksh"],
+  },
+  // Keep legacy alias for backward compatibility
   "bash-ls": {
     command: ["bash-language-server", "start"],
     extensions: [".sh", ".bash", ".zsh", ".ksh"],
@@ -185,14 +201,55 @@ export const BUILTIN_SERVERS: Record<string, Omit<LSPServerConfig, "id">> = {
     command: ["dart", "language-server", "--lsp"],
     extensions: [".dart"],
   },
+  terraform: {
+    command: ["terraform-ls", "serve"],
+    extensions: [".tf", ".tfvars"],
+  },
+  // Legacy alias for backward compatibility
   "terraform-ls": {
     command: ["terraform-ls", "serve"],
     extensions: [".tf", ".tfvars"],
   },
+  prisma: {
+    command: ["prisma", "language-server"],
+    extensions: [".prisma"],
+  },
+  "ocaml-lsp": {
+    command: ["ocamllsp"],
+    extensions: [".ml", ".mli"],
+  },
+  texlab: {
+    command: ["texlab"],
+    extensions: [".tex", ".bib"],
+  },
+  dockerfile: {
+    command: ["docker-langserver", "--stdio"],
+    extensions: [".dockerfile"],
+  },
+  gleam: {
+    command: ["gleam", "lsp"],
+    extensions: [".gleam"],
+  },
+  "clojure-lsp": {
+    command: ["clojure-lsp", "listen"],
+    extensions: [".clj", ".cljs", ".cljc", ".edn"],
+  },
+  nixd: {
+    command: ["nixd"],
+    extensions: [".nix"],
+  },
+  tinymist: {
+    command: ["tinymist"],
+    extensions: [".typ", ".typc"],
+  },
+  "haskell-language-server": {
+    command: ["haskell-language-server-wrapper", "--lsp"],
+    extensions: [".hs", ".lhs"],
+  },
 }
 
 // Synced with OpenCode's language.ts
-// https://github.com/sst/opencode/blob/main/packages/opencode/src/lsp/language.ts
+// https://github.com/sst/opencode/blob/dev/packages/opencode/src/lsp/language.ts
 export const EXT_TO_LANG: Record<string, string> = {
   ".abap": "abap",
   ".bat": "bat",
@@ -306,6 +363,14 @@ export const EXT_TO_LANG: Record<string, string> = {
   ".tf": "terraform",
   ".tfvars": "terraform-vars",
   ".hcl": "hcl",
+  ".nix": "nix",
+  ".typ": "typst",
+  ".typc": "typst",
+  ".ets": "typescript",
+  ".lhs": "haskell",
+  ".kt": "kotlin",
+  ".kts": "kotlin",
+  ".prisma": "prisma",
   // Additional extensions not in OpenCode
   ".h": "c",
   ".hpp": "cpp",


### PR DESCRIPTION
## Summary

Syncs the LSP catalog with the original OpenCode repository to ensure feature parity.

## Changes

### New Language Servers
- **prisma**: Prisma schema support (`.prisma`)
- **ocaml-lsp**: OCaml language support (`.ml`, `.mli`)
- **texlab**: LaTeX support (`.tex`, `.bib`)
- **dockerfile**: Dockerfile support (`.dockerfile`)
- **gleam**: Gleam language support (`.gleam`)
- **clojure-lsp**: Clojure support (`.clj`, `.cljs`, `.cljc`, `.edn`)
- **nixd**: Nix language support (`.nix`)
- **tinymist**: Typst support (`.typ`, `.typc`)
- **haskell-language-server**: Haskell support (`.hs`, `.lhs`)

### New Language Extensions
- `.ets` → `typescript`
- `.lhs` → `haskell`
- `.kt`, `.kts` → `kotlin`
- `.nix` → `nix`
- `.typ`, `.typc` → `typst`
- `.prisma` → `prisma`

### Server ID Updates
- Added `bash` as primary ID (kept `bash-ls` as legacy alias for backward compatibility)
- Added `terraform` as primary ID (kept `terraform-ls` as legacy alias for backward compatibility)

### Install Hints
Added install hints for all new servers.

## Verification
- [x] Typecheck passes
- [x] All 500 tests pass

Closes #454

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs our LSP catalog with OpenCode to match supported languages and conventions. Adds new servers, file extension mappings, and aligns server IDs with backward compatibility.

- **New Features**
  - Added servers: prisma, ocaml-lsp, texlab, dockerfile, gleam, clojure-lsp, nixd, tinymist, haskell-language-server.
  - Extended file mappings: .ets→typescript, .lhs→haskell, .kt/.kts→kotlin, .nix→nix, .typ/.typc→typst, .prisma→prisma.
  - Added install hints for the new servers.

- **Refactors**
  - Adopted OpenCode primary IDs: bash and terraform; kept bash-ls and terraform-ls as legacy aliases.

<sup>Written for commit ffbda5fc131e528bac007985a355d2856a4b1e21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

