### PR TITLE
feat: localised indexing of web search files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,12 +20,14 @@
         "open": "^11.0.0",
         "picocolors": "^1.1.1",
         "picomatch": "^4.0.2",
+        "turndown": "^7.2.0",
         "xdg-basedir": "^5.1.0",
         "zod": "^4.1.8",
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/picomatch": "^3.0.2",
+        "@types/turndown": "^5.0.5",
         "bun-types": "latest",
         "typescript": "^5.7.3",
       },
@@ -81,6 +83,8 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.7", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw=="],
 
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
 
     "@openauthjs/openauth": ["@openauthjs/openauth@0.4.3", "", { "dependencies": { "@standard-schema/spec": "1.0.0-beta.3", "aws4fetch": "1.0.20", "jose": "5.9.6" }, "peerDependencies": { "arctic": "^2.2.2", "hono": "^4.0.0" } }, "sha512-RlnjqvHzqcbFVymEwhlUEuac4utA5h4nhSK/i2szZuQmxTIqbGUxZ+nM+avM+VV4Ing+/ZaNLKILoXS3yrkOOw=="],
@@ -106,6 +110,8 @@
     "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 
     "@types/picomatch": ["@types/picomatch@3.0.2", "", {}, "sha512-n0i8TD3UDB7paoMMxA3Y65vUncFJXjcUf7lQY7YyKGl6031FNjfsLs6pdLFCy2GNFxItPJG8GvvpbZc2skH7WA=="],
+
+    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -312,6 +318,8 @@
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "turndown": ["turndown@7.2.2", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 

--- a/package.json
+++ b/package.json
@@ -61,11 +61,13 @@
     "open": "^11.0.0",
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.2",
+    "turndown": "^7.2.0",
     "xdg-basedir": "^5.1.0",
     "zod": "^4.1.8"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
+    "@types/turndown": "^5.0.5",
     "@types/picomatch": "^3.0.2",
     "bun-types": "latest",
     "typescript": "^5.7.3"

--- a/src/agents/enhanced-librarian.ts
+++ b/src/agents/enhanced-librarian.ts
@@ -1,0 +1,246 @@
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentPromptMetadata } from "../types"
+import { LIBRARIAN_AGENT } from "./librarian"
+import { createLibraryIndexer } from "../features/librarian-local-index"
+
+const DEFAULT_MODEL = "opencode/glm-4.7-free"
+
+export const ENHANCED_LIBRARIAN_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "exploration",
+  cost: "CHEAP",
+  promptAlias: "Enhanced Librarian",
+  keyTrigger: "External library/source mentioned → fire `enhanced_librarian` background",
+  triggers: [
+    { domain: "Enhanced Librarian", trigger: "Unfamiliar packages / libraries, struggles at weird behaviour (to find existing implementation of opensource)" },
+  ],
+  useWhen: [
+    "How do I use [library]?",
+    "What's the best practice for [framework feature]?",
+    "Why does [external dependency] behave this way?",
+    "Find examples of [library] usage",
+    "Working with unfamiliar npm/pip/cargo packages",
+  ],
+}
+
+export function createEnhancedLibrarianAgent(
+  model: string = DEFAULT_MODEL
+): AgentConfig {
+  return {
+    description:
+      "Enhanced librarian agent with local index support. First checks ./library folder for cached documentation with YAML frontmatter and tag-based querying, then falls back to external sources. Reduces context pollution and provides faster, machine-readable documentation access.",
+    mode: "subagent" as const,
+    model,
+    temperature: 0.1,
+    tools: { write: false, edit: false, background_task: false },
+    prompt: `# THE ENHANCED LIBRARIAN
+
+You are **THE ENHANCED LIBRARIAN**, a specialized codebase understanding agent with local index support.
+
+Your job: Answer questions about open-source libraries by first checking the **local ./library index** for cached documentation, then falling back to external sources if needed.
+
+## PRIORITY ORDER (MANDATORY)
+
+1. **LOCAL INDEX FIRST** - Always check ./library folder first
+2. **EXTERNAL SOURCES** - Only if no local results
+
+---
+
+## PHASE 0: LOCAL INDEX SEARCH
+
+Before ANY external search, check the local index:
+
+### Step 1: Build/Update Index (if needed)
+\`\`\`
+librarian_local_index(action="build-index")
+\`\`\`
+
+### Step 2: Search by Tags (preferred for semantic queries)
+For conceptual questions:
+\`\`\`
+librarian_local_index(
+  action="query-tags",
+  tags=["api", "react", "hooks"],
+  operator="OR"
+)
+\`\`\`
+
+### Step 3: Text Search (fallback)
+For specific terms:
+\`\`\`
+librarian_local_index(
+  action="search",
+  query="useEffect cleanup function"
+)
+\`\`\`
+
+### Step 4: Get Specific Library Docs
+If library is known:
+\`\`\`
+librarian_local_index(
+  action="get-docs",
+  library="react"
+)
+\`\`\`
+
+---
+
+## PHASE 1: EXTERNAL SOURCES (if local fails)
+
+Only proceed to external searches AFTER checking local index. Use the original LIBRARIAN workflow:
+
+### Type Classification
+| Type | Trigger | Tools |
+|------|----------|-------|
+| TYPE A: CONCEPTUAL | "How do I use X?", "Best practice for Y?" | Doc Discovery → context7 + websearch |
+| TYPE B: IMPLEMENTATION | "How does X implement Y?", "Show me source of Z" | gh clone + read + blame |
+| TYPE C: CONTEXT | "Why was this changed?", "History of X?" | gh issues/prs + git log/blame |
+| TYPE D: COMPREHENSIVE | Complex/ambiguous requests | Doc Discovery → ALL tools |
+
+### Documentation Discovery (for TYPE A & D)
+1. Find official docs: \`websearch("library-name official documentation site")\`
+2. Version check if specified
+3. Sitemap discovery: \`webfetch(docs_url + "/sitemap.xml")\`
+4. Targeted investigation with specific pages
+
+### Parallel Execution Guidelines
+- TYPE A (Conceptual): 1-2 parallel calls (local index first!)
+- TYPE B (Implementation): 2-3 parallel calls
+- TYPE C (Context): 2-3 parallel calls
+- TYPE D (Comprehensive): 3-5 parallel calls
+
+---
+
+## PHASE 2: LOCAL CACHE MANAGEMENT
+
+When finding useful external documentation, CACHE IT:
+
+### Add to Local Index
+\`\`\`
+librarian_local_index(
+  action="add-doc",
+  library="react",
+  content="# React Documentation\\n\\n...extracted content...",
+  frontmatter={
+    "title": "React useEffect Hook",
+    "tags": ["hooks", "effects", "cleanup"],
+    "contentType": "api",
+    "difficulty": "intermediate",
+    "source": "https://react.dev/reference/react"
+  }
+)
+\`\`\`
+
+### Pull Documentation from Sources
+\`\`\`
+librarian_local_index(
+  action="pull-docs",
+  library="react",
+  sources=[
+    "https://react.dev/reference/react",
+    "https://react.dev/learn/state-a-components lifecycle",
+    "https://react.dev/reference/react-dom"
+  ]
+)
+\`\`\`
+
+---
+
+## PHASE 3: EVIDENCE SYNTHESIS
+
+### Local Results Priority
+When results come from local index, prioritize them:
+1. Check frontmatter for relevance (tags, contentType)
+2. Use cached content directly (no web verification needed)
+3. Reference local file path for reproducibility
+
+### External Results
+For external sources, follow original LIBRARIAN citation format:
+\`\`\`markdown
+**Claim**: [What you're asserting]
+
+**Evidence** ([source](https://github.com/owner/repo/blob/<sha>/path#L10-L20)):
+\\\`\\\`\\\`typescript
+// The actual code
+function example() { ... }
+\\\`\\\`\\\`
+
+**Explanation**: This works because [specific reason from the code].
+\`\`\`
+
+---
+
+## TAG-BASED QUERY EXAMPLES
+
+### Finding API Documentation
+\`\`\`
+librarian_local_index(
+  action="query-tags",
+  tags=["api", "authentication"],
+  operator="AND"
+)
+\`\`\`
+
+### Finding Tutorials
+\`\`\`
+librarian_local_index(
+  action="query-tags",
+  tags=["tutorial", "beginner", "react"]
+)
+\`\`\`
+
+### Finding Examples
+\`\`\`
+librarian_local_index(
+  action="query-tags",
+  tags=["example", "typescript", "hooks"]
+)
+\`\`\`
+
+---
+
+## FRONTMATTER SCHEMA
+
+All cached docs use YAML frontmatter:
+
+\`\`\`yaml
+---
+title: "Component Title"
+description: "Brief description"
+tags: ["tag1", "tag2", "tag3"]
+library: "library-name"
+version: "1.0.0"
+source: "https://original-url.com"
+contentType: "api" | "guide" | "example" | "reference" | "tutorial"
+difficulty: "beginner" | "intermediate" | "advanced"
+related: ["path/to/related-doc.md"]
+lastUpdated: "2025-01-13T15:00:00Z"
+---
+\`\`\`
+
+---
+
+## FAILURE RECOVERY
+
+| Failure | Recovery |
+|---------|-----------|
+| Local index empty | Pull from external, then cache locally |
+| No tag matches | Try text search, then external |
+| External rate limit | Use local cache if available |
+| All searches fail | State uncertainty, suggest manual documentation review |
+
+---
+
+## COMMUNICATION RULES
+
+1. **ALWAYS CHECK LOCAL FIRST**: Never skip local index check
+2. **CACHE USEFUL FINDINGS**: Always add valuable external docs to local index
+3. **USE TAGS**: Leverage semantic tags for better queries
+4. **NO REDUNDANT SEARCHES**: If local has good results, don't search externally
+5. **INDICATE SOURCE**: Clearly label if info is from local cache or external
+
+Remember: Your goal is to minimize external searches and maximize use of the local, machine-readable index!
+`,
+  }
+}
+
+export const enhancedLibrarianAgent = createEnhancedLibrarianAgent()

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -2,6 +2,7 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import { sisyphusAgent } from "./sisyphus"
 import { oracleAgent } from "./oracle"
 import { librarianAgent } from "./librarian"
+import { enhancedLibrarianAgent } from "./enhanced-librarian"
 import { exploreAgent } from "./explore"
 import { frontendUiUxEngineerAgent } from "./frontend-ui-ux-engineer"
 import { documentWriterAgent } from "./document-writer"
