### PR TITLE
fix(test): isolate environment in non-interactive-env hook tests

### DIFF
--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -13,6 +13,11 @@ describe("non-interactive-env hook", () => {
       SHELL: process.env.SHELL,
       PSModulePath: process.env.PSModulePath,
     }
+    // #given clean Unix-like environment for all tests
+    // This prevents CI environments (which may have PSModulePath set) from
+    // triggering PowerShell detection in tests that expect Unix behavior
+    delete process.env.PSModulePath
+    process.env.SHELL = "/bin/bash"
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Fix flaky test failures in non-interactive-env hook that occurred on GitHub Actions CI runners
- Add environment isolation in `beforeEach()` to ensure tests start with clean Unix-like environment

## Changes

- **src/hooks/non-interactive-env/index.test.ts**:
  - Clear `PSModulePath` environment variable in `beforeEach()` to prevent PowerShell detection on Linux CI runners
  - Set `SHELL=/bin/bash` to establish baseline Unix-like environment
  - Add explanatory comment documenting why this isolation is necessary
  - Tests can still override these values for PowerShell-specific test cases

## Context

GitHub Actions CI runners have `PSModulePath` set even on Linux systems, causing the non-interactive-env hook to incorrectly detect PowerShell as the shell. This led to test failures because tests expecting Unix behavior were getting PowerShell environment variables instead.

The fix ensures all tests start from a known, clean state by explicitly clearing platform-specific variables in `beforeEach()`, while still allowing individual tests to set these values when testing PowerShell-specific behavior.

## Testing

```bash
bun run typecheck
bun test
```

All tests pass locally and on CI after this fix.

## Related Issues

- Unblocks PR #821 which was failing due to this test regression

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky non-interactive-env hook tests on CI by resetting shell-related env vars before each test. Ensures Unix-like defaults so tests run consistently while still allowing PowerShell-specific cases.

- **Bug Fixes**
  - Clear PSModulePath in beforeEach to avoid accidental PowerShell detection on Linux CI.
  - Set SHELL=/bin/bash as the baseline; tests can override when needed.

<sup>Written for commit 6015fced3cc844ebc63996277b6ca64e7ef6ee4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

