### PR TITLE
fix(sisyphus_task): resolve sisyphus_task not working in sync mode

### DIFF
--- a/src/tools/sisyphus-task/tools.test.ts
+++ b/src/tools/sisyphus-task/tools.test.ts
@@ -376,7 +376,221 @@ describe("sisyphus-task", () => {
   })
 })
 
-describe("buildSystemContent", () => {
+  describe("sync mode new task (run_in_background=false)", () => {
+    test("sync mode prompt error returns error message immediately", async () => {
+      // #given
+      const { createSisyphusTask } = require("./tools")
+      
+      const mockManager = {
+        launch: async () => ({}),
+      }
+      
+      const mockClient = {
+        session: {
+          create: async () => ({ data: { id: "ses_sync_error_test" } }),
+          prompt: async () => {
+            throw new Error("JSON Parse error: Unexpected EOF")
+          },
+          messages: async () => ({ data: [] }),
+          status: async () => ({ data: {} }),
+        },
+        app: {
+          agents: async () => ({ data: [{ name: "ultrabrain", mode: "subagent" }] }),
+        },
+      }
+      
+      const tool = createSisyphusTask({
+        manager: mockManager,
+        client: mockClient,
+      })
+      
+      const toolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "Sisyphus",
+        abort: new AbortController().signal,
+      }
+      
+      // #when
+      const result = await tool.execute(
+        {
+          description: "Sync error test",
+          prompt: "Do something",
+          category: "ultrabrain",
+          run_in_background: false,
+          skills: [],
+        },
+        toolContext
+      )
+      
+      // #then - should return error message with the prompt error
+      expect(result).toContain("❌")
+      expect(result).toContain("Failed to send prompt")
+      expect(result).toContain("JSON Parse error")
+    })
+
+    test("sync mode success returns task result with content", async () => {
+      // #given
+      const { createSisyphusTask } = require("./tools")
+      
+      const mockManager = {
+        launch: async () => ({}),
+      }
+      
+      const mockClient = {
+        session: {
+          create: async () => ({ data: { id: "ses_sync_success" } }),
+          prompt: async () => ({ data: {} }),
+          messages: async () => ({
+            data: [
+              {
+                info: { role: "assistant", time: { created: Date.now() } },
+                parts: [{ type: "text", text: "Sync task completed successfully" }],
+              },
+            ],
+          }),
+          status: async () => ({ data: { "ses_sync_success": { type: "idle" } } }),
+        },
+        app: {
+          agents: async () => ({ data: [{ name: "ultrabrain", mode: "subagent" }] }),
+        },
+      }
+      
+      const tool = createSisyphusTask({
+        manager: mockManager,
+        client: mockClient,
+      })
+      
+      const toolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "Sisyphus",
+        abort: new AbortController().signal,
+      }
+      
+      // #when
+      const result = await tool.execute(
+        {
+          description: "Sync success test",
+          prompt: "Do something",
+          category: "ultrabrain",
+          run_in_background: false,
+          skills: [],
+        },
+        toolContext
+      )
+      
+      // #then - should return the task result content
+      expect(result).toContain("Sync task completed successfully")
+      expect(result).toContain("Task completed")
+    }, { timeout: 20000 })
+
+    test("sync mode agent not found returns helpful error", async () => {
+      // #given
+      const { createSisyphusTask } = require("./tools")
+      
+      const mockManager = {
+        launch: async () => ({}),
+      }
+      
+      const mockClient = {
+        session: {
+          create: async () => ({ data: { id: "ses_agent_notfound" } }),
+          prompt: async () => {
+            throw new Error("Cannot read property 'name' of undefined agent.name")
+          },
+          messages: async () => ({ data: [] }),
+          status: async () => ({ data: {} }),
+        },
+        app: {
+          agents: async () => ({ data: [{ name: "ultrabrain", mode: "subagent" }] }),
+        },
+      }
+      
+      const tool = createSisyphusTask({
+        manager: mockManager,
+        client: mockClient,
+      })
+      
+      const toolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "Sisyphus",
+        abort: new AbortController().signal,
+      }
+      
+      // #when
+      const result = await tool.execute(
+        {
+          description: "Agent not found test",
+          prompt: "Do something",
+          category: "ultrabrain",
+          run_in_background: false,
+          skills: [],
+        },
+        toolContext
+      )
+      
+      // #then - should return agent not found error
+      expect(result).toContain("❌")
+      expect(result).toContain("not found")
+      expect(result).toContain("registered")
+    })
+
+    test("sync mode passes category model to prompt", async () => {
+      // #given
+      const { createSisyphusTask } = require("./tools")
+      let promptBody: any
+
+      const mockManager = { launch: async () => ({}) }
+      const mockClient = {
+        session: {
+          create: async () => ({ data: { id: "ses_sync_model" } }),
+          prompt: async (input: any) => {
+            promptBody = input.body
+            return { data: {} }
+          },
+          messages: async () => ({
+            data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Done" }] }]
+          }),
+          status: async () => ({ data: {} }),
+        },
+        app: { agents: async () => ({ data: [] }) },
+      }
+
+      const tool = createSisyphusTask({
+        manager: mockManager,
+        client: mockClient,
+        userCategories: {
+          "custom-cat": { model: "provider/custom-model" }
+        }
+      })
+
+      const toolContext = {
+        sessionID: "parent",
+        messageID: "msg",
+        agent: "Sisyphus",
+        abort: new AbortController().signal
+      }
+
+      // #when
+      await tool.execute({
+        description: "Sync model test",
+        prompt: "test",
+        category: "custom-cat",
+        run_in_background: false,
+        skills: []
+      }, toolContext)
+
+      // #then
+      expect(promptBody.model).toEqual({
+        providerID: "provider",
+        modelID: "custom-model"
+      })
+    }, { timeout: 20000 })
+  })
+
+  describe("buildSystemContent", () => {
     test("returns undefined when no skills and no category promptAppend", () => {
       // #given
       const { buildSystemContent } = require("./tools")

--- a/src/tools/sisyphus-task/tools.ts
+++ b/src/tools/sisyphus-task/tools.ts
@@ -418,32 +418,25 @@ System notifies on completion. Use \`background_output\` with task_id="${task.id
           metadata: { sessionId: sessionID, category: args.category, sync: true },
         })
 
-        // Use fire-and-forget prompt() - awaiting causes JSON parse errors with thinking models
-        // Note: Don't pass model in body - use agent's configured model instead
-        let promptError: Error | undefined
-        client.session.prompt({
-          path: { id: sessionID },
-          body: {
-            agent: agentToUse,
-            system: systemContent,
-            tools: {
-              task: false,
-              sisyphus_task: false,
+        try {
+          await client.session.prompt({
+            path: { id: sessionID },
+            body: {
+              agent: agentToUse,
+              system: systemContent,
+              tools: {
+                task: false,
+                sisyphus_task: false,
+              },
+              parts: [{ type: "text", text: args.prompt }],
+              ...(categoryModel ? { model: categoryModel } : {}),
             },
-            parts: [{ type: "text", text: args.prompt }],
-          },
-        }).catch((error) => {
-          promptError = error instanceof Error ? error : new Error(String(error))
-        })
-
-        // Small delay to let the prompt start
-        await new Promise(resolve => setTimeout(resolve, 100))
-
-        if (promptError) {
+          })
+        } catch (promptError) {
           if (toastManager && taskId !== undefined) {
             toastManager.removeTask(taskId)
           }
-          const errorMessage = promptError.message
+          const errorMessage = promptError instanceof Error ? promptError.message : String(promptError)
           if (errorMessage.includes("agent.name") || errorMessage.includes("undefined")) {
             return `❌ Agent "${agentToUse}" not found. Make sure the agent is registered in your opencode.json or provided by a plugin.\n\nSession ID: ${sessionID}`
           }
@@ -462,20 +455,6 @@ System notifies on completion. Use \`background_output\` with task_id="${task.id
 
         while (Date.now() - pollStart < MAX_POLL_TIME_MS) {
           await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS))
-
-          // Check for async errors that may have occurred after the initial 100ms delay
-          // TypeScript doesn't understand async mutation, so we cast to check
-          const asyncError = promptError as Error | undefined
-          if (asyncError) {
-            if (toastManager && taskId !== undefined) {
-              toastManager.removeTask(taskId)
-            }
-            const errorMessage = asyncError.message
-            if (errorMessage.includes("agent.name") || errorMessage.includes("undefined")) {
-              return `❌ Agent "${agentToUse}" not found. Make sure the agent is registered in your opencode.json or provided by a plugin.\n\nSession ID: ${sessionID}`
-            }
-            return `❌ Failed to send prompt: ${errorMessage}\n\nSession ID: ${sessionID}`
-          }
 
           const statusResult = await client.session.status()
           const allStatuses = (statusResult.data ?? {}) as Record<string, { type: string }>


### PR DESCRIPTION
# Summary

This PR fixes a critical issue in the sisyphus_task tool where running in synchronous mode (run_in_background=false) would frequently fail with a JSON Parse error: Unexpected EOF. It also ensures that category-specific models (e.g., for visual or business-logic) are correctly propagated to the subagent in sync mode.

# Changes

## Core Fixes

- Resolved Race Condition in Sync Mode: Replaced a broken "fire-and-forget" prompt pattern in src/tools/sisyphus-task/tools.ts with a proper await on the client.session.prompt call. The previous implementation used a 100ms delay and a .catch() block that often resulted in the request being aborted or racing with session updates, causing truncated JSON responses.
- Fixed Missing Category Model: Added logic to include the categoryModel in the prompt body when executing in sync mode. Previously, the subagent would use its default model instead of the one defined by the task's category.

## Refactoring & Cleanup

- Simplified Error Handling: Removed redundant async error checks and polling delay logic that are no longer necessary now that the prompt request is properly awaited.
- Improved Reliability: Aligned the sync mode implementation with the stable pattern used in call_omo_agent.

# Testing

```bash
bun run typecheck
bun test
```

- Added Sync Mode Test Suite: Introduced a comprehensive describe block in src/tools/sisyphus-task/tools.test.ts covering:
- Increased Test Timeouts: Adjusted timeouts to 20s for sync tests to accommodate the tool's stability polling mechanism.

## Verification Results

- Build: bun run build completes without errors.
- Tests: bun test src/tools/sisyphus-task/tools.test.ts passes with 34 pass / 0 fail.

```
Thinking: The user wants me to test if the sisyphus_task sync mode issue is fixed. Let me run the test with run_in_background=false to see if it still fails.
Testing sync mode:
⚙ sisyphus_task [run_in_background=false, category=quick, description=Test sync mode fix, prompt=Say "Hello, sync mode works!" and nothing else.]
Fixed! ✅
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sync mode failures in sisyphus_task by awaiting the prompt call to remove a race that caused "JSON Parse error: Unexpected EOF". Also ensures the correct category model is sent to the subagent in sync runs.

- **Bug Fixes**
  - Await client.session.prompt in sync mode; remove the 100ms delay and return clearer errors (e.g., agent not found).
  - Pass categoryModel in the prompt body so the correct provider/model is used.
  - Add sync-mode tests (error/success, agent-not-found, model propagation) and increase timeouts to 20s.

<sup>Written for commit 224ddb1dec1e05bb97ddec1a6777f3a2cb33f551. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

