### PR TITLE
fix(skill-mcp): handle pre-parsed object arguments in parseArguments

### DIFF
--- a/src/tools/skill-mcp/tools.ts
+++ b/src/tools/skill-mcp/tools.ts
@@ -69,8 +69,11 @@ function formatAvailableMcps(skills: LoadedSkill[]): string {
   return mcps.length > 0 ? mcps.join("\n") : "  (none found)"
 }
 
-function parseArguments(argsJson: string | undefined): Record<string, unknown> {
+function parseArguments(argsJson: string | Record<string, unknown> | undefined): Record<string, unknown> {
   if (!argsJson) return {}
+  if (typeof argsJson === "object" && argsJson !== null) {
+    return argsJson
+  }
   try {
     const parsed = JSON.parse(argsJson)
     if (typeof parsed !== "object" || parsed === null) {

--- a/src/tools/skill-mcp/types.ts
+++ b/src/tools/skill-mcp/types.ts
@@ -3,6 +3,6 @@ export interface SkillMcpArgs {
   tool_name?: string
   resource_name?: string
   prompt_name?: string
-  arguments?: string
+  arguments?: string | Record<string, unknown>
   grep?: string
 }


### PR DESCRIPTION
## Summary

Fixes an issue where `skill_mcp` fails with `Invalid arguments JSON` error when OpenCode's tool invocation system passes arguments as pre-parsed objects instead of JSON strings.

## Problem

OpenCode's plugin tool system can pass arguments as already-parsed JavaScript objects rather than raw JSON strings. When this happens, the `parseArguments` function receives an object instead of a string, causing:

```
Invalid arguments JSON: JSON Parse error: Unexpected identifier "object"

Expected a valid JSON object, e.g.: '{"key": "value"}'
Received: [object Object]
```

This breaks `skill_mcp` usage with Playwright and other MCP tools.

## Solution

Added a type check in `parseArguments` to handle both cases:
- **String arguments**: Original behavior, parsed via `JSON.parse()`
- **Object arguments**: Already parsed by OpenCode, returned directly

## Changes

- `src/tools/skill-mcp/tools.ts`: Added object type check in `parseArguments`
- `src/tools/skill-mcp/types.ts`: Updated `SkillMcpArgs.arguments` type to accept both string and object

## Testing

Tested with Playwright MCP browser automation - `browser_navigate`, `browser_evaluate`, and other tools now work correctly when arguments are passed as objects by OpenCode.