### PR TITLE
fix(background-agent): pass model on resume to preserve category config

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -397,15 +397,17 @@ export class BackgroundManager {
     log("[background-agent] Resuming task - calling prompt (fire-and-forget) with:", {
       sessionID: existingTask.sessionID,
       agent: existingTask.agent,
+      model: existingTask.model,
       promptLength: input.prompt.length,
     })
 
-    // Note: Don't pass model in body - use agent's configured model instead
     // Use prompt() instead of promptAsync() to properly initialize agent loop
+    // Include model if task has one (preserved from original launch with category config)
     this.client.session.prompt({
       path: { id: existingTask.sessionID },
       body: {
         agent: existingTask.agent,
+        ...(existingTask.model ? { model: existingTask.model } : {}),
         tools: {
           ...getAgentToolRestrictions(existingTask.agent),
           task: false,


### PR DESCRIPTION
## Summary

- Fix model override not persisting when background tasks are resumed via sisyphus_task

## Changes

- `src/features/background-agent/manager.ts`: Add model to prompt body in resume method, matching the launch method pattern
- `src/features/background-agent/manager.test.ts`: Add tests for model persistence on resume

The resume path was missing the model parameter that launch() correctly passes. When a task with a category-configured model was resumed, it would revert to the default model instead of using the stored override.

## Testing

```bash
bun run typecheck
bun test src/features/background-agent/
```

## Related Issues

Closes #826

## Note

CI may fail due to a pre-existing flaky test issue on `dev` branch. See #848 for details.