### PR TITLE
fix(background-agent): address edge cases in task lifecycle

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -433,15 +433,7 @@ export class BackgroundManager {
           task.concurrencyKey = undefined  // Prevent double-release
         }
         // Clean up pendingByParent to prevent stale entries
-        if (task.parentSessionID) {
-          const pending = this.pendingByParent.get(task.parentSessionID)
-          if (pending) {
-            pending.delete(task.id)
-            if (pending.size === 0) {
-              this.pendingByParent.delete(task.parentSessionID)
-            }
-          }
-        }
+        this.cleanupPendingByParent(task)
         this.markForNotification(task)
         await this.notifyParentSession(task)
         log("[background-agent] Task completed via session.idle event:", task.id)
@@ -469,15 +461,7 @@ export class BackgroundManager {
         task.concurrencyKey = undefined  // Prevent double-release
       }
       // Clean up pendingByParent to prevent stale entries
-      if (task.parentSessionID) {
-        const pending = this.pendingByParent.get(task.parentSessionID)
-        if (pending) {
-          pending.delete(task.id)
-          if (pending.size === 0) {
-            this.pendingByParent.delete(task.parentSessionID)
-          }
-        }
-      }
+      this.cleanupPendingByParent(task)
       this.tasks.delete(task.id)
       this.clearNotificationsForTask(task.id)
       subagentSessions.delete(sessionID)
@@ -565,6 +549,21 @@ export class BackgroundManager {
         this.notifications.delete(sessionID)
       } else {
         this.notifications.set(sessionID, filtered)
+      }
+    }
+  }
+
+  /**
+   * Remove task from pending tracking for its parent session.
+   * Cleans up the parent entry if no pending tasks remain.
+   */
+  private cleanupPendingByParent(task: BackgroundTask): void {
+    if (!task.parentSessionID) return
+    const pending = this.pendingByParent.get(task.parentSessionID)
+    if (pending) {
+      pending.delete(task.id)
+      if (pending.size === 0) {
+        this.pendingByParent.delete(task.parentSessionID)
       }
     }
   }
@@ -739,15 +738,7 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
           task.concurrencyKey = undefined  // Prevent double-release
         }
         // Clean up pendingByParent to prevent stale entries
-        if (task.parentSessionID) {
-          const pending = this.pendingByParent.get(task.parentSessionID)
-          if (pending) {
-            pending.delete(task.id)
-            if (pending.size === 0) {
-              this.pendingByParent.delete(task.parentSessionID)
-            }
-          }
-        }
+        this.cleanupPendingByParent(task)
         this.clearNotificationsForTask(taskId)
         this.tasks.delete(taskId)
         subagentSessions.delete(task.sessionID)
@@ -806,15 +797,7 @@ try {
             task.concurrencyKey = undefined  // Prevent double-release
           }
           // Clean up pendingByParent to prevent stale entries
-          if (task.parentSessionID) {
-            const pending = this.pendingByParent.get(task.parentSessionID)
-            if (pending) {
-              pending.delete(task.id)
-              if (pending.size === 0) {
-                this.pendingByParent.delete(task.parentSessionID)
-              }
-            }
-          }
+          this.cleanupPendingByParent(task)
           this.markForNotification(task)
           await this.notifyParentSession(task)
           log("[background-agent] Task completed via polling:", task.id)
@@ -887,15 +870,7 @@ if (lastMessage) {
                     task.concurrencyKey = undefined  // Prevent double-release
                   }
                   // Clean up pendingByParent to prevent stale entries
-                  if (task.parentSessionID) {
-                    const pending = this.pendingByParent.get(task.parentSessionID)
-                    if (pending) {
-                      pending.delete(task.id)
-                      if (pending.size === 0) {
-                        this.pendingByParent.delete(task.parentSessionID)
-                      }
-                    }
-                  }
+                  this.cleanupPendingByParent(task)
                   this.markForNotification(task)
                   await this.notifyParentSession(task)
                   log("[background-agent] Task completed via stability detection:", task.id)


### PR DESCRIPTION
## Summary

Fixes 3 critical edge cases in background agent task lifecycle management:

1. **Reset `startedAt` on resume** - Prevents immediate false completion when resuming tasks
2. **Release concurrency immediately** - Frees slots on completion instead of 5-min delay  
3. **Clean up `pendingByParent`** - Prevents stale entries affecting batch notification logic

## Changes

| Fix | Description | Impact |
|-----|-------------|--------|
| `startedAt` reset | Resumed tasks get fresh timing for MIN_IDLE_TIME_MS check | Prevents false completion |
| Immediate concurrency release | Slots freed on completion with double-release guard | Eliminates bottleneck |
| `pendingByParent` cleanup | Added to ALL completion paths (session.idle, polling, stability, prune) | Correct "all complete" logic |
| Null guard | Check `task.parentSessionID` before Map access | Prevents runtime errors |
| Error handler fixes | Added concurrency release to launch/resume error paths | Resource cleanup on failure |

## Testing

- ✅ `bun run build` - Success
- ✅ `bun test src/features/background-agent/` - 45 tests pass

## Related

- Tested in fork PR: https://github.com/Gladdonilli/oh-my-opencode/pull/2
- All bot reviews (CodeRabbit, Greptile, Qodo) pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes background agent task lifecycle edge cases to prevent false completions, free concurrency immediately, and keep parent pending state accurate. Also configures SDK auth and adds builtin slash commands.

- **Bug Fixes**
  - Reset startedAt on resume to avoid instant completion.
  - Release concurrency on completion and on launch/resume errors; clear key to prevent double-release.
  - Clean up pendingByParent on all completion paths and during prune to remove stale entries.
  - Add null guard when accessing parentSessionID to prevent runtime errors.
  - Remove redundant delayed release logic.
  - Configure SDK client Basic Auth via request interceptor to ensure authenticated requests.

- **New Features**
  - Include builtin slash commands in discovery (loaded first for priority).

<sup>Written for commit 4d966ec99b8c5628071bb3f6ffa651c40c29d4e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

