### PR TITLE
fix(session-recovery): add fallbacks for tool_result_missing and thinking_block_order

### DIFF
--- a/src/hooks/session-recovery/index.ts
+++ b/src/hooks/session-recovery/index.ts
@@ -122,6 +122,12 @@ function extractMessageIndex(error: unknown): number | null {
   return match ? parseInt(match[1], 10) : null
 }
 
+function extractToolUseIdsFromError(error: unknown): string[] {
+  const message = getErrorMessage(error)
+  const matches = message.match(/toolu_[a-zA-Z0-9]+/g)
+  return matches ? [...new Set(matches)] : []
+}
+
 export function detectErrorType(error: unknown): RecoveryErrorType {
   const message = getErrorMessage(error)
 
@@ -155,7 +161,8 @@ function extractToolUseIds(parts: MessagePart[]): string[] {
 async function recoverToolResultMissing(
   client: Client,
   sessionID: string,
-  failedAssistantMsg: MessageData
+  failedAssistantMsg: MessageData,
+  error?: unknown
 ): Promise<boolean> {
   // Try API parts first, fallback to filesystem if empty
   let parts = failedAssistantMsg.parts || []
@@ -168,7 +175,12 @@ async function recoverToolResultMissing(
       input: "state" in p ? (p as { state?: { input?: Record<string, unknown> } }).state?.input : undefined,
     }))
   }
-  const toolUseIds = extractToolUseIds(parts)
+  let toolUseIds = extractToolUseIds(parts)
+
+  // Fallback: extract tool_use IDs directly from error message
+  if (toolUseIds.length === 0 && error) {
+    toolUseIds = extractToolUseIdsFromError(error)
+  }
 
   if (toolUseIds.length === 0) {
     return false
@@ -196,7 +208,7 @@ async function recoverToolResultMissing(
 async function recoverThinkingBlockOrder(
   _client: Client,
   sessionID: string,
-  _failedAssistantMsg: MessageData,
+  failedAssistantMsg: MessageData,
   _directory: string,
   error: unknown
 ): Promise<boolean> {
@@ -205,6 +217,14 @@ async function recoverThinkingBlockOrder(
     const targetMessageID = findMessageByIndexNeedingThinking(sessionID, targetIndex)
     if (targetMessageID) {
       return prependThinkingPart(sessionID, targetMessageID)
+    }
+  }
+
+  // Fallback: try using the failed message ID directly
+  const failedMsgId = failedAssistantMsg.info?.id
+  if (failedMsgId) {
+    if (prependThinkingPart(sessionID, failedMsgId)) {
+      return true
     }
   }
 
@@ -392,7 +412,7 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
       let success = false
 
       if (errorType === "tool_result_missing") {
-        success = await recoverToolResultMissing(ctx.client, sessionID, failedMsg)
+        success = await recoverToolResultMissing(ctx.client, sessionID, failedMsg, info.error)
       } else if (errorType === "thinking_block_order") {
         success = await recoverThinkingBlockOrder(ctx.client, sessionID, failedMsg, ctx.directory, info.error)
         if (success && experimental?.auto_resume) {

--- a/src/hooks/session-recovery/storage.ts
+++ b/src/hooks/session-recovery/storage.ts
@@ -370,20 +370,34 @@ export function findMessagesWithEmptyTextParts(sessionID: string): string[] {
 export function findMessageByIndexNeedingThinking(sessionID: string, targetIndex: number): string | null {
   const messages = readMessages(sessionID)
 
-  if (targetIndex < 0 || targetIndex >= messages.length) return null
+  // API index may differ from storage index due to system messages
+  const indicesToTry = [
+    targetIndex,
+    targetIndex - 1,
+    targetIndex + 1,
+    targetIndex - 2,
+    targetIndex + 2,
+    targetIndex - 3,
+    targetIndex - 4,
+    targetIndex - 5,
+  ]
 
-  const targetMsg = messages[targetIndex]
-  if (targetMsg.role !== "assistant") return null
+  for (const idx of indicesToTry) {
+    if (idx < 0 || idx >= messages.length) continue
 
-  const parts = readParts(targetMsg.id)
-  if (parts.length === 0) return null
+    const targetMsg = messages[idx]
+    if (targetMsg.role !== "assistant") continue
 
-  const sortedParts = [...parts].sort((a, b) => a.id.localeCompare(b.id))
-  const firstPart = sortedParts[0]
-  const firstIsThinking = THINKING_TYPES.has(firstPart.type)
+    const parts = readParts(targetMsg.id)
+    if (parts.length === 0) continue
 
-  if (!firstIsThinking) {
-    return targetMsg.id
+    const sortedParts = [...parts].sort((a, b) => a.id.localeCompare(b.id))
+    const firstPart = sortedParts[0]
+    const firstIsThinking = THINKING_TYPES.has(firstPart.type)
+
+    if (!firstIsThinking) {
+      return targetMsg.id
+    }
   }
 
   return null


### PR DESCRIPTION
## Summary
- Add error parameter to `recoverToolResultMissing` and extract tool_use IDs from error message as fallback
- Add multiple index offsets in `findMessageByIndexNeedingThinking` to handle API/storage index mismatch
- Add `failedAssistantMsg.info.id` as fallback in `recoverThinkingBlockOrder`

## Problem
Session recovery was failing in certain scenarios:

### 1. tool_result_missing error
When `failedAssistantMsg.parts` is empty and storage also has no parts, recovery fails even though the tool_use ID is present in the error message itself.

### 2. thinking_block_order error  
API message index differs from storage index (due to system messages), causing `findMessageByIndexNeedingThinking` to return null.

## Solution
1. **tool_result_missing**: Use `extractToolUseIdsFromError(error)` as fallback to extract IDs directly from error message
2. **thinking_block_order**: 
   - Try multiple index offsets (±5) in `findMessageByIndexNeedingThinking`
   - Use `failedAssistantMsg.info.id` directly as additional fallback

## Test plan
- [x] Verify tool_result_missing recovery works when parts are empty
- [x] Verify thinking_block_order recovery works with index mismatch

Fixes #483

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves session recovery by adding robust fallbacks for tool_result_missing and thinking_block_order errors, so recovery works even with index mismatches or empty parts. This makes recovery more reliable across varied API/storage states.

- **Bug Fixes**
  - tool_result_missing: recoverToolResultMissing accepts error and extracts tool_use IDs from the error message when parts are empty.
  - thinking_block_order: findMessageByIndexNeedingThinking tries index offsets (±5) and recoverThinkingBlockOrder falls back to failedAssistantMsg.info.id when needed.

<sup>Written for commit c6feac9b5bc4503894c22fc02511a2422feeca88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

