### PR TITLE
fix(migration): normalize Orchestrator-Sisyphus name

### DIFF
--- a/src/shared/migration.test.ts
+++ b/src/shared/migration.test.ts
@@ -55,6 +55,7 @@ describe("migrateAgentNames", () => {
     const agents = {
       SISYPHUS: { model: "test" },
       "planner-sisyphus": { prompt: "test" },
+      "Orchestrator-Sisyphus": { model: "openai/gpt-5.2" },
     }
 
     // #when: Migrate agent names
@@ -63,6 +64,7 @@ describe("migrateAgentNames", () => {
     // #then: Case-insensitive lookup should migrate correctly
     expect(migrated["Sisyphus"]).toEqual({ model: "test" })
     expect(migrated["Prometheus (Planner)"]).toEqual({ prompt: "test" })
+    expect(migrated["orchestrator-sisyphus"]).toEqual({ model: "openai/gpt-5.2" })
   })
 
   test("passes through unknown agent names unchanged", () => {

--- a/src/shared/migration.ts
+++ b/src/shared/migration.ts
@@ -20,6 +20,7 @@ export const AGENT_NAME_MAP: Record<string, string> = {
   "frontend-ui-ux-engineer": "frontend-ui-ux-engineer",
   "document-writer": "document-writer",
   "multimodal-looker": "multimodal-looker",
+  "orchestrator-sisyphus": "orchestrator-sisyphus",
 }
 
 export const BUILTIN_AGENT_NAMES = new Set([


### PR DESCRIPTION
## Summary
- Treat `Orchestrator-Sisyphus` as an alias of the built-in `orchestrator-sisyphus` agent during config migration.
- Add a unit test covering the normalization behavior.

## Why
Some users set the agent key as `Orchestrator-Sisyphus` (title-case) and the migration code currently leaves it untouched, which can make the override look ignored. Normalizing it reduces confusion and aligns with the built-in agent key.

Related: #775
