### PR TITLE
fix(keyword-detector): skip keyword detection for background task sessions

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -72,12 +72,11 @@
           "empty-message-sanitizer",
           "thinking-block-validator",
           "ralph-loop",
-          "preemptive-compaction",
           "compaction-context-injector",
           "claude-code-hooks",
           "auto-slash-command",
           "edit-error-recovery",
-          "sisyphus-task-retry",
+          "delegate-task-retry",
           "prometheus-md-only",
           "start-work",
           "sisyphus-orchestrator"
@@ -2134,14 +2133,6 @@
         "auto_resume": {
           "type": "boolean"
         },
-        "preemptive_compaction": {
-          "type": "boolean"
-        },
-        "preemptive_compaction_threshold": {
-          "type": "number",
-          "minimum": 0.5,
-          "maximum": 0.95
-        },
         "truncate_all_tool_outputs": {
           "type": "boolean"
         },
@@ -2234,9 +2225,6 @@
               }
             }
           }
-        },
-        "dcp_for_compaction": {
-          "type": "boolean"
         }
       }
     },

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "oh-my-opencode",
@@ -31,13 +30,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "0.0.0",
-        "oh-my-opencode-darwin-x64": "0.0.0",
-        "oh-my-opencode-linux-arm64": "0.0.0",
-        "oh-my-opencode-linux-arm64-musl": "0.0.0",
-        "oh-my-opencode-linux-x64": "0.0.0",
-        "oh-my-opencode-linux-x64-musl": "0.0.0",
-        "oh-my-opencode-windows-x64": "0.0.0",
+        "oh-my-opencode-darwin-arm64": "3.0.0-beta.8",
+        "oh-my-opencode-darwin-x64": "3.0.0-beta.8",
+        "oh-my-opencode-linux-arm64": "3.0.0-beta.8",
+        "oh-my-opencode-linux-arm64-musl": "3.0.0-beta.8",
+        "oh-my-opencode-linux-x64": "3.0.0-beta.8",
+        "oh-my-opencode-linux-x64-musl": "3.0.0-beta.8",
+        "oh-my-opencode-windows-x64": "3.0.0-beta.8",
       },
     },
   },


### PR DESCRIPTION
## Summary
- Skip all keyword detection for background task sessions
- Prevents mode injection (e.g., `[analyze-mode]`, `[search-mode]`) into subagent sessions
- Fixes incorrect Prometheus planner restrictions being applied to Sisyphus sessions

Closes #713

## Root Cause
The `keyword-detector` hook was injecting mode instructions into background task prompts because it only checked `isNonMainSession` but did **not** check `subagentSessions.has(sessionID)`.

This caused background tasks to receive `[analyze-mode]` prefixes, which triggered `prometheus-md-only` hook restrictions, preventing normal file operations.

## Changes
- `src/hooks/keyword-detector/index.ts`: Add `subagentSessions.has()` check to skip keyword detection entirely for background task sessions

## Pattern Alignment
This fix aligns with the existing pattern used in other hooks:
- `sisyphus-orchestrator/index.ts` (line 504): `const isBackgroundTaskSession = subagentSessions.has(sessionID)`
- `todo-continuation-enforcer.ts` (line 303): `const isBackgroundTaskSession = subagentSessions.has(sessionID)`
- `session-notification.ts` (line 278): `if (subagentSessions.has(sessionID)) return`

## Testing
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] No breaking changes - main session behavior unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip keyword detection for background task sessions to stop mode prefixes (e.g., [analyze-mode], [search-mode]) from being injected. This prevents Prometheus MD-only restrictions on Sisyphus/background tasks and resolves #713.

- Bug Fixes
  - Added subagentSessions.has(sessionID) guard in keyword-detector to bypass detection for background tasks, matching the pattern used in other hooks.

<sup>Written for commit 0823dbe4d4aa366b9699934a856e7adf47e23fb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

