### PR TITLE
fix(skill): enforce agent restriction in createSkillTool

### DIFF
--- a/src/tools/skill/tools.test.ts
+++ b/src/tools/skill/tools.test.ts
@@ -20,6 +20,21 @@ Test skill body content`
   },
 }))
 
+function createMockSkill(name: string, options: { agent?: string } = {}): LoadedSkill {
+  return {
+    name,
+    path: `/test/skills/${name}/SKILL.md`,
+    resolvedPath: `/test/skills/${name}`,
+    definition: {
+      name,
+      description: `Test skill ${name}`,
+      template: "Test template",
+      agent: options.agent,
+    },
+    scope: "opencode-project",
+  }
+}
+
 function createMockSkillWithMcp(name: string, mcpServers: Record<string, unknown>): LoadedSkill {
   return {
     name,
@@ -41,6 +56,47 @@ const mockContext = {
   agent: "test-agent",
   abort: new AbortController().signal,
 }
+
+describe("skill tool - agent restriction", () => {
+  it("allows skill without agent restriction to any agent", async () => {
+    // #given
+    const loadedSkills = [createMockSkill("public-skill")]
+    const tool = createSkillTool({ skills: loadedSkills })
+    const context = { ...mockContext, agent: "any-agent" }
+
+    // #when
+    const result = await tool.execute({ name: "public-skill" }, context)
+
+    // #then
+    expect(result).toContain("public-skill")
+  })
+
+  it("allows skill when agent matches restriction", async () => {
+    // #given
+    const loadedSkills = [createMockSkill("restricted-skill", { agent: "sisyphus" })]
+    const tool = createSkillTool({ skills: loadedSkills })
+    const context = { ...mockContext, agent: "sisyphus" }
+
+    // #when
+    const result = await tool.execute({ name: "restricted-skill" }, context)
+
+    // #then
+    expect(result).toContain("restricted-skill")
+  })
+
+  it("throws error when agent does not match restriction", async () => {
+    // #given
+    const loadedSkills = [createMockSkill("sisyphus-only-skill", { agent: "sisyphus" })]
+    const tool = createSkillTool({ skills: loadedSkills })
+    const context = { ...mockContext, agent: "oracle" }
+
+    // #when / #then
+    await expect(tool.execute({ name: "sisyphus-only-skill" }, context)).rejects.toThrow(
+      'Skill "sisyphus-only-skill" is restricted to agent "sisyphus"'
+    )
+  })
+
+})
 
 describe("skill tool - MCP schema display", () => {
   let manager: SkillMcpManager

--- a/src/tools/skill/tools.test.ts
+++ b/src/tools/skill/tools.test.ts
@@ -96,6 +96,18 @@ describe("skill tool - agent restriction", () => {
     )
   })
 
+  it("throws error when context agent is undefined for restricted skill", async () => {
+    // #given
+    const loadedSkills = [createMockSkill("sisyphus-only-skill", { agent: "sisyphus" })]
+    const tool = createSkillTool({ skills: loadedSkills })
+    const contextWithoutAgent = { ...mockContext, agent: undefined as unknown as string }
+
+    // #when / #then
+    await expect(tool.execute({ name: "sisyphus-only-skill" }, contextWithoutAgent)).rejects.toThrow(
+      'Skill "sisyphus-only-skill" is restricted to agent "sisyphus"'
+    )
+  })
+
 })
 
 describe("skill tool - MCP schema display", () => {

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -156,13 +156,17 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
     args: {
       name: tool.schema.string().describe("The skill identifier from available_skills (e.g., 'code-review')"),
     },
-    async execute(args: SkillArgs) {
+    async execute(args: SkillArgs, ctx?: { agent?: string }) {
       const skills = await getSkills()
       const skill = skills.find(s => s.name === args.name)
 
       if (!skill) {
         const available = skills.map(s => s.name).join(", ")
         throw new Error(`Skill "${args.name}" not found. Available skills: ${available || "none"}`)
+      }
+
+      if (skill.definition.agent && ctx?.agent && skill.definition.agent !== ctx.agent) {
+        throw new Error(`Skill "${args.name}" is restricted to agent "${skill.definition.agent}"`)
       }
 
       let body = await extractSkillBody(skill)

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -165,7 +165,7 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
         throw new Error(`Skill "${args.name}" not found. Available skills: ${available || "none"}`)
       }
 
-      if (skill.definition.agent && ctx?.agent && skill.definition.agent !== ctx.agent) {
+      if (skill.definition.agent && (!ctx?.agent || skill.definition.agent !== ctx.agent)) {
         throw new Error(`Skill "${args.name}" is restricted to agent "${skill.definition.agent}"`)
       }
 


### PR DESCRIPTION
## Summary

- Add agent restriction enforcement in `createSkillTool` execute function
- Skills with `agent` field in definition are now only accessible to the specified agent
- Skills without agent restriction remain available to all agents

Fixes #948

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce agent-specific access in createSkillTool. Skills with an agent set can only be run by that agent; unrestricted skills remain available to all.

- **Bug Fixes**
  - Enforced agent restriction in execute; throws a clear error when the agent does not match or agent context is missing.
  - Updated execute to accept a context with agent for access checks.
  - Added tests for unrestricted, matching, mismatched, and missing agent cases.

<sup>Written for commit 8a41eef0ef24a89f1d144d77939887afc3b526bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

