### PR TITLE
Add support for github copilot for this tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode",
-  "version": "2.12.2",
+  "version": "2.13.0",
   "description": "OpenCode plugin - custom agents (oracle, librarian) and enhanced features",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/agents/copilot-models.ts
+++ b/src/agents/copilot-models.ts
@@ -1,0 +1,170 @@
+/**
+ * GitHub Copilot Model Configuration
+ *
+ * This module defines model mappings for GitHub Copilot LLM subscription.
+ * GitHub Copilot provides access to Claude, GPT, and Gemini models through
+ * a unified subscription, eliminating the need for separate provider accounts.
+ *
+ * Model Selection Strategy:
+ * - Sisyphus (orchestrator): Claude Opus 4.5 for maximum reasoning capability
+ * - Oracle (advisor): GPT-5.2 for strategic analysis and code review
+ * - Librarian (research): Claude Sonnet 4.5 for documentation and OSS research
+ * - Explore (fast search): Claude Haiku 4.5 for blazing fast codebase exploration
+ * - Frontend UI/UX: Gemini 3 Pro for creative UI generation
+ * - Document Writer: Gemini 3 Flash for technical documentation
+ * - Multimodal Looker: Gemini 3 Flash for PDF/image analysis
+ */
+
+/**
+ * Model mapping from provider-specific to GitHub Copilot equivalents.
+ * All models use the "github-copilot/" prefix for routing through Copilot.
+ * 
+ * NOTE: GitHub Copilot uses dots for version numbers (e.g., claude-opus-4.5, not claude-opus-4-5)
+ */
+export const COPILOT_MODEL_MAPPING: Record<string, string> = {
+  // Claude models (Anthropic)
+  "anthropic/claude-opus-4-5": "github-copilot/claude-opus-4.5",
+  "anthropic/claude-sonnet-4-5": "github-copilot/claude-sonnet-4.5",
+  "anthropic/claude-sonnet-4": "github-copilot/claude-sonnet-4",
+  "anthropic/claude-haiku-4-5": "github-copilot/claude-haiku-4.5",
+
+  // GPT models (OpenAI)
+  "openai/gpt-5.2": "github-copilot/gpt-5.2",
+  "openai/gpt-5.1": "github-copilot/gpt-5.1",
+  "openai/gpt-5": "github-copilot/gpt-5",
+  "openai/gpt-5-mini": "github-copilot/gpt-5-mini",
+  "openai/o3": "github-copilot/o3",
+  "openai/o3-mini": "github-copilot/o3-mini",
+
+  // Gemini models (Google)
+  "google/gemini-3-pro-preview": "github-copilot/gemini-3-pro-preview",
+  "google/gemini-3-pro": "github-copilot/gemini-3-pro-preview",
+  "google/gemini-3-flash-preview": "github-copilot/gemini-3-flash-preview",
+  "google/gemini-3-flash": "github-copilot/gemini-3-flash-preview",
+
+  // Free/internal models - map to cheap alternatives
+  "opencode/grok-code": "github-copilot/claude-haiku-4.5",
+}
+
+/**
+ * Default Copilot models for each agent, optimized for their specific use case.
+ * These represent the best model choices when using GitHub Copilot subscription.
+ * 
+ * NOTE: Model names use the exact format from `opencode models github-copilot`
+ */
+export const COPILOT_AGENT_DEFAULTS: Record<string, string> = {
+  // Primary orchestrator - needs maximum reasoning
+  Sisyphus: "github-copilot/claude-opus-4.5",
+
+  // Strategic advisor - GPT excels at logical reasoning
+  oracle: "github-copilot/gpt-5.2",
+
+  // Research and documentation - Sonnet for thorough analysis
+  librarian: "github-copilot/claude-sonnet-4.5",
+
+  // Fast exploration - Haiku for speed, still accurate
+  explore: "github-copilot/claude-haiku-4.5",
+
+  // UI/UX specialist - Gemini's creative strength
+  "frontend-ui-ux-engineer": "github-copilot/gemini-3-pro-preview",
+
+  // Technical writing - Gemini's prose quality
+  "document-writer": "github-copilot/gemini-3-flash-preview",
+
+  // Multimodal analysis - Gemini's vision capability
+  "multimodal-looker": "github-copilot/gemini-3-flash-preview",
+}
+
+/**
+ * Intelligent model switching configuration.
+ * Maps task types to optimal model choices for dynamic selection.
+ */
+export interface ModelSwitchContext {
+  /** Current task category */
+  taskType: "reasoning" | "creative" | "fast" | "multimodal" | "research" | "code"
+  /** Whether deep thinking is needed */
+  requiresThinking: boolean
+  /** Whether speed is prioritized over quality */
+  prioritizeSpeed: boolean
+}
+
+/**
+ * Suggests the optimal Copilot model based on task context.
+ * This enables intelligent model-switching within a session.
+ * 
+ * NOTE: Model names use the exact format from `opencode models github-copilot`
+ */
+export function suggestCopilotModel(context: ModelSwitchContext): string {
+  const { taskType, requiresThinking, prioritizeSpeed } = context
+
+  // Speed-optimized paths
+  if (prioritizeSpeed) {
+    switch (taskType) {
+      case "multimodal":
+        return "github-copilot/gemini-3-flash-preview"
+      case "creative":
+        return "github-copilot/gemini-3-flash-preview"
+      default:
+        return "github-copilot/claude-haiku-4.5"
+    }
+  }
+
+  // Quality-optimized paths
+  switch (taskType) {
+    case "reasoning":
+      return requiresThinking
+        ? "github-copilot/claude-opus-4.5"
+        : "github-copilot/gpt-5.2"
+
+    case "creative":
+      return "github-copilot/gemini-3-pro-preview"
+
+    case "multimodal":
+      return "github-copilot/gemini-3-pro-preview"
+
+    case "research":
+      return "github-copilot/claude-sonnet-4.5"
+
+    case "code":
+      return requiresThinking
+        ? "github-copilot/claude-opus-4.5"
+        : "github-copilot/claude-sonnet-4.5"
+
+    case "fast":
+      return "github-copilot/claude-haiku-4.5"
+
+    default:
+      return "github-copilot/claude-sonnet-4.5"
+  }
+}
+
+/**
+ * Converts a provider-specific model to its Copilot equivalent.
+ * Returns original if no mapping exists.
+ */
+export function toCopilotModel(model: string): string {
+  return COPILOT_MODEL_MAPPING[model] ?? model
+}
+
+/**
+ * Checks if a model is a GitHub Copilot model.
+ */
+export function isCopilotModel(model: string): boolean {
+  return model.startsWith("github-copilot/")
+}
+
+/**
+ * Gets the underlying provider for a Copilot model.
+ * Used for applying correct thinking configurations.
+ */
+export function getCopilotModelProvider(model: string): "anthropic" | "openai" | "google" | null {
+  if (!isCopilotModel(model)) return null
+
+  const modelLower = model.toLowerCase()
+  if (modelLower.includes("claude")) return "anthropic"
+  if (modelLower.includes("gemini")) return "google"
+  if (modelLower.includes("gpt") || modelLower.includes("o1") || modelLower.includes("o3")) {
+    return "openai"
+  }
+  return null
+}

