### PR TITLE
fix(skill-loader): wrap template with skill-instruction tags in sync loader

### DIFF
--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -63,7 +63,7 @@ async function loadSkillFromPath(
 ): Promise<LoadedSkill | null> {
   try {
     const content = await fs.readFile(skillPath, "utf-8")
-    const { data } = parseFrontmatter<SkillMetadata>(content)
+    const { data, body } = parseFrontmatter<SkillMetadata>(content)
     const frontmatterMcp = parseSkillMcpConfigFromFrontmatter(content)
     const mcpJsonMcp = await loadMcpJsonFromDir(resolvedPath)
     const mcpConfig = mcpJsonMcp || frontmatterMcp
@@ -73,14 +73,7 @@ async function loadSkillFromPath(
     const isOpencodeSource = scope === "opencode" || scope === "opencode-project"
     const formattedDescription = `(${scope} - Skill) ${originalDescription}`
 
-    const lazyContent: LazyContentLoader = {
-      loaded: false,
-      content: undefined,
-      load: async () => {
-        if (!lazyContent.loaded) {
-          const fileContent = await fs.readFile(skillPath, "utf-8")
-          const { body } = parseFrontmatter<SkillMetadata>(fileContent)
-          lazyContent.content = `<skill-instruction>
+    const wrappedTemplate = `<skill-instruction>
 Base directory for this skill: ${resolvedPath}/
 File references (@path) in this skill are relative to this directory.
 
@@ -90,6 +83,13 @@ ${body.trim()}
 <user-request>
 $ARGUMENTS
 </user-request>`
+
+    const lazyContent: LazyContentLoader = {
+      loaded: false,
+      content: undefined,
+      load: async () => {
+        if (!lazyContent.loaded) {
+          lazyContent.content = wrappedTemplate
           lazyContent.loaded = true
         }
         return lazyContent.content!
@@ -99,7 +99,7 @@ $ARGUMENTS
     const definition: CommandDefinition = {
       name: skillName,
       description: formattedDescription,
-      template: "",
+      template: wrappedTemplate,
       model: sanitizeModelField(data.model, isOpencodeSource ? "opencode" : "claude-code"),
       agent: data.agent,
       subtask: data.subtask,


### PR DESCRIPTION
## Summary
Fixed the sync skill loader to produce consistently wrapped templates matching the async loader.

## Problem
The sync loader was setting template to an empty string, while the async loader properly wrapped it with <skill-instruction> and <user-request> tags. This caused skills loaded via config-handler.ts to have empty templates.

## Solution
1. Create wrappedTemplate variable upfront with proper tags
2. Use wrappedTemplate for both definition.template and lazyContent.load()
3. Removed redundant file re-read in lazyContent.load()

## Testing
- bun run typecheck passes
- bun run build succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sync skill loader so templates are wrapped with <skill-instruction> and <user-request>, matching the async loader. Prevents empty templates when loading skills via config-handler.

- **Bug Fixes**
  - Use a single wrapped template for definition.template and lazyContent.load() to keep behavior consistent.

- **Refactors**
  - Remove redundant file read in lazyContent.load() by reusing the prepared wrapped template.

<sup>Written for commit c965ec62712e09edd5cb65a3203cf3c63b3ebe83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

