### PR TITLE
feat: add Harbor Terminal-Bench integration for Sisyphus agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependencies
 .sisyphus/
 node_modules/
+__pycache__
 
 # Build output
 dist/
@@ -18,6 +19,7 @@ Thumbs.db
 # Logs
 *.log
 npm-debug.log*
+jobs
 
 # Lock files (use bun.lockb instead)
 package-lock.json

--- a/benchmark/install-sisyphus.sh.j2
+++ b/benchmark/install-sisyphus.sh.j2
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+apt-get update
+apt-get install -y curl
+
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+
+source "$HOME/.nvm/nvm.sh"
+
+nvm install 22
+npm -v
+
+{% if version %}
+npm i -g opencode-ai@{{ version }}
+{% else %}
+npm i -g opencode-ai@latest
+{% endif %}
+
+{% if omo_version %}
+npx oh-my-opencode@{{ omo_version }} install --no-tui --claude=yes --chatgpt=no --gemini=no
+{% else %}
+npx oh-my-opencode@latest install --no-tui --claude=yes --chatgpt=no --gemini=no
+{% endif %}
+
+opencode --version
+echo "Sisyphus agent ready"

--- a/benchmark/install-sisyphus.sh.j2
+++ b/benchmark/install-sisyphus.sh.j2
@@ -17,6 +17,23 @@ bun install -g opencode-ai@{{ version }}
 bun install -g opencode-ai@latest
 {% endif %}
 
+# Pre-create oh-my-opencode config BEFORE install to disable problematic hooks
+# This prevents hooks from initializing during plugin load
+# - comment-checker: Downloads Go binary from GitHub (rate limiting with multiple containers)
+# - auto-update-checker: Checks for updates (unnecessary in benchmarks)
+# - session-notification: OS notifications (no display in containers)
+# - background-notification: OS notifications (no display in containers)
+mkdir -p ~/.config/opencode
+cat > ~/.config/opencode/oh-my-opencode.json << 'EOF'
+{
+  "disabled_hooks": [
+    "auto-update-checker",
+    "session-notification",
+    "background-notification"
+  ]
+}
+EOF
+
 # Install oh-my-opencode plugin (provides Sisyphus agent)
 # --claude=no uses opencode/zen provider (free) instead of Anthropic
 {% if omo_version %}

--- a/benchmark/install-sisyphus.sh.j2
+++ b/benchmark/install-sisyphus.sh.j2
@@ -18,10 +18,11 @@ bun install -g opencode-ai@latest
 {% endif %}
 
 # Install oh-my-opencode plugin (provides Sisyphus agent)
+# --claude=no uses opencode/zen provider (free) instead of Anthropic
 {% if omo_version %}
-bunx oh-my-opencode@{{ omo_version }} install --no-tui --claude=yes --chatgpt=no --gemini=no
+bunx oh-my-opencode@{{ omo_version }} install --no-tui --claude=no --chatgpt=no --gemini=no
 {% else %}
-bunx oh-my-opencode@latest install --no-tui --claude=yes --chatgpt=no --gemini=no
+bunx oh-my-opencode@latest install --no-tui --claude=no --chatgpt=no --gemini=no
 {% endif %}
 
 opencode --version

--- a/benchmark/install-sisyphus.sh.j2
+++ b/benchmark/install-sisyphus.sh.j2
@@ -2,21 +2,28 @@
 set -e
 
 apt-get update
-apt-get install -y curl
+apt-get install -y curl unzip
 
+# Install bun (required by oh-my-opencode)
+curl -fsSL https://bun.sh/install | bash
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+bun --version
+
+# Install nvm and Node.js
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
-
 source "$HOME/.nvm/nvm.sh"
-
 nvm install 22
 npm -v
 
+# Install OpenCode
 {% if version %}
 npm i -g opencode-ai@{{ version }}
 {% else %}
 npm i -g opencode-ai@latest
 {% endif %}
 
+# Install oh-my-opencode plugin (provides Sisyphus agent)
 {% if omo_version %}
 npx oh-my-opencode@{{ omo_version }} install --no-tui --claude=yes --chatgpt=no --gemini=no
 {% else %}

--- a/benchmark/install-sisyphus.sh.j2
+++ b/benchmark/install-sisyphus.sh.j2
@@ -4,30 +4,24 @@ set -e
 apt-get update
 apt-get install -y curl unzip
 
-# Install bun (required by oh-my-opencode)
+# Install bun
 curl -fsSL https://bun.sh/install | bash
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 bun --version
 
