### PR TITLE
Fix session recovery and thinking block validation for extended thinking models

### DIFF
--- a/src/hooks/session-recovery/index.test.ts
+++ b/src/hooks/session-recovery/index.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "bun:test"
-import { detectErrorType } from "./index"
+import { describe, expect, it, beforeEach, afterEach, mock, spyOn } from "bun:test"
+import { detectErrorType, createSessionRecoveryHook } from "./index"
+import * as storage from "./storage"
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs"
+import { join } from "node:path"
+import { PART_STORAGE, MESSAGE_STORAGE } from "./constants"
 
 describe("detectErrorType", () => {
   describe("thinking_block_order errors", () => {
@@ -199,5 +203,164 @@ describe("detectErrorType", () => {
       // #then should return thinking_block_order
       expect(result).toBe("thinking_block_order")
     })
+  })
+})
+
+describe("recoverToolResultMissing", () => {
+  const TEST_SESSION_ID = "ses_test_recovery_123"
+  const TEST_USER_MSG_ID = "msg_user_001"
+  const TEST_PREV_ASSISTANT_ID = "msg_assistant_001"  // Previous assistant with tools
+  const TEST_FAILED_ASSISTANT_ID = "msg_assistant_002"  // Failed message (no parts)
+  const TEST_TOOL_CALL_ID = "toolu_01abc123xyz"
+
+  // Storage paths for test cleanup
+  const getTestPartDir = (msgId: string) => join(PART_STORAGE, msgId)
+  const getTestMessageDir = () => join(MESSAGE_STORAGE, TEST_SESSION_ID)
+
+  beforeEach(() => {
+    // Create test directories
+    const partDir = getTestPartDir(TEST_PREV_ASSISTANT_ID)
+    const msgDir = getTestMessageDir()
+
+    if (!existsSync(partDir)) {
+      mkdirSync(partDir, { recursive: true })
+    }
+    if (!existsSync(msgDir)) {
+      mkdirSync(msgDir, { recursive: true })
+    }
+
+    // Write previous assistant message with tool parts
+    const toolPart = {
+      id: "prt_001",
+      sessionID: TEST_SESSION_ID,
+      messageID: TEST_PREV_ASSISTANT_ID,
+      type: "tool",
+      callID: TEST_TOOL_CALL_ID,
+      tool: "delegate_task",
+      state: {
+        status: "completed",
+        input: { prompt: "test" },
+        output: "done"
+      }
+    }
+    writeFileSync(
+      join(partDir, "prt_001.json"),
+      JSON.stringify(toolPart, null, 2)
+    )
+
+    // Write message metadata for both messages
+    const prevAssistantMeta = {
+      id: TEST_PREV_ASSISTANT_ID,
+      sessionID: TEST_SESSION_ID,
+      role: "assistant",
+      parentID: TEST_USER_MSG_ID,
+      time: { created: 1000, completed: 2000 }
+    }
+    const failedAssistantMeta = {
+      id: TEST_FAILED_ASSISTANT_ID,
+      sessionID: TEST_SESSION_ID,
+      role: "assistant",
+      parentID: TEST_USER_MSG_ID,
+      time: { created: 3000 }
+      // Note: no 'completed' - this message failed
+    }
+    writeFileSync(
+      join(msgDir, `${TEST_PREV_ASSISTANT_ID}.json`),
+      JSON.stringify(prevAssistantMeta, null, 2)
+    )
+    writeFileSync(
+      join(msgDir, `${TEST_FAILED_ASSISTANT_ID}.json`),
+      JSON.stringify(failedAssistantMeta, null, 2)
+    )
+  })
+
+  afterEach(() => {
+    // Cleanup test directories
+    try {
+      rmSync(getTestPartDir(TEST_PREV_ASSISTANT_ID), { recursive: true, force: true })
+      rmSync(getTestPartDir(TEST_FAILED_ASSISTANT_ID), { recursive: true, force: true })
+      rmSync(getTestMessageDir(), { recursive: true, force: true })
+    } catch {
+      // Ignore cleanup errors
+    }
+  })
+
+  it("should find tool_use from PREVIOUS assistant message when failed message has no parts", async () => {
+    // #given
+    // - Previous assistant message (msg_assistant_001) has tool parts with callID
+    // - Failed assistant message (msg_assistant_002) has NO parts (API never responded)
+    // - Error says tool_use without tool_result
+
+    // Mock the client
+    let promptCalled = false
+    let promptBody: unknown = null
+    const mockClient = {
+      session: {
+        abort: mock(() => Promise.resolve()),
+        messages: mock(() => Promise.resolve({
+          data: [
+            {
+              info: {
+                id: TEST_PREV_ASSISTANT_ID,
+                role: "assistant",
+                sessionID: TEST_SESSION_ID,
+              },
+              parts: [
+                {
+                  type: "tool",
+                  callID: TEST_TOOL_CALL_ID,
+                  tool: "delegate_task",
+                  state: { status: "completed", input: {} }
+                }
+              ]
+            },
+            {
+              info: {
+                id: TEST_FAILED_ASSISTANT_ID,
+                role: "assistant",
+                sessionID: TEST_SESSION_ID,
+              },
+              parts: []  // EMPTY - this is the bug scenario
+            }
+          ]
+        })),
+        prompt: mock((args: unknown) => {
+          promptCalled = true
+          promptBody = (args as { body: unknown }).body
+          return Promise.resolve()
+        })
+      },
+      tui: {
+        showToast: mock(() => Promise.resolve())
+      }
+    }
+
+    const mockCtx = {
+      client: mockClient,
+      directory: "/test"
+    }
+
+    const hook = createSessionRecoveryHook(mockCtx as any)
+
+    // #when - recovery is triggered for the failed message
+    const result = await hook.handleSessionRecovery({
+      id: TEST_FAILED_ASSISTANT_ID,
+      role: "assistant",
+      sessionID: TEST_SESSION_ID,
+      error: {
+        message: `messages.1: tool_use ids were found without tool_result blocks immediately after: ${TEST_TOOL_CALL_ID}`
+      }
+    })
+
+    // #then - should have called prompt with tool_result for the tool from PREVIOUS message
+    expect(result).toBe(true)
+    expect(promptCalled).toBe(true)
+    expect(promptBody).toBeDefined()
+
+    const body = promptBody as { parts: Array<{ type: string; tool_use_id: string }> }
+    expect(body.parts).toBeDefined()
+    expect(body.parts.length).toBeGreaterThan(0)
+    expect(body.parts[0].type).toBe("tool_result")
+    expect(body.parts[0].tool_use_id).toBe(TEST_TOOL_CALL_ID)
   })
 })

