### PR TITLE
fix(sisyphus-task): respect user model config in background mode

### DIFF
--- a/src/agents/sisyphus-junior.ts
+++ b/src/agents/sisyphus-junior.ts
@@ -82,7 +82,7 @@ export function createSisyphusJuniorAgent(
   promptAppend?: string
 ): AgentConfig {
   const prompt = buildSisyphusJuniorPrompt(promptAppend)
-  const model = categoryConfig.model
+  const model = categoryConfig.model ?? "anthropic/claude-sonnet-4-5"
 
   const baseRestrictions = createAgentToolRestrictions(BLOCKED_TOOLS)
   const mergedConfig = migrateAgentConfig({

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -150,7 +150,7 @@ export const SisyphusAgentConfigSchema = z.object({
 })
 
 export const CategoryConfigSchema = z.object({
-  model: z.string(),
+  model: z.string().optional(),
   temperature: z.number().min(0).max(2).optional(),
   top_p: z.number().min(0).max(1).optional(),
   maxTokens: z.number().optional(),

--- a/src/tools/sisyphus-task/tools.ts
+++ b/src/tools/sisyphus-task/tools.ts
@@ -69,10 +69,15 @@ function resolveCategoryConfig(
     return null
   }
 
+  let model = userConfig?.model ?? defaultConfig?.model
+  if (categoryName === "general" && !userConfig?.model) {
+    model = undefined
+  }
+
   const config: CategoryConfig = {
     ...defaultConfig,
     ...userConfig,
-    model: userConfig?.model ?? defaultConfig?.model ?? "anthropic/claude-sonnet-4-5",
+    model,
   }
 
   let promptAppend = defaultPromptAppend
@@ -312,7 +317,7 @@ ${textContent || "(No text output)"}`
         }
 
         agentToUse = SISYPHUS_JUNIOR_AGENT
-        categoryModel = parseModelString(resolved.config.model)
+        categoryModel = resolved.config.model ? parseModelString(resolved.config.model) : undefined
         categoryPromptAppend = resolved.promptAppend || undefined
       } else {
         agentToUse = args.subagent_type!.trim()


### PR DESCRIPTION
## Summary
Fixes an issue where `sisyphus_task` running in background mode (`run_in_background=true`) would always force the default model (e.g. `anthropic/claude-sonnet-4-5`) for the `general` category, ignoring user-configured overrides in `agents.Sisyphus-Junior.model`.

## Problem
- When `sisyphus_task` runs in background mode, it explicitly passes a `model` parameter to `manager.launch`.
- This model comes from `resolveCategoryConfig`, which falls back to `DEFAULT_CATEGORIES` if no user override exists for that specific category.
- `DEFAULT_CATEGORIES.general` has a hardcoded model.
- Consequently, even if a user configured a different model for the `Sisyphus-Junior` agent globally, the background task would still use the hardcoded default because the explicit `model` param takes precedence.

## Solution
1. **Schema Update**: Made `CategoryConfig.model` optional in `src/config/schema.ts`.
2. **Logic Update**: In `src/tools/sisyphus-task/tools.ts`, if the category is `general` and the user hasn't explicitly overridden the model in `categories.general.model`, we now set `model` to `undefined`.
   - This allows the background agent to fall back to the `Sisyphus-Junior` agent's configured model (which respects `oh-my-opencode.json` agent overrides).
3. **Safety Fallback**: Updated `src/agents/sisyphus-junior.ts` to handle `undefined` model by falling back to the default, preventing type errors during agent creation.
4. **Consistency**: Kept `DEFAULT_CATEGORIES` in `constants.ts` intact for documentation/consistency purposes.

This change complements PR #718 by ensuring that the flexible model configuration is respected not just at agent creation time, but also during tool execution when parameters are passed to background workers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes background sisyphus_task runs to respect the Sisyphus-Junior agent’s configured model instead of forcing the hardcoded default for the general category.

- **Bug Fixes**
  - Made CategoryConfig.model optional and avoid passing a model for the general category unless the user explicitly overrides it.
  - Updated resolveCategoryConfig to send undefined for general model when not overridden, letting the agent use its configured model.
  - Added a safe default in createSisyphusJuniorAgent so undefined model falls back to "anthropic/claude-sonnet-4-5".

<sup>Written for commit 34a8a36ea311f014415939bcb775e7e8978cf29e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

