### PR TITLE
fix(tools): conditionally register look_at when multimodal-looker enabled

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test"
+import { includesCaseInsensitive } from "./shared"
+
+/**
+ * Tests for conditional tool registration logic in index.ts
+ * 
+ * The actual plugin initialization is complex to test directly,
+ * so we test the underlying logic that determines tool registration.
+ */
+describe("look_at tool conditional registration", () => {
+  describe("isMultimodalLookerEnabled logic", () => {
+    // #given multimodal-looker is in disabled_agents
+    // #when checking if agent is enabled
+    // #then should return false (disabled)
+    it("returns false when multimodal-looker is disabled (exact case)", () => {
+      const disabledAgents = ["multimodal-looker"]
+      const isEnabled = !includesCaseInsensitive(disabledAgents, "multimodal-looker")
+      expect(isEnabled).toBe(false)
+    })
+
+    // #given multimodal-looker is in disabled_agents with different case
+    // #when checking if agent is enabled
+    // #then should return false (case-insensitive match)
+    it("returns false when multimodal-looker is disabled (case-insensitive)", () => {
+      const disabledAgents = ["Multimodal-Looker"]
+      const isEnabled = !includesCaseInsensitive(disabledAgents, "multimodal-looker")
+      expect(isEnabled).toBe(false)
+    })
+
+    // #given multimodal-looker is NOT in disabled_agents
+    // #when checking if agent is enabled
+    // #then should return true (enabled)
+    it("returns true when multimodal-looker is not disabled", () => {
+      const disabledAgents = ["oracle", "librarian"]
+      const isEnabled = !includesCaseInsensitive(disabledAgents, "multimodal-looker")
+      expect(isEnabled).toBe(true)
+    })
+
+    // #given disabled_agents is empty
+    // #when checking if agent is enabled
+    // #then should return true (enabled by default)
+    it("returns true when disabled_agents is empty", () => {
+      const disabledAgents: string[] = []
+      const isEnabled = !includesCaseInsensitive(disabledAgents, "multimodal-looker")
+      expect(isEnabled).toBe(true)
+    })
+
+    // #given disabled_agents is undefined (simulated as empty array)
+    // #when checking if agent is enabled
+    // #then should return true (enabled by default)
+    it("returns true when disabled_agents is undefined (fallback to empty)", () => {
+      const disabledAgents = undefined
+      const isEnabled = !includesCaseInsensitive(disabledAgents ?? [], "multimodal-looker")
+      expect(isEnabled).toBe(true)
+    })
+  })
+
+  describe("conditional tool spread pattern", () => {
+    // #given lookAt is not null (agent enabled)
+    // #when spreading into tool object
+    // #then look_at should be included
+    it("includes look_at when lookAt is not null", () => {
+      const lookAt = { execute: () => {} } // mock tool
+      const tools = {
+        ...(lookAt ? { look_at: lookAt } : {}),
+      }
+      expect(tools).toHaveProperty("look_at")
+    })
+
+    // #given lookAt is null (agent disabled)
+    // #when spreading into tool object
+    // #then look_at should NOT be included
+    it("excludes look_at when lookAt is null", () => {
+      const lookAt = null
+      const tools = {
+        ...(lookAt ? { look_at: lookAt } : {}),
+      }
+      expect(tools).not.toHaveProperty("look_at")
+    })
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,11 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   const backgroundTools = createBackgroundTools(backgroundManager, ctx.client);
 
   const callOmoAgent = createCallOmoAgent(ctx, backgroundManager);
-  const lookAt = createLookAt(ctx);
+  const isMultimodalLookerEnabled = !includesCaseInsensitive(
+    pluginConfig.disabled_agents ?? [],
+    "multimodal-looker"
+  );
+  const lookAt = isMultimodalLookerEnabled ? createLookAt(ctx) : null;
   const delegateTask = createDelegateTask({
     manager: backgroundManager,
     client: ctx.client,
@@ -300,7 +304,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       ...builtinTools,
       ...backgroundTools,
       call_omo_agent: callOmoAgent,
-      look_at: lookAt,
+      ...(lookAt ? { look_at: lookAt } : {}),
       delegate_task: delegateTask,
       skill: skillTool,
       skill_mcp: skillMcpTool,


### PR DESCRIPTION
## Summary
- Conditionally register `look_at` tool only when `multimodal-looker` agent is enabled
- Uses `includesCaseInsensitive` for case-insensitive agent name matching
- Adds unit tests for the conditional registration logic

## Problem
The `look_at` tool was registered unconditionally but depends on the `multimodal-looker` agent. When users disabled the agent via `disabled_agents` config, the tool would fail at runtime.

## Solution
Check if `multimodal-looker` is in `pluginConfig.disabled_agents` before registering the `look_at` tool. Pattern follows existing skill filtering logic.

Fixes #722

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Register the look_at tool only when the multimodal-looker agent is enabled. Prevents runtime failures when the agent is disabled via disabled_agents.

- **Bug Fixes**
  - Check disabled_agents (case-insensitive) before creating look_at.
  - Omit look_at from the tools map when the agent is disabled.
  - Add unit tests covering enabled/disabled and case-insensitive matching.

<sup>Written for commit 1f552cedad91d8bc2c32f0521d8ef8e0776300a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

