### PR TITLE
fix: run build before npm publish to include correct version

### DIFF
--- a/script/publish.ts
+++ b/script/publish.ts
@@ -114,6 +114,9 @@ function getDistTag(version: string): string | null {
 }
 
 async function buildAndPublish(version: string): Promise<void> {
+  console.log("\nBuilding before publish...")
+  await $`bun run clean && bun run build`
+
   console.log("\nPublishing to npm...")
   const distTag = getDistTag(version)
   const tagArgs = distTag ? ["--tag", distTag] : []


### PR DESCRIPTION
## Summary
- Fixes CLI `--version` returning old version (e.g., `2.14.0` when `3.0.0-beta.2` is installed)

## Problem
The publish script uses `--ignore-scripts` which skips the `prepublishOnly` hook. This caused the CLI bundle to contain the old version string because:
1. `package.json` version was updated
2. But `bun run build` was never executed before `npm publish`
3. The previous build (with old version) was published

## Solution
Explicitly run `bun run clean && bun run build` before `npm publish` in the `buildAndPublish()` function.

## Testing
- Verified `bunx oh-my-opencode@3.0.0-beta.2 --version` returns `2.14.0` (bug confirmed)
- Checked built `dist/cli/index.js` contains hardcoded `version: "2.14.0"` 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the CLI before npm publish so --version reports the correct version instead of an old one. The publish script now runs bun run clean && bun run build before publishing, since --ignore-scripts bypasses prepublishOnly.

<sup>Written for commit 9d5a5fa0114ce190b9dffffacd4b4045c80d83ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

