### PR TITLE
fix: background task completion detection and silent notifications

### DIFF
--- a/src/features/background-agent/index.ts
+++ b/src/features/background-agent/index.ts
@@ -1,3 +1,3 @@
 export * from "./types"
-export { BackgroundManager } from "./manager"
+export { BackgroundManager, type PendingNotification } from "./manager"
 export { ConcurrencyManager } from "./concurrency"

--- a/src/features/background-agent/types.ts
+++ b/src/features/background-agent/types.ts
@@ -32,6 +32,10 @@ export interface BackgroundTask {
   concurrencyKey?: string
   /** Parent session's agent name for notification */
   parentAgent?: string
+  /** Last message count for stability detection */
+  lastMsgCount?: number
+  /** Number of consecutive polls with stable message count */
+  stablePolls?: number
 }
 
 export interface LaunchInput {

--- a/src/hooks/background-notification/index.ts
+++ b/src/hooks/background-notification/index.ts
@@ -9,13 +9,49 @@ interface EventInput {
   event: Event
 }
 
+interface ToolExecuteInput {
+  sessionID?: string
+  tool: string
+}
+
+interface ToolExecuteOutput {
+  title: string
+  output: string
+  metadata: unknown
+}
+
 export function createBackgroundNotificationHook(manager: BackgroundManager) {
   const eventHandler = async ({ event }: EventInput) => {
     manager.handleEvent(event)
   }
 
+  const toolExecuteAfterHandler = async (
+    input: ToolExecuteInput,
+    output: ToolExecuteOutput
+  ) => {
+    const sessionID = input.sessionID
+    if (!sessionID) return
+
+    if (!manager.hasPendingNotifications(sessionID)) return
+
+    const notifications = manager.consumePendingNotifications(sessionID)
+    if (notifications.length === 0) return
+
+    const messages = notifications.map((n) => {
+      if (n.status === "error") {
+        return `[BACKGROUND TASK FAILED] Task "${n.description}" failed after ${n.duration}. Error: ${n.error || "Unknown error"}. Use background_output with task_id="${n.taskId}" for details.`
+      }
+      return `[BACKGROUND TASK COMPLETED] Task "${n.description}" finished in ${n.duration}. Use background_output with task_id="${n.taskId}" to get results.`
+    })
+
+    const injection = "\n\n---\n" + messages.join("\n") + "\n---"
+
+    output.output = output.output + injection
+  }
+
   return {
     event: eventHandler,
+    "tool.execute.after": toolExecuteAfterHandler,
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -522,9 +522,10 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       await emptyTaskResponseDetector?.["tool.execute.after"](input, output);
       await agentUsageReminder?.["tool.execute.after"](input, output);
       await interactiveBashSession?.["tool.execute.after"](input, output);
-      await editErrorRecovery?.["tool.execute.after"](input, output);
+await editErrorRecovery?.["tool.execute.after"](input, output);
       await sisyphusOrchestrator?.["tool.execute.after"]?.(input, output);
       await taskResumeInfo["tool.execute.after"](input, output);
+      await backgroundNotificationHook?.["tool.execute.after"]?.(input, output);
     },
   };
 };

--- a/src/tools/background-task/tools.ts
+++ b/src/tools/background-task/tools.ts
@@ -193,7 +193,7 @@ Session ID: ${task.sessionID}
 (No messages found)`
   }
 
-  const assistantMessages = messages.filter(
+const assistantMessages = messages.filter(
     (m) => m.info?.role === "assistant"
   )
 
@@ -210,8 +210,15 @@ Session ID: ${task.sessionID}
 (No assistant response found)`
   }
 
-  const lastMessage = assistantMessages[assistantMessages.length - 1]
-  const textParts = lastMessage?.parts?.filter(
+  // Sort by time descending (newest first), take first result - matches sync pattern
+  const sortedMessages = [...assistantMessages].sort((a, b) => {
+    const timeA = String((a as { info?: { time?: string } }).info?.time ?? "")
+    const timeB = String((b as { info?: { time?: string } }).info?.time ?? "")
+    return timeB.localeCompare(timeA)
+  })
+  
+  const lastMessage = sortedMessages[0]
+  const textParts = lastMessage.parts?.filter(
     (p) => p.type === "text"
   ) ?? []
   const textContent = textParts

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -194,4 +194,4 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
   })
 }
 
