### PR TITLE
fix(prometheus-md-only): cross-platform .sisyphus path handling

### DIFF
--- a/src/hooks/prometheus-md-only/constants.ts
+++ b/src/hooks/prometheus-md-only/constants.ts
@@ -4,7 +4,7 @@ export const PROMETHEUS_AGENTS = ["Prometheus (Planner)"]
 
 export const ALLOWED_EXTENSIONS = [".md"]
 
-export const ALLOWED_PATH_PREFIX = ".sisyphus/"
+export const ALLOWED_PATH_PREFIX = ".sisyphus"
 
 export const BLOCKED_TOOLS = ["Write", "Edit", "write", "edit"]
 

--- a/src/hooks/prometheus-md-only/index.test.ts
+++ b/src/hooks/prometheus-md-only/index.test.ts
@@ -70,7 +70,7 @@ describe("prometheus-md-only", () => {
         callID: "call-1",
       }
       const output = {
-        args: { filePath: "/project/.sisyphus/plans/work-plan.md" },
+        args: { filePath: "/tmp/test/.sisyphus/plans/work-plan.md" },
       }
 
       // #when / #then
@@ -287,6 +287,138 @@ describe("prometheus-md-only", () => {
       }
       const output = {
         args: { filePath: "/path/to/file.ts" },
+      }
+
+      // #when / #then
+      await expect(
+        hook["tool.execute.before"](input, output)
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe("cross-platform path validation", () => {
+    beforeEach(() => {
+      setupMessageStorage(TEST_SESSION_ID, "Prometheus (Planner)")
+    })
+
+    test("should allow Windows-style backslash paths under .sisyphus/", async () => {
+      // #given
+      const hook = createPrometheusMdOnlyHook(createMockPluginInput())
+      const input = {
+        tool: "Write",
+        sessionID: TEST_SESSION_ID,
+        callID: "call-1",
+      }
+      const output = {
+        args: { filePath: ".sisyphus\\plans\\work-plan.md" },
+      }
+
+      // #when / #then
+      await expect(
+        hook["tool.execute.before"](input, output)
+      ).resolves.toBeUndefined()
+    })
+
+    test("should allow mixed separator paths under .sisyphus/", async () => {
+      // #given
+      const hook = createPrometheusMdOnlyHook(createMockPluginInput())
+      const input = {
+        tool: "Write",
+        sessionID: TEST_SESSION_ID,
+        callID: "call-1",
+      }
+      const output = {
+        args: { filePath: ".sisyphus\\plans/work-plan.MD" },
+      }
+
+      // #when / #then
+      await expect(
+        hook["tool.execute.before"](input, output)
+      ).resolves.toBeUndefined()
+    })
+
+    test("should allow uppercase .MD extension", async () => {
+      // #given
+      const hook = createPrometheusMdOnlyHook(createMockPluginInput())
+      const input = {
+        tool: "Write",
+        sessionID: TEST_SESSION_ID,
+        callID: "call-1",
+      }
+      const output = {
+        args: { filePath: ".sisyphus/plans/work-plan.MD" },
+      }
+
+      // #when / #then
+      await expect(
+        hook["tool.execute.before"](input, output)
+      ).resolves.toBeUndefined()
+    })
+
+    test("should block paths outside workspace root even if containing .sisyphus", async () => {
+      // #given
+      const hook = createPrometheusMdOnlyHook(createMockPluginInput())
+      const input = {
+        tool: "Write",
+        sessionID: TEST_SESSION_ID,
+        callID: "call-1",
+      }
+      const output = {
+        args: { filePath: "/other/project/.sisyphus/plans/x.md" },
+      }
+
+      // #when / #then
+      await expect(
+        hook["tool.execute.before"](input, output)
+      ).rejects.toThrow("can only write/edit .md files inside .sisyphus/")
+    })
+
+    test("should block nested .sisyphus directories", async () => {
+      // #given
+      const hook = createPrometheusMdOnlyHook(createMockPluginInput())
+      const input = {
+        tool: "Write",
+        sessionID: TEST_SESSION_ID,
+        callID: "call-1",
+      }
+      const output = {
+        args: { filePath: "src/.sisyphus/plans/x.md" },
+      }
+
+      // #when / #then
+      await expect(
+        hook["tool.execute.before"](input, output)
+      ).rejects.toThrow("can only write/edit .md files inside .sisyphus/")
+    })
+
+    test("should block path traversal attempts", async () => {
+      // #given
+      const hook = createPrometheusMdOnlyHook(createMockPluginInput())
+      const input = {
+        tool: "Write",
+        sessionID: TEST_SESSION_ID,
+        callID: "call-1",
+      }
+      const output = {
+        args: { filePath: ".sisyphus/../secrets.md" },
+      }
+
+      // #when / #then
+      await expect(
+        hook["tool.execute.before"](input, output)
+      ).rejects.toThrow("can only write/edit .md files inside .sisyphus/")
+    })
+
+    test("should allow case-insensitive .SISYPHUS directory", async () => {
+      // #given
+      const hook = createPrometheusMdOnlyHook(createMockPluginInput())
+      const input = {
+        tool: "Write",
+        sessionID: TEST_SESSION_ID,
+        callID: "call-1",
+      }
+      const output = {
+        args: { filePath: ".SISYPHUS/plans/work-plan.md" },
       }
 
       // #when / #then


### PR DESCRIPTION
**Summary**
- Fix Windows path validation in prometheus-md-only hook that blocked valid .sisyphus/*.md writes
- Replace brittle string.includes() checks with robust path.resolve/relative validation
- Add security hardening: workspace confinement, traversal blocking, nested directory rejection

**Changes**
- constants.ts: Remove trailing slash from ALLOWED_PATH_PREFIX (.sisyphus/ → .sisyphus)
- index.ts: Rewrite isAllowedFile() to use Node's path module for cross-platform compatibility
  - Workspace confinement via path.resolve/path.relative
  - Case-insensitive extension and directory matching
  - Block paths outside workspace root, nested .sisyphus, and traversal attempts
- index.test.ts: Add 7 new tests for Windows separators, mixed separators, case-insensitivity, and security invariants

**Testing**
bun run typecheck
bun test src/hooks/prometheus-md-only/index.test.ts
All 20 tests pass on Windows.

**Specifically asked Prometheus to do a test write and got this.**
Yes! The write succeeded without any blocking. I just created .sisyphus/plans/test-plan.md with a comprehensive test plan demonstrating all the fixed behaviors.
Is it "easier now"? Absolutely. Before the fix, Windows users would get blocked even with valid .sisyphus\plans\file.md paths because the hook used brittle string checks (includes(".sisyphus/")) that failed on backslashes. Now the robust path.resolve/relative validation handles:
- ✅ Windows backslashes: .sisyphus\plans\x.md
- ✅ Mixed separators: .sisyphus\plans/x.md  
- ✅ Case-insensitive: .SISYPHUS/plans/x.MD
- ✅ Security: blocks outside root, nested .sisyphus, traversal
The fix makes Prometheus planning workflow work correctly on Windows without any manual path manipulation. Users can just use natural Windows paths and the hook handles the rest.


Related Issues
Closes #630

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cross-platform path validation in the prometheus-md-only hook so Prometheus can write .sisyphus/*.md on Windows without false blocks. Adds strict workspace-root checks and security hardening; addresses Linear #630.

- **Bug Fixes**
  - Validate paths with Node path.resolve/relative; support backslashes/mixed separators and case-insensitive .md/.sisyphus.
  - Confine writes to ctx.directory; block traversal, outside-root paths, and nested .sisyphus.
  - Normalize ALLOWED_PATH_PREFIX (remove trailing slash).
  - Add 7 tests for Windows and security cases; all tests pass.

<sup>Written for commit c721d4f544f842e84db8bbfe40ecd681bb1a06ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

