### PR TITLE
fix(lsp): handle warmupClient initialization errors

### DIFF
--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -4,6 +4,7 @@ import { extname, resolve } from "path"
 import { pathToFileURL } from "node:url"
 import { getLanguageId } from "./config"
 import type { Diagnostic, ResolvedServer } from "./types"
+import { log } from "../../shared/logger"
 
 interface ManagedClient {
   client: LSPClient
@@ -149,13 +150,19 @@ class LSPServerManager {
       isInitializing: true,
     })
 
-    initPromise.then(() => {
-      const m = this.clients.get(key)
-      if (m) {
-        m.initPromise = undefined
-        m.isInitializing = false
-      }
-    })
+    initPromise
+      .then(() => {
+        const m = this.clients.get(key)
+        if (m) {
+          m.initPromise = undefined
+          m.isInitializing = false
+        }
+      })
+      .catch((err) => {
+        log(`[lsp] warmupClient failed for ${server.id}:`, err?.message ?? err)
+        this.clients.delete(key)
+        client.stop().catch(() => {})
+      })
   }
 
   releaseClient(root: string, serverId: string): void {


### PR DESCRIPTION
## Summary

Fix unhandled promise rejection in `warmupClient()` that causes process crash when LSP server fails to start.

## Problem

`warmupClient()` uses a fire-and-forget pattern but had no error handling:

```typescript
initPromise.then(() => {
  // success handling only
})
// ❌ No .catch() - unhandled rejection if start() or initialize() fails
```

When the LSP server binary is not found, has permission issues, or fails to initialize, the promise rejection goes unhandled, causing:
- `UnhandledPromiseRejection` error
- Process exit with code 1

## Reproduction

```typescript
lspManager.warmupClient("/tmp", {
  id: "fake-lsp",
  command: ["nonexistent-binary"],
  filetypes: ["fake"],
})
// Before: Exit code 1, UnhandledPromiseRejection
// After: Error logged, process continues normally
```

## Solution

Add `.catch()` handler to:
1. Log the error with context (server ID)
2. Clean up the failed client from the map
3. Stop the client to release resources

## Changes

- `src/tools/lsp/client.ts`: Add error handling to `warmupClient()` initialization promise

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle LSP warmup initialization errors to prevent unhandled promise rejections and process crashes. warmupClient() now catches start/initialize failures, logs the error with server ID, removes the failed client, and stops it so the process keeps running.

<sup>Written for commit 161da10fc229ab4dce4383a41ab162af116874a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

