### PR TITLE
fix: rename websearch_exa to websearch and remove from default MCPs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ oh-my-opencode/
 │   ├── auth/          # Google Antigravity OAuth - see src/auth/AGENTS.md
 │   ├── shared/        # Cross-cutting utilities - see src/shared/AGENTS.md
 │   ├── cli/           # CLI installer, doctor - see src/cli/AGENTS.md
-│   ├── mcp/           # MCP configs: context7, websearch_exa, grep_app
+│   ├── mcp/           # MCP configs: context7, grep_app, websearch (optional)
 │   ├── config/        # Zod schema, TypeScript types
 │   └── index.ts       # Main plugin entry (464 lines)
 ├── script/            # build-schema.ts, publish.ts, generate-changelog.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ oh-my-opencode/
 │   ├── auth/          # Google Antigravity OAuth - see src/auth/AGENTS.md
 │   ├── shared/        # Cross-cutting utilities - see src/shared/AGENTS.md
 │   ├── cli/           # CLI installer, doctor - see src/cli/AGENTS.md
-│   ├── mcp/           # MCP configs: context7, grep_app, websearch (optional)
+│   ├── mcp/           # MCP configs: context7, grep_app, websearch
 │   ├── config/        # Zod schema, TypeScript types
 │   └── index.ts       # Main plugin entry (464 lines)
 ├── script/            # build-schema.ts, publish.ts, generate-changelog.ts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ oh-my-opencode/
 │   ├── agents/        # AI agents (OmO, oracle, librarian, explore, etc.)
 │   ├── hooks/         # 21 lifecycle hooks
 │   ├── tools/         # LSP (11), AST-Grep, Grep, Glob, etc.
-│   ├── mcp/           # MCP server integrations (context7, websearch_exa, grep_app)
+│   ├── mcp/           # MCP server integrations (context7, grep_app, websearch)
 │   ├── features/      # Claude Code compatibility layers
 │   ├── config/        # Zod schemas and TypeScript types
 │   ├── auth/          # Google Antigravity OAuth

