### PR TITLE
docs: add sponsors Suyeol Jeon (devxoul) and Daewoong An (devwon)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1048,5 +1048,8 @@ OpenCode が Debian / ArchLinux だとしたら、Oh My OpenCode は Ubuntu / [O
 - **Numman Ali** [GitHub](https://github.com/numman-ali) [X](https://x.com/nummanali)
   - 最初のスポンサー
 - **Aaron Iker** [GitHub](https://github.com/aaroniker) [X](https://x.com/aaroniker)
+- **Suyeol Jeon (devxoul)** [GitHub](https://github.com/devxoul)
+  - 私のキャリアをスタートさせてくださった方であり、優れたエージェンティックワークフローをどのように構築できるかについて多大なインスピレーションを与えてくださった方です。優れたチームを作るために優れたシステムをどう設計すべきか多くのことを学び、その学びがこのharnessを作る上で大きな助けとなりました。
+- **Daewoong An (devwon)** [GitHub](https://github.com/devwon)
 
 *素晴らしいヒーロー画像を作成してくれた [@junhoyeo](https://github.com/junhoyeo) に感謝します*

--- a/README.ko.md
+++ b/README.ko.md
@@ -1041,5 +1041,8 @@ OpenCode 를 사용하여 이 프로젝트의 99% 를 작성했습니다. 기능
 - **Numman Ali** [GitHub](https://github.com/numman-ali) [X](https://x.com/nummanali)
   - 첫 번째 스폰서
 - **Aaron Iker** [GitHub](https://github.com/aaroniker) [X](https://x.com/aaroniker)
+- **전수열 (devxoul)** [GitHub](https://github.com/devxoul)
+  - 저의 커리어 시작을 만들어주신분이며, 좋은 에이전틱 워크플로우를 어떻게 만들 수 있을까에 대해 많은 영감을 주신 분입니다. 좋은 팀을 만들기 위해 좋은 시스템을 어떻게 설계 할 수 있을지 많은 배움을 얻었고 그러한 내용들이 이 harness를 만드는데에 큰 도움이 되었습니다.
+- **안대웅 (devwon)** [GitHub](https://github.com/devwon)
 
 *멋진 히어로 이미지를 만들어주신 히어로 [@junhoyeo](https://github.com/junhoyeo) 께 감사드립니다*

--- a/README.md
+++ b/README.md
@@ -1103,5 +1103,8 @@ I have no affiliation with any project or model mentioned here. This is purely p
 - **Numman Ali** [GitHub](https://github.com/numman-ali) [X](https://x.com/nummanali)
   - The first sponsor
 - **Aaron Iker** [GitHub](https://github.com/aaroniker) [X](https://x.com/aaroniker)
+- **Suyeol Jeon (devxoul)** [GitHub](https://github.com/devxoul)
+  - The person who launched my career and inspired me deeply on how to build great agentic workflows. I learned so much about designing great systems to build great teams, and those lessons were instrumental in creating this harness.
+- **Daewoong An (devwon)** [GitHub](https://github.com/devwon)
 
 *Special thanks to [@junhoyeo](https://github.com/junhoyeo) for this amazing hero image.*

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1051,5 +1051,8 @@ Oh My OpenCode 送你重构工具（重命名、代码操作）。
 - **Numman Ali** [GitHub](https://github.com/numman-ali) [X](https://x.com/nummanali)
   - 第一位赞助者
 - **Aaron Iker** [GitHub](https://github.com/aaroniker) [X](https://x.com/aaroniker)
+- **Suyeol Jeon (devxoul)** [GitHub](https://github.com/devxoul)
+  - 他是开启我职业生涯的人，也是在如何构建优秀的代理工作流方面给了我很多启发的人。我从他那里学到了很多关于如何设计好的系统来打造优秀团队的知识，这些经验对开发这个harness起到了巨大的帮助作用。
+- **Daewoong An (devwon)** [GitHub](https://github.com/devwon)
 
 *感谢 [@junhoyeo](https://github.com/junhoyeo) 制作了这张超帅的 hero 图。*


### PR DESCRIPTION
## Summary

- Added **Suyeol Jeon (devxoul)** as a sponsor with a special acknowledgment message translated across all README languages (EN, KO, JA, ZH-CN)
- Added **Daewoong An (devwon)** as a sponsor

## Special Acknowledgment for devxoul

The author wanted to express special thanks to Suyeol Jeon for:
- Launching the author's career
- Providing inspiration on how to build great agentic workflows
- Teaching about designing good systems to build great teams
- These lessons being instrumental in creating this harness

---

🤖 Generated with assistance of [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Suyeol Jeon (devxoul) and Daewoong An (devwon) to the Sponsors section across all README translations, with a special acknowledgment for devxoul. Keeps sponsor credits consistent in EN, KO, JA, and ZH-CN.

<sup>Written for commit 8aadf4316cd04beabadc405281be41d0c64b3b9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

