### PR TITLE
feat(mcp): add answeroverflow MCP for Discord community Q&A search

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -15,7 +15,8 @@
         "enum": [
           "websearch_exa",
           "context7",
-          "grep_app"
+          "grep_app",
+          "answeroverflow"
         ]
       }
     },

--- a/src/cli/doctor/checks/mcp.test.ts
+++ b/src/cli/doctor/checks/mcp.test.ts
@@ -9,12 +9,13 @@ describe("mcp check", () => {
       const servers = mcp.getBuiltinMcpInfo()
 
       // #then should include expected servers
-      expect(servers.length).toBe(3)
+      expect(servers.length).toBe(4)
       expect(servers.every((s) => s.type === "builtin")).toBe(true)
       expect(servers.every((s) => s.enabled === true)).toBe(true)
       expect(servers.map((s) => s.id)).toContain("context7")
       expect(servers.map((s) => s.id)).toContain("websearch_exa")
       expect(servers.map((s) => s.id)).toContain("grep_app")
+      expect(servers.map((s) => s.id)).toContain("answeroverflow")
     })
   })
 
@@ -37,7 +38,7 @@ describe("mcp check", () => {
 
       // #then should pass
       expect(result.status).toBe("pass")
-      expect(result.message).toContain("3")
+      expect(result.message).toContain("4")
       expect(result.message).toContain("enabled")
     })
 
@@ -50,6 +51,7 @@ describe("mcp check", () => {
       expect(result.details?.some((d) => d.includes("context7"))).toBe(true)
       expect(result.details?.some((d) => d.includes("websearch_exa"))).toBe(true)
       expect(result.details?.some((d) => d.includes("grep_app"))).toBe(true)
+      expect(result.details?.some((d) => d.includes("answeroverflow"))).toBe(true)
     })
   })
 

--- a/src/cli/doctor/checks/mcp.ts
+++ b/src/cli/doctor/checks/mcp.ts
@@ -5,7 +5,7 @@ import type { CheckResult, CheckDefinition, McpServerInfo } from "../types"
 import { CHECK_IDS, CHECK_NAMES } from "../constants"
 import { parseJsonc } from "../../../shared"
 
-const BUILTIN_MCP_SERVERS = ["context7", "websearch_exa", "grep_app"]
+const BUILTIN_MCP_SERVERS = ["context7", "websearch_exa", "grep_app", "answeroverflow"]
 
 const MCP_CONFIG_PATHS = [
   join(homedir(), ".claude", ".mcp.json"),

--- a/src/mcp/answeroverflow.ts
+++ b/src/mcp/answeroverflow.ts
@@ -1,0 +1,5 @@
+export const answeroverflow = {
+  type: "remote" as const,
+  url: "https://answeroverflow.com/mcp",
+  enabled: true,
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,6 +1,7 @@
 import { websearch_exa } from "./websearch-exa"
 import { context7 } from "./context7"
 import { grep_app } from "./grep-app"
+import { answeroverflow } from "./answeroverflow"
 import type { McpName } from "./types"
 
 export { McpNameSchema, type McpName } from "./types"
@@ -9,6 +10,7 @@ const allBuiltinMcps: Record<McpName, { type: "remote"; url: string; enabled: bo
   websearch_exa,
   context7,
   grep_app,
+  answeroverflow,
 }
 
 export function createBuiltinMcps(disabledMcps: McpName[] = []) {

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
 
-export const McpNameSchema = z.enum(["websearch_exa", "context7", "grep_app"])
+export const McpNameSchema = z.enum(["websearch_exa", "context7", "grep_app", "answeroverflow"])
 
 export type McpName = z.infer<typeof McpNameSchema>


### PR DESCRIPTION
👋 Hey just recently started using oh-my-opencode & thought it'd be useful to add https://answeroverflow.com/mcp as a default MCP 

It indexes content from developer Discord servers, similar vein to context7 but allows for the agent to get up to date information about problems people are running into. I develop with it a lot locally and find it useful - fair disclosure I develop Answer Overflow so feel free to reject this one if it seems self promotey / doesn't seem helpful but I think it's good for the agents 

Tested locally by building oh-my-opencode & using it as a plugin, let me know if there's any MCP tweaks requested also 


======= AI Generated Summary Below =======

## Summary

- Add [answeroverflow.com](https://answeroverflow.com) MCP integration for searching indexed Discord community discussions
- Provides access to real developer Q&A from Discord servers

## Tools Provided

| Tool | Description |
|------|-------------|
| `answeroverflow_search_answeroverflow` | Search across all indexed Discord communities |
| `answeroverflow_search_servers` | Discover indexed Discord servers |
| `answeroverflow_get_thread_messages` | Get full thread context |
| `answeroverflow_find_similar_threads` | Find related discussions |

## Changes

- `src/mcp/answeroverflow.ts` - New MCP config pointing to `https://answeroverflow.com/mcp`
- `src/mcp/types.ts` - Added `answeroverflow` to `McpNameSchema`
- `src/mcp/index.ts` - Import and register in `allBuiltinMcps`
- `src/cli/doctor/checks/mcp.ts` - Added to `BUILTIN_MCP_SERVERS`
- `src/cli/doctor/checks/mcp.test.ts` - Updated test assertions (3→4 servers)
- `assets/oh-my-opencode.schema.json` - Regenerated

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] MCP tests pass (8/8)
- [x] Verified all 4 tools work via direct invocation

## Usage

Disable via config if needed:
```json
{
  "disabled_mcps": ["answeroverflow"]
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Answer Overflow MCP to search indexed Discord community Q&A directly from the app. It’s enabled by default and expands builtin MCP coverage.

- New Features
  - New remote MCP at https://answeroverflow.com/mcp with four tools: search discussions, discover servers, get thread messages, find similar threads.
  - Registered as a builtin; doctor check and tests updated to expect 4 builtin servers.
  - Updated schema and types to include "answeroverflow". Disable via config: disabled_mcps: ["answeroverflow"].

<sup>Written for commit 09872fc0cb20454c09c0d01cad64fed72275c91b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
