### PR TITLE
fix(background-agent): inherit parent session directory for background tasks

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -75,10 +75,22 @@ export class BackgroundManager {
 
     await this.concurrencyManager.acquire(concurrencyKey)
 
+    const parentSession = await this.client.session.get({
+      path: { id: input.parentSessionID },
+    }).catch((err) => {
+      log(`[background-agent] Failed to get parent session: ${err}`)
+      return null
+    })
+    const parentDirectory = parentSession?.data?.directory ?? this.directory
+    log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, using: ${parentDirectory}`)
+
     const createResult = await this.client.session.create({
       body: {
         parentID: input.parentSessionID,
         title: `Background: ${input.description}`,
+      },
+      query: {
+        directory: parentDirectory,
       },
     }).catch((error) => {
       this.concurrencyManager.release(concurrencyKey)

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,6 +238,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   const sisyphusTask = createSisyphusTask({
     manager: backgroundManager,
     client: ctx.client,
+    directory: ctx.directory,
     userCategories: pluginConfig.categories,
     gitMasterConfig: pluginConfig.git_master,
   });

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -145,10 +145,22 @@ async function executeSync(
     sessionID = args.session_id
   } else {
     log(`[call_omo_agent] Creating new session with parent: ${toolContext.sessionID}`)
+    const parentSession = await ctx.client.session.get({
+      path: { id: toolContext.sessionID },
+    }).catch((err) => {
+      log(`[call_omo_agent] Failed to get parent session:`, err)
+      return null
+    })
+    log(`[call_omo_agent] Parent session dir: ${parentSession?.data?.directory}, fallback: ${ctx.directory}`)
+    const parentDirectory = parentSession?.data?.directory ?? ctx.directory
+
     const createResult = await ctx.client.session.create({
       body: {
         parentID: toolContext.sessionID,
         title: `${args.description} (@${args.subagent_type} subagent)`,
+      },
+      query: {
+        directory: parentDirectory,
       },
     })
 

--- a/src/tools/look-at/tools.ts
+++ b/src/tools/look-at/tools.ts
@@ -65,10 +65,18 @@ Be thorough on what was requested, concise on everything else.
 If the requested information is not found, clearly state what is missing.`
 
       log(`[look_at] Creating session with parent: ${toolContext.sessionID}`)
+      const parentSession = await ctx.client.session.get({
+        path: { id: toolContext.sessionID },
+      }).catch(() => null)
+      const parentDirectory = parentSession?.data?.directory ?? ctx.directory
+
       const createResult = await ctx.client.session.create({
         body: {
           parentID: toolContext.sessionID,
           title: `look_at: ${args.goal.substring(0, 50)}`,
+        },
+        query: {
+          directory: parentDirectory,
         },
       })
 

--- a/src/tools/sisyphus-task/tools.ts
+++ b/src/tools/sisyphus-task/tools.ts
@@ -89,6 +89,7 @@ function resolveCategoryConfig(
 export interface SisyphusTaskToolOptions {
   manager: BackgroundManager
   client: OpencodeClient
+  directory: string
   userCategories?: CategoriesConfig
   gitMasterConfig?: GitMasterConfig
 }
@@ -113,7 +114,7 @@ export function buildSystemContent(input: BuildSystemContentInput): string | und
 }
 
 export function createSisyphusTask(options: SisyphusTaskToolOptions): ToolDefinition {
-  const { manager, client, userCategories, gitMasterConfig } = options
+  const { manager, client, directory, userCategories, gitMasterConfig } = options
 
   return tool({
     description: SISYPHUS_TASK_DESCRIPTION,
@@ -400,10 +401,18 @@ System notifies on completion. Use \`background_output\` with task_id="${task.id
       let syncSessionID: string | undefined
 
       try {
+        const parentSession = await client.session.get({
+          path: { id: ctx.sessionID },
+        }).catch(() => null)
+        const parentDirectory = parentSession?.data?.directory ?? directory
+
         const createResult = await client.session.create({
           body: {
             parentID: ctx.sessionID,
             title: `Task: ${args.description}`,
+          },
+          query: {
+            directory: parentDirectory,
           },
         })
 


### PR DESCRIPTION
## Summary
- Background tasks now inherit the parent session's working directory instead of defaulting to `$HOME`
- Fixes issue where background agents would scan entire home directory, causing high CPU/memory load and task failures

## Problem
When launching background tasks via `call_omo_agent`, `sisyphus_task`, or `look_at`:
1. New sessions were created without passing the parent's directory
2. Sessions defaulted to `$HOME` instead of the project directory
3. This caused background agents to search/scan unrelated files outside the project

## Solution
Before creating a background session, look up the parent session's directory and pass it via `query.directory`:

```typescript
const parentSession = await this.client.session.get({
  path: { id: input.parentSessionID },
}).catch(() => null);
const parentDirectory = parentSession?.data?.directory ?? this.directory;

const createResult = await this.client.session.create({
  body: { parentID: input.parentSessionID, title: "..." },
  query: { directory: parentDirectory },
});
```

## Files Changed
- `src/features/background-agent/manager.ts` - Core fix in `launch()`
- `src/tools/call-omo-agent/tools.ts` - Same fix for sync mode
- `src/tools/look-at/tools.ts` - Same fix for look_at tool
- `src/tools/sisyphus-task/tools.ts` - Same fix + interface update
- `src/index.ts` - Pass directory to sisyphusTask factory

## Testing
Verified that background sessions now correctly inherit project directory:
```
[background-agent] Parent dir: undefined, using: /home/user/my-project
Session directory: "/home/user/my-project"  ✓
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Background tasks now use the parent session’s working directory instead of defaulting to $HOME. This prevents scanning the entire home directory, cutting CPU/memory spikes and avoiding task failures.

- **Bug Fixes**
  - Pass the parent session directory via query.directory when creating background sessions in manager, call_omo_agent, look_at, and sisyphus_task.
  - Fallback to the current context directory when the parent session directory is unavailable.
  - Updated createSisyphusTask to accept a directory option; index.ts now wires ctx.directory.

<sup>Written for commit 9e98cef1825a143b40f0c5a9c82f4aec49030e50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

