### PR TITLE
fix(cli): add copilot install flag

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,12 +26,13 @@ program
   .option("--claude <value>", "Claude subscription: no, yes, max20")
   .option("--chatgpt <value>", "ChatGPT subscription: no, yes")
   .option("--gemini <value>", "Gemini integration: no, yes")
+  .option("--copilot <value>", "GitHub Copilot subscription: no, yes")
   .option("--skip-auth", "Skip authentication setup hints")
   .addHelpText("after", `
 Examples:
   $ bunx oh-my-opencode install
-  $ bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes
-  $ bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no
+  $ bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes --copilot=no
+  $ bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no --copilot=yes
 
 Model Providers:
   Claude      Required for Sisyphus (main orchestrator) and Librarian agents
@@ -44,6 +45,7 @@ Model Providers:
       claude: options.claude,
       chatgpt: options.chatgpt,
       gemini: options.gemini,
+      copilot: options.copilot,
       skipAuth: options.skipAuth ?? false,
     }
     const exitCode = await install(args)


### PR DESCRIPTION
Installer validation already requires --copilot, but the CLI command did not expose the option, so non-TUI runs could not supply the flag. Add the option and update help examples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the --copilot flag in the CLI install command so non-TUI runs can set GitHub Copilot subscription and pass installer validation. Updated help examples and forwarded the flag to installer args.

<sup>Written for commit 70bca4a7a61471d5c1bfcc73564c4d962d7aa125. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

