### PR TITLE
Fix flowchart syntax in orchestration guide

### DIFF
--- a/docs/orchestration-guide.md
+++ b/docs/orchestration-guide.md
@@ -37,7 +37,7 @@ Oh-My-OpenCode solves this by clearly separating two roles:
 ## 2. Overall Architecture
 
 ```mermaid
-graph TD
+flowchart TD
     User[User Request] --> Prometheus
     
     subgraph Planning Phase
@@ -48,7 +48,7 @@ graph TD
         Prometheus --> PlanFile["/.sisyphus/plans/{name}.md"]
     end
     
-    PlanFile --> StartWork[/start-work]
+    PlanFile --> StartWork[//start-work/]
     StartWork --> BoulderState[boulder.json]
     
     subgraph Execution Phase


### PR DESCRIPTION
Updated the flowchart syntax in the orchestration guide.

## Summary

Updated the flowchart syntax in the orchestration guide.

- 

## Changes

Fix the syntax error

- 

## Screenshots

<img width="1149" height="957" alt="image" src="https://github.com/user-attachments/assets/2f7cb43a-1af9-47d8-a3da-3f8c9132db02" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Mermaid flowchart syntax in the orchestration guide so the diagram renders correctly. Switched graph TD to flowchart TD and corrected the StartWork node label.

<sup>Written for commit 2b9c8f25e8a341ab766ac8c2d1a8da2764e93a7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

