### PR TITLE
fix(sisyphus-task): preserve agent and model on resume

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -642,6 +642,54 @@ describe("BackgroundManager.resume", () => {
     // #then
     expect(result.progress?.toolCalls).toBe(42)
   })
+
+  test("resume should pass existing task model to session.prompt", async () => {
+    // #given
+    const { BackgroundManager } = require("./manager")
+
+    const promptCalls: any[] = []
+    const mockClient = {
+      session: {
+        create: async () => ({ data: { id: "session-a" } }),
+        prompt: async (input: any) => {
+          promptCalls.push(input)
+          return { data: {} }
+        },
+      },
+    }
+
+    const realManager = new BackgroundManager({
+      client: mockClient,
+      directory: "/tmp",
+    })
+
+    try {
+      const model = { providerID: "google", modelID: "antigravity-gemini-3-flash" }
+
+      const task = await realManager.launch({
+        description: "Launch with model",
+        prompt: "do work",
+        agent: "Sisyphus-Junior",
+        parentSessionID: "parent-session",
+        parentMessageID: "parent-message",
+        model,
+      })
+
+      // #when
+      await realManager.resume({
+        sessionId: task.sessionID,
+        prompt: "resume",
+        parentSessionID: "parent-2",
+        parentMessageID: "msg-2",
+      })
+
+      // #then
+      expect(promptCalls.length).toBeGreaterThanOrEqual(2)
+      expect(promptCalls[1].body.model).toEqual(model)
+    } finally {
+      realManager.cleanup()
+    }
+  })
 })
 
 describe("LaunchInput.skillContent", () => {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -306,12 +306,12 @@ export class BackgroundManager {
       promptLength: input.prompt.length,
     })
 
-    // Note: Don't pass model in body - use agent's configured model instead
     // Use prompt() instead of promptAsync() to properly initialize agent loop
     this.client.session.prompt({
       path: { id: existingTask.sessionID },
       body: {
         agent: existingTask.agent,
+        ...(existingTask.model ? { model: existingTask.model } : {}),
         tools: {
           task: false,
           sisyphus_task: false,

--- a/src/tools/sisyphus-task/tools.test.ts
+++ b/src/tools/sisyphus-task/tools.test.ts
@@ -439,6 +439,144 @@ describe("sisyphus-task", () => {
     expect(result).toContain("Background task resumed")
     expect(result).toContain("task-456")
   })
+
+  test("sync resume passes original session agent to session.prompt", async () => {
+    // #given
+    const { createSisyphusTask } = require("./tools")
+    const { setSessionAgent } = require("../../features/claude-code-session-state")
+    
+    const sessionIdToResume = "ses_agent_preserve_test"
+    const originalAgent = "oracle"
+    
+    setSessionAgent(sessionIdToResume, originalAgent)
+    
+    let promptBody: any
+    
+    const mockManager = {
+      resume: async () => ({})
+    }
+    
+    const mockClient = {
+      session: {
+        prompt: async (input: any) => {
+          promptBody = input.body
+          return { data: {} }
+        },
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "assistant", time: { created: Date.now() } },
+              parts: [{ type: "text", text: "Result from oracle agent" }],
+            },
+          ],
+        }),
+      },
+    }
+    
+    const tool = createSisyphusTask({
+      manager: mockManager,
+      client: mockClient,
+    })
+    
+    const toolContext = {
+      sessionID: "parent-session",
+      messageID: "parent-message",
+      agent: "Sisyphus",
+      abort: new AbortController().signal,
+    }
+    
+    // #when
+    await tool.execute(
+      {
+        description: "Resume agent test",
+        prompt: "Continue with original agent",
+        resume: sessionIdToResume,
+        run_in_background: false,
+        skills: [],
+      },
+      toolContext
+    )
+    
+    // #then - session.prompt should include the original agent
+    expect(promptBody.agent).toBe(originalAgent)
+  }, { timeout: 10000 })
+
+  test("sync resume passes original session model to session.prompt when available", async () => {
+    // #given
+    const { createSisyphusTask } = require("./tools")
+    const { MESSAGE_STORAGE } = require("../../features/hook-message-injector")
+    const { join } = require("node:path")
+    const { mkdir, writeFile, rm } = require("node:fs/promises")
+
+    const sessionIdToResume = "ses_model_preserve_test"
+    const messageDir = join(MESSAGE_STORAGE, sessionIdToResume)
+
+    await mkdir(messageDir, { recursive: true })
+
+    try {
+      await writeFile(
+        join(messageDir, "000.json"),
+        JSON.stringify({
+          agent: "Sisyphus-Junior",
+          model: { providerID: "google", modelID: "antigravity-gemini-3-flash" },
+        }),
+        "utf-8"
+      )
+
+      let promptBody: any
+
+      const mockManager = {
+        resume: async () => ({}),
+      }
+
+      const mockClient = {
+        session: {
+          prompt: async (input: any) => {
+            promptBody = input.body
+            return { data: {} }
+          },
+          messages: async () => ({
+            data: [
+              {
+                info: { role: "assistant", time: { created: Date.now() } },
+                parts: [{ type: "text", text: "Result" }],
+              },
+            ],
+          }),
+        },
+      }
+
+      const tool = createSisyphusTask({
+        manager: mockManager,
+        client: mockClient,
+      })
+
+      const toolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "Sisyphus",
+        abort: new AbortController().signal,
+      }
+
+      // #when
+      await tool.execute(
+        {
+          description: "Resume model test",
+          prompt: "Continue with original model",
+          resume: sessionIdToResume,
+          run_in_background: false,
+          skills: [],
+        },
+        toolContext
+      )
+
+      // #then
+      expect(promptBody.agent).toBe("Sisyphus-Junior")
+      expect(promptBody.model).toEqual({ providerID: "google", modelID: "antigravity-gemini-3-flash" })
+    } finally {
+      await rm(messageDir, { recursive: true, force: true })
+    }
+  }, { timeout: 10000 })
 })
 
   describe("sync mode new task (run_in_background=false)", () => {

--- a/src/tools/sisyphus-task/tools.ts
+++ b/src/tools/sisyphus-task/tools.ts
@@ -202,11 +202,25 @@ Use \`background_output\` with task_id="${task.id}" to check progress.`
         const taskId = `resume_sync_${args.resume.slice(0, 8)}`
         const startTime = new Date()
 
+        const resumeMessageDir = getMessageDir(args.resume)
+        const resumePrevMessage = resumeMessageDir ? findNearestMessageWithFields(resumeMessageDir) : null
+        const resumeFirstMessageAgent = resumeMessageDir ? findFirstMessageWithAgent(resumeMessageDir) : null
+
+        const originalSessionAgent =
+          getSessionAgent(args.resume) ??
+          resumeFirstMessageAgent ??
+          resumePrevMessage?.agent
+
+        const originalSessionModel =
+          resumePrevMessage?.model?.providerID && resumePrevMessage?.model?.modelID
+            ? { providerID: resumePrevMessage.model.providerID, modelID: resumePrevMessage.model.modelID }
+            : undefined
+
         if (toastManager) {
           toastManager.addTask({
             id: taskId,
             description: args.description,
-            agent: "resume",
+            agent: originalSessionAgent ?? "resume",
             isBackground: false,
           })
         }
@@ -217,17 +231,19 @@ Use \`background_output\` with task_id="${task.id}" to check progress.`
         })
 
         try {
-          await client.session.prompt({
-            path: { id: args.resume },
-            body: {
-              tools: {
-                task: false,
-                sisyphus_task: false,
-                call_omo_agent: true,
+            await client.session.prompt({
+              path: { id: args.resume },
+              body: {
+                ...(originalSessionAgent ? { agent: originalSessionAgent } : {}),
+                ...(originalSessionModel ? { model: originalSessionModel } : {}),
+                tools: {
+                  task: false,
+                  sisyphus_task: false,
+                  call_omo_agent: true,
+                },
+                parts: [{ type: "text", text: args.prompt }],
               },
-              parts: [{ type: "text", text: args.prompt }],
-            },
-          })
+            })
         } catch (promptError) {
           if (toastManager) {
             toastManager.removeTask(taskId)


### PR DESCRIPTION
Resuming a sisyphus_task session now continues with the original session context instead of falling back to defaults. Sync resume retrieves and forwards the prior agent and { providerID, modelID } into client.session.prompt, and the toast reflects the actual resumed agent. This fixes category-based resumes that could fail with ProviderModelNotFoundError → immediate cancel → JSON Parse error: Unexpected EOF, and adds tests covering agent/model propagation for both sync resume and BackgroundManager resume.

## Summary

- Fix `sisyphus_task` resume so it preserves the original session `agent` and `model` (provider/model ID), instead of falling back to defaults.
- Prevents category-based resume failures that manifested as `ProviderModelNotFoundError` → immediate cancel → `JSON Parse error: Unexpected EOF`.
- Adds regression tests for both sync resume and BackgroundManager resume paths

## Changes

- `src/tools/sisyphus-task/tools.ts`: sync resume now retrieves prior session context and passes `{ agent, model }` into `client.session.prompt`; toast uses the resolved agent.
- `src/features/background-agent/manager.ts`: background resume now forwards any stored task `model` override into `session.prompt`.
- `src/tools/sisyphus-task/tools.test.ts`: add test asserting model propagation on sync resume.
- `src/features/background-agent/manager.test.ts`: add test asserting model propagation on BackgroundManager resume.

## Testing

```bash
bun run typecheck
bun test src/tools/sisyphus-task/tools.test.ts src/features/background-agent/manager.test.ts
```
Also ask Sisyphus to test resuming a sisyphus_task call with both an agent and category and see it shouldn't fall back either model or agent.

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->
Closes #748

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resuming a sisyphus_task session now keeps the original agent and model, so resumes continue with the same context instead of falling back to defaults. This prevents category-based resumes from failing (ProviderModelNotFoundError → cancel → JSON parse error) and closes #748.

- **Bug Fixes**
  - Sync resume reads the prior agent and model from session history and passes them to client.session.prompt.
  - BackgroundManager.resume forwards any stored task model to session.prompt.
  - Toast shows the actual resumed agent; added tests covering both sync and background paths.

<sup>Written for commit 3d0f236aca4e2b037620de50021d70c39894ac2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

