### PR TITLE
docs: rename Orchestrator-Sisyphus to Atlas

### DIFF
--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -54,7 +54,7 @@ For complex or critical tasks, press **Tab** to switch to Prometheus (Planner) m
 
 2. **Plan generation** - Based on the interview, Prometheus generates a detailed work plan with tasks, acceptance criteria, and guardrails. Optionally reviewed by Momus (plan reviewer) for high-accuracy validation.
 
-3. **Run `/start-work`** - The Orchestrator-Sisyphus takes over:
+3. **Run `/start-work`** - The Atlas takes over:
    - Distributes tasks to specialized sub-agents
    - Verifies each task completion independently
    - Accumulates learnings across tasks
@@ -84,7 +84,7 @@ The orchestrator is designed to execute work plans created by Prometheus. Using 
 4. Run /start-work → Orchestrator executes
 ```
 
-**Prometheus and Orchestrator-Sisyphus are a pair. Always use them together.**
+**Prometheus and Atlas are a pair. Always use them together.**
 
 ---
 

--- a/docs/guide/understanding-orchestration-system.md
+++ b/docs/guide/understanding-orchestration-system.md
@@ -1,6 +1,6 @@
 # Understanding the Orchestration System
 
-Oh My OpenCode's orchestration system transforms a simple AI agent into a coordinated development team. This document explains how the Prometheus → Orchestrator → Junior workflow creates high-quality, reliable code output.
+Oh My OpenCode's orchestration system transforms a simple AI agent into a coordinated development team. This document explains how the Prometheus → Atlas → Junior workflow creates high-quality, reliable code output.
 
 ---
 
@@ -29,7 +29,7 @@ flowchart TB
     end
     
     subgraph Execution["Execution Layer (Orchestrator)"]
-        Orchestrator["⚡ Orchestrator-Sisyphus<br/>(Conductor)<br/>Claude Opus 4.5"]
+        Orchestrator["⚡ Atlas<br/>(Conductor)<br/>Claude Opus 4.5"]
     end
     
     subgraph Workers["Worker Layer (Specialized Agents)"]
@@ -152,7 +152,7 @@ If REJECTED, Prometheus fixes issues and resubmits. **No maximum retry limit.**
 
 ---
 
-## Layer 2: Execution (Orchestrator-Sisyphus)
+## Layer 2: Execution (Atlas)
 
 ### The Conductor Mindset
 
@@ -160,7 +160,7 @@ The Orchestrator is like an orchestra conductor: **it doesn't play instruments, 
 
 ```mermaid
 flowchart LR
-    subgraph Orchestrator["Orchestrator-Sisyphus"]
+    subgraph Orchestrator["Atlas"]
         Read["1. Read Plan"]
         Analyze["2. Analyze Tasks"]
         Wisdom["3. Accumulate Wisdom"]