-export const skill = createSkillTool()
+export const skill: ToolDefinition = createSkillTool()

--- a/src/tools/slashcommand/tools.ts
+++ b/src/tools/slashcommand/tools.ts
@@ -249,4 +249,4 @@ export function createSlashcommandTool(options: SlashcommandToolOptions = {}): T
 }
 
 // Default instance for backward compatibility (lazy loading)
-export const slashcommand = createSlashcommandTool()
+export const slashcommand: ToolDefinition = createSlashcommandTool()


### PR DESCRIPTION
## Summary

- Fix background tasks that hang indefinitely due to missing `sessionStatus` in polling loop
- Add silent notification system that injects completion messages into tool output instead of interrupting chat
- Fix TypeScript TS2742 errors with explicit `ToolDefinition` type annotations

## Changes

### Completion Detection (PR #592 re-implementation)
- Remove early `continue` when `sessionStatus` is undefined - allows fall-through to message-based detection
- Add stability detection: complete when message count unchanged for 3 consecutive polls (after 10s minimum runtime)
- Add `lastMsgCount` and `stablePolls` fields to `BackgroundTask` interface
- Add `MIN_STABILITY_TIME_MS` constant (10 seconds)

### Silent Notification System (new feature)
- Add `PendingNotification` interface and `pendingNotifications` map to `BackgroundManager`
- Add `hasPendingNotifications()` and `consumePendingNotifications()` methods
- Replace `session.prompt()` with storing notifications for later injection
- Add `tool.execute.after` hook handler that injects pending notifications into tool output
- Wire up hook in `src/index.ts`

### Other Fixes
- Change task retention from 200ms to 5 minutes for `background_output` retrieval
- Fix `formatTaskResult` to sort messages by time descending (matches sync pattern)
- Add `String()` wrapper for `localeCompare` to handle non-string time values
- Fix TS2742 by adding explicit `ToolDefinition` type annotations to `skill` and `slashcommand` exports

## Testing

- Tested with 8 parallel background tasks (4 quick + 4 explore)
- All tasks complete in ~14-15 seconds
- Silent notifications successfully injected into tool output
- `bun run typecheck` passes
- `bun run build` succeeds

## Files Modified

| File | Change |
|------|--------|
| `src/features/background-agent/types.ts` | Add `lastMsgCount`, `stablePolls` fields |
| `src/features/background-agent/manager.ts` | Add stability detection, silent notification storage, 5-min retention |
| `src/features/background-agent/index.ts` | Export `PendingNotification` type |
| `src/hooks/background-notification/index.ts` | Add `tool.execute.after` handler |
| `src/index.ts` | Wire up notification hook |
| `src/tools/background-task/tools.ts` | Fix `formatTaskResult` sorting |
| `src/tools/skill/tools.ts` | Add `: ToolDefinition` type annotation |
| `src/tools/slashcommand/tools.ts` | Add `: ToolDefinition` type annotation |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes background tasks that could hang and adds silent, inline notifications injected into tool outputs. Improves completion detection, keeps results available longer, and resolves TypeScript typing errors.

- **Bug Fixes**
  - Allow message-based completion when sessionStatus is missing.
  - Add stability detection (complete after 3 unchanged polls, after 10s).
  - Retain completed tasks for 5 minutes for background_output retrieval.
  - Sort assistant messages by newest first; handle non-string times safely.

- **New Features**
  - Silent notifications: store pending messages and inject them via a tool.execute.after hook (no chat interruption).
  - Export PendingNotification and add hasPendingNotifications/consumePendingNotifications helpers.
  - Add explicit ToolDefinition annotations for skill and slashcommand to fix TS2742.

<sup>Written for commit 9e812608791f49bf915c418d5aa3b59363a35f86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

