### PR TITLE
fix(doctor): handle file:// protocol for local dev plugin detection

### DIFF
--- a/src/cli/doctor/checks/plugin.ts
+++ b/src/cli/doctor/checks/plugin.ts
@@ -22,6 +22,9 @@ function findPluginEntry(plugins: string[]): { entry: string; isPinned: boolean;
       const version = isPinned ? plugin.split("@")[1] : null
       return { entry: plugin, isPinned, version }
     }
+    if (plugin.startsWith("file://") && plugin.includes(PACKAGE_NAME)) {
+      return { entry: plugin, isPinned: false, version: "local-dev" }
+    }
   }
   return null
 }


### PR DESCRIPTION
## Summary
- Added handling for `file://` protocol in the doctor plugin check
- Correctly identifies local dev plugins when installed via `file://` protocol
- Returns version as "local-dev" for file-based plugin references

## Changes
- Modified `src/cli/doctor/checks/plugin.ts` to detect file:// protocol entries
- Ensures proper plugin detection for local development workflows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update doctor plugin check to detect plugins installed via file:// during local development. These are now recognized as installed and reported with version "local-dev" to avoid false warnings.

<sup>Written for commit 45fe9578ec7494692819efe2cbfb13fcbfd2372b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

