### PR TITLE
fix(agents): block call_omo_agent from Prometheus planner

### DIFF
--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -305,6 +305,12 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
         call_omo_agent: false,
       };
     }
+    if (agentResult["Prometheus (Planner)"]) {
+      (agentResult["Prometheus (Planner)"] as { tools?: Record<string, unknown> }).tools = {
+        ...(agentResult["Prometheus (Planner)"] as { tools?: Record<string, unknown> }).tools,
+        call_omo_agent: false,
+      };
+    }
 
     config.permission = {
       ...(config.permission as Record<string, unknown>),


### PR DESCRIPTION
Block `call_omo_agent` tool from Prometheus (Planner) and Orchestrator Sisyphus agents.

## Changes
- Added `call_omo_agent: false` to Prometheus (Planner) agent tools config
- Orchestrator Sisyphus already had this restriction

## Why
These agents should not spawn other agents via `call_omo_agent` tool directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the call_omo_agent tool for Prometheus (Planner) to prevent it from spawning other agents. Matches the existing Orchestrator Sisyphus restriction.

<sup>Written for commit cae27208cc4a0fced20f2499dcff7f08c1320755. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

