### PR TITLE
feat: add experimental flag to allow background agent subagents

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -970,7 +970,8 @@ OpenCode でサポートされるすべての LSP 構成およびカスタム設
     "preemptive_compaction_threshold": 0.85,
     "truncate_all_tool_outputs": true,
     "aggressive_truncation": true,
-    "auto_resume": true
+    "auto_resume": true,
+    "allow_background_agent_subagents": false
   }
 }
 ```
@@ -982,6 +983,7 @@ OpenCode でサポートされるすべての LSP 構成およびカスタム設
 | `aggressive_truncation`           | `false`    | トークン制限を超えた場合、ツール出力を積極的に切り詰めて制限内に収めます。デフォルトの切り詰めより積極的です。不十分な場合は要約/復元にフォールバックします。                 |
 | `auto_resume`                     | `false`    | thinking block エラーや thinking disabled violation からの回復成功後、自動的にセッションを再開します。最後のユーザーメッセージを抽出して続行します。                        |
 | `dcp_for_compaction`              | `false`    | コンパクション用DCP（動的コンテキスト整理）を有効化 - トークン制限超過時に最初に実行されます。コンパクション前に重複したツール呼び出しと古いツール出力を整理します。                |
+| `allow_background_agent_subagents` | `false`   | バックグラウンドエージェントが `call_omo_agent` を介して再帰的にサブエージェントを生成することを許可します。**警告:** 指数関数的なタスクの急増（800+タスク）を引き起こす可能性があります。大規模な並列エージェントオーケストレーションが必要な場合にのみ有効にしてください。 |
 
 **警告**：これらの機能は実験的であり、予期しない動作を引き起こす可能性があります。影響を理解した場合にのみ有効にしてください。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -963,7 +963,8 @@ OpenCode 에서 지원하는 모든 LSP 구성 및 커스텀 설정 (opencode.js
     "preemptive_compaction_threshold": 0.85,
     "truncate_all_tool_outputs": true,
     "aggressive_truncation": true,
-    "auto_resume": true
+    "auto_resume": true,
+    "allow_background_agent_subagents": false
   }
 }
 ```
@@ -975,6 +976,7 @@ OpenCode 에서 지원하는 모든 LSP 구성 및 커스텀 설정 (opencode.js
 | `aggressive_truncation`           | `false` | 토큰 제한을 초과하면 도구 출력을 공격적으로 잘라내어 제한 내에 맞춥니다. 기본 truncation보다 더 공격적입니다. 부족하면 요약/복구로 fallback합니다.                      |
 | `auto_resume`                     | `false` | thinking block 에러나 thinking disabled violation으로부터 성공적으로 복구한 후 자동으로 세션을 재개합니다. 마지막 사용자 메시지를 추출하여 계속합니다.                |
 | `dcp_for_compaction`              | `false` | 컴팩션용 DCP(동적 컨텍스트 정리) 활성화 - 토큰 제한 초과 시 먼저 실행됩니다. 컴팩션 전에 중복 도구 호출과 오래된 도구 출력을 정리합니다.                                  |
+| `allow_background_agent_subagents` | `false` | 백그라운드 에이전트가 `call_omo_agent`를 통해 재귀적으로 하위 에이전트를 생성할 수 있도록 허용합니다. **경고:** 기하급수적인 태스크 폭증(800+ 태스크)을 유발할 수 있습니다. 대규모 병렬 에이전트 오케스트레이션이 필요한 경우에만 활성화하세요. |
 
 **경고**: 이 기능들은 실험적이며 예상치 못한 동작을 유발할 수 있습니다. 의미를 이해한 경우에만 활성화하세요.
 

--- a/README.md
+++ b/README.md
@@ -1031,7 +1031,8 @@ Opt-in experimental features that may change or be removed in future versions. U
     "preemptive_compaction_threshold": 0.85,
     "truncate_all_tool_outputs": true,
     "aggressive_truncation": true,
-    "auto_resume": true
+    "auto_resume": true,
+    "allow_background_agent_subagents": false
   }
 }
 ```
@@ -1043,6 +1044,7 @@ Opt-in experimental features that may change or be removed in future versions. U
 | `aggressive_truncation`     | `false` | When token limit is exceeded, aggressively truncates tool outputs to fit within limits. More aggressive than the default truncation behavior. Falls back to summarize/revert if insufficient. |
 | `auto_resume`               | `false` | Automatically resumes session after successful recovery from thinking block errors or thinking disabled violations. Extracts the last user message and continues.                            |
 | `dcp_for_compaction`        | `false` | Enable DCP (Dynamic Context Pruning) for compaction - runs first when token limit exceeded. Prunes duplicate tool calls and old tool outputs before running compaction.                      |
+| `allow_background_agent_subagents` | `false` | Allow background agents to spawn recursive subagents via `call_omo_agent`. **WARNING:** May cause exponential task cascades (800+ tasks). Only enable if you need heavy parallel agent orchestration. |
 
 **Warning**: These features are experimental and may cause unexpected behavior. Enable only if you understand the implications.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -974,7 +974,8 @@ Oh My OpenCode 送你重构工具（重命名、代码操作）。
     "preemptive_compaction_threshold": 0.85,
     "truncate_all_tool_outputs": true,
     "aggressive_truncation": true,
-    "auto_resume": true
+    "auto_resume": true,
+    "allow_background_agent_subagents": false
   }
 }
 ```
