### PR TITLE
fix(lsp): normalize Windows drive letter case for consistent URIs

### DIFF
--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -10,7 +10,7 @@ import type { Diagnostic, ResolvedServer } from "./types"
  * Windows paths are case-insensitive, but file:// URIs are case-sensitive.
  * This ensures the drive letter is always uppercase (D: not d:).
  */
-function normalizePath(filePath: string): string {
+export function normalizePath(filePath: string): string {
   const resolved = resolve(filePath)
   // On Windows, normalize drive letter to uppercase
   if (process.platform === "win32" && /^[a-z]:/.test(resolved)) {

--- a/src/tools/lsp/utils.ts
+++ b/src/tools/lsp/utils.ts
@@ -1,7 +1,7 @@
 import { extname, resolve } from "path"
 import { fileURLToPath } from "node:url"
 import { existsSync, readFileSync, writeFileSync } from "fs"
-import { LSPClient, lspManager } from "./client"
+import { LSPClient, lspManager, normalizePath } from "./client"
 import { findServerForExtension } from "./config"
 import { SYMBOL_KIND_MAP, SEVERITY_MAP } from "./constants"
 import type {
@@ -19,7 +19,7 @@ import type {
 } from "./types"
 
 export function findWorkspaceRoot(filePath: string): string {
-  let dir = resolve(filePath)
+  let dir = normalizePath(filePath)
 
   if (!existsSync(dir) || !require("fs").statSync(dir).isDirectory()) {
     dir = require("path").dirname(dir)
@@ -80,7 +80,7 @@ export function formatServerLookupError(result: Exclude<ServerLookupResult, { st
 }
 
 export async function withLspClient<T>(filePath: string, fn: (client: LSPClient) => Promise<T>): Promise<T> {
-  const absPath = resolve(filePath)
+  const absPath = normalizePath(filePath)
   const ext = extname(absPath)
   const result = findServerForExtension(ext)
 


### PR DESCRIPTION
## Summary

- Normalize Windows drive letter to uppercase before generating file:// URIs

## Problem

On Windows, `lsp_document_symbols`, `lsp_hover`, and other LSP operations fail with:
```
Error: failed to decode textDocument/documentSymbol request: unresolvable URI at (root).textDocument.uri
```

### Root cause

Windows paths are **case-insensitive**, but `file://` URIs are **case-sensitive**.

```typescript
pathToFileURL('D:/path/file.cpp').href  // -> file:///D:/path/file.cpp
pathToFileURL('d:/path/file.cpp').href  // -> file:///d:/path/file.cpp  (different!)
```

If the input path to `openFile()` has a different drive letter case than subsequent calls to `documentSymbols()`, the URIs won't match, and clangd rejects with "unresolvable URI".

### Why diagnostics worked

`lsp_diagnostics` worked because it falls back to cached `publishDiagnostics` notifications from clangd, which are sent after `didOpen` regardless of subsequent request failures.

## Solution

Add `normalizePath()` function that:
1. Resolves the path to absolute
2. On Windows, normalizes drive letter to uppercase

Applied to all LSP client methods: `openFile`, `definition`, `references`, `documentSymbols`, `diagnostics`, `prepareRename`, `rename`.

## Testing

- [x] Existing tests pass (`bun test src/tools/lsp/`)
- [x] Verified URI generation is now consistent regardless of input case

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Windows drive letters to uppercase before generating file:// URIs so all LSP requests use a consistent URI. Fixes clangd “unresolvable URI” errors in hover, document symbols, definition, references, and rename.

- **Bug Fixes**
  - Added normalizePath() to uppercase drive letters on Windows and used it in openFile, definition, references, documentSymbols, diagnostics, prepareRename, and rename.
  - Ensures URIs in didOpen and subsequent requests match even when input paths differ by drive letter case.
  - Applied normalization in withLspClient and findWorkspaceRoot for consistent client setup and workspace detection.

<sup>Written for commit 3adcba6e4fec53526af201edad69d37183702422. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

