### PR TITLE
fix(lsp): Windows-compatible file URI generation and workspace root detection

### DIFF
--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -1,6 +1,7 @@
 import { spawn, type Subprocess } from "bun"
 import { readFileSync } from "fs"
 import { extname, resolve } from "path"
+import { pathToFileURL } from "node:url"
 import { getLanguageId } from "./config"
 import type { Diagnostic, ResolvedServer } from "./types"
 
@@ -427,7 +428,7 @@ export class LSPClient {
   }
 
   async initialize(): Promise<void> {
-    const rootUri = `file://${this.root}`
+    const rootUri = pathToFileURL(this.root).href
     await this.send("initialize", {
       processId: process.pid,
       rootUri,
@@ -497,7 +498,7 @@ export class LSPClient {
 
     this.notify("textDocument/didOpen", {
       textDocument: {
-        uri: `file://${absPath}`,
+        uri: pathToFileURL(absPath).href,
         languageId,
         version: 1,
         text,
@@ -512,7 +513,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/hover", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
     })
   }
@@ -521,7 +522,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/definition", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
     })
   }
@@ -530,7 +531,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/references", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
       context: { includeDeclaration },
     })
@@ -540,7 +541,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/documentSymbol", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
     })
   }
 
@@ -550,7 +551,7 @@ export class LSPClient {
 
   async diagnostics(filePath: string): Promise<{ items: Diagnostic[] }> {
     const absPath = resolve(filePath)
-    const uri = `file://${absPath}`
+    const uri = pathToFileURL(absPath).href
     await this.openFile(absPath)
     await new Promise((r) => setTimeout(r, 500))
 
@@ -571,7 +572,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/prepareRename", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
     })
   }
@@ -580,7 +581,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/rename", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
       newName,
     })
@@ -597,7 +598,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/codeAction", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       range: {
         start: { line: startLine - 1, character: startChar },
         end: { line: endLine - 1, character: endChar },