@@ -986,6 +987,7 @@ Oh My OpenCode 送你重构工具（重命名、代码操作）。
 | `aggressive_truncation`           | `false` | 超出 token 限制时，激进地截断工具输出以适应限制。比默认截断更激进。不够的话会回退到摘要/恢复。                                                     |
 | `auto_resume`                     | `false` | 从 thinking block 错误或 thinking disabled violation 成功恢复后，自动恢复会话。提取最后一条用户消息继续执行。                                     |
 | `dcp_for_compaction`              | `false` | 启用压缩用 DCP（动态上下文剪枝）- 在超出 token 限制时首先执行。在压缩前清理重复的工具调用和旧的工具输出。                                            |
+| `allow_background_agent_subagents` | `false` | 允许后台代理通过 `call_omo_agent` 递归生成子代理。**警告：** 可能导致指数级任务爆发（800+ 任务）。仅在需要大规模并行代理编排时启用。 |
 
 **警告**：这些功能是实验性的，可能会导致意外行为。只有在理解其影响的情况下才启用。
 

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -1516,6 +1516,9 @@
         },
         "dcp_for_compaction": {
           "type": "boolean"
+        },
+        "allow_background_agent_subagents": {
+          "type": "boolean"
         }
       }
     },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -183,6 +183,8 @@ export const ExperimentalConfigSchema = z.object({
   dynamic_context_pruning: DynamicContextPruningConfigSchema.optional(),
   /** Enable DCP (Dynamic Context Pruning) for compaction - runs first when token limit exceeded (default: false) */
   dcp_for_compaction: z.boolean().optional(),
+  /** Allow background agents to spawn recursive subagents via call_omo_agent (default: false). WARNING: May cause exponential task cascades. */
+  allow_background_agent_subagents: z.boolean().optional(),
 })
 
 export const SkillSourceSchema = z.union([

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     ? createEditErrorRecoveryHook(ctx)
     : null;
 
-  const backgroundManager = new BackgroundManager(ctx);
+  const backgroundManager = new BackgroundManager(ctx, pluginConfig.experimental);
 
   const todoContinuationEnforcer = isHookEnabled("todo-continuation-enforcer")
     ? createTodoContinuationEnforcer(ctx, { backgroundManager })


### PR DESCRIPTION
## Summary

Adds `allow_background_agent_subagents` experimental flag to enable users to opt-in to recursive background agent spawning via `call_omo_agent`.

This addresses the use case mentioned in #536 where some users want to call heavy tasks as `background_tasks` with full agent orchestration capabilities, despite the risk of exponential task cascades (800+ tasks).

## Changes

- ✅ Add `allow_background_agent_subagents` flag to `ExperimentalConfigSchema` (`src/config/schema.ts`)
- ✅ Update `BackgroundManager` constructor to accept `ExperimentalConfig` parameter
- ✅ Update `BackgroundManager.launch()` to conditionally apply `call_omo_agent` restriction based on flag
- ✅ Pass experimental config from main plugin to `BackgroundManager` (`src/index.ts`)
- ✅ Update all 4 language versions of README with flag documentation:
  - `README.md` (English)
  - `README.ko.md` (Korean)
  - `README.ja.md` (Japanese)
  - `README.zh-cn.md` (Chinese)
- ✅ Regenerate JSON schema (`assets/oh-my-opencode.schema.json`)

## Configuration

```json
{
  "experimental": {
    "allow_background_agent_subagents": false
  }
}
```

**Default:** `false` (safe default - prevents recursive spawning)

**When enabled:** Background agents can call `call_omo_agent` to spawn subagents recursively.

**WARNING:** May cause exponential task cascades (800+ tasks). Only enable if you need heavy parallel agent orchestration.

## Testing

- ✅ All 621 tests pass
- ✅ TypeScript compilation successful
- ✅ JSON schema regenerated successfully

## Related

Closes #536

cc @junhoyeo @code-yeongyu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an experimental flag to let background agents spawn subagents via call_omo_agent. Default is off to prevent runaway task cascades; opt-in for heavy parallel orchestration.

- **New Features**
  - Added allow_background_agent_subagents to ExperimentalConfigSchema.
  - BackgroundManager now takes experimental config and conditionally allows call_omo_agent.
  - Passed experimental config from the main plugin to BackgroundManager.
  - Updated README (EN/KO/JA/ZH) and regenerated JSON schema.

- **Migration**
  - To enable: set experimental.allow_background_agent_subagents to true in config.

<sup>Written for commit 05ad2a4badbf2bb7b7882f98c23ac6a4f2c1fb05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

