### PR TITLE
fix(config): resolve category to model for Prometheus (Planner) agent

### DIFF
--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -1,28 +1,32 @@
 import { describe, test, expect } from "bun:test"
-import { resolveModelFromCategoryWithUserOverride } from "./config-handler"
+import { resolveCategoryConfig } from "./config-handler"
 import type { CategoryConfig } from "../config/schema"
 
-describe("Prometheus category model resolution", () => {
-  test("resolves ultrabrain category to openai/gpt-5.2", () => {
+describe("Prometheus category config resolution", () => {
+  test("resolves ultrabrain category config", () => {
     // #given
     const categoryName = "ultrabrain"
 
     // #when
-    const model = resolveModelFromCategoryWithUserOverride(categoryName)
+    const config = resolveCategoryConfig(categoryName)
 
     // #then
-    expect(model).toBe("openai/gpt-5.2")
+    expect(config).toBeDefined()
+    expect(config?.model).toBe("openai/gpt-5.2")
+    expect(config?.temperature).toBe(0.1)
   })
 
-  test("resolves visual-engineering category to gemini model", () => {
+  test("resolves visual-engineering category config", () => {
     // #given
     const categoryName = "visual-engineering"
 
     // #when
-    const model = resolveModelFromCategoryWithUserOverride(categoryName)
+    const config = resolveCategoryConfig(categoryName)
 
     // #then
-    expect(model).toBe("google/gemini-3-pro-preview")
+    expect(config).toBeDefined()
+    expect(config?.model).toBe("google/gemini-3-pro-preview")
+    expect(config?.temperature).toBe(0.7)
   })
 
   test("user categories override default categories", () => {
@@ -36,10 +40,12 @@ describe("Prometheus category model resolution", () => {
     }
 
     // #when
-    const model = resolveModelFromCategoryWithUserOverride(categoryName, userCategories)
+    const config = resolveCategoryConfig(categoryName, userCategories)
 
     // #then
-    expect(model).toBe("google/antigravity-claude-opus-4-5-thinking")
+    expect(config).toBeDefined()
+    expect(config?.model).toBe("google/antigravity-claude-opus-4-5-thinking")
+    expect(config?.temperature).toBe(0.1)
   })
 
   test("returns undefined for unknown category", () => {
@@ -47,10 +53,10 @@ describe("Prometheus category model resolution", () => {
     const categoryName = "nonexistent-category"
 
     // #when
-    const model = resolveModelFromCategoryWithUserOverride(categoryName)
+    const config = resolveCategoryConfig(categoryName)
 
     // #then
-    expect(model).toBeUndefined()
+    expect(config).toBeUndefined()
   })
 
   test("falls back to default when user category has no entry", () => {
@@ -63,9 +69,36 @@ describe("Prometheus category model resolution", () => {
     }
 
     // #when
-    const model = resolveModelFromCategoryWithUserOverride(categoryName, userCategories)
+    const config = resolveCategoryConfig(categoryName, userCategories)
 
     // #then
-    expect(model).toBe("openai/gpt-5.2")
+    expect(config).toBeDefined()
+    expect(config?.model).toBe("openai/gpt-5.2")
+    expect(config?.temperature).toBe(0.1)
+  })
+
+  test("preserves all category properties (temperature, top_p, tools, etc.)", () => {
+    // #given
+    const categoryName = "custom-category"
+    const userCategories: Record<string, CategoryConfig> = {
+      "custom-category": {
+        model: "test/model",
+        temperature: 0.5,
+        top_p: 0.9,
+        maxTokens: 32000,
+        tools: { tool1: true, tool2: false },
+      },
+    }
+
+    // #when
+    const config = resolveCategoryConfig(categoryName, userCategories)
+
+    // #then
+    expect(config).toBeDefined()
+    expect(config?.model).toBe("test/model")
+    expect(config?.temperature).toBe(0.5)
+    expect(config?.top_p).toBe(0.9)
+    expect(config?.maxTokens).toBe(32000)
+    expect(config?.tools).toEqual({ tool1: true, tool2: false })
   })
 })

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -34,12 +34,11 @@ export interface ConfigHandlerDeps {
   modelCacheState: ModelCacheState;
 }
 
-export function resolveModelFromCategoryWithUserOverride(
+export function resolveCategoryConfig(
   categoryName: string,
   userCategories?: Record<string, CategoryConfig>
-): string | undefined {
-  const categoryConfig = userCategories?.[categoryName] ?? DEFAULT_CATEGORIES[categoryName];
-  return categoryConfig?.model;
+): CategoryConfig | undefined {
+  return userCategories?.[categoryName] ?? DEFAULT_CATEGORIES[categoryName];
 }
 
 export function createConfigHandler(deps: ConfigHandlerDeps) {
@@ -188,18 +187,20 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
             | undefined;
         const defaultModel = config.model as string | undefined;
 
-        const resolvedModelFromCategory =
-          prometheusOverride?.category && !prometheusOverride?.model
-            ? resolveModelFromCategoryWithUserOverride(
-                prometheusOverride.category,
-                pluginConfig.categories
-              )
-            : undefined;
+        // Resolve full category config (model, temperature, top_p, tools, etc.)
+        // Apply all category properties when category is specified, but explicit
+        // overrides (model, temperature, etc.) will take precedence during merge
+        const categoryConfig = prometheusOverride?.category
+          ? resolveCategoryConfig(
+              prometheusOverride.category,
+              pluginConfig.categories
+            )
+          : undefined;
 
         const prometheusBase = {
           model:
             prometheusOverride?.model ??
-            resolvedModelFromCategory ??
+            categoryConfig?.model ??
             defaultModel ??
             "anthropic/claude-opus-4-5",
           mode: "primary" as const,
@@ -207,6 +208,24 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
           permission: PROMETHEUS_PERMISSION,
           description: `${configAgent?.plan?.description ?? "Plan agent"} (Prometheus - OhMyOpenCode)`,
           color: (configAgent?.plan?.color as string) ?? "#FF6347",
+          // Apply category properties (temperature, top_p, tools, etc.)
+          ...(categoryConfig?.temperature !== undefined
+            ? { temperature: categoryConfig.temperature }
+            : {}),
+          ...(categoryConfig?.top_p !== undefined
+            ? { top_p: categoryConfig.top_p }
+            : {}),
+          ...(categoryConfig?.maxTokens !== undefined
+            ? { maxTokens: categoryConfig.maxTokens }
+            : {}),
+          ...(categoryConfig?.tools ? { tools: categoryConfig.tools } : {}),
+          ...(categoryConfig?.thinking ? { thinking: categoryConfig.thinking } : {}),
+          ...(categoryConfig?.reasoningEffort !== undefined
+            ? { reasoningEffort: categoryConfig.reasoningEffort }
+            : {}),
+          ...(categoryConfig?.textVerbosity !== undefined
+            ? { textVerbosity: categoryConfig.textVerbosity }
+            : {}),
         };
 
         agentConfig["Prometheus (Planner)"] = prometheusOverride


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- Fix Prometheus (Planner) ignoring `category` configuration and always using hardcoded fallback model
- Add category-to-model resolution that respects user-defined categories in `oh-my-opencode.json`

The config schema accepts either model OR category (or both). My fix ensures that when you specify category without model, it correctly resolves the category to get the model. Before the fix, the category field was accepted by the schema but ignored at runtime.

## Changes

<!-- What was changed and how. List specific modifications. -->

- Add `resolveModelFromCategoryWithUserOverride()` helper function that resolves category names to models (user categories take precedence over defaults)
- Import `DEFAULT_CATEGORIES` and `CategoryConfig` type
- Update Prometheus agent config building to use resolved category model in priority chain: `override.model → resolvedCategoryModel → systemDefault → fallback`
- Add 5 BDD test cases for category resolution logic

**Before:** Config with `"Prometheus (Planner)": { "category": "ultrabrain" }` would use `anthropic/claude-opus-4-5`

**After:** Same config correctly resolves to `openai/gpt-5.2` (from ultrabrain category)

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test src/plugin-handlers/config-handler.test.ts
bun test
```

- 5 new tests in `config-handler.test.ts`
- All 962 tests pass
- Manually rebuilt and used local plugin to test that config is used properly -> You end up with a "GPT 5.2 Medium" Prometheus

```bash
{
  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
  "categories": {
    "ultrabrain": {
      "model": "openai/gpt-5.2",
      "variant": "xhigh",
      "temperature": 0.1
    }
  },
  "agents": {
    "Prometheus (Planner)": {
      "category": "ultrabrain",
      "variant": "medium"
    }
  }
}
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Prometheus (Planner) ignoring the category setting by resolving categories to full configs and applying them. When only a category is set in oh-my-opencode.json, the correct model and settings (temperature, tools, etc.) are now used.

- **Bug Fixes**
  - Added category config resolver that prefers user categories over defaults.
  - Prometheus config now prioritizes: explicit model → resolved category model → system default → fallback, and applies all category properties with explicit overrides taking precedence.
  - Added 6 tests covering resolution, overrides, fallbacks, and property preservation.

<sup>Written for commit 903c18955daf388a35d303cee9c4c92da216b325. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

