### PR TITLE
[fix] docs: remove unsupported --chatgpt installer flag from docs and workflow

### DIFF
--- a/.github/workflows/sisyphus-agent.yml
+++ b/.github/workflows/sisyphus-agent.yml
@@ -103,7 +103,7 @@ jobs:
           opencode --version
 
           # Run local oh-my-opencode install (uses built dist)
-          bun run dist/cli/index.js install --no-tui --claude=max20 --chatgpt=no --gemini=no --copilot=no
+          bun run dist/cli/index.js install --no-tui --claude=max20 --gemini=no --copilot=no
 
           # Override plugin to use local file reference
           OPENCODE_JSON=~/.config/opencode/opencode.json

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -42,8 +42,8 @@ Ask the user these 3 questions to determine CLI options:
    - If **no** → `--claude=no`
 
 2. **Do you have a ChatGPT Subscription?**
-   - If **yes** → `--chatgpt=yes`
-   - If **no** → `--chatgpt=no`
+  - Note: ChatGPT/OpenAI is configured via OpenCode's authentication flow (use `opencode auth login`).
+    There is no `--chatgpt` CLI flag for the installer; authenticate OpenAI after installation.
 
 3. **Will you integrate Gemini models?**
    - If **yes** → `--gemini=yes`
@@ -74,14 +74,14 @@ Spawn a subagent to handle installation and report back - to save context.
 Based on user's answers, run the CLI installer with appropriate flags:
 
 ```bash
-bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --chatgpt=<yes|no> --gemini=<yes|no> --copilot=<yes|no>
+bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --gemini=<yes|no> --copilot=<yes|no>
 ```
 
 **Examples:**
-- User has all subscriptions with max20: `bunx oh-my-opencode install --no-tui --claude=max20 --chatgpt=yes --gemini=yes --copilot=no`
-- User has only Claude (no max20): `bunx oh-my-opencode install --no-tui --claude=yes --chatgpt=no --gemini=no --copilot=no`
-- User has only GitHub Copilot: `bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no --copilot=yes`
-- User has no subscriptions: `bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no`
+- User has all subscriptions with max20: `bunx oh-my-opencode install --no-tui --claude=max20 --gemini=yes --copilot=no`
+- User has only Claude (no max20): `bunx oh-my-opencode install --no-tui --claude=yes --gemini=no --copilot=no`
+- User has only GitHub Copilot: `bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=yes`
+- User has no subscriptions: `bunx oh-my-opencode install --no-tui --claude=no --gemini=no`
 
 The CLI will:
 - Register the plugin in `opencode.json`
@@ -188,7 +188,7 @@ bunx oh-my-opencode install
 Or use non-interactive mode:
 
 ```bash
-bunx oh-my-opencode install --no-tui --claude=no --chatgpt=no --gemini=no --copilot=yes
+bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=yes
 ```
 
 Then authenticate with GitHub:


### PR DESCRIPTION
## Summary

- Remove unsupported `--chatgpt` installer flag references from documentation and CI workflow.
- Clarify that ChatGPT/OpenAI should be configured via `opencode auth login` (not via an installer flag).

## Changes

- `docs/guide/installation.md`: removed `--chatgpt` examples and added a note instructing users to authenticate OpenAI via `opencode auth login`.
- `.github/workflows/sisyphus-agent.yml`: removed `--chatgpt` from the `bun run ... install` command to match the installer implementation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unsupported --chatgpt installer flag from docs and the CI workflow, and updated CLI examples to match the current installer. Clarified that OpenAI/ChatGPT should be configured via opencode auth login after installation.

<sup>Written for commit 23cb5ece6fbc8d2762ec8a20522501c95c3027ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

