### PR TITLE
fix(ci): build Windows binary natively to fix segfault

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -29,7 +29,12 @@ permissions:
 
 jobs:
   publish-platform:
-    runs-on: ubuntu-latest
+    # Use windows-latest for Windows to avoid cross-compilation segfault (oven-sh/bun#18416)
+    # Fixes: #873, #844
+    runs-on: ${{ matrix.platform == 'windows-x64' && 'windows-latest' || 'ubuntu-latest' }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       max-parallel: 2


### PR DESCRIPTION
## Summary

- Build Windows binary natively on `windows-latest` runner instead of cross-compiling from Ubuntu
- Fixes segmentation fault when running standalone Windows executable

Fixes #873, Fixes #844

## Root Cause

Bun's cross-compilation from Linux to Windows produces binaries that crash with:
```
panic(main thread): Segmentation fault at address 0xFFFFFFFFFFFFFFFF
```

This is a known Bun issue: [oven-sh/bun#18416](https://github.com/oven-sh/bun/issues/18416)

**Evidence:**
- Cross-compiled binary (Ubuntu → Windows): crashes
- Natively built binary (Windows → Windows): works

## Changes

- `.github/workflows/publish-platform.yml`:
  - Use conditional `runs-on`: `windows-latest` for Windows, `ubuntu-latest` for others
  - Add `shell: bash` default for consistent behavior across runners

## Why This Differs from PR #938

PR #938 modifies `publish.yml` (main package workflow), but platform binaries are actually built and published by `publish-platform.yml`. This PR fixes the correct workflow.

| Approach | Workflow Modified | Complexity |
|----------|------------------|------------|
| PR #938 | publish.yml | Adds separate job + artifact upload/download |
| This PR | publish-platform.yml | Simple conditional runner selection |

## Testing

- [x] YAML syntax validation passed
- [ ] CI will validate on merge


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build Windows binaries natively on windows-latest to fix the segmentation fault in the standalone Windows executable. This avoids Bun’s Linux→Windows cross-compilation bug (bun#18416) and fixes #873 and #844.

- **Bug Fixes**
  - Use conditional runs-on in publish-platform.yml: windows-latest for windows-x64, ubuntu-latest for others.
  - Set defaults.run.shell to bash for consistent behavior across runners.
  - Build via the correct workflow (publish-platform.yml) that publishes platform binaries.

<sup>Written for commit b0a5530f198597a752304184a70d8cf197eb4937. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

