### PR TITLE
feat(cli): add --githubcopilot and --local install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 No stupid token consumption massive subagents here. No bloat tools here.
 
 **Certified, Verified, Tested, Actually Useful Harness in Production, after $24,000 worth of tokens spent.**
-**START WITH YOUR ChatGPT, Claude, Gemini SUBSCRIPTIONS. WE ALL COVER THEM.**
+**START WITH YOUR ChatGPT, Claude, Gemini, GitHub Copilot SUBSCRIPTIONS. WE ALL COVER THEM.**
 
 
 <div align="center">
@@ -132,7 +132,7 @@ Meet Sisyphus: The Batteries-Included Agent that codes like you.
 
 [Claude Code](https://www.claude.com/product/claude-code) is great.
 But if you're a hacker, you'll fall head over heels for [OpenCode](https://github.com/sst/opencode).
-**START WITH YOUR ChatGPT, Claude, Gemini SUBSCRIPTIONS. WE ALL COVER THEM.**
+**START WITH YOUR ChatGPT, Claude, Gemini, GitHub Copilot SUBSCRIPTIONS. WE ALL COVER THEM.**
 
 - Endlessly extensible. Endlessly customizable.
 - Zero screen flicker.
@@ -250,7 +250,7 @@ follow these steps:
 
 ### Step 0: Ask user about subscriptions
 
-Ask the user these 3 questions to determine CLI options:
+Ask the user these 4 questions to determine CLI options:
 
 1. **Do you have a Claude Pro/Max Subscription?**
    - If **yes**: **Are you on max20 (20x mode)?**
@@ -265,6 +265,10 @@ Ask the user these 3 questions to determine CLI options:
 3. **Will you integrate Gemini models?**
    - If **yes** → `--gemini=yes`
    - If **no** → `--gemini=no`
+
+4. **Do you have GitHub Copilot access?**
+   - If **yes** → `--githubcopilot=yes`
+   - If **no** → `--githubcopilot=no`
 
 ### Step 1: Install OpenCode (if not installed)
 
@@ -285,13 +289,14 @@ Spawn a subagent to handle installation and report back - to save context.
 Based on user's answers, run the CLI installer with appropriate flags:
 
 ```bash
-bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --chatgpt=<yes|no> --gemini=<yes|no>
+bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --chatgpt=<yes|no> --gemini=<yes|no> --githubcopilot=<yes|no>
 ```
 
 **Examples:**
-- User has all subscriptions with max20: `bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes`
-- User has only Claude (no max20): `bunx oh-my-opencode install --no-tui --claude=yes --chatgpt=no --gemini=no`
-- User has no subscriptions: `bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no`
+- User has all subscriptions with max20 and GitHub Copilot: `bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes --githubcopilot=yes`
+- User has only GitHub Copilot: `bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no --githubcopilot=yes`
+- User has only Claude (no max20): `bunx oh-my-opencode install --no-tui --claude=yes --chatgpt=no --gemini=no --githubcopilot=no`
+- User has no subscriptions: `bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no --githubcopilot=no`
 
 The CLI will:
 - Register the plugin in `opencode.json`
@@ -483,13 +488,13 @@ To remove oh-my-opencode:
 
 ### Agents: Your Teammates
 
-- **Sisyphus** (`anthropic/claude-opus-4-5`): **The default agent.** A powerful AI orchestrator for OpenCode. Plans, delegates, and executes complex tasks using specialized subagents with aggressive parallel execution. Emphasizes background task delegation and todo-driven workflow. Uses Claude Opus 4.5 with extended thinking (32k budget) for maximum reasoning capability.
-- **oracle** (`openai/gpt-5.2`): Architecture, code review, strategy. Uses GPT-5.2 for its stellar logical reasoning and deep analysis. Inspired by AmpCode.
-- **librarian** (`anthropic/claude-sonnet-4-5` or `google/gemini-3-flash`): Multi-repo analysis, doc lookup, implementation examples. Uses Gemini 3 Flash when Antigravity auth is configured, otherwise Claude Sonnet 4.5 for deep codebase understanding and GitHub research with evidence-based answers. Inspired by AmpCode.
-- **explore** (`opencode/grok-code`, `google/gemini-3-flash`, or `anthropic/claude-haiku-4-5`): Fast codebase exploration and pattern matching. Uses Gemini 3 Flash when Antigravity auth is configured, Haiku when Claude max20 is available, otherwise Grok. Inspired by Claude Code.
-- **frontend-ui-ux-engineer** (`google/gemini-3-pro-high`): A designer turned developer. Builds gorgeous UIs. Gemini excels at creative, beautiful UI code.
-- **document-writer** (`google/gemini-3-flash`): Technical writing expert. Gemini is a wordsmith—writes prose that flows.
-- **multimodal-looker** (`google/gemini-3-flash`): Visual content specialist. Analyzes PDFs, images, diagrams to extract information.
+- **Sisyphus** (`anthropic/claude-opus-4-5` or `github-copilot/claude-opus-4.5`): **The default agent.** A powerful AI orchestrator for OpenCode. Plans, delegates, and executes complex tasks using specialized subagents with aggressive parallel execution. Emphasizes background task delegation and todo-driven workflow. Uses Claude Opus 4.5 with extended thinking (32k budget) for maximum reasoning capability.
+- **oracle** (`openai/gpt-5.2` or `github-copilot/gpt-5.2`): Architecture, code review, strategy. Uses GPT-5.2 for its stellar logical reasoning and deep analysis. Inspired by AmpCode.
+- **librarian** (`anthropic/claude-sonnet-4-5`, `google/gemini-3-flash`, or `github-copilot/claude-haiku-4.5`): Multi-repo analysis, doc lookup, implementation examples. Uses GitHub Copilot Haiku when configured, otherwise Gemini 3 Flash with Antigravity auth or Claude Sonnet 4.5 for deep codebase understanding and GitHub research with evidence-based answers. Inspired by AmpCode.
+- **explore** (`opencode/grok-code`, `google/gemini-3-flash`, or `anthropic/claude-haiku-4-5` or `github-copilot/claude-haiku-4.5`): Fast codebase exploration and pattern matching. Uses Gemini 3 Flash when Antigravity auth is configured, Haiku when Claude max20 is available, GitHub Copilot Haiku when configured otherwise Grok. Inspired by Claude Code.
+- **frontend-ui-ux-engineer** (`google/gemini-3-pro-high` or `github-copilot/gemini-3-pro-preview`): A designer turned developer. Builds gorgeous UIs. Gemini excels at creative, beautiful UI code.
+- **document-writer** (`google/gemini-3-flash` or `github-copilot/gemini-3-pro-preview`): Technical writing expert. Gemini is a wordsmith—writes prose that flows.
+- **multimodal-looker** (`google/gemini-3-flash` or `github-copilot/gemini-3-flash-preview`): Visual content specialist. Analyzes PDFs, images, diagrams to extract information.
 
 The main agent invokes these automatically, but you can call them explicitly:
 

--- a/src/cli/config-manager.ts
+++ b/src/cli/config-manager.ts
@@ -14,19 +14,39 @@ interface ConfigContext {
   binary: OpenCodeBinaryType
   version: string | null
   paths: OpenCodeConfigPaths
+  isLocal: boolean
 }
 
 let configContext: ConfigContext | null = null
 
 export function initConfigContext(binary: OpenCodeBinaryType, version: string | null): void {
+  if (configContext?.isLocal) {
+    return
+  }
   const paths = getOpenCodeConfigPaths({ binary, version })
-  configContext = { binary, version, paths }
+  configContext = { binary, version, paths, isLocal: false }
+}
+
+export function initLocalConfigContext(directory: string = process.cwd()): void {
+  const localDir = join(directory, ".opencode")
+  configContext = {
+    binary: "opencode",
+    version: null,
+    paths: {
+      configDir: localDir,
+      configJson: join(localDir, "opencode.json"),
+      configJsonc: join(localDir, "opencode.jsonc"),
+      packageJson: join(localDir, "package.json"),
+      omoConfig: join(localDir, "oh-my-opencode.json"),
+    },
+    isLocal: true,
+  }
 }
 
 export function getConfigContext(): ConfigContext {
   if (!configContext) {
     const paths = getOpenCodeConfigPaths({ binary: "opencode", version: null })
-    configContext = { binary: "opencode", version: null, paths }
+    configContext = { binary: "opencode", version: null, paths, isLocal: false }
   }
   return configContext
 }
@@ -273,37 +293,47 @@ export function generateOmoConfig(installConfig: InstallConfig): Record<string, 
 
   const agents: Record<string, Record<string, unknown>> = {}
 
-  if (!installConfig.hasClaude) {
-    agents["Sisyphus"] = { model: "opencode/glm-4.7-free" }
-  }
-
-  agents["librarian"] = { model: "opencode/glm-4.7-free" }
-
-  // Gemini models use `antigravity-` prefix for explicit Antigravity quota routing
-  // @see ANTIGRAVITY_PROVIDER_CONFIG comments for rationale
-  if (installConfig.hasGemini) {
-    agents["explore"] = { model: "google/antigravity-gemini-3-flash" }
-  } else if (installConfig.hasClaude && installConfig.isMax20) {
-    agents["explore"] = { model: "anthropic/claude-haiku-4-5" }
+  if (installConfig.hasGitHubCopilot) {
+    agents["Sisyphus"] = { model: "github-copilot/claude-opus-4.5" }
+    agents["librarian"] = { model: "github-copilot/claude-haiku-4.5" }
+    agents["explore"] = { model: "github-copilot/claude-haiku-4.5" }
+    agents["oracle"] = { model: "github-copilot/gpt-5.2" }
+    agents["frontend-ui-ux-engineer"] = { model: "github-copilot/gemini-3-pro-preview" }
+    agents["document-writer"] = { model: "github-copilot/gemini-3-pro-preview" }
+    agents["multimodal-looker"] = { model: "github-copilot/gemini-3-flash-preview" }
   } else {
-    agents["explore"] = { model: "opencode/glm-4.7-free" }
-  }
-
-  if (!installConfig.hasChatGPT) {
-    agents["oracle"] = {
-      model: installConfig.hasClaude ? "anthropic/claude-opus-4-5" : "opencode/glm-4.7-free",
+    if (!installConfig.hasClaude) {
+      agents["Sisyphus"] = { model: "opencode/glm-4.7-free" }
     }
-  }
 
-  if (installConfig.hasGemini) {
-    agents["frontend-ui-ux-engineer"] = { model: "google/antigravity-gemini-3-pro-high" }
-    agents["document-writer"] = { model: "google/antigravity-gemini-3-flash" }
-    agents["multimodal-looker"] = { model: "google/antigravity-gemini-3-flash" }
-  } else {
-    const fallbackModel = installConfig.hasClaude ? "anthropic/claude-opus-4-5" : "opencode/glm-4.7-free"
-    agents["frontend-ui-ux-engineer"] = { model: fallbackModel }
-    agents["document-writer"] = { model: fallbackModel }
-    agents["multimodal-looker"] = { model: fallbackModel }
+    agents["librarian"] = { model: "opencode/glm-4.7-free" }
+
+    // Gemini models use `antigravity-` prefix for explicit Antigravity quota routing
+    // @see ANTIGRAVITY_PROVIDER_CONFIG comments for rationale
+    if (installConfig.hasGemini) {
+      agents["explore"] = { model: "google/antigravity-gemini-3-flash" }
+    } else if (installConfig.hasClaude && installConfig.isMax20) {
+      agents["explore"] = { model: "anthropic/claude-haiku-4-5" }
+    } else {
+      agents["explore"] = { model: "opencode/glm-4.7-free" }
+    }
+
+    if (!installConfig.hasChatGPT) {
+      agents["oracle"] = {
+        model: installConfig.hasClaude ? "anthropic/claude-opus-4-5" : "opencode/glm-4.7-free",
+      }
+    }
+
+    if (installConfig.hasGemini) {
+      agents["frontend-ui-ux-engineer"] = { model: "google/antigravity-gemini-3-pro-high" }
+      agents["document-writer"] = { model: "google/antigravity-gemini-3-flash" }
+      agents["multimodal-looker"] = { model: "google/antigravity-gemini-3-flash" }
+    } else {
+      const fallbackModel = installConfig.hasClaude ? "anthropic/claude-opus-4-5" : "opencode/glm-4.7-free"
+      agents["frontend-ui-ux-engineer"] = { model: fallbackModel }
+      agents["document-writer"] = { model: fallbackModel }
+      agents["multimodal-looker"] = { model: fallbackModel }
+    }
   }
 
   if (Object.keys(agents).length > 0) {
@@ -645,6 +675,7 @@ export function detectCurrentConfig(): DetectedConfig {
     isMax20: true,
     hasChatGPT: true,
     hasGemini: false,
+    hasGitHubCopilot: false,
   }
 
   const { format, path } = detectConfigFormat()
@@ -690,6 +721,11 @@ export function detectCurrentConfig(): DetectedConfig {
     }
 
     const agents = omoConfig.agents ?? {}
+
+    // Detect GitHub Copilot - check if any agent uses github-copilot/ models
+    result.hasGitHubCopilot = Object.values(agents).some(
+      (agent) => typeof agent === "object" && agent !== null && "model" in agent && String(agent.model).startsWith("github-copilot/")
+    )
 
     if (agents["Sisyphus"]?.model === "opencode/glm-4.7-free") {
       result.hasClaude = false

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,20 +23,24 @@ program
   .command("install")
   .description("Install and configure oh-my-opencode with interactive setup")
   .option("--no-tui", "Run in non-interactive mode (requires all options)")
+  .option("--local", "Install to project-local .opencode directory instead of global config")
   .option("--claude <value>", "Claude subscription: no, yes, max20")
   .option("--chatgpt <value>", "ChatGPT subscription: no, yes")
   .option("--gemini <value>", "Gemini integration: no, yes")
+  .option("--githubcopilot <value>", "GitHub Copilot access: no, yes")
   .option("--skip-auth", "Skip authentication setup hints")
   .addHelpText("after", `
 Examples:
   $ bunx oh-my-opencode install
-  $ bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes
-  $ bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no
+  $ bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes --githubcopilot=yes
+  $ bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no --githubcopilot=yes
+  $ bunx oh-my-opencode install --local --no-tui --claude=no --chatgpt=no --gemini=no --githubcopilot=yes
 
 Model Providers:
-  Claude      Required for Sisyphus (main orchestrator) and Librarian agents
-  ChatGPT     Powers the Oracle agent for debugging and architecture
-  Gemini      Powers frontend, documentation, and multimodal agents
+  Claude        Required for Sisyphus (main orchestrator) and Librarian agents
+  ChatGPT       Powers the Oracle agent for debugging and architecture
+  Gemini         Powers frontend, documentation, and multimodal agents
+  GitHub Copilot Built-in OpenCode provider for Claude, GPT, and Gemini models
 `)
   .action(async (options) => {
     const args: InstallArgs = {
@@ -44,7 +48,9 @@ Model Providers:
       claude: options.claude,
       chatgpt: options.chatgpt,
       gemini: options.gemini,
+      githubcopilot: options.githubcopilot,
       skipAuth: options.skipAuth ?? false,
+      local: options.local ?? false,
     }
     const exitCode = await install(args)
     process.exit(exitCode)

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -9,6 +9,7 @@ import {
   addAuthPlugins,
   addProviderConfig,
   detectCurrentConfig,
+  initLocalConfigContext,
 } from "./config-manager"
 
 const SYMBOLS = {
@@ -38,6 +39,7 @@ function formatConfigSummary(config: InstallConfig): string {
   lines.push(formatProvider("Claude", config.hasClaude, claudeDetail))
   lines.push(formatProvider("ChatGPT", config.hasChatGPT))
   lines.push(formatProvider("Gemini", config.hasGemini))
+  lines.push(formatProvider("GitHub Copilot", config.hasGitHubCopilot))
 
   lines.push("")
   lines.push(color.dim("─".repeat(40)))
@@ -46,14 +48,16 @@ function formatConfigSummary(config: InstallConfig): string {
   lines.push(color.bold(color.white("Agent Configuration")))
   lines.push("")
 
-  const sisyphusModel = config.hasClaude ? "claude-opus-4-5" : "glm-4.7-free"
-  const oracleModel = config.hasChatGPT ? "gpt-5.2" : (config.hasClaude ? "claude-opus-4-5" : "glm-4.7-free")
-  const librarianModel = "glm-4.7-free"
-  const frontendModel = config.hasGemini ? "antigravity-gemini-3-pro-high" : (config.hasClaude ? "claude-opus-4-5" : "glm-4.7-free")
+  const sisyphusModel = config.hasGitHubCopilot ? "github-copilot/claude-opus-4.5" : (config.hasClaude ? "claude-opus-4-5" : "glm-4.7-free")
+  const oracleModel = config.hasGitHubCopilot ? "github-copilot/gpt-5.2" : (config.hasChatGPT ? "gpt-5.2" : (config.hasClaude ? "claude-opus-4-5" : "glm-4.7-free"))
+  const librarianModel = config.hasGitHubCopilot ? "github-copilot/claude-haiku-4.5" : "glm-4.7-free"
+  const exploreModel = config.hasGitHubCopilot ? "github-copilot/claude-haiku-4.5" : (config.hasGemini ? "google/antigravity-gemini-3-flash" : (config.hasClaude && config.isMax20 ? "anthropic/claude-haiku-4-5" : "opencode/grok-code"))
+  const frontendModel = config.hasGitHubCopilot ? "github-copilot/gemini-3-pro-preview" : (config.hasGemini ? "antigravity-gemini-3-pro-high" : (config.hasClaude ? "claude-opus-4-5" : "glm-4.7-free"))
 
   lines.push(`  ${SYMBOLS.bullet} Sisyphus     ${SYMBOLS.arrow} ${color.cyan(sisyphusModel)}`)
   lines.push(`  ${SYMBOLS.bullet} Oracle       ${SYMBOLS.arrow} ${color.cyan(oracleModel)}`)
   lines.push(`  ${SYMBOLS.bullet} Librarian    ${SYMBOLS.arrow} ${color.cyan(librarianModel)}`)
+  lines.push(`  ${SYMBOLS.bullet} Explore      ${SYMBOLS.arrow} ${color.cyan(exploreModel)}`)
   lines.push(`  ${SYMBOLS.bullet} Frontend     ${SYMBOLS.arrow} ${color.cyan(frontendModel)}`)
 
   return lines.join("\n")
@@ -130,6 +134,12 @@ function validateNonTuiArgs(args: InstallArgs): { valid: boolean; errors: string
     errors.push(`Invalid --gemini value: ${args.gemini} (expected: no, yes)`)
   }
 
+  if (args.githubcopilot === undefined) {
+    errors.push("--githubcopilot is required (values: no, yes)")
+  } else if (!["no", "yes"].includes(args.githubcopilot)) {
+    errors.push(`Invalid --githubcopilot value: ${args.githubcopilot} (expected: no, yes)`)
+  }
+
   return { valid: errors.length === 0, errors }
 }
 
@@ -139,10 +149,11 @@ function argsToConfig(args: InstallArgs): InstallConfig {
     isMax20: args.claude === "max20",
     hasChatGPT: args.chatgpt === "yes",
     hasGemini: args.gemini === "yes",
+    hasGitHubCopilot: args.githubcopilot === "yes",
   }
 }
 
-function detectedToInitialValues(detected: DetectedConfig): { claude: ClaudeSubscription; chatgpt: BooleanArg; gemini: BooleanArg } {
+function detectedToInitialValues(detected: DetectedConfig): { claude: ClaudeSubscription; chatgpt: BooleanArg; gemini: BooleanArg; githubcopilot: BooleanArg } {
   let claude: ClaudeSubscription = "no"
   if (detected.hasClaude) {
     claude = detected.isMax20 ? "max20" : "yes"
@@ -152,6 +163,7 @@ function detectedToInitialValues(detected: DetectedConfig): { claude: ClaudeSubs
     claude,
     chatgpt: detected.hasChatGPT ? "yes" : "no",
     gemini: detected.hasGemini ? "yes" : "no",
+    githubcopilot: detected.hasGitHubCopilot ? "yes" : "no",
   }
 }
 
@@ -201,11 +213,26 @@ async function runTuiMode(detected: DetectedConfig): Promise<InstallConfig | nul
     return null
   }
 
+  const githubcopilot = await p.select({
+    message: "Do you have GitHub Copilot access?",
+    options: [
+      { value: "no" as const, label: "No", hint: "Agents will use provider models" },
+      { value: "yes" as const, label: "Yes", hint: "Use GitHub Copilot models via GitHub provider" },
+    ],
+    initialValue: initial.githubcopilot,
+  })
+
+  if (p.isCancel(githubcopilot)) {
+    p.cancel("Installation cancelled.")
+    return null
+  }
+
   return {
     hasClaude: claude !== "no",
     isMax20: claude === "max20",
     hasChatGPT: chatgpt === "yes",
     hasGemini: gemini === "yes",
+    hasGitHubCopilot: githubcopilot === "yes",
   }
 }
 
@@ -218,9 +245,13 @@ async function runNonTuiInstall(args: InstallArgs): Promise<number> {
       console.log(`  ${SYMBOLS.bullet} ${err}`)
     }
     console.log()
-    printInfo("Usage: bunx oh-my-opencode install --no-tui --claude=<no|yes|max20> --chatgpt=<no|yes> --gemini=<no|yes>")
+    printInfo("Usage: bunx oh-my-opencode install --no-tui --claude=<no|yes|max20> --chatgpt=<no|yes> --gemini=<no|yes> --githubcopilot=<no|yes>")
     console.log()
     return 1
+  }
+
+  if (args.local) {
+    initLocalConfigContext()
   }
 
   const detected = detectCurrentConfig()
@@ -244,7 +275,7 @@ async function runNonTuiInstall(args: InstallArgs): Promise<number> {
 
   if (isUpdate) {
     const initial = detectedToInitialValues(detected)
-    printInfo(`Current config: Claude=${initial.claude}, ChatGPT=${initial.chatgpt}, Gemini=${initial.gemini}`)
+    printInfo(`Current config: Claude=${initial.claude}, ChatGPT=${initial.chatgpt}, Gemini=${initial.gemini}, GitHub Copilot=${initial.githubcopilot}`)
   }
 
   const config = argsToConfig(args)
@@ -257,7 +288,7 @@ async function runNonTuiInstall(args: InstallArgs): Promise<number> {
   }
   printSuccess(`Plugin ${isUpdate ? "verified" : "added"} ${SYMBOLS.arrow} ${color.dim(pluginResult.configPath)}`)
 
-  if (config.hasGemini || config.hasChatGPT) {
+  if (config.hasGemini || config.hasChatGPT || config.hasGitHubCopilot) {
     printStep(step++, totalSteps, "Adding auth plugins...")
     const authResult = await addAuthPlugins(config)
     if (!authResult.success) {
@@ -287,11 +318,11 @@ async function runNonTuiInstall(args: InstallArgs): Promise<number> {
 
   printBox(formatConfigSummary(config), isUpdate ? "Updated Configuration" : "Installation Complete")
 
-  if (!config.hasClaude && !config.hasChatGPT && !config.hasGemini) {
+  if (!config.hasClaude && !config.hasChatGPT && !config.hasGemini && !config.hasGitHubCopilot) {
     printWarning("No model providers configured. Using opencode/glm-4.7-free as fallback.")
   }
 
-  if ((config.hasClaude || config.hasChatGPT || config.hasGemini) && !args.skipAuth) {
+  if ((config.hasClaude || config.hasChatGPT || config.hasGemini || config.hasGitHubCopilot) && !args.skipAuth) {
     console.log(color.bold("Next Steps - Authenticate your providers:"))
     console.log()
     if (config.hasClaude) {
@@ -302,6 +333,9 @@ async function runNonTuiInstall(args: InstallArgs): Promise<number> {
     }
     if (config.hasGemini) {
       console.log(`  ${SYMBOLS.arrow} ${color.dim("opencode auth login")} ${color.gray("(select Google → OAuth with Antigravity)")}`)
+    }
+    if (config.hasGitHubCopilot) {
+      console.log(`  ${SYMBOLS.arrow} ${color.dim("opencode auth login")} ${color.gray("(select GitHub → GitHub Copilot)")}`)
     }
     console.log()
   }
@@ -331,6 +365,10 @@ export async function install(args: InstallArgs): Promise<number> {
     return runNonTuiInstall(args)
   }
 
+  if (args.local) {
+    initLocalConfigContext()
+  }
+
   const detected = detectCurrentConfig()
   const isUpdate = detected.isInstalled
 
@@ -338,7 +376,7 @@ export async function install(args: InstallArgs): Promise<number> {
 
   if (isUpdate) {
     const initial = detectedToInitialValues(detected)
-    p.log.info(`Existing configuration detected: Claude=${initial.claude}, ChatGPT=${initial.chatgpt}, Gemini=${initial.gemini}`)
+    p.log.info(`Existing configuration detected: Claude=${initial.claude}, ChatGPT=${initial.chatgpt}, Gemini=${initial.gemini}, GitHub Copilot=${initial.githubcopilot}`)
   }
 
   const s = p.spinner()
@@ -368,7 +406,7 @@ export async function install(args: InstallArgs): Promise<number> {
   }
   s.stop(`Plugin added to ${color.cyan(pluginResult.configPath)}`)
 
-  if (config.hasGemini || config.hasChatGPT) {
+  if (config.hasGemini || config.hasChatGPT || config.hasGitHubCopilot) {
     s.start("Adding auth plugins (fetching latest versions)")
     const authResult = await addAuthPlugins(config)
     if (!authResult.success) {
@@ -397,13 +435,13 @@ export async function install(args: InstallArgs): Promise<number> {
   }
   s.stop(`Config written to ${color.cyan(omoResult.configPath)}`)
 
-  if (!config.hasClaude && !config.hasChatGPT && !config.hasGemini) {
+  if (!config.hasClaude && !config.hasChatGPT && !config.hasGemini && !config.hasGitHubCopilot) {
     p.log.warn("No model providers configured. Using opencode/glm-4.7-free as fallback.")
   }
 
   p.note(formatConfigSummary(config), isUpdate ? "Updated Configuration" : "Installation Complete")
 
-  if ((config.hasClaude || config.hasChatGPT || config.hasGemini) && !args.skipAuth) {
+  if ((config.hasClaude || config.hasChatGPT || config.hasGemini || config.hasGitHubCopilot) && !args.skipAuth) {
     const steps: string[] = []
     if (config.hasClaude) {
       steps.push(`${color.dim("opencode auth login")} ${color.gray("(select Anthropic → Claude Pro/Max)")}`)
@@ -413,6 +451,9 @@ export async function install(args: InstallArgs): Promise<number> {
     }
     if (config.hasGemini) {
       steps.push(`${color.dim("opencode auth login")} ${color.gray("(select Google → OAuth with Antigravity)")}`)
+    }
+    if (config.hasGitHubCopilot) {
+      steps.push(`${color.dim("opencode auth login")} ${color.gray("(select GitHub → GitHub Copilot)")}`)
     }
     p.note(steps.join("\n"), "Next Steps - Authenticate your providers")
   }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -6,7 +6,9 @@ export interface InstallArgs {
   claude?: ClaudeSubscription
   chatgpt?: BooleanArg
   gemini?: BooleanArg
+  githubcopilot?: BooleanArg
   skipAuth?: boolean
+  local?: boolean
 }
 
 export interface InstallConfig {
@@ -14,6 +16,7 @@ export interface InstallConfig {
   isMax20: boolean
   hasChatGPT: boolean
   hasGemini: boolean
+  hasGitHubCopilot: boolean
 }
 
 export interface ConfigMergeResult {
@@ -28,4 +31,5 @@ export interface DetectedConfig {
   isMax20: boolean
   hasChatGPT: boolean
   hasGemini: boolean
+  hasGitHubCopilot: boolean
 }


### PR DESCRIPTION
## Summary

Need to install oh-my-opencode in a local folder with Github Copilot subscription option. While its possible to manually edit the oh-my-opecode.json file after the fact, it will be easier to have this as a CLI option to configure (--githubcopilot similar to --claude, --chatgpt, --gemini). Also explicitly added a --local  option to CLI to allow creating everything in project specific .opencode instead of ~/.config/opencode

feat(cli): add --githubcopilot and --local install options
Add two new CLI options for the install command:
- --githubcopilot: Enable GitHub Copilot as a model provider with full
  agent configuration (claude-opus-4.5 for Sisyphus, gpt-5.2 for Oracle,
  claude-haiku-4.5 for Librarian/Explore, gemini-3-pro-preview for
  Frontend/Document-Writer, gemini-3-flash-preview for Multimodal-Looker)
- --local: Write configuration to project-local .opencode/ directory
  instead of global ~/.config/opencode/, enabling per-project customization
- Update README.md with new options and usage examples.

## Changes

###  --githubcopilot Option
#### Files Modified:
- src/cli/types.ts: Add githubcopilot to InstallArgs, hasGitHubCopilot to InstallConfig/DetectedConfig
- src/cli/install.ts: Add validation, TUI prompt, config summary display with GitHub Copilot models
- src/cli/config-manager.ts: Add generateOmoConfig priority for GitHub Copilot models, detection logic
- src/cli/index.ts: Add --githubcopilot option and help text
- README.md: Add GitHub Copilot examples and agent model documentation
#### GitHub Copilot Model Mapping:
| Agent                    | Model                              |
|--------------------------|------------------------------------|
| Sisyphus                 | github-copilot/claude-opus-4.5    |
| Oracle                   | github-copilot/gpt-5.2            |
| Librarian                | github-copilot/claude-haiku-4.5   |
| Explore                  | github-copilot/claude-haiku-4.5   |
| Frontend UI/UX Engineer  | github-copilot/gemini-3-pro-preview |
| Document Writer          | github-copilot/gemini-3-pro-preview |
| Multimodal Looker        | github-copilot/gemini-3-flash-preview |
#### Usage:
```bash
bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no --githubcopilot=yes
```

###  --local Option
#### Files Modified:
- src/cli/types.ts: Add local?: boolean to InstallArgs
- src/cli/index.ts: Add --local option to install command
- src/cli/config-manager.ts: Add isLocal to ConfigContext, add initLocalConfigContext()
- src/cli/install.ts: Add local context initialization in both TUI and non-TUI modes
#### Key Design Decision:
The isLocal flag in ConfigContext prevents findOpenCodeBinaryWithVersion() from
overwriting the local context when it calls initConfigContext() during OpenCode
version detection.
#### Output Paths:
| Mode    | OpenCode Config              | oh-my-opencode Config              |
|---------|------------------------------|------------------------------------|
| Global  | ~/.config/opencode/opencode.json | ~/.config/opencode/oh-my-opencode.json |
| Local   | .opencode/opencode.json      | .opencode/oh-my-opencode.json      |
#### Usage:
bunx oh-my-opencode install --local --no-tui --claude=no --chatgpt=no --gemini=no --githubcopilot=yes

## Testing
```
bun run build
bun ./oh-my-opencode/dist/cli/index.js install --no-tui --claude=no --chatgpt=no --gemini=no --githubcopilot=yes
```
OR 
```
bun run build
bun ./oh-my-opencode/dist/cli/index.js install --no-tui --local --claude=no --chatgpt=no --gemini=no --githubcopilot=yes
```

## Related Issues
Not created 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two new CLI options: --githubcopilot to configure agents to GitHub Copilot models, and --local to install per-project in .opencode. This makes setup easier for Copilot users and enables project-specific configs.

- **New Features**
  - --githubcopilot=<yes|no>: Maps agents to GitHub Copilot models (e.g., Sisyphus → github-copilot/claude-opus-4.5, Oracle → github-copilot/gpt-5.2). Adds Copilot auth hints and detection in existing configs.
  - --local: Writes opencode.json and oh-my-opencode.json to .opencode/ in the project. Keeps the local context stable during version detection.
  - TUI and --no-tui support: New Copilot prompt; in non-interactive mode, --githubcopilot is required.
  - README updated with examples and provider docs.

- **Migration**
  - Global: bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no --githubcopilot=yes
  - Project-local: bunx oh-my-opencode install --local --no-tui --claude=no --chatgpt=no --gemini=no --githubcopilot=yes

<sup>Written for commit b302dac1476abe880c2ff02c82ed2473584fa53d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