--- a/src/agents/document-writer.ts
+++ b/src/agents/document-writer.ts
@@ -1,7 +1,8 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
+import { COPILOT_AGENT_DEFAULTS } from "./copilot-models"
 
-const DEFAULT_MODEL = "google/gemini-3-flash-preview"
+const DEFAULT_MODEL = COPILOT_AGENT_DEFAULTS["document-writer"]
 
 export const DOCUMENT_WRITER_PROMPT_METADATA: AgentPromptMetadata = {
   category: "specialist",

--- a/src/agents/explore.ts
+++ b/src/agents/explore.ts
@@ -1,7 +1,8 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
+import { COPILOT_AGENT_DEFAULTS } from "./copilot-models"
 
-const DEFAULT_MODEL = "opencode/grok-code"
+const DEFAULT_MODEL = COPILOT_AGENT_DEFAULTS["explore"]
 
 export const EXPLORE_PROMPT_METADATA: AgentPromptMetadata = {
   category: "exploration",

--- a/src/agents/frontend-ui-ux-engineer.ts
+++ b/src/agents/frontend-ui-ux-engineer.ts
@@ -1,7 +1,8 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
+import { COPILOT_AGENT_DEFAULTS } from "./copilot-models"
 
-const DEFAULT_MODEL = "google/gemini-3-pro-preview"
+const DEFAULT_MODEL = COPILOT_AGENT_DEFAULTS["frontend-ui-ux-engineer"]
 
 export const FRONTEND_PROMPT_METADATA: AgentPromptMetadata = {
   category: "specialist",

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -18,5 +18,6 @@ export const builtinAgents: Record<string, AgentConfig> = {
 }
 
 export * from "./types"
+export * from "./copilot-models"
 export { createBuiltinAgents } from "./utils"
 export type { AvailableAgent } from "./sisyphus-prompt-builder"

--- a/src/agents/librarian.ts
+++ b/src/agents/librarian.ts
@@ -1,7 +1,8 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
+import { COPILOT_AGENT_DEFAULTS } from "./copilot-models"
 
-const DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
+const DEFAULT_MODEL = COPILOT_AGENT_DEFAULTS["librarian"]
 
 export const LIBRARIAN_PROMPT_METADATA: AgentPromptMetadata = {
   category: "exploration",

--- a/src/agents/multimodal-looker.ts
+++ b/src/agents/multimodal-looker.ts
@@ -1,7 +1,8 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
+import { COPILOT_AGENT_DEFAULTS } from "./copilot-models"
 
-const DEFAULT_MODEL = "google/gemini-3-flash"
+const DEFAULT_MODEL = COPILOT_AGENT_DEFAULTS["multimodal-looker"]
 
 export const MULTIMODAL_LOOKER_PROMPT_METADATA: AgentPromptMetadata = {
   category: "utility",

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -1,8 +1,9 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentPromptMetadata } from "./types"
 import { isGptModel } from "./types"
+import { COPILOT_AGENT_DEFAULTS } from "./copilot-models"
 
-const DEFAULT_MODEL = "openai/gpt-5.2"
+const DEFAULT_MODEL = COPILOT_AGENT_DEFAULTS["oracle"]
 
 export const ORACLE_PROMPT_METADATA: AgentPromptMetadata = {
   category: "advisor",

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -1,5 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import { isGptModel } from "./types"
+import { COPILOT_AGENT_DEFAULTS } from "./copilot-models"
 import type { AvailableAgent, AvailableTool, AvailableSkill } from "./sisyphus-prompt-builder"
 import {
   buildKeyTriggersSection,
@@ -14,7 +15,7 @@ import {
   categorizeTools,
 } from "./sisyphus-prompt-builder"
 
-const DEFAULT_MODEL = "anthropic/claude-opus-4-5"
+const DEFAULT_MODEL = COPILOT_AGENT_DEFAULTS["Sisyphus"]
 
 const SISYPHUS_ROLE_SECTION = `<Role>
 You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -56,6 +56,14 @@ export function isGptModel(model: string): boolean {
   return model.startsWith("openai/") || model.startsWith("github-copilot/gpt-")
 }
 
+export function isClaudeModel(model: string): boolean {
+  return model.startsWith("anthropic/") || model.includes("claude")
+}
+
+export function isGeminiModel(model: string): boolean {
+  return model.startsWith("google/") || model.includes("gemini")
+}
+
 export type BuiltinAgentName =
   | "Sisyphus"
   | "oracle"

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -2,14 +2,14 @@ import { describe, test, expect } from "bun:test"
 import { createBuiltinAgents } from "./utils"
 
 describe("createBuiltinAgents with model overrides", () => {
-  test("Sisyphus with default model has thinking config", () => {
+  test("Sisyphus with default model has thinking config (Copilot Claude)", () => {
     // #given - no overrides
 
     // #when
     const agents = createBuiltinAgents()
 
-    // #then
-    expect(agents.Sisyphus.model).toBe("anthropic/claude-opus-4-5")
+    // #then - default is now github-copilot/claude-opus-4.5
+    expect(agents.Sisyphus.model).toBe("github-copilot/claude-opus-4.5")
     expect(agents.Sisyphus.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
     expect(agents.Sisyphus.reasoningEffort).toBeUndefined()
   })
@@ -42,14 +42,14 @@ describe("createBuiltinAgents with model overrides", () => {
     expect(agents.Sisyphus.thinking).toBeUndefined()
   })
 
-  test("Oracle with default model has reasoningEffort", () => {
+  test("Oracle with default model has reasoningEffort (Copilot GPT)", () => {
     // #given - no overrides
 
     // #when
     const agents = createBuiltinAgents()
 
-    // #then
-    expect(agents.oracle.model).toBe("openai/gpt-5.2")
+    // #then - default is now github-copilot/gpt-5.2
+    expect(agents.oracle.model).toBe("github-copilot/gpt-5.2")
     expect(agents.oracle.reasoningEffort).toBe("medium")
     expect(agents.oracle.textVerbosity).toBe("high")
     expect(agents.oracle.thinking).toBeUndefined()
@@ -83,5 +83,25 @@ describe("createBuiltinAgents with model overrides", () => {
     // #then
     expect(agents.Sisyphus.model).toBe("github-copilot/gpt-5.2")
     expect(agents.Sisyphus.temperature).toBe(0.5)
+  })
+
+  test("Explore agent uses Copilot Haiku by default", () => {
+    // #given - no overrides
+
+    // #when
+    const agents = createBuiltinAgents()
+
+    // #then - default is now github-copilot/claude-haiku-4.5
+    expect(agents.explore.model).toBe("github-copilot/claude-haiku-4.5")
+  })
+
+  test("Frontend agent uses Copilot Gemini by default", () => {
+    // #given - no overrides
+
+    // #when
+    const agents = createBuiltinAgents()
+
+    // #then - default is now github-copilot/gemini-3-pro-preview
+    expect(agents["frontend-ui-ux-engineer"].model).toBe("github-copilot/gemini-3-pro-preview")
   })
 })


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- Migrates all agents to use GitHub Copilot LLM subscription as the default model provider
- Implements intelligent model-switching based on task type (reasoning, creative, fast, multimodal, research, code)

## Changes

<!-- What was changed and how. List specific modifications. -->

- **New file: `src/agents/copilot-models.ts`** - Centralized GitHub Copilot model configuration with:
  - Model mapping from provider-specific to Copilot equivalents
  - Default agent model assignments optimized per agent purpose
  - `suggestCopilotModel()` function for intelligent model switching
  - Helper functions: `toCopilotModel()`, `isCopilotModel()`, `getCopilotModelProvider()`

- **Updated agent defaults** - All 7 agents now use `github-copilot/` prefixed models:
  | Agent | Old Model | New Model |
  |-------|-----------|-----------|
  | Sisyphus | `anthropic/claude-opus-4-5` | `github-copilot/claude-opus-4.5` |
  | Oracle | `openai/gpt-5.2` | `github-copilot/gpt-5.2` |
  | Librarian | `anthropic/claude-sonnet-4-5` | `github-copilot/claude-sonnet-4.5` |
  | Explore | `opencode/grok-code` | `github-copilot/claude-haiku-4.5` |
  | Frontend | `google/gemini-3-pro-preview` | `github-copilot/gemini-3-pro-preview` |
  | Document Writer | `google/gemini-3-flash-preview` | `github-copilot/gemini-3-flash-preview` |
  | Multimodal | `google/gemini-3-flash` | `github-copilot/gemini-3-flash-preview` |

- **Updated `src/agents/types.ts`** - Added `isClaudeModel()` and `isGeminiModel()` helper functions

- **Updated `src/agents/index.ts`** - Exports new `copilot-models` module

- **Version bump** - `2.12.2` → `2.13.0`

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

N/A - Configuration change, no UI modifications.

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test src/agents
bun run build
```

All 8 agent tests pass, confirming:
- Sisyphus uses `github-copilot/claude-opus-4.5` with thinking config
- Oracle uses `github-copilot/gpt-5.2` with reasoningEffort
- Explore uses `github-copilot/claude-haiku-4.5`
- Frontend uses `github-copilot/gemini-3-pro-preview`
- Model overrides still work correctly
- GPT/Claude detection functions properly for thinking/reasoning config

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches all agents to GitHub Copilot models and adds smart model switching by task type. This unifies model provider usage and picks better defaults per agent.

- **New Features**
  - Added src/agents/copilot-models.ts with provider→Copilot mapping and helpers (toCopilotModel, isCopilotModel, getCopilotModelProvider).
  - Introduced suggestCopilotModel() for dynamic selection across reasoning, creative, fast, multimodal, research, and code tasks.
  - Updated agent defaults to github-copilot/* equivalents (e.g., Sisyphus=claude-opus-4.5, Oracle=gpt-5.2, Explore=claude-haiku-4.5, Frontend=gemini-3-pro-preview).
  - Added isClaudeModel and isGeminiModel in types.ts; exported copilot-models from index.ts.
  - Updated tests for new defaults; version bump to 2.13.0.

<sup>Written for commit 6351f91651039139049999eb555d7618ca946953. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

