### PR TITLE
docs: add localized Chinese translation for oh-my-opencode README

### DIFF
--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -419,7 +419,7 @@ opencode auth login
 
 **除非用户明确要求，否则不要更改模型设置或禁用功能（智能体、钩子、MCP）。**
 
-该插件默认情况下运行良好。除了推荐的 `google_auth: true` 设置外，不要在没有明确请求的情况下更改其他设置或关闭功能。
+该插件默认情况下运行良好。未使用外部 Antigravity 插件时保持 `google_auth: true`；如果按上方说明接入 `opencode-antigravity-auth`，请将 `google_auth` 设为 `false` 并覆盖智能体模型。除此之外，不要在没有明确请求的情况下更改其他设置或关闭功能。
 
 ### 验证安装
 
@@ -568,7 +568,7 @@ gh repo star code-yeongyu/oh-my-opencode
 
 这些工具使智能体能够引用之前的对话并在会话之间保持连续性。
 
-#### 上下文就是你徐雅蝶一切
+#### 上下文就是一切
 - **目录 AGENTS.md / README.md 注入器**：读取文件时自动注入 `AGENTS.md` 和 `README.md`。从文件目录向上遍历到项目根目录，收集路径上的**所有** `AGENTS.md` 文件。支持嵌套的目录特定说明：
   ```
   project/


### PR DESCRIPTION
## Summary

- Update zh-CN translation to sync with latest oh-my-opencode README
- Improve terminology localization for better native Chinese reading experience
- Standardize technical terms while preserving original document structure

## Changes

- Synced all sections with latest upstream documentation
- Localized non-standard terminology (e.g., agent → 智能体, hook → 钩子, skill → 技能)
- Preserved code blocks, tables, links, and markdown formatting
- Maintained professional technical writing style throughout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the Simplified Chinese README to match the latest upstream and improve native readability. Standardizes key terms and expands content to cover new features and configuration while preserving structure and technical accuracy.

- **Refactors**
  - Synced zh-CN README with current upstream (headings, TOC, structure).
  - Standardized terminology: Agent→智能体, Hook→钩子, Skill→技能; unified phrasing.
  - Expanded coverage: Sisyphus 编排器、类别委派（sisyphus_task）、内置技能（playwright、git-master）、技能内置 MCP。
  - Updated install/auth guides: bunx/npx 注意事项，Anthropic、Google Antigravity、OpenAI Codex 流程与模型覆盖；明确何时使用 google_auth: true 与 false（基于是否接入 Antigravity 插件）。
  - Added config docs: disabled_skills、git_master、categories、并发限制、完整钩子清单（含 auto-update/startup-toast、preemptive-compaction）、实验项、环境变量。

<sup>Written for commit 4e9f3843f27a453ecd65793ea9571ab5a1bc4123. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