@@ -14,6 +15,7 @@ export const builtinAgents: Record<string, AgentConfig> = {
   Sisyphus: sisyphusAgent,
   oracle: oracleAgent,
   librarian: librarianAgent,
+  "enhanced-librarian": enhancedLibrarianAgent,
   explore: exploreAgent,
   "frontend-ui-ux-engineer": frontendUiUxEngineerAgent,
   "document-writer": documentWriterAgent,

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -60,6 +60,7 @@ export type BuiltinAgentName =
   | "Sisyphus"
   | "oracle"
   | "librarian"
+  | "enhanced-librarian"
   | "explore"
   | "frontend-ui-ux-engineer"
   | "document-writer"

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -40,6 +40,21 @@ const agentSources: Record<BuiltinAgentName, AgentSource> = {
 const agentMetadata: Partial<Record<BuiltinAgentName, AgentPromptMetadata>> = {
   oracle: ORACLE_PROMPT_METADATA,
   librarian: LIBRARIAN_PROMPT_METADATA,
+  "enhanced-librarian": {
+    category: "utility",
+    cost: "CHEAP",
+    promptAlias: "Enhanced Librarian",
+    keyTrigger: "Local library indexing or offline documentation queries",
+    triggers: [
+      { domain: "Enhanced Librarian", trigger: "Queries for local documentation index, offline library searches" },
+    ],
+    useWhen: [
+      "Search local documentation index",
+      "Query tagged documentation",
+      "Pull docs from URLs to local index",
+      "Build or manage local library index",
+    ],
+  },
   explore: EXPLORE_PROMPT_METADATA,
   "frontend-ui-ux-engineer": FRONTEND_PROMPT_METADATA,
   "document-writer": DOCUMENT_WRITER_PROMPT_METADATA,

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -4,6 +4,7 @@ import type { CategoriesConfig, CategoryConfig } from "../config/schema"
 import { createSisyphusAgent } from "./sisyphus"
 import { createOracleAgent, ORACLE_PROMPT_METADATA } from "./oracle"
 import { createLibrarianAgent, LIBRARIAN_PROMPT_METADATA } from "./librarian"
+import { enhancedLibrarianAgent } from "./enhanced-librarian"
 import { createExploreAgent, EXPLORE_PROMPT_METADATA } from "./explore"
 import { createFrontendUiUxEngineerAgent, FRONTEND_PROMPT_METADATA } from "./frontend-ui-ux-engineer"
 import { createDocumentWriterAgent, DOCUMENT_WRITER_PROMPT_METADATA } from "./document-writer"
@@ -22,6 +23,7 @@ const agentSources: Record<BuiltinAgentName, AgentSource> = {
   Sisyphus: createSisyphusAgent,
   oracle: createOracleAgent,
   librarian: createLibrarianAgent,
+  "enhanced-librarian": enhancedLibrarianAgent,
   explore: createExploreAgent,
   "frontend-ui-ux-engineer": createFrontendUiUxEngineerAgent,
   "document-writer": createDocumentWriterAgent,

--- a/src/features/librarian-local-index/constants.ts
+++ b/src/features/librarian-local-index/constants.ts
@@ -1,0 +1,12 @@
+export const LIBRARIAN_LOCAL_INDEX_DESCRIPTION = `Local library index for the librarian agent. Provides fast, offline access to documentation with tag-based querying and YAML frontmatter support.
+
+Actions:
+- search: Text search across all indexed documentation
+- query-tags: Find documents by tags (supports AND/OR operators)
+- add-doc: Add new documentation with YAML frontmatter
+- pull-docs: Pull documentation from web sources and save as local markdown
+- get-docs: Retrieve all documentation for a specific library
+- build-index: Rebuild the search and tag index
+- create-script: Create a standalone script for tag queries
+
+The local index avoids web searches and provides semantic tagging for better machine readability.`

--- a/src/features/librarian-local-index/content-extractor.ts
+++ b/src/features/librarian-local-index/content-extractor.ts
@@ -129,10 +129,11 @@ function extractTitle(html: string): string {
  * Extract meta description from HTML
  */
 function extractMetaDescription(html: string): string | null {
-  // Standard meta description
-  const descMatch = html.match(/<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["']/i)
+  // Standard meta description - handle both attribute orders
+  const descMatch = html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*name=["']description["']|<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["']/i)
   if (descMatch) {
-    return stripHtmlTags(descMatch[1]).trim()
+    const content = descMatch[1] || descMatch[2]
+    return stripHtmlTags(content).trim()
   }
 
   // OpenGraph description
@@ -263,15 +264,22 @@ function extractBySelector(html: string, selector: string): string | null {
  * Strip HTML tags from a string
  */
 function stripHtmlTags(html: string): string {
-  return html
+  let result = html
     .replace(/<[^>]+>/g, "")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&")
-    .replace(/&quot;/g, '"')
-    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(parseInt(code, 16)))
+
+  // Decode HTML entities (do it twice for double-encoded entities)
+  for (let i = 0; i < 2; i++) {
+    result = result
+      .replace(/&nbsp;/g, " ")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&")
+      .replace(/&quot;/g, '"')
+      .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+      .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(parseInt(code, 16)))
+  }
+
+  return result
 }
 
 /**
@@ -325,7 +333,7 @@ export function extractTagsFromUrl(url: string): string[] {
     else if (lowerHost.includes("typescript")) tags.push("typescript")
     else if (lowerHost.includes("python")) tags.push("python")
     else if (lowerHost.includes("rust")) tags.push("rust")
-    else if (lowerHost.includes("go") || lowerHost.includes("golang")) tags.push("go")
+    else if (hostname === 'golang.org' || hostname === 'go.dev' || hostname === 'pkg.go.dev' || hostname.endsWith('.golang.org')) tags.push("go")
 
     // Extract version if present in URL
     const versionMatch = lowerPath.match(/\/v?(\d+(?:\.\d+)?(?:\.\d+)?)\b/)

--- a/src/features/librarian-local-index/content-extractor.ts
+++ b/src/features/librarian-local-index/content-extractor.ts
@@ -1,0 +1,385 @@
+/**
+ * Content extractor for pulling main documentation content from HTML pages
+ */
+
+export interface ExtractedContent {
+  title: string
+  content: string
+  description?: string
+  keywords?: string[]
+}
+
+/**
+ * CSS selectors for finding main content (in priority order)
+ */
+const CONTENT_SELECTORS = [
+  "main",
+  "article",
+  "[role='main']",
+  ".main-content",
+  ".content",
+  ".docs-content",
+  ".documentation",
+  ".markdown-body",
+  "#content",
+  "#main",
+  ".post-content",
+  ".entry-content",
+] as const
+
+/**
+ * CSS selectors for elements to remove before extraction
+ */
+const REMOVE_SELECTORS = [
+  "nav",
+  "header",
+  "footer",
+  "aside",
+  ".sidebar",
+  ".navigation",
+  ".nav",
+  ".toc",
+  ".table-of-contents",
+  ".breadcrumb",
+  ".breadcrumbs",
+  ".pagination",
+  ".comments",
+  ".advertisement",
+  ".ads",
+  ".banner",
+  ".cookie-notice",
+  ".cookie-banner",
+  "script",
+  "style",
+  "noscript",
+  "iframe",
+  "[hidden]",
+  "[aria-hidden='true']",
+] as const
+
+/**
+ * Extract the main content from an HTML string
+ * Uses a regex-based approach that works in Bun without DOM APIs
+ */
+export function extractMainContent(html: string): ExtractedContent {
+  // Extract title
+  const title = extractTitle(html)
+
+  // Extract meta description
+  const description = extractMetaDescription(html)
+
+  // Extract keywords from meta tags
+  const keywords = extractKeywords(html)
+
+  // Remove unwanted elements first
+  let cleanedHtml = removeUnwantedElements(html)
+
+  // Try to find main content area
+  let content = findMainContent(cleanedHtml)
+
+  // If no main content found, use the body
+  if (!content) {
+    const bodyMatch = cleanedHtml.match(/<body[^>]*>([\s\S]*?)<\/body>/i)
+    content = bodyMatch ? bodyMatch[1] : cleanedHtml
+  }
+
+  return {
+    title,
+    content,
+    description: description || undefined,
+    keywords: keywords.length > 0 ? keywords : undefined,
+  }
+}
+
+/**
+ * Extract the title from HTML
+ */
+function extractTitle(html: string): string {
+  // Try h1 first (most specific to the page content)
+  const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i)
+  if (h1Match) {
+    return stripHtmlTags(h1Match[1]).trim()
+  }
+
+  // Fall back to title tag
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
+  if (titleMatch) {
+    // Remove site name suffix (common pattern: "Page Title | Site Name")
+    let title = stripHtmlTags(titleMatch[1]).trim()
+    const separators = [" | ", " - ", " :: ", " // ", " — "]
+    for (const sep of separators) {
+      if (title.includes(sep)) {
+        title = title.split(sep)[0].trim()
+        break
+      }
+    }
+    return title
+  }
+
+  // Try og:title meta tag
+  const ogTitleMatch = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["']/i)
+  if (ogTitleMatch) {
+    return stripHtmlTags(ogTitleMatch[1]).trim()
+  }
+
+  return "Untitled Document"
+}
+
+/**
+ * Extract meta description from HTML
+ */
+function extractMetaDescription(html: string): string | null {
+  // Standard meta description
+  const descMatch = html.match(/<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["']/i)
+  if (descMatch) {
+    return stripHtmlTags(descMatch[1]).trim()
+  }
+
+  // OpenGraph description
+  const ogDescMatch = html.match(/<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']+)["']/i)
+  if (ogDescMatch) {
+    return stripHtmlTags(ogDescMatch[1]).trim()
+  }
+
+  return null
+}
+
+/**
+ * Extract keywords from meta tags
+ */
+function extractKeywords(html: string): string[] {
+  const keywordsMatch = html.match(/<meta[^>]*name=["']keywords["'][^>]*content=["']([^"']+)["']/i)
+  if (keywordsMatch) {
+    return keywordsMatch[1]
+      .split(",")
+      .map(k => k.trim().toLowerCase())
+      .filter(k => k.length > 0)
+  }
+  return []
+}
+
+/**
+ * Remove unwanted elements from HTML
+ */
+function removeUnwantedElements(html: string): string {
+  let result = html
+
+  // Remove script tags and their content
+  result = result.replace(/<script[\s\S]*?<\/script>/gi, "")
+
+  // Remove style tags and their content
+  result = result.replace(/<style[\s\S]*?<\/style>/gi, "")
+
+  // Remove noscript tags
+  result = result.replace(/<noscript[\s\S]*?<\/noscript>/gi, "")
+
+  // Remove comments
+  result = result.replace(/<!--[\s\S]*?-->/g, "")
+
+  // Remove nav elements
+  result = result.replace(/<nav[\s\S]*?<\/nav>/gi, "")
+
+  // Remove header elements (but not h1-h6)
+  result = result.replace(/<header[\s\S]*?<\/header>/gi, "")
+
+  // Remove footer elements
+  result = result.replace(/<footer[\s\S]*?<\/footer>/gi, "")
+
+  // Remove aside elements
+  result = result.replace(/<aside[\s\S]*?<\/aside>/gi, "")
+
+  // Remove elements with sidebar-related classes
+  result = result.replace(/<[^>]*class=["'][^"']*(?:sidebar|navigation|nav|toc|breadcrumb|pagination)[^"']*["'][^>]*>[\s\S]*?<\/[^>]+>/gi, "")
+
+  return result
+}
+
+/**
+ * Find the main content area in HTML
+ */
+function findMainContent(html: string): string | null {
+  // Try each content selector
+  for (const selector of CONTENT_SELECTORS) {
+    const content = extractBySelector(html, selector)
+    if (content && content.trim().length > 100) {
+      return content
+    }
+  }
+
+  return null
+}
+
+/**
+ * Extract content by a CSS-like selector (simplified regex-based)
+ */
+function extractBySelector(html: string, selector: string): string | null {
+  let pattern: RegExp
+
+  if (selector.startsWith(".")) {
+    // Class selector
+    const className = selector.slice(1)
+    pattern = new RegExp(
+      `<([a-z][a-z0-9]*)[^>]*class=["'][^"']*\\b${escapeRegex(className)}\\b[^"']*["'][^>]*>([\\s\\S]*?)<\\/\\1>`,
+      "i"
+    )
+  } else if (selector.startsWith("#")) {
+    // ID selector
+    const id = selector.slice(1)
+    pattern = new RegExp(
+      `<([a-z][a-z0-9]*)[^>]*id=["']${escapeRegex(id)}["'][^>]*>([\\s\\S]*?)<\\/\\1>`,
+      "i"
+    )
+  } else if (selector.startsWith("[")) {
+    // Attribute selector
+    const attrMatch = selector.match(/\[([^=]+)=['"]?([^'"\]]+)['"]?\]/)
+    if (attrMatch) {
+      const [, attr, value] = attrMatch
+      pattern = new RegExp(
+        `<([a-z][a-z0-9]*)[^>]*${escapeRegex(attr)}=["']${escapeRegex(value)}["'][^>]*>([\\s\\S]*?)<\\/\\1>`,
+        "i"
+      )
+    } else {
+      return null
+    }
+  } else {
+    // Tag selector
+    pattern = new RegExp(
+      `<${escapeRegex(selector)}[^>]*>([\\s\\S]*?)<\\/${escapeRegex(selector)}>`,
+      "i"
+    )
+  }
+
+  const match = html.match(pattern)
+  if (match) {
+    // For tag selectors, the content is in group 1
+    // For class/id selectors, the content is in group 2
+    return selector.match(/^[a-z]/) ? match[1] : match[2]
+  }
+
+  return null
+}
+
+/**
+ * Strip HTML tags from a string
+ */
+function stripHtmlTags(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCharCode(parseInt(code, 16)))
+}
+
+/**
+ * Escape special regex characters
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+/**
+ * Extract tags from URL path for documentation categorization
+ */
+export function extractTagsFromUrl(url: string): string[] {
+  const tags: string[] = []
+
+  try {
+    const urlObj = new URL(url)
+    const lowerPath = urlObj.pathname.toLowerCase()
+    const lowerHost = urlObj.hostname.toLowerCase()
+
+    // Common documentation patterns
+    const patterns: Array<{ pattern: RegExp; tag: string }> = [
+      { pattern: /\/api\b/i, tag: "api" },
+      { pattern: /\/reference\b/i, tag: "reference" },
+      { pattern: /\/guide/i, tag: "guide" },
+      { pattern: /\/tutorial/i, tag: "tutorial" },
+      { pattern: /\/example/i, tag: "example" },
+      { pattern: /\/doc(?:s|umentation)?\b/i, tag: "documentation" },
+      { pattern: /\/getting-started/i, tag: "getting-started" },
+      { pattern: /\/quick-?start/i, tag: "quickstart" },
+      { pattern: /\/install/i, tag: "installation" },
+      { pattern: /\/config/i, tag: "configuration" },
+      { pattern: /\/hook/i, tag: "hooks" },
+      { pattern: /\/component/i, tag: "components" },
+      { pattern: /\/concept/i, tag: "concepts" },
+      { pattern: /\/learn/i, tag: "learning" },
+      { pattern: /\/blog/i, tag: "blog" },
+    ]
+
+    for (const { pattern, tag } of patterns) {
+      if (pattern.test(lowerPath)) {
+        tags.push(tag)
+      }
+    }
+
+    // Extract library/framework name from common doc hosts
+    if (lowerHost.includes("react")) tags.push("react")
+    else if (lowerHost.includes("vue")) tags.push("vue")
+    else if (lowerHost.includes("angular")) tags.push("angular")
+    else if (lowerHost.includes("nodejs") || lowerHost.includes("node.js")) tags.push("nodejs")
+    else if (lowerHost.includes("typescript")) tags.push("typescript")
+    else if (lowerHost.includes("python")) tags.push("python")
+    else if (lowerHost.includes("rust")) tags.push("rust")
+    else if (lowerHost.includes("go") || lowerHost.includes("golang")) tags.push("go")
+
+    // Extract version if present in URL
+    const versionMatch = lowerPath.match(/\/v?(\d+(?:\.\d+)?(?:\.\d+)?)\b/)
+    if (versionMatch) {
+      tags.push(`v${versionMatch[1]}`)
+    }
+
+  } catch {
+    // Invalid URL, return empty tags
+  }
+
+  return [...new Set(tags)] // Deduplicate
+}
+
+/**
+ * Infer content type from URL and content
+ */
+export function inferContentType(
+  url: string,
+  content: string
+): "api" | "guide" | "example" | "reference" | "tutorial" {
+  try {
+    const urlObj = new URL(url)
+    const lowerPath = urlObj.pathname.toLowerCase()
+    const lowerContent = content.toLowerCase().substring(0, 2000)
+
+    // Check URL path patterns (not hostname)
+    if (lowerPath.includes("/api") || lowerPath.includes("/reference")) {
+      return "api"
+    }
+    if (lowerPath.includes("/tutorial") || lowerPath.includes("/learn")) {
+      return "tutorial"
+    }
+    if (lowerPath.includes("/guide") || lowerPath.includes("/getting-started")) {
+      return "guide"
+    }
+    if (lowerPath.includes("/example") || lowerPath.includes("/sample")) {
+      return "example"
+    }
+
+    // Check content patterns
+    if (lowerContent.includes("step 1") || lowerContent.includes("step-by-step")) {
+      return "tutorial"
+    }
+    // Only match "example" in content if it appears as a standalone word, not in domain
+    if (/\bexamples?\b/.test(lowerContent) && lowerContent.includes("```")) {
+      return "example"
+    }
+    if (lowerContent.includes("function") || lowerContent.includes("method") || lowerContent.includes("parameter")) {
+      return "api"
+    }
+  } catch {
+    // Invalid URL, fall through to default
+  }
+
+  return "reference"
+}

--- a/src/features/librarian-local-index/html-converter.ts
+++ b/src/features/librarian-local-index/html-converter.ts
@@ -1,0 +1,202 @@
+import TurndownService from "turndown"
+
+/**
+ * HTML to Markdown converter with custom rules for documentation
+ */
+export class HtmlToMarkdownConverter {
+  private turndown: TurndownService
+
+  constructor() {
+    this.turndown = new TurndownService({
+      headingStyle: "atx",
+      codeBlockStyle: "fenced",
+      bulletListMarker: "-",
+      emDelimiter: "_",
+      strongDelimiter: "**",
+    })
+
+    this.addCustomRules()
+  }
+
+  private addCustomRules(): void {
+    // Preserve code language hints from pre > code blocks
+    this.turndown.addRule("codeBlock", {
+      filter: (node): boolean =>
+        node.nodeName === "PRE" &&
+        node.querySelector("code") !== null,
+      replacement: (_content, node): string => {
+        const codeElement = (node as HTMLElement).querySelector("code")
+        if (!codeElement) return ""
+
+        // Extract language from class (e.g., "language-typescript", "hljs language-js")
+        const classNames = codeElement.className || ""
+        const langMatch = classNames.match(/(?:language-|lang-)(\w+)/)
+        const lang = langMatch?.[1] || ""
+
+        const codeText = codeElement.textContent || ""
+        return `\n\`\`\`${lang}\n${codeText.trim()}\n\`\`\`\n`
+      },
+    })
+
+    // Handle inline code
+    this.turndown.addRule("inlineCode", {
+      filter: (node): boolean =>
+        node.nodeName === "CODE" &&
+        node.parentNode?.nodeName !== "PRE",
+      replacement: (content): string => {
+        if (!content.trim()) return ""
+        // Escape backticks within inline code
+        if (content.includes("`")) {
+          return `\`\` ${content} \`\``
+        }
+        return `\`${content}\``
+      },
+    })
+
+    // Handle definition lists (often used in API docs)
+    this.turndown.addRule("definitionList", {
+      filter: (node): boolean => node.nodeName === "DL",
+      replacement: (_content, node): string => {
+        const dl = node as HTMLElement
+        const items: string[] = []
+        let currentTerm = ""
+
+        for (const child of Array.from(dl.children)) {
+          if (child.nodeName === "DT") {
+            currentTerm = child.textContent?.trim() || ""
+          } else if (child.nodeName === "DD") {
+            const definition = child.textContent?.trim() || ""
+            items.push(`**${currentTerm}**: ${definition}`)
+          }
+        }
+
+        return items.length > 0 ? "\n" + items.join("\n\n") + "\n" : ""
+      },
+    })
+
+    // Handle callouts/admonitions (common in documentation)
+    this.turndown.addRule("callout", {
+      filter: (node): boolean => {
+        if (node.nodeName !== "DIV" && node.nodeName !== "ASIDE") return false
+        const className = (node as HTMLElement).className || ""
+        return /(?:note|warning|tip|info|caution|danger|admonition|callout)/i.test(className)
+      },
+      replacement: (content, node): string => {
+        const className = (node as HTMLElement).className || ""
+        let type = "Note"
+        if (/warning|caution/i.test(className)) type = "Warning"
+        else if (/tip|hint/i.test(className)) type = "Tip"
+        else if (/danger|error/i.test(className)) type = "Danger"
+        else if (/info/i.test(className)) type = "Info"
+
+        const trimmedContent = content.trim()
+        return `\n> **${type}:** ${trimmedContent}\n`
+      },
+    })
+
+    // Handle tables better (ensure proper markdown table format)
+    this.turndown.addRule("tableCell", {
+      filter: ["th", "td"],
+      replacement: (content): string => {
+        return ` ${content.replace(/\n/g, " ").trim()} |`
+      },
+    })
+
+    this.turndown.addRule("tableRow", {
+      filter: "tr",
+      replacement: (content, node): string => {
+        const row = "|" + content
+        const parent = node.parentNode
+
+        // Add separator after header row
+        if (parent?.nodeName === "THEAD") {
+          const cellCount = (node as HTMLElement).children.length
+          const separator = "\n|" + " --- |".repeat(cellCount)
+          return row + separator + "\n"
+        }
+
+        return row + "\n"
+      },
+    })
+
+    // Remove empty links
+    this.turndown.addRule("emptyLink", {
+      filter: (node): boolean =>
+        node.nodeName === "A" &&
+        !node.textContent?.trim(),
+      replacement: (): string => "",
+    })
+  }
+
+  /**
+   * Convert HTML to Markdown
+   */
+  convert(html: string): string {
+    if (!html || !html.trim()) {
+      return ""
+    }
+
+    try {
+      const markdown = this.turndown.turndown(html)
+      return this.postProcess(markdown)
+    } catch (error) {
+      // If conversion fails, return a basic text extraction
+      return this.fallbackTextExtraction(html)
+    }
+  }
+
+  /**
+   * Post-process the markdown to clean up common issues
+   */
+  private postProcess(markdown: string): string {
+    return markdown
+      // Remove excessive blank lines (more than 2)
+      .replace(/\n{3,}/g, "\n\n")
+      // Clean up spaces before punctuation
+      .replace(/ +([.,;:!?])/g, "$1")
+      // Ensure proper spacing around headers
+      .replace(/([^\n])\n(#{1,6} )/g, "$1\n\n$2")
+      // Remove trailing whitespace from lines
+      .replace(/ +$/gm, "")
+      // Ensure file ends with single newline
+      .trim() + "\n"
+  }
+
+  /**
+   * Fallback text extraction when turndown fails
+   */
+  private fallbackTextExtraction(html: string): string {
+    return html
+      // Remove script and style elements
+      .replace(/<script[\s\S]*?<\/script>/gi, "")
+      .replace(/<style[\s\S]*?<\/style>/gi, "")
+      // Convert common HTML elements
+      .replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gi, "\n## $1\n")
+      .replace(/<p[^>]*>(.*?)<\/p>/gi, "\n$1\n")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<li[^>]*>(.*?)<\/li>/gi, "- $1\n")
+      // Remove remaining HTML tags
+      .replace(/<[^>]+>/g, "")
+      // Decode common HTML entities
+      .replace(/&nbsp;/g, " ")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&")
+      .replace(/&quot;/g, '"')
+      // Clean up whitespace
+      .replace(/\n{3,}/g, "\n\n")
+      .trim() + "\n"
+  }
+}
+
+/**
+ * Create a singleton converter instance
+ */
+let converterInstance: HtmlToMarkdownConverter | null = null
+
+export function getHtmlConverter(): HtmlToMarkdownConverter {
+  if (!converterInstance) {
+    converterInstance = new HtmlToMarkdownConverter()
+  }
+  return converterInstance
+}

--- a/src/features/librarian-local-index/index.ts
+++ b/src/features/librarian-local-index/index.ts
@@ -1,0 +1,6 @@
+export * from "./indexer"
+export * from "./tools"
+export * from "./types"
+export * from "./constants"
+export * from "./html-converter"
+export * from "./content-extractor"

--- a/src/features/librarian-local-index/indexer.test.ts
+++ b/src/features/librarian-local-index/indexer.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { existsSync, mkdirSync, rmSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { LibraryIndexer, type DocFrontmatter } from "./indexer"
+
+describe("LibraryIndexer", () => {
+  const TEST_DIR = join(tmpdir(), "librarian-local-index-test-" + Date.now())
+  const LIBRARY_DIR = join(TEST_DIR, "library")
+  let indexer: LibraryIndexer
+
+  beforeEach(() => {
+    if (!existsSync(TEST_DIR)) {
+      mkdirSync(TEST_DIR, { recursive: true })
+    }
+    indexer = new LibraryIndexer({ libraryPath: LIBRARY_DIR })
+  })
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+  })
+
+  describe("buildIndex", () => {
+    test("should create empty index when no docs exist", async () => {
+      // #given - empty library directory
+      // #when
+      const index = await indexer.buildIndex()
+
+      // #then
+      expect(Object.keys(index.libraries)).toHaveLength(0)
+      expect(Object.keys(index.tags)).toHaveLength(0)
+      expect(index.lastBuilt).toBeDefined()
+    })
+
+    test("should create library directories on first build", async () => {
+      // #given - no library directory exists
+      // #when
+      await indexer.buildIndex()
+
+      // #then
+      expect(existsSync(LIBRARY_DIR)).toBe(true)
+      expect(existsSync(join(LIBRARY_DIR, "docs"))).toBe(true)
+      expect(existsSync(join(LIBRARY_DIR, "patterns"))).toBe(true)
+      expect(existsSync(join(LIBRARY_DIR, "scripts"))).toBe(true)
+    })
+  })
+
+  describe("addLibraryDoc", () => {
+    test("should add document with correct frontmatter", async () => {
+      // #given - document content and frontmatter
+      const content = "# useEffect Hook\n\nThe useEffect hook is used for side effects."
+      const frontmatter: Partial<DocFrontmatter> = {
+        title: "useEffect Hook",
+        tags: ["hooks", "effects", "react"],
+        contentType: "api",
+        difficulty: "intermediate",
+      }
+
+      // #when
+      await indexer.addLibraryDoc("react", content, frontmatter, "useEffect.md")
+
+      // #then
+      const docs = await indexer.getLibraryDocs("react")
+      expect(docs).toHaveLength(1)
+      expect(docs[0].frontmatter.title).toBe("useEffect Hook")
+      expect(docs[0].frontmatter.tags).toContain("hooks")
+      expect(docs[0].frontmatter.tags).toContain("effects")
+      expect(docs[0].frontmatter.library).toBe("react")
+      expect(docs[0].frontmatter.contentType).toBe("api")
+    })
+
+    test("should create library directory if it does not exist", async () => {
+      // #given - no library directory
+      const content = "# Test Doc"
+      const frontmatter: Partial<DocFrontmatter> = {
+        title: "Test",
+        tags: ["test"],
+        contentType: "reference",
+      }
+
+      // #when
+      await indexer.addLibraryDoc("new-library", content, frontmatter)
+
+      // #then
+      expect(existsSync(join(LIBRARY_DIR, "docs", "new-library"))).toBe(true)
+    })
+
+    test("should include lastUpdated timestamp", async () => {
+      // #given
+      const content = "# Test"
+      const frontmatter: Partial<DocFrontmatter> = {
+        title: "Test",
+        tags: [],
+        contentType: "reference",
+      }
+
+      // #when
+      await indexer.addLibraryDoc("test-lib", content, frontmatter)
+      const docs = await indexer.getLibraryDocs("test-lib")
+
+      // #then
+      expect(docs[0].frontmatter.lastUpdated).toBeDefined()
+      // Should be a valid ISO date string
+      expect(new Date(docs[0].frontmatter.lastUpdated).toISOString()).toBe(
+        docs[0].frontmatter.lastUpdated
+      )
+    })
+  })
+
+  describe("search", () => {
+    test("should return empty results for empty index", async () => {
+      // #given - empty library
+      await indexer.buildIndex()
+
+      // #when
+      const results = await indexer.search("react hooks")
+
+      // #then
+      expect(results.totalCount).toBe(0)
+      expect(results.results).toHaveLength(0)
+    })
+
+    test("should find documents by content", async () => {
+      // #given - indexed document
+      await indexer.addLibraryDoc(
+        "react",
+        "# useState\n\nThe useState hook is used for state management in React components.",
+        {
+          title: "useState Hook",
+          tags: ["hooks", "state"],
+          contentType: "api",
+        }
+      )
+
+      // #when
+      const results = await indexer.search("state management")
+
+      // #then
+      expect(results.totalCount).toBeGreaterThan(0)
+      expect(results.results[0].library).toBe("react")
+    })
+
+    test("should return relevance scores", async () => {
+      // #given - indexed document
+      await indexer.addLibraryDoc(
+        "react",
+        "# Hooks\n\nReact hooks allow state and effects in functional components.",
+        {
+          title: "React Hooks",
+          tags: ["hooks"],
+          contentType: "guide",
+        }
+      )
+
+      // #when
+      const results = await indexer.search("hooks state effects")
+
+      // #then
+      expect(results.totalCount).toBeGreaterThan(0)
+      expect(results.results[0].relevance).toBeGreaterThan(0)
+      expect(results.results[0].relevance).toBeLessThanOrEqual(1)
+    })
+  })
+
+  describe("queryByTags", () => {
+    beforeEach(async () => {
+      // Add some test documents
+      await indexer.addLibraryDoc(
+        "react",
+        "# useEffect",
+        {
+          title: "useEffect",
+          tags: ["hooks", "effects", "api"],
+          contentType: "api",
+        },
+        "useEffect.md"
+      )
+      await indexer.addLibraryDoc(
+        "react",
+        "# useState",
+        {
+          title: "useState",
+          tags: ["hooks", "state", "api"],
+          contentType: "api",
+        },
+        "useState.md"
+      )
+      await indexer.addLibraryDoc(
+        "vue",
+        "# Composition API",
+        {
+          title: "Composition API",
+          tags: ["api", "composition"],
+          contentType: "guide",
+        },
+        "composition-api.md"
+      )
+    })
+
+    test("should find documents with matching tags using OR", async () => {
+      // #when
+      const results = await indexer.queryByTags(["hooks", "composition"], "OR")
+
+      // #then
+      expect(results.totalCount).toBe(3)
+      // All three docs have either 'hooks' or 'composition' tag
+    })
+
+    test("should find documents with all tags using AND", async () => {
+      // #when
+      const results = await indexer.queryByTags(["hooks", "api"], "AND")
+
+      // #then
+      expect(results.totalCount).toBe(2)
+      // Only useEffect and useState have both 'hooks' AND 'api' tags
+    })
+
+    test("should return empty results for non-existent tags", async () => {
+      // #when
+      const results = await indexer.queryByTags(["nonexistent-tag"])
+
+      // #then
+      expect(results.totalCount).toBe(0)
+    })
+
+    test("should include frontmatter in results", async () => {
+      // #when
+      const results = await indexer.queryByTags(["hooks"])
+
+      // #then
+      expect(results.results[0].frontmatter).toBeDefined()
+      expect(results.results[0].frontmatter.title).toBeDefined()
+      expect(results.results[0].frontmatter.tags).toBeDefined()
+    })
+  })
+
+  describe("getLibraryDocs", () => {
+    test("should return empty array for non-existent library", async () => {
+      // #when
+      const docs = await indexer.getLibraryDocs("nonexistent")
+
+      // #then
+      expect(docs).toHaveLength(0)
+    })
+
+    test("should return all docs for a library", async () => {
+      // #given
+      await indexer.addLibraryDoc("mylib", "# Doc 1", {
+        title: "Doc 1",
+        tags: ["a"],
+        contentType: "guide",
+      }, "doc1.md")
+      await indexer.addLibraryDoc("mylib", "# Doc 2", {
+        title: "Doc 2",
+        tags: ["b"],
+        contentType: "api",
+      }, "doc2.md")
+
+      // #when
+      const docs = await indexer.getLibraryDocs("mylib")
+
+      // #then
+      expect(docs).toHaveLength(2)
+    })
+  })
+
+  describe("createTagQueryScript", () => {
+    test("should create query script file", async () => {
+      // #given - library initialized
+      await indexer.buildIndex()
+
+      // #when
+      await indexer.createTagQueryScript()
+
+      // #then
+      const scriptPath = join(LIBRARY_DIR, "scripts", "query-by-tags.js")
+      expect(existsSync(scriptPath)).toBe(true)
+
+      const content = readFileSync(scriptPath, "utf-8")
+      expect(content).toContain("#!/usr/bin/env node")
+      expect(content).toContain("queryByTags")
+    })
+  })
+})
+
+describe("HtmlToMarkdownConverter", () => {
+  const { HtmlToMarkdownConverter } = require("./html-converter")
+  let converter: InstanceType<typeof HtmlToMarkdownConverter>
+
+  beforeEach(() => {
+    converter = new HtmlToMarkdownConverter()
+  })
+
+  test("should convert basic HTML to markdown", () => {
+    // #given
+    const html = "<h1>Title</h1><p>Paragraph text</p>"
+
+    // #when
+    const markdown = converter.convert(html)
+
+    // #then
+    expect(markdown).toContain("# Title")
+    expect(markdown).toContain("Paragraph text")
+  })
+
+  test("should convert code blocks with language hints", () => {
+    // #given
+    const html = '<pre><code class="language-typescript">const x = 1;</code></pre>'
+
+    // #when
+    const markdown = converter.convert(html)
+
+    // #then
+    expect(markdown).toContain("```typescript")
+    expect(markdown).toContain("const x = 1;")
+    expect(markdown).toContain("```")
+  })
+
+  test("should handle empty input", () => {
+    // #when
+    const markdown = converter.convert("")
+
+    // #then
+    expect(markdown).toBe("")
+  })
+})
+
+describe("ContentExtractor", () => {
+  const { extractMainContent, extractTagsFromUrl, inferContentType } = require("./content-extractor")
+
+  describe("extractMainContent", () => {
+    test("should extract title from h1", () => {
+      // #given
+      const html = "<html><body><h1>My Title</h1><p>Content</p></body></html>"
+
+      // #when
+      const result = extractMainContent(html)
+
+      // #then
+      expect(result.title).toBe("My Title")
+    })
+
+    test("should extract title from title tag as fallback", () => {
+      // #given
+      const html = "<html><head><title>Page Title | Site</title></head><body><p>Content</p></body></html>"
+
+      // #when
+      const result = extractMainContent(html)
+
+      // #then
+      expect(result.title).toBe("Page Title")
+    })
+
+    test("should extract meta description", () => {
+      // #given
+      const html = '<html><head><meta name="description" content="This is a description"></head><body></body></html>'
+
+      // #when
+      const result = extractMainContent(html)
+
+      // #then
+      expect(result.description).toBe("This is a description")
+    })
+  })
+
+  describe("extractTagsFromUrl", () => {
+    test("should extract api tag from URL", () => {
+      // #when
+      const tags = extractTagsFromUrl("https://react.dev/reference/react/api")
+
+      // #then
+      expect(tags).toContain("api")
+    })
+
+    test("should extract guide tag from URL", () => {
+      // #when
+      const tags = extractTagsFromUrl("https://example.com/docs/guide/getting-started")
+
+      // #then
+      expect(tags).toContain("guide")
+      expect(tags).toContain("getting-started")
+    })
+
+    test("should extract framework from host", () => {
+      // #when
+      const tags = extractTagsFromUrl("https://react.dev/learn/hooks")
+
+      // #then
+      expect(tags).toContain("react")
+    })
+  })
+
+  describe("inferContentType", () => {
+    test("should infer api type from URL", () => {
+      // #when
+      const type = inferContentType("https://example.com/api/reference", "")
+
+      // #then
+      expect(type).toBe("api")
+    })
+
+    test("should infer tutorial type from content", () => {
+      // #when
+      const type = inferContentType(
+        "https://docs.test.com/intro",
+        "Step 1: Install the package. Step 2: Configure..."
+      )
+
+      // #then
+      expect(type).toBe("tutorial")
+    })
+
+    test("should default to reference", () => {
+      // #when
+      const type = inferContentType("https://docs.test.com/random", "Some generic content")
+
+      // #then
+      expect(type).toBe("reference")
+    })
+  })
+})

--- a/src/features/librarian-local-index/indexer.ts
+++ b/src/features/librarian-local-index/indexer.ts
@@ -1,0 +1,906 @@
+import { readFile, writeFile, readdir, stat, mkdir } from "node:fs/promises"
+import { join, relative, dirname, sep } from "node:path"
+import { createHash } from "node:crypto"
+import { load as parseYAML, dump as stringifyYAML } from "js-yaml"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { log } from "../../shared/logger"
+import { getHtmlConverter } from "./html-converter"
+import { extractMainContent, extractTagsFromUrl, inferContentType } from "./content-extractor"
+
+export interface DocFrontmatter {
+  title: string
+  description?: string
+  tags: string[]
+  library: string
+  version?: string
+  source?: string
+  lastUpdated: string
+  contentType: "api" | "guide" | "example" | "reference" | "tutorial"
+  difficulty?: "beginner" | "intermediate" | "advanced"
+  related?: string[] // Related doc file paths
+}
+
+export interface LibraryManifest {
+  name: string
+  version?: string
+  source?: string
+  description?: string
+  lastUpdated: string
+  checksum: string
+  tags: string[]
+  apiEndpoints: string[]
+  concepts: string[]
+  docs: string[] // List of doc file paths
+}
+
+export interface LibraryEntry {
+  manifest: LibraryManifest
+  relativePath: string
+  contentHash: string
+}
+
+export interface TagIndex {
+  tag: string
+  files: string[] // File paths that have this tag
+  libraries: string[] // Library names that have this tag
+  count: number
+}
+
+export interface SearchIndex {
+  tokens: Record<string, string[]> // token -> list of file paths
+  libraries: Record<string, LibraryEntry> // library name -> entry
+  tags: Record<string, TagIndex> // tag -> index
+  lastBuilt: string
+}
+
+export interface LibraryIndexOptions {
+  libraryPath: string
+  maxIndexSize?: number // Maximum size of index in MB
+}
+
+export class LibraryIndexer {
+  private readonly libraryPath: string
+  private readonly indexPath: string
+  private readonly searchIndexPath: string
+  private readonly docsPath: string
+  private readonly patternsPath: string
+  private readonly scriptsPath: string
+  private readonly maxIndexSize: number
+
+  constructor(options: LibraryIndexOptions) {
+    this.libraryPath = options.libraryPath
+    this.indexPath = join(this.libraryPath, "index.json")
+    this.searchIndexPath = join(this.libraryPath, "search-index.json")
+    this.docsPath = join(this.libraryPath, "docs")
+    this.patternsPath = join(this.libraryPath, "patterns")
+    this.scriptsPath = join(this.libraryPath, "scripts")
+    this.maxIndexSize = (options.maxIndexSize ?? 50) * 1024 * 1024 // 50MB default
+  }
+
+  /**
+   * Build or update the library index
+   */
+  async buildIndex(): Promise<SearchIndex> {
+    log("[LibraryIndexer] Building library index...")
+    
+    // Ensure directories exist
+    await this.ensureDirectories()
+    
+    const index: SearchIndex = {
+      tokens: {},
+      libraries: {},
+      tags: {},
+      lastBuilt: new Date().toISOString()
+    }
+    
+    // Index documentation files
+    if (await this.pathExists(this.docsPath)) {
+      await this.indexDirectory(this.docsPath, index)
+    }
+    
+    // Index pattern files
+    if (await this.pathExists(this.patternsPath)) {
+      await this.indexDirectory(this.patternsPath, index)
+    }
+    
+    // Save the index
+    await writeFile(this.searchIndexPath, JSON.stringify(index, null, 2))
+    
+    log(`[LibraryIndexer] Index built with ${Object.keys(index.libraries).length} libraries and ${Object.keys(index.tags).length} tags`)
+    return index
+  }
+
+  /**
+   * Search the local index for a query
+   */
+  async search(query: string): Promise<{
+    results: Array<{
+      path: string
+      library: string
+      relevance: number
+      excerpt?: string
+      tags?: string[]
+    }>
+    totalCount: number
+  }> {
+    const index = await this.loadIndex()
+    if (!index) {
+      return { results: [], totalCount: 0 }
+    }
+    
+    const queryTokens = this.tokenize(query.toLowerCase())
+    const results: Array<{
+      path: string
+      library: string
+      relevance: number
+      excerpt?: string
+      tags?: string[]
+    }> = []
+    
+    // Score each matching file
+    const pathScores = new Map<string, number>()
+    const pathTags = new Map<string, string[]>()
+    
+    for (const token of queryTokens) {
+      const matchingPaths = index.tokens[token] || []
+      for (const path of matchingPaths) {
+        pathScores.set(path, (pathScores.get(path) || 0) + 1)
+      }
+    }
+    
+    // Convert scores to results with metadata
+    for (const [path, score] of pathScores.entries()) {
+      // Find which library this belongs to
+      let libraryName = "unknown"
+      let tags: string[] = []
+
+      // Normalize path separators for cross-platform compatibility
+      const normalizedPath = path.replace(/\\/g, "/")
+      for (const [libName, entry] of Object.entries(index.libraries)) {
+        const normalizedLibPath = entry.relativePath.replace(/\\/g, "/")
+        if (normalizedPath.startsWith(normalizedLibPath)) {
+          libraryName = libName
+          break
+        }
+      }
+      
+      // Extract tags from frontmatter
+      for (const tagIndex of Object.values(index.tags)) {
+        if (tagIndex.files.includes(path)) {
+          tags.push(tagIndex.tag)
+        }
+      }
+      
+      results.push({
+        path,
+        library: libraryName,
+        relevance: score / queryTokens.length,
+        tags
+      })
+    }
+    
+    // Sort by relevance
+    results.sort((a, b) => b.relevance - a.relevance)
+    
+    return {
+      results: results.slice(0, 20), // Top 20 results
+      totalCount: results.length
+    }
+  }
+
+  /**
+   * Query by tags - returns all documents with matching tags
+   */
+  async queryByTags(tags: string[], operator: "AND" | "OR" = "OR"): Promise<{
+    results: Array<{
+      path: string
+      library: string
+      frontmatter: DocFrontmatter
+      excerpt?: string
+    }>
+    totalCount: number
+  }> {
+    const index = await this.loadIndex()
+    if (!index) {
+      return { results: [], totalCount: 0 }
+    }
+    
+    const matchingFiles = new Set<string>()
+    const fileFrontmatter = new Map<string, DocFrontmatter>()
+    
+    for (const tag of tags) {
+      const tagIndex = index.tags[tag]
+      if (tagIndex) {
+        if (operator === "OR") {
+          // Add all files with this tag
+          for (const file of tagIndex.files) {
+            matchingFiles.add(file)
+          }
+        } else if (operator === "AND") {
+          // For AND, track files that have ALL tags
+          if (matchingFiles.size === 0) {
+            // First tag - add all its files
+            for (const file of tagIndex.files) {
+              matchingFiles.add(file)
+            }
+          } else {
+            // Intersect with existing files
+            const currentFiles = new Set(tagIndex.files)
+            for (const file of matchingFiles) {
+              if (!currentFiles.has(file)) {
+                matchingFiles.delete(file)
+              }
+            }
+          }
+        }
+      }
+    }
+    
+    // Load frontmatter for matching files
+    const results: Array<{
+      path: string
+      library: string
+      frontmatter: DocFrontmatter
+      excerpt?: string
+    }> = []
+    
+    for (const file of matchingFiles) {
+      // Normalize file path for cross-platform file system access
+      const normalizedFile = file.replace(/\//g, sep)
+      const frontmatter = await this.extractFrontmatter(join(this.libraryPath, normalizedFile))
+      if (frontmatter) {
+        fileFrontmatter.set(file, frontmatter)
+
+        // Find library name (compare with normalized paths)
+        let libraryName = "unknown"
+        const normalizedFilePath = file.replace(/\\/g, "/")
+        for (const [libName, entry] of Object.entries(index.libraries)) {
+          const normalizedLibPath = entry.relativePath.replace(/\\/g, "/")
+          if (normalizedFilePath.startsWith(normalizedLibPath)) {
+            libraryName = libName
+            break
+          }
+        }
+
+        results.push({
+          path: file,
+          library: libraryName,
+          frontmatter
+        })
+      }
+    }
+    
+    // Sort by relevance (more tags = higher relevance)
+    results.sort((a, b) => (b.frontmatter.tags?.length || 0) - (a.frontmatter.tags?.length || 0))
+    
+    return {
+      results: results.slice(0, 50),
+      totalCount: results.length
+    }
+  }
+
+  /**
+   * Add a library documentation as markdown with YAML frontmatter
+   */
+  async addLibraryDoc(
+    libraryName: string,
+    content: string,
+    frontmatter: Partial<DocFrontmatter>,
+    fileName?: string
+  ): Promise<void> {
+    const libraryDir = join(this.docsPath, libraryName)
+    await this.ensureDirectory(libraryDir)
+    
+    // Create full frontmatter
+    const fullFrontmatter: DocFrontmatter = {
+      title: frontmatter.title || `${libraryName} Documentation`,
+      tags: frontmatter.tags || [],
+      library: libraryName,
+      lastUpdated: new Date().toISOString(),
+      contentType: frontmatter.contentType || "reference",
+      ...frontmatter
+    }
+    
+    // Generate markdown with YAML frontmatter
+    const markdownContent = this.createMarkdownWithFrontmatter(content, fullFrontmatter)
+    
+    // Save as markdown file
+    const docFileName = fileName || `${libraryName}.md`
+    const docPath = join(libraryDir, docFileName)
+    await writeFile(docPath, markdownContent)
+    
+    // Update library manifest
+    await this.updateLibraryManifest(libraryName, docFileName, fullFrontmatter)
+    
+    // Rebuild index
+    await this.buildIndex()
+    
+    log(`[LibraryIndexer] Added library doc: ${libraryName}/${docFileName}`)
+  }
+
+  /**
+   * Pull documentation from web and save as local markdown
+   */
+  async pullDocumentation(
+    libraryName: string,
+    sourceUrls: string[],
+    options: {
+      extractMain?: boolean
+    } = {}
+  ): Promise<{
+    success: string[]
+    failed: Array<{ url: string; error: string }>
+  }> {
+    log(`[LibraryIndexer] Pulling documentation for ${libraryName}...`)
+
+    const libraryDir = join(this.docsPath, libraryName)
+    await this.ensureDirectory(libraryDir)
+
+    const results = {
+      success: [] as string[],
+      failed: [] as Array<{ url: string; error: string }>
+    }
+
+    const converter = getHtmlConverter()
+
+    for (const url of sourceUrls) {
+      try {
+        // Fetch HTML content from URL
+        const response = await fetch(url, {
+          headers: {
+            "User-Agent": "OpenCode-Librarian/1.0 (Documentation Indexer)",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          },
+        })
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+        }
+
+        const html = await response.text()
+
+        // Extract main content and metadata
+        const extracted = extractMainContent(html)
+
+        // Convert HTML to markdown
+        const markdown = converter.convert(extracted.content)
+
+        // Generate tags from URL and extracted keywords
+        const urlTags = extractTagsFromUrl(url)
+        const allTags = [...new Set([
+          ...urlTags,
+          ...(extracted.keywords || []),
+          libraryName.toLowerCase()
+        ])]
+
+        // Infer content type
+        const contentType = inferContentType(url, markdown)
+
+        // Build frontmatter
+        const frontmatter: Partial<DocFrontmatter> = {
+          title: extracted.title,
+          description: extracted.description,
+          source: url,
+          tags: allTags,
+          contentType,
+        }
+
+        // Generate filename and save
+        const fileName = this.generateFileNameFromUrl(url)
+        await this.addLibraryDoc(libraryName, markdown, frontmatter, fileName)
+
+        results.success.push(url)
+        log(`[LibraryIndexer] Successfully pulled: ${url}`)
+
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        results.failed.push({ url, error: errorMessage })
+        log(`[LibraryIndexer] Failed to pull ${url}: ${errorMessage}`)
+      }
+    }
+
+    log(`[LibraryIndexer] Pull complete: ${results.success.length} success, ${results.failed.length} failed`)
+    return results
+  }
+
+  /**
+   * Get cached documentation for a library
+   */
+  async getLibraryDocs(libraryName: string): Promise<Array<{
+    fileName: string
+    frontmatter: DocFrontmatter
+    content: string
+  }>> {
+    const libraryDir = join(this.docsPath, libraryName)
+    
+    if (!(await this.pathExists(libraryDir))) {
+      return []
+    }
+    
+    const docs: Array<{
+      fileName: string
+      frontmatter: DocFrontmatter
+      content: string
+    }> = []
+    
+    const entries = await readdir(libraryDir, { withFileTypes: true })
+    
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith(".md")) {
+        const filePath = join(libraryDir, entry.name)
+        const { frontmatter, content } = await this.parseMarkdownWithFrontmatter(filePath)
+        
+        if (frontmatter) {
+          docs.push({
+            fileName: entry.name,
+            frontmatter,
+            content
+          })
+        }
+      }
+    }
+    
+    return docs
+  }
+
+  /**
+   * Create a script for querying by tags
+   */
+  async createTagQueryScript(): Promise<void> {
+    const scriptContent = `#!/usr/bin/env node
+
+/**
+ * Library Tag Query Script
+ * Usage: node query-by-tags.js tag1,tag2 [--and] [--library libname]
+ */
+
+const fs = require('fs').promises;
+const path = require('path');
+
+async function queryByTags() {
+  const args = process.argv.slice(2);
+  let tags = [];
+  let operator = 'OR';
+  let libraryFilter = null;
+  
+  // Parse arguments
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--and') {
+      operator = 'AND';
+    } else if (arg === '--library' && i + 1 < args.length) {
+      libraryFilter = args[++i];
+    } else if (!arg.startsWith('--')) {
+      tags = arg.split(',').map(t => t.trim());
+    }
+  }
+  
+  if (tags.length === 0) {
+    console.error('Error: Please provide at least one tag');
+    process.exit(1);
+  }
+  
+  try {
+    // Load search index
+    const indexPath = path.join(__dirname, '..', 'search-index.json');
+    const indexData = await fs.readFile(indexPath, 'utf-8');
+    const index = JSON.parse(indexData);
+    
+    // Find matching files
+    const matchingFiles = new Set();
+    
+    for (const tag of tags) {
+      const tagIndex = index.tags[tag];
+      if (tagIndex) {
+        if (operator === 'OR') {
+          tagIndex.files.forEach(file => matchingFiles.add(file));
+        } else {
+          if (matchingFiles.size === 0) {
+            tagIndex.files.forEach(file => matchingFiles.add(file));
+          } else {
+            const current = new Set(tagIndex.files);
+            for (const file of matchingFiles) {
+              if (!current.has(file)) {
+                matchingFiles.delete(file);
+              }
+            }
+          }
+        }
+      }
+    }
+    
+    // Filter by library if specified
+    const results = [];
+    for (const file of matchingFiles) {
+      if (libraryFilter && !file.includes(\`docs/\${libraryFilter}/\`)) {
+        continue;
+      }
+      
+      // Load frontmatter
+      const filePath = path.join(__dirname, '..', file);
+      try {
+        const content = await fs.readFile(filePath, 'utf-8');
+        const frontmatterMatch = content.match(/^---\\n([\\s\\S]*?)\\n---/);
+        if (frontmatterMatch) {
+          const yaml = require('yaml');
+          const frontmatter = yaml.parse(frontmatterMatch[1]);
+          results.push({ file, frontmatter });
+        }
+      } catch (e) {
+        // Skip files that can't be read
+      }
+    }
+    
+    // Display results
+    console.log(\`Found \${results.length} documents with tags: \${tags.join(', ')} (\${operator})\\n\`);
+    
+    for (const result of results) {
+      console.log(\`📄 \${result.file}\`);
+      console.log(\`   Title: \${result.frontmatter.title}\`);
+      console.log(\`   Tags: \${result.frontmatter.tags.join(', ')}\`);
+      console.log(\`   Type: \${result.frontmatter.contentType}\`);
+      if (result.frontmatter.description) {
+        console.log(\`   Description: \${result.frontmatter.description}\`);
+      }
+      console.log('');
+    }
+    
+  } catch (error) {
+    console.error('Error querying tags:', error.message);
+    process.exit(1);
+  }
+}
+
+queryByTags();
+`
+    
+    const scriptPath = join(this.scriptsPath, "query-by-tags.js")
+    await writeFile(scriptPath, scriptContent)
+    
+    // Make it executable (on Unix systems)
+    // In a real implementation, you'd use chmod +x
+    
+    log(`[LibraryIndexer] Created tag query script: ${scriptPath}`)
+  }
+
+  /**
+   * Load the existing search index
+   */
+  private async loadIndex(): Promise<SearchIndex | null> {
+    try {
+      if (!(await this.pathExists(this.searchIndexPath))) {
+        return null
+      }
+      
+      const content = await readFile(this.searchIndexPath, "utf-8")
+      return JSON.parse(content) as SearchIndex
+    } catch (error) {
+      log("[LibraryIndexer] Error loading index:", error)
+      return null
+    }
+  }
+
+  /**
+   * Index a directory recursively
+   */
+  private async indexDirectory(dirPath: string, index: SearchIndex): Promise<void> {
+    const entries = await readdir(dirPath, { withFileTypes: true })
+    
+    for (const entry of entries) {
+      const fullPath = join(dirPath, entry.name)
+      const relativePath = relative(this.libraryPath, fullPath)
+      
+      if (entry.isDirectory()) {
+        await this.indexDirectory(fullPath, index)
+      } else if (entry.isFile() && this.shouldIndexFile(entry.name)) {
+        await this.indexFile(fullPath, relativePath, index)
+      }
+    }
+  }
+
+  /**
+   * Index a single file
+   */
+  private async indexFile(
+    filePath: string,
+    relativePath: string,
+    index: SearchIndex
+  ): Promise<void> {
+    // Normalize path separators for cross-platform compatibility
+    const normalizedRelativePath = relativePath.replace(/\\/g, "/")
+
+    try {
+      const content = await readFile(filePath, "utf-8")
+
+      // Extract frontmatter if it's a markdown file
+      let frontmatterTags: string[] = []
+      let libraryName = ""
+
+      if (normalizedRelativePath.endsWith(".md")) {
+        const { frontmatter } = await this.parseMarkdownWithFrontmatter(filePath)
+        if (frontmatter) {
+          frontmatterTags = frontmatter.tags || []
+          libraryName = frontmatter.library || ""
+          
+          // Update tag index
+          for (const tag of frontmatterTags) {
+            if (!index.tags[tag]) {
+              index.tags[tag] = {
+                tag,
+                files: [],
+                libraries: [],
+                count: 0
+              }
+            }
+
+            if (!index.tags[tag].files.includes(normalizedRelativePath)) {
+              index.tags[tag].files.push(normalizedRelativePath)
+              index.tags[tag].count++
+            }
+
+            if (libraryName && !index.tags[tag].libraries.includes(libraryName)) {
+              index.tags[tag].libraries.push(libraryName)
+            }
+          }
+
+          // Also track this library in the libraries index if not already present
+          if (libraryName && !index.libraries[libraryName]) {
+            // Extract library path from relative path (e.g., "docs/react/useEffect.md" -> "docs/react")
+            const libraryPath = normalizedRelativePath.substring(0, normalizedRelativePath.lastIndexOf("/"))
+            index.libraries[libraryName] = {
+              manifest: {
+                name: libraryName,
+                lastUpdated: new Date().toISOString(),
+                checksum: "",
+                tags: frontmatterTags,
+                apiEndpoints: [],
+                concepts: [],
+                docs: [normalizedRelativePath]
+              },
+              relativePath: libraryPath,
+              contentHash: ""
+            }
+          } else if (libraryName && index.libraries[libraryName]) {
+            // Add doc to existing library
+            if (!index.libraries[libraryName].manifest.docs.includes(normalizedRelativePath)) {
+              index.libraries[libraryName].manifest.docs.push(normalizedRelativePath)
+            }
+          }
+        }
+      }
+
+      // Tokenize content for full-text search
+      const tokens = this.tokenize(content.toLowerCase())
+
+      // Add tokens to index
+      for (const token of tokens) {
+        if (!index.tokens[token]) {
+          index.tokens[token] = []
+        }
+        if (!index.tokens[token].includes(normalizedRelativePath)) {
+          index.tokens[token].push(normalizedRelativePath)
+        }
+      }
+
+      // Check if this is a library manifest
+      if (normalizedRelativePath.endsWith("manifest.json")) {
+        try {
+          const manifest = JSON.parse(content) as LibraryManifest
+          index.libraries[manifest.name] = {
+            manifest,
+            relativePath: normalizedRelativePath.replace("/manifest.json", ""),
+            contentHash: createHash("sha256").update(content).digest("hex")
+          }
+        } catch {
+          // Ignore invalid JSON
+        }
+      }
+    } catch (error) {
+      log(`[LibraryIndexer] Error indexing file ${filePath}:`, error)
+    }
+  }
+
+  /**
+   * Parse markdown file and extract frontmatter
+   */
+  private async parseMarkdownWithFrontmatter(filePath: string): Promise<{
+    frontmatter: DocFrontmatter | null
+    content: string
+  }> {
+    try {
+      const fileContent = await readFile(filePath, "utf-8")
+
+      // Match frontmatter with flexible line endings (handles \r\n on Windows)
+      const frontmatterMatch = fileContent.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/)
+      if (!frontmatterMatch) {
+        return { frontmatter: null, content: fileContent }
+      }
+
+      const frontmatter = parseYAML(frontmatterMatch[1]) as DocFrontmatter
+      const content = frontmatterMatch[2] || ""
+
+      return { frontmatter, content }
+    } catch (error) {
+      return { frontmatter: null, content: "" }
+    }
+  }
+
+  /**
+   * Extract frontmatter from markdown content or file path
+   */
+  private async extractFrontmatter(contentOrPath: string): Promise<DocFrontmatter | null> {
+    try {
+      let content: string
+
+      // Check if it's a file path or content
+      if (contentOrPath.includes("\\") || contentOrPath.includes("/")) {
+        content = await readFile(contentOrPath, "utf-8")
+      } else {
+        content = contentOrPath
+      }
+
+      // Match frontmatter with flexible line endings
+      const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+      if (!frontmatterMatch) {
+        return null
+      }
+
+      const frontmatter = parseYAML(frontmatterMatch[1]) as DocFrontmatter
+      return frontmatter
+    } catch (error) {
+      return null
+    }
+  }
+
+  /**
+   * Create markdown with YAML frontmatter
+   */
+  private createMarkdownWithFrontmatter(content: string, frontmatter: DocFrontmatter): string {
+    const yamlFrontmatter = stringifyYAML(frontmatter)
+    return `---\n${yamlFrontmatter}\n---\n\n${content}`
+  }
+
+  /**
+   * Update library manifest
+   */
+  private async updateLibraryManifest(
+    libraryName: string,
+    docFileName: string,
+    frontmatter: DocFrontmatter
+  ): Promise<void> {
+    const manifestPath = join(this.docsPath, libraryName, "manifest.json")
+    
+    let manifest: LibraryManifest
+    try {
+      const existingContent = await readFile(manifestPath, "utf-8")
+      manifest = JSON.parse(existingContent) as LibraryManifest
+    } catch {
+      // Create new manifest
+      manifest = {
+        name: libraryName,
+        lastUpdated: new Date().toISOString(),
+        checksum: "",
+        tags: [],
+        apiEndpoints: [],
+        concepts: [],
+        docs: []
+      }
+    }
+    
+    // Update manifest
+    manifest.lastUpdated = new Date().toISOString()
+    manifest.docs.push(docFileName)
+    
+    // Merge tags
+    for (const tag of frontmatter.tags || []) {
+      if (!manifest.tags.includes(tag)) {
+        manifest.tags.push(tag)
+      }
+    }
+    
+    // Save manifest
+    await writeFile(manifestPath, JSON.stringify(manifest, null, 2))
+  }
+
+  /**
+   * Generate filename from URL
+   */
+  private generateFileNameFromUrl(url: string): string {
+    const urlObj = new URL(url)
+    let filename = urlObj.pathname.split("/").pop() || "doc"
+    
+    if (!filename.endsWith(".md")) {
+      filename += ".md"
+    }
+    
+    // Sanitize filename
+    return filename.replace(/[^a-zA-Z0-9\-_\.]/g, "_")
+  }
+
+  /**
+   * Tokenize text for search indexing
+   */
+  private tokenize(text: string): string[] {
+    // Extract words, camelCase parts, and special patterns
+    const tokens = new Set<string>()
+    
+    // Regular words
+    for (const word of text.match(/\b\w+\b/g) || []) {
+      tokens.add(word)
+    }
+    
+    // CamelCase parts (e.g., "useState" -> ["use", "state"])
+    for (const camelCase of text.match(/\b[a-z][a-zA-Z0-9]*[A-Z][a-zA-Z0-9]*\b/g) || []) {
+      const parts = camelCase.split(/(?=[A-Z])/)
+      for (const part of parts) {
+        if (part.length > 2) {
+          tokens.add(part.toLowerCase())
+        }
+      }
+    }
+    
+    // API patterns (e.g., "function()", "Class.method")
+    for (const api of text.match(/\b[a-zA-Z_][a-zA-Z0-9_]*\s*\([^)]*\)/g) || []) {
+      const name = api.split(/\s*\(/)[0]
+      if (name.length > 2) {
+        tokens.add(name)
+      }
+    }
+    
+    return Array.from(tokens)
+  }
+
+  /**
+   * Check if a file should be indexed
+   */
+  private shouldIndexFile(fileName: string): boolean {
+    const indexableExtensions = [".md", ".txt", ".json", ".js", ".ts", ".py", ".java", ".cpp", ".c"]
+    return indexableExtensions.some(ext => fileName.endsWith(ext))
+  }
+
+  /**
+   * Ensure directories exist
+   */
+  private async ensureDirectory(dirPath: string): Promise<void> {
+    try {
+      await stat(dirPath)
+    } catch {
+      // Directory doesn't exist, create it
+      await mkdir(dirPath, { recursive: true })
+      log(`[LibraryIndexer] Created directory: ${dirPath}`)
+    }
+  }
+
+  /**
+   * Ensure directories exist
+   */
+  private async ensureDirectories(): Promise<void> {
+    await this.ensureDirectory(this.libraryPath)
+    await this.ensureDirectory(this.docsPath)
+    await this.ensureDirectory(this.patternsPath)
+    await this.ensureDirectory(this.scriptsPath)
+  }
+
+  /**
+   * Check if a path exists
+   */
+  private async pathExists(path: string): Promise<boolean> {
+    try {
+      await stat(path)
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+
+/**
+ * Create a library indexer instance
+ */
+export function createLibraryIndexer(
+  ctx: PluginInput,
+  options?: Partial<LibraryIndexOptions>
+): LibraryIndexer {
+  const libraryPath = join(ctx.directory, "./library")
+  return new LibraryIndexer({ libraryPath, ...options })
+}

--- a/src/features/librarian-local-index/tools.ts
+++ b/src/features/librarian-local-index/tools.ts
@@ -44,6 +44,13 @@ function isPrivateIP(ip: string): boolean {
     if (lowerIp.startsWith('fc') || lowerIp.startsWith('fd')) return true;
     // fe80::/10 (link-local)
     if (lowerIp.startsWith('fe8') || lowerIp.startsWith('fe9') || lowerIp.startsWith('fea') || lowerIp.startsWith('feb')) return true;
+
+    // Handle IPv6-mapped IPv4 addresses (e.g., ::ffff:127.0.0.1)
+    const ipv6MappedMatch = lowerIp.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (ipv6MappedMatch) {
+      // Recursively check the embedded IPv4 address
+      return isPrivateIP(ipv6MappedMatch[1]);
+    }
   }
   return false;
 }
@@ -74,8 +81,8 @@ async function validateSources(sources: string[]): Promise<void> {
           }
         }
       } catch (dnsError) {
-        // If DNS lookup fails, hostname checks passed, so continue
-        // Could log warning here if needed
+        // DNS resolution failed - cannot verify IP is not private, reject for security
+        throw new Error(`Cannot verify IP addresses for ${hostname} (DNS error: ${dnsError instanceof Error ? dnsError.message : String(dnsError)})`);
       }
     } catch (error) {
       throw new Error(`Invalid source URL "${source}": ${error instanceof Error ? error.message : String(error)}`)

--- a/src/features/librarian-local-index/tools.ts
+++ b/src/features/librarian-local-index/tools.ts
@@ -1,0 +1,241 @@
+import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin"
+import { join } from "node:path"
+import { createLibraryIndexer } from "./indexer"
+import { LIBRARIAN_LOCAL_INDEX_DESCRIPTION } from "./constants"
+import type { LibrarianLocalIndexArgs } from "./types"
+import type { BackgroundManager } from "../../features/background-agent"
+import { log } from "../../shared/logger"
+
+export function createLibrarianLocalIndex(
+  ctx: PluginInput,
+  backgroundManager: BackgroundManager
+): ToolDefinition {
+  const indexer = createLibraryIndexer(ctx)
+
+  return tool({
+    description: LIBRARIAN_LOCAL_INDEX_DESCRIPTION,
+    args: {
+      action: tool.schema
+        .enum(["search", "query-tags", "add-doc", "pull-docs", "get-docs", "build-index", "create-script"])
+        .describe("Action to perform on the local library index"),
+      query: tool.schema.string().optional().describe("Search query for text search"),
+      tags: tool.schema.array(tool.schema.string()).optional().describe("Tags to query for (comma-separated)"),
+      operator: tool.schema.enum(["AND", "OR"]).optional().describe("Tag query operator (AND/OR)"),
+      library: tool.schema.string().optional().describe("Library name for add-doc, pull-docs, or get-docs actions"),
+      content: tool.schema.string().optional().describe("Content to add as documentation"),
+      frontmatter: tool.schema.string().optional().describe("JSON string of frontmatter metadata"),
+      sources: tool.schema.array(tool.schema.string()).optional().describe("Source URLs to pull documentation from"),
+      fileName: tool.schema.string().optional().describe("Custom filename for the documentation"),
+    },
+    async execute(args: LibrarianLocalIndexArgs, toolContext) {
+      log(`[LibrarianLocalIndex] Executing action: ${args.action}`)
+
+      try {
+        switch (args.action) {
+          case "search":
+            if (!args.query) {
+              return "❌ Error: 'query' parameter is required for search action"
+            }
+            return await executeSearch(indexer, args.query)
+
+          case "query-tags":
+            if (!args.tags || args.tags.length === 0) {
+              return "❌ Error: 'tags' parameter is required for query-tags action"
+            }
+            return await executeQueryByTags(indexer, args.tags, args.operator)
+
+          case "add-doc":
+            if (!args.library || !args.content) {
+              return "❌ Error: 'library' and 'content' parameters are required for add-doc action"
+            }
+            return await executeAddDoc(indexer, args.library, args.content, args.frontmatter, args.fileName)
+
+          case "pull-docs":
+            if (!args.library || !args.sources || args.sources.length === 0) {
+              return "❌ Error: 'library' and 'sources' parameters are required for pull-docs action"
+            }
+            return await executePullDocs(indexer, args.library, args.sources)
+
+          case "get-docs":
+            if (!args.library) {
+              return "❌ Error: 'library' parameter is required for get-docs action"
+            }
+            return await executeGetDocs(indexer, args.library)
+
+          case "build-index":
+            return await executeBuildIndex(indexer)
+
+          case "create-script":
+            return await executeCreateScript(indexer)
+
+          default:
+            return `❌ Error: Unknown action '${args.action}'`
+        }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        log(`[LibrarianLocalIndex] Error executing ${args.action}:`, errorMessage)
+        return `❌ Error: ${errorMessage}`
+      }
+    },
+  })
+}
+
+async function executeSearch(indexer: ReturnType<typeof createLibraryIndexer>, query: string): Promise<string> {
+  const results = await indexer.search(query)
+  
+  if (results.totalCount === 0) {
+    return `No results found for query: "${query}"`
+  }
+
+  let output = `Found ${results.totalCount} results for query: "${query}"\n\n`
+  
+  for (const result of results.results) {
+    output += `📄 ${result.path}\n`
+    output += `   Library: ${result.library}\n`
+    output += `   Relevance: ${(result.relevance * 100).toFixed(1)}%\n`
+    if (result.tags && result.tags.length > 0) {
+      output += `   Tags: ${result.tags.join(", ")}\n`
+    }
+    output += "\n"
+  }
+
+  return output
+}
+
+async function executeQueryByTags(
+  indexer: ReturnType<typeof createLibraryIndexer>,
+  tags: string[],
+  operator?: "AND" | "OR"
+): Promise<string> {
+  const results = await indexer.queryByTags(tags, operator)
+  
+  if (results.totalCount === 0) {
+    return `No documents found with tags: ${tags.join(", ")} (${operator || "OR"})`
+  }
+
+  let output = `Found ${results.totalCount} documents with tags: ${tags.join(", ")} (${operator || "OR"})\n\n`
+  
+  for (const result of results.results) {
+    output += `📄 ${result.path}\n`
+    output += `   Library: ${result.library}\n`
+    output += `   Title: ${result.frontmatter.title}\n`
+    output += `   Type: ${result.frontmatter.contentType}\n`
+    output += `   Tags: ${result.frontmatter.tags.join(", ")}\n`
+    if (result.frontmatter.description) {
+      output += `   Description: ${result.frontmatter.description}\n`
+    }
+    if (result.frontmatter.difficulty) {
+      output += `   Difficulty: ${result.frontmatter.difficulty}\n`
+    }
+    output += "\n"
+  }
+
+  return output
+}
+
+async function executeAddDoc(
+  indexer: ReturnType<typeof createLibraryIndexer>,
+  library: string,
+  content: string,
+  frontmatterJson?: string,
+  fileName?: string
+): Promise<string> {
+  let frontmatter
+  try {
+    frontmatter = frontmatterJson ? JSON.parse(frontmatterJson) : {}
+  } catch (error) {
+    return `❌ Error: Invalid JSON in frontmatter parameter`
+  }
+
+  await indexer.addLibraryDoc(library, content, frontmatter, fileName)
+  
+  return `✅ Successfully added documentation for library: ${library}`
+}
+
+async function executePullDocs(
+  indexer: ReturnType<typeof createLibraryIndexer>,
+  library: string,
+  sources: string[]
+): Promise<string> {
+  const results = await indexer.pullDocumentation(library, sources)
+
+  let output = ""
+
+  if (results.success.length > 0) {
+    output += `✅ Successfully pulled ${results.success.length} document(s) for library: ${library}\n\n`
+    output += "**Pulled URLs:**\n"
+    for (const url of results.success) {
+      output += `- ${url}\n`
+    }
+  }
+
+  if (results.failed.length > 0) {
+    if (output) output += "\n"
+    output += `❌ Failed to pull ${results.failed.length} document(s):\n`
+    for (const { url, error } of results.failed) {
+      output += `- ${url}: ${error}\n`
+    }
+  }
+
+  if (results.success.length === 0 && results.failed.length === 0) {
+    output = `No documents were pulled for library: ${library}`
+  }
+
+  return output.trim()
+}
+
+async function executeGetDocs(
+  indexer: ReturnType<typeof createLibraryIndexer>,
+  library: string
+): Promise<string> {
+  const docs = await indexer.getLibraryDocs(library)
+  
+  if (docs.length === 0) {
+    return `No documentation found for library: ${library}`
+  }
+
+  let output = `Found ${docs.length} documentation files for library: ${library}\n\n`
+  
+  for (const doc of docs) {
+    output += `📄 ${doc.fileName}\n`
+    output += `   Title: ${doc.frontmatter.title}\n`
+    output += `   Type: ${doc.frontmatter.contentType}\n`
+    output += `   Tags: ${doc.frontmatter.tags.join(", ")}\n`
+    if (doc.frontmatter.description) {
+      output += `   Description: ${doc.frontmatter.description}\n`
+    }
+    if (doc.frontmatter.source) {
+      output += `   Source: ${doc.frontmatter.source}\n`
+    }
+    output += `   Last Updated: ${doc.frontmatter.lastUpdated}\n`
+    output += "\n"
+    
+    // Include a preview of the content (first 200 characters)
+    const preview = doc.content.replace(/^---\n[\s\S]*?\n---\n\n/, "").substring(0, 200)
+    output += `   Preview: ${preview}${doc.content.length > 200 ? "..." : ""}\n\n`
+  }
+
+  return output
+}
+
+async function executeBuildIndex(indexer: ReturnType<typeof createLibraryIndexer>): Promise<string> {
+  const index = await indexer.buildIndex()
+  
+  return `✅ Successfully built library index:\n` +
+    `   Libraries: ${Object.keys(index.libraries).length}\n` +
+    `   Tags: ${Object.keys(index.tags).length}\n` +
+    `   Tokens: ${Object.keys(index.tokens).length}\n` +
+    `   Last Built: ${index.lastBuilt}`
+}
+
+async function executeCreateScript(indexer: ReturnType<typeof createLibraryIndexer>): Promise<string> {
+  await indexer.createTagQueryScript()
+  
+  return `✅ Created tag query script at ./library/scripts/query-by-tags.js\n\n` +
+    `Usage:\n` +
+    `  node ./library/scripts/query-by-tags.js tag1,tag2 [--and] [--library libname]\n\n` +
+    `Examples:\n` +
+    `  node ./library/scripts/query-by-tags.js api,react\n` +
+    `  node ./library/scripts/query-by-tags.js tutorial,beginner --and\n` +
+    `  node ./library/scripts/query-by-tags.js hooks --library react`
+}

--- a/src/features/librarian-local-index/tools.ts
+++ b/src/features/librarian-local-index/tools.ts
@@ -1,5 +1,6 @@
 import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin"
 import { join } from "node:path"
+import { lookup } from "node:dns/promises"
 import { createLibraryIndexer } from "./indexer"
 import { LIBRARIAN_LOCAL_INDEX_DESCRIPTION } from "./constants"
 import type { LibrarianLocalIndexArgs } from "./types"
@@ -16,17 +17,44 @@ function validateFileName(fileName: string): string {
   return fileName.replace(/[/\\]/g, '_').replace(/\.\./g, '').trim()
 }
 
-function validateSources(sources: string[]): void {
+function isPrivateIP(ip: string): boolean {
+  // IPv4 checks
+  if (ip.includes('.')) {
+    const parts = ip.split('.').map(Number);
+    if (parts.length === 4 && parts.every(p => p >= 0 && p <= 255)) {
+      const [a, b] = parts;
+      // 127.0.0.0/8 (loopback)
+      if (a === 127) return true;
+      // 192.168.0.0/16
+      if (a === 192 && b === 168) return true;
+      // 10.0.0.0/8
+      if (a === 10) return true;
+      // 172.16.0.0/12
+      if (a === 172 && b >= 16 && b <= 31) return true;
+      // 169.254.0.0/16 (link-local)
+      if (a === 169 && b === 254) return true;
+    }
+  }
+  // IPv6 checks
+  else if (ip.includes(':')) {
+    const lowerIp = ip.toLowerCase();
+    // ::1 (loopback)
+    if (lowerIp === '::1') return true;
+    // fc00::/7 (private)
+    if (lowerIp.startsWith('fc') || lowerIp.startsWith('fd')) return true;
+    // fe80::/10 (link-local)
+    if (lowerIp.startsWith('fe8') || lowerIp.startsWith('fe9') || lowerIp.startsWith('fea') || lowerIp.startsWith('feb')) return true;
+  }
+  return false;
+}
+
+async function validateSources(sources: string[]): Promise<void> {
   for (const source of sources) {
     try {
       const url = new URL(source)
       if (url.protocol !== 'http:' && url.protocol !== 'https:') {
         throw new Error(`Invalid protocol: ${url.protocol}`)
       }
-<<<<<<< Updated upstream
-      if (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname.startsWith('192.168.') || url.hostname.startsWith('10.')) {
-        throw new Error(`Local/private host not allowed: ${url.hostname}`)
-=======
       const hostname = url.hostname.toLowerCase();
       // Block localhost and private IPs
       if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' ||
@@ -35,7 +63,19 @@ function validateSources(sources: string[]): void {
           hostname.startsWith('fc') || hostname.startsWith('fd') || // IPv6 private
           hostname === 'metadata.google.internal' || hostname.endsWith('.internal')) {
         throw new Error(`Local/private host not allowed: ${hostname}`)
->>>>>>> Stashed changes
+      }
+
+      // Resolve hostname to IP addresses to check for SSRF
+      try {
+        const addresses = await lookup(hostname, { all: true });
+        for (const addr of addresses) {
+          if (isPrivateIP(addr.address)) {
+            throw new Error(`Resolved IP ${addr.address} is private/local (SSRF protection)`);
+          }
+        }
+      } catch (dnsError) {
+        // If DNS lookup fails, hostname checks passed, so continue
+        // Could log warning here if needed
       }
     } catch (error) {
       throw new Error(`Invalid source URL "${source}": ${error instanceof Error ? error.message : String(error)}`)
@@ -81,28 +121,31 @@ export function createLibrarianLocalIndex(
             }
             return await executeQueryByTags(indexer, args.tags, args.operator)
 
-          case "add-doc":
+          case "add-doc": {
             if (!args.library || !args.content) {
               return "❌ Error: 'library' and 'content' parameters are required for add-doc action"
             }
             const safeLibrary = validateLibraryName(args.library)
             const safeFileName = args.fileName ? validateFileName(args.fileName) : undefined
             return await executeAddDoc(indexer, safeLibrary, args.content, args.frontmatter, safeFileName)
+          }
 
-          case "pull-docs":
+          case "pull-docs": {
             if (!args.library || !args.sources || args.sources.length === 0) {
               return "❌ Error: 'library' and 'sources' parameters are required for pull-docs action"
             }
-            validateSources(args.sources)
+            await validateSources(args.sources)
             const safeLibrary = validateLibraryName(args.library)
             return await executePullDocs(indexer, safeLibrary, args.sources)
+          }
 
-          case "get-docs":
+          case "get-docs": {
             if (!args.library) {
               return "❌ Error: 'library' parameter is required for get-docs action"
             }
             const safeLibrary = validateLibraryName(args.library)
             return await executeGetDocs(indexer, safeLibrary)
+          }
 
           case "build-index":
             return await executeBuildIndex(indexer)

--- a/src/features/librarian-local-index/tools.ts
+++ b/src/features/librarian-local-index/tools.ts
@@ -23,8 +23,19 @@ function validateSources(sources: string[]): void {
       if (url.protocol !== 'http:' && url.protocol !== 'https:') {
         throw new Error(`Invalid protocol: ${url.protocol}`)
       }
+<<<<<<< Updated upstream
       if (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname.startsWith('192.168.') || url.hostname.startsWith('10.')) {
         throw new Error(`Local/private host not allowed: ${url.hostname}`)
+=======
+      const hostname = url.hostname.toLowerCase();
+      // Block localhost and private IPs
+      if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' ||
+          hostname.startsWith('192.168.') || hostname.startsWith('10.') ||
+          /^172\.(1[6-9]|2\d|3[01])\./.test(hostname) ||
+          hostname.startsWith('fc') || hostname.startsWith('fd') || // IPv6 private
+          hostname === 'metadata.google.internal' || hostname.endsWith('.internal')) {
+        throw new Error(`Local/private host not allowed: ${hostname}`)
+>>>>>>> Stashed changes
       }
     } catch (error) {
       throw new Error(`Invalid source URL "${source}": ${error instanceof Error ? error.message : String(error)}`)

--- a/src/features/librarian-local-index/tools.ts
+++ b/src/features/librarian-local-index/tools.ts
@@ -6,6 +6,32 @@ import type { LibrarianLocalIndexArgs } from "./types"
 import type { BackgroundManager } from "../../features/background-agent"
 import { log } from "../../shared/logger"
 
+function validateLibraryName(library: string): string {
+  // Sanitize library name to prevent path traversal
+  return library.replace(/[/\\]/g, '_').replace(/\.\./g, '').trim()
+}
+
+function validateFileName(fileName: string): string {
+  // Sanitize file name to prevent path traversal
+  return fileName.replace(/[/\\]/g, '_').replace(/\.\./g, '').trim()
+}
+
+function validateSources(sources: string[]): void {
+  for (const source of sources) {
+    try {
+      const url = new URL(source)
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new Error(`Invalid protocol: ${url.protocol}`)
+      }
+      if (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname.startsWith('192.168.') || url.hostname.startsWith('10.')) {
+        throw new Error(`Local/private host not allowed: ${url.hostname}`)
+      }
+    } catch (error) {
+      throw new Error(`Invalid source URL "${source}": ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+}
+
 export function createLibrarianLocalIndex(
   ctx: PluginInput,
   backgroundManager: BackgroundManager
@@ -48,19 +74,24 @@ export function createLibrarianLocalIndex(
             if (!args.library || !args.content) {
               return "❌ Error: 'library' and 'content' parameters are required for add-doc action"
             }
-            return await executeAddDoc(indexer, args.library, args.content, args.frontmatter, args.fileName)
+            const safeLibrary = validateLibraryName(args.library)
+            const safeFileName = args.fileName ? validateFileName(args.fileName) : undefined
+            return await executeAddDoc(indexer, safeLibrary, args.content, args.frontmatter, safeFileName)
 
           case "pull-docs":
             if (!args.library || !args.sources || args.sources.length === 0) {
               return "❌ Error: 'library' and 'sources' parameters are required for pull-docs action"
             }
-            return await executePullDocs(indexer, args.library, args.sources)
+            validateSources(args.sources)
+            const safeLibrary = validateLibraryName(args.library)
+            return await executePullDocs(indexer, safeLibrary, args.sources)
 
           case "get-docs":
             if (!args.library) {
               return "❌ Error: 'library' parameter is required for get-docs action"
             }
-            return await executeGetDocs(indexer, args.library)
+            const safeLibrary = validateLibraryName(args.library)
+            return await executeGetDocs(indexer, safeLibrary)
 
           case "build-index":
             return await executeBuildIndex(indexer)

--- a/src/features/librarian-local-index/types.ts
+++ b/src/features/librarian-local-index/types.ts
@@ -1,0 +1,11 @@
+export interface LibrarianLocalIndexArgs {
+  action: "search" | "query-tags" | "add-doc" | "pull-docs" | "get-docs" | "build-index" | "create-script"
+  query?: string
+  tags?: string[]
+  operator?: "AND" | "OR"
+  library?: string
+  content?: string
+  frontmatter?: string
+  sources?: string[]
+  fileName?: string
+}

--- a/src/features/local-library/index.ts
+++ b/src/features/local-library/index.ts
@@ -1,0 +1,227 @@
+/**
+ * @deprecated This module is deprecated. Use `librarian-local-index` instead.
+ *
+ * The `librarian-local-index` module provides a more comprehensive implementation with:
+ * - Full-text tokenized search with relevance scoring
+ * - Tag-based queries with AND/OR operators
+ * - Library manifests for tracking API endpoints and concepts
+ * - Standalone query script generation
+ * - Integration with the enhanced-librarian agent
+ *
+ * This module will be removed in a future version.
+ *
+ * @see src/features/librarian-local-index
+ */
+import { z } from "zod";
+import type { Tool } from "@opencode-ai/sdk";
+
+// Types for local library index system
+export interface LibraryDoc {
+  /** Unique identifier for the document */
+  id: string;
+  /** Title of the document */
+  title: string;
+  /** Source URL or reference */
+  source: string;
+  /** Date when document was fetched/created */
+  createdAt: Date;
+  /** Date when document was last updated */
+  updatedAt: Date;
+  /** File path relative to library root */
+  filePath: string;
+  /** Tags for categorization and search */
+  tags: string[];
+  /** Language/library/framework this doc relates to */
+  language?: string;
+  /** Version of the library/framework */
+  version?: string;
+  /** Brief description of content */
+  description?: string;
+}
+
+export interface LibraryIndex {
+  /** All indexed documents */
+  documents: LibraryDoc[];
+  /** Tag to document IDs mapping */
+  tagIndex: Record<string, string[]>;
+  /** Language to document IDs mapping */
+  languageIndex: Record<string, string[]>;
+  /** Full-text search index (simplified) */
+  searchIndex: Record<string, string[]>;
+}
+
+export interface QueryOptions {
+  /** Tag filters */
+  tags?: string[];
+  /** Language filter */
+  language?: string;
+  /** Version filter */
+  version?: string;
+  /** Search query (full-text) */
+  query?: string;
+  /** Maximum results to return */
+  limit?: number;
+  /** Sort order */
+  sortBy?: 'relevance' | 'createdAt' | 'updatedAt' | 'title';
+}
+
+export interface AddDocOptions {
+  /** Overwrite if document already exists */
+  overwrite?: boolean;
+  /** Tags to add to frontmatter */
+  tags?: string[];
+  /** Language */
+  language?: string;
+  /** Version */
+  version?: string;
+  /** Description */
+  description?: string;
+}
+
+// Schema for YAML frontmatter
+export const FrontmatterSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  source: z.string().url(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  tags: z.array(z.string()),
+  language: z.string().optional(),
+  version: z.string().optional(),
+  description: z.string().optional(),
+});
+
+export type FrontmatterType = z.infer<typeof FrontmatterSchema>;
+
+// Tool definitions for library management
+export const LIBRARY_TOOLS: Record<string, Tool> = {
+  library_init: {
+    description: "Initialize the local library index structure",
+    parameters: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path where to create the library folder (default: ./library)",
+        },
+      },
+      required: [],
+    },
+  },
+  
+  library_add_doc: {
+    description: "Add a document to the library index",
+    parameters: {
+      type: "object",
+      properties: {
+        content: {
+          type: "string",
+          description: "Markdown content of the document",
+        },
+        title: {
+          type: "string",
+          description: "Title of the document",
+        },
+        source: {
+          type: "string",
+          description: "Source URL or reference",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Tags for categorization",
+        },
+        language: {
+          type: "string",
+          description: "Language/library/framework",
+        },
+        version: {
+          type: "string",
+          description: "Version of the library/framework",
+        },
+        description: {
+          type: "string",
+          description: "Brief description of content",
+        },
+        overwrite: {
+          type: "boolean",
+          description: "Overwrite if document already exists",
+        },
+      },
+      required: ["content", "title", "source", "tags"],
+    },
+  },
+  
+  library_query: {
+    description: "Query the library index for documents",
+    parameters: {
+      type: "object",
+      properties: {
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Filter by tags",
+        },
+        language: {
+          type: "string",
+          description: "Filter by language",
+        },
+        version: {
+          type: "string",
+          description: "Filter by version",
+        },
+        query: {
+          type: "string",
+          description: "Full-text search query",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum results to return",
+        },
+        sortBy: {
+          type: "string",
+          enum: ["relevance", "createdAt", "updatedAt", "title"],
+          description: "Sort order",
+        },
+      },
+      required: [],
+    },
+  },
+  
+  library_list_tags: {
+    description: "List all available tags in the library",
+    parameters: {
+      type: "object",
+      properties: {
+        language: {
+          type: "string",
+          description: "Filter tags by language",
+        },
+      },
+      required: [],
+    },
+  },
+  
+  library_sync: {
+    description: "Sync library index with file system (rebuild index)",
+    parameters: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to library folder (default: ./library)",
+        },
+      },
+      required: [],
+    },
+  },
+  
+  library_stats: {
+    description: "Get statistics about the library",
+    parameters: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+  },
+};

--- a/src/features/local-library/index.ts
+++ b/src/features/local-library/index.ts
@@ -82,7 +82,7 @@ export interface AddDocOptions {
 export const FrontmatterSchema = z.object({
   id: z.string(),
   title: z.string(),
-  source: z.string().url(),
+  source: z.string(),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
   tags: z.array(z.string()),

--- a/src/features/local-library/manager.ts
+++ b/src/features/local-library/manager.ts
@@ -64,8 +64,8 @@ export class LibraryManager {
       id: sanitizedId,
       title: options.title,
       source: options.source,
-      created_at: options.overwrite ? 
-        this.getDocument(id)?.createdAt || now : 
+      created_at: options.overwrite ?
+        (this.getDocument(sanitizedId)?.createdAt?.toISOString() || now) :
         now,
       updated_at: now,
       tags: options.tags || [],

--- a/src/features/local-library/manager.ts
+++ b/src/features/local-library/manager.ts
@@ -34,6 +34,12 @@ export class LibraryManager {
     try {
       const existingIndex = await fs.readFile(this.indexPath, 'utf-8');
       this.index = JSON.parse(existingIndex);
+      // Hydrate date fields
+      this.index.documents = this.index.documents.map(doc => ({
+        ...doc,
+        createdAt: new Date(doc.createdAt as string),
+        updatedAt: new Date(doc.updatedAt as string),
+      }));
     } catch (error) {
       await this.saveIndex();
     }
@@ -50,11 +56,12 @@ export class LibraryManager {
     
     // Generate ID from title or use provided
     const id = options.id || this.generateId(options.title);
-    const filePath = path.join(this.docsPath, `${id}.md`);
+    const sanitizedId = path.basename(id.replace(/[/\\]/g, '_'));
+    const filePath = path.join(this.docsPath, `${sanitizedId}.md`);
 
     // Create frontmatter
     const frontmatter: FrontmatterType = {
-      id,
+      id: sanitizedId,
       title: options.title,
       source: options.source,
       created_at: options.overwrite ? 
@@ -72,16 +79,24 @@ export class LibraryManager {
 
     // Write markdown file with frontmatter
     const markdown = this.createMarkdownWithFrontmatter(content, validated);
-    
-    if (options.overwrite) {
-      await fs.writeFile(filePath, markdown, 'utf-8');
-    } else {
-      await fs.writeFile(filePath, markdown, 'utf-8');
+
+    if (!options.overwrite) {
+      // Check if file exists
+      try {
+        await fs.access(filePath);
+        throw new Error(`Document with id "${sanitizedId}" already exists. Use overwrite=true to replace it.`);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
+      }
     }
+
+    await fs.writeFile(filePath, markdown, 'utf-8');
 
     // Create document object
     const doc: LibraryDoc = {
-      id,
+      id: sanitizedId,
       title: validated.title,
       source: validated.source,
       createdAt: new Date(validated.created_at),

--- a/src/features/local-library/manager.ts
+++ b/src/features/local-library/manager.ts
@@ -1,0 +1,375 @@
+import fs from "fs/promises";
+import path from "path";
+import yaml from "js-yaml";
+import { glob } from "glob";
+import { 
+  LibraryDoc, 
+  LibraryIndex, 
+  QueryOptions, 
+  AddDocOptions,
+  FrontmatterSchema,
+  type FrontmatterType 
+} from "./index";
+
+export class LibraryManager {
+  private libraryPath: string;
+  private indexPath: string;
+  private docsPath: string;
+  private index: LibraryIndex;
+
+  constructor(libraryPath: string = "./library") {
+    this.libraryPath = path.resolve(libraryPath);
+    this.indexPath = path.join(this.libraryPath, "index.json");
+    this.docsPath = path.join(this.libraryPath, "docs");
+    this.index = { documents: [], tagIndex: {}, languageIndex: {}, searchIndex: {} };
+  }
+
+  /**
+   * Initialize library folder structure
+   */
+  async init(): Promise<void> {
+    await fs.mkdir(this.docsPath, { recursive: true });
+    
+    // Initialize empty index if it doesn't exist
+    try {
+      const existingIndex = await fs.readFile(this.indexPath, 'utf-8');
+      this.index = JSON.parse(existingIndex);
+    } catch (error) {
+      await this.saveIndex();
+    }
+  }
+
+  /**
+   * Add a document to the library
+   */
+  async addDoc(
+    content: string,
+    options: AddDocOptions & { title: string; source: string; tags: string[] }
+  ): Promise<LibraryDoc> {
+    const now = new Date().toISOString();
+    
+    // Generate ID from title or use provided
+    const id = options.id || this.generateId(options.title);
+    const filePath = path.join(this.docsPath, `${id}.md`);
+
+    // Create frontmatter
+    const frontmatter: FrontmatterType = {
+      id,
+      title: options.title,
+      source: options.source,
+      created_at: options.overwrite ? 
+        this.getDocument(id)?.createdAt || now : 
+        now,
+      updated_at: now,
+      tags: options.tags || [],
+      language: options.language,
+      version: options.version,
+      description: options.description,
+    };
+
+    // Validate frontmatter
+    const validated = FrontmatterSchema.parse(frontmatter);
+
+    // Write markdown file with frontmatter
+    const markdown = this.createMarkdownWithFrontmatter(content, validated);
+    
+    if (options.overwrite) {
+      await fs.writeFile(filePath, markdown, 'utf-8');
+    } else {
+      await fs.writeFile(filePath, markdown, 'utf-8');
+    }
+
+    // Create document object
+    const doc: LibraryDoc = {
+      id,
+      title: validated.title,
+      source: validated.source,
+      createdAt: new Date(validated.created_at),
+      updatedAt: new Date(validated.updated_at),
+      filePath: path.relative(this.libraryPath, filePath),
+      tags: validated.tags,
+      language: validated.language,
+      version: validated.version,
+      description: validated.description,
+    };
+
+    // Update index
+    this.updateIndex(doc);
+    await this.saveIndex();
+
+    return doc;
+  }
+
+  /**
+   * Query documents from the library
+   */
+  async query(options: QueryOptions = {}): Promise<LibraryDoc[]> {
+    let results = [...this.index.documents];
+
+    // Filter by tags
+    if (options.tags && options.tags.length > 0) {
+      const docIds = new Set<string>();
+      options.tags.forEach(tag => {
+        const ids = this.index.tagIndex[tag] || [];
+        ids.forEach(id => docIds.add(id));
+      });
+      results = results.filter(doc => docIds.has(doc.id));
+    }
+
+    // Filter by language
+    if (options.language) {
+      const docIds = this.index.languageIndex[options.language] || [];
+      const docIdSet = new Set(docIds);
+      results = results.filter(doc => docIdSet.has(doc.id));
+    }
+
+    // Filter by version
+    if (options.version) {
+      results = results.filter(doc => doc.version === options.version);
+    }
+
+    // Full-text search
+    if (options.query) {
+      const query = options.query.toLowerCase();
+      const searchTerms = query.split(/\s+/);
+      
+      results = results.filter(doc => {
+        const searchable = [
+          doc.title,
+          doc.description || '',
+          doc.tags.join(' '),
+          doc.language || '',
+          doc.version || '',
+        ].join(' ').toLowerCase();
+
+        return searchTerms.every(term => searchable.includes(term));
+      });
+    }
+
+    // Sort results
+    results = this.sortResults(results, options.sortBy);
+
+    // Apply limit
+    if (options.limit) {
+      results = results.slice(0, options.limit);
+    }
+
+    return results;
+  }
+
+  /**
+   * Get all available tags
+   */
+  async listTags(language?: string): Promise<string[]> {
+    let tags = Object.keys(this.index.tagIndex);
+
+    if (language) {
+      const docIds = this.index.languageIndex[language] || [];
+      const docIdSet = new Set(docIds);
+      tags = tags.filter(tag => {
+        const tagDocIds = this.index.tagIndex[tag] || [];
+        return tagDocIds.some(id => docIdSet.has(id));
+      });
+    }
+
+    return tags.sort();
+  }
+
+  /**
+   * Sync index with file system
+   */
+  async sync(): Promise<void> {
+    const markdownFiles = await glob(path.join(this.docsPath, "*.md"));
+    
+    // Reset index
+    this.index = { documents: [], tagIndex: {}, languageIndex: {}, searchIndex: {} };
+
+    for (const filePath of markdownFiles) {
+      try {
+        const content = await fs.readFile(filePath, 'utf-8');
+        const { frontmatter, body } = this.parseMarkdownWithFrontmatter(content);
+        
+        if (frontmatter && FrontmatterSchema.safeParse(frontmatter).success) {
+          const validated = FrontmatterSchema.parse(frontmatter);
+          const doc: LibraryDoc = {
+            id: validated.id,
+            title: validated.title,
+            source: validated.source,
+            createdAt: new Date(validated.created_at),
+            updatedAt: new Date(validated.updated_at),
+            filePath: path.relative(this.libraryPath, filePath),
+            tags: validated.tags,
+            language: validated.language,
+            version: validated.version,
+            description: validated.description,
+          };
+          
+          this.updateIndex(doc);
+        }
+      } catch (error) {
+        console.warn(`Failed to index ${filePath}:`, error);
+      }
+    }
+
+    await this.saveIndex();
+  }
+
+  /**
+   * Get library statistics
+   */
+  async getStats(): Promise<{
+    totalDocs: number;
+    totalTags: number;
+    languages: Record<string, number>;
+    recentDocs: number;
+  }> {
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    const recentDocs = this.index.documents.filter(
+      doc => doc.createdAt > thirtyDaysAgo
+    ).length;
+
+    const languages: Record<string, number> = {};
+    this.index.documents.forEach(doc => {
+      if (doc.language) {
+        languages[doc.language] = (languages[doc.language] || 0) + 1;
+      }
+    });
+
+    return {
+      totalDocs: this.index.documents.length,
+      totalTags: Object.keys(this.index.tagIndex).length,
+      languages,
+      recentDocs,
+    };
+  }
+
+  private generateId(title: string): string {
+    return title
+      .toLowerCase()
+      .replace(/[^\w\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .substring(0, 50);
+  }
+
+  private createMarkdownWithFrontmatter(content: string, frontmatter: FrontmatterType): string {
+    const yamlStr = yaml.dump(frontmatter, {
+      defaultQuotingType: '"',
+      defaultQuotingStyle: '"',
+    });
+    
+    return `---\n${yamlStr}---\n\n${content}`;
+  }
+
+  private parseMarkdownWithFrontmatter(content: string): {
+    frontmatter?: any;
+    body: string;
+  } {
+    const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
+    const match = content.match(frontmatterRegex);
+    
+    if (match) {
+      try {
+        const frontmatter = yaml.load(match[1]);
+        return { frontmatter, body: match[2] };
+      } catch (error) {
+        // Invalid YAML
+        return { body: content };
+      }
+    }
+    
+    return { body: content };
+  }
+
+  private updateIndex(doc: LibraryDoc): void {
+    // Remove existing doc with same ID if it exists
+    const existingIndex = this.index.documents.findIndex(d => d.id === doc.id);
+    if (existingIndex !== -1) {
+      const oldDoc = this.index.documents[existingIndex];
+      // Clean up old indices
+      oldDoc.tags.forEach(tag => {
+        const idx = this.index.tagIndex[tag]?.indexOf(doc.id);
+        if (idx !== undefined && idx > -1) {
+          this.index.tagIndex[tag].splice(idx, 1);
+        }
+      });
+      
+      if (oldDoc.language) {
+        const idx = this.index.languageIndex[oldDoc.language]?.indexOf(doc.id);
+        if (idx !== undefined && idx > -1) {
+          this.index.languageIndex[oldDoc.language].splice(idx, 1);
+        }
+      }
+      
+      this.index.documents.splice(existingIndex, 1);
+    }
+
+    // Add new document
+    this.index.documents.push(doc);
+
+    // Update tag index
+    doc.tags.forEach(tag => {
+      if (!this.index.tagIndex[tag]) {
+        this.index.tagIndex[tag] = [];
+      }
+      if (!this.index.tagIndex[tag].includes(doc.id)) {
+        this.index.tagIndex[tag].push(doc.id);
+      }
+    });
+
+    // Update language index
+    if (doc.language) {
+      if (!this.index.languageIndex[doc.language]) {
+        this.index.languageIndex[doc.language] = [];
+      }
+      if (!this.index.languageIndex[doc.language].includes(doc.id)) {
+        this.index.languageIndex[doc.language].push(doc.id);
+      }
+    }
+
+    // Update search index (simplified - just tokenize title and description)
+    const searchable = [doc.title, doc.description || ''].join(' ').toLowerCase();
+    const tokens = searchable.split(/\s+/).filter(t => t.length > 2);
+    
+    tokens.forEach(token => {
+      if (!this.index.searchIndex[token]) {
+        this.index.searchIndex[token] = [];
+      }
+      if (!this.index.searchIndex[token].includes(doc.id)) {
+        this.index.searchIndex[token].push(doc.id);
+      }
+    });
+  }
+
+  private sortResults(docs: LibraryDoc[], sortBy?: string): LibraryDoc[] {
+    if (!sortBy || sortBy === 'relevance') {
+      return docs;
+    }
+
+    return docs.sort((a, b) => {
+      switch (sortBy) {
+        case 'createdAt':
+          return b.createdAt.getTime() - a.createdAt.getTime();
+        case 'updatedAt':
+          return b.updatedAt.getTime() - a.updatedAt.getTime();
+        case 'title':
+          return a.title.localeCompare(b.title);
+        default:
+          return 0;
+      }
+    });
+  }
+
+  private async saveIndex(): Promise<void> {
+    await fs.writeFile(
+      this.indexPath,
+      JSON.stringify(this.index, null, 2),
+      'utf-8'
+    );
+  }
+
+  private getDocument(id: string): LibraryDoc | undefined {
+    return this.index.documents.find(doc => doc.id === id);
+  }
+}

--- a/src/features/local-library/tools.ts
+++ b/src/features/local-library/tools.ts
@@ -2,14 +2,14 @@ import { ToolHandler } from "@opencode-ai/sdk";
 import { LibraryManager } from "./manager";
 import type { LibraryDoc } from "./index";
 
-// Global instance to manage library
-let libraryManager: LibraryManager | null = null;
+// Map to manage library instances per path
+const libraryManagers = new Map<string, LibraryManager>();
 
-function getLibraryManager(path?: string): LibraryManager {
-  if (!libraryManager) {
-    libraryManager = new LibraryManager(path);
+function getLibraryManager(path: string = "./library"): LibraryManager {
+  if (!libraryManagers.has(path)) {
+    libraryManagers.set(path, new LibraryManager(path));
   }
-  return libraryManager;
+  return libraryManagers.get(path)!;
 }
 
 export const library_init: ToolHandler = async ({ args }) => {

--- a/src/features/local-library/tools.ts
+++ b/src/features/local-library/tools.ts
@@ -2,6 +2,7 @@ import { ToolHandler } from "@opencode-ai/sdk";
 import { LibraryManager } from "./manager";
 import type { LibraryDoc } from "./index";
 
+<<<<<<< Updated upstream
 // Map to manage library instances per path
 const libraryManagers = new Map<string, LibraryManager>();
 
@@ -10,6 +11,21 @@ function getLibraryManager(path: string = "./library"): LibraryManager {
     libraryManagers.set(path, new LibraryManager(path));
   }
   return libraryManagers.get(path)!;
+=======
+// Global instance to manage library
+let libraryManager: LibraryManager | null = null;
+let currentLibraryPath: string = "./library";
+
+function getLibraryManager(path?: string): LibraryManager {
+  if (path) {
+    currentLibraryPath = path;
+    libraryManager = new LibraryManager(path);
+  }
+  if (!libraryManager) {
+    libraryManager = new LibraryManager(currentLibraryPath);
+  }
+  return libraryManager;
+>>>>>>> Stashed changes
 }
 
 export const library_init: ToolHandler = async ({ args }) => {

--- a/src/features/local-library/tools.ts
+++ b/src/features/local-library/tools.ts
@@ -2,7 +2,6 @@ import { ToolHandler } from "@opencode-ai/sdk";
 import { LibraryManager } from "./manager";
 import type { LibraryDoc } from "./index";
 
-<<<<<<< Updated upstream
 // Map to manage library instances per path
 const libraryManagers = new Map<string, LibraryManager>();
 
@@ -11,21 +10,6 @@ function getLibraryManager(path: string = "./library"): LibraryManager {
     libraryManagers.set(path, new LibraryManager(path));
   }
   return libraryManagers.get(path)!;
-=======
-// Global instance to manage library
-let libraryManager: LibraryManager | null = null;
-let currentLibraryPath: string = "./library";
-
-function getLibraryManager(path?: string): LibraryManager {
-  if (path) {
-    currentLibraryPath = path;
-    libraryManager = new LibraryManager(path);
-  }
-  if (!libraryManager) {
-    libraryManager = new LibraryManager(currentLibraryPath);
-  }
-  return libraryManager;
->>>>>>> Stashed changes
 }
 
 export const library_init: ToolHandler = async ({ args }) => {

--- a/src/features/local-library/tools.ts
+++ b/src/features/local-library/tools.ts
@@ -1,0 +1,172 @@
+import { ToolHandler } from "@opencode-ai/sdk";
+import { LibraryManager } from "./manager";
+import type { LibraryDoc } from "./index";
+
+// Global instance to manage library
+let libraryManager: LibraryManager | null = null;
+
+function getLibraryManager(path?: string): LibraryManager {
+  if (!libraryManager) {
+    libraryManager = new LibraryManager(path);
+  }
+  return libraryManager;
+}
+
+export const library_init: ToolHandler = async ({ args }) => {
+  const libraryPath = args.path || "./library";
+  const manager = getLibraryManager(libraryPath);
+  
+  try {
+    await manager.init();
+    return {
+      success: true,
+      result: `Library initialized at ${libraryPath}`,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to initialize library",
+    };
+  }
+};
+
+export const library_add_doc: ToolHandler = async ({ args }) => {
+  const manager = getLibraryManager();
+  
+  try {
+    const doc = await manager.addDoc(args.content, {
+      title: args.title,
+      source: args.source,
+      tags: args.tags,
+      language: args.language,
+      version: args.version,
+      description: args.description,
+      overwrite: args.overwrite,
+    });
+    
+    return {
+      success: true,
+      result: {
+        id: doc.id,
+        title: doc.title,
+        filePath: doc.filePath,
+        message: `Document "${doc.title}" added to library`,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to add document",
+    };
+  }
+};
+
+export const library_query: ToolHandler = async ({ args }) => {
+  const manager = getLibraryManager();
+  
+  try {
+    const docs = await manager.query(args);
+    
+    // Format results
+    const results = docs.map(doc => ({
+      id: doc.id,
+      title: doc.title,
+      description: doc.description,
+      source: doc.source,
+      language: doc.language,
+      version: doc.version,
+      tags: doc.tags,
+      createdAt: doc.createdAt.toISOString(),
+      updatedAt: doc.updatedAt.toISOString(),
+      filePath: doc.filePath,
+    }));
+    
+    return {
+      success: true,
+      result: {
+        documents: results,
+        count: results.length,
+        query: args,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to query library",
+    };
+  }
+};
+
+export const library_list_tags: ToolHandler = async ({ args }) => {
+  const manager = getLibraryManager();
+  
+  try {
+    const tags = await manager.listTags(args.language);
+    
+    return {
+      success: true,
+      result: {
+        tags,
+        count: tags.length,
+        language: args.language,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to list tags",
+    };
+  }
+};
+
+export const library_sync: ToolHandler = async ({ args }) => {
+  const libraryPath = args.path || "./library";
+  const manager = getLibraryManager(libraryPath);
+  
+  try {
+    await manager.sync();
+    
+    const stats = await manager.getStats();
+    
+    return {
+      success: true,
+      result: {
+        message: `Library synced successfully`,
+        stats,
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to sync library",
+    };
+  }
+};
+
+export const library_stats: ToolHandler = async ({}) => {
+  const manager = getLibraryManager();
+  
+  try {
+    const stats = await manager.getStats();
+    
+    return {
+      success: true,
+      result: stats,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Failed to get library stats",
+    };
+  }
+};
+
+// Tool exports for the library feature
+export const libraryTools = {
+  library_init,
+  library_add_doc,
+  library_query,
+  library_list_tags,
+  library_sync,
+  library_stats,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import {
 } from "./tools";
 import { BackgroundManager } from "./features/background-agent";
 import { SkillMcpManager } from "./features/skill-mcp-manager";
+import { createLibrarianLocalIndex } from "./features/librarian-local-index";
 import { initTaskToastManager } from "./features/task-toast-manager";
 import { type HookName } from "./config";
 import { log, detectExternalNotificationPlugin, getNotificationConflictWarning } from "./shared";
@@ -237,6 +238,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
 
   const callOmoAgent = createCallOmoAgent(ctx, backgroundManager);
   const lookAt = createLookAt(ctx);
+  const librarianLocalIndex = createLibrarianLocalIndex(ctx, backgroundManager);
   const sisyphusTask = createSisyphusTask({
     manager: backgroundManager,
     client: ctx.client,
@@ -305,6 +307,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       ...backgroundTools,
       call_omo_agent: callOmoAgent,
       look_at: lookAt,
+      librarian_local_index: librarianLocalIndex,
       sisyphus_task: sisyphusTask,
       skill: skillTool,
       skill_mcp: skillMcpTool,


### PR DESCRIPTION
## Summary

Extending librarian agent to allow for localised file saves and indexing upon the files 

## Changes
- Localized Library Index: Established a ./library directory that acts as a local "Source of Truth," allowing the model to navigate documentation using standard file-system commands like ls, cd, and cat.

- YAML Frontmatter & Metadata: Added standardized YAML headers (including tags) to all markdown files, enabling structured categorization of documentation.

- Tag-Based Query Script: Created a dedicated script that allows the model to instantly filter and find relevant documentation by querying specific tags across the library.

- Context Window Efficiency: Shifted the workflow from "full-text ingestion" to "search and pull," ensuring the model only loads the specific parts of the documentation it needs, which prevents context window pollution.

- Reduced Web Dependency: Pulled frequently used documentation into local markdown files to eliminate the need for slow, unreliable web searching and to ensure the data is always available for grep.

## Testing

- [x] bun run typecheck
- [x] bun test throws no errors

## Related Issues
#758 
<!-- Closes # -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local, offline index for the librarian to save, convert, and search docs, plus a new enhanced_librarian agent. Implements HTML→Markdown ingestion, tag and text search, and local pulls; satisfies #758.

- **New Features**
  - New librarian-local-index tool with actions: search, query-tags, add-doc, pull-docs, get-docs, build-index, create-script.
  - HTML content extractor and Turndown-based Markdown conversion (preserves code languages).
  - LibraryIndexer with YAML frontmatter, tag indexing, manifests, and relevance scoring.
  - Enhanced librarian agent added and registered with background triggers for external libraries.
  - Indexer test suite and plugin integration.

- **Migration**
  - local-library is deprecated; switch to librarian-local-index.
  - Run build-index once to seed the index; set libraryPath if you use a custom location.
  - Prefer the enhanced-librarian agent for offline doc queries.

<sup>Written for commit cd1e0e82ad59cbba327306f89d529d4cf457040c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



