### PR TITLE
feat(tools): disable call_omo_agent by default, enable via sisyphus_task

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -152,7 +152,6 @@ export class BackgroundManager {
         system: input.skillContent,
         tools: {
           task: false,
-          call_omo_agent: false,
         },
         parts: [{ type: "text", text: input.prompt }],
       },
@@ -313,7 +312,6 @@ export class BackgroundManager {
         agent: existingTask.agent,
         tools: {
           task: false,
-          call_omo_agent: false,
         },
         parts: [{ type: "text", text: input.prompt }],
       },

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -282,6 +282,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     config.tools = {
       ...(config.tools as Record<string, unknown>),
       "grep_app_*": false,
+      call_omo_agent: false,
     };
 
     if (agentResult.explore) {


### PR DESCRIPTION
Disable call_omo_agent tool by default to reduce tool noise. Now enabled only through sisyphus_task.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable call_omo_agent by default to cut tool noise and prevent unexpected agent calls. It’s now only enabled when running a sisyphus_task.

- **Refactors**
  - Set call_omo_agent: false in plugin config; enabled only via sisyphus_task.
  - Removed per-request call_omo_agent flag from BackgroundManager to use central config.

<sup>Written for commit 4fe4fb1adf540b87a8352f25c589464935e41a56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

