### PR TITLE
docs(zh-cn): add installation instructions for human users

### DIFF
--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -206,7 +206,21 @@ oMoMoMoMoMo···
 
 ### 人类专用
 
-这种脏活累活让 LLM Agent 干。把这个链接复制粘贴到 opencode 会话里，让它自己动：
+运行交互式安装程序：
+
+```bash
+bunx oh-my-opencode install
+# 如果 bunx 不好使就换 npx
+npx oh-my-opencode install
+```
+
+> **Ubuntu/Debian 用户注意**：如果你是用 Snap 装的 Bun (`/snap/bin/bun`)，由于 Snap 的沙箱机制，`bunx` 会报 "script not found" 错误。要么改用 `npx`，要么用官方脚本重装 Bun：`curl -fsSL https://bun.sh/install | bash`
+
+按提示配置你的 Claude、ChatGPT 和 Gemini 订阅。安装完成后，按指引完成各提供商的认证。
+
+**备选方案：让 LLM Agent 干**
+
+把下面这行复制粘贴到新的 opencode 会话里：
 ```
 Install and configure by following the instructions here https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/README.md
 ```


### PR DESCRIPTION
- Add interactive installer commands (bunx/npx oh-my-opencode install)
- Add note for Ubuntu/Debian users about Snap-installed Bun limitations
- Reorganize section to prioritize manual installation over LLM Agent approach

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds human-friendly install steps to README.zh-cn, including interactive installer commands (bunx/npx) and guidance to configure Claude, ChatGPT, and Gemini. Notes Snap-installed Bun limitations on Ubuntu/Debian and reorders the section to favor manual setup over the LLM Agent approach.

<sup>Written for commit 81063be36d53297bd5cd7d60f604fd1bbc969297. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

