### PR TITLE
fix: sync CLI version with package.json during publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,6 +103,12 @@ jobs:
           echo "=== package.json scripts ==="
           cat package.json | jq '.scripts'
 
+      - name: Bump Version
+        run: bun run script/bump-version.ts
+        env:
+          BUMP: ${{ inputs.bump }}
+          VERSION: ${{ inputs.version }}
+
       - name: Build
         run: |
           echo "=== Running bun build (main) ==="

--- a/script/bump-version.ts
+++ b/script/bump-version.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun"
+
+const PACKAGE_NAME = "oh-my-opencode"
+const bump = process.env.BUMP as "major" | "minor" | "patch" | undefined
+const versionOverride = process.env.VERSION
+
+console.log("=== Bumping oh-my-opencode version ===\n")
+
+async function fetchPreviousVersion(): Promise<string> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${PACKAGE_NAME}/latest`)
+    if (!res.ok) throw new Error(`Failed to fetch: ${res.statusText}`)
+    const data = (await res.json()) as { version: string }
+    console.log(`Previous npm version: ${data.version}`)
+    return data.version
+  } catch {
+    console.log("No previous version found on npm, starting from 0.0.0")
+    return "0.0.0"
+  }
+}
+
+function bumpVersion(version: string, type: "major" | "minor" | "patch"): string {
+  const [major, minor, patch] = version.split(".").map(Number)
+  switch (type) {
+    case "major":
+      return `${major + 1}.0.0`
+    case "minor":
+      return `${major}.${minor + 1}.0`
+    case "patch":
+      return `${major}.${minor}.${patch + 1}`
+  }
+}
+
+async function updatePackageVersion(newVersion: string): Promise<void> {
+  const pkgPath = new URL("../package.json", import.meta.url).pathname
+  let pkg = await Bun.file(pkgPath).text()
+  pkg = pkg.replace(/"version": "[^"]+"/, `"version": "${newVersion}"`)
+  await Bun.file(pkgPath).write(pkg)
+  console.log(`Updated package.json version to: ${newVersion}`)
+}
+
+async function checkVersionExists(version: string): Promise<boolean> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${PACKAGE_NAME}/${version}`)
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+async function main() {
+  const previous = await fetchPreviousVersion()
+  const newVersion = versionOverride || (bump ? bumpVersion(previous, bump) : bumpVersion(previous, "patch"))
+  console.log(`New version: ${newVersion}\n`)
+
+  if (await checkVersionExists(newVersion)) {
+    console.log(`Version ${newVersion} already exists on npm. Skipping bump.`)
+    process.exit(0)
+  }
+
+  await updatePackageVersion(newVersion)
+
+  console.log(`\n=== Successfully bumped version to ${newVersion} ===`)
+  console.log(`New version will be embedded in the next build.`)
+}
+
+main()

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -293,17 +293,35 @@ async function checkVersionExists(version: string): Promise<boolean> {
   }
 }
 
+async function getCurrentPackageVersion(): Promise<string> {
+  const pkgPath = new URL("../package.json", import.meta.url).pathname
+  const pkg = await Bun.file(pkgPath).json()
+  return pkg.version as string
+}
+
 async function main() {
   const previous = await fetchPreviousVersion()
-  const newVersion = versionOverride || (bump ? bumpVersion(previous, bump) : bumpVersion(previous, "patch"))
-  console.log(`New version: ${newVersion}\n`)
+  const currentVersion = await getCurrentPackageVersion()
+  const expectedVersion = versionOverride || (bump ? bumpVersion(previous, bump) : bumpVersion(previous, "patch"))
+  
+  // Check if version was already bumped (e.g., by bump-version.ts in workflow)
+  const newVersion = currentVersion !== previous ? currentVersion : expectedVersion
+  console.log(`Current package.json version: ${currentVersion}`)
+  console.log(`Expected version: ${expectedVersion}`)
+  console.log(`Publishing version: ${newVersion}\n`)
 
   if (await checkVersionExists(newVersion)) {
     console.log(`Version ${newVersion} already exists on npm. Skipping publish.`)
     process.exit(0)
   }
 
-  await updateAllPackageVersions(newVersion)
+  // Only update packages if version not already bumped by bump-version.ts
+  if (currentVersion === previous) {
+    console.log("Version not yet bumped, updating all package versions...")
+    await updateAllPackageVersions(newVersion)
+  } else {
+    console.log("Version already bumped, skipping package.json updates")
+  }
   const changelog = await generateChangelog(previous)
   const contributors = await getContributors(previous)
   const notes = [...changelog, ...contributors]


### PR DESCRIPTION
## Summary

Fixes #501 - CLI `-v` flag now reports the correct version matching package.json

## Problem

- `bunx oh-my-opencode -v` reported outdated version (e.g., 2.13.2)
- `bunx oh-my-opencode get-local-version` showed correct version (e.g., 2.14.0) from package.json
- **Root cause:** Publish workflow built CLI before bumping version in package.json, so the old version was embedded in dist/cli/index.js

## Solution

1. **Created `script/bump-version.ts`** - Standalone script to bump version in package.json
2. **Modified publish workflow** - Added "Bump Version" step BEFORE "Build" step
3. **Modified `script/publish.ts`** - Skip version bump if package.json already updated

## Workflow Changes

**Before:**
1. Build (embeds OLD version)
2. Publish script (bumps package.json to NEW version)
3. Publish to npm (NEW package.json + OLD dist/cli/index.js) ❌

**After:**
1. Bump Version (updates package.json to NEW version)
2. Build (embeds NEW version into dist/cli/index.js) ✅
3. Publish script (skips version bump, publishes to npm)

## Testing

- ✅ Local build test confirms version correctly embedded in bundle
- ✅ Workflow guarantees version sync between package.json and CLI
- ✅ Next publish will have matching versions across all files

## Files Changed

- `script/bump-version.ts` (new) - Version bumping logic
- `.github/workflows/publish.yml` - Added bump step before build
- `script/publish.ts` - Added logic to skip version bump if already done

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the CLI -v output with package.json by bumping the version before build in the publish workflow and skipping redundant bumps. Fixes #501.

- **Bug Fixes**
  - Added script/bump-version.ts to bump the version (supports BUMP and VERSION env vars).
  - Updated publish.yml to run the bump step before Build.
  - Updated publish.ts to detect a pre-bumped version and avoid bumping again, ensuring the built CLI embeds the correct version.

<sup>Written for commit c66c6d458c33272c4b173cb3a4e7691d2b5e9ffe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

