### PR TITLE
Remove dead aggressive_truncation config option

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1022,8 +1022,8 @@ OpenCode でサポートされるすべての LSP 構成およびカスタム設
   "experimental": {
     "preemptive_compaction_threshold": 0.85,
     "truncate_all_tool_outputs": true,
-    "aggressive_truncation": true,
-    "auto_resume": true
+    "auto_resume": true,
+    "dcp_for_compaction": true
   }
 }
 ```
@@ -1032,7 +1032,6 @@ OpenCode でサポートされるすべての LSP 構成およびカスタム設
 | --------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `preemptive_compaction_threshold` | `0.85`     | プリエンプティブコンパクションをトリガーする閾値（0.5-0.95）。`preemptive-compaction` フックはデフォルトで有効です。このオプションで閾値をカスタマイズできます。                 |
 | `truncate_all_tool_outputs`       | `false`    | ホワイトリストのツール（Grep、Glob、LSP、AST-grep）だけでなく、すべてのツール出力を切り詰めます。Tool output truncator はデフォルトで有効です - `disabled_hooks`で無効化できます。 |
-| `aggressive_truncation`           | `false`    | トークン制限を超えた場合、ツール出力を積極的に切り詰めて制限内に収めます。デフォルトの切り詰めより積極的です。不十分な場合は要約/復元にフォールバックします。                 |
 | `auto_resume`                     | `false`    | thinking block エラーや thinking disabled violation からの回復成功後、自動的にセッションを再開します。最後のユーザーメッセージを抽出して続行します。                        |
 | `dcp_for_compaction`              | `false`    | コンパクション用DCP（動的コンテキスト整理）を有効化 - トークン制限超過時に最初に実行されます。コンパクション前に重複したツール呼び出しと古いツール出力を整理します。                |
 

--- a/README.md
+++ b/README.md
@@ -1093,8 +1093,8 @@ Opt-in experimental features that may change or be removed in future versions. U
   "experimental": {
     "preemptive_compaction_threshold": 0.85,
     "truncate_all_tool_outputs": true,
-    "aggressive_truncation": true,
-    "auto_resume": true
+    "auto_resume": true,
+    "dcp_for_compaction": true
   }
 }
 ```
@@ -1103,7 +1103,6 @@ Opt-in experimental features that may change or be removed in future versions. U
 | --------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `preemptive_compaction_threshold` | `0.85`  | Threshold percentage (0.5-0.95) to trigger preemptive compaction. The `preemptive-compaction` hook is enabled by default; this option customizes the threshold.                               |
 | `truncate_all_tool_outputs`       | `false` | Truncates ALL tool outputs instead of just whitelisted tools (Grep, Glob, LSP, AST-grep). Tool output truncator is enabled by default - disable via `disabled_hooks`.                         |
-| `aggressive_truncation`           | `false` | When token limit is exceeded, aggressively truncates tool outputs to fit within limits. More aggressive than the default truncation behavior. Falls back to summarize/revert if insufficient. |
 | `auto_resume`                     | `false` | Automatically resumes session after successful recovery from thinking block errors or thinking disabled violations. Extracts the last user message and continues.                             |
 | `dcp_for_compaction`              | `false` | Enable DCP (Dynamic Context Pruning) for compaction - runs first when token limit exceeded. Prunes duplicate tool calls and old tool outputs before running compaction.                       |
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1023,8 +1023,8 @@ Oh My OpenCode 送你重构工具（重命名、代码操作）。
   "experimental": {
     "preemptive_compaction_threshold": 0.85,
     "truncate_all_tool_outputs": true,
-    "aggressive_truncation": true,
-    "auto_resume": true
+    "auto_resume": true,
+    "dcp_for_compaction": true
   }
 }
 ```
@@ -1033,7 +1033,6 @@ Oh My OpenCode 送你重构工具（重命名、代码操作）。
 | --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `preemptive_compaction_threshold` | `0.85`  | 触发预防性压缩的阈值比例（0.5-0.95）。`preemptive-compaction` 钩子默认启用；此选项用于自定义阈值。                                                     |
 | `truncate_all_tool_outputs`       | `false` | 截断所有工具输出，而不仅仅是白名单工具（Grep、Glob、LSP、AST-grep）。Tool output truncator 默认启用 - 使用 `disabled_hooks` 禁用。                    |
-| `aggressive_truncation`           | `false` | 超出 token 限制时，激进地截断工具输出以适应限制。比默认截断更激进。不够的话会回退到摘要/恢复。                                                     |
 | `auto_resume`                     | `false` | 从 thinking block 错误或 thinking disabled violation 成功恢复后，自动恢复会话。提取最后一条用户消息继续执行。                                     |
 | `dcp_for_compaction`              | `false` | 启用压缩用 DCP（动态上下文剪枝）- 在超出 token 限制时首先执行。在压缩前清理重复的工具调用和旧的工具输出。                                            |
 

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -1406,9 +1406,6 @@
     "experimental": {
       "type": "object",
       "properties": {
-        "aggressive_truncation": {
-          "type": "boolean"
-        },
         "auto_resume": {
           "type": "boolean"
         },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -171,7 +171,6 @@ export const DynamicContextPruningConfigSchema = z.object({
 })
 
 export const ExperimentalConfigSchema = z.object({
-  aggressive_truncation: z.boolean().optional(),
   auto_resume: z.boolean().optional(),
   /** Enable preemptive compaction at threshold (default: true since v2.9.0) */
   preemptive_compaction: z.boolean().optional(),

--- a/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
@@ -117,7 +117,6 @@ describe("executeCompact lock management", () => {
 
     const experimental = {
       truncate_all_tool_outputs: false,
-      aggressive_truncation: true,
     }
     const dcpForCompaction = true
 


### PR DESCRIPTION
## Summary

- Remove `aggressive_truncation` from `ExperimentalConfigSchema` - it was defined in schema but never consumed by any code
- Remove from JSON schema (`assets/oh-my-opencode.schema.json`)
- Clean up test file that referenced the dead option
- Update all README docs (EN, JA, ZH-CN) to remove documentation for the non-functional option

## Background

While auditing config options, found that `experimental.aggressive_truncation` was:
1. Defined in the zod schema
2. Documented in READMEs
3. Present in JSON schema
4. **Never actually used** - only appeared in one test file

This removes the dead config option to avoid user confusion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused experimental.aggressive_truncation config option to avoid confusion and keep config docs in sync. Dropped it from the zod schema, JSON schema, the test, and README examples (EN, JA, ZH-CN).

<sup>Written for commit a5820754a0156c9e9def8f49fe9dc0467071db12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

