### PR TITLE
fix: prevent builtin MCPs from overwriting user MCP configs

### DIFF
--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -348,8 +348,8 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       : { servers: {} };
 
     config.mcp = {
-      ...(config.mcp as Record<string, unknown>),
       ...createBuiltinMcps(pluginConfig.disabled_mcps),
+      ...(config.mcp as Record<string, unknown>),
       ...mcpResult.servers,
       ...pluginComponents.mcpServers,
     };


### PR DESCRIPTION
Summary
- Fix builtin MCP configs (context7, websearch, grep_app) overwriting user-defined MCP configs
- User's custom headers (e.g., API keys) are now preserved instead of being replaced by plugin defaults

Changes
- Reordered spread operators in src/plugin-handlers/config-handler.ts so plugin builtin MCPs are applied first, allowing user configs to override them
config.mcp = {
+     ...createBuiltinMcps(pluginConfig.disabled_mcps),
      ...(config.mcp as Record<string, unknown>),
-     ...createBuiltinMcps(pluginConfig.disabled_mcps),
      ...mcpResult.servers,
      ...pluginComponents.mcpServers,
};

Testing
bun run typecheck
bun run build

Manual verification:
1. Add custom headers to an MCP in ~/.config/opencode/opencode.json:
{
  mcp: {
    context7: {
      type: remote,
      url: https://mcp.context7.com/mcp,
      headers: { CONTEXT7_API_KEY: your-key }
    }
  }
}
2. Run opencode debug config
3. Verify context7 config includes your headers field (previously it was stripped)

Related Issues
<!-- No existing issue found for this bug -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent built-in MCP configs (context7, websearch, grep_app) from overwriting user MCP settings so custom headers and other overrides are preserved.

<sup>Written for commit 7b41d4a203786d11918f4ad8728d53c443c6ff3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

