### PR TITLE
fix(mcp): disable OAuth auto-detection for built-in MCPs

### DIFF
--- a/src/mcp/context7.ts
+++ b/src/mcp/context7.ts
@@ -2,4 +2,5 @@ export const context7 = {
   type: "remote" as const,
   url: "https://mcp.context7.com/mcp",
   enabled: true,
+  oauth: false as const,
 }

--- a/src/mcp/grep-app.ts
+++ b/src/mcp/grep-app.ts
@@ -2,4 +2,5 @@ export const grep_app = {
   type: "remote" as const,
   url: "https://mcp.grep.app",
   enabled: true,
+  oauth: false as const,
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -10,6 +10,7 @@ type RemoteMcpConfig = {
   url: string
   enabled: boolean
   headers?: Record<string, string>
+  oauth?: false
 }
 
 const allBuiltinMcps: Record<McpName, RemoteMcpConfig> = {

--- a/src/mcp/websearch.ts
+++ b/src/mcp/websearch.ts
@@ -5,4 +5,6 @@ export const websearch = {
   headers: process.env.EXA_API_KEY
     ? { "x-api-key": process.env.EXA_API_KEY }
     : undefined,
+  // Disable OAuth auto-detection - Exa uses API key header, not OAuth
+  oauth: false as const,
 }


### PR DESCRIPTION
## Summary

- Fixes issue where only 1 of 3 built-in MCP servers was enabled despite all having `enabled: true`
- Only `websearch` was working; `context7` and `grep_app` were being disabled

## Root Cause

OpenCode's OAuth auto-detection was interfering with MCP initialization. Remote MCP servers trigger OAuth detection by default, which can mark MCPs as `needs_auth` or `disabled` status even when they don't require OAuth.

## Fix

Added `oauth: false as const` to all 3 built-in MCP configs to explicitly disable OAuth auto-detection:

- `context7` - uses no auth
- `grep_app` - uses no auth  
- `websearch` - uses API key header auth (EXA_API_KEY), not OAuth

## Changes

| File | Change |
|------|--------|
| `src/mcp/context7.ts` | Add `oauth: false as const` |
| `src/mcp/grep-app.ts` | Add `oauth: false as const` |
| `src/mcp/websearch.ts` | Add `oauth: false as const` |
| `src/mcp/index.ts` | Add `oauth?: false` to `RemoteMcpConfig` type |

## Testing

- Build succeeds
- MCP tests pass (6/6)
- OpenCode status bar shows "3 MCP" after fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled OAuth auto-detection for built-in MCPs so they no longer get incorrectly marked as needing auth. All three servers (context7, grep_app, websearch) now initialize and stay enabled.

- **Bug Fixes**
  - Set oauth: false on context7, grep_app, and websearch.
  - Added oauth?: false to RemoteMcpConfig.
  - Websearch uses EXA_API_KEY header auth, not OAuth.

<sup>Written for commit 0ed1d183d44240abe8e74f49cb3155eb69fa4cd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

