### PR TITLE
fix(hooks): use unix shell syntax for bash tool on all platforms

### DIFF
--- a/src/hooks/non-interactive-env/index.ts
+++ b/src/hooks/non-interactive-env/index.ts
@@ -1,7 +1,8 @@
 import type { PluginInput } from "@opencode-ai/plugin"
+import type { ShellType } from "../../shared"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
 import { isNonInteractive } from "./detector"
-import { log, detectShellType, buildEnvPrefix } from "../../shared"
+import { log, buildEnvPrefix } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -50,7 +51,10 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
         return
       }
 
-      const shellType = detectShellType()
+      // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
+      // (via Git Bash, WSL, etc.), so we always use unix export syntax.
+      // This fixes GitHub issues #983 and #889.
+      const shellType: ShellType = "unix"
       const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
       output.args.command = `${envPrefix} ${command}`
 


### PR DESCRIPTION
## Summary

- Force unix shell syntax (`export`) for bash tool commands regardless of platform detection
- The bash tool always runs in a Unix-like shell (bash/sh), even on Windows (via Git Bash, WSL, etc.)

## Problem

On Windows, `detectShellType()` may return "cmd" or "powershell" based on environment variables, causing the hook to generate `set VAR=value &&` or `$env:VAR='value';` syntax. However, the bash tool always executes commands in a Unix-like shell, so these syntaxes fail.

## Solution

Hardcode `shellType = "unix"` for bash tool commands, ensuring `export VAR=value;` syntax is always used.

## Testing

- Added tests for Windows scenarios (PowerShell env, no SHELL env, Git Bash)
- All tests pass: `bun test src/hooks/non-interactive-env/`
- Typecheck passes: `bun run typecheck`

Fixes #983
Fixes #889

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always use Unix shell syntax (export) for bash tool commands on all platforms to prevent failures on Windows. Fixes incorrect env prefix generation when Windows env suggests cmd or PowerShell.

- **Bug Fixes**
  - Force shellType = "unix" in non-interactive-env hook; stop using detectShellType for bash tool.
  - Ensure buildEnvPrefix outputs export VAR=value; for all platforms.
  - Updated tests for Windows (PowerShell env, no SHELL, Git Bash) to confirm export syntax and command chaining.

Fixes #983
Fixes #889

<sup>Written for commit 02aa3e7e918e952b65e7450e3cc4323b868fee0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

