### PR TITLE
fix(auto-slash-command): substitute $ARGUMENTS placeholder in skill templates

### DIFF
--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -163,7 +163,8 @@ async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<st
   const commandDir = cmd.path ? dirname(cmd.path) : process.cwd()
   const withFileRefs = await resolveFileReferencesInText(content, commandDir)
   const resolvedContent = await resolveCommandsInText(withFileRefs)
-  sections.push(resolvedContent.trim())
+  const withArgs = resolvedContent.replace(/\$ARGUMENTS/g, () => args || "")
+  sections.push(withArgs.trim())
 
   if (args) {
     sections.push("\n\n---\n")


### PR DESCRIPTION
## Summary
- Fix $ARGUMENTS placeholder not being substituted when skills are invoked without arguments
- Closes #640

## Problem
When a skill was invoked as `/my-skill` (without arguments), the `$ARGUMENTS` placeholder remained as literal text in the prompt. This caused the agent to see `<user-request>$ARGUMENTS</user-request>` instead of an empty user request, making it ignore the skill instructions entirely.

## Solution
In `formatCommandTemplate()`, substitute `$ARGUMENTS` with actual arguments (or empty string) before adding the content to the output. Uses function replacement to prevent `$` sequences in user args from being interpreted as special patterns.

## Test Plan
- [x] Existing tests pass (`bun test src/hooks/auto-slash-command/`)
- [x] Type check passes (`bun run typecheck`)
- [x] Build succeeds (`bun run build`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes $ARGUMENTS substitution in auto-slash-command skill templates to prevent the placeholder from appearing when a skill is invoked without arguments. We now replace $ARGUMENTS with the provided args or an empty string using function replacement, so the agent sees a clean prompt and follows the skill instructions.

<sup>Written for commit b7b8772a0eda157029dd622526e06dc2e5d1b78b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

