### PR TITLE
Fix MCP disabled flag not removing previously loaded servers

### DIFF
--- a/src/features/claude-code-mcp-loader/loader.ts
+++ b/src/features/claude-code-mcp-loader/loader.ts
@@ -77,7 +77,13 @@ export async function loadMcpConfigs(): Promise<McpLoadResult> {
 
     for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
       if (serverConfig.disabled) {
-        log(`Skipping disabled MCP server "${name}"`, { path })
+        log(`Disabling MCP server "${name}"`, { path })
+        delete servers[name]
+        const existingIndex = loadedServers.findIndex((s) => s.name === name)
+        if (existingIndex !== -1) {
+          loadedServers.splice(existingIndex, 1)
+          log(`Removed previously loaded MCP server "${name}"`, { path })
+        }
         continue
       }
 


### PR DESCRIPTION
## Problem

When using the `disabled: true` flag in MCP configs (e.g., `.claude/.mcp.json`), the flag was only skipping the loading of that server. It did **not** remove servers that were already loaded from earlier config files.

This made it impossible to disable project-level MCPs using local overrides.

## Root Cause

The MCP loader processes configs in order: user → project → local. When encountering `disabled: true`, the code would skip loading but wouldn't remove previously-loaded servers with the same name.

## Solution

Modified `src/features/claude-code-mcp-loader/loader.ts` to:
- Delete the server from the `servers` object
- Remove it from the `loadedServers` array
- Log the removal action

Now the `disabled` flag works as intended: later configs can override and disable servers from earlier configs.

## Testing

- `bun run typecheck` passes
- `bun run build` succeeds
- Manually verified that `.claude/.mcp.json` with `disabled: true` now properly disables project-level MCPs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP config disabled flag so it removes servers loaded by earlier configs. Local overrides now correctly disable matching servers by deleting them from the servers object and loadedServers list, with a log entry for removals.

<sup>Written for commit ca79f83951679a7734493df73b317ca1dd8e6c2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