--- a/src/hooks/session-recovery/index.ts
+++ b/src/hooks/session-recovery/index.ts
@@ -152,23 +152,80 @@ function extractToolUseIds(parts: MessagePart[]): string[] {
   return parts.filter((p): p is ToolUsePart => p.type === "tool_use" && !!p.id).map((p) => p.id)
 }
 
+function convertStoredPartsToMessageParts(messageID: string): MessagePart[] {
+  const storedParts = readParts(messageID)
+  return storedParts.map((p) => ({
+    type: p.type === "tool" ? "tool_use" : p.type,
+    id: "callID" in p ? (p as { callID?: string }).callID : p.id,
+    name: "tool" in p ? (p as { tool?: string }).tool : undefined,
+    input: "state" in p ? (p as { state?: { input?: Record<string, unknown> } }).state?.input : undefined,
+  }))
+}
+
+function normalizePartsToToolUse(parts: MessagePart[]): MessagePart[] {
+  // Convert OpenCode format (type: "tool", callID) to Anthropic format (type: "tool_use", id)
+  return parts.map((p) => {
+    if (p.type === "tool" || p.type === "tool_use") {
+      const callID = (p as { callID?: string }).callID
+      return {
+        ...p,
+        type: "tool_use" as const,
+        id: callID || p.id,
+      }
+    }
+    return p
+  })
+}
+
+function getToolUseIdsFromMessage(msg: MessageData): string[] {
+  let parts = msg.parts || []
+
+  // Fallback to filesystem storage if API parts are empty
+  if (parts.length === 0 && msg.info?.id) {
+    parts = convertStoredPartsToMessageParts(msg.info.id)
+  }
+
+  // Normalize to Anthropic format and extract IDs
+  const normalizedParts = normalizePartsToToolUse(parts)
+  return extractToolUseIds(normalizedParts)
+}
+
+function findToolUseIdsFromMessages(
+  failedAssistantMsg: MessageData,
+  allMessages: MessageData[]
+): string[] {
+  // First try the failed message itself
+  let toolUseIds = getToolUseIdsFromMessage(failedAssistantMsg)
+
+  if (toolUseIds.length > 0) {
+    return toolUseIds
+  }
+
+  // Failed message has no tool parts - search backwards for previous assistant message with tools
+  // This handles the case where API error occurred on a NEW assistant message that has no parts yet
+  const failedMsgId = failedAssistantMsg.info?.id
+  const failedMsgIndex = allMessages.findIndex((m) => m.info?.id === failedMsgId)
+
+  for (let i = failedMsgIndex - 1; i >= 0; i--) {
+    const msg = allMessages[i]
+    if (msg.info?.role !== "assistant") continue
+
+    toolUseIds = getToolUseIdsFromMessage(msg)
+    if (toolUseIds.length > 0) {
+      return toolUseIds
+    }
+  }
+
+  return []
+}
+
 async function recoverToolResultMissing(
   client: Client,
   sessionID: string,
-  failedAssistantMsg: MessageData
+  failedAssistantMsg: MessageData,
+  allMessages: MessageData[]
 ): Promise<boolean> {
-  // Try API parts first, fallback to filesystem if empty
-  let parts = failedAssistantMsg.parts || []
-  if (parts.length === 0 && failedAssistantMsg.info?.id) {
-    const storedParts = readParts(failedAssistantMsg.info.id)
-    parts = storedParts.map((p) => ({
-      type: p.type === "tool" ? "tool_use" : p.type,
-      id: "callID" in p ? (p as { callID?: string }).callID : p.id,
-      name: "tool" in p ? (p as { tool?: string }).tool : undefined,
-      input: "state" in p ? (p as { state?: { input?: Record<string, unknown> } }).state?.input : undefined,
-    }))
-  }
-  const toolUseIds = extractToolUseIds(parts)
+  const toolUseIds = findToolUseIdsFromMessages(failedAssistantMsg, allMessages)
 
   if (toolUseIds.length === 0) {
     return false
@@ -392,7 +449,7 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
       let success = false
 
       if (errorType === "tool_result_missing") {
-        success = await recoverToolResultMissing(ctx.client, sessionID, failedMsg)
+        success = await recoverToolResultMissing(ctx.client, sessionID, failedMsg, msgs ?? [])
       } else if (errorType === "thinking_block_order") {
         success = await recoverThinkingBlockOrder(ctx.client, sessionID, failedMsg, ctx.directory, info.error)
         if (success && experimental?.auto_resume) {

--- a/src/hooks/thinking-block-validator/index.ts
+++ b/src/hooks/thinking-block-validator/index.ts
@@ -63,14 +63,21 @@ function hasContentParts(parts: Part[]): boolean {
   })
 }
 
+// Meta types that don't count as "content" for thinking validation
+const META_TYPES = new Set(["step-start", "step-finish"])
+
 /**
  * Check if a message starts with a thinking/reasoning block
+ * Skips meta-types like step-start/step-finish
  */
 function startsWithThinkingBlock(parts: Part[]): boolean {
   if (!parts || parts.length === 0) return false
 
-  const firstPart = parts[0]
-  const type = firstPart.type as string
+  // Find first non-meta part
+  const firstContentPart = parts.find(p => !META_TYPES.has(p.type as string))
+  if (!firstContentPart) return false
+
+  const type = firstContentPart.type as string
   return type === "thinking" || type === "reasoning"
 }
 
@@ -140,8 +147,13 @@ export function createThinkingBlockValidatorHook(): MessagesTransformHook {
       }
 
       // Get the model info from the last user message
+      // Model can be in info.modelID, info.model.modelID, or info.model (string)
       const lastUserMessage = messages.findLast(m => m.info.role === "user")
-      const modelID = (lastUserMessage?.info as any)?.modelID || ""
+      const info = lastUserMessage?.info as any
+      const modelID = info?.modelID
+        || info?.model?.modelID
+        || (typeof info?.model === "string" ? info.model : "")
+        || ""
 
       // Only process if extended thinking might be enabled
       if (!isExtendedThinkingModel(modelID)) {


### PR DESCRIPTION
## Problem

Users experience frequent API errors when using extended thinking models (Claude Opus 4.5, Sonnet 4.5, GPT 5.2):

1. **`tool_use ids were found without tool_result blocks`** - Session recovery fails silently
2. **`first block must be thinking or redacted_thinking, found tool_use`** - Thinking block validator doesn't catch all cases

These errors interrupt workflows and require manual intervention.

## Investigation

### Issue 1: Session recovery looks at wrong message

When the `tool_use without tool_result` error occurs, the session recovery hook tries to inject synthetic `tool_result` blocks. However, it was looking at the **failed** assistant message to extract `tool_use` IDs.

The problem: when the API rejects a request, the **new** assistant message being created has **no parts** - the API never responded. The `tool_use` blocks are in the **previous** assistant message that completed successfully.

Evidence from storage inspection:
```
msg_bd18c80f8001: assistant, parts: [tool(completed), tool(completed), ...]  ← has tool_use
msg_bd18cab20001: assistant, parts: []  ← EMPTY, this is the failed message
```

The recovery was extracting tool IDs from the empty failed message, finding nothing, and returning `false`.

### Issue 2: Model ID not found in thinking block validator

The `thinking-block-validator` hook checks if extended thinking is enabled by looking up the model ID. It was checking `info.modelID`, but OpenCode stores model info as `info.model.modelID`.

Debug logging revealed:
```
[thinking-block-validator] modelID=, isThinking=false, msgCount=41
```

Empty model ID → hook returns early → no validation happens.

### Issue 3: step-start counted as first part

Even after fixing the model detection, the validator was flagging almost every message for fixing. The check `parts[0].type === "thinking"` failed because `parts[0]` was typically `step-start` (an OpenCode meta-type), not the actual content.

Parts are ordered by ID (creation time). `step-start` is created first, so it appears before `thinking` in the array - but it's not sent to the API.

## Solution

### 1. Session recovery: search backwards for tool_use

When the failed message has no tool parts, search backwards through all messages to find the most recent assistant message with `tool_use` blocks:

```typescript
function findToolUseIdsFromMessages(failedMsg, allMessages) {
  // First try the failed message itself
  let ids = getToolUseIdsFromMessage(failedMsg)
  if (ids.length > 0) return ids

  // Search backwards for previous assistant message with tools
  const failedIndex = allMessages.findIndex(m => m.info?.id === failedMsg.info?.id)
  for (let i = failedIndex - 1; i >= 0; i--) {
    if (allMessages[i].info?.role !== "assistant") continue
    ids = getToolUseIdsFromMessage(allMessages[i])
    if (ids.length > 0) return ids
  }
  return []
}
```

Also added normalization to handle both OpenCode format (`type: "tool", callID`) and Anthropic format (`type: "tool_use", id`).

### 2. Thinking block validator: fix model ID lookup

Check multiple possible locations for the model ID:

```typescript
const info = lastUserMessage?.info
const modelID = info?.modelID
  || info?.model?.modelID
  || (typeof info?.model === "string" ? info.model : "")
  || ""
```

### 3. Thinking block validator: skip meta-types

Skip `step-start` and `step-finish` when determining the "first" part:

```typescript
const META_TYPES = new Set(["step-start", "step-finish"])

function startsWithThinkingBlock(parts) {
  const firstContentPart = parts.find(p => !META_TYPES.has(p.type))
  if (!firstContentPart) return false
  return firstContentPart.type === "thinking" || firstContentPart.type === "reasoning"
}
```

## Testing

Added test case for the session recovery fix:
- Creates scenario where previous assistant message has completed tool calls
- Failed assistant message has empty parts array
- Verifies recovery finds tool IDs from previous message and sends correct `tool_result`

All existing tests pass.

## Files Changed

- `src/hooks/session-recovery/index.ts` - Search backwards for tool_use when failed message is empty
- `src/hooks/session-recovery/index.test.ts` - Add test for the fix
- `src/hooks/thinking-block-validator/index.ts` - Fix model ID lookup, skip meta-types

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session recovery and thinking block validation for extended-thinking models to stop recurring API errors and prevent session interruptions.

- **Bug Fixes**
  - Session recovery searches previous assistant messages for tool_use IDs, falls back to stored parts, and normalizes "tool" to "tool_use".
  - Thinking validator reads model ID from info.modelID or info.model.modelID and skips step-start/step-finish when checking the first content part.
  - Added a test for recovering tool_result when the failed message has no parts; existing tests pass.

<sup>Written for commit ec98ce2fe3399cf068767318b3d75559b16398b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

