### PR TITLE
feat(hooks): add comment-checker gating to skip unnecessary CLI calls

### DIFF
--- a/src/hooks/claude-code-hooks/post-tool-use.ts
+++ b/src/hooks/claude-code-hooks/post-tool-use.ts
@@ -155,7 +155,8 @@ export async function executePostToolUseHooks(
                 systemMessage: output.systemMessage,
               }
             }
-          } catch {
+          } catch (e) {
+            log("PostToolUse", `Failed to parse hook output: ${e}`)
           }
         } else if (result.exitCode !== 0 && result.exitCode !== 2) {
           try {

--- a/src/hooks/claude-code-hooks/post-tool-use.ts
+++ b/src/hooks/claude-code-hooks/post-tool-use.ts
@@ -156,7 +156,7 @@ export async function executePostToolUseHooks(
               }
             }
           } catch (e) {
-            log("PostToolUse", `Failed to parse hook output: ${e}`)
+            log(`PostToolUse: Failed to parse hook output: ${e}`)
           }
         } else if (result.exitCode !== 0 && result.exitCode !== 2) {
           try {

--- a/src/hooks/comment-checker/index.test.ts
+++ b/src/hooks/comment-checker/index.test.ts
@@ -1,0 +1,39 @@
+import { shouldRunCommentChecker } from "./index"
+
+describe("comment-checker gating", () => {
+  it("#then returns true when content includes line comments", () => {
+    expect(
+      shouldRunCommentChecker({
+        filePath: "/tmp/example.ts",
+        content: "const x = 1 // comment",
+        tool: "write",
+        sessionID: "s1",
+        timestamp: Date.now(),
+      })
+    ).toBe(true)
+  })
+
+  it("#then returns true when edits include hash comments", () => {
+    expect(
+      shouldRunCommentChecker({
+        filePath: "/tmp/example.py",
+        edits: [{ old_string: "a", new_string: "# comment" }],
+        tool: "multiedit",
+        sessionID: "s1",
+        timestamp: Date.now(),
+      })
+    ).toBe(true)
+  })
+
+  it("#then returns false when no comment markers are present", () => {
+    expect(
+      shouldRunCommentChecker({
+        filePath: "/tmp/example.ts",
+        newString: "const value = 2",
+        tool: "edit",
+        sessionID: "s1",
+        timestamp: Date.now(),
+      })
+    ).toBe(false)
+  })
+})

--- a/src/hooks/comment-checker/index.ts
+++ b/src/hooks/comment-checker/index.ts
@@ -20,7 +20,7 @@ function debugLog(...args: unknown[]) {
 const pendingCalls = new Map<string, PendingCall>()
 const PENDING_CALL_TTL = 60_000
 
-const COMMENT_MARKERS = ["//", "/*", "*/", "#", "<!--", "-->", "'''", "\"\"\""]
+const COMMENT_MARKERS = ["//", "/*", "*/", "#", "<!--", "-->", "'''", "\"\"\"", "--"]
 
 function hasCommentMarkers(value?: string): boolean {
   if (!value) {

--- a/src/hooks/comment-checker/index.ts
+++ b/src/hooks/comment-checker/index.ts
@@ -20,6 +20,32 @@ function debugLog(...args: unknown[]) {
 const pendingCalls = new Map<string, PendingCall>()
 const PENDING_CALL_TTL = 60_000
 
+const COMMENT_MARKERS = ["//", "/*", "*/", "#", "<!--", "-->", "'''", "\"\"\""]
+
+function hasCommentMarkers(value?: string): boolean {
+  if (!value) {
+    return false
+  }
+
+  return COMMENT_MARKERS.some((marker) => value.includes(marker))
+}
+
+export function shouldRunCommentChecker(pendingCall: PendingCall): boolean {
+  if (hasCommentMarkers(pendingCall.content)) {
+    return true
+  }
+
+  if (hasCommentMarkers(pendingCall.oldString) || hasCommentMarkers(pendingCall.newString)) {
+    return true
+  }
+
+  if (pendingCall.edits) {
+    return pendingCall.edits.some((edit) => hasCommentMarkers(edit.old_string) || hasCommentMarkers(edit.new_string))
+  }
+
+  return false
+}
+
 let cliPathPromise: Promise<string | null> | null = null
 let cleanupIntervalStarted = false
 
@@ -126,7 +152,11 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
           return
         }
         
-        // CLI mode only
+        if (!shouldRunCommentChecker(pendingCall)) {
+          debugLog("skipping comment check - no comment markers detected")
+          return
+        }
+
         debugLog("using CLI:", cliPath)
         await processWithCli(input, pendingCall, output, cliPath, config?.custom_prompt)
       } catch (err) {

--- a/src/hooks/comment-checker/index.ts
+++ b/src/hooks/comment-checker/index.ts
@@ -20,7 +20,7 @@ function debugLog(...args: unknown[]) {
 const pendingCalls = new Map<string, PendingCall>()
 const PENDING_CALL_TTL = 60_000
 
-const COMMENT_MARKERS = ["//", "/*", "*/", "#", "<!--", "-->", "'''", "\"\"\"", "--"]
+const COMMENT_MARKERS = ["//", "/*", "*/", "#", "<!--", "-->", "'''", "\"\"\"", "-- "]
 
 function hasCommentMarkers(value?: string): boolean {
   if (!value) {

--- a/src/hooks/comment-checker/index.ts
+++ b/src/hooks/comment-checker/index.ts
@@ -20,7 +20,9 @@ function debugLog(...args: unknown[]) {
 const pendingCalls = new Map<string, PendingCall>()
 const PENDING_CALL_TTL = 60_000
 
-const COMMENT_MARKERS = ["//", "/*", "*/", "#", "<!--", "-->", "'''", "\"\"\"", "-- "]
+// "--" may match CLI args (--help), but false positives are acceptable for gating.
+// False negatives (missing Lua/Haskell/Ada comments like --comment) are worse.
+const COMMENT_MARKERS = ["//", "/*", "*/", "#", "<!--", "-->", "'''", "\"\"\"", "--"]
 
 function hasCommentMarkers(value?: string): boolean {
   if (!value) {


### PR DESCRIPTION
# feat(hooks): add comment-checker gating to skip unnecessary CLI calls

- Add shouldRunCommentChecker() to detect comment markers in content
- Skip CLI execution when no comment-bearing content detected
- Reduce blocking latency for edits without comments

## Summary

- Add content-based gating to skip comment-checker CLI when no comment markers present
- Reduce unnecessary blocking latency for edits/writes that don't contain comments

## Changes

- `src/hooks/comment-checker/index.ts`: Added `shouldRunCommentChecker()` with `COMMENT_MARKERS` detection, integrated gating into `processWithCli()` flow
- `src/hooks/comment-checker/index.test.ts`: Added unit tests for gating behavior

## Testing

```bash
bun run typecheck
bun test src/hooks/comment-checker/index.test.ts
```

## Related Issues

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the comment-checker only when content or edits contain comment markers, skipping the CLI to reduce latency for non-comment edits.

- **New Features**
  - Added shouldRunCommentChecker to detect //, /* */, #, <!-- -->, ''', """, and --.
  - Integrated gating before invoking the CLI to return early when no markers are found.
  - Added unit tests for content, edits, and no-marker cases.

- **Bug Fixes**
  - Log errors when parsing post-tool-use hook output fails.

<sup>Written for commit abb7e19e24fb38699ac4bb5590a5ff303c52982e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