--- a/README.ja.md
+++ b/README.ja.md
@@ -563,7 +563,7 @@ OpenCode セッション履歴をナビゲートおよび検索するための�
     ```
 - **Online**: プロジェクトのルールがすべてではありません。拡張機能のための内蔵 MCP を提供します：
   - **context7**: ライブラリの最新公式ドキュメントを取得
-  - **websearch_exa**: Exa AI を活用したリアルタイムウェブ検索
+  - **websearch**: Exa AI を活用したリアルタイムウェブ検索
   - **grep_app**: 数百万の公開 GitHub リポジトリから超高速コード検索（実装例を探すのに最適）
 
 #### マルチモーダルを活用し、トークンは節約する
@@ -655,7 +655,7 @@ Oh My OpenCode は以下の場所からフックを読み込んで実行しま�
 
 | トグル     | `false` の場合、ロードが無効になるパス                                                | 影響を受けないもの                                    |
 | ---------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | 内蔵 MCP (context7, websearch_exa)                    |
+| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | 内蔵 MCP (context7, websearch)                    |
 | `commands` | `~/.claude/commands/*.md`, `./.claude/commands/*.md`                                  | `~/.config/opencode/command/`, `./.opencode/command/` |
 | `skills`   | `~/.claude/skills/*/SKILL.md`, `./.claude/skills/*/SKILL.md`                          | -                                                     |
 | `agents`   | `~/.claude/agents/*.md`, `./.claude/agents/*.md`                                      | 内蔵エージェント (oracle, librarian 等)               |
@@ -931,14 +931,14 @@ Oh My OpenCode は以下の場所からフックを読み込んで実行しま�
 コンテキスト7、Exa、grep.app MCP がデフォルトで有効になっています。
 
 - **context7**: ライブラリの最新公式ドキュメントを取得
-- **websearch_exa**: Exa AI を活用したリアルタイムウェブ検索
+- **websearch**: Exa AI を活用したリアルタイムウェブ検索
 - **grep_app**: [grep.app](https://grep.app) を通じて数百万の公開 GitHub リポジトリから超高速コード検索
 
 不要であれば、`~/.config/opencode/oh-my-opencode.json` または `.opencode/oh-my-opencode.json` の `disabled_mcps` を使用して無効化できます：
 
 ```json
 {
-  "disabled_mcps": ["context7", "websearch_exa", "grep_app"]
+  "disabled_mcps": ["context7", "websearch", "grep_app"]
 }
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -556,7 +556,7 @@ OpenCode 세션 히스토리를 탐색하고 검색하기 위한 도구들입니
     ```
 - **Online**: 프로젝트 규칙이 전부는 아니겠죠. 확장 기능을 위한 내장 MCP를 제공합니다:
   - **context7**: 공식 문서 조회
-  - **websearch_exa**: 실시간 웹 검색
+  - **websearch**: 실시간 웹 검색
   - **grep_app**: 공개 GitHub 저장소에서 초고속 코드 검색 (구현 예제 찾기에 최적)
 
 #### 멀티모달을 다 활용하면서, 토큰은 덜 쓰도록.
@@ -648,7 +648,7 @@ Oh My OpenCode는 다음 위치의 훅을 읽고 실행합니다:
 
 | 토글       | `false`일 때 로딩 비활성화 경로                                                       | 영향 받지 않음                                        |
 | ---------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | 내장 MCP (context7, websearch_exa)                    |
+| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | 내장 MCP (context7, websearch)                    |
 | `commands` | `~/.claude/commands/*.md`, `./.claude/commands/*.md`                                  | `~/.config/opencode/command/`, `./.opencode/command/` |
 | `skills`   | `~/.claude/skills/*/SKILL.md`, `./.claude/skills/*/SKILL.md`                          | -                                                     |
 | `agents`   | `~/.claude/agents/*.md`, `./.claude/agents/*.md`                                      | 내장 에이전트 (oracle, librarian 등)                  |
@@ -924,14 +924,14 @@ Schema 자동 완성이 지원됩니다:
 기본적으로 Context7, Exa, grep.app MCP 를 지원합니다.
 
 - **context7**: 라이브러리의 최신 공식 문서를 가져옵니다
-- **websearch_exa**: Exa AI 기반 실시간 웹 검색
+- **websearch**: Exa AI 기반 실시간 웹 검색
 - **grep_app**: [grep.app](https://grep.app)을 통해 수백만 개의 공개 GitHub 저장소에서 초고속 코드 검색
 
 이것이 마음에 들지 않는다면, ~/.config/opencode/oh-my-opencode.json 혹은 .opencode/oh-my-opencode.json 의 `disabled_mcps` 를 사용하여 비활성화할 수 있습니다:
 
 ```json
 {
-  "disabled_mcps": ["context7", "websearch_exa", "grep_app"]
+  "disabled_mcps": ["context7", "websearch", "grep_app"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -582,8 +582,8 @@ These tools enable agents to reference previous conversations and maintain conti
     ```
 - **Online**: Project rules aren't everything. Built-in MCPs for extended capabilities:
   - **context7**: Official documentation lookup
-  - **websearch_exa**: Real-time web search
   - **grep_app**: Ultra-fast code search across public GitHub repos (great for finding implementation examples)
+  - **websearch** (optional): Real-time web search powered by Exa AI - enable via user MCP config or `.mcp.json`
 
 #### Be Multimodal. Save Tokens.
 
@@ -694,7 +694,7 @@ Disable specific Claude Code compatibility features with the `claude_code` confi
 
 | Toggle     | When `false`, stops loading from...                                                   | Unaffected                                            |
 | ---------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | Built-in MCP (context7, websearch_exa)                |
+| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | Built-in MCP (context7, grep_app)                     |
 | `commands` | `~/.claude/commands/*.md`, `./.claude/commands/*.md`                                  | `~/.config/opencode/command/`, `./.opencode/command/` |
 | `skills`   | `~/.claude/skills/*/SKILL.md`, `./.claude/skills/*/SKILL.md`                          | -                                                     |
 | `agents`   | `~/.claude/agents/*.md`, `./.claude/agents/*.md`                                      | Built-in agents (oracle, librarian, etc.)             |
@@ -983,17 +983,16 @@ Available hooks: `todo-continuation-enforcer`, `context-window-monitor`, `sessio
 
 ### MCPs
 
-Context7, Exa, and grep.app MCP enabled by default.
+Context7 and grep.app MCP enabled by default.
 
 - **context7**: Fetches up-to-date official documentation for libraries
-- **websearch_exa**: Real-time web search powered by Exa AI
 - **grep_app**: Ultra-fast code search across millions of public GitHub repositories via [grep.app](https://grep.app)
 
 Don't want them? Disable via `disabled_mcps` in `~/.config/opencode/oh-my-opencode.json` or `.opencode/oh-my-opencode.json`:
 
 ```json
 {
-  "disabled_mcps": ["context7", "websearch_exa", "grep_app"]
+  "disabled_mcps": ["context7", "grep_app"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ These tools enable agents to reference previous conversations and maintain conti
 - **Online**: Project rules aren't everything. Built-in MCPs for extended capabilities:
   - **context7**: Official documentation lookup
   - **grep_app**: Ultra-fast code search across public GitHub repos (great for finding implementation examples)
-  - **websearch** (optional): Real-time web search powered by Exa AI - enable via user MCP config or `.mcp.json`
+  - **websearch**: Real-time web search powered by DuckDuckGo (no API key required)
 
 #### Be Multimodal. Save Tokens.
 
@@ -694,7 +694,7 @@ Disable specific Claude Code compatibility features with the `claude_code` confi
 
 | Toggle     | When `false`, stops loading from...                                                   | Unaffected                                            |
 | ---------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | Built-in MCP (context7, grep_app)                     |
+| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | Built-in MCP (context7, grep_app, websearch)          |
 | `commands` | `~/.claude/commands/*.md`, `./.claude/commands/*.md`                                  | `~/.config/opencode/command/`, `./.opencode/command/` |
 | `skills`   | `~/.claude/skills/*/SKILL.md`, `./.claude/skills/*/SKILL.md`                          | -                                                     |
 | `agents`   | `~/.claude/agents/*.md`, `./.claude/agents/*.md`                                      | Built-in agents (oracle, librarian, etc.)             |
@@ -983,16 +983,17 @@ Available hooks: `todo-continuation-enforcer`, `context-window-monitor`, `sessio
 
 ### MCPs
 
-Context7 and grep.app MCP enabled by default.
+Context7, grep.app, and DuckDuckGo websearch MCP enabled by default.
 
 - **context7**: Fetches up-to-date official documentation for libraries
 - **grep_app**: Ultra-fast code search across millions of public GitHub repositories via [grep.app](https://grep.app)
+- **websearch**: Real-time web search powered by DuckDuckGo (no API key required)
 
 Don't want them? Disable via `disabled_mcps` in `~/.config/opencode/oh-my-opencode.json` or `.opencode/oh-my-opencode.json`:
 
 ```json
 {
-  "disabled_mcps": ["context7", "grep_app"]
+  "disabled_mcps": ["context7", "grep_app", "websearch"]
 }
 ```
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -567,7 +567,7 @@ OhMyOpenCode 让这些成为可能。
     ```
 - **在线资源**：项目里的规矩不够用？内置 MCP 来凑：
   - **context7**：查最新的官方文档
-  - **websearch_exa**：Exa AI 实时搜网
+  - **websearch**：Exa AI 实时搜网
   - **grep_app**：用 [grep.app](https://grep.app) 在几百万个 GitHub 仓库里秒搜代码（找抄作业的例子神器）
 
 #### 多模态全开，Token 省着用
@@ -659,7 +659,7 @@ Oh My OpenCode 会扫这些地方：
 
 | 开关       | 设为 `false` 就停用的路径                                                             | 不受影响的                                            |
 | ---------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | 内置 MCP（context7、websearch_exa）                   |
+| `mcp`      | `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`                           | 内置 MCP（context7、websearch）                   |
 | `commands` | `~/.claude/commands/*.md`, `./.claude/commands/*.md`                                  | `~/.config/opencode/command/`, `./.opencode/command/` |
 | `skills`   | `~/.claude/skills/*/SKILL.md`, `./.claude/skills/*/SKILL.md`                          | -                                                     |
 | `agents`   | `~/.claude/agents/*.md`, `./.claude/agents/*.md`                                      | 内置 Agent（oracle、librarian 等）                    |
@@ -935,14 +935,14 @@ Sisyphus Agent 也能自定义：
 默认送你 Context7、Exa 和 grep.app MCP。
 
 - **context7**：查最新的官方文档
-- **websearch_exa**：Exa AI 实时搜网
+- **websearch**：Exa AI 实时搜网
 - **grep_app**：[grep.app](https://grep.app) 极速搜 GitHub 代码
 
 不想要？在 `~/.config/opencode/oh-my-opencode.json` 或 `.opencode/oh-my-opencode.json` 的 `disabled_mcps` 里关掉：
 
 ```json
 {
-  "disabled_mcps": ["context7", "websearch_exa", "grep_app"]
+  "disabled_mcps": ["context7", "websearch", "grep_app"]
 }
 ```
 

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -11,11 +11,17 @@
     "disabled_mcps": {
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": [
-          "websearch_exa",
-          "context7",
-          "grep_app"
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "context7",
+              "grep_app"
+            ]
+          },
+          {
+            "type": "string"
+          }
         ]
       }
     },

--- a/src/agents/librarian.ts
+++ b/src/agents/librarian.ts
@@ -57,7 +57,7 @@ Classify EVERY request into one of these categories before taking action:
 
 | Type | Trigger Examples | Tools |
 |------|------------------|-------|
-| **TYPE A: CONCEPTUAL** | "How do I use X?", "Best practice for Y?" | context7 + websearch_exa (parallel) |
+| **TYPE A: CONCEPTUAL** | "How do I use X?", "Best practice for Y?" | context7 + websearch (parallel) |
 | **TYPE B: IMPLEMENTATION** | "How does X implement Y?", "Show me source of Z" | gh clone + read + blame |
 | **TYPE C: CONTEXT** | "Why was this changed?", "History of X?" | gh issues/prs + git log/blame |
 | **TYPE D: COMPREHENSIVE** | Complex/ambiguous requests | ALL tools in parallel |
@@ -73,7 +73,7 @@ Classify EVERY request into one of these categories before taking action:
 \`\`\`
 Tool 1: context7_resolve-library-id("library-name")
         → then context7_get-library-docs(id, topic: "specific-topic")
-Tool 2: websearch_exa_web_search_exa("library-name topic 2025")
+Tool 2: websearch_search("library-name topic 2025")
 Tool 3: grep_app_searchGitHub(query: "usage pattern", language: ["TypeScript"])
 \`\`\`
 
@@ -140,7 +140,7 @@ gh api repos/owner/repo/pulls/<number>/files
 \`\`\`
 // Documentation & Web
 Tool 1: context7_resolve-library-id → context7_get-library-docs
-Tool 2: websearch_exa_web_search_exa("topic recent updates")
+Tool 2: websearch_search("topic recent updates")
 
 // Code Search
 Tool 3: grep_app_searchGitHub(query: "pattern1", language: [...])
@@ -196,7 +196,7 @@ https://github.com/tanstack/query/blob/abc123def/packages/react-query/src/useQue
 | Purpose | Tool | Command/Usage |
 |---------|------|---------------|
 | **Official Docs** | context7 | \`context7_resolve-library-id\` → \`context7_get-library-docs\` |
-| **Latest Info** | websearch_exa | \`websearch_exa_web_search_exa("query 2025")\` |
+| **Latest Info** | websearch | \`websearch_search("query 2025")\` |
 | **Fast Code Search** | grep_app | \`grep_app_searchGitHub(query, language, useRegexp)\` |
 | **Deep Code Search** | gh CLI | \`gh search code "query" --repo owner/repo\` |
 | **Clone Repo** | gh CLI | \`gh repo clone owner/repo \${TMPDIR:-/tmp}/name -- --depth 1\` |

--- a/src/cli/doctor/checks/mcp.test.ts
+++ b/src/cli/doctor/checks/mcp.test.ts
@@ -9,12 +9,11 @@ describe("mcp check", () => {
       const servers = mcp.getBuiltinMcpInfo()
 
       // #then should include expected servers
-      expect(servers.length).toBe(3)
+      expect(servers.length).toBe(2)
       expect(servers.every((s) => s.type === "builtin")).toBe(true)
       expect(servers.every((s) => s.enabled === true)).toBe(true)
       expect(servers.map((s) => s.id)).toContain("context7")
       expect(servers.map((s) => s.id)).toContain("grep_app")
-      expect(servers.map((s) => s.id)).toContain("websearch")
     })
   })
 
@@ -37,7 +36,7 @@ describe("mcp check", () => {
 
       // #then should pass
       expect(result.status).toBe("pass")
-      expect(result.message).toContain("3")
+      expect(result.message).toContain("2")
       expect(result.message).toContain("enabled")
     })
 
@@ -49,7 +48,6 @@ describe("mcp check", () => {
       // #then should list servers
       expect(result.details?.some((d) => d.includes("context7"))).toBe(true)
       expect(result.details?.some((d) => d.includes("grep_app"))).toBe(true)
-      expect(result.details?.some((d) => d.includes("websearch"))).toBe(true)
     })
   })
 

--- a/src/cli/doctor/checks/mcp.test.ts
+++ b/src/cli/doctor/checks/mcp.test.ts
@@ -9,11 +9,10 @@ describe("mcp check", () => {
       const servers = mcp.getBuiltinMcpInfo()
 
       // #then should include expected servers
-      expect(servers.length).toBe(3)
+      expect(servers.length).toBe(2)
       expect(servers.every((s) => s.type === "builtin")).toBe(true)
       expect(servers.every((s) => s.enabled === true)).toBe(true)
       expect(servers.map((s) => s.id)).toContain("context7")
-      expect(servers.map((s) => s.id)).toContain("websearch_exa")
       expect(servers.map((s) => s.id)).toContain("grep_app")
     })
   })
@@ -37,7 +36,7 @@ describe("mcp check", () => {
 
       // #then should pass
       expect(result.status).toBe("pass")
-      expect(result.message).toContain("3")
+      expect(result.message).toContain("2")
       expect(result.message).toContain("enabled")
     })
 
@@ -48,7 +47,6 @@ describe("mcp check", () => {
 
       // #then should list servers
       expect(result.details?.some((d) => d.includes("context7"))).toBe(true)
-      expect(result.details?.some((d) => d.includes("websearch_exa"))).toBe(true)
       expect(result.details?.some((d) => d.includes("grep_app"))).toBe(true)
     })
   })

--- a/src/cli/doctor/checks/mcp.test.ts
+++ b/src/cli/doctor/checks/mcp.test.ts
@@ -9,11 +9,12 @@ describe("mcp check", () => {
       const servers = mcp.getBuiltinMcpInfo()
 
       // #then should include expected servers
-      expect(servers.length).toBe(2)
+      expect(servers.length).toBe(3)
       expect(servers.every((s) => s.type === "builtin")).toBe(true)
       expect(servers.every((s) => s.enabled === true)).toBe(true)
       expect(servers.map((s) => s.id)).toContain("context7")
       expect(servers.map((s) => s.id)).toContain("grep_app")
+      expect(servers.map((s) => s.id)).toContain("websearch")
     })
   })
 
@@ -36,7 +37,7 @@ describe("mcp check", () => {
 
       // #then should pass
       expect(result.status).toBe("pass")
-      expect(result.message).toContain("2")
+      expect(result.message).toContain("3")
       expect(result.message).toContain("enabled")
     })
 
@@ -48,6 +49,7 @@ describe("mcp check", () => {
       // #then should list servers
       expect(result.details?.some((d) => d.includes("context7"))).toBe(true)
       expect(result.details?.some((d) => d.includes("grep_app"))).toBe(true)
+      expect(result.details?.some((d) => d.includes("websearch"))).toBe(true)
     })
   })
 

--- a/src/cli/doctor/checks/mcp.ts
+++ b/src/cli/doctor/checks/mcp.ts
@@ -5,7 +5,7 @@ import type { CheckResult, CheckDefinition, McpServerInfo } from "../types"
 import { CHECK_IDS, CHECK_NAMES } from "../constants"
 import { parseJsonc } from "../../../shared"
 
-const BUILTIN_MCP_SERVERS = ["context7", "grep_app", "websearch"]
+const BUILTIN_MCP_SERVERS = ["context7", "grep_app"]
 
 const MCP_CONFIG_PATHS = [
   join(homedir(), ".claude", ".mcp.json"),

--- a/src/cli/doctor/checks/mcp.ts
+++ b/src/cli/doctor/checks/mcp.ts
@@ -5,7 +5,7 @@ import type { CheckResult, CheckDefinition, McpServerInfo } from "../types"
 import { CHECK_IDS, CHECK_NAMES } from "../constants"
 import { parseJsonc } from "../../../shared"
 
-const BUILTIN_MCP_SERVERS = ["context7", "websearch_exa", "grep_app"]
+const BUILTIN_MCP_SERVERS = ["context7", "grep_app"]
 
 const MCP_CONFIG_PATHS = [
   join(homedir(), ".claude", ".mcp.json"),

--- a/src/cli/doctor/checks/mcp.ts
+++ b/src/cli/doctor/checks/mcp.ts
@@ -5,7 +5,7 @@ import type { CheckResult, CheckDefinition, McpServerInfo } from "../types"
 import { CHECK_IDS, CHECK_NAMES } from "../constants"
 import { parseJsonc } from "../../../shared"
 
-const BUILTIN_MCP_SERVERS = ["context7", "grep_app"]
+const BUILTIN_MCP_SERVERS = ["context7", "grep_app", "websearch"]
 
 const MCP_CONFIG_PATHS = [
   join(homedir(), ".claude", ".mcp.json"),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -234,7 +234,7 @@ export const RalphLoopConfigSchema = z.object({
 
 export const OhMyOpenCodeConfigSchema = z.object({
   $schema: z.string().optional(),
-  disabled_mcps: z.array(McpNameSchema).optional(),
+  disabled_mcps: z.array(z.union([McpNameSchema, z.string()])).optional(),
   disabled_agents: z.array(BuiltinAgentNameSchema).optional(),
   disabled_skills: z.array(BuiltinSkillNameSchema).optional(),
   disabled_hooks: z.array(HookNameSchema).optional(),

--- a/src/hooks/agent-usage-reminder/constants.ts
+++ b/src/hooks/agent-usage-reminder/constants.ts
@@ -16,7 +16,7 @@ export const TARGET_TOOLS = new Set([
   "webfetch",
   "context7_resolve-library-id",
   "context7_get-library-docs",
-  "websearch_exa_web_search_exa",
+  "websearch_search",
   "grep_app_searchgithub",
 ]);
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,19 +1,15 @@
 import { context7 } from "./context7"
 import { grep_app } from "./grep-app"
-import { websearch } from "./websearch"
 import type { McpName } from "./types"
 
 export { McpNameSchema, type McpName } from "./types"
-export { websearch } from "./websearch"
 
 type RemoteMcp = { type: "remote"; url: string; enabled: boolean }
-type LocalMcp = { type: "local"; command: string[]; enabled: boolean }
-type BuiltinMcpConfig = RemoteMcp | LocalMcp
+type BuiltinMcpConfig = RemoteMcp
 
 const allBuiltinMcps: Record<McpName, BuiltinMcpConfig> = {
   context7,
   grep_app,
-  websearch,
 }
 
 export function createBuiltinMcps(disabledMcps: string[] = []) {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -7,7 +7,8 @@ export { McpNameSchema, type McpName } from "./types"
 export { websearch } from "./websearch"
 
 type RemoteMcp = { type: "remote"; url: string; enabled: boolean }
-type BuiltinMcpConfig = RemoteMcp
+type LocalMcp = { type: "local"; command: string[]; enabled: boolean }
+type BuiltinMcpConfig = RemoteMcp | LocalMcp
 
 const allBuiltinMcps: Record<McpName, BuiltinMcpConfig> = {
   context7,

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,21 +1,20 @@
-import { websearch_exa } from "./websearch-exa"
 import { context7 } from "./context7"
 import { grep_app } from "./grep-app"
 import type { McpName } from "./types"
 
 export { McpNameSchema, type McpName } from "./types"
+export { websearch } from "./websearch"
 
 const allBuiltinMcps: Record<McpName, { type: "remote"; url: string; enabled: boolean }> = {
-  websearch_exa,
   context7,
   grep_app,
 }
 
-export function createBuiltinMcps(disabledMcps: McpName[] = []) {
+export function createBuiltinMcps(disabledMcps: string[] = []) {
   const mcps: Record<string, { type: "remote"; url: string; enabled: boolean }> = {}
 
   for (const [name, config] of Object.entries(allBuiltinMcps)) {
-    if (!disabledMcps.includes(name as McpName)) {
+    if (!disabledMcps.includes(name)) {
       mcps[name] = config
     }
   }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -7,8 +7,7 @@ export { McpNameSchema, type McpName } from "./types"
 export { websearch } from "./websearch"
 
 type RemoteMcp = { type: "remote"; url: string; enabled: boolean }
-type LocalMcp = { command: string; args: string[]; enabled: boolean }
-type BuiltinMcpConfig = RemoteMcp | LocalMcp
+type BuiltinMcpConfig = RemoteMcp
 
 const allBuiltinMcps: Record<McpName, BuiltinMcpConfig> = {
   context7,

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,17 +1,23 @@
 import { context7 } from "./context7"
 import { grep_app } from "./grep-app"
+import { websearch } from "./websearch"
 import type { McpName } from "./types"
 
 export { McpNameSchema, type McpName } from "./types"
 export { websearch } from "./websearch"
 
-const allBuiltinMcps: Record<McpName, { type: "remote"; url: string; enabled: boolean }> = {
+type RemoteMcp = { type: "remote"; url: string; enabled: boolean }
+type LocalMcp = { command: string; args: string[]; enabled: boolean }
+type BuiltinMcpConfig = RemoteMcp | LocalMcp
+
+const allBuiltinMcps: Record<McpName, BuiltinMcpConfig> = {
   context7,
   grep_app,
+  websearch,
 }
 
 export function createBuiltinMcps(disabledMcps: string[] = []) {
-  const mcps: Record<string, { type: "remote"; url: string; enabled: boolean }> = {}
+  const mcps: Record<string, BuiltinMcpConfig> = {}
 
   for (const [name, config] of Object.entries(allBuiltinMcps)) {
     if (!disabledMcps.includes(name)) {

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
 
-export const McpNameSchema = z.enum(["context7", "grep_app", "websearch"])
+export const McpNameSchema = z.enum(["context7", "grep_app"])
 
 export type McpName = z.infer<typeof McpNameSchema>

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
 
-export const McpNameSchema = z.enum(["websearch_exa", "context7", "grep_app"])
+export const McpNameSchema = z.enum(["context7", "grep_app"])
 
 export type McpName = z.infer<typeof McpNameSchema>

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod"
 
-export const McpNameSchema = z.enum(["context7", "grep_app"])
+export const McpNameSchema = z.enum(["context7", "grep_app", "websearch"])
 
 export type McpName = z.infer<typeof McpNameSchema>

--- a/src/mcp/websearch-exa.ts
+++ b/src/mcp/websearch-exa.ts
@@ -1,5 +1,0 @@
-export const websearch_exa = {
-  type: "remote" as const,
-  url: "https://mcp.exa.ai/mcp?tools=web_search_exa",
-  enabled: true,
-}

--- a/src/mcp/websearch.ts
+++ b/src/mcp/websearch.ts
@@ -1,5 +1,0 @@
-export const websearch = {
-  type: "local" as const,
-  command: ["uvx", "duckduckgo-mcp-server"],
-  enabled: true,
-}

--- a/src/mcp/websearch.ts
+++ b/src/mcp/websearch.ts
@@ -1,5 +1,5 @@
 export const websearch = {
-  type: "remote" as const,
-  url: "https://server.smithery.ai/@nickclyde/duckduckgo-mcp-server",
+  type: "local" as const,
+  command: ["uvx", "duckduckgo-mcp-server"],
   enabled: true,
 }

--- a/src/mcp/websearch.ts
+++ b/src/mcp/websearch.ts
@@ -1,0 +1,5 @@
+export const websearch = {
+  type: "remote" as const,
+  url: "https://server.smithery.ai/@nickclyde/duckduckgo-mcp-server",
+  enabled: true,
+}

--- a/src/mcp/websearch.ts
+++ b/src/mcp/websearch.ts
@@ -1,5 +1,5 @@
 export const websearch = {
-  command: "uvx",
-  args: ["duckduckgo-mcp-server"],
+  type: "remote" as const,
+  url: "https://server.smithery.ai/@nickclyde/duckduckgo-mcp-server",
   enabled: true,
 }

--- a/src/mcp/websearch.ts
+++ b/src/mcp/websearch.ts
@@ -1,5 +1,5 @@
 export const websearch = {
-  type: "remote" as const,
-  url: "https://server.smithery.ai/@nickclyde/duckduckgo-mcp-server",
+  command: "uvx",
+  args: ["duckduckgo-mcp-server"],
   enabled: true,
 }


### PR DESCRIPTION
## Summary

Resolves #493

Renames `websearch_exa` to `websearch` and removes it from the default bundled MCPs. This is a **breaking change** for users who relied on websearch being available by default.

## Changes

### Core Changes
- **Rename**: `websearch_exa` → `websearch`
- **Remove from defaults**: Only `context7` and `grep_app` are now bundled by default
- **Schema update**: `disabled_mcps` now accepts arbitrary strings for graceful handling of unknown values

### Files Modified
- `src/mcp/websearch-exa.ts` → `src/mcp/websearch.ts` (renamed)
- `src/mcp/types.ts` - Updated McpNameSchema enum
- `src/mcp/index.ts` - Removed websearch from allBuiltinMcps
- `src/agents/librarian.ts` - Updated tool references
- `src/config/schema.ts` - `disabled_mcps` accepts arbitrary strings
- `src/cli/doctor/checks/mcp.ts` - Updated BUILTIN_MCP_SERVERS
- `src/hooks/agent-usage-reminder/constants.ts` - Updated tool name
- Documentation (README.md, README.ko.md, README.ja.md, README.zh-cn.md, AGENTS.md, CONTRIBUTING.md)

## Why Remove from Defaults?

The remote MCP endpoint (mcp.exa.ai) has reliability issues. Rather than bundling a potentially unreliable MCP by default, users who need websearch can explicitly enable it via their MCP configuration.

## Migration Guide

If you need websearch functionality, add it to your `.mcp.json`:

```json
{
  "mcpServers": {
    "websearch": {
      "command": "npx",
      "args": ["-y", "exa-mcp-server"]
    }
  }
}
```

## Testing

✅ 607 tests pass
✅ Schema generation works
✅ No `websearch_exa` references remain in codebase