### PR TITLE
fix: LSP tools Windows compatibility - use pathToFileURL for proper URI generation

### DIFF
--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -1,6 +1,7 @@
 import { spawn, type Subprocess } from "bun"
 import { readFileSync } from "fs"
 import { extname, resolve } from "path"
+import { pathToFileURL } from "node:url"
 import { getLanguageId } from "./config"
 import type { Diagnostic, ResolvedServer } from "./types"
 
@@ -427,7 +428,7 @@ export class LSPClient {
   }
 
   async initialize(): Promise<void> {
-    const rootUri = `file://${this.root}`
+    const rootUri = pathToFileURL(this.root).href
     await this.send("initialize", {
       processId: process.pid,
       rootUri,
@@ -497,7 +498,7 @@ export class LSPClient {
 
     this.notify("textDocument/didOpen", {
       textDocument: {
-        uri: `file://${absPath}`,
+        uri: pathToFileURL(absPath).href,
         languageId,
         version: 1,
         text,
@@ -512,7 +513,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/hover", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
     })
   }
@@ -521,7 +522,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/definition", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
     })
   }
@@ -530,7 +531,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/references", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
       context: { includeDeclaration },
     })
@@ -540,7 +541,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/documentSymbol", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
     })
   }
 
@@ -550,7 +551,7 @@ export class LSPClient {
 
   async diagnostics(filePath: string): Promise<{ items: Diagnostic[] }> {
     const absPath = resolve(filePath)
-    const uri = `file://${absPath}`
+    const uri = pathToFileURL(absPath).href
     await this.openFile(absPath)
     await new Promise((r) => setTimeout(r, 500))
 
@@ -571,7 +572,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/prepareRename", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
     })
   }
@@ -580,7 +581,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/rename", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
       newName,
     })
@@ -597,7 +598,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/codeAction", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       range: {
         start: { line: startLine - 1, character: startChar },
         end: { line: endLine - 1, character: endChar },

--- a/src/tools/lsp/utils.ts
+++ b/src/tools/lsp/utils.ts
@@ -30,12 +30,14 @@ export function findWorkspaceRoot(filePath: string): string {
 
   const markers = [".git", "package.json", "pyproject.toml", "Cargo.toml", "go.mod", "pom.xml", "build.gradle"]
 
-  while (dir !== "/") {
+  let prevDir = ""
+  while (dir !== prevDir) {
     for (const marker of markers) {
       if (existsSync(require("path").join(dir, marker))) {
         return dir
       }
     }
+    prevDir = dir
     dir = require("path").dirname(dir)
   }
 


### PR DESCRIPTION
## Summary

Fix LSP tools failing on Windows with "unresolvable URI" error.

Fixes #684

## Changes

### 1. `src/tools/lsp/client.ts`

Use `pathToFileURL()` from `node:url` instead of string template for file URIs:

```typescript
// Before (broken on Windows)
const rootUri = `file://${this.root}`
textDocument: { uri: `file://${absPath}` }

// After (works on all platforms)
import { pathToFileURL } from "node:url"
const rootUri = pathToFileURL(this.root).href
textDocument: { uri: pathToFileURL(absPath).href }
```

**Why**: On Windows, `file://${path}` generates invalid URIs like `file://E:\path` instead of `file:///E:/path`.

### 2. `src/tools/lsp/utils.ts`

Fix `findWorkspaceRoot()` loop condition:

```typescript
// Before (Unix only)
while (dir !== "/")

// After (cross-platform)
let prevDir = ""
while (dir !== prevDir)
```

**Why**: On Windows, the root is `C:\` not `/`, so the original condition never terminates properly.

## Testing

Tested on Windows 11 with clangd 21.1.8:
- ✅ `lsp_hover` - works
- ✅ `lsp_document_symbols` - works
- ✅ `lsp_goto_definition` - works
- ✅ `lsp_find_references` - works
- ✅ `lsp_prepare_rename` - works
- ✅ `lsp_workspace_symbols` - works
- ✅ `lsp_diagnostics` - works
- ✅ `lsp_code_actions` - works