--- a/src/tools/lsp/utils.test.ts
+++ b/src/tools/lsp/utils.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test"
+import { pathToFileURL } from "node:url"
+
+describe("pathToFileURL cross-platform compatibility", () => {
+  test("converts absolute path to file URI with proper format", () => {
+    //#given
+    const absPath = process.platform === "win32" 
+      ? "C:\\Users\\user\\project\\file.ts"
+      : "/home/user/project/file.ts"
+
+    //#when
+    const uri = pathToFileURL(absPath).href
+
+    //#then
+    expect(uri).toMatch(/^file:\/\/\//)
+    expect(uri).toContain("file.ts")
+    if (process.platform === "win32") {
+      expect(uri).toMatch(/^file:\/\/\/[A-Z]:\//)
+      expect(uri).not.toContain("\\")
+    }
+  })
+
+  test("handles paths with spaces", () => {
+    //#given
+    const pathWithSpaces = process.platform === "win32"
+      ? "C:\\Users\\my project\\file.ts"
+      : "/home/user/my project/file.ts"
+
+    //#when
+    const uri = pathToFileURL(pathWithSpaces).href
+
+    //#then
+    expect(uri).toContain("my%20project")
+  })
+
+  test("handles paths with special characters", () => {
+    //#given
+    const pathWithSpecial = process.platform === "win32"
+      ? "C:\\Users\\file (1).ts"
+      : "/home/user/project/file (1).ts"
+
+    //#when
+    const uri = pathToFileURL(pathWithSpecial).href
+
+    //#then
+    expect(uri).toContain("file%20(1).ts")
+  })
+
+  test("pathToFileURL produces valid URIs without backslashes", () => {
+    //#given
+    const testPath = process.platform === "win32"
+      ? "C:\\test\\path.ts"
+      : "/test/path.ts"
+
+    //#when
+    const uri = pathToFileURL(testPath).href
+
+    //#then
+    expect(uri).not.toContain("\\")
+    expect(uri).toMatch(/^file:\/\/\//)
+  })
+})
+
+describe("findWorkspaceRoot cross-platform", () => {
+  test("loop condition works on Unix (reaches root)", () => {
+    //#given
+    let dir = "/home/user/deep/nested/path"
+    let prevDir = ""
+    let iterations = 0
+    const maxIterations = 100
+
+    //#when
+    while (dir !== prevDir && iterations < maxIterations) {
+      prevDir = dir
+      dir = require("path").dirname(dir)
+      iterations++
+    }
+
+    //#then
+    expect(dir).toBe("/")
+    expect(prevDir).toBe("/")
+    expect(iterations).toBeLessThan(maxIterations)
+  })
+
+  test("loop condition works on Windows (reaches root)", () => {
+    //#given
+    let dir = "C:\\Users\\user\\deep\\nested\\path"
+    let prevDir = ""
+    let iterations = 0
+    const maxIterations = 100
+
+    //#when
+    while (dir !== prevDir && iterations < maxIterations) {
+      prevDir = dir
+      dir = require("path").win32.dirname(dir)
+      iterations++
+    }
+
+    //#then
+    expect(dir).toBe("C:\\")
+    expect(prevDir).toBe("C:\\")
+    expect(iterations).toBeLessThan(maxIterations)
+  })
+
+  test("old Unix-only condition would fail on Windows", () => {
+    //#given
+    let dir = "C:\\Users\\user\\path"
+    let iterations = 0
+    const maxIterations = 10
+
+    //#when
+    // Old condition: while (dir !== "/")
+    while (dir !== "/" && iterations < maxIterations) {
+      dir = require("path").win32.dirname(dir)
+      iterations++
+    }
+
+    //#then
+    // Would hit max iterations because Windows root is never "/"
+    expect(iterations).toBe(maxIterations)
+    expect(dir).not.toBe("/")
+  })
+
+  test("new cross-platform condition handles both Unix and Windows", () => {
+    //#given
+    const testPaths = [
+      "/home/user/project",
+      "C:\\Users\\user\\project",
+      "/",
+      "C:\\",
+    ]
+
+    //#when
+    //#then
+    for (const startPath of testPaths) {
+      let dir = startPath
+      let prevDir = ""
+      let iterations = 0
+      const maxIterations = 100
+      const isWindows = startPath.includes("\\")
+
+      while (dir !== prevDir && iterations < maxIterations) {
+        prevDir = dir
+        dir = isWindows ? require("path").win32.dirname(dir) : require("path").posix.dirname(dir)
+        iterations++
+      }
+
+      expect(iterations).toBeLessThan(maxIterations)
+      expect(dir).toBe(prevDir)
+    }
+  })
+})

--- a/src/tools/lsp/utils.ts
+++ b/src/tools/lsp/utils.ts
@@ -30,12 +30,14 @@ export function findWorkspaceRoot(filePath: string): string {
 
   const markers = [".git", "package.json", "pyproject.toml", "Cargo.toml", "go.mod", "pom.xml", "build.gradle"]
 
-  while (dir !== "/") {
+  let prevDir = ""
+  while (dir !== prevDir) {
     for (const marker of markers) {
       if (existsSync(require("path").join(dir, marker))) {
         return dir
       }
     }
+    prevDir = dir
     dir = require("path").dirname(dir)
   }
 


### PR DESCRIPTION
## Summary

Fixes LSP tools failing on Windows with "unresolvable URI" errors by:
- Using `pathToFileURL()` for proper file URI generation
- Fixing `findWorkspaceRoot()` loop to work on Windows

## Changes

### 1. File URI Generation (client.ts)
- **Before**: Used template literals `file://${path}` - generates invalid URIs on Windows
- **After**: Uses `pathToFileURL(path).href` - proper cross-platform URIs

Example:
- ❌ Windows before: `file://E:\jianwang4\file.cpp` (invalid)
- ✅ Windows after: `file:///E:/jianwang4/file.cpp` (valid)
- ✅ Unix: `file:///home/user/file.ts` (valid)

### 2. Workspace Root Detection (utils.ts)
- **Before**: Loop condition `while (dir !== "/")` - infinite loop on Windows
- **After**: Loop condition `while (dir !== prevDir)` - works on all platforms

### 3. Tests (utils.test.ts)
- Cross-platform pathToFileURL behavior verification
- Workspace root loop termination tests for Unix and Windows
- Special character and space handling

## Testing

```bash
bun test src/tools/lsp/utils.test.ts  # All tests pass
bun run typecheck                      # No type errors
bun run build                          # Build successful
```

## Affected Files

- `src/tools/lsp/client.ts` - 10 file URI occurrences fixed
- `src/tools/lsp/utils.ts` - Loop condition fixed
- `src/tools/lsp/utils.test.ts` - New test coverage

Closes #684

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LSP on Windows by generating correct file URIs and making workspace root detection cross-platform. Eliminates “unresolvable URI” errors and the infinite loop; closes #684.

- **Bug Fixes**
  - Use pathToFileURL(...).href for all file URIs in the LSP client.
  - Change findWorkspaceRoot to compare dir with prevDir so the loop ends on both Windows and Unix.

<sup>Written for commit e9198a4ca5e9c704fd4e494dd81c0b261079f216. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

