### PR TITLE
fix(prometheus): prevent agent fallback to build in background tasks

### DIFF
--- a/src/features/claude-code-session-state/state.ts
+++ b/src/features/claude-code-session-state/state.ts
@@ -9,3 +9,23 @@ export function setMainSession(id: string | undefined) {
 export function getMainSessionID(): string | undefined {
   return mainSessionID
 }
+
+const sessionAgentMap = new Map<string, string>()
+
+export function setSessionAgent(sessionID: string, agent: string): void {
+  if (!sessionAgentMap.has(sessionID)) {
+    sessionAgentMap.set(sessionID, agent)
+  }
+}
+
+export function updateSessionAgent(sessionID: string, agent: string): void {
+  sessionAgentMap.set(sessionID, agent)
+}
+
+export function getSessionAgent(sessionID: string): string | undefined {
+  return sessionAgentMap.get(sessionID)
+}
+
+export function clearSessionAgent(sessionID: string): void {
+  sessionAgentMap.delete(sessionID)
+}

--- a/src/features/hook-message-injector/index.ts
+++ b/src/features/hook-message-injector/index.ts
@@ -1,4 +1,4 @@
-export { injectHookMessage, findNearestMessageWithFields } from "./injector"
+export { injectHookMessage, findNearestMessageWithFields, findFirstMessageWithAgent } from "./injector"
 export type { StoredMessage } from "./injector"
 export type { MessageMeta, OriginalMessageContext, TextPart } from "./types"
 export { MESSAGE_STORAGE } from "./constants"

--- a/src/features/hook-message-injector/injector.ts
+++ b/src/features/hook-message-injector/injector.ts
@@ -48,6 +48,35 @@ export function findNearestMessageWithFields(messageDir: string): StoredMessage 
   return null
 }
 
+/**
+ * Finds the FIRST (oldest) message in the session with agent field.
+ * This is used to get the original agent that started the session,
+ * avoiding issues where newer messages may have a different agent
+ * due to OpenCode's internal agent switching.
+ */
+export function findFirstMessageWithAgent(messageDir: string): string | null {
+  try {
+    const files = readdirSync(messageDir)
+      .filter((f) => f.endsWith(".json"))
+      .sort() // Oldest first (no reverse)
+
+    for (const file of files) {
+      try {
+        const content = readFileSync(join(messageDir, file), "utf-8")
+        const msg = JSON.parse(content) as StoredMessage
+        if (msg.agent) {
+          return msg.agent
+        }
+      } catch {
+        continue
+      }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
 function generateMessageId(): string {
   const timestamp = Date.now().toString(16)
   const random = Math.random().toString(36).substring(2, 14)

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,8 @@ import { getSystemMcpServerNames } from "./features/claude-code-mcp-loader";
 import {
   setMainSession,
   getMainSessionID,
+  setSessionAgent,
+  clearSessionAgent,
 } from "./features/claude-code-session-state";
 import {
   builtinTools,
@@ -428,8 +430,19 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
           setMainSession(undefined);
         }
         if (sessionInfo?.id) {
+          clearSessionAgent(sessionInfo.id);
           await skillMcpManager.disconnectSession(sessionInfo.id);
           await lspManager.cleanupTempDirectoryClients();
+        }
+      }
+
+      if (event.type === "message.updated") {
+        const info = props?.info as Record<string, unknown> | undefined;
+        const sessionID = info?.sessionID as string | undefined;
+        const agent = info?.agent as string | undefined;
+        const role = info?.role as string | undefined;
+        if (sessionID && agent && role === "user") {
+          setSessionAgent(sessionID, agent);
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes the issue where Prometheus Planner Agent falls back to Build agent mid-session when background task notifications are injected.

## Root Cause

When Prometheus spawns background tasks via `sisyphus_task` or `call_omo_agent`, the `parentAgent` field was being read from message files that OpenCode had already written with `agent: "build"`. This caused background task completion notifications to be sent with `agent: "build"`, switching the session agent.

## Changes

### 1. Created `findFirstMessageWithAgent()` 
- Reads the **oldest** message file to get the original session agent
- Avoids pollution from newer messages where OpenCode has switched the agent

### 2. Fixed parentAgent resolution in 3 tools
- **`sisyphus_task/tools.ts`**: Updated to use `findFirstMessageWithAgent`
- **`call_omo_agent/tools.ts`**: Added full parentAgent resolution (was missing entirely)
- **`background_task/tools.ts`**: Updated to use `findFirstMessageWithAgent`

### 3. Fixed `message.updated` event handler
- Only tracks agent from **user messages** (role === "user")
- Prevents pollution from assistant/system messages generated by OpenCode

### 4. Updated `prometheus-md-only` hook
- Uses `findFirstMessageWithAgent` for consistency

## Priority Chain

\`\`\`typescript
const parentAgent = ctx.agent ?? sessionAgent ?? firstMessageAgent ?? prevMessage?.agent
\`\`\`

1. \`ctx.agent\` - from OpenCode context (usually undefined)
2. \`sessionAgent\` - tracked from user messages (handles explicit agent changes)
3. \`firstMessageAgent\` - from oldest message file (primary fix)
4. \`prevMessage?.agent\` - from newest message file (fallback)

## Testing

- [x] Builds successfully
- [x] Typecheck passes
- [x] Manual test: Prometheus spawning background tasks remains as Prometheus

## Related Issues

Fixes the Prometheus → Build fallback bug discussed in development sessions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Prometheus sessions from switching to Build when background task notifications are injected. Background tasks now inherit the original session agent consistently.

- **Bug Fixes**
  - Read the original agent from the oldest message using findFirstMessageWithAgent.
  - Track session agent only from user messages; clear on session end.
  - Standardize parentAgent priority: ctx.agent > sessionAgent > firstMessageAgent > prevMessage.agent across sisyphus_task, call_omo_agent, and background_task.
  - Update prometheus-md-only hook to use the same agent resolution.
  - Add debug logs for parentAgent resolution.

<sup>Written for commit 1f915aa05fade46ddb9f36a115c2b29a4de0d2e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



