### PR TITLE
fix(test): increase timeout in duration test to prevent flakiness

### DIFF
--- a/src/cli/doctor/runner.test.ts
+++ b/src/cli/doctor/runner.test.ts
@@ -30,7 +30,7 @@ describe("runner", () => {
         name: "Test Check",
         category: "installation",
         check: async () => {
-          await new Promise((r) => setTimeout(r, 10))
+          await new Promise((r) => setTimeout(r, 50))
           return { name: "Test", status: "pass", message: "OK" }
         },
       }


### PR DESCRIPTION
## Summary

Fixes CI test failure in `src/cli/doctor/runner.test.ts` where the duration measurement test was flaky.

## Problem

The test expected `>= 10ms` duration after sleeping for `10ms`, but occasionally received `9ms` due to:
- Timer precision limitations
- Measurement overhead
- Non-deterministic setTimeout behavior

## Solution

Increased the sleep duration from `10ms` to `50ms` while keeping the `>= 10ms` assertion. This provides sufficient buffer to prevent flakiness while still validating that duration measurement works correctly.

## Testing

- ✅ Specific test now passes consistently: `bun test src/cli/doctor/runner.test.ts`
- ✅ Full test suite passes: `607 pass, 0 fail` across 53 files

Closes #507

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased sleep in the runner duration test from 10ms to 50ms to eliminate CI flakiness, preventing occasional under-10ms readings from timer precision and overhead while still asserting >=10ms duration. Fixes #507.

<sup>Written for commit df9a92755965135d7740b579153dc880fc5ed277. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

