### PR TITLE
fix(ci): enable platform package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,7 +141,6 @@ jobs:
           CI: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-          SKIP_PLATFORM_PACKAGES: true
 
       - name: Delete draft release
         run: gh release delete next --yes 2>/dev/null || echo "No draft release to delete"


### PR DESCRIPTION
## Problem

The platform-specific npm packages (oh-my-opencode-linux-x64, oh-my-opencode-darwin-arm64, etc.) are returning 404 from npm because they were never published.

## Root Cause

`SKIP_PLATFORM_PACKAGES: true` was added in commit 0230e71b by @justsisyphus on Jan 16 as a temporary workaround when OIDC wasn't configured for the platform packages. The 'for now' workaround was never removed.

## Fix

Remove the `SKIP_PLATFORM_PACKAGES: true` flag so the publish workflow publishes all 8 packages (main + 7 platform binaries).

## Note

For the first publish of the platform packages, ensure `NPM_TOKEN` is configured as a repo secret since OIDC/Trusted Publisher can only be configured after the packages exist on npm.

After the first successful publish, configure Trusted Publisher on npmjs.com for each of the 8 packages to enable OIDC authentication going forward.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable publishing of platform-specific npm packages by removing SKIP_PLATFORM_PACKAGES from the CI workflow. Fixes 404 installs for platform binaries and ensures the main package plus 7 platform packages are published.

- **Migration**
  - For the first publish, add NPM_TOKEN as a repo secret.
  - After the first successful publish, configure Trusted Publisher (OIDC) on npm for all 8 packages.

<sup>Written for commit f76e90932a08964ac182a0250a5ea83091aa9a63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