@@ -352,7 +352,7 @@ delegate_task(
 ```mermaid
 sequenceDiagram
     participant User
-    participant Orchestrator as Orchestrator-Sisyphus
+    participant Orchestrator as Atlas
     participant Junior as Sisyphus-Junior
     participant Notepad as .sisyphus/notepads/
     
@@ -392,7 +392,7 @@ sequenceDiagram
 ### 1. Separation of Concerns
 
 - **Planning** (Prometheus): High reasoning, interview, strategic thinking
-- **Orchestration** (Sisyphus): Coordination, verification, wisdom accumulation
+- **Orchestration** (Atlas): Coordination, verification, wisdom accumulation
 - **Execution** (Junior): Focused implementation, no distractions
 
 ### 2. Explicit Over Implicit

--- a/docs/orchestration-guide.md
+++ b/docs/orchestration-guide.md
@@ -6,9 +6,10 @@
 |------------|----------|-------------|
 | **Simple** | Just prompt | Simple tasks, quick fixes, single-file changes |
 | **Complex + Lazy** | Just type `ulw` or `ultrawork` | Complex tasks where explaining context is tedious. Agent figures it out. |
-| **Complex + Precise** | `@plan` → `/start-work` | Precise, multi-step work requiring true orchestration. Prometheus plans, Sisyphus executes. |
+| **Complex + Precise** | `@plan` → `/start-work` | Precise, multi-step work requiring true orchestration. Prometheus plans, Atlas executes. |
 
 **Decision Flow:**
+
 ```
 Is it a quick fix or simple task?
   └─ YES → Just prompt normally
@@ -30,7 +31,7 @@ Traditional AI agents often mix planning and execution, leading to context pollu
 Oh-My-OpenCode solves this by clearly separating two roles:
 
 1. **Prometheus (Planner)**: A pure strategist who never writes code. Establishes perfect plans through interviews and analysis.
-2. **Sisyphus (Executor)**: An orchestrator who executes plans. Delegates work to specialized agents and never stops until completion.
+2. **Atlas (Executor)**: An orchestrator who executes plans. Delegates work to specialized agents and never stops until completion.
 
 ---
 
@@ -52,10 +53,10 @@ flowchart TD
     StartWork --> BoulderState[boulder.json]
     
     subgraph Execution Phase
-        BoulderState --> Sisyphus[Sisyphus<br>Orchestrator]
-        Sisyphus --> Oracle[Oracle]
-        Sisyphus --> Frontend[Frontend<br>Engineer]
-        Sisyphus --> Explore[Explore]
+        BoulderState --> Atlas[Atlas<br>Orchestrator]
+        Atlas --> Oracle[Oracle]
+        Atlas --> Frontend[Frontend<br>Engineer]
+        Atlas --> Explore[Explore]
     end
 ```
 
@@ -64,22 +65,26 @@ flowchart TD
 ## 3. Key Components
 
 ### 🔮 Prometheus (The Planner)
+
 - **Model**: `anthropic/claude-opus-4-5`
 - **Role**: Strategic planning, requirements interviews, work plan creation
 - **Constraint**: **READ-ONLY**. Can only create/modify markdown files within `.sisyphus/` directory.
 - **Characteristic**: Never writes code directly, focuses solely on "how to do it".
 
-### 🦉 Metis (The Consultant)
+### 🦉 Metis (The Plan Consultant)
+
 - **Role**: Pre-analysis and gap detection
 - **Function**: Identifies hidden user intent, prevents AI over-engineering, eliminates ambiguity.
 - **Workflow**: Metis consultation is mandatory before plan creation.
 
-### ⚖️ Momus (The Reviewer)
+### ⚖️ Momus (The Plan Reviewer)
+
 - **Role**: High-precision plan validation (High Accuracy Mode)
 - **Function**: Rejects and demands revisions until the plan is perfect.
 - **Trigger**: Activated when user requests "high accuracy".
 
-### 🪨 Sisyphus (The Orchestrator)
+### ⚡ Atlas (The Plan Executor)
+
 - **Model**: `anthropic/claude-opus-4-5` (Extended Thinking 32k)
 - **Role**: Execution and delegation
 - **Characteristic**: Doesn't do everything directly, actively delegates to specialized agents (Frontend, Librarian, etc.).
@@ -89,6 +94,7 @@ flowchart TD
 ## 4. Workflow
 
 ### Phase 1: Interview and Planning (Interview Mode)
+
 Prometheus starts in **interview mode** by default. Instead of immediately creating a plan, it collects sufficient context.
 
 1. **Intent Identification**: Classifies whether the user's request is Refactoring or New Feature.
@@ -96,6 +102,7 @@ Prometheus starts in **interview mode** by default. Instead of immediately creat
 3. **Draft Creation**: Continuously records discussion content in `.sisyphus/drafts/`.
 
 ### Phase 2: Plan Generation
+
 When the user requests "Make it a plan", plan generation begins.
 
 1. **Metis Consultation**: Confirms any missed requirements or risk factors.
@@ -103,10 +110,11 @@ When the user requests "Make it a plan", plan generation begins.
 3. **Handoff**: Once plan creation is complete, guides user to use `/start-work` command.
 
 ### Phase 3: Execution
+
 When the user enters `/start-work`, the execution phase begins.
 
 1. **State Management**: Creates `boulder.json` file to track current plan and session ID.
-2. **Task Execution**: Sisyphus reads the plan and processes TODOs one by one.
+2. **Task Execution**: Atlas reads the plan and processes TODOs one by one.
 3. **Delegation**: UI work is delegated to Frontend agent, complex logic to Oracle.
 4. **Continuity**: Even if the session is interrupted, work continues in the next session through `boulder.json`.
 
@@ -115,11 +123,15 @@ When the user enters `/start-work`, the execution phase begins.
 ## 5. Commands and Usage
 
 ### `@plan [request]`
+
 Invokes Prometheus to start a planning session.
+
 - Example: `@plan "I want to refactor the authentication system to NextAuth"`
 
 ### `/start-work`
+
 Executes the generated plan.
+
 - Function: Finds plan in `.sisyphus/plans/` and enters execution mode.
 - If there's interrupted work, automatically resumes from where it left off.
 
@@ -132,7 +144,7 @@ You can control related features in `oh-my-opencode.json`.
 ```jsonc
 {
   "sisyphus_agent": {
-    "disabled": false,           // Enable Sisyphus orchestration (default: false)
+    "disabled": false,           // Enable Atlas orchestration (default: false)
     "planner_enabled": true,     // Enable Prometheus (default: true)
     "replace_plan": true         // Replace default plan agent with Prometheus (default: true)
   },


### PR DESCRIPTION
## Summary

- Rename "Orchestrator-Sisyphus" to "Atlas" across all documentation files to prevent confusion with the Sisyphus agent

## Changes

 - docs/guide/overview.md: Updated 2 references ("Orchestrator-Sisyphus" → "Atlas")
 - docs/guide/understanding-orchestration-system.md: Updated 6 references including Mermaid flowchart and sequence diagram labels
 - docs/orchestration-guide.md: Renamed "Sisyphus (The Orchestrator)" to "Atlas (The Orchestrator)" with 6 line changes, plus minor formatting improvements


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the orchestrator from “Orchestrator-Sisyphus” to “Atlas” across documentation to reduce confusion with the Sisyphus-Junior agent. Updates include text, tables, and Mermaid/sequence diagram labels; no code or config changes.

<sup>Written for commit 326878273091c131d5747651bf3817ca1476bd03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

