### PR TITLE
Add xhigh reasoningEffort to config schema

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -1783,7 +1783,8 @@
             "enum": [
               "low",
               "medium",
-              "high"
+              "high",
+              "xhigh"
             ]
           },
           "textVerbosity": {

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -345,6 +345,20 @@ describe("CategoryConfigSchema", () => {
     }
   })
 
+  test("accepts reasoningEffort as optional string with xhigh", () => {
+    // #given
+    const config = { model: "openai/gpt-5.2", reasoningEffort: "xhigh" }
+
+    // #when
+    const result = CategoryConfigSchema.safeParse(config)
+
+    // #then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.reasoningEffort).toBe("xhigh")
+    }
+  })
+
   test("rejects non-string variant", () => {
     // #given
     const config = { model: "openai/gpt-5.2", variant: 123 }

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -347,7 +347,7 @@ describe("CategoryConfigSchema", () => {
 
   test("accepts reasoningEffort as optional string with xhigh", () => {
     // #given
-    const config = { model: "openai/gpt-5.2", reasoningEffort: "xhigh" }
+    const config = { reasoningEffort: "xhigh" }
 
     // #when
     const result = CategoryConfigSchema.safeParse(config)

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -157,7 +157,7 @@ export const CategoryConfigSchema = z.object({
     type: z.enum(["enabled", "disabled"]),
     budgetTokens: z.number().optional(),
   }).optional(),
-  reasoningEffort: z.enum(["low", "medium", "high"]).optional(),
+  reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]).optional(),
   textVerbosity: z.enum(["low", "medium", "high"]).optional(),
   tools: z.record(z.string(), z.boolean()).optional(),
   prompt_append: z.string().optional(),


### PR DESCRIPTION
## Summary

- Allow `reasoningEffort: "xhigh"` in category config schema.

## Changes

- Extend `CategoryConfigSchema` reasoningEffort enum with `xhigh`.
- Regenerate `assets/oh-my-opencode.schema.json`.

## Testing

```bash
bun test src/config/schema.test.ts
```

## Related Issues

- N/A



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for reasoningEffort: "xhigh" in the category config schema to enable higher reasoning mode where supported. Regenerates the JSON schema and adds a test; backward compatible since the field remains optional.

<sup>Written for commit 8c16bcc42a46f24bba3e5232502c8079fa0eec54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



