### PR TITLE
feat(todo-continuation): respect awaiting_input status for interactive workflows

### DIFF
--- a/src/hooks/todo-continuation-enforcer.ts
+++ b/src/hooks/todo-continuation-enforcer.ts
@@ -65,7 +65,15 @@ function getMessageDir(sessionID: string): string | null {
 }
 
 function getIncompleteCount(todos: Todo[]): number {
-  return todos.filter(t => t.status !== "completed" && t.status !== "cancelled").length
+  return todos.filter(t => 
+    t.status !== "completed" && 
+    t.status !== "cancelled" &&
+    t.status !== "awaiting_input"
+  ).length
+}
+
+function getAwaitingInputCount(todos: Todo[]): number {
+  return todos.filter(t => t.status === "awaiting_input").length
 }
 
 interface MessageInfo {
@@ -320,6 +328,13 @@ export function createTodoContinuationEnforcer(
       }
 
       const incompleteCount = getIncompleteCount(todos)
+      const awaitingInputCount = getAwaitingInputCount(todos)
+      
+      if (awaitingInputCount > 0) {
+        log(`[${HOOK_NAME}] Skipped: ${awaitingInputCount} task(s) awaiting user input`, { sessionID, awaitingInputCount })
+        return
+      }
+      
       if (incompleteCount === 0) {
         log(`[${HOOK_NAME}] All todos complete`, { sessionID, total: todos.length })
         return


### PR DESCRIPTION
## Summary

Add support for `awaiting_input` todo status to allow agents to signal intentional pauses while waiting for user input at interactive checkpoints.

## Problem

The `todo-continuation-enforcer` is excellent for ensuring agents complete their work—it's one of the key features that makes Sisyphus so effective. However, some agent workflows intentionally require user input at specific checkpoints:

- **Discovery agents**: Need user confirmation on project-specific configuration before proceeding
- **Planning agents**: Present a plan and wait for approval before execution  
- **Review workflows**: Show findings and ask "should I proceed?" or "anything to correct?"
- **Multi-phase workflows**: Pause between phases for user checkpoint

Currently, when an agent pauses to ask for user input while having pending todos, the enforcer interprets this as "agent stopped prematurely" and injects continuation prompts—preventing the user from interacting.

## Solution

Add `awaiting_input` as a recognized todo status that signals "this task is intentionally paused waiting for external input."

This is a minimal, semantic change that:
- Lets agents explicitly signal when they're waiting for user input
- Preserves auto-continuation for all other scenarios  
- Requires no configuration changes
- Works for any agent without pre-registration

## Changes

```typescript
// Before
function getIncompleteCount(todos: Todo[]): number {
  return todos.filter(t => t.status !== "completed" && t.status !== "cancelled").length
}

// After  
function getIncompleteCount(todos: Todo[]): number {
  return todos.filter(t => 
    t.status !== "completed" && 
    t.status !== "cancelled" &&
    t.status !== "awaiting_input"
  ).length
}
```

Also added:
- `getAwaitingInputCount()` helper function
- Logging when tasks are awaiting user input

## Example Usage

When an agent needs user input:
1. Mark the interactive task as `awaiting_input`
2. Ask the user your question
3. After user responds, mark the task `in_progress` or `completed` and continue

```
Agent todos:
  1. [completed] Scan codebase
  2. [completed] Detect technology stack  
  3. [awaiting_input] Define hard rules    ← Waiting for user
  4. [pending] Generate documentation

Hook behavior:
  - Sees awaiting_input task
  - Recognizes intentional pause
  - Does NOT inject continuation
```

## Why This Approach

| Alternative | Drawback |
|-------------|----------|
| `skipAgents` config | Requires knowing agent names upfront; blanket skip loses continuation benefits |
| Disable hook entirely | Loses auto-continuation for all workflows |
| Complete todos before asking | Loses progress tracking and task context |
| **`awaiting_input` status** | Semantic, precise, agent-controlled, minimal change |

## Backward Compatibility

- **Fully backward compatible**—existing agents/workflows unchanged
- Agents that don't use `awaiting_input` behave exactly as before
- No config schema changes required
- No breaking changes to existing behavior

## Testing

The existing test file should be extended with:
- Test that continuation is skipped when todos have `awaiting_input` status
- Test that continuation resumes when `awaiting_input` task is changed to `in_progress`

---

Thank you for building such a powerful agent framework—the todo-continuation-enforcer is genuinely one of the features that makes oh-my-opencode stand out. This small addition would make it even more flexible for diverse agent workflows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for the awaiting_input todo status so agents can pause at interactive checkpoints without being forced to continue. This keeps normal auto-continuation for all other cases.

- **New Features**
  - Exclude awaiting_input from the incomplete todo count.
  - Add getAwaitingInputCount() and log when tasks are waiting for input.

<sup>Written for commit 8ca8acedfadc39c0255f8ebc5c52e864f53de3ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

