### PR TITLE
fix(doctor): improve AST-Grep NAPI detection for bunx environments

### DIFF
--- a/src/cli/doctor/checks/dependencies.test.ts
+++ b/src/cli/doctor/checks/dependencies.test.ts
@@ -16,10 +16,10 @@ describe("dependencies check", () => {
   })
 
   describe("checkAstGrepNapi", () => {
-    it("returns dependency info", () => {
+    it("returns dependency info", async () => {
       // #given
       // #when checking ast-grep napi
-      const info = deps.checkAstGrepNapi()
+      const info = await deps.checkAstGrepNapi()
 
       // #then should return valid info
       expect(info.name).toBe("AST-Grep NAPI")
@@ -95,7 +95,7 @@ describe("dependencies check", () => {
 
     it("returns pass when installed", async () => {
       // #given napi installed
-      checkSpy = spyOn(deps, "checkAstGrepNapi").mockReturnValue({
+      checkSpy = spyOn(deps, "checkAstGrepNapi").mockResolvedValue({
         name: "AST-Grep NAPI",
         required: false,
         installed: true,


### PR DESCRIPTION
## Summary

Fixes #898 - Doctor AST-Grep NAPI check reports false negatives when running via `bunx`

### Problem

When running oh-my-opencode via `bunx oh-my-opencode`, the `require.resolve("@ast-grep/napi")` call in `checkAstGrepNapi()` fails even when the module is installed at `~/.config/opencode/node_modules/@ast-grep/napi`. This is because bunx executes from a temporary directory where the module isn't directly resolvable.

### Solution

- Replace synchronous `require.resolve()` with async dynamic `import()` which works in bunx environments
- Add fallback path checks for common installation locations:
  - `~/.config/opencode/node_modules/@ast-grep/napi`
  - `${cwd}/node_modules/@ast-grep/napi`
- Convert `checkAstGrepNapi()` from sync to async function
- Update tests accordingly

### Testing

- All 524 tests pass
- Tested locally with bunx environment simulation

### Changes

- `src/cli/doctor/checks/dependencies.ts` - Improved NAPI detection logic
- `src/cli/doctor/checks/dependencies.test.ts` - Updated tests for async function

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false negatives in the Doctor AST-Grep NAPI check when running via bunx. Ensures @ast-grep/napi is detected from bunx temp dirs and common install locations. Fixes #898.

- **Bug Fixes**
  - Use async dynamic import instead of require.resolve in checkAstGrepNapi.
  - Add fallback checks for ~/.config/opencode/node_modules/@ast-grep/napi and cwd/node_modules/@ast-grep/napi.
  - Convert checkAstGrepNapi to async; update callers and tests.

<sup>Written for commit be9d6c00614ae45602c4f5d42f65f94573f2a57a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

