### PR TITLE
docs: add plugins and plugins_override toggle documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,8 @@ Disable specific Claude Code compatibility features with the `claude_code` confi
     "commands": false,
     "skills": false,
     "agents": false,
-    "hooks": false
+    "hooks": false,
+    "plugins": false
   }
 }
 ```
@@ -699,8 +700,24 @@ Disable specific Claude Code compatibility features with the `claude_code` confi
 | `skills`   | `~/.claude/skills/*/SKILL.md`, `./.claude/skills/*/SKILL.md`                          | -                                                     |
 | `agents`   | `~/.claude/agents/*.md`, `./.claude/agents/*.md`                                      | Built-in agents (oracle, librarian, etc.)             |
 | `hooks`    | `~/.claude/settings.json`, `./.claude/settings.json`, `./.claude/settings.local.json` | -                                                     |
+| `plugins`  | `~/.claude/plugins/` (Claude Code marketplace plugins)                                | -                                                     |
 
 All toggles default to `true` (enabled). Omit the `claude_code` object for full Claude Code compatibility.
+
+**Selectively disable specific plugins** using `plugins_override`:
+
+```json
+{
+  "claude_code": {
+    "plugins_override": {
+      "claude-mem@thedotmack": false,
+      "some-other-plugin@marketplace": false
+    }
+  }
+}
+```
+
+This allows you to keep the plugin system enabled while disabling specific plugins by their full identifier (`plugin-name@marketplace-name`).
 
 ### Not Just for the Agents
 


### PR DESCRIPTION
## Summary

- Add documentation for the `plugins` toggle option in `claude_code` config
- Add documentation for the `plugins_override` option to selectively disable specific plugins
- Update the compatibility toggles table to include the new `plugins` option

## Problem

The `plugins` and `plugins_override` configuration options were supported by the codebase but not documented in the README. Users had no way to know how to:

1. Disable all Claude Code marketplace plugins
2. Selectively disable specific plugins while keeping others enabled

## Solution

Added the missing documentation to the "Compatibility Toggles" section, including:

- The `plugins: false` option in the example JSON
- A new row in the toggles table explaining what `plugins` controls
- A new section showing how to use `plugins_override` with specific plugin identifiers

## Testing

Documentation-only change, no code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for the plugins and plugins_override options in the claude_code config so users can disable all marketplace plugins or selectively turn off specific ones. Updates the compatibility toggles table and example JSON to include plugins.

<sup>Written for commit c7e05eeb617a86d0209270c7dbea915211e250d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

