### PR TITLE
docs: update beta version to 3.0.0-beta.7 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > [!TIP]
 >
-> [![The Orchestrator is now available in beta.](./.github/assets/orchestrator-sisyphus.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.1)
+> [![The Orchestrator is now available in beta.](./.github/assets/orchestrator-sisyphus.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.7)
 > > **The Orchestrator is now available in beta. Use `oh-my-opencode@3.0.0-beta.7` to install it.**
 >
 > Be with us!


### PR DESCRIPTION
## Summary

- Update beta version from `3.0.0-beta.6` to `3.0.0-beta.7` in README.md installation instructions

## Changes

- Updated the installation instruction text in README.md tip section to reference the latest beta version (3.0.0-beta.7)

## Related Issues

<!-- Relates to the beta.7 release -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated README to reference oh-my-opencode@3.0.0-beta.7 in the install command and release link.

<sup>Written for commit 49384fa8048520caf8a1630482671849738f83f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

