### PR TITLE
feat(mcp-loader): add timeout and oauth support for Claude Code MCP servers

### DIFF
--- a/src/features/claude-code-mcp-loader/transformer.test.ts
+++ b/src/features/claude-code-mcp-loader/transformer.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "bun:test"
+import { transformMcpServer } from "./transformer"
+
+describe("transformMcpServer", () => {
+  describe("local (stdio) servers", () => {
+    it("transforms basic stdio server", () => {
+      // #given
+      const server = {
+        command: "npx",
+        args: ["@playwright/mcp@latest"],
+      }
+
+      // #when
+      const result = transformMcpServer("playwright", server)
+
+      // #then
+      expect(result.type).toBe("local")
+      expect(result).toHaveProperty("command", ["npx", "@playwright/mcp@latest"])
+      expect(result.enabled).toBe(true)
+    })
+
+    it("includes timeout when specified", () => {
+      // #given
+      const server = {
+        command: "npx",
+        args: ["-y", "agent-arena"],
+        timeout: 600000,
+      }
+
+      // #when
+      const result = transformMcpServer("arena", server)
+
+      // #then
+      expect(result.type).toBe("local")
+      expect(result).toHaveProperty("timeout", 600000)
+    })
+
+    it("includes environment variables", () => {
+      // #given
+      const server = {
+        command: "npx",
+        args: ["some-mcp"],
+        env: { API_KEY: "secret" },
+      }
+
+      // #when
+      const result = transformMcpServer("test", server)
+
+      // #then
+      expect(result.type).toBe("local")
+      expect(result).toHaveProperty("environment", { API_KEY: "secret" })
+    })
+
+    it("does not include timeout when not specified", () => {
+      // #given
+      const server = {
+        command: "npx",
+        args: ["some-mcp"],
+      }
+
+      // #when
+      const result = transformMcpServer("test", server)
+
+      // #then
+      expect(result).not.toHaveProperty("timeout")
+    })
+  })
+
+  describe("remote (http/sse) servers", () => {
+    it("transforms http server", () => {
+      // #given
+      const server = {
+        type: "http" as const,
+        url: "https://mcp.example.com",
+      }
+
+      // #when
+      const result = transformMcpServer("remote", server)
+
+      // #then
+      expect(result.type).toBe("remote")
+      expect(result).toHaveProperty("url", "https://mcp.example.com")
+      expect(result.enabled).toBe(true)
+    })
+
+    it("transforms sse server", () => {
+      // #given
+      const server = {
+        type: "sse" as const,
+        url: "https://mcp.example.com/sse",
+      }
+
+      // #when
+      const result = transformMcpServer("remote-sse", server)
+
+      // #then
+      expect(result.type).toBe("remote")
+      expect(result).toHaveProperty("url", "https://mcp.example.com/sse")
+    })
+
+    it("includes headers when specified", () => {
+      // #given
+      const server = {
+        type: "http" as const,
+        url: "https://mcp.example.com",
+        headers: { Authorization: "Bearer token" },
+      }
+
+      // #when
+      const result = transformMcpServer("remote", server)
+
+      // #then
+      expect(result).toHaveProperty("headers", { Authorization: "Bearer token" })
+    })
+
+    it("includes timeout when specified", () => {
+      // #given
+      const server = {
+        type: "http" as const,
+        url: "https://mcp.example.com",
+        timeout: 120000,
+      }
+
+      // #when
+      const result = transformMcpServer("remote", server)
+
+      // #then
+      expect(result.type).toBe("remote")
+      expect(result).toHaveProperty("timeout", 120000)
+    })
+
+    it("does not include timeout when not specified", () => {
+      // #given
+      const server = {
+        type: "http" as const,
+        url: "https://mcp.example.com",
+      }
+
+      // #when
+      const result = transformMcpServer("remote", server)
+
+      // #then
+      expect(result).not.toHaveProperty("timeout")
+    })
+  })
+
+  describe("error handling", () => {
+    it("throws error when http server has no url", () => {
+      // #given
+      const server = {
+        type: "http" as const,
+      }
+
+      // #when & #then
+      expect(() => transformMcpServer("broken", server)).toThrow(
+        'MCP server "broken" requires url for type "http"'
+      )
+    })
+
+    it("throws error when stdio server has no command", () => {
+      // #given
+      const server = {
+        type: "stdio" as const,
+      }
+
+      // #when & #then
+      expect(() => transformMcpServer("broken", server)).toThrow(
+        'MCP server "broken" requires command for stdio type'
+      )
+    })
+  })
+})