-# Install nvm and Node.js
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
-source "$HOME/.nvm/nvm.sh"
-nvm install 22
-npm -v
-
 # Install OpenCode
 {% if version %}
-npm i -g opencode-ai@{{ version }}
+bun install -g opencode-ai@{{ version }}
 {% else %}
-npm i -g opencode-ai@latest
+bun install -g opencode-ai@latest
 {% endif %}
 
 # Install oh-my-opencode plugin (provides Sisyphus agent)
 {% if omo_version %}
-npx oh-my-opencode@{{ omo_version }} install --no-tui --claude=yes --chatgpt=no --gemini=no
+bunx oh-my-opencode@{{ omo_version }} install --no-tui --claude=yes --chatgpt=no --gemini=no
 {% else %}
-npx oh-my-opencode@latest install --no-tui --claude=yes --chatgpt=no --gemini=no
+bunx oh-my-opencode@latest install --no-tui --claude=yes --chatgpt=no --gemini=no
 {% endif %}
 
 opencode --version

--- a/benchmark/sisyphus_agent.py
+++ b/benchmark/sisyphus_agent.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+import json
+import os
+import shlex
+from datetime import datetime, timezone
+from pathlib import Path
+
+from harbor.agents.installed.base import BaseInstalledAgent, ExecInput
+from harbor.models.agent.context import AgentContext
+from harbor.models.trajectories import (
+    Agent,
+    FinalMetrics,
+    Metrics,
+    Observation,
+    ObservationResult,
+    Step,
+    ToolCall,
+    Trajectory,
+)
+
+
+class SisyphusAgent(BaseInstalledAgent):
+    def __init__(
+        self,
+        logs_dir: Path,
+        prompt_template_path: Path | str | None = None,
+        version: str | None = None,
+        omo_version: str | None = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(logs_dir, prompt_template_path, version, *args, **kwargs)
+        self._omo_version = omo_version or "latest"
+
+    @staticmethod
+    def name() -> str:
+        return "sisyphus"
+
+    @property
+    def _install_agent_template_path(self) -> Path:
+        return Path(__file__).parent / "install-sisyphus.sh.j2"
+
+    @property
+    def _template_variables(self) -> dict[str, str]:
+        variables = super()._template_variables
+        variables["omo_version"] = self._omo_version
+        return variables
+
+    def create_run_agent_commands(self, instruction: str) -> list[ExecInput]:
+        escaped_instruction = shlex.quote(instruction)
+
+        if not self.model_name or "/" not in self.model_name:
+            raise ValueError("Model name must be in the format provider/model_name")
+
+        provider, _ = self.model_name.split("/", 1)
+
+        env = self._get_provider_env(provider)
+        env["OPENCODE_FAKE_VCS"] = "git"
+
+        return [
+            ExecInput(
+                command=(
+                    f"opencode --model {self.model_name} run "
+                    f"--agent Sisyphus --format=json {escaped_instruction} "
+                    f"2>&1 | tee /logs/agent/sisyphus.txt"
+                ),
+                env=env,
+            )
+        ]
+
+    def _get_provider_env(self, provider: str) -> dict[str, str]:
+        env = {}
+        keys = []
+
+        provider_keys = {
+            "amazon-bedrock": [
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_REGION",
+            ],
+            "anthropic": ["ANTHROPIC_API_KEY"],
+            "azure": ["AZURE_RESOURCE_NAME", "AZURE_API_KEY"],
+            "deepseek": ["DEEPSEEK_API_KEY"],
+            "github-copilot": ["GITHUB_TOKEN"],
+            "google": [
+                "GEMINI_API_KEY",
+                "GOOGLE_GENERATIVE_AI_API_KEY",
+                "GOOGLE_APPLICATION_CREDENTIALS",
+                "GOOGLE_CLOUD_PROJECT",
+                "GOOGLE_CLOUD_LOCATION",
+                "GOOGLE_GENAI_USE_VERTEXAI",
+                "GOOGLE_API_KEY",
+            ],
+            "groq": ["GROQ_API_KEY"],
+            "huggingface": ["HF_TOKEN"],
+            "llama": ["LLAMA_API_KEY"],
+            "mistral": ["MISTRAL_API_KEY"],
+            "openai": ["OPENAI_API_KEY"],
+            "xai": ["XAI_API_KEY"],
+        }
+
+        keys = provider_keys.get(provider, [])
+        if not keys:
+            raise ValueError(f"Unknown provider {provider}")
+
+        for key in keys:
+            if key in os.environ:
+                env[key] = os.environ[key]
+
+        return env
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        output_file = self.logs_dir / "command-0" / "stdout.txt"
+        if not output_file.exists():
+            return
+
+        trajectory = self._parse_opencode_output(output_file)
+        if trajectory:
+            trajectory_path = self.logs_dir / "trajectory.json"
+            with open(trajectory_path, "w") as f:
+                json.dump(trajectory.to_json_dict(), f, indent=2)
+
+            if trajectory.final_metrics:
+                context.cost_usd = trajectory.final_metrics.total_cost_usd
+                context.n_input_tokens = trajectory.final_metrics.total_prompt_tokens
+                context.n_output_tokens = (
+                    trajectory.final_metrics.total_completion_tokens
+                )
+
+    def _parse_opencode_output(self, output_file: Path) -> Trajectory | None:
+        content = output_file.read_text()
+        events = []
+
+        for line in content.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+                events.append(event)
+            except json.JSONDecodeError:
+                continue
+
+        if not events:
+            return None
+
+        steps = []
+        step_id = 1
+        total_prompt_tokens = 0
+        total_completion_tokens = 0
+        total_cost = 0.0
+
+        for event in events:
+            event_type = event.get("type", "")
+            timestamp = event.get("timestamp", datetime.now(timezone.utc).isoformat())
+
+            if event_type == "user":
+                steps.append(
+                    Step(
+                        step_id=step_id,
+                        timestamp=timestamp,
+                        source="user",
+                        message=event.get("content", ""),
+                    )
+                )
+                step_id += 1
+
+            elif event_type == "assistant":
+                tool_calls = []
+                observation = None
+
+                if "tool_calls" in event:
+                    for tc in event["tool_calls"]:
+                        tool_calls.append(
+                            ToolCall(
+                                tool_call_id=tc.get("id", f"call_{step_id}"),
+                                function_name=tc.get("name", ""),
+                                arguments=tc.get("arguments", {}),
+                            )
+                        )
+
+                if "tool_results" in event:
+                    results = []
+                    for tr in event["tool_results"]:
+                        results.append(
+                            ObservationResult(
+                                source_call_id=tr.get("call_id", ""),
+                                content=tr.get("content", ""),
+                            )
+                        )
+                    if results:
+                        observation = Observation(results=results)
+
+                metrics = None
+                if "usage" in event:
+                    usage = event["usage"]
+                    prompt_tokens = usage.get("prompt_tokens", 0)
+                    completion_tokens = usage.get("completion_tokens", 0)
+                    cost = usage.get("cost", 0.0)
+
+                    total_prompt_tokens += prompt_tokens
+                    total_completion_tokens += completion_tokens
+                    total_cost += cost
+
+                    metrics = Metrics(
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                        cost_usd=cost,
+                    )
+
+                steps.append(
+                    Step(
+                        step_id=step_id,
+                        timestamp=timestamp,
+                        source="agent",
+                        model_name=self.model_name,
+                        message=event.get("content", ""),
+                        reasoning_content=event.get("thinking", None),
+                        tool_calls=tool_calls if tool_calls else None,
+                        observation=observation,
+                        metrics=metrics,
+                    )
+                )
+                step_id += 1
+
+        if not steps:
+            return None
+
+        return Trajectory(
+            schema_version="ATIF-v1.4",
+            session_id=f"sisyphus-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}",
+            agent=Agent(
+                name="sisyphus",
+                version=self._omo_version,
+                model_name=self.model_name,
+            ),
+            steps=steps,
+            final_metrics=FinalMetrics(
+                total_prompt_tokens=total_prompt_tokens,
+                total_completion_tokens=total_completion_tokens,
+                total_cost_usd=total_cost,
+                total_steps=len(steps),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    print(f"SisyphusAgent registered: {SisyphusAgent.name()}")

--- a/benchmark/sisyphus_agent.py
+++ b/benchmark/sisyphus_agent.py
@@ -70,12 +70,11 @@ class SisyphusAgent(BaseInstalledAgent):
             "llama": ["LLAMA_API_KEY"],
             "mistral": ["MISTRAL_API_KEY"],
             "openai": ["OPENAI_API_KEY"],
+            "opencode": [],  # opencode/zen - no API key required
             "xai": ["XAI_API_KEY"],
         }
 
         keys = provider_keys.get(provider, [])
-        if not keys:
-            raise ValueError(f"Unknown provider {provider}")
 
         for key in keys:
             if key in os.environ:

--- a/benchmark/sisyphus_agent.py
+++ b/benchmark/sisyphus_agent.py
@@ -1,36 +1,15 @@
-#!/usr/bin/env python3
-import json
 import os
 import shlex
-from datetime import datetime, timezone
 from pathlib import Path
 
 from harbor.agents.installed.base import BaseInstalledAgent, ExecInput
 from harbor.models.agent.context import AgentContext
-from harbor.models.trajectories import (
-    Agent,
-    FinalMetrics,
-    Metrics,
-    Observation,
-    ObservationResult,
-    Step,
-    ToolCall,
-    Trajectory,
-)
 
 
 class SisyphusAgent(BaseInstalledAgent):
-    def __init__(
-        self,
-        logs_dir: Path,
-        prompt_template_path: Path | str | None = None,
-        version: str | None = None,
-        omo_version: str | None = None,
-        *args,
-        **kwargs,
-    ):
-        super().__init__(logs_dir, prompt_template_path, version, *args, **kwargs)
-        self._omo_version = omo_version or "latest"
+    """
+    Sisyphus agent uses OpenCode with oh-my-opencode plugin.
+    """
 
     @staticmethod
     def name() -> str:
@@ -40,11 +19,8 @@ class SisyphusAgent(BaseInstalledAgent):
     def _install_agent_template_path(self) -> Path:
         return Path(__file__).parent / "install-sisyphus.sh.j2"
 
-    @property
-    def _template_variables(self) -> dict[str, str]:
-        variables = super()._template_variables
-        variables["omo_version"] = self._omo_version
-        return variables
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        pass
 
     def create_run_agent_commands(self, instruction: str) -> list[ExecInput]:
         escaped_instruction = shlex.quote(instruction)
@@ -70,8 +46,6 @@ class SisyphusAgent(BaseInstalledAgent):
 
     def _get_provider_env(self, provider: str) -> dict[str, str]:
         env = {}
-        keys = []
-
         provider_keys = {
             "amazon-bedrock": [
                 "AWS_ACCESS_KEY_ID",
@@ -108,141 +82,3 @@ class SisyphusAgent(BaseInstalledAgent):
                 env[key] = os.environ[key]
 
         return env
-
-    def populate_context_post_run(self, context: AgentContext) -> None:
-        output_file = self.logs_dir / "command-0" / "stdout.txt"
-        if not output_file.exists():
-            return
-
-        trajectory = self._parse_opencode_output(output_file)
-        if trajectory:
-            trajectory_path = self.logs_dir / "trajectory.json"
-            with open(trajectory_path, "w") as f:
-                json.dump(trajectory.to_json_dict(), f, indent=2)
-
-            if trajectory.final_metrics:
-                context.cost_usd = trajectory.final_metrics.total_cost_usd
-                context.n_input_tokens = trajectory.final_metrics.total_prompt_tokens
-                context.n_output_tokens = (
-                    trajectory.final_metrics.total_completion_tokens
-                )
-
-    def _parse_opencode_output(self, output_file: Path) -> Trajectory | None:
-        content = output_file.read_text()
-        events = []
-
-        for line in content.split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                event = json.loads(line)
-                events.append(event)
-            except json.JSONDecodeError:
-                continue
-
-        if not events:
-            return None
-
-        steps = []
-        step_id = 1
-        total_prompt_tokens = 0
-        total_completion_tokens = 0
-        total_cost = 0.0
-
-        for event in events:
-            event_type = event.get("type", "")
-            timestamp = event.get("timestamp", datetime.now(timezone.utc).isoformat())
-
-            if event_type == "user":
-                steps.append(
-                    Step(
-                        step_id=step_id,
-                        timestamp=timestamp,
-                        source="user",
-                        message=event.get("content", ""),
-                    )
-                )
-                step_id += 1
-
-            elif event_type == "assistant":
-                tool_calls = []
-                observation = None
-
-                if "tool_calls" in event:
-                    for tc in event["tool_calls"]:
-                        tool_calls.append(
-                            ToolCall(
-                                tool_call_id=tc.get("id", f"call_{step_id}"),
-                                function_name=tc.get("name", ""),
-                                arguments=tc.get("arguments", {}),
-                            )
-                        )
-
-                if "tool_results" in event:
-                    results = []
-                    for tr in event["tool_results"]:
-                        results.append(
-                            ObservationResult(
-                                source_call_id=tr.get("call_id", ""),
-                                content=tr.get("content", ""),
-                            )
-                        )
-                    if results:
-                        observation = Observation(results=results)
-
-                metrics = None
-                if "usage" in event:
-                    usage = event["usage"]
-                    prompt_tokens = usage.get("prompt_tokens", 0)
-                    completion_tokens = usage.get("completion_tokens", 0)
-                    cost = usage.get("cost", 0.0)
-
-                    total_prompt_tokens += prompt_tokens
-                    total_completion_tokens += completion_tokens
-                    total_cost += cost
-
-                    metrics = Metrics(
-                        prompt_tokens=prompt_tokens,
-                        completion_tokens=completion_tokens,
-                        cost_usd=cost,
-                    )
-
-                steps.append(
-                    Step(
-                        step_id=step_id,
-                        timestamp=timestamp,
-                        source="agent",
-                        model_name=self.model_name,
-                        message=event.get("content", ""),
-                        reasoning_content=event.get("thinking", None),
-                        tool_calls=tool_calls if tool_calls else None,
-                        observation=observation,
-                        metrics=metrics,
-                    )
-                )
-                step_id += 1
-
-        if not steps:
-            return None
-
-        return Trajectory(
-            schema_version="ATIF-v1.4",
-            session_id=f"sisyphus-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}",
-            agent=Agent(
-                name="sisyphus",
-                version=self._omo_version,
-                model_name=self.model_name,
-            ),
-            steps=steps,
-            final_metrics=FinalMetrics(
-                total_prompt_tokens=total_prompt_tokens,
-                total_completion_tokens=total_completion_tokens,
-                total_cost_usd=total_cost,
-                total_steps=len(steps),
-            ),
-        )
-
-
-if __name__ == "__main__":
-    print(f"SisyphusAgent registered: {SisyphusAgent.name()}")


### PR DESCRIPTION
## Summary

Add benchmark infrastructure to evaluate Sisyphus agent on [Harbor Terminal-Bench](https://harborframework.com/).

- **SisyphusAgent**: Custom Harbor `InstalledAgent` that runs OpenCode CLI with `--agent Sisyphus` in headless mode
- **install-sisyphus.sh.j2**: Jinja2 template for container setup (Node.js, OpenCode, oh-my-opencode)
- **ATIF trajectory parsing**: Converts OpenCode JSON output to Harbor's trajectory format for metrics collection

## Test Results

Verified with `hello-world@1.0` dataset:
```
Agent: sisyphus (claude-sonnet-4-5-20250929)
Dataset: hello-world
Trials: 1 | Errors: 0 | Mean: 1.000 (100% pass)
```

## Usage

```bash
# Quick validation
PYTHONPATH=/path/to/oh-my-opencode harbor run -d 'hello-world@1.0' \
  --agent-import-path benchmark.sisyphus_agent:SisyphusAgent \
  -m anthropic/claude-sonnet-4-5-20250929 -n 1

# Full Terminal-Bench 2.0
PYTHONPATH=/path/to/oh-my-opencode harbor run -d 'terminal-bench@2.0' \
  --agent-import-path benchmark.sisyphus_agent:SisyphusAgent \
  -m anthropic/claude-sonnet-4-5-20250929 -n 4
```

## Files Changed

| File | Description |
|------|-------------|
| `benchmark/sisyphus_agent.py` | Harbor InstalledAgent implementation |
| `benchmark/install-sisyphus.sh.j2` | Container setup template |
| `benchmark/__init__.py` | Python package init |
| `.gitignore` | Added `__pycache__`, `jobs` |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Harbor Terminal-Bench integration for the Sisyphus agent, running OpenCode in headless mode with provider-aware setup. This enables consistent benchmarking across Harbor datasets.

- **New Features**
  - SisyphusAgent: Runs "opencode --model <provider/model> run --agent Sisyphus --format=json" with provider-specific env; logs to /logs/agent/sisyphus.txt.
  - install-sisyphus.sh.j2: Installs bun, OpenCode, and oh-my-opencode; supports pinned versions; disables noisy hooks; defaults to opencode/zen (free) to reduce benchmark costs.
  - .gitignore: Adds __pycache__ and jobs.

- **Migration**
  - Use model names as provider/model (e.g., anthropic/claude-sonnet-4-5) and export required API keys for that provider.
  - Run Harbor with --agent-import-path benchmark.sisyphus_agent:SisyphusAgent against desired datasets.

<sup>Written for commit 8eee7ad1d5108c83bd958f57896e88ea1e66c656. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

