### PR TITLE
fix: prevent background agents from spawning recursive subagents via call_omo_agent

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -116,6 +116,7 @@ export class BackgroundManager {
         tools: {
           task: false,
           background_task: false,
+          call_omo_agent: false,
         },
         parts: [{ type: "text", text: input.prompt }],
       },


### PR DESCRIPTION
## Summary

- Added `call_omo_agent: false` to background agent tool restrictions in `BackgroundManager.launch()`
- Prevents background agents from spawning recursive subagents (explore/librarian)
- Aligns with existing restrictions for `task` and `background_task` tools

## Problem

After OpenCode 1.1.1 breaking changes to the permission system, background agents were missing the `call_omo_agent` restriction. This allowed them to spawn explore/librarian subagents recursively, creating unwanted nesting:

```
main agent → background agent → call_omo_agent → explore/librarian
```

## Solution

Added `call_omo_agent: false` to the tools restriction in `src/features/background-agent/manager.ts` at line 119:

```typescript
tools: {
  task: false,
  background_task: false,
  call_omo_agent: false,  // NEW: prevents recursive subagent spawning
}
```

This matches the pattern used in `src/tools/call-omo-agent/tools.ts` for sync mode execution.

## Testing

- Verified the change compiles
- Follows existing patterns for tool restrictions
- Consistent with explore/librarian agent restrictions in config-handler.ts

Fixes #535

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent background agents from spawning recursive subagents by disallowing call_omo_agent in BackgroundManager. Stops explore/librarian nesting and aligns with task/background_task restrictions; fixes #535.

<sup>Written for commit 3a701ce3610e701c4737729e858c959d0160c3ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

