### PR TITLE
fix: prevent auto-update from downgrading prerelease/dist-tag versions

### DIFF
--- a/src/hooks/auto-update-checker/index.test.ts
+++ b/src/hooks/auto-update-checker/index.test.ts
@@ -1,18 +1,5 @@
 import { describe, test, expect } from "bun:test"
-
-const isPrereleaseVersion = (version: string): boolean => {
-  return version.includes("-")
-}
-
-const isDistTag = (version: string): boolean => {
-  const startsWithDigit = /^\d/.test(version)
-  return !startsWithDigit
-}
-
-const isPrereleaseOrDistTag = (pinnedVersion: string | null): boolean => {
-  if (!pinnedVersion) return false
-  return isPrereleaseVersion(pinnedVersion) || isDistTag(pinnedVersion)
-}
+import { isPrereleaseVersion, isDistTag, isPrereleaseOrDistTag } from "./index"
 
 describe("auto-update-checker", () => {
   describe("isPrereleaseVersion", () => {

--- a/src/hooks/auto-update-checker/index.ts
+++ b/src/hooks/auto-update-checker/index.ts
@@ -9,16 +9,16 @@ import type { AutoUpdateCheckerOptions } from "./types"
 
 const SISYPHUS_SPINNER = ["·", "•", "●", "○", "◌", "◦", " "]
 
-function isPrereleaseVersion(version: string): boolean {
+export function isPrereleaseVersion(version: string): boolean {
   return version.includes("-")
 }
 
-function isDistTag(version: string): boolean {
+export function isDistTag(version: string): boolean {
   const startsWithDigit = /^\d/.test(version)
   return !startsWithDigit
 }
 
-function isPrereleaseOrDistTag(pinnedVersion: string | null): boolean {
+export function isPrereleaseOrDistTag(pinnedVersion: string | null): boolean {
   if (!pinnedVersion) return false
   return isPrereleaseVersion(pinnedVersion) || isDistTag(pinnedVersion)
 }


### PR DESCRIPTION
## Summary

- Fix auto-update checker incorrectly downgrading pinned prerelease versions to stable
- Add tests for prerelease/dist-tag detection logic

## Problem

When a user pins oh-my-opencode to a beta version (e.g., `oh-my-opencode@3.0.0-beta.1` or `@beta`), the auto-update checker would "update" it to the stable `latest` version from npm (e.g., `2.14.0`), effectively downgrading their installation.

## Solution

Added `isPrereleaseOrDistTag()` check that skips auto-update when the pinned version:
- Contains `-` (prerelease like `3.0.0-beta.1`, `1.0.0-alpha`, `2.0.0-rc.1`)
- Is a dist-tag (non-semver string like `beta`, `next`, `canary`)

## Changes

- `src/hooks/auto-update-checker/index.ts`: Added helper functions and guard in update logic
- `src/hooks/auto-update-checker/index.test.ts`: Added 13 tests covering the new logic

Fixes #613

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent auto-update from downgrading pinned prerelease or dist-tag installs; users on beta/alpha/rc or dist-tags stay on their chosen channel. Fixes #613.

- **Bug Fixes**
  - Skip auto-update when the pinned version is a prerelease (contains “-”) or a dist-tag (non-semver like beta, next, canary).
  - Added tests for prerelease/dist-tag detection and update behavior.

<sup>Written for commit a145be4a435a831dcbfea8a4b57697b5e8e94f0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

