### PR TITLE
fix(session): preserve custom agent after switching

### DIFF
--- a/src/features/claude-code-session-state/state.test.ts
+++ b/src/features/claude-code-session-state/state.test.ts
@@ -123,4 +123,40 @@ describe("claude-code-session-state", () => {
       expect(getSessionAgent(sessionID)).toBeUndefined()
     })
   })
+
+  describe("issue #893: custom agent switch reset", () => {
+    test("should preserve custom agent when default agent is sent on subsequent messages", () => {
+      // #given - user switches to custom agent "MyCustomAgent"
+      const sessionID = "test-session-custom"
+      const customAgent = "MyCustomAgent"
+      const defaultAgent = "Sisyphus"
+
+      // User switches to custom agent (via UI)
+      setSessionAgent(sessionID, customAgent)
+      expect(getSessionAgent(sessionID)).toBe(customAgent)
+
+      // #when - first message after switch sends default agent
+      // This simulates the bug: input.agent = "Sisyphus" on first message
+      // Using setSessionAgent (first-write wins) should preserve custom agent
+      setSessionAgent(sessionID, defaultAgent)
+
+      // #then - custom agent should be preserved, NOT overwritten
+      expect(getSessionAgent(sessionID)).toBe(customAgent)
+    })
+
+    test("should allow explicit agent update via updateSessionAgent", () => {
+      // #given - custom agent is set
+      const sessionID = "test-session-explicit"
+      const customAgent = "MyCustomAgent"
+      const newAgent = "AnotherAgent"
+
+      setSessionAgent(sessionID, customAgent)
+
+      // #when - explicit update (user intentionally switches)
+      updateSessionAgent(sessionID, newAgent)
+
+      // #then - should be updated
+      expect(getSessionAgent(sessionID)).toBe(newAgent)
+    })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,7 +310,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
 
     "chat.message": async (input, output) => {
       if (input.agent) {
-        updateSessionAgent(input.sessionID, input.agent);
+        setSessionAgent(input.sessionID, input.agent);
       }
 
       const message = (output as { message: { variant?: string } }).message


### PR DESCRIPTION
## Summary

- Fix custom agent being reset to "Sisyphus" on first message after switching
- Use `setSessionAgent` (first-write wins) instead of `updateSessionAgent` in `chat.message` handler
- Add tests for issue #893 scenario

## Root Cause

In `src/index.ts:312-314`, `updateSessionAgent` was called on every message with `input.agent`. When user switches to a custom agent via UI, the first message still has `input.agent = "Sisyphus"` (the default), which overwrote the custom agent.

## Fix

Changed from `updateSessionAgent` to `setSessionAgent` which only sets the agent if NOT already present (first-write wins). The explicit agent switch via `message.updated` event still uses `updateSessionAgent` to allow intentional agent changes.

Fixes #893


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the selected custom agent after switching, preventing a reset to the default “Sisyphus” on the first post-switch message. Fixes #893 by using first-write wins in the message handler.

- **Bug Fixes**
  - Use setSessionAgent in chat.message so the default agent doesn’t overwrite a custom agent.
  - Keep explicit agent changes via updateSessionAgent for intentional switches.
  - Add tests covering the #893 scenario.

<sup>Written for commit 16fbfb7de4930303d487f3abc643e1d2b21cdb30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

