### PR TITLE
fix: prevent Prometheus agent fallback to Build agent

### DIFF
--- a/src/features/claude-code-session-state/state.test.ts
+++ b/src/features/claude-code-session-state/state.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import {
+  setSessionAgent,
+  getSessionAgent,
+  clearSessionAgent,
+  setMainSession,
+  getMainSessionID,
+} from "./state"
+
+describe("session agent tracking", () => {
+  beforeEach(() => {
+    // #given - clean state before each test
+    clearSessionAgent("test-session-1")
+    clearSessionAgent("test-session-2")
+  })
+
+  test("should set and get session agent", () => {
+    // #given - a session ID and agent name
+    const sessionID = "test-session-1"
+    const agentName = "Prometheus (Planner)"
+
+    // #when - setSessionAgent is called
+    setSessionAgent(sessionID, agentName)
+
+    // #then - getSessionAgent should return the agent name
+    expect(getSessionAgent(sessionID)).toBe(agentName)
+  })
+
+  test("should return undefined for unknown session", () => {
+    // #given - no agent has been set for this session
+    const sessionID = "unknown-session"
+
+    // #when - getSessionAgent is called
+    const result = getSessionAgent(sessionID)
+
+    // #then - it should return undefined
+    expect(result).toBeUndefined()
+  })
+
+  test("should clear session agent", () => {
+    // #given - a session with an agent set
+    const sessionID = "test-session-1"
+    setSessionAgent(sessionID, "Prometheus (Planner)")
+
+    // #when - clearSessionAgent is called
+    clearSessionAgent(sessionID)
+
+    // #then - getSessionAgent should return undefined
+    expect(getSessionAgent(sessionID)).toBeUndefined()
+  })
+
+  test("should track multiple sessions independently", () => {
+    // #given - two different sessions
+    const session1 = "test-session-1"
+    const session2 = "test-session-2"
+    const agent1 = "Prometheus (Planner)"
+    const agent2 = "Sisyphus"
+
+    // #when - different agents are set for each session
+    setSessionAgent(session1, agent1)
+    setSessionAgent(session2, agent2)
+
+    // #then - each session should return its own agent
+    expect(getSessionAgent(session1)).toBe(agent1)
+    expect(getSessionAgent(session2)).toBe(agent2)
+  })
+
+  test("should overwrite agent when set again", () => {
+    // #given - a session with an agent already set
+    const sessionID = "test-session-1"
+    setSessionAgent(sessionID, "Prometheus (Planner)")
+
+    // #when - a different agent is set for the same session
+    setSessionAgent(sessionID, "Sisyphus")
+
+    // #then - the new agent should be returned
+    expect(getSessionAgent(sessionID)).toBe("Sisyphus")
+  })
+})
+
+describe("main session tracking", () => {
+  beforeEach(() => {
+    // #given - clean state
+    setMainSession(undefined)
+  })
+
+  test("should set and get main session ID", () => {
+    // #given - a session ID
+    const sessionID = "main-test-session"
+
+    // #when - setMainSession is called
+    setMainSession(sessionID)
+
+    // #then - getMainSessionID should return the session ID
+    expect(getMainSessionID()).toBe(sessionID)
+  })
+
+  test("should return undefined when no main session is set", () => {
+    // #given - no main session has been set
+    setMainSession(undefined)
+
+    // #when - getMainSessionID is called
+    const result = getMainSessionID()
+
+    // #then - it should return undefined
+    expect(result).toBeUndefined()
+  })
+})

