### PR TITLE
fix: auto-truncate question option labels exceeding 30 characters

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -29,3 +29,4 @@ export { createPrometheusMdOnlyHook } from "./prometheus-md-only";
 export { createTaskResumeInfoHook } from "./task-resume-info";
 export { createStartWorkHook } from "./start-work";
 export { createSisyphusOrchestratorHook } from "./sisyphus-orchestrator";
+export { createQuestionLabelTruncatorHook } from "./question-label-truncator";

--- a/src/hooks/question-label-truncator/index.ts
+++ b/src/hooks/question-label-truncator/index.ts
@@ -1,0 +1,63 @@
+import type { Plugin } from "@opencode-ai/plugin";
+
+const MAX_LABEL_LENGTH = 30;
+
+interface QuestionOption {
+  label: string;
+  description?: string;
+}
+
+interface Question {
+  question: string;
+  header?: string;
+  options: QuestionOption[];
+  multiSelect?: boolean;
+}
+
+interface AskUserQuestionArgs {
+  questions: Question[];
+}
+
+function truncateLabel(label: string, maxLength: number = MAX_LABEL_LENGTH): string {
+  if (label.length <= maxLength) {
+    return label;
+  }
+  return label.substring(0, maxLength - 3) + "...";
+}
+
+function truncateQuestionLabels(args: AskUserQuestionArgs): AskUserQuestionArgs {
+  if (!args.questions || !Array.isArray(args.questions)) {
+    return args;
+  }
+
+  return {
+    ...args,
+    questions: args.questions.map((question) => ({
+      ...question,
+      options: question.options?.map((option) => ({
+        ...option,
+        label: truncateLabel(option.label),
+      })) ?? [],
+    })),
+  };
+}
+
+export function createQuestionLabelTruncatorHook(): Pick<
+  Plugin,
+  "tool.execute.before"
+> {
+  return {
+    "tool.execute.before": async (input, output) => {
+      const toolName = input.tool?.toLowerCase();
+
+      if (toolName === "askuserquestion" || toolName === "ask_user_question") {
+        const args = output.args as AskUserQuestionArgs | undefined;
+
+        if (args?.questions) {
+          const truncatedArgs = truncateQuestionLabels(args);
+          Object.assign(output.args as object, truncatedArgs);
+        }
+      }
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
   createStartWorkHook,
   createSisyphusOrchestratorHook,
   createPrometheusMdOnlyHook,
+  createQuestionLabelTruncatorHook,
 } from "./hooks";
 import {
   contextCollector,
@@ -207,6 +208,8 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   const prometheusMdOnly = isHookEnabled("prometheus-md-only")
     ? createPrometheusMdOnlyHook(ctx)
     : null;
+
+  const questionLabelTruncator = createQuestionLabelTruncatorHook();
 
   const taskResumeInfo = createTaskResumeInfoHook();
 
@@ -458,6 +461,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     },
 
     "tool.execute.before": async (input, output) => {
+      await questionLabelTruncator["tool.execute.before"]?.(input, output);
       await claudeCodeHooks["tool.execute.before"](input, output);
       await nonInteractiveEnv?.["tool.execute.before"](input, output);
       await commentChecker?.["tool.execute.before"](input, output);


### PR DESCRIPTION
## Summary

- Adds a new `question-label-truncator` hook that automatically truncates AskUserQuestion option labels to ≤30 characters
- Fixes validation errors when AI generates labels longer than the allowed limit
- Labels exceeding 30 characters are truncated with "..." suffix

## Problem

When AI generates `AskUserQuestion` tool calls with option labels longer than 30 characters, opencode validation rejects them with error:

```
Error: The question tool was called with invalid arguments: [
  {
    "origin": "string",
    "code": "too_big",
    "maximum": 30,
    "inclusive": true,
    "path": ["questions", 0, "options", 0, "label"],
    "message": "Too big: expected string to have <=30 characters"
  }
]
```

## Solution

This PR adds a pre-tool-use hook that intercepts `AskUserQuestion` tool calls and automatically truncates any labels that exceed 30 characters before validation occurs.

## Test plan

- [x] Verify hook is called before tool validation
- [ ] Test with question labels > 30 characters - should be truncated
- [ ] Test with question labels ≤ 30 characters - should remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically truncate AskUserQuestion option labels to 30 characters to prevent validation failures. Truncation adds "..." and runs before tool validation.

- **Bug Fixes**
  - Added createQuestionLabelTruncatorHook to pre-truncate AskUserQuestion option labels >30 chars with "...".
  - Runs on tool.execute.before to avoid "Too big" errors; labels ≤30 chars are unchanged.

<sup>Written for commit 35a744e4ef2a28b283e1d6f29bfa43c209d8d236. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

