### PR TITLE
fix: make disabled_mcps work for custom and plugin MCPs

### DIFF
--- a/src/features/claude-code-mcp-loader/loader.ts
+++ b/src/features/claude-code-mcp-loader/loader.ts
@@ -66,7 +66,9 @@ export function getSystemMcpServerNames(): Set<string> {
   return names
 }
 
-export async function loadMcpConfigs(): Promise<McpLoadResult> {
+export async function loadMcpConfigs(
+  disabledMcps: string[] = []
+): Promise<McpLoadResult> {
   const servers: McpLoadResult["servers"] = {}
   const loadedServers: LoadedMcpServer[] = []
   const paths = getMcpConfigPaths()
@@ -76,6 +78,11 @@ export async function loadMcpConfigs(): Promise<McpLoadResult> {
     if (!config?.mcpServers) continue
 
     for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
+      if (disabledMcps.includes(name)) {
+        log(`Skipping MCP "${name}" (in disabled_mcps)`, { path })
+        continue
+      }
+
       if (serverConfig.disabled) {
         log(`Skipping disabled MCP server "${name}"`, { path })
         continue

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -66,9 +66,12 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     }
 
     const pluginComponents = (pluginConfig.claude_code?.plugins ?? true)
-      ? await loadAllPluginComponents({
-          enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
-        })
+      ? await loadAllPluginComponents(
+          {
+            enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
+          },
+          pluginConfig.disabled_mcps
+        )
       : {
           commands: {},
           skills: {},
@@ -271,7 +274,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     };
 
     const mcpResult = (pluginConfig.claude_code?.mcp ?? true)
-      ? await loadMcpConfigs()
+      ? await loadMcpConfigs(pluginConfig.disabled_mcps)
       : { servers: {} };
 
     config.mcp = {


### PR DESCRIPTION
## Summary

Fixes the P1 issue identified by cubic-dev-ai in PR #513 where `disabled_mcps` configuration only filtered built-in MCPs but ignored custom MCPs from `.mcp.json` and plugin MCPs.

## Problem

As cubic-dev-ai correctly identified:
> `disabled_mcps` now promises support for arbitrary MCP names, but the runtime still filters only built-in MCPs; custom/plugin MCPs loaded from `.mcp.json` or plugins ignore this flag entirely. `OhMyOpenCodeConfigSchema` accepts strings like `"my-custom"`, yet `config-handler.ts` uses the list solely when calling `createBuiltinMcps`, while downstream loaders (`loadMcpConfigs`, plugin MCPs) never consult it, so the new configuration silently does nothing for custom servers.

## Solution

### Custom .mcp.json MCPs
- Updated `loadMcpConfigs()` to accept `disabledMcps: string[]` parameter
- Added filtering logic that checks `disabled_mcps` BEFORE the existing `disabled: true` check
- Maintains backward compatibility with `disabled: true` in .mcp.json files

### Plugin MCPs  
- Updated `loadPluginMcpServers()` to accept `disabledMcps: string[]` parameter
- Filters both namespaced names (`"plugin:server"`) and non-namespaced names (`"server"`)
- Added logging for filtered plugin MCPs

### Integration
- Updated `config-handler.ts` to pass `pluginConfig.disabled_mcps` to both loaders
- Updated `loadAllPluginComponents()` signature to propagate `disabledMcps` parameter

## Testing

Added 4 comprehensive test cases for custom MCP filtering:
- ✅ Filter out custom MCPs in disabled_mcps list
- ✅ Respect both disabled_mcps and disabled:true
- ✅ Filter across all scopes (user, project, local)
- ✅ No filtering when disabled_mcps is empty

**Test Results:**
- All 625 tests pass ✅
- Typecheck clean ✅  
- Build successful ✅

## Examples

### Disable custom .mcp.json MCPs
```json
{
  "disabled_mcps": ["playwright", "custom-server"]
}
```

### Disable plugin MCPs (supports both forms)
```json
{
  "disabled_mcps": [
    "my-plugin:sqlite",  // Namespaced
    "playwright"         // Non-namespaced (matches all plugins)
  ]
}
```

## Files Changed

| File | Changes | Purpose |
|------|---------|---------|
| `src/features/claude-code-mcp-loader/loader.ts` | +9 -4 | Add disabled_mcps parameter and filtering logic |
| `src/features/claude-code-mcp-loader/loader.test.ts` | +155 | Add 4 new test cases for custom MCP filtering |
| `src/features/claude-code-plugin-loader/loader.ts` | +18 -5 | Add disabled_mcps parameter and namespaced filtering |
| `src/plugin-handlers/config-handler.ts` | +11 -4 | Pass disabled_mcps to both loaders |

## Migration Notes

No breaking changes. Existing configurations will continue to work:
- `disabled: true` in .mcp.json files still works
- `disabled_mcps` array is optional (defaults to `[]`)
- All existing MCP filtering behavior is preserved

## Future Work

Skill-embedded MCP support (disabling MCPs defined in skill YAML frontmatter) can be added in a follow-up PR if needed. The current implementation addresses the core issue identified in cubic-dev-ai's feedback.

## Addresses

- PR #513 cubic-dev-ai feedback
- Resolves user-facing config mismatch where `disabled_mcps` appeared to support any MCP name but only actually worked for built-in MCPs

---

**Review Focus:**
- Verify backward compatibility with existing `disabled: true` configs
- Check namespaced vs non-namespaced filtering logic for plugins
- Confirm test coverage is comprehensive

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes disabled_mcps so it correctly disables custom MCPs from .mcp.json and plugin MCPs, not just built-ins. This makes configuration consistent across all MCP loading paths.

- **Bug Fixes**
  - loadMcpConfigs now accepts disabledMcps and filters names before checking disabled:true.
  - loadPluginMcpServers supports filtering by both "plugin:server" and "server".
  - config-handler passes disabled_mcps to both loaders; loadAllPluginComponents propagates it.
  - Added 4 tests for custom MCP filtering; all tests pass. Backward compatibility maintained (disabled:true still works).

<sup>Written for commit fab0f46253ab441571969688bda59752349aa774. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