--- a/src/features/claude-code-session-state/state.ts
+++ b/src/features/claude-code-session-state/state.ts
@@ -9,3 +9,34 @@ export function setMainSession(id: string | undefined) {
 export function getMainSessionID(): string | undefined {
   return mainSessionID
 }
+
+/**
+ * Session-to-agent mapping.
+ * Tracks which agent is active for each session to prevent agent fallback issues.
+ * This is critical for maintaining agent context during hook message injection.
+ */
+const sessionAgentMap = new Map<string, string>()
+
+/**
+ * Set the active agent for a session.
+ * Called when a session starts or when agent context is detected.
+ */
+export function setSessionAgent(sessionID: string, agent: string): void {
+  sessionAgentMap.set(sessionID, agent)
+}
+
+/**
+ * Get the active agent for a session.
+ * Returns undefined if no agent is tracked for this session.
+ */
+export function getSessionAgent(sessionID: string): string | undefined {
+  return sessionAgentMap.get(sessionID)
+}
+
+/**
+ * Clear the agent tracking for a session.
+ * Called when a session ends.
+ */
+export function clearSessionAgent(sessionID: string): void {
+  sessionAgentMap.delete(sessionID)
+}

--- a/src/features/hook-message-injector/injector.ts
+++ b/src/features/hook-message-injector/injector.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { join } from "node:path"
 import { MESSAGE_STORAGE, PART_STORAGE } from "./constants"
 import type { MessageMeta, OriginalMessageContext, TextPart, ToolPermission } from "./types"
+import { getSessionAgent } from "../claude-code-session-state"
 
 export interface StoredMessage {
   agent?: string
@@ -109,7 +110,7 @@ export function injectHookMessage(
   const messageID = generateMessageId()
   const partID = generatePartId()
 
-  const resolvedAgent = originalMessage.agent ?? fallback?.agent ?? "general"
+  const resolvedAgent = originalMessage.agent ?? fallback?.agent ?? getSessionAgent(sessionID) ?? "general"
   const resolvedModel =
     originalMessage.model?.providerID && originalMessage.model?.modelID
       ? { providerID: originalMessage.model.providerID, modelID: originalMessage.model.modelID }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,8 @@ import { getSystemMcpServerNames } from "./features/claude-code-mcp-loader";
 import {
   setMainSession,
   getMainSessionID,
+  setSessionAgent,
+  clearSessionAgent,
 } from "./features/claude-code-session-state";
 import {
   builtinTools,
@@ -428,6 +430,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
           setMainSession(undefined);
         }
         if (sessionInfo?.id) {
+          clearSessionAgent(sessionInfo.id);
           await skillMcpManager.disconnectSession(sessionInfo.id);
           await lspManager.cleanupTempDirectoryClients();
         }
@@ -456,6 +459,14 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
               })
               .catch(() => {});
           }
+        }
+      }
+
+      // Track agent for each session to preserve context during hook injection
+      if (event.type === "message.updated") {
+        const info = props?.info as { sessionID?: string; agent?: string } | undefined;
+        if (info?.sessionID && info?.agent) {
+          setSessionAgent(info.sessionID, info.agent);
         }
       }
     },


### PR DESCRIPTION
## Summary

Fixes the issue where Prometheus Planner Agent falls back to Build agent after some messages.

## Problem

When hooks inject messages, the agent resolution in `hook-message-injector/injector.ts` had this fallback chain:
```typescript
const resolvedAgent = originalMessage.agent ?? fallback?.agent ?? "general"
```

If both `originalMessage.agent` and `findNearestMessageWithFields()` failed to provide an agent name, it defaulted to `"general"` which maps to the Build agent, causing Prometheus context to be lost.

## Solution

Added session-level agent tracking to preserve agent context:

1. **`state.ts`** - Added `sessionAgentMap` with `setSessionAgent()`, `getSessionAgent()`, `clearSessionAgent()` functions
2. **`injector.ts`** - Updated fallback chain to use session agent before defaulting to "general":
   ```typescript
   const resolvedAgent = originalMessage.agent ?? fallback?.agent ?? getSessionAgent(sessionID) ?? "general"
   ```
3. **`index.ts`** - Track agent on `message.updated` events, clear on `session.deleted`

## Testing

- Added 7 tests for session agent tracking functions
- All 1006 tests pass
- TypeScript type check passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Prometheus Planner agent from falling back to the Build agent during hook message injection. Tracks the active agent per session to preserve context across messages.

- **Bug Fixes**
  - Added session-level agent tracking (set/get/clear) in session state.
  - Used session agent as fallback in hook-message injector before "general".
  - Tracked agents on message.updated; cleared on session.deleted.
  - Added tests for session agent tracking.

<sup>Written for commit d9fa61fd513748ac28430ee3a561846686bb55c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

