### PR TITLE
fix(sisyphus-task): guard client.session.get and update sync mode tests

### DIFF
--- a/src/tools/sisyphus-task/tools.test.ts
+++ b/src/tools/sisyphus-task/tools.test.ts
@@ -452,6 +452,7 @@ describe("sisyphus-task", () => {
       
       const mockClient = {
         session: {
+          get: async () => ({ data: { directory: "/project" } }),
           create: async () => ({ data: { id: "ses_sync_error_test" } }),
           prompt: async () => {
             throw new Error("JSON Parse error: Unexpected EOF")
@@ -504,6 +505,7 @@ describe("sisyphus-task", () => {
       
       const mockClient = {
         session: {
+          get: async () => ({ data: { directory: "/project" } }),
           create: async () => ({ data: { id: "ses_sync_success" } }),
           prompt: async () => ({ data: {} }),
           messages: async () => ({
@@ -560,6 +562,7 @@ describe("sisyphus-task", () => {
       
       const mockClient = {
         session: {
+          get: async () => ({ data: { directory: "/project" } }),
           create: async () => ({ data: { id: "ses_agent_notfound" } }),
           prompt: async () => {
             throw new Error("Cannot read property 'name' of undefined agent.name")
@@ -610,6 +613,7 @@ describe("sisyphus-task", () => {
       const mockManager = { launch: async () => ({}) }
       const mockClient = {
         session: {
+          get: async () => ({ data: { directory: "/project" } }),
           create: async () => ({ data: { id: "ses_sync_model" } }),
           prompt: async (input: any) => {
             promptBody = input.body

--- a/src/tools/sisyphus-task/tools.ts
+++ b/src/tools/sisyphus-task/tools.ts
@@ -407,9 +407,9 @@ System notifies on completion. Use \`background_output\` with task_id="${task.id
       let syncSessionID: string | undefined
 
       try {
-        const parentSession = await client.session.get({
-          path: { id: ctx.sessionID },
-        }).catch(() => null)
+        const parentSession = client.session.get
+          ? await client.session.get({ path: { id: ctx.sessionID } }).catch(() => null)
+          : null
         const parentDirectory = parentSession?.data?.directory ?? directory
 
         const createResult = await client.session.create({


### PR DESCRIPTION
## Problem
PR #731 added `client.session.get` for directory inheritance but didn't update tests. The `.catch()` pattern only handles Promise rejections, not synchronous TypeError when the method is undefined.

## Solution
1. **Guard clause in implementation** - Check if `client.session.get` exists before calling (defensive coding for older clients)
2. **Updated test mocks** - Added `get` mock to 4 sync mode tests so they properly test the real code path

## Changes
- `src/tools/sisyphus-task/tools.ts` - Guard clause for `client.session.get`
- `src/tools/sisyphus-task/tools.test.ts` - Added `get` mock to 4 tests

## Verification
All 27 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in sync mode by guarding client.session.get and keeps tests aligned with the directory inheritance behavior. This restores compatibility with older clients that don’t implement session.get.

- **Bug Fixes**
  - Guard client.session.get before calling; fall back when unavailable to avoid TypeError.
  - Update four sync mode tests to mock session.get and verify directory inheritance.

<sup>Written for commit 444b7ce991d2aa2eff97d009a7dce1043a0fcaad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

