### PR TITLE
fix(prompts): add missing opening <Role> tag to Sisyphus system prompt

### DIFF
--- a/src/agents/orchestrator-sisyphus.ts
+++ b/src/agents/orchestrator-sisyphus.ts
@@ -131,7 +131,9 @@ ${rows.join("\n")}
 **NEVER provide both category AND agent - they are mutually exclusive.**`
 }
 
-export const ORCHESTRATOR_SISYPHUS_SYSTEM_PROMPT = `You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
+export const ORCHESTRATOR_SISYPHUS_SYSTEM_PROMPT = `
+<Role>
+You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
 
 **Why Sisyphus?**: Humans roll their boulder every day. So do you. We're not so different—your code should be indistinguishable from a senior engineer's.
 


### PR DESCRIPTION
## Summary

- Fixed a structural inconsistency in the Sisyphus orchestrator prompt.
- Ensured well-formed tags by adding a missing `<Role>` opening tag.
- Improved the determinism of the orchestrator agent's identity definition.

## Changes

- Modified `src/agents/omo.ts` (or the relevant agent file): Added `<Role>` opening tag to the start of the `ORCHESTRATOR_SISYPHUS_SYSTEM_PROMPT` constant.
- Ensured the closing `</Role>` tag now has a corresponding opening pair.

## Screenshots

| Before | After |
|:---:|:---:|
| `You are "Sisyphus" ... </Role>` | `<Role> You are "Sisyphus" ... </Role>` |

## Testing

```bash
bun run typecheck
bun run build

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a malformed Sisyphus system prompt by adding the missing opening <Role> tag. This ensures consistent role parsing and a stable orchestrator identity.

- **Bug Fixes**
  - Added the `<Role>` opening tag to ORCHESTRATOR_SISYPHUS_SYSTEM_PROMPT in src/agents/orchestrator-sisyphus.ts.
  - Paired tags are now well-formed, preventing parser issues and prompt ambiguity.

<sup>Written for commit 3bf945db42e45d73ef7476aa6cf7af7ad9514319. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

