### PR TITLE
docs(i18n): add plugins and plugins_override toggle documentation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -646,7 +646,8 @@ Oh My OpenCode は以下の場所からフックを読み込んで実行しま�
     "commands": false,
     "skills": false,
     "agents": false,
-    "hooks": false
+    "hooks": false,
+    "plugins": false
   }
 }
 ```
@@ -658,8 +659,24 @@ Oh My OpenCode は以下の場所からフックを読み込んで実行しま�
 | `skills`   | `~/.claude/skills/*/SKILL.md`, `./.claude/skills/*/SKILL.md`                          | -                                                     |
 | `agents`   | `~/.claude/agents/*.md`, `./.claude/agents/*.md`                                      | 内蔵エージェント (oracle, librarian 等)               |
 | `hooks`    | `~/.claude/settings.json`, `./.claude/settings.json`, `./.claude/settings.local.json` | -                                                     |
+| `plugins`  | `~/.claude/plugins/` (Claude Code マーケットプレイスプラグイン)                       | -                                                     |
 
 すべてのトグルはデフォルトで `true` (有効) です。完全な Claude Code 互換性を望む場合は `claude_code` オブジェクトを省略してください。
+
+**特定のプラグインだけを無効化** するには `plugins_override` を使用します：
+
+```json
+{
+  "claude_code": {
+    "plugins_override": {
+      "claude-mem@thedotmack": false,
+      "some-other-plugin@marketplace": false
+    }
+  }
+}
+```
+
+プラグインシステム自体は有効にしたまま、特定のプラグインだけをその完全な識別子 (`plugin-name@marketplace-name`) で無効化できます。
 
 ### エージェントのためだけでなく、あなたのために
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -647,7 +647,8 @@ Oh My OpenCode 会扫这些地方：
     "commands": false,
     "skills": false,
     "agents": false,
-    "hooks": false
+    "hooks": false,
+    "plugins": false
   }
 }
 ```
@@ -659,8 +660,24 @@ Oh My OpenCode 会扫这些地方：
 | `skills`   | `~/.claude/skills/*/SKILL.md`, `./.claude/skills/*/SKILL.md`                          | -                                                     |
 | `agents`   | `~/.claude/agents/*.md`, `./.claude/agents/*.md`                                      | 内置 Agent（oracle、librarian 等）                    |
 | `hooks`    | `~/.claude/settings.json`, `./.claude/settings.json`, `./.claude/settings.local.json` | -                                                     |
+| `plugins`  | `~/.claude/plugins/`（Claude Code 市场插件）                                          | -                                                     |
 
 默认都是 `true`（开）。想全兼容 Claude Code？那就别写 `claude_code` 这段。
+
+**只禁用特定插件**用 `plugins_override`：
+
+```json
+{
+  "claude_code": {
+    "plugins_override": {
+      "claude-mem@thedotmack": false,
+      "some-other-plugin@marketplace": false
+    }
+  }
+}
+```
+
+这样插件系统还是开着的，只是用完整标识符（`plugin-name@marketplace-name`）关掉特定插件。
 
 ### 不只是为了 Agent，也是为了你
 


### PR DESCRIPTION
## Summary

Follow-up to #481. Adds the same `plugins` and `plugins_override` documentation to the Japanese and Chinese README files.

## Changes

- Added `plugins` toggle to the compatibility toggles table in README.ja.md and README.zh-cn.md
- Added `plugins_override` example and explanation in both files
- Translations match the style of existing content in each README

## Related

- Follow-up to #481

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add plugins toggle and plugins_override documentation to README.ja.md and README.zh-cn.md, including a table entry and a JSON example for disabling specific plugins. Keeps i18n docs in sync with the main README.

<sup>Written for commit 8cb40f7cedfec1cfae4c1dff73390b8b7e8c4671. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

