### PR TITLE
fix(background-agent): pass model to promptAsync in launch and resume

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -766,3 +766,161 @@ function buildNotificationPromptBody(task: BackgroundTask): Record<string, unkno
 
   return body
 }
+
+describe("LaunchInput.model", () => {
+  test("model should be optional in LaunchInput type", () => {
+    // #given
+    const input: import("./types").LaunchInput = {
+      description: "test",
+      prompt: "test prompt",
+      agent: "explore",
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-msg",
+    }
+
+    // #when / #then - should compile without model
+    expect(input.model).toBeUndefined()
+  })
+
+  test("model can be provided in LaunchInput", () => {
+    // #given
+    const input: import("./types").LaunchInput = {
+      description: "test",
+      prompt: "test prompt",
+      agent: "explore",
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-msg",
+      model: { providerID: "cliproxy", modelID: "gemini-claude-sonnet-4-5" },
+    }
+
+    // #when / #then
+    expect(input.model).toEqual({ providerID: "cliproxy", modelID: "gemini-claude-sonnet-4-5" })
+  })
+
+  test("model should be stored in BackgroundTask", () => {
+    // #given
+    const task: import("./types").BackgroundTask = {
+      id: "task-1",
+      sessionID: "session-1",
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-msg",
+      description: "test task",
+      prompt: "test prompt",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(),
+      model: { providerID: "cliproxy", modelID: "gemini-claude-sonnet-4-5" },
+    }
+
+    // #when / #then
+    expect(task.model).toEqual({ providerID: "cliproxy", modelID: "gemini-claude-sonnet-4-5" })
+  })
+})
+
+describe("BackgroundManager.launch - model propagation", () => {
+  test("should pass model to promptAsync when launching background task", async () => {
+    // #given
+    let capturedBody: Record<string, unknown> | undefined
+
+    const mockClient = {
+      session: {
+        create: async () => ({ data: { id: "test-session-id" } }),
+        promptAsync: async (args: { body: Record<string, unknown> }) => {
+          capturedBody = args.body
+          return Promise.resolve()
+        },
+        status: async () => ({ data: {} }),
+        messages: async () => ({ data: [] }),
+        todo: async () => ({ data: [] }),
+        prompt: async () => Promise.resolve(),
+      },
+    }
+
+    const mockCtx = {
+      client: mockClient,
+      directory: "/test",
+    }
+
+    const { BackgroundManager } = await import("./manager")
+    const manager = new BackgroundManager(mockCtx as never)
+
+    // #when
+    await manager.launch({
+      description: "test task",
+      prompt: "test prompt",
+      agent: "explore",
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-msg",
+      model: { providerID: "cliproxy", modelID: "gemini-claude-sonnet-4-5" },
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    // #then
+    expect(capturedBody).toBeDefined()
+    expect(capturedBody?.model).toEqual({ providerID: "cliproxy", modelID: "gemini-claude-sonnet-4-5" })
+  })
+
+  test("should pass model to promptAsync when resuming background task", async () => {
+    // #given
+    let capturedBody: Record<string, unknown> | undefined
+    let createCallCount = 0
+
+    const mockClient = {
+      session: {
+        create: async () => {
+          createCallCount++
+          return { data: { id: `test-session-${createCallCount}` } }
+        },
+        promptAsync: async (args: { body: Record<string, unknown> }) => {
+          capturedBody = args.body
+          return Promise.resolve()
+        },
+        status: async () => ({ data: {} }),
+        messages: async () => ({ data: [] }),
+        todo: async () => ({ data: [] }),
+        prompt: async () => Promise.resolve(),
+      },
+    }
+
+    const mockCtx = {
+      client: mockClient,
+      directory: "/test",
+    }
+
+    const { BackgroundManager } = await import("./manager")
+    const manager = new BackgroundManager(mockCtx as never)
+
+    // First launch a task with a model
+    const task = await manager.launch({
+      description: "test task",
+      prompt: "initial prompt",
+      agent: "explore",
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-msg",
+      model: { providerID: "cliproxy", modelID: "gemini-claude-sonnet-4-5" },
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    // #when - resume the task
+    let resumeCapturedBody: Record<string, unknown> | undefined
+    mockClient.session.promptAsync = async (args: { body: Record<string, unknown> }) => {
+      resumeCapturedBody = args.body
+      return Promise.resolve()
+    }
+
+    await manager.resume({
+      sessionId: task.sessionID,
+      prompt: "continue the work",
+      parentSessionID: "new-parent-session",
+      parentMessageID: "new-parent-msg",
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    // #then - model should be passed from existing task
+    expect(resumeCapturedBody).toBeDefined()
+    expect(resumeCapturedBody?.model).toEqual({ providerID: "cliproxy", modelID: "gemini-claude-sonnet-4-5" })
+  })
+})

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -123,6 +123,7 @@ export class BackgroundManager {
       path: { id: sessionID },
       body: {
         agent: input.agent,
+        model: input.model,
         system: input.skillContent,
         tools: {
           task: false,
@@ -265,6 +266,7 @@ export class BackgroundManager {
       path: { id: existingTask.sessionID },
       body: {
         agent: existingTask.agent,
+        model: existingTask.model,
         tools: {
           task: false,
           call_omo_agent: false,


### PR DESCRIPTION
## Summary

When launching or resuming background tasks via `sisyphus_task` with a category, the resolved model was ignored. `BackgroundManager.launch()` and `resume()` accepted a `model` parameter but never passed it to `promptAsync()`, causing OpenCode to fall back to the agent's hardcoded default model.

This fix ensures the `model` field is passed to `promptAsync()` in both `launch()` and `resume()` paths, allowing category-based model overrides to work correctly.

## Problem

```typescript
// Before: model was stored but never used
this.client.session.promptAsync({
  path: { id: sessionID },
  body: {
    agent: input.agent,
    // model: input.model,  ← MISSING
    system: input.skillContent,
    ...
  },
})
```

## Solution

```typescript
// After: model is now passed to promptAsync
this.client.session.promptAsync({
  path: { id: sessionID },
  body: {
    agent: input.agent,
    model: input.model,  // ← Added
    system: input.skillContent,
    ...
  },
})
```

## Changes

| File | Change |
|------|--------|
| `manager.ts` | Pass `model` to `promptAsync()` in `launch()` |
| `manager.ts` | Pass `model` to `promptAsync()` in `resume()` |
| `manager.test.ts` | Add TDD integration tests verifying model propagation |

## Test Coverage

- Type-level tests for `LaunchInput.model` and `BackgroundTask.model`
- Integration tests capturing `promptAsync` body to verify model propagation
- Both `launch()` and `resume()` code paths tested
- **26 tests pass, 0 failures**

## Related

This completes the work started in #548 (model-based concurrency management) by ensuring the model is actually used when making API calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes background-agent tasks not using the resolved model when launching or resuming. The model is now passed to promptAsync so category-based overrides take effect instead of the agent’s default.

- **Bug Fixes**
  - Pass model to promptAsync in BackgroundManager.launch() and resume().
  - Add tests to confirm model propagation and keep LaunchInput.model optional.

<sup>Written for commit cb4ddc354169c37f9a7aaaf6536a734141f2e3b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

