### PR TITLE
feat(skill-loader): integrate plugin skills into unified skill discovery

### DIFF
--- a/src/features/claude-code-plugin-loader/loader.ts
+++ b/src/features/claude-code-plugin-loader/loader.ts
@@ -9,7 +9,7 @@ import { log } from "../../shared/logger"
 import { expandEnvVarsInObject } from "../claude-code-mcp-loader/env-expander"
 import { transformMcpServer } from "../claude-code-mcp-loader/transformer"
 import type { CommandDefinition, CommandFrontmatter } from "../claude-code-command-loader/types"
-import type { SkillMetadata } from "../opencode-skill-loader/types"
+import type { SkillMetadata, LoadedSkill } from "../opencode-skill-loader/types"
 import type { AgentFrontmatter } from "../claude-code-agent-loader/types"
 import type { ClaudeCodeMcpConfig, McpServerConfig } from "../claude-code-mcp-loader/types"
 import type {
@@ -327,6 +327,81 @@ $ARGUMENTS
   return skills
 }
 
+export function discoverPluginSkills(options?: PluginLoaderOptions): LoadedSkill[] {
+  const { plugins } = discoverInstalledPlugins(options)
+  const skills: LoadedSkill[] = []
+
+  for (const plugin of plugins) {
+    if (!plugin.skillsDir || !existsSync(plugin.skillsDir)) continue
+
+    const entries = readdirSync(plugin.skillsDir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue
+
+      const skillPath = join(plugin.skillsDir, entry.name)
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
+
+      const resolvedPath = resolveSymlink(skillPath)
+      const skillMdPath = join(resolvedPath, "SKILL.md")
+      if (!existsSync(skillMdPath)) continue
+
+      try {
+        const content = readFileSync(skillMdPath, "utf-8")
+        const { data, body } = parseFrontmatter<SkillMetadata>(content)
+
+        const skillName = data.name || entry.name
+        const namespacedName = `${plugin.name}:${skillName}`
+        const originalDescription = data.description || ""
+        const formattedDescription = `(plugin: ${plugin.name}) ${originalDescription}`
+
+        const wrappedTemplate = `<skill-instruction>
+Base directory for this skill: ${resolvedPath}/
+File references (@path) in this skill are relative to this directory.
+
+${body.trim()}
+</skill-instruction>
+
+<user-request>
+$ARGUMENTS
+</user-request>`
+
+        const allowedTools = data["allowed-tools"]
+          ? data["allowed-tools"].split(/\s+/).filter(Boolean)
+          : undefined
+
+        const loadedSkill: LoadedSkill = {
+          name: namespacedName,
+          path: skillMdPath,
+          resolvedPath,
+          definition: {
+            name: namespacedName,
+            description: formattedDescription,
+            template: wrappedTemplate,
+            model: sanitizeModelField(data.model),
+            agent: data.agent,
+            subtask: data.subtask,
+            argumentHint: data["argument-hint"],
+          },
+          scope: "plugin",
+          license: data.license,
+          compatibility: data.compatibility,
+          metadata: data.metadata,
+          allowedTools,
+          mcpConfig: data.mcp,
+        }
+
+        skills.push(loadedSkill)
+        log(`Discovered plugin skill: ${namespacedName}`, { path: resolvedPath })
+      } catch (error) {
+        log(`Failed to discover plugin skill: ${skillPath}`, error)
+      }
+    }
+  }
+
+  return skills
+}
+
 function parseToolsConfig(toolsStr?: string): Record<string, boolean> | undefined {
   if (!toolsStr) return undefined
 
@@ -453,7 +528,7 @@ export function loadPluginHooksConfigs(
 
 export interface PluginComponentsResult {
   commands: Record<string, CommandDefinition>
-  skills: Record<string, CommandDefinition>
+  skills: LoadedSkill[]
   agents: Record<string, AgentConfig>
   mcpServers: Record<string, McpServerConfig>
   hooksConfigs: HooksConfig[]
@@ -466,13 +541,13 @@ export async function loadAllPluginComponents(options?: PluginLoaderOptions): Pr
 
   const [commands, skills, agents, mcpServers, hooksConfigs] = await Promise.all([
     Promise.resolve(loadPluginCommands(plugins)),
-    Promise.resolve(loadPluginSkillsAsCommands(plugins)),
+    Promise.resolve(discoverPluginSkills(options)),
     Promise.resolve(loadPluginAgents(plugins)),
     loadPluginMcpServers(plugins),
     Promise.resolve(loadPluginHooksConfigs(plugins)),
   ])
 
-  log(`Loaded ${plugins.length} plugins with ${Object.keys(commands).length} commands, ${Object.keys(skills).length} skills, ${Object.keys(agents).length} agents, ${Object.keys(mcpServers).length} MCP servers`)
+  log(`Loaded ${plugins.length} plugins with ${Object.keys(commands).length} commands, ${skills.length} skills, ${Object.keys(agents).length} agents, ${Object.keys(mcpServers).length} MCP servers`)
 
   return {
     commands,

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -9,6 +9,7 @@ import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { SkillScope, SkillMetadata, LoadedSkill, LazyContentLoader } from "./types"
 import type { SkillMcpConfig } from "../skill-mcp-manager/types"
+import { discoverPluginSkills } from "../claude-code-plugin-loader"
 
 function parseSkillMcpConfigFromFrontmatter(content: string): SkillMcpConfig | undefined {
   const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
@@ -201,29 +202,32 @@ export async function loadOpencodeProjectSkills(): Promise<Record<string, Comman
 
 export interface DiscoverSkillsOptions {
   includeClaudeCodePaths?: boolean
+  includePlugins?: boolean
 }
 
 export async function discoverAllSkills(): Promise<LoadedSkill[]> {
-  const [opencodeProjectSkills, projectSkills, opencodeGlobalSkills, userSkills] = await Promise.all([
+  const [opencodeProjectSkills, projectSkills, opencodeGlobalSkills, userSkills, pluginSkills] = await Promise.all([
     discoverOpencodeProjectSkills(),
     discoverProjectClaudeSkills(),
     discoverOpencodeGlobalSkills(),
     discoverUserClaudeSkills(),
+    Promise.resolve(discoverPluginSkills()),
   ])
 
-  return [...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills]
+  return [...pluginSkills, ...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills]
 }
 
 export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promise<LoadedSkill[]> {
-  const { includeClaudeCodePaths = true } = options
+  const { includeClaudeCodePaths = true, includePlugins = true } = options
 
-  const [opencodeProjectSkills, opencodeGlobalSkills] = await Promise.all([
+  const [opencodeProjectSkills, opencodeGlobalSkills, pluginSkills] = await Promise.all([
     discoverOpencodeProjectSkills(),
     discoverOpencodeGlobalSkills(),
+    includePlugins ? Promise.resolve(discoverPluginSkills()) : Promise.resolve([]),
   ])
 
   if (!includeClaudeCodePaths) {
-    return [...opencodeProjectSkills, ...opencodeGlobalSkills]
+    return [...pluginSkills, ...opencodeProjectSkills, ...opencodeGlobalSkills]
   }
 
   const [projectSkills, userSkills] = await Promise.all([
@@ -231,7 +235,7 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
     discoverUserClaudeSkills(),
   ])
 
-  return [...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills]
+  return [...pluginSkills, ...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills]
 }
 
 export async function getSkillByName(name: string, options: DiscoverSkillsOptions = {}): Promise<LoadedSkill | undefined> {

--- a/src/features/opencode-skill-loader/merger.ts
+++ b/src/features/opencode-skill-loader/merger.ts
@@ -12,10 +12,11 @@ import { deepMerge } from "../../shared/deep-merge"
 const SCOPE_PRIORITY: Record<SkillScope, number> = {
   builtin: 1,
   config: 2,
-  user: 3,
-  opencode: 4,
-  project: 5,
-  "opencode-project": 6,
+  plugin: 3,
+  user: 4,
+  opencode: 5,
+  project: 6,
+  "opencode-project": 7,
 }
 
 function builtinToLoaded(builtin: BuiltinSkill): LoadedSkill {

--- a/src/features/opencode-skill-loader/types.ts
+++ b/src/features/opencode-skill-loader/types.ts
@@ -1,7 +1,7 @@
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { SkillMcpConfig } from "../skill-mcp-manager/types"
 
-export type SkillScope = "builtin" | "config" | "user" | "project" | "opencode" | "opencode-project"
+export type SkillScope = "builtin" | "config" | "plugin" | "user" | "project" | "opencode" | "opencode-project"
 
 export interface SkillMetadata {
   name?: string

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -13,6 +13,8 @@ import {
   loadOpencodeGlobalSkills,
   loadOpencodeProjectSkills,
 } from "../features/opencode-skill-loader";
+import type { LoadedSkill } from "../features/opencode-skill-loader/types";
+import type { CommandDefinition } from "../features/claude-code-command-loader/types";
 import {
   loadUserAgents,
   loadProjectAgents,
@@ -83,7 +85,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
         })
       : {
           commands: {},
-          skills: {},
+          skills: [] as LoadedSkill[],
           agents: {},
           mcpServers: {},
           hooksConfigs: [],
@@ -381,6 +383,15 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       loadOpencodeProjectSkills(),
     ]);
 
+    const pluginSkillsAsCommands = pluginComponents.skills.reduce<Record<string, CommandDefinition>>(
+      (acc, skill) => {
+        const { name: _name, ...rest } = skill.definition;
+        acc[skill.name] = rest as CommandDefinition;
+        return acc;
+      },
+      {}
+    );
+
     config.command = {
       ...builtinCommands,
       ...userCommands,
@@ -393,7 +404,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       ...opencodeProjectCommands,
       ...opencodeProjectSkills,
       ...pluginComponents.commands,
-      ...pluginComponents.skills,
+      ...pluginSkillsAsCommands,
     };
   };
 }

--- a/src/tools/slashcommand/types.ts
+++ b/src/tools/slashcommand/types.ts
@@ -1,6 +1,6 @@
 import type { LoadedSkill, LazyContentLoader } from "../../features/opencode-skill-loader"
 
-export type CommandScope = "builtin" | "config" | "user" | "project" | "opencode" | "opencode-project"
+export type CommandScope = "builtin" | "config" | "plugin" | "user" | "project" | "opencode" | "opencode-project"
 
 export interface CommandMetadata {
   name: string


### PR DESCRIPTION
## Summary

This PR fixes an issue where Claude Code plugin skills were only available via slash commands (`/plugin:skill-name`) but not through the skill tool (`mcp_skill`).

## Problem

Previously, plugin skills were loaded separately from other skills:
- `loadPluginSkillsAsCommands()` returned `Record<string, CommandDefinition>` for slash commands
- `discoverSkills()` did not include plugin skills
- `mergeSkills()` never received plugin skills

This meant users couldn't use plugin skills through the automatic skill discovery in `mcp_skill`.

## Solution

- Add `discoverPluginSkills()` function that returns `LoadedSkill[]`
- Integrate plugin skills into `discoverSkills()` and `discoverAllSkills()`
- Change `PluginComponentsResult.skills` type from `Record<string, CommandDefinition>` to `LoadedSkill[]`
- Add `'plugin'` to `SkillScope` with appropriate priority (after config, before user)
- Convert `LoadedSkill[]` to `CommandDefinition` in config-handler for backward compatibility

## Changes

| File | Change |
|------|--------|
| `opencode-skill-loader/types.ts` | Add `'plugin'` to `SkillScope` |
| `opencode-skill-loader/merger.ts` | Add `'plugin'` to `SCOPE_PRIORITY` |
| `claude-code-plugin-loader/loader.ts` | Add `discoverPluginSkills()`, change `loadAllPluginComponents` return type |
| `opencode-skill-loader/loader.ts` | Include plugin skills in `discoverSkills()` |
| `plugin-handlers/config-handler.ts` | Convert `LoadedSkill[]` to slash commands |
| `slashcommand/types.ts` | Add `'plugin'` to `CommandScope` |

## Result

Plugin skills are now accessible through both:
- Slash commands: `/plugin:skill-name`
- Skill tool: `mcp_skill` with automatic discovery

## Testing

- [x] Build passes
- [x] Existing tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unified skill discovery now includes Claude Code plugin skills. Plugin skills work in mcp_skill and remain available via /plugin:skill-name.

- **New Features**
  - Added discoverPluginSkills() and included plugin skills in discoverSkills()/discoverAllSkills().
  - Changed PluginComponentsResult.skills to LoadedSkill[].
  - Added "plugin" to SkillScope with priority after config, before user.
  - Converted plugin LoadedSkill[] to slash commands in the config handler for backward compatibility.

<sup>Written for commit 51fa98764e8a87a87f9699b69f77a4efbe71d13c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

