### PR TITLE
fix(lsp): add data dir to LSP server detection paths

### DIFF
--- a/src/tools/lsp/config.ts
+++ b/src/tools/lsp/config.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "fs"
 import { join } from "path"
 import { BUILTIN_SERVERS, EXT_TO_LANG, LSP_INSTALL_HINTS } from "./constants"
 import type { ResolvedServer, ServerLookupResult } from "./types"
-import { getOpenCodeConfigDir } from "../../shared"
+import { getOpenCodeConfigDir, getDataDir } from "../../shared"
 
 interface LspEntry {
   disabled?: boolean
@@ -201,10 +201,12 @@ export function isServerInstalled(command: string[]): boolean {
 
   const cwd = process.cwd()
   const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+  const dataDir = join(getDataDir(), "opencode")
   const additionalBases = [
     join(cwd, "node_modules", ".bin"),
     join(configDir, "bin"),
     join(configDir, "node_modules", ".bin"),
+    join(dataDir, "bin"),
   ]
 
   for (const base of additionalBases) {


### PR DESCRIPTION
## Summary

- Add ~/.local/share/opencode/bin to LSP server detection paths

## Problem

OpenCode downloads LSP servers (like clangd) to ~/.local/share/opencode/bin, but the isServerInstalled() function only checked ~/.config/opencode/bin. This caused LSP tools to incorrectly report servers as not installed even when OpenCode had successfully downloaded them.

### Reproduction steps:
1. Use OpenCode on a fresh machine
2. OpenCode auto-downloads clangd to ~/.local/share/opencode/bin/clangd_21.1.8/bin/clangd.exe
3. Run lsp_servers tool - shows clangd [not installed]
4. Run lsp_diagnostics - fails with LSP server clangd is configured but NOT INSTALLED

### Root cause:
isServerInstalled() in src/tools/lsp/config.ts checks:
- ~/.config/opencode/bin
- ~/.config/opencode/node_modules/.bin

But OpenCode actually stores downloaded LSP binaries in:
- ~/.local/share/opencode/bin

## Solution

Import getDataDir() from shared utilities and add ~/.local/share/opencode/bin to the additionalBases array in isServerInstalled().

## Testing

- [x] Existing tests pass (bun test src/tools/lsp/)
- [x] Manually verified clangd detection works after fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix LSP server detection by including OpenCode’s data dir (~/.local/share/opencode/bin). LSP tools now correctly detect installed servers like clangd instead of reporting “not installed.”

- **Bug Fixes**
  - Use getDataDir() and add data dir bin to isServerInstalled() search paths.
  - Verified clangd detection; existing tests pass.

<sup>Written for commit 7c89a8d09e5c6844d35ad934d68068722384ebf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

