### PR TITLE
Add current date to omo-env context

### DIFF
--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -99,7 +99,14 @@ export function createEnvContext(): string {
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
   const locale = Intl.DateTimeFormat().resolvedOptions().locale
 
-  const timeStr = now.toLocaleTimeString("en-US", {
+  const dateStr = now.toLocaleDateString(locale, {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+
+  const timeStr = now.toLocaleTimeString(locale, {
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
@@ -108,6 +115,7 @@ export function createEnvContext(): string {
 
   return `
 <omo-env>
+  Current date: ${dateStr}
   Current time: ${timeStr}
   Timezone: ${timezone}
   Locale: ${locale}


### PR DESCRIPTION
The `omo-env` block already injects time, timezone, and locale. But it's missing the date. So when a model reasons about "recent" libraries or "current" best practices, it's flying blind and will trigger search like `movies in 2024-2025` instead of 2026.

This PR adds one line:

```
Current date: Mon, Jan 20, 2026
```

Small change. But now the model knows when it is, not just what time it is.

Also switched from hardcoded `en-US` to the user's actual locale. If you're in Tokyo, you should see Japanese date formatting.

**Changes:**
- Add `Current date` field using `toLocaleDateString()` with user locale
- Use locale-aware formatting for both date and time

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds current date to omo-env and uses the user's locale for date/time formatting. Improves context accuracy and shows date/time in the expected local format.

- **New Features**
  - Adds "Current date" using toLocaleDateString with the resolved locale.
  - Replaces hardcoded en-US time formatting with locale-aware formatting.

<sup>Written for commit 193c1761303439ccb9dd6632b16cd5e4ced8cad1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

