### PR TITLE
ci: improve publish workflow UX with beta release example

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,9 +105,9 @@ jobs:
       - name: Build
         run: |
           echo "=== Running bun build (main) ==="
-          bun build src/index.ts src/google-auth.ts --outdir dist --target bun --format esm --external @ast-grep/napi
+          bun build src/index.ts --outdir dist --target bun --format esm --external @ast-grep/napi
           echo "=== Running bun build (CLI) ==="
-          bun build src/cli/index.ts --outdir dist/cli --target bun --format esm
+          bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external @ast-grep/napi
           echo "=== Running tsc ==="
           tsc --emitDeclarationOnly
           echo "=== Running build:schema ==="


### PR DESCRIPTION
## Summary
- Set default bump option to `patch` (most common use case)
- Reorder options: patch → minor → major (frequency order)
- Add helpful description for version override explaining beta release usage

## Example
To release `3.0.0-beta.6`:
```
gh workflow run publish -f bump=patch -f version=3.0.0-beta.6
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the GitHub Actions publish workflow UX and fix the publish build step.
Default bump is patch, choices ordered by frequency, version override takes precedence and supports betas, and the build removes non-existent google-auth.ts and adds the missing --external flag.

<sup>Written for commit 4a94f89858a1a8d5ee13b443774d41dabff39c23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

