### PR TITLE
test: stabilize non-interactive env hook

### DIFF
--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -12,12 +12,15 @@ describe("non-interactive-env hook", () => {
     originalEnv = {
       SHELL: process.env.SHELL,
       PSModulePath: process.env.PSModulePath,
+      CI: process.env.CI,
+      OPENCODE_NON_INTERACTIVE: process.env.OPENCODE_NON_INTERACTIVE,
     }
     // #given clean Unix-like environment for all tests
     // This prevents CI environments (which may have PSModulePath set) from
     // triggering PowerShell detection in tests that expect Unix behavior
     delete process.env.PSModulePath
     process.env.SHELL = "/bin/bash"
+    process.env.OPENCODE_NON_INTERACTIVE = "true"
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- force non-interactive env in tests to stabilize hook behavior
- prevent CI env detection from skipping git command prefix checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes non-interactive-env hook tests by forcing a non-interactive Unix-like environment. Sets OPENCODE_NON_INTERACTIVE=true and normalizes SHELL/PSModulePath so CI detection doesn't skip git command prefix checks.

<sup>Written for commit 4e8106b01930dab32e37547069cb6463a758e647. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

