### PR TITLE
feat: add OPENCODE_CONFIG_DIR environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ No stupid token consumption massive subagents here. No bloat tools here.
     - [MCPs](#mcps)
     - [LSP](#lsp)
     - [Experimental](#experimental)
+    - [Environment Variables](#environment-variables)
   - [Author's Note](#authors-note)
   - [Warnings](#warnings)
   - [Loved by professionals at](#loved-by-professionals-at)
@@ -1180,6 +1181,12 @@ Opt-in experimental features that may change or be removed in future versions. U
 | `dcp_for_compaction`              | `false` | Enable DCP (Dynamic Context Pruning) for compaction - runs first when token limit exceeded. Prunes duplicate tool calls and old tool outputs before running compaction.                       |
 
 **Warning**: These features are experimental and may cause unexpected behavior. Enable only if you understand the implications.
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `OPENCODE_CONFIG_DIR` | Override the OpenCode configuration directory. Useful for profile isolation with tools like [OCX](https://github.com/kdcokenny/ocx) ghost mode. |
 
 
 ## Author's Note

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 
 export type OpenCodeBinaryType = "opencode" | "opencode-desktop"
 
@@ -47,6 +47,11 @@ function getTauriConfigDir(identifier: string): string {
 }
 
 function getCliConfigDir(): string {
+  const envConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim()
+  if (envConfigDir) {
+    return resolve(envConfigDir)
+  }
+
   if (process.platform === "win32") {
     const crossPlatformDir = join(homedir(), ".config", "opencode")
     const crossPlatformConfig = join(crossPlatformDir, "opencode.json")
@@ -107,6 +112,11 @@ export function getOpenCodeConfigPaths(options: OpenCodeConfigDirOptions): OpenC
 
 export function detectExistingConfigDir(binary: OpenCodeBinaryType, version?: string | null): string | null {
   const locations: string[] = []
+
+  const envConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim()
+  if (envConfigDir) {
+    locations.push(resolve(envConfigDir))
+  }
 
   if (binary === "opencode-desktop") {
     const identifier = isDevBuild(version) ? TAURI_APP_IDENTIFIER_DEV : TAURI_APP_IDENTIFIER


### PR DESCRIPTION
## Summary

Adds `OPENCODE_CONFIG_DIR` environment variable support for config directory override, enabling compatibility with [OCX](https://github.com/kdcokenny/ocx) ghost mode profiles.

Closes #627

## Changes

- Add env var check at start of `getCliConfigDir()` in `src/shared/opencode-config-dir.ts`
- Update `detectExistingConfigDir()` to include env var path in locations array
- Add 7 comprehensive tests for the new functionality
- Document in README under Configuration → Environment Variables

## Behavior

| Scenario | Result |
|----------|--------|
| `OPENCODE_CONFIG_DIR=/custom/path` | Uses `/custom/path` |
| `OPENCODE_CONFIG_DIR=./relative` | Resolves to absolute path |
| `OPENCODE_CONFIG_DIR=""` or whitespace | Falls back to default |
| Env var not set | Falls back to XDG_CONFIG_HOME or ~/.config/opencode |

## Testing

- 7 new tests added, all passing
- Follows existing `CLAUDE_CONFIG_DIR` pattern in codebase

## OCX Integration

OCX ghost mode can now set the env var when spawning OpenCode:
```bash
OPENCODE_CONFIG_DIR=~/.config/opencode/profiles/work opencode
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OPENCODE_CONFIG_DIR to let users override the OpenCode config directory. This enables OCX ghost mode profile isolation while keeping defaults when the env var isn’t set.

- **New Features**
  - getCliConfigDir uses OPENCODE_CONFIG_DIR when set, resolves relative paths, ignores empty/whitespace, and takes priority over XDG_CONFIG_HOME.
  - detectExistingConfigDir includes the env var path in its search order.
  - Added README docs and 7 tests covering override, fallback, and precedence.

<sup>Written for commit 0e7516c62b483253ce4b58b47c2ff897e6f4c19e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

