### PR TITLE
fix(test): update sisyphus-orchestrator test assertion

### DIFF
--- a/src/hooks/sisyphus-orchestrator/index.test.ts
+++ b/src/hooks/sisyphus-orchestrator/index.test.ts
@@ -175,8 +175,8 @@ describe("sisyphus-orchestrator hook", () => {
         output
       )
 
-      // #then - output should be transformed (original output replaced)
-      expect(output.output).not.toContain("Task completed successfully")
+      // #then - output should be transformed (original output preserved for debugging)
+      expect(output.output).toContain("Task completed successfully")
       expect(output.output).toContain("SUBAGENT WORK COMPLETED")
       expect(output.output).toContain("test-plan")
       expect(output.output).toContain("SUBAGENTS LIE")


### PR DESCRIPTION
## Summary

Fixes failing test: `should transform output when caller is orchestrator-sisyphus with boulder state`

## Problem

The implementation was updated to preserve original subagent responses for debugging purposes, but the test still expected the response to be stripped.

## Solution

Updated the test assertion from `.not.toContain()` to `.toContain()` to match the intended behavior where subagent responses are preserved under "Subagent Response:" section.

## Verification

- [x] Test passes locally
- [x] Full test suite passes (1052 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the sisyphus-orchestrator test to expect preserved subagent output. This fixes the failing assertion and aligns the test with current behavior.

<sup>Written for commit d1ffecd887835f41e7e68769347b7c19033d073c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

