### PR TITLE
docs: add fraud warning about impersonation site

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,3 +1,14 @@
+> [!WARNING]
+> **セキュリティ警告：なりすましサイト**
+>
+> **ohmyopencode.comは本プロジェクトとは一切関係ありません。** 当方はそのサイトを運営しておらず、推奨もしていません。
+>
+> OhMyOpenCodeは**無料かつオープンソース**です。「公式」を名乗るサードパーティサイトでインストーラーをダウンロードしたり、支払い情報を入力したり**しないでください**。
+>
+> なりすましサイトはペイウォールの裏にあるため、**何が配布されているか確認できません**。そこからのダウンロードは**潜在的に危険なもの**として扱ってください。
+>
+> ✅ 公式ダウンロード：https://github.com/code-yeongyu/oh-my-opencode/releases
+
 > [!NOTE]
 >
 > [![Sisyphus Labs — Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+> [!WARNING]
+> **Security warning: impersonation site**
+>
+> **ohmyopencode.com is NOT affiliated with this project.** We do not operate or endorse that site.
+>
+> OhMyOpenCode is **free and open-source**. Do **not** download installers or enter payment details on third-party sites that claim to be "official."
+>
+> Because the impersonation site is behind a paywall, we **cannot verify what it distributes**. Treat any downloads from it as **potentially unsafe**.
+>
+> ✅ Official downloads: https://github.com/code-yeongyu/oh-my-opencode/releases
+
 > [!NOTE]
 >
 > [![Sisyphus Labs — Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1,3 +1,14 @@
+> [!WARNING]
+> **安全警告：冒充网站**
+>
+> **ohmyopencode.com 与本项目无关。** 我们不运营或认可该网站。
+>
+> OhMyOpenCode 是**免费且开源的**。请**勿**在声称"官方"的第三方网站下载安装程序或输入付款信息。
+>
+> 由于该冒充网站设有付费墙，我们**无法验证其分发的内容**。请将来自该网站的任何下载视为**潜在不安全**。
+>
+> ✅ 官方下载地址：https://github.com/code-yeongyu/oh-my-opencode/releases
+
 > [!NOTE]
 >
 > [![Sisyphus Labs — Sisyphus 是像你的团队一样编码的智能体。](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)


### PR DESCRIPTION
## Summary
- Adds a prominent [!WARNING] callout to all README files (English, Japanese, Chinese)
- Warns users that ohmyopencode.com is NOT affiliated with this project
- Directs users to the official GitHub releases page for downloads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a prominent security warning to all READMEs (English, Japanese, Chinese) about the impersonation site ohmyopencode.com. Directs users to the official GitHub releases page for safe downloads.

<sup>Written for commit d520aa00ad991ec9cd2012cfe349fcdff82d6d55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

