### PR TITLE
fix(skill-loader): implement eager loading for skills

### DIFF
--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -84,7 +84,10 @@ ${body.trim()}
 $ARGUMENTS
 </user-request>`
 
-    const lazyContent: LazyContentLoader = {
+    // RATIONALE: We read the file eagerly to ensure atomic consistency between
+    // metadata and body. We maintain the LazyContentLoader interface for
+    // compatibility, but the state is effectively eager.
+    const eagerLoader: LazyContentLoader = {
       loaded: true,
       content: templateContent,
       load: async () => templateContent,
@@ -111,7 +114,7 @@ $ARGUMENTS
       metadata: data.metadata,
       allowedTools: parseAllowedTools(data["allowed-tools"]),
       mcpConfig,
-      lazyContent,
+      lazyContent: eagerLoader,
     }
   } catch {
     return null


### PR DESCRIPTION
## Summary
Fixes a bug where skills loaded from `~/.claude/skills` (and other directories processed by `opencode-skill-loader`) would return empty text when invoked as slash commands.

## Problem
The `opencode-skill-loader` was initializing `CommandDefinition.template` as an empty string (`""`) and relying on `lazyContent.load()` to populate it. However, the OpenCode command system likely accesses the `template` property directly without triggering the lazy loader, resulting in empty output.

## Solution
Modified `src/features/opencode-skill-loader/loader.ts` to implement eager loading, similar to how `claude-code-plugin-loader` works:
1. Destructure `body` from `parseFrontmatter` immediately.
2. Construct the template string with the `<skill-instruction>` wrapper.
3. Assign the content directly to `definition.template`.
4. Update `lazyContent` to return the pre-loaded content (preserving interface compatibility but removing the double file read).

## Verification
- [x] `bun run typecheck` passed
- [x] `bun run build` passed
- [x] Verified locally by loading the plugin in OpenCode and invoking a skill from `~/.claude/skills`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty output from skill slash commands by eagerly loading skill templates in opencode-skill-loader. Aligns behavior with claude-code-plugin-loader and removes unnecessary file reads.

- **Bug Fixes**
  - Parse frontmatter body once and build the <skill-instruction> template.
  - Set definition.template immediately; lazyContent returns the preloaded string.
  - Prevents empty templates for skills from ~/.claude/skills and project directories.

<sup>Written for commit 79bd75b3dbf5f62d8b20ff8d85a9919cc6f9a7ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

