### PR TITLE
fix(lsp): use pathToFileURL for Windows-compatible file URIs [backport v2.x]

### DIFF
--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -1,6 +1,7 @@
 import { spawn, type Subprocess } from "bun"
 import { readFileSync } from "fs"
 import { extname, resolve } from "path"
+import { pathToFileURL } from "node:url"
 import { getLanguageId } from "./config"
 import type { Diagnostic, ResolvedServer } from "./types"
 
@@ -407,7 +408,7 @@ export class LSPClient {
   }
 
   async initialize(): Promise<void> {
-    const rootUri = `file://${this.root}`
+    const rootUri = pathToFileURL(this.root).href
     await this.send("initialize", {
       processId: process.pid,
       rootUri,
@@ -477,7 +478,7 @@ export class LSPClient {
 
     this.notify("textDocument/didOpen", {
       textDocument: {
-        uri: `file://${absPath}`,
+        uri: pathToFileURL(absPath).href,
         languageId,
         version: 1,
         text,
@@ -492,7 +493,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/hover", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
     })
   }
@@ -501,7 +502,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/definition", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
     })
   }
@@ -510,7 +511,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/references", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
       context: { includeDeclaration },
     })
@@ -520,7 +521,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/documentSymbol", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
     })
   }
 
@@ -530,7 +531,7 @@ export class LSPClient {
 
   async diagnostics(filePath: string): Promise<{ items: Diagnostic[] }> {
     const absPath = resolve(filePath)
-    const uri = `file://${absPath}`
+    const uri = pathToFileURL(absPath).href
     await this.openFile(absPath)
     await new Promise((r) => setTimeout(r, 500))
 
@@ -551,7 +552,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/prepareRename", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
     })
   }
@@ -560,7 +561,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/rename", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       position: { line: line - 1, character },
       newName,
     })
@@ -577,7 +578,7 @@ export class LSPClient {
     const absPath = resolve(filePath)
     await this.openFile(absPath)
     return this.send("textDocument/codeAction", {
-      textDocument: { uri: `file://${absPath}` },
+      textDocument: { uri: pathToFileURL(absPath).href },
       range: {
         start: { line: startLine - 1, character: startChar },
         end: { line: endLine - 1, character: endChar },


### PR DESCRIPTION
## Summary

Backport the Windows LSP file URI fix to the stable v2.x branch.

## Problem

On Windows, the LSP client generates invalid file URIs using string template literals:
```
file://D:\path\file.cpp  (invalid)
```

The correct format should be:
```
file:///D:/path/file.cpp  (valid)
```

This causes LSP operations like document symbols, hover, go-to-definition, find-references, etc. to fail with:
```
Error: failed to decode textDocument/documentSymbol request: unresolvable URI at (root).textDocument.uri
```

## Solution

Replace all `\`file://\${path}\`` string templates with `pathToFileURL(path).href` from `node:url`, which properly handles path-to-URI conversion on all platforms.

## Changes

- Import `pathToFileURL` from `node:url`
- Replace 11 occurrences of `\`file://\${...}\`` with `pathToFileURL(...).href`

## Testing

Tested on Windows 11 with clangd LSP server:
- ✅ `lsp_document_symbols` - works
- ✅ `lsp_hover` - works  
- ✅ `lsp_find_references` - works
- ✅ `lsp_goto_definition` - works
- ✅ `lsp_diagnostics` - works
- ✅ `lsp_workspace_symbols` - works

## Related

This is a backport of the fix that already exists in v3.0.0-beta (commit 8ed3f7e, PR #689).

Requesting this backport for users on the stable v2.x branch who cannot upgrade to v3.0.0-beta.

## Checklist

- [x] Code follows project conventions
- [x] Changes are minimal and focused
- [x] Tested on Windows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows LSP errors by generating correct file URIs with pathToFileURL. Backports the v3 fix to the stable v2.x branch.

- **Bug Fixes**
  - Use node:url pathToFileURL(...).href for all LSP file URIs (root, open, hover, definition, references, symbols, diagnostics, rename, code actions).
  - Restores LSP functionality on Windows.

<sup>Written for commit bf79ef97796fc72ddf6443a017fbabb67f1c6b46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

