### PR TITLE
fix: run autoSlashCommand before claudeCodeHooks to fix slash command detection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -316,10 +316,13 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     },
 
     "chat.message": async (input, output) => {
+      // autoSlashCommand must run first, before any hook prepends content to the message.
+      // Otherwise, slash commands like "/preflight" won't be detected because the text
+      // no longer starts with "/" after claudeCodeHooks prepends hook content.
+      await autoSlashCommand?.["chat.message"]?.(input, output);
       await keywordDetector?.["chat.message"]?.(input, output);
       await claudeCodeHooks["chat.message"]?.(input, output);
       await contextInjector["chat.message"]?.(input, output);
-      await autoSlashCommand?.["chat.message"]?.(input, output);
       await startWork?.["chat.message"]?.(input, output);
 
       if (ralphLoop) {


### PR DESCRIPTION
## Summary

- Reorders chat.message hooks so `autoSlashCommand` runs first before `claudeCodeHooks`

## Problem

Slash commands (e.g., `/preflight`, `/frontend-dev`) return empty content because:

1. `claudeCodeHooks` runs first and prepends hook content to `output.parts[idx].text`
2. The user's message changes from `"/preflight"` to `"[hook content]\n\n/preflight"`
3. `autoSlashCommand` runs next and calls `detectSlashCommand(text)`
4. `trimmed.startsWith("/")` returns `false` because text now starts with hook content
5. Slash command is not detected, returns empty

## Fix

Move `autoSlashCommand` to run **before** any hook that modifies the message content. This ensures slash commands are detected and replaced before content modification occurs.

## Testing

1. Before fix: Type `/preflight` → empty response
2. After fix: Type `/preflight` → full skill content returned

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run autoSlashCommand before claudeCodeHooks so slash commands are detected correctly. Commands like /preflight now return the expected content instead of an empty response.

<sup>Written for commit 391c7dcf6b8d72219e0d38d8d2ec6ca36978fc8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

