### PR TITLE
fix: add model fallback from agent/category configs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,13 +27,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.0.0-beta.11",
-        "oh-my-opencode-darwin-x64": "3.0.0-beta.11",
-        "oh-my-opencode-linux-arm64": "3.0.0-beta.11",
-        "oh-my-opencode-linux-arm64-musl": "3.0.0-beta.11",
-        "oh-my-opencode-linux-x64": "3.0.0-beta.11",
-        "oh-my-opencode-linux-x64-musl": "3.0.0-beta.11",
-        "oh-my-opencode-windows-x64": "3.0.0-beta.11",
+        "oh-my-opencode-darwin-arm64": "3.0.0-beta.13",
+        "oh-my-opencode-darwin-x64": "3.0.0-beta.13",
+        "oh-my-opencode-linux-arm64": "3.0.0-beta.13",
+        "oh-my-opencode-linux-arm64-musl": "3.0.0-beta.13",
+        "oh-my-opencode-linux-x64": "3.0.0-beta.13",
+        "oh-my-opencode-linux-x64-musl": "3.0.0-beta.13",
+        "oh-my-opencode-windows-x64": "3.0.0-beta.13",
       },
     },
   },
@@ -224,20 +224,6 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.0.0-beta.11", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7cFv2bbz9HTY7sshgVTu+IhvYf7CT0czDYqHEB+dYfEqFU6TaoSMimq6uHqcWegUUR1T7PNmc0dyjYVw69FeVA=="],
-
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.0.0-beta.11", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-rGAbDdUySWITIdm2yiuNFB9lFYaSXT8LMtg97LTlOO5vZbI3M+obIS3QlIkBtAhgOTIPB7Ni+T0W44OmJpHoYA=="],
-
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.0.0-beta.11", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-F9dqwWwGAdqeSkE7Tre5DmHQXwDpU2Z8Jk0lwTJMLj+kMqYFDVPjLPo4iVUdwPpxpmm0pR84u/oonG/2+84/zw=="],
-
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.0.0-beta.11", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H+zOtHkHd+TmdPj64M1A0zLOk7OHIK4C8yqfLFhfizOIBffT1yOhAs6EpK3EqPhfPLu54ADgcQcu8W96VP24UA=="],
-
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.0.0-beta.11", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-IG+KODTJ8rs6cEJ2wN6Zpr6YtvCS5OpYP6jBdGJltmUpjQdMhdMsaY3ysZk+9Vxpx2KC3xj5KLHV1USg3uBTeg=="],
-
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.0.0-beta.11", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-irV+AuWrHqNm7VT7HO56qgymR0+vEfJbtB3vCq68kprH2V4NQmGp2MNKIYPnUCYL7NEK3H2NX+h06YFZJ/8ELQ=="],
-
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.0.0-beta.11", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-exZ/NEwGBlxyWszN7dvOfzbYX0cuhBZXftqAAFOlVP26elDHdo+AmSmLR/4cJyzpR9nCWz4xvl/RYF84bY6OEA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -106,13 +106,38 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     }
 
     if (!(config.model as string | undefined)?.trim()) {
-      const paths = getOpenCodeConfigPaths({ binary: "opencode", version: null })
-      throw new Error(
-        'oh-my-opencode requires a default model.\n\n' +
-        `Add this to ${paths.configJsonc}:\n\n` +
-        '  "model": "anthropic/claude-sonnet-4-5"\n\n' +
-        '(Replace with your preferred provider/model)'
-      )
+      let fallbackModel: string | undefined
+
+      for (const agentConfig of Object.values(pluginConfig.agents ?? {})) {
+        const model = (agentConfig as { model?: string })?.model
+        if (model && typeof model === 'string' && model.trim()) {
+          fallbackModel = model.trim()
+          break
+        }
+      }
+
+      if (!fallbackModel) {
+        for (const categoryConfig of Object.values(pluginConfig.categories ?? {})) {
+          const model = (categoryConfig as { model?: string })?.model
+          if (model && typeof model === 'string' && model.trim()) {
+            fallbackModel = model.trim()
+            break
+          }
+        }
+      }
+
+      if (fallbackModel) {
+        config.model = fallbackModel
+        log(`No default model specified, using fallback from config: ${fallbackModel}`)
+      } else {
+        const paths = getOpenCodeConfigPaths({ binary: "opencode", version: null })
+        throw new Error(
+          'oh-my-opencode requires a default model.\n\n' +
+          `Add this to ${paths.configJsonc}:\n\n` +
+          '  "model": "anthropic/claude-sonnet-4-5"\n\n' +
+          '(Replace with your preferred provider/model)'
+        )
+      }
     }
 
     // Migrate disabled_agents from old names to new names


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->
**How to reproduce**: Upgrade to `oh-my-opencode@3.0.0-beta.13` and run `opencode --hostname 127.0.0.1 --port 4098`
- Add automatic model fallback from agents or categories config when default model field is missing
- Fix "oh-my-opencode requires a default model" error introduced in beta.12
- Improve backward compatibility with existing configuration files

## Changes
<!-- What was changed and how. List specific modifications. -->
Added model fallback logic in src/plugin-handlers/config-handler.ts:
1. When `config.model` is empty, first search for models in `pluginConfig.agents`
2. If not found in agents, search for models in `pluginConfig.categories`
3. Use the found model as default and log the fallback
4. Only throw error when no model is found in all cases

<!-- What was changed and how. List specific modifications. --> 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|<img width="450" alt="Before: Error message" src="https://github.com/user-attachments/assets/adaaa5cc-18f9-4c87-accf-d552408ba571" />|<img width="450" alt="After: Working correctly" src="https://github.com/user-attachments/assets/a8d57a94-a49e-4681-83f6-18c6ed9a666f" />|
## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->
Closes #991



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic model fallback from agent or category configs when the default model is missing, fixing the startup error after upgrading to beta.12. Improves backward compatibility and updates binaries to beta.13.

- **Bug Fixes**
  - If config.model is empty, use the first model found in agents, then categories; log the fallback and only error if none found.
  - Fixes “oh-my-opencode requires a default model” on startup; closes #991.

- **Dependencies**
  - Update platform-specific oh-my-opencode packages from 3.0.0-beta.11 to 3.0.0-beta.13.

<sup>Written for commit 5b85a854461632a041be50e56c4ed55b63aa3cc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

