### PR TITLE
feat: add display_name config option for agents

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -124,6 +124,9 @@
             "description": {
               "type": "string"
             },
+            "display_name": {
+              "type": "string"
+            },
             "mode": {
               "type": "string",
               "enum": [
@@ -236,6 +239,9 @@
               "type": "boolean"
             },
             "description": {
+              "type": "string"
+            },
+            "display_name": {
               "type": "string"
             },
             "mode": {
@@ -352,6 +358,9 @@
             "description": {
               "type": "string"
             },
+            "display_name": {
+              "type": "string"
+            },
             "mode": {
               "type": "string",
               "enum": [
@@ -464,6 +473,9 @@
               "type": "boolean"
             },
             "description": {
+              "type": "string"
+            },
+            "display_name": {
               "type": "string"
             },
             "mode": {
@@ -580,6 +592,9 @@
             "description": {
               "type": "string"
             },
+            "display_name": {
+              "type": "string"
+            },
             "mode": {
               "type": "string",
               "enum": [
@@ -692,6 +707,9 @@
               "type": "boolean"
             },
             "description": {
+              "type": "string"
+            },
+            "display_name": {
               "type": "string"
             },
             "mode": {
@@ -808,6 +826,9 @@
             "description": {
               "type": "string"
             },
+            "display_name": {
+              "type": "string"
+            },
             "mode": {
               "type": "string",
               "enum": [
@@ -920,6 +941,9 @@
               "type": "boolean"
             },
             "description": {
+              "type": "string"
+            },
+            "display_name": {
               "type": "string"
             },
             "mode": {
@@ -1036,6 +1060,9 @@
             "description": {
               "type": "string"
             },
+            "display_name": {
+              "type": "string"
+            },
             "mode": {
               "type": "string",
               "enum": [
@@ -1150,6 +1177,9 @@
             "description": {
               "type": "string"
             },
+            "display_name": {
+              "type": "string"
+            },
             "mode": {
               "type": "string",
               "enum": [
@@ -1262,6 +1292,9 @@
               "type": "boolean"
             },
             "description": {
+              "type": "string"
+            },
+            "display_name": {
               "type": "string"
             },
             "mode": {

--- a/src/agents/sisyphus-prompt-builder.ts
+++ b/src/agents/sisyphus-prompt-builder.ts
@@ -4,6 +4,7 @@ export interface AvailableAgent {
   name: BuiltinAgentName
   description: string
   metadata: AgentPromptMetadata
+  displayName?: string
 }
 
 export interface AvailableTool {
@@ -136,7 +137,7 @@ export function buildToolSelectionTable(
 
   for (const agent of sortedAgents) {
     const shortDesc = agent.description.split(".")[0] || agent.description
-    rows.push(`| \`${agent.name}\` agent | ${agent.metadata.cost} | ${shortDesc} |`)
+    rows.push(`| \`${agent.displayName ?? agent.name}\` agent | ${agent.metadata.cost} | ${shortDesc} |`)
   }
 
   rows.push("")
@@ -195,7 +196,7 @@ export function buildDelegationTable(agents: AvailableAgent[]): string {
 
   for (const agent of agents) {
     for (const trigger of agent.metadata.triggers) {
-      rows.push(`| ${trigger.domain} | \`${agent.name}\` | ${trigger.trigger} |`)
+      rows.push(`| ${trigger.domain} | \`${agent.displayName ?? agent.name}\` | ${trigger.trigger} |`)
     }
   }
 
@@ -325,7 +326,7 @@ export function buildUltraworkAgentSection(agents: AvailableAgent[]): string {
   for (const agent of sortedAgents) {
     const shortDesc = agent.description.split(".")[0] || agent.description
     const suffix = (agent.name === "explore" || agent.name === "librarian") ? " (multiple)" : ""
-    lines.push(`- **${agent.name}${suffix}**: ${shortDesc}`)
+    lines.push(`- **${agent.displayName ?? agent.name}${suffix}**: ${shortDesc}`)
   }
 
   return lines.join("\n")

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -73,6 +73,7 @@ export type AgentName = BuiltinAgentName
 
 export type AgentOverrideConfig = Partial<AgentConfig> & {
   prompt_append?: string
+  display_name?: string
 }
 
 export type AgentOverrides = Partial<Record<OverridableAgentName, AgentOverrideConfig>>

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -120,6 +120,7 @@ export function createBuiltinAgents(
         name: agentName,
         description: config.description ?? "",
         metadata,
+        displayName: override?.display_name,
       })
     }
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -90,6 +90,7 @@ export const AgentOverrideConfigSchema = z.object({
   tools: z.record(z.string(), z.boolean()).optional(),
   disable: z.boolean().optional(),
   description: z.string().optional(),
+  display_name: z.string().optional(),
   mode: z.enum(["subagent", "primary", "all"]).optional(),
   color: z
     .string()

--- a/src/features/background-agent/index.ts
+++ b/src/features/background-agent/index.ts
@@ -1,3 +1,3 @@
 export * from "./types"
-export { BackgroundManager } from "./manager"
+export { BackgroundManager, type AgentDisplayNames } from "./manager"
 export { ConcurrencyManager } from "./concurrency"

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -56,6 +56,8 @@ function getMessageDir(sessionID: string): string | null {
   return null
 }
 
+export type AgentDisplayNames = Record<string, string>
+
 export class BackgroundManager {
   private tasks: Map<string, BackgroundTask>
   private notifications: Map<string, BackgroundTask[]>
@@ -63,13 +65,19 @@ export class BackgroundManager {
   private directory: string
   private pollingInterval?: ReturnType<typeof setInterval>
   private concurrencyManager: ConcurrencyManager
+  private displayNames: AgentDisplayNames
 
-  constructor(ctx: PluginInput, config?: BackgroundTaskConfig) {
+  constructor(ctx: PluginInput, config?: BackgroundTaskConfig, displayNames?: AgentDisplayNames) {
     this.tasks = new Map()
     this.notifications = new Map()
     this.client = ctx.client
     this.directory = ctx.directory
     this.concurrencyManager = new ConcurrencyManager(config)
+    this.displayNames = displayNames ?? {}
+  }
+
+  getDisplayName(agent: string): string {
+    return this.displayNames[agent] ?? agent
   }
 
   async launch(input: LaunchInput): Promise<BackgroundTask> {
@@ -327,6 +335,7 @@ export class BackgroundManager {
 
   private notifyParentSession(task: BackgroundTask): void {
     const duration = this.formatDuration(task.startedAt, task.completedAt)
+    const agentDisplayName = this.getDisplayName(task.agent)
 
     log("[background-agent] notifyParentSession called for task:", task.id)
 
@@ -336,14 +345,14 @@ export class BackgroundManager {
       tuiClient.tui.showToast({
         body: {
           title: "Background Task Completed",
-          message: `Task "${task.description}" finished in ${duration}.`,
+          message: `Task "${task.description}" (${agentDisplayName}) finished in ${duration}.`,
           variant: "success",
           duration: 5000,
         },
       }).catch(() => {})
     }
 
-    const message = `[BACKGROUND TASK COMPLETED] Task "${task.description}" finished in ${duration}. Use background_output with task_id="${task.id}" to get results.`
+    const message = `[BACKGROUND TASK COMPLETED] Task "${task.description}" (${agentDisplayName}) finished in ${duration}. Use background_output with task_id="${task.id}" to get results.`
 
     log("[background-agent] Sending notification to parent session:", { parentSessionID: task.parentSessionID })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,17 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     ? createEditErrorRecoveryHook(ctx)
     : null;
 
-  const backgroundManager = new BackgroundManager(ctx);
+  const agentDisplayNames: Record<string, string> = {};
+  if (pluginConfig.agents) {
+    for (const [name, override] of Object.entries(pluginConfig.agents)) {
+      const displayName = (override as { display_name?: string } | undefined)?.display_name;
+      if (displayName) {
+        agentDisplayNames[name] = displayName;
+      }
+    }
+  }
+
+  const backgroundManager = new BackgroundManager(ctx, pluginConfig.background_task, agentDisplayNames);
 
   const todoContinuationEnforcer = isHookEnabled("todo-continuation-enforcer")
     ? createTodoContinuationEnforcer(ctx, { backgroundManager })
@@ -188,7 +198,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     : null;
   const backgroundTools = createBackgroundTools(backgroundManager, ctx.client);
 
-  const callOmoAgent = createCallOmoAgent(ctx, backgroundManager);
+  const callOmoAgent = createCallOmoAgent(ctx, backgroundManager, agentDisplayNames);
   const lookAt = createLookAt(ctx);
   const disabledSkills = new Set(pluginConfig.disabled_skills ?? []);
   const systemMcpNames = getSystemMcpServerNames();

--- a/src/tools/background-task/tools.ts
+++ b/src/tools/background-task/tools.ts
@@ -81,12 +81,13 @@ export function createBackgroundTask(manager: BackgroundManager): ToolDefinition
           metadata: { sessionId: task.sessionID },
         })
 
+        const agentDisplayName = manager.getDisplayName(task.agent)
         return `Background task launched successfully.
 
 Task ID: ${task.id}
 Session ID: ${task.sessionID}
 Description: ${task.description}
-Agent: ${task.agent}
+Agent: ${agentDisplayName}
 Status: ${task.status}
 
 The system will notify you when the task completes.
@@ -110,9 +111,10 @@ function truncateText(text: string, maxLength: number): string {
   return text.slice(0, maxLength) + "..."
 }
 
-function formatTaskStatus(task: BackgroundTask): string {
+function formatTaskStatus(task: BackgroundTask, agentDisplayName?: string): string {
   const duration = formatDuration(task.startedAt, task.completedAt)
   const promptPreview = truncateText(task.prompt, 500)
+  const displayName = agentDisplayName ?? task.agent
   
   let progressSection = ""
   if (task.progress?.lastTool) {
@@ -151,7 +153,7 @@ ${truncated}
 |-------|-------|
 | Task ID | \`${task.id}\` |
 | Description | ${task.description} |
-| Agent | ${task.agent} |
+| Agent | ${displayName} |
 | Status | **${task.status}** |
 | Duration | ${duration} |
 | Session ID | \`${task.sessionID}\` |${progressSection}
@@ -249,6 +251,7 @@ export function createBackgroundOutput(manager: BackgroundManager, client: Openc
 
         const shouldBlock = args.block === true
         const timeoutMs = Math.min(args.timeout ?? 60000, 600000)
+        const agentDisplayName = manager.getDisplayName(task.agent)
 
         // Already completed: return result immediately (regardless of block flag)
         if (task.status === "completed") {
@@ -257,12 +260,12 @@ export function createBackgroundOutput(manager: BackgroundManager, client: Openc
 
         // Error or cancelled: return status immediately
         if (task.status === "error" || task.status === "cancelled") {
-          return formatTaskStatus(task)
+          return formatTaskStatus(task, agentDisplayName)
         }
 
         // Non-blocking and still running: return status
         if (!shouldBlock) {
-          return formatTaskStatus(task)
+          return formatTaskStatus(task, agentDisplayName)
         }
 
         // Blocking: poll until completion or timeout
@@ -281,7 +284,7 @@ export function createBackgroundOutput(manager: BackgroundManager, client: Openc
           }
 
           if (currentTask.status === "error" || currentTask.status === "cancelled") {
-            return formatTaskStatus(currentTask)
+            return formatTaskStatus(currentTask, manager.getDisplayName(currentTask.agent))
           }
         }
 
@@ -290,7 +293,7 @@ export function createBackgroundOutput(manager: BackgroundManager, client: Openc
         if (!finalTask) {
           return `Task was deleted: ${args.task_id}`
         }
-        return `Timeout exceeded (${timeoutMs}ms). Task still ${finalTask.status}.\n\n${formatTaskStatus(finalTask)}`
+        return `Timeout exceeded (${timeoutMs}ms). Task still ${finalTask.status}.\n\n${formatTaskStatus(finalTask, manager.getDisplayName(finalTask.agent))}`
       } catch (error) {
         return `Error getting output: ${error instanceof Error ? error.message : String(error)}`
       }

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -1,7 +1,7 @@
 import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin"
 import { ALLOWED_AGENTS, CALL_OMO_AGENT_DESCRIPTION } from "./constants"
 import type { CallOmoAgentArgs } from "./types"
-import type { BackgroundManager } from "../../features/background-agent"
+import type { BackgroundManager, AgentDisplayNames } from "../../features/background-agent"
 import { log } from "../../shared/logger"
 
 type ToolContextWithMetadata = {
@@ -14,12 +14,14 @@ type ToolContextWithMetadata = {
 
 export function createCallOmoAgent(
   ctx: PluginInput,
-  backgroundManager: BackgroundManager
+  backgroundManager: BackgroundManager,
+  displayNames?: AgentDisplayNames
 ): ToolDefinition {
   const agentDescriptions = ALLOWED_AGENTS.map(
     (name) => `- ${name}: Specialized agent for ${name} tasks`
   ).join("\n")
   const description = CALL_OMO_AGENT_DESCRIPTION.replace("{agents}", agentDescriptions)
+  const getDisplayName = (agent: string) => displayNames?.[agent] ?? agent
 
   return tool({
     description,
@@ -46,10 +48,10 @@ export function createCallOmoAgent(
         if (args.session_id) {
           return `Error: session_id is not supported in background mode. Use run_in_background=false to continue an existing session.`
         }
-        return await executeBackground(args, toolCtx, backgroundManager)
+        return await executeBackground(args, toolCtx, backgroundManager, getDisplayName)
       }
 
-      return await executeSync(args, toolCtx, ctx)
+      return await executeSync(args, toolCtx, ctx, getDisplayName)
     },
   })
 }
@@ -57,7 +59,8 @@ export function createCallOmoAgent(
 async function executeBackground(
   args: CallOmoAgentArgs,
   toolContext: ToolContextWithMetadata,
-  manager: BackgroundManager
+  manager: BackgroundManager,
+  getDisplayName: (agent: string) => string
 ): Promise<string> {
   try {
     const task = await manager.launch({
@@ -73,12 +76,13 @@ async function executeBackground(
       metadata: { sessionId: task.sessionID },
     })
 
+    const agentDisplayName = getDisplayName(task.agent)
     return `Background agent task launched successfully.
 
 Task ID: ${task.id}
 Session ID: ${task.sessionID}
 Description: ${task.description}
-Agent: ${task.agent} (subagent)
+Agent: ${agentDisplayName} (subagent)
 Status: ${task.status}
 
 The system will notify you when the task completes.
@@ -94,9 +98,11 @@ Use \`background_output\` tool with task_id="${task.id}" to check progress:
 async function executeSync(
   args: CallOmoAgentArgs,
   toolContext: ToolContextWithMetadata,
-  ctx: PluginInput
+  ctx: PluginInput,
+  getDisplayName: (agent: string) => string
 ): Promise<string> {
   let sessionID: string
+  const agentDisplayName = getDisplayName(args.subagent_type)
 
   if (args.session_id) {
     log(`[call_omo_agent] Using existing session: ${args.session_id}`)
@@ -113,7 +119,7 @@ async function executeSync(
     const createResult = await ctx.client.session.create({
       body: {
         parentID: toolContext.sessionID,
-        title: `${args.description} (@${args.subagent_type} subagent)`,
+        title: `${args.description} (@${agentDisplayName} subagent)`,
       },
     })
 


### PR DESCRIPTION
## Summary

Adds `display_name` config option for agents, allowing users to customize how agent names appear in output/prompts.

**Example usage:**
```json
{
  "agents": {
    "oracle": { "display_name": "🔮 The All-Knowing One" },
    "librarian": { "display_name": "📚 Book Nerd" },
    "explore": { "display_name": "🕵️ Detective Pikachu" }
  }
}
```

## Changes

- Added `display_name` to `AgentOverrideConfigSchema` in Zod schema
- Added `displayName` field to `AvailableAgent` interface
- Updated Sisyphus prompt builder to use `displayName ?? name` pattern
- Updated `BackgroundManager` to store and use display names
- Updated `background_task` and `call_omo_agent` tools to show display names
- Regenerated JSON schema

## Where Display Names Appear

1. Sisyphus prompt tables (Tool Selection, Delegation, Ultrawork sections)
2. Background task launch output
3. Background task status/completion messages
4. Toast notifications
5. Sync subagent session titles

## Verification

- ✅ TypeScript typecheck passes
- ✅ All 648 tests pass
- ✅ Build succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a display_name config for agents so you can show friendly names across prompts, background tasks, and notifications. If not set, it falls back to the agent’s name.

- **New Features**
  - Config: Added display_name to the agent override schema and JSON schema.
  - Prompting: Sisyphus tables and ultrawork/delegation sections use display_name.
  - Background tasks: Manager stores display names; toasts, completion messages, background_output, and tool outputs display them.
  - Subagents: call_omo_agent uses display_name in session titles and messages; wiring added in index to pass config through.

<sup>Written for commit f73dade89e594b54310c1a3f3da656ca8432c7c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