--- a/src/features/claude-code-mcp-loader/transformer.ts
+++ b/src/features/claude-code-mcp-loader/transformer.ts
@@ -30,6 +30,10 @@ export function transformMcpServer(
       config.headers = expanded.headers
     }
 
+    if (expanded.timeout !== undefined) {
+      config.timeout = expanded.timeout
+    }
+
     return config
   }
 
@@ -47,6 +51,10 @@ export function transformMcpServer(
 
   if (expanded.env && Object.keys(expanded.env).length > 0) {
     config.environment = expanded.env
+  }
+
+  if (expanded.timeout !== undefined) {
+    config.timeout = expanded.timeout
   }
 
   return config

--- a/src/features/claude-code-mcp-loader/types.ts
+++ b/src/features/claude-code-mcp-loader/types.ts
@@ -8,6 +8,8 @@ export interface ClaudeCodeMcpServer {
   env?: Record<string, string>
   headers?: Record<string, string>
   disabled?: boolean
+  /** Timeout in ms for MCP server requests */
+  timeout?: number
 }
 
 export interface ClaudeCodeMcpConfig {
@@ -19,6 +21,14 @@ export interface McpLocalConfig {
   command: string[]
   environment?: Record<string, string>
   enabled?: boolean
+  /** Timeout in ms for MCP server requests */
+  timeout?: number
+}
+
+export interface McpOAuthConfig {
+  clientId?: string
+  clientSecret?: string
+  scope?: string
 }
 
 export interface McpRemoteConfig {
@@ -26,6 +36,10 @@ export interface McpRemoteConfig {
   url: string
   headers?: Record<string, string>
   enabled?: boolean
+  /** OAuth config, or false to disable OAuth auto-detection */
+  oauth?: McpOAuthConfig | false
+  /** Timeout in ms for MCP server requests */
+  timeout?: number
 }
 
 export type McpServerConfig = McpLocalConfig | McpRemoteConfig


### PR DESCRIPTION
## Summary

Add support for additional opencode MCP configuration options when loading Claude Code `.mcp.json` files:

- **timeout**: Custom timeout in milliseconds for MCP server requests
- **oauth**: OAuth configuration for remote servers (type definitions only)

## Motivation

Long-running MCP operations (e.g., multi-agent arena discussions) were timing out because the transformer wasn't passing through the `timeout` field from Claude Code's `.mcp.json` configuration to opencode's MCP config format.

Reference: https://opencode.ai/docs/mcp-servers

## Changes

### `types.ts`
- Added `timeout?: number` to `ClaudeCodeMcpServer`, `McpLocalConfig`, and `McpRemoteConfig`
- Added `McpOAuthConfig` interface for OAuth configuration
- Added `oauth?: McpOAuthConfig | false` to `McpRemoteConfig`

### `transformer.ts`
- Pass through `timeout` field for both local and remote MCP servers

### `transformer.test.ts` (new)
- Added comprehensive tests for transformer functionality
- Tests cover timeout handling for both local and remote servers

## Testing

```bash
bun test src/features/claude-code-mcp-loader/
# 16 pass, 0 fail
```

## Example Usage

In Claude Code's `.mcp.json`:
```json
{
  "mcpServers": {
    "arena": {
      "command": "npx",
      "args": ["-y", "agent-arena"],
      "timeout": 600000
    }
  }
}
```

This timeout will now be properly passed through to opencode's MCP configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds timeout support and OAuth type definitions to the Claude Code MCP loader so .mcp.json timeouts pass through to opencode and long-running requests don’t fail.

- **New Features**
  - Passes through timeout for local (stdio) and remote servers.
  - Adds McpOAuthConfig and optional oauth on remote servers (types only).
  - Adds transformer tests for timeout handling and error cases.

<sup>Written for commit 4ee2467fd3a6d8a748582cf4863e01dd127ab7c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

