### PR TITLE
fix(prometheus-md-only): normalize path separators for Windows compatibility

### DIFF
--- a/src/hooks/prometheus-md-only/index.ts
+++ b/src/hooks/prometheus-md-only/index.ts
@@ -9,7 +9,9 @@ export * from "./constants"
 
 function isAllowedFile(filePath: string): boolean {
   const hasAllowedExtension = ALLOWED_EXTENSIONS.some(ext => filePath.endsWith(ext))
-  const isInAllowedPath = filePath.includes(ALLOWED_PATH_PREFIX)
+  // Normalize path separators for cross-platform compatibility (Windows uses backslashes)
+  const normalizedPath = filePath.replace(/\\/g, "/")
+  const isInAllowedPath = normalizedPath.includes(ALLOWED_PATH_PREFIX)
   return hasAllowedExtension && isInAllowedPath
 }
 


### PR DESCRIPTION
## Summary

- Fixes Windows path validation in prometheus-md-only hook
- Normalizes backslashes to forward slashes before checking `.sisyphus/` prefix

## Problem

On Windows, paths use backslashes (`C:\project\.sisyphus\plans\...`) but the hook was checking for forward slashes (`.sisyphus/`), causing valid `.sisyphus/` paths to be incorrectly rejected.

**Exact error encountered:**

```
Error: [prometheus-md-only] Prometheus (Planner) can only write/edit .md files inside .sisyphus/ directory. Attempted to modify: C:\project\.sisyphus\plans\plan.md. Prometheus is a READ-ONLY planner. Use /start-work to execute the plan.
```

The path IS inside `.sisyphus/` and IS a `.md` file, but was incorrectly blocked due to backslash path separators.

## Solution

Added path normalization in `isAllowedFile()`:

```typescript
const normalizedPath = filePath.replace(/\/g, "/")
const isInAllowedPath = normalizedPath.includes(ALLOWED_PATH_PREFIX)
```

## Testing

- All 14 existing tests pass
- Manually verified Windows paths work correctly