### PR TITLE
feat(lsp): add kotlin-ls LSP server support

### DIFF
--- a/src/tools/lsp/constants.ts
+++ b/src/tools/lsp/constants.ts
@@ -80,6 +80,7 @@ export const LSP_INSTALL_HINTS: Record<string, string> = {
   tinymist: "See https://github.com/Myriad-Dreamin/tinymist",
   "haskell-language-server": "ghcup install hls",
   bash: "npm install -g bash-language-server",
+  "kotlin-ls": "See https://github.com/Kotlin/kotlin-lsp",
 }
 
 // Synced with OpenCode's server.ts
@@ -245,6 +246,10 @@ export const BUILTIN_SERVERS: Record<string, Omit<LSPServerConfig, "id">> = {
   "haskell-language-server": {
     command: ["haskell-language-server-wrapper", "--lsp"],
     extensions: [".hs", ".lhs"],
+  },
+  "kotlin-ls": {
+    command: ["kotlin-lsp"],
+    extensions: [".kt", ".kts"],
   },
 }
 


### PR DESCRIPTION
## Summary
- Add Kotlin LSP server (kotlin-ls) to the built-in servers catalog
- Syncs with OpenCode's server.ts which has KotlinLS defined

## Changes
- Added `kotlin-ls` entry to `BUILTIN_SERVERS` with `kotlin-lsp` command
- Added installation hint pointing to https://github.com/Kotlin/kotlin-lsp
- Extensions `.kt` and `.kts` were already mapped in `EXT_TO_LANG`

## Testing
- `bun run typecheck` ✅
- `bun run build` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Kotlin LSP support by registering kotlin-ls in the built-in servers (command: kotlin-lsp), synced with OpenCode’s server.ts. Adds an install hint to https://github.com/Kotlin/kotlin-lsp so .kt and .kts work out of the box.

<sup>Written for commit 87fc3ae19a28a92253fd278347ed65c386061ee8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

