### PR TITLE
feat(todo-continuation-enforcer): include remaining todo list in system reminder

### DIFF
--- a/src/hooks/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer.test.ts
@@ -407,6 +407,59 @@ describe("todo-continuation-enforcer", () => {
     
     // Should NOT include completed task
     expect(promptText).not.toContain("Update documentation")
+    
+    // Should include status indicators (🔄 for in_progress, ⏳ for pending)
+    expect(promptText).toContain("🔄")
+    expect(promptText).toContain("⏳")
+    
+    // Should include priority labels with correct format
+    expect(promptText).toContain("[HIGH]")
+    expect(promptText).toContain("[MED]")
+    
+    // Should have complete formatted entries
+    expect(promptText).toContain("🔄 [MED] Add unit tests")
+    expect(promptText).toContain("⏳ [HIGH] Fix authentication bug")
+    expect(promptText).toContain("⏳ [HIGH] Review code changes")
+  })
+
+  test("should handle undefined priority gracefully", async () => {
+    // #given - session with todos that have undefined/missing priority
+    const sessionID = "main-undefined-priority"
+    setMainSession(sessionID)
+
+    const mockInput = createMockPluginInput()
+    mockInput.client.session.todo = async () => ({ data: [
+      { id: "1", content: "Task with no priority", status: "pending", priority: undefined },
+      { id: "2", content: "Task with null priority", status: "pending", priority: null },
+      { id: "3", content: "Task with empty priority", status: "in_progress", priority: "" },
+      { id: "4", content: "Normal high priority", status: "pending", priority: "high" },
+    ]})
+
+    const hook = createTodoContinuationEnforcer(mockInput, {
+      backgroundManager: createMockBackgroundManager(false),
+    })
+
+    // #when - session goes idle and countdown completes
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
+    await new Promise(r => setTimeout(r, 2500))
+
+    // #then - should handle undefined priority with [NONE] label
+    expect(promptCalls.length).toBe(1)
+    const promptText = promptCalls[0].text
+    
+    // Should contain all tasks
+    expect(promptText).toContain("Task with no priority")
+    expect(promptText).toContain("Task with null priority")
+    expect(promptText).toContain("Task with empty priority")
+    expect(promptText).toContain("Normal high priority")
+    
+    // Should have [NONE] for undefined/null/empty priorities
+    expect(promptText).toContain("[NONE]")
+    
+    // Should still have [HIGH] for the normal priority task
+    expect(promptText).toContain("[HIGH]")
   })
 
   test("should not have 10s throttle between injections", async () => {

--- a/src/hooks/todo-continuation-enforcer.ts
+++ b/src/hooks/todo-continuation-enforcer.ts
@@ -95,7 +95,14 @@ function formatRemainingTodos(todos: Todo[]): string {
   
   const lines = incompleteTodos.map((todo, idx) => {
     const statusIndicator = todo.status === "in_progress" ? "🔄" : "⏳"
-    const priorityLabel = todo.priority === "high" ? "[HIGH]" : todo.priority === "medium" ? "[MED]" : "[LOW]"
+    const priorityLabel =
+      todo.priority === "high"
+        ? "[HIGH]"
+        : todo.priority === "medium"
+          ? "[MED]"
+          : todo.priority === "low"
+            ? "[LOW]"
+            : "[NONE]"
     return `  ${idx + 1}. ${statusIndicator} ${priorityLabel} ${todo.content}`
   })
   


### PR DESCRIPTION
## Summary

- Enhanced the todo continuation system reminder to display the actual remaining todos with content, status, and priority
- Previously only showed: `[Status: 1/4 completed, 3 remaining]`
- Now shows the full task list for better agent context

## New Format

```
[Status: 2/8 completed, 6 remaining]

Remaining Tasks:
  1. 🔄 [HIGH] Implement login endpoint
  2. ⏳ [HIGH] Add password hashing utility
  3. ⏳ [MED] Implement token validation middleware
  4. ⏳ [MED] Add auth tests - login success case
  5. ⏳ [LOW] Add auth tests - login failure case
  6. ⏳ [LOW] Update API documentation
```

## Changes

- Added `getIncompleteTodos()` helper function
- Added `formatRemainingTodos()` to format todos with status indicators (🔄/⏳) and priority labels ([HIGH]/[MED]/[LOW])
- Updated prompt generation to include formatted todo list
- Added test case to verify the new format

## Testing

- All 23 tests pass
- TypeScript compilation passes
- Manually verified in local OpenCode instance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The continuation system reminder now lists the actual remaining todos with content, status icons, and priority labels for better context. It also handles missing priorities with a [NONE] label.

- **New Features**
  - Added a "Remaining Tasks" section to the prompt with 🔄/⏳ status icons and [HIGH]/[MED]/[LOW] priority labels.
  - Introduced getIncompleteTodos and formatRemainingTodos helpers and integrated them into prompt generation.

- **Bug Fixes**
  - Show [NONE] for undefined/null/empty priorities and added tests to verify labels and formatting (excluding completed tasks).

<sup>Written for commit 8a56ecacc614a315594ab77e372ee57fc10e79b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

