### PR TITLE
fix(sisyphus-orchestrator): update test assertions to match new prompt text

### DIFF
--- a/src/hooks/sisyphus-orchestrator/index.test.ts
+++ b/src/hooks/sisyphus-orchestrator/index.test.ts
@@ -140,7 +140,7 @@ describe("sisyphus-orchestrator hook", () => {
 
       // #then - standalone verification reminder appended
       expect(output.output).toContain("Task completed successfully")
-      expect(output.output).toContain("MANDATORY VERIFICATION")
+      expect(output.output).toContain("MANDATORY:")
       expect(output.output).toContain("sisyphus_task(resume=")
       
       cleanupMessageStorage(sessionID)
@@ -179,7 +179,7 @@ describe("sisyphus-orchestrator hook", () => {
       expect(output.output).toContain("Task completed successfully")
       expect(output.output).toContain("SUBAGENT WORK COMPLETED")
       expect(output.output).toContain("test-plan")
-      expect(output.output).toContain("SUBAGENTS LIE")
+      expect(output.output).toContain("LIE")
       expect(output.output).toContain("sisyphus_task(resume=")
       
       cleanupMessageStorage(sessionID)
@@ -217,7 +217,7 @@ describe("sisyphus-orchestrator hook", () => {
       // #then - output transformed even when complete (shows 2/2 done)
       expect(output.output).toContain("SUBAGENT WORK COMPLETED")
       expect(output.output).toContain("2/2 done")
-      expect(output.output).toContain("0 left")
+      expect(output.output).toContain("0 remaining")
       
       cleanupMessageStorage(sessionID)
     })
@@ -327,7 +327,7 @@ describe("sisyphus-orchestrator hook", () => {
       // #then - output should contain plan name and progress
       expect(output.output).toContain("my-feature")
       expect(output.output).toContain("1/3 done")
-      expect(output.output).toContain("2 left")
+      expect(output.output).toContain("2 remaining")
       
       cleanupMessageStorage(sessionID)
     })
@@ -364,7 +364,7 @@ describe("sisyphus-orchestrator hook", () => {
       // #then - should include resume instructions and verification
       expect(output.output).toContain("sisyphus_task(resume=")
       expect(output.output).toContain("[x]")
-      expect(output.output).toContain("MANDATORY VERIFICATION")
+      expect(output.output).toContain("MANDATORY:")
       
       cleanupMessageStorage(sessionID)
     })


### PR DESCRIPTION
## Summary

Update 5 test assertions in `src/hooks/sisyphus-orchestrator/index.test.ts` to match new prompt text:

- `"MANDATORY VERIFICATION"` → `"MANDATORY:"` (2 places)
- `"SUBAGENTS LIE"` → `"LIE"` (1 place)
- `"0 left"` → `"0 remaining"` (1 place)
- `"2 left"` → `"2 remaining"` (1 place)

## Context

Fixes test failures introduced in commit 9bed597 which updated the prompt text in the sisyphus-orchestrator.

## Notes

This follows the **section-markers testing best practice**: assertions match stable marker substrings rather than full prose, making tests resilient to minor wording changes while still verifying the essential content structure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update 5 assertions in src/hooks/sisyphus-orchestrator/index.test.ts to match updated prompt text and fix failing tests. Use stable marker substrings (e.g., "MANDATORY:", "LIE", "0 remaining", "2 remaining") to reduce brittleness.

<sup>Written for commit b8a8cc95e2133b66ac8f93f89cbe9dde776fdaf0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

