### PR TITLE
fix(sisyphus-orchestrator): preserve subagent response in output transformation

### DIFF
--- a/src/hooks/sisyphus-orchestrator/index.ts
+++ b/src/hooks/sisyphus-orchestrator/index.ts
@@ -640,10 +640,20 @@ export function createSisyphusOrchestratorHook(
             })
           }
 
+          // Preserve original subagent response - critical for debugging failed tasks
+          const originalResponse = output.output
+
           output.output = `
 ## SUBAGENT WORK COMPLETED
 
 ${fileChanges}
+
+---
+
+**Subagent Response:**
+
+${originalResponse}
+
 <system-reminder>
 ${buildOrchestratorReminder(boulderState.plan_name, progress, subagentSessionId)}
 </system-reminder>`


### PR DESCRIPTION
## Problem

When `sisyphus_task` completes in boulder/orchestrator mode, the `tool.execute.after` hook replaces the entire subagent response with git diff stats. This causes issues when:

1. Resuming a subagent that failed to complete its task
2. Debugging why a subagent couldn't fix something
3. Understanding what the subagent actually reported

The orchestrator sees identical output each time (just git stats), making it appear the subagent is "stuck in a loop" when in reality the response is being discarded.

## Solution

Preserve the original subagent response by storing it before transformation and including it in the output:

```typescript
const originalResponse = output.output

output.output = `
## SUBAGENT WORK COMPLETED

${fileChanges}

---

**Subagent Response:**

${originalResponse}

<system-reminder>...</system-reminder>`
```

## Testing

- Manual verification: Resumed subagent tasks now show their actual response
- No breaking changes to existing behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the original subagent response in Sisyphus orchestrator output instead of replacing it with git diff stats. This fixes confusing “loop” outputs and improves debugging and resume flows.

- **Bug Fixes**
  - Store the subagent's original output and include it below file change stats.
  - Prevent loss of subagent details when tasks complete, aiding failed task resume and troubleshooting.

<sup>Written for commit aa44c54068cd7dc1939896033ef8dfbb6bdc5732. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

