### PR TITLE
fix(git-master): inject user config into skill prompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     manager: backgroundManager,
     client: ctx.client,
     userCategories: pluginConfig.categories,
+    gitMasterConfig: pluginConfig.git_master,
   });
   const disabledSkills = new Set(pluginConfig.disabled_skills ?? []);
   const systemMcpNames = getSystemMcpServerNames();

--- a/src/tools/sisyphus-task/tools.ts
+++ b/src/tools/sisyphus-task/tools.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import type { BackgroundManager } from "../../features/background-agent"
 import type { SisyphusTaskArgs } from "./types"
-import type { CategoryConfig, CategoriesConfig } from "../../config/schema"
+import type { CategoryConfig, CategoriesConfig, GitMasterConfig } from "../../config/schema"
 import { SISYPHUS_TASK_DESCRIPTION, DEFAULT_CATEGORIES, CATEGORY_PROMPT_APPENDS } from "./constants"
 import { findNearestMessageWithFields, MESSAGE_STORAGE } from "../../features/hook-message-injector"
 import { resolveMultipleSkills } from "../../features/opencode-skill-loader/skill-content"
@@ -89,6 +89,7 @@ export interface SisyphusTaskToolOptions {
   manager: BackgroundManager
   client: OpencodeClient
   userCategories?: CategoriesConfig
+  gitMasterConfig?: GitMasterConfig
 }
 
 export interface BuildSystemContentInput {
@@ -111,7 +112,7 @@ export function buildSystemContent(input: BuildSystemContentInput): string | und
 }
 
 export function createSisyphusTask(options: SisyphusTaskToolOptions): ToolDefinition {
-  const { manager, client, userCategories } = options
+  const { manager, client, userCategories, gitMasterConfig } = options
 
   return tool({
     description: SISYPHUS_TASK_DESCRIPTION,
@@ -136,7 +137,7 @@ export function createSisyphusTask(options: SisyphusTaskToolOptions): ToolDefini
 
       let skillContent: string | undefined
       if (args.skills.length > 0) {
-        const { resolved, notFound } = resolveMultipleSkills(args.skills)
+        const { resolved, notFound } = resolveMultipleSkills(args.skills, { gitMasterConfig })
         if (notFound.length > 0) {
           const available = createBuiltinSkills().map(s => s.name).join(", ")
           return `❌ Skills not found: ${notFound.join(", ")}. Available: ${available}`


### PR DESCRIPTION
## Summary

- Makes `git_master` config (`commit_footer`, `include_co_authored_by`) actually work
- Config values are now injected into the git-master skill template at load time

## Problem

The `git_master` config was defined in schema but never consumed. Users setting `include_co_authored_by: false` had no effect.

## Solution

- Added `injectGitMasterConfig()` in `skill-content.ts` that prepends config values as a header to the git-master skill template
- Passed `gitMasterConfig` through `SisyphusTaskToolOptions` → `resolveMultipleSkills()`
- Config header explicitly tells the agent whether footers/co-author are enabled or disabled

## Files Changed

| File | Change |
|------|--------|
| `skill-content.ts` | Added config injection logic |
| `tools.ts` | Accept and pass `gitMasterConfig` |
| `index.ts` | Pass `pluginConfig.git_master` to tool |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes git_master so commit_footer and include_co_authored_by settings take effect by injecting user config into the git-master skill prompt at load time. The agent now knows whether to add footers and Co-authored-by lines.

- **Bug Fixes**
  - Added injectGitMasterConfig() to prepend a config header to the git-master template.
  - Passed gitMasterConfig through SisyphusTask options into resolveMultipleSkills().
  - index.ts now forwards pluginConfig.git_master to the tool.

<sup>Written for commit 812467025186d47336746b750669b2181976358f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

