### PR TITLE
fix(skill-mcp): allow object args and strip quotes

### DIFF
--- a/src/tools/skill-mcp/tools.ts
+++ b/src/tools/skill-mcp/tools.ts
@@ -118,7 +118,7 @@ export function createSkillMcpTool(options: SkillMcpToolOptions): ToolDefinition
       resource_name: tool.schema.string().optional().describe("MCP resource URI to read"),
       prompt_name: tool.schema.string().optional().describe("MCP prompt to get"),
       arguments: tool.schema
-        .union([tool.schema.string(), tool.schema.record(tool.schema.unknown())])
+        .union([tool.schema.string(), tool.schema.record(tool.schema.string(), tool.schema.unknown())])
         .optional()
         .describe("JSON string or object of arguments"),
       grep: tool.schema


### PR DESCRIPTION
## Summary
This PR fixes two issues with the `skill_mcp` tool that caused failures when arguments were passed as objects or single-quoted strings (common with LLMs).

1.  **Schema Fix**: Updated `arguments` parameter schema in `src/tools/skill-mcp/tools.ts` to accept both `string` and `Record<string, unknown>`. This prevents Zod from coercing object inputs into `[object Object]`, which caused JSON parsing failures.
2.  **Parser Fix**: Updated `parseArguments` function to strip outer single quotes from string inputs before parsing. This handles cases where LLMs wrap the JSON string in single quotes (e.g., `'{"key": "value"}'`), which previously caused `JSON.parse` to fail.

These changes ensure the `skill_mcp` tool robustly handles various argument formats generated by agents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes skill_mcp argument handling to accept both JSON strings and objects, and strips outer single quotes before parsing to prevent failures. This makes LLM-generated calls more reliable and prevents JSON parsing and coercion errors.

- **Bug Fixes**
  - Updated arguments schema to accept string or object, avoiding Zod coercion to "[object Object]".
  - parseArguments now removes outer single quotes before JSON.parse.

<sup>Written for commit 65a567e0b41d09da45d26bdf66ab2a62ed52568d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

