### PR TITLE
fix: use correct 'skills' directory path and respect OPENCODE_CONFIG_DIR

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -147,8 +147,8 @@ Three specializations in one:
 ### Custom Skills
 
 Load custom skills from:
-- `.opencode/skill/*/SKILL.md` (project)
-- `~/.config/opencode/skill/*/SKILL.md` (user)
+- `.opencode/skills/*/SKILL.md` (project)
+- `~/.config/opencode/skills/*/SKILL.md` (user)
 - `.claude/skills/*/SKILL.md` (Claude Code compat)
 - `~/.claude/skills/*/SKILL.md` (Claude Code user)
 

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -36,7 +36,7 @@ features/
 | Type | Priority (highest first) |
 |------|--------------------------|
 | Commands | `.opencode/command/` > `~/.config/opencode/command/` > `.claude/commands/` > `~/.claude/commands/` |
-| Skills | `.opencode/skill/` > `~/.config/opencode/skill/` > `.claude/skills/` > `~/.claude/skills/` |
+| Skills | `.opencode/skills/` > `~/.config/opencode/skills/` > `.claude/skills/` > `~/.claude/skills/` |
 | Agents | `.claude/agents/` > `~/.claude/agents/` |
 | MCPs | `.claude/.mcp.json` > `.mcp.json` > `~/.claude/.mcp.json` |
 

--- a/src/features/opencode-skill-loader/async-loader.test.ts
+++ b/src/features/opencode-skill-loader/async-loader.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "os"
 import type { LoadedSkill } from "./types"
 
 const TEST_DIR = join(tmpdir(), "async-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skill")
+const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)

--- a/src/features/opencode-skill-loader/loader.test.ts
+++ b/src/features/opencode-skill-loader/loader.test.ts
@@ -4,7 +4,7 @@ import { join } from "path"
 import { tmpdir } from "os"
 
 const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
-const SKILLS_DIR = join(TEST_DIR, ".opencode", "skill")
+const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
 
 function createTestSkill(name: string, content: string, mcpJson?: object): string {
   const skillDir = join(SKILLS_DIR, name)

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -1,11 +1,11 @@
 import { promises as fs } from "fs"
 import { join, basename } from "path"
-import { homedir } from "os"
 import yaml from "js-yaml"
 import { parseFrontmatter } from "../../shared/frontmatter"
 import { sanitizeModelField } from "../../shared/model-sanitizer"
 import { resolveSymlinkAsync, isMarkdownFile } from "../../shared/file-utils"
 import { getClaudeConfigDir } from "../../shared"
+import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { SkillScope, SkillMetadata, LoadedSkill, LazyContentLoader } from "./types"
 import type { SkillMcpConfig } from "../skill-mcp-manager/types"
@@ -187,13 +187,14 @@ export async function loadProjectSkills(): Promise<Record<string, CommandDefinit
 }
 
 export async function loadOpencodeGlobalSkills(): Promise<Record<string, CommandDefinition>> {
-  const opencodeSkillsDir = join(homedir(), ".config", "opencode", "skill")
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+  const opencodeSkillsDir = join(configDir, "skills")
   const skills = await loadSkillsFromDir(opencodeSkillsDir, "opencode")
   return skillsToRecord(skills)
 }
 
 export async function loadOpencodeProjectSkills(): Promise<Record<string, CommandDefinition>> {
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "skill")
+  const opencodeProjectDir = join(process.cwd(), ".opencode", "skills")
   const skills = await loadSkillsFromDir(opencodeProjectDir, "opencode-project")
   return skillsToRecord(skills)
 }
@@ -249,11 +250,12 @@ export async function discoverProjectClaudeSkills(): Promise<LoadedSkill[]> {
 }
 
 export async function discoverOpencodeGlobalSkills(): Promise<LoadedSkill[]> {
-  const opencodeSkillsDir = join(homedir(), ".config", "opencode", "skill")
+  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+  const opencodeSkillsDir = join(configDir, "skills")
   return loadSkillsFromDir(opencodeSkillsDir, "opencode")
 }
 
 export async function discoverOpencodeProjectSkills(): Promise<LoadedSkill[]> {
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "skill")
+  const opencodeProjectDir = join(process.cwd(), ".opencode", "skills")
   return loadSkillsFromDir(opencodeProjectDir, "opencode-project")
 }

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -18,7 +18,7 @@ export interface SkillInfo {
 }
 
 export interface SkillLoadOptions {
-  /** When true, only load from OpenCode paths (.opencode/skill/, ~/.config/opencode/skill/) */
+  /** When true, only load from OpenCode paths (.opencode/skills/, ~/.config/opencode/skills/) */
   opencodeOnly?: boolean
   /** Pre-merged skills to use instead of discovering */
   skills?: LoadedSkill[]


### PR DESCRIPTION
## Summary

- Fix skills directory path from `skill` (singular) to `skills` (plural) to match OpenCode standard
- Respect `OPENCODE_CONFIG_DIR` environment variable for global skills discovery

Fixes #810 #930

## Problem

According to the [official OpenCode documentation](https://opencode.ai/docs/skills/#place-files), skills should be placed in:
- Project config: `.opencode/skills/<name>/SKILL.md`
- Global config: `~/.config/opencode/skills/<name>/SKILL.md`

However, oh-my-opencode was incorrectly looking in:
- `.opencode/skill/` (singular)
- `~/.config/opencode/skill/` (singular)

Additionally, the `OPENCODE_CONFIG_DIR` environment variable was not being respected for global skills, preventing users from using custom config directories.

## Changes

| File | Change |
|------|--------|
| `src/features/opencode-skill-loader/loader.ts` | Changed `skill` to `skills` and used `getOpenCodeConfigDir()` to respect `OPENCODE_CONFIG_DIR` |
| `src/features/opencode-skill-loader/loader.test.ts` | Updated test path |
| `src/features/opencode-skill-loader/async-loader.test.ts` | Updated test path |
| `src/tools/skill/types.ts` | Updated documentation comment |
| `src/features/AGENTS.md` | Updated documentation |
| `docs/features.md` | Updated documentation |

## Testing

- All skill-related tests pass (57 tests)
- Verified the fix aligns with OpenCode standard paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the correct "skills" directory and honor OPENCODE_CONFIG_DIR for OpenCode skill discovery. Aligns project and global paths with the OpenCode standard and fixes #810 #930.

- **Bug Fixes**
  - Load skills from .opencode/skills and global config via getOpenCodeConfigDir (respects OPENCODE_CONFIG_DIR).
  - Updated tests and docs to reflect the correct paths.

- **Migration**
  - Move any skills from .opencode/skill to .opencode/skills.
  - If using a custom global config directory, set OPENCODE_CONFIG_DIR.

<sup>Written for commit 1a4106120d5263ae217692625ba761a667c22dd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

