### PR TITLE
fix(cli): preserve user config on reinstall

### DIFF
--- a/src/cli/config-manager.ts
+++ b/src/cli/config-manager.ts
@@ -341,7 +341,6 @@ export function writeOmoConfig(installConfig: InstallConfig): ConfigMergeResult 
           return { success: true, configPath: omoConfigPath }
         }
 
-        delete existing.agents
         const merged = deepMerge(existing, newConfig)
         writeFileSync(omoConfigPath, JSON.stringify(merged, null, 2) + "\n")
       } catch (parseErr) {


### PR DESCRIPTION
## Summary

Fixes #556 - `bunx opencode install` now preserves user configurations instead of overwriting them.

## Problem

Previously, the `writeOmoConfig` function in `src/cli/config-manager.ts` would:
1. Read existing user config
2. **Delete the entire `agents` object** from existing config
3. Merge with new install config
4. Write result

This caused all user customizations to be lost when reinstalling.

## Solution

Removed the `delete existing.agents` line (line 344) and rely on the existing `deepMerge` function to properly merge configurations:
- Existing agent configs are preserved
- Only fields specified in new install config are updated
- User customizations survive reinstalls

## Changes

- Removed `delete existing.agents` from `writeOmoConfig` function
- The `deepMerge` function already handles deep object merging correctly

## Testing

- Type check: ✅ Passed
- Build: ✅ Successful
- Existing tests: ✅ All passing

## Example

**Before (overwrites):**
```json
// User's config
{
  "agents": {
    "oracle": { "model": "custom-model", "temperature": 0.5 }
  }
}

// After reinstall - LOST!
{
  "agents": {
    "oracle": { "model": "openai/gpt-5.2" }
  }
}
```

**After (merges):**
```json
// User's config
{
  "agents": {
    "oracle": { "model": "custom-model", "temperature": 0.5 }
  }
}

// After reinstall - PRESERVED!
{
  "agents": {
    "oracle": { "model": "openai/gpt-5.2", "temperature": 0.5 }
  }
}
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves user configurations during reinstall so custom agent settings aren’t lost. bunx opencode install now merges configs instead of overwriting the agents object.

- **Bug Fixes**
  - Removed deletion of existing.agents in writeOmoConfig.
  - Rely on deepMerge to update only fields provided by the installer.

<sup>Written for commit 7853f1f4bfefa02b9b3700ae52f767742c4d9e64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

