### PR TITLE
fix(hooks): handle todowrite todos passed as string instead of array

### DIFF
--- a/src/hooks/claude-code-hooks/index.ts
+++ b/src/hooks/claude-code-hooks/index.ts
@@ -202,6 +202,18 @@ export function createClaudeCodeHooksHook(
       input: { tool: string; sessionID: string; callID: string },
       output: { args: Record<string, unknown> }
     ): Promise<void> => {
+      if (input.tool === "todowrite" && typeof output.args.todos === "string") {
+        try {
+          const parsed = JSON.parse(output.args.todos as string)
+          if (Array.isArray(parsed)) {
+            output.args.todos = parsed
+            log("todowrite: parsed todos string to array", { sessionID: input.sessionID })
+          }
+        } catch (e) {
+          log("todowrite: failed to parse todos string", { sessionID: input.sessionID, error: String(e) })
+        }
+      }
+
       const claudeConfig = await loadClaudeHooksConfig()
       const extendedConfig = await loadPluginExtendedConfig()
 


### PR DESCRIPTION
## Summary
- Fix `todowrite` tool failing with "expected array, received string" error when LLMs pass todos as a JSON string instead of an array
- Update `tool.execute.before` hook to parse string input before Zod validation

## Problem
When invoking the `todowrite` tool, some LLM tool-calling interfaces pass the `todos` parameter as a JSON string instead of an array. This caused failures like:

```
Error: The todowrite tool was called with invalid arguments: [
  {
    "expected": "array",
    "code": "invalid_type",
    "path": ["todos"],
    "message": "Invalid input: expected array, received string"
  }
]
```

The root cause: OpenCode's `TodoWriteTool` uses Zod schema `z.array(...)` for validation, but the LLM sometimes sends the array as a stringified JSON.

## Solution
Add a pre-validation check in `tool.execute.before` hook that detects when `todos` is a string and parses it to an array before the tool execution.

This is similar to the fix in #532 which handled `skill_mcp` arguments passed as object instead of string (opposite direction).

## Test Plan
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds  
- [x] Manually verified todowrite works after the fix (tested in local OpenCode session)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes todowrite failures when LLMs send todos as a JSON string. The before-execute hook now parses string todos to an array (with success/error logs) before Zod validation so the tool runs correctly.

<sup>Written for commit f105cebbbbc21428f9a75909817285c8e608ec19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

