### PR TITLE
fix(agents): respect user model override for orchestrator-sisyphus

### DIFF
--- a/src/agents/orchestrator-sisyphus.ts
+++ b/src/agents/orchestrator-sisyphus.ts
@@ -5,6 +5,8 @@ import type { CategoryConfig } from "../config/schema"
 import { DEFAULT_CATEGORIES, CATEGORY_DESCRIPTIONS } from "../tools/sisyphus-task/constants"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
+const DEFAULT_MODEL = "anthropic/claude-sonnet-4-5"
+
 /**
  * Orchestrator Sisyphus - Master Orchestrator Agent
  *
@@ -1432,7 +1434,10 @@ function buildDynamicOrchestratorPrompt(ctx?: OrchestratorContext): string {
     .replace("{SKILLS_SECTION}", skillsSection)
 }
 
-export function createOrchestratorSisyphusAgent(ctx?: OrchestratorContext): AgentConfig {
+export function createOrchestratorSisyphusAgent(
+  model: string = DEFAULT_MODEL,
+  ctx?: OrchestratorContext
+): AgentConfig {
   const restrictions = createAgentToolRestrictions([
     "task",
     "call_omo_agent",
@@ -1442,7 +1447,7 @@ export function createOrchestratorSisyphusAgent(ctx?: OrchestratorContext): Agen
     description:
       "Orchestrates work via sisyphus_task() to complete ALL tasks in a todo list until fully done",
     mode: "primary" as const,
-    model: "anthropic/claude-sonnet-4-5",
+    model,
     temperature: 0.1,
     prompt: buildDynamicOrchestratorPrompt(ctx),
     thinking: { type: "enabled", budgetTokens: 32000 },

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -176,7 +176,8 @@ export function createBuiltinAgents(
 
   if (!disabledAgents.includes("orchestrator-sisyphus")) {
     const orchestratorOverride = agentOverrides["orchestrator-sisyphus"]
-    let orchestratorConfig = createOrchestratorSisyphusAgent({ availableAgents })
+    const orchestratorModel = orchestratorOverride?.model
+    let orchestratorConfig = createOrchestratorSisyphusAgent(orchestratorModel, { availableAgents })
 
     if (orchestratorOverride) {
       orchestratorConfig = mergeAgentConfig(orchestratorConfig, orchestratorOverride)


### PR DESCRIPTION
## Summary

Fixes #601 - The orchestrator-sisyphus agent was ignoring user model configuration and always using the hardcoded model `anthropic/claude-sonnet-4-5`.

## Changes

- Added `DEFAULT_MODEL` constant for orchestrator-sisyphus (following the pattern used by other agents)
- Updated `createOrchestratorSisyphusAgent` to accept a `model` parameter with the default value
- Updated `utils.ts` to pass the user-configured model when creating the orchestrator-sisyphus agent

## Root Cause

The `createOrchestratorSisyphusAgent` function had a hardcoded model string instead of accepting it as a parameter like other agents (sisyphus, oracle, librarian, etc.).

## Testing

- [x] TypeScript type check passes
- [x] Agent tests pass (15 tests)
- [x] LSP diagnostics clean on modified files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes orchestrator-sisyphus respect the user’s model override instead of always using a hardcoded model. The agent now uses the model set in user config.

- **Bug Fixes**
  - Added DEFAULT_MODEL for orchestrator-sisyphus.
  - Updated createOrchestratorSisyphusAgent to accept a model parameter with a default.
  - Passed the user-configured model in utils when creating the agent.

<sup>Written for commit e4de7e1c373a10b8aff70c5ed256a460bdc75a71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

