### PR TITLE
fix: remove author name from agent system prompts to prevent unintended language inference

### DIFF
--- a/src/agents/orchestrator-sisyphus.ts
+++ b/src/agents/orchestrator-sisyphus.ts
@@ -132,7 +132,6 @@ ${rows.join("\n")}
 }
 
 export const ORCHESTRATOR_SISYPHUS_SYSTEM_PROMPT = `You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
-Named by [YeonGyu Kim](https://github.com/code-yeongyu).
 
 **Why Sisyphus?**: Humans roll their boulder every day. So do you. We're not so different—your code should be indistinguishable from a senior engineer's.
 

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -18,7 +18,6 @@ const DEFAULT_MODEL = "anthropic/claude-opus-4-5"
 
 const SISYPHUS_ROLE_SECTION = `<Role>
 You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
-Named by [YeonGyu Kim](https://github.com/code-yeongyu).
 
 **Why Sisyphus?**: Humans roll their boulder every day. So do you. We're not so different—your code should be indistinguishable from a senior engineer's.
 


### PR DESCRIPTION
## Problem

The Sisyphus agent system prompt includes the line:

```
Named by [YeonGyu Kim](https://github.com/code-yeongyu).
```

This causes LLMs to sometimes infer Korean language output, even when the user's system locale is `en-US`. The model sees a Korean name in the system prompt and interprets it as a signal to respond in Korean.

**Example output (unintended Korean):**
```
Max‑research 요약
- RH는 리만 제타 함수의 비자명한 영점들이 모두 Re(s)=1/2 위에 있다는 주장.
- 소수 분포의 오차항을 사실상 최적 수준으로 묶어주며...
```

## Solution

Remove the author attribution from the runtime system prompts in:
- `src/agents/sisyphus.ts`
- `src/agents/orchestrator-sisyphus.ts`

The author attribution is preserved in:
- README files
- LICENSE.md
- package.json

## Changes

- Removed `Named by [YeonGyu Kim](https://github.com/code-yeongyu).` from `SISYPHUS_ROLE_SECTION`
- Removed the same line from `ORCHESTRATOR_SISYPHUS_SYSTEM_PROMPT`

## Test Plan

- [x] Verified the change removes the Korean name from system prompts
- [ ] Test that Sisyphus agent responds in the user's expected language

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the author attribution from Sisyphus system prompts to prevent unintended Korean responses. Ensures the agent replies in the user’s expected language based on locale.

<sup>Written for commit e77369b37484eba39ee551397fa249a14a4faad8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

