### PR TITLE
fix: resolve version at runtime to fix stale version display

### DIFF
--- a/src/cli/get-local-version/formatter.ts
+++ b/src/cli/get-local-version/formatter.ts
@@ -1,5 +1,6 @@
 import color from "picocolors"
 import type { VersionInfo } from "./types"
+import { getChannelLabel } from "../../shared/version"
 
 const SYMBOLS = {
   check: color.green("✓"),
@@ -9,6 +10,12 @@ const SYMBOLS = {
   warn: color.yellow("⚠"),
   pin: color.magenta("📌"),
   dev: color.cyan("🔧"),
+  channel: color.yellow("⚡"),
+}
+
+function formatChannel(channel: string | undefined): string {
+  if (!channel || channel === "stable") return ""
+  return color.yellow(` (${getChannelLabel(channel as any)})`)
 }
 
 export function formatVersionOutput(info: VersionInfo): string {
@@ -20,13 +27,28 @@ export function formatVersionOutput(info: VersionInfo): string {
   lines.push("")
 
   if (info.currentVersion) {
-    lines.push(`  Current Version: ${color.cyan(info.currentVersion)}`)
+    const channelBadge = formatChannel(info.currentChannel)
+    lines.push(`  Current Version: ${color.cyan(info.currentVersion)}${channelBadge}`)
   } else {
     lines.push(`  Current Version: ${color.dim("unknown")}`)
   }
 
-  if (!info.isLocalDev && info.latestVersion) {
-    lines.push(`  Latest Version:  ${color.cyan(info.latestVersion)}`)
+  // Show latest for channel if different from current
+  if (!info.isLocalDev && info.latestForChannel) {
+    lines.push(`  Latest${info.currentChannel !== "stable" ? ` (${info.currentChannel})` : ""}:  ${color.cyan(info.latestForChannel)}`)
+  } else if (!info.isLocalDev && info.latestVersion) {
+    lines.push(`  Latest Stable:   ${color.cyan(info.latestVersion)}`)
+  }
+
+  // Show available channels if we have them
+  if (info.availableChannels) {
+    const channels = Object.entries(info.availableChannels)
+      .filter(([tag, version]) => version && tag !== "latest")
+      .map(([tag, version]) => `${tag}@${version}`)
+    
+    if (channels.length > 0) {
+      lines.push(`  Other Channels:  ${color.dim(channels.join(", "))}`)
+    }
   }
 
   lines.push("")
@@ -36,8 +58,15 @@ export function formatVersionOutput(info: VersionInfo): string {
       lines.push(`  ${SYMBOLS.check} ${color.green("You're up to date!")}`)
       break
     case "outdated":
-      lines.push(`  ${SYMBOLS.warn} ${color.yellow("Update available")}`)
-      lines.push(`  ${color.dim("Run:")} ${color.cyan("cd ~/.config/opencode && bun update oh-my-opencode")}`)
+      const updateLabel = info.updateType && info.updateType !== "none" 
+        ? `${info.updateType} update` 
+        : "Update"
+      lines.push(`  ${SYMBOLS.warn} ${color.yellow(`${updateLabel} available`)}`)
+      if (info.currentChannel === "stable") {
+        lines.push(`  ${color.dim("Run:")} ${color.cyan("cd ~/.config/opencode && bun update oh-my-opencode")}`)
+      } else {
+        lines.push(`  ${color.dim("Run:")} ${color.cyan(`cd ~/.config/opencode && bun update oh-my-opencode@${info.currentChannel}`)}`)
+      }
       break
     case "local-dev":
       lines.push(`  ${SYMBOLS.dev} ${color.cyan("Running in local development mode")}`)

--- a/src/cli/get-local-version/index.ts
+++ b/src/cli/get-local-version/index.ts
@@ -1,29 +1,39 @@
-import { getCachedVersion, getLatestVersion, isLocalDevMode, findPluginEntry } from "../../hooks/auto-update-checker/checker"
+import { findPluginEntry } from "../../hooks/auto-update-checker/checker"
+import { CACHE_DIR } from "../../hooks/auto-update-checker/constants"
+import { checkVersion, detectChannel } from "../../shared/version"
 import type { GetLocalVersionOptions, VersionInfo } from "./types"
 import { formatVersionOutput, formatJsonOutput } from "./formatter"
 
 export async function getLocalVersion(options: GetLocalVersionOptions = {}): Promise<number> {
   const directory = options.directory ?? process.cwd()
-  
+
   try {
-    if (isLocalDevMode(directory)) {
-      const currentVersion = getCachedVersion()
+    const pluginInfo = findPluginEntry(directory)
+    
+    // Check for local dev mode (file:// protocol)
+    const isLocalDev = pluginInfo?.entry.startsWith("file://") ?? false
+
+    if (isLocalDev) {
+      // Use the new version system even for local dev
+      const result = await checkVersion({ cacheDir: CACHE_DIR })
       const info: VersionInfo = {
-        currentVersion,
+        currentVersion: result.currentVersion,
         latestVersion: null,
         isUpToDate: false,
         isLocalDev: true,
         isPinned: false,
         pinnedVersion: null,
         status: "local-dev",
+        currentChannel: result.currentChannel,
       }
-      
+
       console.log(options.json ? formatJsonOutput(info) : formatVersionOutput(info))
       return 0
     }
 
-    const pluginInfo = findPluginEntry(directory)
+    // Check for pinned version (but still show channel info)
     if (pluginInfo?.isPinned) {
+      const pinnedChannel = detectChannel(pluginInfo.pinnedVersion ?? "")
       const info: VersionInfo = {
         currentVersion: pluginInfo.pinnedVersion,
         latestVersion: null,
@@ -32,14 +42,17 @@ export async function getLocalVersion(options: GetLocalVersionOptions = {}): Pro
         isPinned: true,
         pinnedVersion: pluginInfo.pinnedVersion,
         status: "pinned",
+        currentChannel: pinnedChannel,
       }
-      
+
       console.log(options.json ? formatJsonOutput(info) : formatVersionOutput(info))
       return 0
     }
 
-    const currentVersion = getCachedVersion()
-    if (!currentVersion) {
+    // Full version check using new system
+    const result = await checkVersion({ cacheDir: CACHE_DIR })
+
+    if (result.currentVersion === "unknown") {
       const info: VersionInfo = {
         currentVersion: null,
         latestVersion: null,
@@ -49,42 +62,43 @@ export async function getLocalVersion(options: GetLocalVersionOptions = {}): Pro
         pinnedVersion: null,
         status: "unknown",
       }
-      
+
       console.log(options.json ? formatJsonOutput(info) : formatVersionOutput(info))
       return 1
     }
 
-    const latestVersion = await getLatestVersion()
-    
-    if (!latestVersion) {
+    if (!result.latestForChannel) {
       const info: VersionInfo = {
-        currentVersion,
+        currentVersion: result.currentVersion,
         latestVersion: null,
         isUpToDate: false,
         isLocalDev: false,
         isPinned: false,
         pinnedVersion: null,
         status: "error",
+        currentChannel: result.currentChannel,
       }
-      
+
       console.log(options.json ? formatJsonOutput(info) : formatVersionOutput(info))
       return 0
     }
 
-    const isUpToDate = currentVersion === latestVersion
     const info: VersionInfo = {
-      currentVersion,
-      latestVersion,
-      isUpToDate,
+      currentVersion: result.currentVersion,
+      latestVersion: result.latestStable,
+      isUpToDate: !result.needsUpdate,
       isLocalDev: false,
       isPinned: false,
       pinnedVersion: null,
-      status: isUpToDate ? "up-to-date" : "outdated",
+      status: result.needsUpdate ? "outdated" : "up-to-date",
+      currentChannel: result.currentChannel,
+      latestForChannel: result.latestForChannel,
+      updateType: result.updateType,
+      availableChannels: result.availableChannels,
     }
 
     console.log(options.json ? formatJsonOutput(info) : formatVersionOutput(info))
     return 0
-
   } catch (error) {
     const info: VersionInfo = {
       currentVersion: null,
@@ -95,7 +109,7 @@ export async function getLocalVersion(options: GetLocalVersionOptions = {}): Pro
       pinnedVersion: null,
       status: "error",
     }
-    
+
     console.log(options.json ? formatJsonOutput(info) : formatVersionOutput(info))
     return 1
   }

--- a/src/cli/get-local-version/types.ts
+++ b/src/cli/get-local-version/types.ts
@@ -1,3 +1,5 @@
+import type { ReleaseChannel, DistTags } from "../../shared/version"
+
 export interface VersionInfo {
   currentVersion: string | null
   latestVersion: string | null
@@ -6,6 +8,11 @@ export interface VersionInfo {
   isPinned: boolean
   pinnedVersion: string | null
   status: "up-to-date" | "outdated" | "local-dev" | "pinned" | "error" | "unknown"
+  // New fields for channel-aware versioning
+  currentChannel?: ReleaseChannel
+  latestForChannel?: string | null
+  updateType?: "major" | "minor" | "patch" | "prerelease" | "none"
+  availableChannels?: DistTags
 }
 
 export interface GetLocalVersionOptions {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,9 +9,10 @@ import type { InstallArgs } from "./types"
 import type { RunOptions } from "./run"
 import type { GetLocalVersionOptions } from "./get-local-version/types"
 import type { DoctorOptions } from "./doctor"
+import { getRuntimeVersionCached } from "../shared/version"
 
-const packageJson = await import("../../package.json")
-const VERSION = packageJson.version
+// Use runtime version resolution to avoid build-time bundling issues
+const VERSION = getRuntimeVersionCached().version
 
 const program = new Command()
 

--- a/src/hooks/auto-update-checker/index.ts
+++ b/src/hooks/auto-update-checker/index.ts
@@ -1,16 +1,23 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { getCachedVersion, getLocalDevVersion, findPluginEntry, getLatestVersion, updatePinnedVersion } from "./checker"
+import { findPluginEntry, updatePinnedVersion } from "./checker"
 import { invalidatePackage } from "./cache"
-import { PACKAGE_NAME } from "./constants"
+import { PACKAGE_NAME, CACHE_DIR } from "./constants"
 import { log } from "../../shared/logger"
 import { getConfigLoadErrors, clearConfigLoadErrors } from "../../shared/config-errors"
 import { runBunInstall } from "../../cli/config-manager"
 import type { AutoUpdateCheckerOptions } from "./types"
+import {
+  checkVersion,
+  detectChannel,
+  isPrerelease,
+  getChannelLabel,
+  type VersionCheckResult,
+} from "../../shared/version"
 
 const SISYPHUS_SPINNER = ["·", "•", "●", "○", "◌", "◦", " "]
 
 export function isPrereleaseVersion(version: string): boolean {
-  return version.includes("-")
+  return isPrerelease(version)
 }
 
 export function isDistTag(version: string): boolean {
@@ -26,14 +33,15 @@ export function isPrereleaseOrDistTag(pinnedVersion: string | null): boolean {
 export function createAutoUpdateCheckerHook(ctx: PluginInput, options: AutoUpdateCheckerOptions = {}) {
   const { showStartupToast = true, isSisyphusEnabled = false, autoUpdate = true } = options
 
-  const getToastMessage = (isUpdate: boolean, latestVersion?: string): string => {
+  const getToastMessage = (isUpdate: boolean, latestVersion?: string, channel?: string): string => {
+    const channelNote = channel && channel !== "stable" ? ` (${channel})` : ""
     if (isSisyphusEnabled) {
       return isUpdate
-        ? `Sisyphus on steroids is steering OpenCode.\nv${latestVersion} available. Restart to apply.`
+        ? `Sisyphus on steroids is steering OpenCode.\nv${latestVersion}${channelNote} available. Restart to apply.`
         : `Sisyphus on steroids is steering OpenCode.`
     }
     return isUpdate
-      ? `OpenCode is now on Steroids. oMoMoMoMo...\nv${latestVersion} available. Restart OpenCode to apply.`
+      ? `OpenCode is now on Steroids. oMoMoMoMo...\nv${latestVersion}${channelNote} available. Restart OpenCode to apply.`
       : `OpenCode is now on Steroids. oMoMoMoMo...`
   }
 
@@ -50,13 +58,17 @@ export function createAutoUpdateCheckerHook(ctx: PluginInput, options: AutoUpdat
       hasChecked = true
 
       setTimeout(async () => {
-        const cachedVersion = getCachedVersion()
-        const localDevVersion = getLocalDevVersion(ctx.directory)
-        const displayVersion = localDevVersion ?? cachedVersion
-
         await showConfigErrorsIfAny(ctx)
 
-        if (localDevVersion) {
+        // Use new version checking system
+        const versionResult = await checkVersion({ cacheDir: CACHE_DIR })
+        const displayVersion = versionResult.currentVersion
+
+        // Check for local dev mode
+        const pluginInfo = findPluginEntry(ctx.directory)
+        const isLocalDev = pluginInfo?.entry.startsWith("file://") ?? false
+
+        if (isLocalDev) {
           if (showStartupToast) {
             showLocalDevToast(ctx, displayVersion, isSisyphusEnabled).catch(() => {})
           }
@@ -68,7 +80,7 @@ export function createAutoUpdateCheckerHook(ctx: PluginInput, options: AutoUpdat
           showVersionToast(ctx, displayVersion, getToastMessage(false)).catch(() => {})
         }
 
-        runBackgroundUpdateCheck(ctx, autoUpdate, getToastMessage).catch(err => {
+        runBackgroundUpdateCheckV2(ctx, autoUpdate, versionResult, getToastMessage).catch(err => {
           log("[auto-update-checker] Background update check failed:", err)
         })
       }, 0)
@@ -76,10 +88,18 @@ export function createAutoUpdateCheckerHook(ctx: PluginInput, options: AutoUpdat
   }
 }
 
-async function runBackgroundUpdateCheck(
+/**
+ * New version-aware update check using the shared version module
+ * 
+ * The version module already determines the best version to offer:
+ * - Stable users: only stable updates
+ * - Beta users: whichever is newer (beta or stable)
+ */
+async function runBackgroundUpdateCheckV2(
   ctx: PluginInput,
   autoUpdate: boolean,
-  getToastMessage: (isUpdate: boolean, latestVersion?: string) => string
+  versionResult: VersionCheckResult,
+  getToastMessage: (isUpdate: boolean, latestVersion?: string, channel?: string) => string
 ): Promise<void> {
   const pluginInfo = findPluginEntry(ctx.directory)
   if (!pluginInfo) {
@@ -87,51 +107,47 @@ async function runBackgroundUpdateCheck(
     return
   }
 
-  const cachedVersion = getCachedVersion()
-  const currentVersion = cachedVersion ?? pluginInfo.pinnedVersion
-  if (!currentVersion) {
-    log("[auto-update-checker] No version found (cached or pinned)")
+  const { currentVersion, currentChannel, latestForChannel, needsUpdate, updateType } = versionResult
+
+  if (!needsUpdate || !latestForChannel) {
+    log(`[auto-update-checker] No update needed (${currentVersion} ${currentChannel})`)
     return
   }
 
-  const latestVersion = await getLatestVersion()
-  if (!latestVersion) {
-    log("[auto-update-checker] Failed to fetch latest version")
-    return
-  }
+  const targetChannel = detectChannel(latestForChannel)
+  log(`[auto-update-checker] Update available: ${currentVersion} (${currentChannel}) → ${latestForChannel} (${targetChannel})`)
 
-  if (currentVersion === latestVersion) {
-    log("[auto-update-checker] Already on latest version")
-    return
-  }
-
-  log(`[auto-update-checker] Update available: ${currentVersion} → ${latestVersion}`)
-
+  // Show notification for all updates
   if (!autoUpdate) {
-    await showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
+    await showUpdateAvailableToast(ctx, latestForChannel, (isUpdate, version) => 
+      getToastMessage(isUpdate, version, targetChannel !== "stable" ? getChannelLabel(targetChannel) : undefined)
+    )
     log("[auto-update-checker] Auto-update disabled, notification only")
     return
   }
 
-  // Check if current version is a prerelease - don't auto-downgrade prerelease to stable
-  if (isPrereleaseVersion(currentVersion)) {
-    log(`[auto-update-checker] Skipping auto-update for prerelease version: ${currentVersion}`)
-    return
-  }
-
+  // Handle pinned versions - only auto-update if pinned to a dist-tag (like "beta")
+  // Don't auto-update if pinned to a specific version like "3.0.0-beta.2"
   if (pluginInfo.isPinned) {
-    if (isPrereleaseOrDistTag(pluginInfo.pinnedVersion)) {
-      log(`[auto-update-checker] Skipping auto-update for prerelease/dist-tag: ${pluginInfo.pinnedVersion}`)
+    // If pinned to a dist-tag (e.g., "beta", "latest"), we can update
+    // If pinned to a specific version, skip auto-update
+    if (!isDistTag(pluginInfo.pinnedVersion ?? "")) {
+      log(`[auto-update-checker] Skipping auto-update for pinned version: ${pluginInfo.pinnedVersion}`)
+      await showUpdateAvailableToast(ctx, latestForChannel, (isUpdate, version) => 
+        getToastMessage(isUpdate, version, targetChannel !== "stable" ? getChannelLabel(targetChannel) : undefined)
+      )
       return
     }
 
-    const updated = updatePinnedVersion(pluginInfo.configPath, pluginInfo.entry, latestVersion)
+    const updated = updatePinnedVersion(pluginInfo.configPath, pluginInfo.entry, latestForChannel)
     if (!updated) {
-      await showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
+      await showUpdateAvailableToast(ctx, latestForChannel, (isUpdate, version) => 
+        getToastMessage(isUpdate, version, targetChannel !== "stable" ? getChannelLabel(targetChannel) : undefined)
+      )
       log("[auto-update-checker] Failed to update pinned version in config")
       return
     }
-    log(`[auto-update-checker] Config updated: ${pluginInfo.entry} → ${PACKAGE_NAME}@${latestVersion}`)
+    log(`[auto-update-checker] Config updated: ${pluginInfo.entry} → ${PACKAGE_NAME}@${latestForChannel}`)
   }
 
   invalidatePackage(PACKAGE_NAME)
@@ -139,10 +155,12 @@ async function runBackgroundUpdateCheck(
   const installSuccess = await runBunInstallSafe()
 
   if (installSuccess) {
-    await showAutoUpdatedToast(ctx, currentVersion, latestVersion)
-    log(`[auto-update-checker] Update installed: ${currentVersion} → ${latestVersion}`)
+    await showAutoUpdatedToast(ctx, currentVersion, latestForChannel)
+    log(`[auto-update-checker] Update installed: ${currentVersion} → ${latestForChannel} (${updateType})`)
   } else {
-    await showUpdateAvailableToast(ctx, latestVersion, getToastMessage)
+    await showUpdateAvailableToast(ctx, latestForChannel, (isUpdate, version) => 
+      getToastMessage(isUpdate, version, targetChannel !== "stable" ? getChannelLabel(targetChannel) : undefined)
+    )
     log("[auto-update-checker] bun install failed; update not installed (falling back to notification-only)")
   }
 }

--- a/src/shared/version/channels.ts
+++ b/src/shared/version/channels.ts
@@ -1,0 +1,138 @@
+/**
+ * Release channel detection and management
+ */
+
+import type { ReleaseChannel } from "./types"
+import { parse } from "./semver"
+
+/**
+ * Patterns to detect release channel from prerelease string
+ * Order matters - more specific patterns first
+ */
+const CHANNEL_PATTERNS: [RegExp, ReleaseChannel][] = [
+  [/^alpha/, "alpha"],
+  [/^a\.?\d/, "alpha"],
+  [/^beta/, "beta"],
+  [/^b\.?\d/, "beta"],
+  [/^rc/, "rc"],
+  [/^canary/, "canary"],
+  [/^dev/, "dev"],
+  [/^nightly/, "dev"],
+  [/^next/, "beta"], // treat "next" as beta equivalent
+  [/^preview/, "beta"],
+  [/^snapshot/, "dev"],
+]
+
+/**
+ * Detect the release channel from a version string
+ */
+export function detectChannel(version: string): ReleaseChannel {
+  const parsed = parse(version)
+  if (!parsed || parsed.prerelease.length === 0) return "stable"
+
+  const prereleaseStr = parsed.prerelease.join(".").toLowerCase()
+
+  for (const [pattern, channel] of CHANNEL_PATTERNS) {
+    if (pattern.test(prereleaseStr)) return channel
+  }
+
+  // Unknown prerelease type defaults to beta (safer than assuming dev)
+  return "beta"
+}
+
+/**
+ * Get the stability priority of a channel (higher = more stable)
+ */
+export function getChannelPriority(channel: ReleaseChannel): number {
+  const priorities: Record<ReleaseChannel, number> = {
+    stable: 100,
+    rc: 80,
+    beta: 60,
+    alpha: 40,
+    canary: 20,
+    dev: 0,
+  }
+  return priorities[channel]
+}
+
+/**
+ * Check if a user on currentChannel should be offered updates to targetChannel
+ *
+ * Rules:
+ * - Stable users only see stable updates
+ * - Prerelease users can update within their channel or to more stable channels
+ * - Users are never auto-downgraded to less stable channels
+ */
+export function shouldUpdateToChannel(
+  currentChannel: ReleaseChannel,
+  targetChannel: ReleaseChannel
+): boolean {
+  // Stable users should NOT be pushed to prerelease
+  if (currentChannel === "stable") {
+    return targetChannel === "stable"
+  }
+
+  // Prerelease users can move to same or more stable channel
+  return getChannelPriority(targetChannel) >= getChannelPriority(currentChannel)
+}
+
+/**
+ * Map npm dist-tag name to release channel
+ */
+export function mapDistTagToChannel(tag: string): ReleaseChannel {
+  const mapping: Record<string, ReleaseChannel> = {
+    latest: "stable",
+    beta: "beta",
+    alpha: "alpha",
+    rc: "rc",
+    canary: "canary",
+    next: "beta",
+    dev: "dev",
+    nightly: "dev",
+  }
+  return mapping[tag.toLowerCase()] ?? "beta"
+}
+
+/**
+ * Map release channel to expected npm dist-tag
+ */
+export function mapChannelToDistTag(channel: ReleaseChannel): string {
+  const mapping: Record<ReleaseChannel, string> = {
+    stable: "latest",
+    beta: "beta",
+    alpha: "alpha",
+    rc: "rc",
+    canary: "canary",
+    dev: "dev",
+  }
+  return mapping[channel]
+}
+
+/**
+ * Get a human-readable label for a channel
+ */
+export function getChannelLabel(channel: ReleaseChannel): string {
+  const labels: Record<ReleaseChannel, string> = {
+    stable: "Stable",
+    beta: "Beta",
+    alpha: "Alpha",
+    rc: "Release Candidate",
+    canary: "Canary",
+    dev: "Development",
+  }
+  return labels[channel]
+}
+
+/**
+ * Check if a channel is considered a prerelease channel
+ */
+export function isPrereleaseChannel(channel: ReleaseChannel): boolean {
+  return channel !== "stable"
+}
+
+/**
+ * Get all channels ordered by stability (most stable first)
+ */
+export function getChannelsByStability(): ReleaseChannel[] {
+  return ["stable", "rc", "beta", "alpha", "canary", "dev"]
+}

--- a/src/shared/version/index.ts
+++ b/src/shared/version/index.ts
@@ -1,0 +1,156 @@
+/**
+ * Version management module
+ *
+ * Provides comprehensive version handling including:
+ * - Semver parsing and comparison
+ * - Release channel detection
+ * - NPM registry integration
+ * - Runtime version resolution
+ */
+
+export * from "./types"
+export * from "./semver"
+export * from "./channels"
+export * from "./registry"
+export * from "./resolver"
+
+import type { VersionCheckResult, ReleaseChannel, DistTags } from "./types"
+import { resolveVersion, getRuntimeVersionCached } from "./resolver"
+import { fetchDistTags } from "./registry"
+import { detectChannel, shouldUpdateToChannel, mapChannelToDistTag } from "./channels"
+import { gt, diff } from "./semver"
+import { log } from "../logger"
+
+export interface CheckVersionOptions {
+  cacheDir?: string
+  localDevPath?: string
+}
+
+/**
+ * Complete version check - determines if update is needed based on channel-aware logic
+ *
+ * This is the main entry point for version checking. It:
+ * 1. Resolves the current version (runtime, cached, or local-dev)
+ * 2. Detects the release channel of the current version
+ * 3. Fetches all available dist-tags from npm
+ * 4. Determines if an update is available
+ *
+ * Update logic:
+ * - Stable users: only see stable updates
+ * - Beta/prerelease users: see whichever is newer (beta OR stable)
+ *   e.g., if on beta.2 and stable 3.0.0 releases, offer stable
+ */
+export async function checkVersion(options: CheckVersionOptions = {}): Promise<VersionCheckResult> {
+  const resolved = resolveVersion({
+    cacheDir: options.cacheDir,
+    localDevPath: options.localDevPath,
+  })
+  const currentVersion = resolved.version
+  const currentChannel = detectChannel(currentVersion)
+
+  log(`[version] Current: ${currentVersion} (${currentChannel}) from ${resolved.source}`)
+
+  const distTags = await fetchDistTags()
+
+  if (!distTags) {
+    log(`[version] Failed to fetch dist-tags, returning no-update result`)
+    return {
+      currentVersion,
+      currentChannel,
+      latestForChannel: null,
+      latestStable: "unknown",
+      needsUpdate: false,
+      updateType: "none",
+      availableChannels: { latest: "unknown" },
+    }
+  }
+
+  const latestStable = distTags.latest ?? "unknown"
+
+  // Find the best version to offer based on user's channel
+  let latestForChannel: string | null = null
+
+  if (currentChannel === "stable") {
+    // Stable users only see stable updates
+    latestForChannel = latestStable
+  } else {
+    // Prerelease users: offer whichever is newer - their channel's latest OR stable
+    const channelTag = mapChannelToDistTag(currentChannel)
+    const latestInChannel = distTags[channelTag] ?? null
+
+    if (latestInChannel && latestStable !== "unknown") {
+      // Compare channel version vs stable, offer the newer one
+      latestForChannel = gt(latestStable, latestInChannel) ? latestStable : latestInChannel
+      log(`[version] Beta user: comparing ${latestInChannel} (${currentChannel}) vs ${latestStable} (stable) -> offering ${latestForChannel}`)
+    } else if (latestInChannel) {
+      latestForChannel = latestInChannel
+    } else {
+      // No tag for their channel, fall back to stable
+      latestForChannel = latestStable
+    }
+  }
+
+  // Determine if update is needed
+  let needsUpdate = false
+  let updateType: VersionCheckResult["updateType"] = "none"
+
+  if (latestForChannel && currentVersion !== "unknown" && latestForChannel !== "unknown") {
+    if (gt(latestForChannel, currentVersion)) {
+      needsUpdate = true
+      updateType = diff(currentVersion, latestForChannel) ?? "none"
+    }
+  }
+
+  log(
+    `[version] Check result: ${currentVersion} (${currentChannel}) -> ${latestForChannel} | needsUpdate: ${needsUpdate} (${updateType})`
+  )
+
+  return {
+    currentVersion,
+    currentChannel,
+    latestForChannel,
+    latestStable,
+    needsUpdate,
+    updateType,
+    availableChannels: distTags,
+  }
+}
+
+/**
+ * Quick check if current version is a prerelease
+ */
+export function isCurrentVersionPrerelease(): boolean {
+  const resolved = getRuntimeVersionCached()
+  const channel = detectChannel(resolved.version)
+  return channel !== "stable"
+}
+
+/**
+ * Get the current version string (cached for performance)
+ */
+export function getCurrentVersion(): string {
+  return getRuntimeVersionCached().version
+}
+
+/**
+ * Get detailed version info including source
+ */
+export function getCurrentVersionInfo() {
+  return getRuntimeVersionCached()
+}
+
+/**
+ * Utility to format version check result for display
+ */
+export function formatVersionStatus(result: VersionCheckResult): string {
+  if (result.currentVersion === "unknown") {
+    return "Version: Unknown"
+  }
+
+  const channelLabel = result.currentChannel === "stable" ? "" : ` (${result.currentChannel})`
+  const status = result.needsUpdate
+    ? `Update available: ${result.latestForChannel}`
+    : "Up to date"
+
+  return `v${result.currentVersion}${channelLabel} - ${status}`
+}

--- a/src/shared/version/registry.ts
+++ b/src/shared/version/registry.ts
@@ -1,0 +1,91 @@
+/**
+ * NPM registry interaction for version information
+ */
+
+import type { DistTags, ReleaseChannel } from "./types"
+import { mapChannelToDistTag } from "./channels"
+import { log } from "../logger"
+
+const PACKAGE_NAME = "oh-my-opencode"
+const REGISTRY_URL = `https://registry.npmjs.org/-/package/${PACKAGE_NAME}/dist-tags`
+const FETCH_TIMEOUT = 5000
+
+/**
+ * Fetch all dist-tags from npm registry
+ */
+export async function fetchDistTags(): Promise<DistTags | null> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT)
+
+  try {
+    const response = await fetch(REGISTRY_URL, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    })
+
+    if (!response.ok) {
+      log(`[version/registry] Failed to fetch dist-tags: ${response.status}`)
+      return null
+    }
+
+    const data = (await response.json()) as DistTags
+    log(`[version/registry] Fetched dist-tags:`, Object.keys(data).join(", "))
+    return data
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      log(`[version/registry] Fetch timeout after ${FETCH_TIMEOUT}ms`)
+    } else {
+      log(`[version/registry] Fetch error:`, err)
+    }
+    return null
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+/**
+ * Get the latest version for a specific channel
+ */
+export async function getLatestForChannel(channel: ReleaseChannel): Promise<string | null> {
+  const tags = await fetchDistTags()
+  if (!tags) return null
+
+  const tag = mapChannelToDistTag(channel)
+  return tags[tag] ?? null
+}
+
+/**
+ * Get the latest stable version
+ */
+export async function getLatestStable(): Promise<string | null> {
+  const tags = await fetchDistTags()
+  return tags?.latest ?? null
+}
+
+/**
+ * Get the latest beta version
+ */
+export async function getLatestBeta(): Promise<string | null> {
+  const tags = await fetchDistTags()
+  return tags?.beta ?? null
+}
+
+/**
+ * Check if a specific version exists as a dist-tag
+ */
+export async function isDistTagVersion(version: string): Promise<boolean> {
+  const tags = await fetchDistTags()
+  if (!tags) return false
+
+  return Object.values(tags).includes(version)
+}
+
+/**
+ * Get all available dist-tag names
+ */
+export async function getAvailableDistTags(): Promise<string[]> {
+  const tags = await fetchDistTags()
+  if (!tags) return []
+
+  return Object.keys(tags)
+}

--- a/src/shared/version/resolver.ts
+++ b/src/shared/version/resolver.ts
@@ -1,0 +1,190 @@
+/**
+ * Runtime version resolution
+ *
+ * Resolves the current version at RUNTIME by finding package.json,
+ * avoiding the build-time bundling issue where version gets frozen.
+ */
+
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import type { VersionResolveResult } from "./types"
+import { log } from "../logger"
+
+const PACKAGE_NAME = "oh-my-opencode"
+
+/**
+ * Find package.json by walking up from a starting path
+ */
+function findPackageJsonUp(startPath: string): string | null {
+  try {
+    const stat = fs.statSync(startPath)
+    let dir = stat.isDirectory() ? startPath : path.dirname(startPath)
+
+    for (let i = 0; i < 10; i++) {
+      const pkgPath = path.join(dir, "package.json")
+
+      if (fs.existsSync(pkgPath)) {
+        try {
+          const content = fs.readFileSync(pkgPath, "utf-8")
+          const pkg = JSON.parse(content)
+          if (pkg.name === PACKAGE_NAME) return pkgPath
+        } catch {
+          // Invalid JSON, continue searching
+        }
+      }
+
+      const parent = path.dirname(dir)
+      if (parent === dir) break
+      dir = parent
+    }
+  } catch {
+    // Stat failed
+  }
+
+  return null
+}
+
+/**
+ * Resolve version at RUNTIME by finding package.json relative to this file.
+ * This avoids the build-time bundling issue.
+ */
+export function resolveRuntimeVersion(): VersionResolveResult {
+  try {
+    // Get directory of this file at runtime
+    const currentFile = fileURLToPath(import.meta.url)
+    const currentDir = path.dirname(currentFile)
+
+    const pkgPath = findPackageJsonUp(currentDir)
+
+    if (pkgPath) {
+      const content = fs.readFileSync(pkgPath, "utf-8")
+      const pkg = JSON.parse(content)
+
+      if (pkg.version) {
+        log(`[version/resolver] Found runtime version: ${pkg.version} at ${pkgPath}`)
+        return {
+          version: pkg.version,
+          source: "runtime",
+          path: pkgPath,
+        }
+      }
+    }
+
+    log(`[version/resolver] Could not find package.json for ${PACKAGE_NAME}`)
+    return { version: "unknown", source: "unknown" }
+  } catch (err) {
+    log(`[version/resolver] Error resolving runtime version:`, err)
+    return { version: "unknown", source: "unknown" }
+  }
+}
+
+/**
+ * Get version from OpenCode's plugin cache directory
+ */
+export function getCachedVersion(cacheDir: string): VersionResolveResult {
+  const pkgPath = path.join(cacheDir, "node_modules", PACKAGE_NAME, "package.json")
+
+  try {
+    if (fs.existsSync(pkgPath)) {
+      const content = fs.readFileSync(pkgPath, "utf-8")
+      const pkg = JSON.parse(content)
+
+      if (pkg.version) {
+        log(`[version/resolver] Found cached version: ${pkg.version} at ${pkgPath}`)
+        return {
+          version: pkg.version,
+          source: "cached",
+          path: pkgPath,
+        }
+      }
+    }
+  } catch (err) {
+    log(`[version/resolver] Error reading cached version:`, err)
+  }
+
+  return { version: "unknown", source: "unknown" }
+}
+
+/**
+ * Get version from a local development path (file:// protocol)
+ */
+export function getLocalDevVersion(localPath: string): VersionResolveResult {
+  try {
+    const pkgPath = findPackageJsonUp(localPath)
+
+    if (pkgPath) {
+      const content = fs.readFileSync(pkgPath, "utf-8")
+      const pkg = JSON.parse(content)
+
+      if (pkg.version) {
+        log(`[version/resolver] Found local dev version: ${pkg.version} at ${pkgPath}`)
+        return {
+          version: pkg.version,
+          source: "local-dev",
+          path: pkgPath,
+        }
+      }
+    }
+  } catch (err) {
+    log(`[version/resolver] Error reading local dev version:`, err)
+  }
+
+  return { version: "unknown", source: "unknown" }
+}
+
+/**
+ * Main version resolver - tries multiple sources in priority order
+ */
+export function resolveVersion(options: {
+  cacheDir?: string
+  localDevPath?: string
+  preferRuntime?: boolean
+} = {}): VersionResolveResult {
+  const { cacheDir, localDevPath, preferRuntime = true } = options
+
+  // Local dev takes highest priority
+  if (localDevPath) {
+    const localDev = getLocalDevVersion(localDevPath)
+    if (localDev.source === "local-dev") return localDev
+  }
+
+  // Runtime resolution (from this package's location)
+  if (preferRuntime) {
+    const runtime = resolveRuntimeVersion()
+    if (runtime.source === "runtime") return runtime
+  }
+
+  // Cached version from OpenCode's plugin cache
+  if (cacheDir) {
+    const cached = getCachedVersion(cacheDir)
+    if (cached.source === "cached") return cached
+  }
+
+  // Fallback to runtime if cache failed
+  if (!preferRuntime) {
+    return resolveRuntimeVersion()
+  }
+
+  return { version: "unknown", source: "unknown" }
+}
+
+// Cache the runtime version to avoid repeated filesystem access
+let cachedRuntimeVersion: VersionResolveResult | null = null
+
+/**
+ * Get runtime version with caching (for performance)
+ */
+export function getRuntimeVersionCached(): VersionResolveResult {
+  if (!cachedRuntimeVersion) {
+    cachedRuntimeVersion = resolveRuntimeVersion()
+  }
+  return cachedRuntimeVersion
+}
+
+/**
+ * Clear the runtime version cache (useful after updates)
+ */
+export function clearRuntimeVersionCache(): void {
+  cachedRuntimeVersion = null
+}

--- a/src/shared/version/semver.ts
+++ b/src/shared/version/semver.ts
@@ -1,0 +1,188 @@
+/**
+ * Zero-dependency semver parsing and comparison
+ */
+
+import type { ParsedVersion, VersionDiff } from "./types"
+
+const SEMVER_REGEX = /^v?(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z0-9.-]+))?(?:\+([a-zA-Z0-9.-]+))?$/
+
+/**
+ * Parse a semver version string into its components
+ */
+export function parse(version: string): ParsedVersion | null {
+  const match = version.trim().match(SEMVER_REGEX)
+  if (!match) return null
+
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+    prerelease: match[4] ? match[4].split(".") : [],
+    build: match[5] ? match[5].split(".") : [],
+    raw: version,
+  }
+}
+
+/**
+ * Compare two semver versions
+ * Returns: -1 if a < b, 0 if a === b, 1 if a > b
+ */
+export function compare(a: string, b: string): -1 | 0 | 1 {
+  const pa = parse(a)
+  const pb = parse(b)
+
+  // Fallback to string comparison if parsing fails
+  if (!pa || !pb) return a < b ? -1 : a > b ? 1 : 0
+
+  // Compare major.minor.patch
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (pa[key] > pb[key]) return 1
+    if (pa[key] < pb[key]) return -1
+  }
+
+  // Prerelease versions have lower precedence than release versions
+  // 1.0.0-alpha < 1.0.0
+  if (pa.prerelease.length === 0 && pb.prerelease.length > 0) return 1
+  if (pa.prerelease.length > 0 && pb.prerelease.length === 0) return -1
+
+  // Both have prereleases, compare them
+  const maxLen = Math.max(pa.prerelease.length, pb.prerelease.length)
+  for (let i = 0; i < maxLen; i++) {
+    const ai = pa.prerelease[i]
+    const bi = pb.prerelease[i]
+
+    // Shorter prerelease has lower precedence
+    // 1.0.0-alpha < 1.0.0-alpha.1
+    if (ai === undefined) return -1
+    if (bi === undefined) return 1
+
+    // Numeric identifiers compared as integers
+    const aNum = parseInt(ai, 10)
+    const bNum = parseInt(bi, 10)
+
+    if (!isNaN(aNum) && !isNaN(bNum)) {
+      if (aNum > bNum) return 1
+      if (aNum < bNum) return -1
+    } else if (!isNaN(aNum)) {
+      // Numeric < alphanumeric
+      return -1
+    } else if (!isNaN(bNum)) {
+      return 1
+    } else {
+      // Both alphanumeric, compare as strings
+      if (ai > bi) return 1
+      if (ai < bi) return -1
+    }
+  }
+
+  return 0
+}
+
+/**
+ * Check if version a is greater than version b
+ */
+export function gt(a: string, b: string): boolean {
+  return compare(a, b) === 1
+}
+
+/**
+ * Check if version a is less than version b
+ */
+export function lt(a: string, b: string): boolean {
+  return compare(a, b) === -1
+}
+
+/**
+ * Check if version a equals version b
+ */
+export function eq(a: string, b: string): boolean {
+  return compare(a, b) === 0
+}
+
+/**
+ * Check if version a is greater than or equal to version b
+ */
+export function gte(a: string, b: string): boolean {
+  return compare(a, b) >= 0
+}
+
+/**
+ * Check if version a is less than or equal to version b
+ */
+export function lte(a: string, b: string): boolean {
+  return compare(a, b) <= 0
+}
+
+/**
+ * Check if a version string contains prerelease identifiers
+ */
+export function isPrerelease(version: string): boolean {
+  const parsed = parse(version)
+  return parsed ? parsed.prerelease.length > 0 : false
+}
+
+/**
+ * Get the difference type between two versions
+ */
+export function diff(a: string, b: string): VersionDiff | null {
+  const pa = parse(a)
+  const pb = parse(b)
+  if (!pa || !pb) return null
+  if (eq(a, b)) return "none"
+
+  if (pa.major !== pb.major) return "major"
+  if (pa.minor !== pb.minor) return "minor"
+  if (pa.patch !== pb.patch) return "patch"
+  return "prerelease"
+}
+
+/**
+ * Coerce a loose version string into a valid semver
+ * e.g., "3" -> "3.0.0", "3.1" -> "3.1.0"
+ */
+export function coerce(version: string): string | null {
+  // Already valid?
+  if (parse(version)) return version
+
+  // Try to extract numbers
+  const match = version.match(/v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/)
+  if (!match) return null
+
+  const major = match[1] ?? "0"
+  const minor = match[2] ?? "0"
+  const patch = match[3] ?? "0"
+
+  return `${major}.${minor}.${patch}`
+}
+
+/**
+ * Get the maximum version from an array
+ */
+export function maxVersion(versions: string[]): string | null {
+  if (versions.length === 0) return null
+
+  return versions.reduce((max, v) => (gt(v, max) ? v : max), versions[0])
+}
+
+/**
+ * Get the minimum version from an array
+ */
+export function minVersion(versions: string[]): string | null {
+  if (versions.length === 0) return null
+
+  return versions.reduce((min, v) => (lt(v, min) ? v : min), versions[0])
+}
+
+/**
+ * Sort versions in ascending order
+ */
+export function sort(versions: string[]): string[] {
+  return [...versions].sort(compare)
+}
+
+/**
+ * Sort versions in descending order
+ */
+export function rsort(versions: string[]): string[] {
+  return [...versions].sort((a, b) => compare(b, a))
+}

--- a/src/shared/version/types.ts
+++ b/src/shared/version/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Version module types
+ */
+
+export type ReleaseChannel = "stable" | "beta" | "alpha" | "rc" | "canary" | "dev"
+
+export interface ParsedVersion {
+  major: number
+  minor: number
+  patch: number
+  prerelease: string[] // ["beta", "2"] for 3.0.0-beta.2
+  build: string[] // ["abc123"] for 3.0.0+abc123
+  raw: string
+}
+
+export interface DistTags {
+  latest: string
+  beta?: string
+  alpha?: string
+  rc?: string
+  canary?: string
+  next?: string
+  [key: string]: string | undefined
+}
+
+export interface VersionCheckResult {
+  currentVersion: string
+  currentChannel: ReleaseChannel
+  latestForChannel: string | null
+  latestStable: string
+  needsUpdate: boolean
+  updateType: "major" | "minor" | "patch" | "prerelease" | "none"
+  availableChannels: DistTags
+}
+
+export interface VersionResolveResult {
+  version: string
+  source: "runtime" | "cached" | "config-pinned" | "local-dev" | "unknown"
+  path?: string
+}
+
+export type VersionDiff = "major" | "minor" | "patch" | "prerelease" | "none"


### PR DESCRIPTION
## Summary
- Fixes the issue where `--version` shows stale/incorrect version after updates
- Adds channel-aware version checking (beta users get beta OR stable, whichever is newer)
- Properly compares versions using semver instead of string equality

## Problem
The CLI was bundling `package.json` at build time, causing the version to be frozen to whatever was in the source when built - not the actual installed version. This led to:
- `oh-my-opencode --version` showing `2.14.0` even when `3.0.0-beta.2` was installed
- Beta users not being notified of newer stable releases
- String comparison (`!==`) instead of semver causing incorrect update suggestions

## Solution
Created a new `src/shared/version/` module with:

| File | Purpose |
|------|---------|
| `semver.ts` | Zero-dependency semver parsing & comparison |
| `channels.ts` | Release channel detection (stable/beta/alpha/rc) |
| `registry.ts` | NPM registry integration (fetches all dist-tags) |
| `resolver.ts` | Runtime version resolution |
| `index.ts` | Main `checkVersion()` API |

### Key Changes
1. **Runtime version resolution** - Version is now read from `package.json` at runtime by walking up from the executing file, not bundled at build time

2. **Channel-aware updates**:
   - Stable users: only see stable updates
   - Beta users: see whichever is newer (beta OR stable)
   - e.g., if on `3.0.0-beta.2` and `3.0.0` stable releases, user is offered stable

3. **Proper semver comparison** - Uses actual semver logic instead of string equality

## Testing
```bash
$ oh-my-opencode --version
3.0.0-beta.2  # Now shows correct version

$ oh-my-opencode get-local-version
oh-my-opencode Version Information
──────────────────────────────────────────────────

  Current Version: 3.0.0-beta.2 (Beta)
  Latest (beta):  3.0.0-beta.2
  Other Channels:  beta@3.0.0-beta.2

  ✓ You're up to date!
```

## Files Changed
- `src/shared/version/` - New version management module (6 files)
- `src/cli/index.ts` - Use runtime version
- `src/cli/get-local-version/` - Use new version utilities, show channel info
- `src/hooks/auto-update-checker/index.ts` - Channel-aware update checking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale --version by resolving the version at runtime and adds channel-aware updates using proper semver. CLI and auto-update now respect and display release channels so users get the right updates.

- **New Features**
  - New shared version module: zero-dep semver, channel detection, NPM dist-tags, and runtime version resolver.
  - Channel-aware updates: stable sees stable; prerelease users get the newer of their channel or stable.
  - get-local-version shows channel, latest for channel, other available channels, and channel-specific update hints.
  - Auto-update checker uses the new logic and includes channel info in notifications.

- **Bug Fixes**
  - --version now reflects the installed version (no more build-time freeze).
  - Update checks use semver instead of string comparison, preventing incorrect prompts.
  - Pinned exact versions are not auto-updated; pinned dist-tags are updated safely.

<sup>Written for commit fc554c540035d3fc0af79eb9acc19205f7edf676. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

