### PR TITLE
fix(ci): run tests on PRs to dev branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, dev]
   pull_request:
-    branches: [master]
+    branches: [dev]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Previously, CI tests only ran on PRs targeting `master` branch
- Since `dev` is the main development branch where PRs are opened, this was a gap in coverage
- This change ensures all PRs to `dev` are tested before merge

## Changes

- Updated `.github/workflows/ci.yml` to trigger on `pull_request` events to `dev` branch instead of `master`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable CI tests on PRs targeting the dev branch so changes are validated before merge. Updated the CI workflow to trigger on pull_request events for dev.

<sup>Written for commit 15e3e16bf2b67d73d74b30ca9030b5c716c43b40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

