### PR TITLE
feat(config): add hierarchical project config loading + deterministic precedence

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{ts,tsx,js,jsx,json,md}]
+indent_style = space
+indent_size = 2

--- a/bun.lock
+++ b/bun.lock
@@ -27,13 +27,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.0.0-beta.11",
-        "oh-my-opencode-darwin-x64": "3.0.0-beta.11",
-        "oh-my-opencode-linux-arm64": "3.0.0-beta.11",
-        "oh-my-opencode-linux-arm64-musl": "3.0.0-beta.11",
-        "oh-my-opencode-linux-x64": "3.0.0-beta.11",
-        "oh-my-opencode-linux-x64-musl": "3.0.0-beta.11",
-        "oh-my-opencode-windows-x64": "3.0.0-beta.11",
+        "oh-my-opencode-darwin-arm64": "3.0.0-beta.13",
+        "oh-my-opencode-darwin-x64": "3.0.0-beta.13",
+        "oh-my-opencode-linux-arm64": "3.0.0-beta.13",
+        "oh-my-opencode-linux-arm64-musl": "3.0.0-beta.13",
+        "oh-my-opencode-linux-x64": "3.0.0-beta.13",
+        "oh-my-opencode-linux-x64-musl": "3.0.0-beta.13",
+        "oh-my-opencode-windows-x64": "3.0.0-beta.13",
       },
     },
   },
@@ -224,20 +224,6 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.0.0-beta.11", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7cFv2bbz9HTY7sshgVTu+IhvYf7CT0czDYqHEB+dYfEqFU6TaoSMimq6uHqcWegUUR1T7PNmc0dyjYVw69FeVA=="],
-
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.0.0-beta.11", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-rGAbDdUySWITIdm2yiuNFB9lFYaSXT8LMtg97LTlOO5vZbI3M+obIS3QlIkBtAhgOTIPB7Ni+T0W44OmJpHoYA=="],
-
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.0.0-beta.11", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-F9dqwWwGAdqeSkE7Tre5DmHQXwDpU2Z8Jk0lwTJMLj+kMqYFDVPjLPo4iVUdwPpxpmm0pR84u/oonG/2+84/zw=="],
-
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.0.0-beta.11", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H+zOtHkHd+TmdPj64M1A0zLOk7OHIK4C8yqfLFhfizOIBffT1yOhAs6EpK3EqPhfPLu54ADgcQcu8W96VP24UA=="],
-
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.0.0-beta.11", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-IG+KODTJ8rs6cEJ2wN6Zpr6YtvCS5OpYP6jBdGJltmUpjQdMhdMsaY3ysZk+9Vxpx2KC3xj5KLHV1USg3uBTeg=="],
-
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.0.0-beta.11", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-irV+AuWrHqNm7VT7HO56qgymR0+vEfJbtB3vCq68kprH2V4NQmGp2MNKIYPnUCYL7NEK3H2NX+h06YFZJ/8ELQ=="],
-
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.0.0-beta.11", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-exZ/NEwGBlxyWszN7dvOfzbYX0cuhBZXftqAAFOlVP26elDHdo+AmSmLR/4cJyzpR9nCWz4xvl/RYF84bY6OEA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -37,14 +37,18 @@ It asks about your providers (Claude, OpenAI, Gemini, etc.) and generates optima
 
 ## Config File Locations
 
-Config file locations (priority order):
-1. `.opencode/oh-my-opencode.json` (project)
-2. User config (platform-specific):
+Config file locations (priority order, later overrides earlier):
+1. User config (platform-specific)
+2. `OH_MY_OPENCODE_CONFIG` (explicit config path)
+3. Project config(s) from project root → current directory (searches upward for `.opencode/oh-my-opencode.jsonc|.json`)
+4. `OH_MY_OPENCODE_CONFIG_CONTENT` (inline JSONC string)
 
 | Platform        | User Config Path                                                                                            |
 | --------------- | ----------------------------------------------------------------------------------------------------------- |
 | **Windows**     | `~/.config/opencode/oh-my-opencode.json` (preferred) or `%APPDATA%\opencode\oh-my-opencode.json` (fallback) |
 | **macOS/Linux** | `~/.config/opencode/oh-my-opencode.json`                                                                    |
+
+You can override the user config directory via `OH_MY_OPENCODE_CONFIG_DIR`.
 
 Schema autocomplete supported:
 
@@ -542,6 +546,9 @@ Opt-in experimental features that may change or be removed in future versions. U
 
 ## Environment Variables
 
-| Variable              | Description                                                                                                                                     |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OPENCODE_CONFIG_DIR` | Override the OpenCode configuration directory. Useful for profile isolation with tools like [OCX](https://github.com/kdcokenny/ocx) ghost mode. |
+| Variable                        | Description                                                                                                                                     |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OH_MY_OPENCODE_CONFIG_DIR`     | Override the Oh My OpenCode user config directory. Falls back to OpenCode's config dir when unset.                                             |
+| `OH_MY_OPENCODE_CONFIG`         | Explicit config file path (JSON or JSONC). Overrides user config, overridden by project config.                                                |
+| `OH_MY_OPENCODE_CONFIG_CONTENT` | Inline JSONC config string with highest precedence.                                                                                           |
+| `OPENCODE_CONFIG_DIR`           | Override the OpenCode configuration directory. Used as a fallback when `OH_MY_OPENCODE_CONFIG_DIR` is not set.                                |

--- a/src/cli/doctor/checks/config.test.ts
+++ b/src/cli/doctor/checks/config.test.ts
@@ -1,37 +1,37 @@
-import { describe, it, expect, spyOn, afterEach } from "bun:test"
-import * as config from "./config"
+import { describe, it, expect, spyOn, afterEach } from "bun:test";
+import * as config from "./config";
 
 describe("config check", () => {
   describe("validateConfig", () => {
     it("returns valid: false for non-existent file", () => {
       // #given non-existent file path
       // #when validating
-      const result = config.validateConfig("/non/existent/path.json")
+      const result = config.validateConfig("/non/existent/path.json");
 
       // #then should indicate invalid
-      expect(result.valid).toBe(false)
-      expect(result.errors.length).toBeGreaterThan(0)
-    })
-  })
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
 
   describe("getConfigInfo", () => {
     it("returns exists: false when no config found", () => {
       // #given no config file exists
       // #when getting config info
-      const info = config.getConfigInfo()
+      const info = config.getConfigInfo();
 
       // #then should handle gracefully
-      expect(typeof info.exists).toBe("boolean")
-      expect(typeof info.valid).toBe("boolean")
-    })
-  })
+      expect(typeof info.exists).toBe("boolean");
+      expect(typeof info.valid).toBe("boolean");
+    });
+  });
 
   describe("checkConfigValidity", () => {
-    let getInfoSpy: ReturnType<typeof spyOn>
+    let getInfoSpy: ReturnType<typeof spyOn>;
 
     afterEach(() => {
-      getInfoSpy?.mockRestore()
-    })
+      getInfoSpy?.mockRestore();
+    });
 
     it("returns pass when no config exists (uses defaults)", async () => {
       // #given no config file
@@ -41,15 +41,15 @@ describe("config check", () => {
         format: null,
         valid: true,
         errors: [],
-      })
+      });
 
       // #when checking validity
-      const result = await config.checkConfigValidity()
+      const result = await config.checkConfigValidity();
 
       // #then should pass with default message
-      expect(result.status).toBe("pass")
-      expect(result.message).toContain("default")
-    })
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("default");
+    });
 
     it("returns pass when config is valid", async () => {
       // #given valid config
@@ -59,15 +59,15 @@ describe("config check", () => {
         format: "json",
         valid: true,
         errors: [],
-      })
+      });
 
       // #when checking validity
-      const result = await config.checkConfigValidity()
+      const result = await config.checkConfigValidity();
 
       // #then should pass
-      expect(result.status).toBe("pass")
-      expect(result.message).toContain("JSON")
-    })
+      expect(result.status).toBe("pass");
+      expect(result.message).toContain("JSON");
+    });
 
     it("returns fail when config has validation errors", async () => {
       // #given invalid config
@@ -77,27 +77,27 @@ describe("config check", () => {
         format: "json",
         valid: false,
         errors: ["agents.oracle: Invalid model format"],
-      })
+      });
 
       // #when checking validity
-      const result = await config.checkConfigValidity()
+      const result = await config.checkConfigValidity();
 
       // #then should fail with errors
-      expect(result.status).toBe("fail")
-      expect(result.details?.some((d) => d.includes("Error"))).toBe(true)
-    })
-  })
+      expect(result.status).toBe("fail");
+      expect(result.details?.some((d) => d.includes("Error"))).toBe(true);
+    });
+  });
 
   describe("getConfigCheckDefinition", () => {
     it("returns valid check definition", () => {
       // #given
       // #when getting definition
-      const def = config.getConfigCheckDefinition()
+      const def = config.getConfigCheckDefinition();
 
       // #then should have required properties
-      expect(def.id).toBe("config-validation")
-      expect(def.category).toBe("configuration")
-      expect(def.critical).toBe(false)
-    })
-  })
-})
+      expect(def.id).toBe("config-validation");
+      expect(def.category).toBe("configuration");
+      expect(def.critical).toBe(false);
+    });
+  });
+});

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -1,119 +1,289 @@
-import { describe, expect, it } from "bun:test";
-import { mergeConfigs } from "./plugin-config";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { OhMyOpenCodeConfig } from "./config";
+import { loadPluginConfig, mergeConfigs } from "./plugin-config";
+
+const ENV_KEYS = [
+	"OH_MY_OPENCODE_CONFIG_DIR",
+	"OH_MY_OPENCODE_CONFIG",
+	"OH_MY_OPENCODE_CONFIG_CONTENT",
+];
+
+let envSnapshot: Record<string, string | undefined> = {};
+
+function snapshotEnv(): void {
+	envSnapshot = Object.fromEntries(
+		ENV_KEYS.map((key) => [key, process.env[key]]),
+	);
+}
+
+function restoreEnv(): void {
+	for (const key of ENV_KEYS) {
+		const value = envSnapshot[key];
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+}
+
+function createTempDir(name: string): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), `omo-${name}-`));
+}
+
+function writeJson(filePath: string, data: unknown): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+function cleanupDir(dirPath: string): void {
+	fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+beforeEach(() => {
+	snapshotEnv();
+});
+
+afterEach(() => {
+	restoreEnv();
+});
 
 describe("mergeConfigs", () => {
-  describe("categories merging", () => {
-    // #given base config has categories, override has different categories
-    // #when merging configs
-    // #then should deep merge categories, not override completely
+	describe("categories merging", () => {
+		// #given base config has categories, override has different categories
+		// #when merging configs
+		// #then should deep merge categories, not override completely
 
-    it("should deep merge categories from base and override", () => {
-      const base = {
-        categories: {
-          general: {
-            model: "openai/gpt-5.2",
-            temperature: 0.5,
-          },
-          quick: {
-            model: "anthropic/claude-haiku-4-5",
-          },
-        },
-      } as OhMyOpenCodeConfig;
+		it("should deep merge categories from base and override", () => {
+			const base = {
+				categories: {
+					general: {
+						model: "openai/gpt-5.2",
+						temperature: 0.5,
+					},
+					quick: {
+						model: "anthropic/claude-haiku-4-5",
+					},
+				},
+			} as OhMyOpenCodeConfig;
 
-      const override = {
-        categories: {
-          general: {
-            temperature: 0.3,
-          },
-          visual: {
-            model: "google/gemini-3-pro-preview",
-          },
-        },
-      } as unknown as OhMyOpenCodeConfig;
+			const override = {
+				categories: {
+					general: {
+						temperature: 0.3,
+					},
+					visual: {
+						model: "google/gemini-3-pro-preview",
+					},
+				},
+			} as unknown as OhMyOpenCodeConfig;
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      // #then general.model should be preserved from base
-      expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
-      // #then general.temperature should be overridden
-      expect(result.categories?.general?.temperature).toBe(0.3);
-      // #then quick should be preserved from base
-      expect(result.categories?.quick?.model).toBe("anthropic/claude-haiku-4-5");
-      // #then visual should be added from override
-      expect(result.categories?.visual?.model).toBe("google/gemini-3-pro-preview");
-    });
+			// #then general.model should be preserved from base
+			expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
+			// #then general.temperature should be overridden
+			expect(result.categories?.general?.temperature).toBe(0.3);
+			// #then quick should be preserved from base
+			expect(result.categories?.quick?.model).toBe(
+				"anthropic/claude-haiku-4-5",
+			);
+			// #then visual should be added from override
+			expect(result.categories?.visual?.model).toBe(
+				"google/gemini-3-pro-preview",
+			);
+		});
 
-    it("should preserve base categories when override has no categories", () => {
-      const base: OhMyOpenCodeConfig = {
-        categories: {
-          general: {
-            model: "openai/gpt-5.2",
-          },
-        },
-      };
+		it("should preserve base categories when override has no categories", () => {
+			const base: OhMyOpenCodeConfig = {
+				categories: {
+					general: {
+						model: "openai/gpt-5.2",
+					},
+				},
+			};
 
-      const override: OhMyOpenCodeConfig = {};
+			const override: OhMyOpenCodeConfig = {};
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
-    });
+			expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
+		});
 
-    it("should use override categories when base has no categories", () => {
-      const base: OhMyOpenCodeConfig = {};
+		it("should use override categories when base has no categories", () => {
+			const base: OhMyOpenCodeConfig = {};
 
-      const override: OhMyOpenCodeConfig = {
-        categories: {
-          general: {
-            model: "openai/gpt-5.2",
-          },
-        },
-      };
+			const override: OhMyOpenCodeConfig = {
+				categories: {
+					general: {
+						model: "openai/gpt-5.2",
+					},
+				},
+			};
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
-    });
-  });
+			expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
+		});
+	});
 
-  describe("existing behavior preservation", () => {
-    it("should deep merge agents", () => {
-      const base: OhMyOpenCodeConfig = {
-        agents: {
-          oracle: { model: "openai/gpt-5.2" },
-        },
-      };
+	describe("existing behavior preservation", () => {
+		it("should deep merge agents", () => {
+			const base: OhMyOpenCodeConfig = {
+				agents: {
+					oracle: { model: "openai/gpt-5.2" },
+				},
+			};
 
-      const override: OhMyOpenCodeConfig = {
-        agents: {
-          oracle: { temperature: 0.5 },
-          explore: { model: "anthropic/claude-haiku-4-5" },
-        },
-      };
+			const override: OhMyOpenCodeConfig = {
+				agents: {
+					oracle: { temperature: 0.5 },
+					explore: { model: "anthropic/claude-haiku-4-5" },
+				},
+			};
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      expect(result.agents?.oracle?.model).toBe("openai/gpt-5.2");
-      expect(result.agents?.oracle?.temperature).toBe(0.5);
-      expect(result.agents?.explore?.model).toBe("anthropic/claude-haiku-4-5");
-    });
+			expect(result.agents?.oracle?.model).toBe("openai/gpt-5.2");
+			expect(result.agents?.oracle?.temperature).toBe(0.5);
+			expect(result.agents?.explore?.model).toBe("anthropic/claude-haiku-4-5");
+		});
 
-    it("should merge disabled arrays without duplicates", () => {
-      const base: OhMyOpenCodeConfig = {
-        disabled_hooks: ["comment-checker", "think-mode"],
-      };
+		it("should merge disabled arrays without duplicates", () => {
+			const base: OhMyOpenCodeConfig = {
+				disabled_hooks: ["comment-checker", "think-mode"],
+			};
 
-      const override: OhMyOpenCodeConfig = {
-        disabled_hooks: ["think-mode", "session-recovery"],
-      };
+			const override: OhMyOpenCodeConfig = {
+				disabled_hooks: ["think-mode", "session-recovery"],
+			};
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      expect(result.disabled_hooks).toContain("comment-checker");
-      expect(result.disabled_hooks).toContain("think-mode");
-      expect(result.disabled_hooks).toContain("session-recovery");
-      expect(result.disabled_hooks?.length).toBe(3);
-    });
-  });
+			expect(result.disabled_hooks).toContain("comment-checker");
+			expect(result.disabled_hooks).toContain("think-mode");
+			expect(result.disabled_hooks).toContain("session-recovery");
+			expect(result.disabled_hooks?.length).toBe(3);
+		});
+	});
+});
+
+describe("loadPluginConfig precedence", () => {
+	// #given multiple config sources
+	// #when loading plugin config
+	// #then apply precedence user < env path < project < inline
+
+	it("prefers jsonc over json for user config", () => {
+		const tempDir = createTempDir("jsonc");
+		const projectRoot = path.join(tempDir, "project");
+
+		fs.mkdirSync(projectRoot, { recursive: true });
+		writeJson(path.join(projectRoot, "package.json"), { name: "test" });
+
+		process.env.OH_MY_OPENCODE_CONFIG_DIR = tempDir;
+
+		const jsonPath = path.join(tempDir, "oh-my-opencode.json");
+		const jsoncPath = path.join(tempDir, "oh-my-opencode.jsonc");
+
+		writeJson(jsonPath, { auto_update: false });
+		writeJson(jsoncPath, { auto_update: true });
+
+		const config = loadPluginConfig(projectRoot, {});
+
+		expect(config.auto_update).toBe(true);
+
+		cleanupDir(tempDir);
+	});
+
+	it("applies precedence user < env path < project", () => {
+		const tempDir = createTempDir("precedence");
+		const projectRoot = path.join(tempDir, "project");
+		const projectConfigPath = path.join(
+			projectRoot,
+			".opencode",
+			"oh-my-opencode.json",
+		);
+
+		fs.mkdirSync(projectRoot, { recursive: true });
+		writeJson(path.join(projectRoot, "package.json"), { name: "test" });
+
+		process.env.OH_MY_OPENCODE_CONFIG_DIR = tempDir;
+
+		writeJson(path.join(tempDir, "oh-my-opencode.json"), {
+			auto_update: false,
+		});
+
+		const envConfigPath = path.join(tempDir, "env.json");
+		writeJson(envConfigPath, { auto_update: true });
+		process.env.OH_MY_OPENCODE_CONFIG = envConfigPath;
+
+		writeJson(projectConfigPath, { auto_update: false });
+
+		const config = loadPluginConfig(projectRoot, {});
+
+		expect(config.auto_update).toBe(false);
+
+		cleanupDir(tempDir);
+	});
+
+	it("applies inline content with highest precedence", () => {
+		const tempDir = createTempDir("inline");
+		const projectRoot = path.join(tempDir, "project");
+		const projectConfigPath = path.join(
+			projectRoot,
+			".opencode",
+			"oh-my-opencode.json",
+		);
+
+		fs.mkdirSync(projectRoot, { recursive: true });
+		writeJson(path.join(projectRoot, "package.json"), { name: "test" });
+
+		process.env.OH_MY_OPENCODE_CONFIG_DIR = tempDir;
+
+		writeJson(path.join(tempDir, "oh-my-opencode.json"), {
+			auto_update: false,
+		});
+
+		writeJson(projectConfigPath, { auto_update: false });
+
+		process.env.OH_MY_OPENCODE_CONFIG_CONTENT = JSON.stringify({
+			auto_update: true,
+		});
+
+		const config = loadPluginConfig(projectRoot, {});
+
+		expect(config.auto_update).toBe(true);
+
+		cleanupDir(tempDir);
+	});
+
+	it("merges project configs from root to leaf", () => {
+		const tempDir = createTempDir("search-up");
+		const projectRoot = path.join(tempDir, "project");
+		const nestedDir = path.join(projectRoot, "apps", "demo");
+
+		fs.mkdirSync(nestedDir, { recursive: true });
+		writeJson(path.join(projectRoot, "package.json"), { name: "test" });
+
+		writeJson(path.join(projectRoot, ".opencode", "oh-my-opencode.json"), {
+			auto_update: false,
+			disabled_hooks: ["think-mode"],
+		});
+
+		writeJson(path.join(nestedDir, ".opencode", "oh-my-opencode.json"), {
+			auto_update: true,
+			disabled_hooks: ["comment-checker"],
+		});
+
+		const config = loadPluginConfig(nestedDir, {});
+
+		expect(config.auto_update).toBe(true);
+		expect(config.disabled_hooks).toContain("think-mode");
+		expect(config.disabled_hooks).toContain("comment-checker");
+
+		cleanupDir(tempDir);
+	});
 });

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -6,282 +6,280 @@ import type { OhMyOpenCodeConfig } from "./config";
 import { loadPluginConfig, mergeConfigs } from "./plugin-config";
 
 const ENV_KEYS = [
-	"OH_MY_OPENCODE_CONFIG_DIR",
-	"OH_MY_OPENCODE_CONFIG",
-	"OH_MY_OPENCODE_CONFIG_CONTENT",
+  "OH_MY_OPENCODE_CONFIG_DIR",
+  "OH_MY_OPENCODE_CONFIG",
+  "OH_MY_OPENCODE_CONFIG_CONTENT",
 ];
 
 let envSnapshot: Record<string, string | undefined> = {};
 
 function snapshotEnv(): void {
-	envSnapshot = Object.fromEntries(
-		ENV_KEYS.map((key) => [key, process.env[key]]),
-	);
+  envSnapshot = Object.fromEntries(
+    ENV_KEYS.map((key) => [key, process.env[key]]),
+  );
 }
 
 function restoreEnv(): void {
-	for (const key of ENV_KEYS) {
-		const value = envSnapshot[key];
-		if (value === undefined) {
-			delete process.env[key];
-		} else {
-			process.env[key] = value;
-		}
-	}
+  for (const key of ENV_KEYS) {
+    const value = envSnapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
 }
 
 function createTempDir(name: string): string {
-	return fs.mkdtempSync(path.join(os.tmpdir(), `omo-${name}-`));
+  return fs.mkdtempSync(path.join(os.tmpdir(), `omo-${name}-`));
 }
 
 function writeJson(filePath: string, data: unknown): void {
-	fs.mkdirSync(path.dirname(filePath), { recursive: true });
-	fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
 }
 
 function cleanupDir(dirPath: string): void {
-	fs.rmSync(dirPath, { recursive: true, force: true });
+  fs.rmSync(dirPath, { recursive: true, force: true });
 }
 
 beforeEach(() => {
-	snapshotEnv();
+  snapshotEnv();
 });
 
 afterEach(() => {
-	restoreEnv();
+  restoreEnv();
 });
 
 describe("mergeConfigs", () => {
-	describe("categories merging", () => {
-		// #given base config has categories, override has different categories
-		// #when merging configs
-		// #then should deep merge categories, not override completely
+  describe("categories merging", () => {
+    // #given base config has categories, override has different categories
+    // #when merging configs
+    // #then should deep merge categories, not override completely
 
-		it("should deep merge categories from base and override", () => {
-			const base = {
-				categories: {
-					general: {
-						model: "openai/gpt-5.2",
-						temperature: 0.5,
-					},
-					quick: {
-						model: "anthropic/claude-haiku-4-5",
-					},
-				},
-			} as OhMyOpenCodeConfig;
+    it("should deep merge categories from base and override", () => {
+      const base = {
+        categories: {
+          general: {
+            model: "openai/gpt-5.2",
+            temperature: 0.5,
+          },
+          quick: {
+            model: "anthropic/claude-haiku-4-5",
+          },
+        },
+      } as OhMyOpenCodeConfig;
 
-			const override = {
-				categories: {
-					general: {
-						temperature: 0.3,
-					},
-					visual: {
-						model: "google/gemini-3-pro",
-					},
-				},
-			} as unknown as OhMyOpenCodeConfig;
+      const override = {
+        categories: {
+          general: {
+            temperature: 0.3,
+          },
+          visual: {
+            model: "google/gemini-3-pro-preview",
+          },
+        },
+      } as unknown as OhMyOpenCodeConfig;
 
-			const result = mergeConfigs(base, override);
+      const result = mergeConfigs(base, override);
 
-			// #then general.model should be preserved from base
-			expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
-			// #then general.temperature should be overridden
-			expect(result.categories?.general?.temperature).toBe(0.3);
-			// #then quick should be preserved from base
-			expect(result.categories?.quick?.model).toBe(
-				"anthropic/claude-haiku-4-5",
-			);
-			// #then visual should be added from override
-			expect(result.categories?.visual?.model).toBe("google/gemini-3-pro");
-		});
+      // #then general.model should be preserved from base
+      expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
+      // #then general.temperature should be overridden
+      expect(result.categories?.general?.temperature).toBe(0.3);
+      // #then quick should be preserved from base
+      expect(result.categories?.quick?.model).toBe("anthropic/claude-haiku-4-5");
+      // #then visual should be added from override
+      expect(result.categories?.visual?.model).toBe("google/gemini-3-pro-preview");
+    });
 
-		it("should preserve base categories when override has no categories", () => {
-			const base: OhMyOpenCodeConfig = {
-				categories: {
-					general: {
-						model: "openai/gpt-5.2",
-					},
-				},
-			};
+    it("should preserve base categories when override has no categories", () => {
+      const base: OhMyOpenCodeConfig = {
+        categories: {
+          general: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      };
 
-			const override: OhMyOpenCodeConfig = {};
+      const override: OhMyOpenCodeConfig = {};
 
-			const result = mergeConfigs(base, override);
+      const result = mergeConfigs(base, override);
 
-			expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
-		});
+      expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
+    });
 
-		it("should use override categories when base has no categories", () => {
-			const base: OhMyOpenCodeConfig = {};
+    it("should use override categories when base has no categories", () => {
+      const base: OhMyOpenCodeConfig = {};
 
-			const override: OhMyOpenCodeConfig = {
-				categories: {
-					general: {
-						model: "openai/gpt-5.2",
-					},
-				},
-			};
+      const override: OhMyOpenCodeConfig = {
+        categories: {
+          general: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      };
 
-			const result = mergeConfigs(base, override);
+      const result = mergeConfigs(base, override);
 
-			expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
-		});
-	});
+      expect(result.categories?.general?.model).toBe("openai/gpt-5.2");
+    });
+  });
 
-	describe("existing behavior preservation", () => {
-		it("should deep merge agents", () => {
-			const base: OhMyOpenCodeConfig = {
-				agents: {
-					oracle: { model: "openai/gpt-5.2" },
-				},
-			};
+  describe("existing behavior preservation", () => {
+    it("should deep merge agents", () => {
+      const base: OhMyOpenCodeConfig = {
+        agents: {
+          oracle: { model: "openai/gpt-5.2" },
+        },
+      };
 
-			const override: OhMyOpenCodeConfig = {
-				agents: {
-					oracle: { temperature: 0.5 },
-					explore: { model: "anthropic/claude-haiku-4-5" },
-				},
-			};
+      const override: OhMyOpenCodeConfig = {
+        agents: {
+          oracle: { temperature: 0.5 },
+          explore: { model: "anthropic/claude-haiku-4-5" },
+        },
+      };
 
-			const result = mergeConfigs(base, override);
+      const result = mergeConfigs(base, override);
 
-			expect(result.agents?.oracle?.model).toBe("openai/gpt-5.2");
-			expect(result.agents?.oracle?.temperature).toBe(0.5);
-			expect(result.agents?.explore?.model).toBe("anthropic/claude-haiku-4-5");
-		});
+      expect(result.agents?.oracle?.model).toBe("openai/gpt-5.2");
+      expect(result.agents?.oracle?.temperature).toBe(0.5);
+      expect(result.agents?.explore?.model).toBe("anthropic/claude-haiku-4-5");
+    });
 
-		it("should merge disabled arrays without duplicates", () => {
-			const base: OhMyOpenCodeConfig = {
-				disabled_hooks: ["comment-checker", "think-mode"],
-			};
+    it("should merge disabled arrays without duplicates", () => {
+      const base: OhMyOpenCodeConfig = {
+        disabled_hooks: ["comment-checker", "think-mode"],
+      };
 
-			const override: OhMyOpenCodeConfig = {
-				disabled_hooks: ["think-mode", "session-recovery"],
-			};
+      const override: OhMyOpenCodeConfig = {
+        disabled_hooks: ["think-mode", "session-recovery"],
+      };
 
-			const result = mergeConfigs(base, override);
+      const result = mergeConfigs(base, override);
 
-			expect(result.disabled_hooks).toContain("comment-checker");
-			expect(result.disabled_hooks).toContain("think-mode");
-			expect(result.disabled_hooks).toContain("session-recovery");
-			expect(result.disabled_hooks?.length).toBe(3);
-		});
-	});
+      expect(result.disabled_hooks).toContain("comment-checker");
+      expect(result.disabled_hooks).toContain("think-mode");
+      expect(result.disabled_hooks).toContain("session-recovery");
+      expect(result.disabled_hooks?.length).toBe(3);
+    });
+  });
 });
 
 describe("loadPluginConfig precedence", () => {
-	// #given multiple config sources
-	// #when loading plugin config
-	// #then apply precedence user < env path < project < inline
+  // #given multiple config sources
+  // #when loading plugin config
+  // #then apply precedence user < env path < project < inline
 
-	it("prefers jsonc over json for user config", () => {
-		const tempDir = createTempDir("jsonc");
-		const projectRoot = path.join(tempDir, "project");
+  it("prefers jsonc over json for user config", () => {
+    const tempDir = createTempDir("jsonc");
+    const projectRoot = path.join(tempDir, "project");
 
-		fs.mkdirSync(projectRoot, { recursive: true });
-		writeJson(path.join(projectRoot, "package.json"), { name: "test" });
+    fs.mkdirSync(projectRoot, { recursive: true });
+    writeJson(path.join(projectRoot, "package.json"), { name: "test" });
 
-		process.env.OH_MY_OPENCODE_CONFIG_DIR = tempDir;
+    process.env.OH_MY_OPENCODE_CONFIG_DIR = tempDir;
 
-		const jsonPath = path.join(tempDir, "oh-my-opencode.json");
-		const jsoncPath = path.join(tempDir, "oh-my-opencode.jsonc");
+    const jsonPath = path.join(tempDir, "oh-my-opencode.json");
+    const jsoncPath = path.join(tempDir, "oh-my-opencode.jsonc");
 
-		writeJson(jsonPath, { auto_update: false });
-		writeJson(jsoncPath, { auto_update: true });
+    writeJson(jsonPath, { auto_update: false });
+    writeJson(jsoncPath, { auto_update: true });
 
-		const config = loadPluginConfig(projectRoot, {});
+    const config = loadPluginConfig(projectRoot, {});
 
-		expect(config.auto_update).toBe(true);
+    expect(config.auto_update).toBe(true);
 
-		cleanupDir(tempDir);
-	});
+    cleanupDir(tempDir);
+  });
 
-	it("applies precedence user < env path < project", () => {
-		const tempDir = createTempDir("precedence");
-		const projectRoot = path.join(tempDir, "project");
-		const projectConfigPath = path.join(
-			projectRoot,
-			".opencode",
-			"oh-my-opencode.json",
-		);
+  it("applies precedence user < env path < project", () => {
+    const tempDir = createTempDir("precedence");
+    const projectRoot = path.join(tempDir, "project");
+    const projectConfigPath = path.join(
+      projectRoot,
+      ".opencode",
+      "oh-my-opencode.json",
+    );
 
-		fs.mkdirSync(projectRoot, { recursive: true });
-		writeJson(path.join(projectRoot, "package.json"), { name: "test" });
+    fs.mkdirSync(projectRoot, { recursive: true });
+    writeJson(path.join(projectRoot, "package.json"), { name: "test" });
 
-		process.env.OH_MY_OPENCODE_CONFIG_DIR = tempDir;
+    process.env.OH_MY_OPENCODE_CONFIG_DIR = tempDir;
 
-		writeJson(path.join(tempDir, "oh-my-opencode.json"), {
-			auto_update: false,
-		});
+    writeJson(path.join(tempDir, "oh-my-opencode.json"), {
+      auto_update: false,
+    });
 
-		const envConfigPath = path.join(tempDir, "env.json");
-		writeJson(envConfigPath, { auto_update: true });
-		process.env.OH_MY_OPENCODE_CONFIG = envConfigPath;
+    const envConfigPath = path.join(tempDir, "env.json");
+    writeJson(envConfigPath, { auto_update: true });
+    process.env.OH_MY_OPENCODE_CONFIG = envConfigPath;
 
-		writeJson(projectConfigPath, { auto_update: false });
+    writeJson(projectConfigPath, { auto_update: false });
 
-		const config = loadPluginConfig(projectRoot, {});
+    const config = loadPluginConfig(projectRoot, {});
 
-		expect(config.auto_update).toBe(false);
+    expect(config.auto_update).toBe(false);
 
-		cleanupDir(tempDir);
-	});
+    cleanupDir(tempDir);
+  });
 
-	it("applies inline content with highest precedence", () => {
-		const tempDir = createTempDir("inline");
-		const projectRoot = path.join(tempDir, "project");
-		const projectConfigPath = path.join(
-			projectRoot,
-			".opencode",
-			"oh-my-opencode.json",
-		);
+  it("applies inline content with highest precedence", () => {
+    const tempDir = createTempDir("inline");
+    const projectRoot = path.join(tempDir, "project");
+    const projectConfigPath = path.join(
+      projectRoot,
+      ".opencode",
+      "oh-my-opencode.json",
+    );
 
-		fs.mkdirSync(projectRoot, { recursive: true });
-		writeJson(path.join(projectRoot, "package.json"), { name: "test" });
+    fs.mkdirSync(projectRoot, { recursive: true });
+    writeJson(path.join(projectRoot, "package.json"), { name: "test" });
 
-		process.env.OH_MY_OPENCODE_CONFIG_DIR = tempDir;
+    process.env.OH_MY_OPENCODE_CONFIG_DIR = tempDir;
 
-		writeJson(path.join(tempDir, "oh-my-opencode.json"), {
-			auto_update: false,
-		});
+    writeJson(path.join(tempDir, "oh-my-opencode.json"), {
+      auto_update: false,
+    });
 
-		writeJson(projectConfigPath, { auto_update: false });
+    writeJson(projectConfigPath, { auto_update: false });
 
-		process.env.OH_MY_OPENCODE_CONFIG_CONTENT = JSON.stringify({
-			auto_update: true,
-		});
+    process.env.OH_MY_OPENCODE_CONFIG_CONTENT = JSON.stringify({
+      auto_update: true,
+    });
 
-		const config = loadPluginConfig(projectRoot, {});
+    const config = loadPluginConfig(projectRoot, {});
 
-		expect(config.auto_update).toBe(true);
+    expect(config.auto_update).toBe(true);
 
-		cleanupDir(tempDir);
-	});
+    cleanupDir(tempDir);
+  });
 
-	it("merges project configs from root to leaf", () => {
-		const tempDir = createTempDir("search-up");
-		const projectRoot = path.join(tempDir, "project");
-		const nestedDir = path.join(projectRoot, "apps", "demo");
+  it("merges project configs from root to leaf", () => {
+    const tempDir = createTempDir("search-up");
+    const projectRoot = path.join(tempDir, "project");
+    const nestedDir = path.join(projectRoot, "apps", "demo");
 
-		fs.mkdirSync(nestedDir, { recursive: true });
-		writeJson(path.join(projectRoot, "package.json"), { name: "test" });
+    fs.mkdirSync(nestedDir, { recursive: true });
+    writeJson(path.join(projectRoot, "package.json"), { name: "test" });
 
-		writeJson(path.join(projectRoot, ".opencode", "oh-my-opencode.json"), {
-			auto_update: false,
-			disabled_hooks: ["think-mode"],
-		});
+    writeJson(path.join(projectRoot, ".opencode", "oh-my-opencode.json"), {
+      auto_update: false,
+      disabled_hooks: ["think-mode"],
+    });
 
-		writeJson(path.join(nestedDir, ".opencode", "oh-my-opencode.json"), {
-			auto_update: true,
-			disabled_hooks: ["comment-checker"],
-		});
+    writeJson(path.join(nestedDir, ".opencode", "oh-my-opencode.json"), {
+      auto_update: true,
+      disabled_hooks: ["comment-checker"],
+    });
 
-		const config = loadPluginConfig(nestedDir, {});
+    const config = loadPluginConfig(nestedDir, {});
 
-		expect(config.auto_update).toBe(true);
-		expect(config.disabled_hooks).toContain("think-mode");
-		expect(config.disabled_hooks).toContain("comment-checker");
+    expect(config.auto_update).toBe(true);
+    expect(config.disabled_hooks).toContain("think-mode");
+    expect(config.disabled_hooks).toContain("comment-checker");
 
-		cleanupDir(tempDir);
-	});
+    cleanupDir(tempDir);
+  });
 });

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -50,7 +50,7 @@ export function loadConfigFromPath(
 
 export function loadConfigFromContent(
   content: string,
-  source: string
+  source: string,
 ): OhMyOpenCodeConfig | null {
   try {
     const rawConfig = parseJsonc<Record<string, unknown>>(content);
@@ -123,7 +123,7 @@ function getProjectConfigPaths(directory: string): string[] {
 
 export function mergeConfigs(
   base: OhMyOpenCodeConfig,
-  override: OhMyOpenCodeConfig
+  override: OhMyOpenCodeConfig,
 ): OhMyOpenCodeConfig {
   return {
     ...base,
@@ -166,7 +166,7 @@ export function mergeConfigs(
 
 export function loadPluginConfig(
   directory: string,
-  _ctx: unknown
+  _ctx: unknown,
 ): OhMyOpenCodeConfig {
   const configDir = getOhMyOpenCodeConfigDir();
   const userBasePath = path.join(configDir, "oh-my-opencode");
@@ -195,7 +195,7 @@ export function loadPluginConfig(
   if (inlineConfigContent) {
     const inlineConfig = loadConfigFromContent(
       inlineConfigContent,
-      "OH_MY_OPENCODE_CONFIG_CONTENT"
+      "OH_MY_OPENCODE_CONFIG_CONTENT",
     );
     if (inlineConfig) {
       config = mergeConfigs(config, inlineConfig);

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { OhMyOpenCodeConfigSchema, type OhMyOpenCodeConfig } from "./config";
+
+import { type OhMyOpenCodeConfig, OhMyOpenCodeConfigSchema } from "./config";
 import { findProjectRoot } from "./hooks/rules-injector/finder";
 import {
 	addConfigLoadError,

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -1,214 +1,213 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-
 import { type OhMyOpenCodeConfig, OhMyOpenCodeConfigSchema } from "./config";
 import { findProjectRoot } from "./hooks/rules-injector/finder";
 import {
-	addConfigLoadError,
-	deepMerge,
-	detectConfigFile,
-	getOpenCodeConfigDir,
-	log,
-	migrateConfig,
-	migrateConfigFile,
-	parseJsonc,
+  addConfigLoadError,
+  deepMerge,
+  detectConfigFile,
+  getOpenCodeConfigDir,
+  log,
+  migrateConfig,
+  migrateConfigFile,
+  parseJsonc,
 } from "./shared";
 
 export function loadConfigFromPath(
-	configPath: string,
+  configPath: string,
 ): OhMyOpenCodeConfig | null {
-	try {
-		if (fs.existsSync(configPath)) {
-			const content = fs.readFileSync(configPath, "utf-8");
-			const rawConfig = parseJsonc<Record<string, unknown>>(content);
+  try {
+    if (fs.existsSync(configPath)) {
+      const content = fs.readFileSync(configPath, "utf-8");
+      const rawConfig = parseJsonc<Record<string, unknown>>(content);
 
-			migrateConfigFile(configPath, rawConfig);
+      migrateConfigFile(configPath, rawConfig);
 
-			const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
+      const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
 
-			if (!result.success) {
-				const errorMsg = result.error.issues
-					.map((i) => `${i.path.join(".")}: ${i.message}`)
-					.join(", ");
-				log(`Config validation error in ${configPath}:`, result.error.issues);
-				addConfigLoadError({
-					path: configPath,
-					error: `Validation error: ${errorMsg}`,
-				});
-				return null;
-			}
+      if (!result.success) {
+        const errorMsg = result.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join(", ");
+        log(`Config validation error in ${configPath}:`, result.error.issues);
+        addConfigLoadError({
+          path: configPath,
+          error: `Validation error: ${errorMsg}`,
+        });
+        return null;
+      }
 
-			log(`Config loaded from ${configPath}`, { agents: result.data.agents });
-			return result.data;
-		}
-	} catch (err) {
-		const errorMsg = err instanceof Error ? err.message : String(err);
-		log(`Error loading config from ${configPath}:`, err);
-		addConfigLoadError({ path: configPath, error: errorMsg });
-	}
-	return null;
+      log(`Config loaded from ${configPath}`, { agents: result.data.agents });
+      return result.data;
+    }
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    log(`Error loading config from ${configPath}:`, err);
+    addConfigLoadError({ path: configPath, error: errorMsg });
+  }
+  return null;
 }
 
 export function loadConfigFromContent(
-	content: string,
-	source: string,
+  content: string,
+  source: string
 ): OhMyOpenCodeConfig | null {
-	try {
-		const rawConfig = parseJsonc<Record<string, unknown>>(content);
+  try {
+    const rawConfig = parseJsonc<Record<string, unknown>>(content);
 
-		migrateConfig(rawConfig);
+    migrateConfig(rawConfig);
 
-		const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
+    const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
 
-		if (!result.success) {
-			const errorMsg = result.error.issues
-				.map((i) => `${i.path.join(".")}: ${i.message}`)
-				.join(", ");
-			log(`Config validation error in ${source}:`, result.error.issues);
-			addConfigLoadError({
-				path: source,
-				error: `Validation error: ${errorMsg}`,
-			});
-			return null;
-		}
+    if (!result.success) {
+      const errorMsg = result.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join(", ");
+      log(`Config validation error in ${source}:`, result.error.issues);
+      addConfigLoadError({
+        path: source,
+        error: `Validation error: ${errorMsg}`,
+      });
+      return null;
+    }
 
-		log(`Config loaded from ${source}`, { agents: result.data.agents });
-		return result.data;
-	} catch (err) {
-		const errorMsg = err instanceof Error ? err.message : String(err);
-		log(`Error loading config from ${source}:`, err);
-		addConfigLoadError({ path: source, error: errorMsg });
-	}
-	return null;
+    log(`Config loaded from ${source}`, { agents: result.data.agents });
+    return result.data;
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    log(`Error loading config from ${source}:`, err);
+    addConfigLoadError({ path: source, error: errorMsg });
+  }
+  return null;
 }
 
 function getOhMyOpenCodeConfigDir(): string {
-	const envDir = process.env.OH_MY_OPENCODE_CONFIG_DIR?.trim();
-	if (envDir) return envDir;
-	return getOpenCodeConfigDir({ binary: "opencode" });
+  const envDir = process.env.OH_MY_OPENCODE_CONFIG_DIR?.trim();
+  if (envDir) return envDir;
+  return getOpenCodeConfigDir({ binary: "opencode" });
 }
 
 function getDetectedConfigPath(basePath: string): string {
-	const detected = detectConfigFile(basePath);
-	return detected.format !== "none" ? detected.path : `${basePath}.json`;
+  const detected = detectConfigFile(basePath);
+  return detected.format !== "none" ? detected.path : `${basePath}.json`;
 }
 
 function getProjectConfigPaths(directory: string): string[] {
-	const resolvedDir = path.resolve(directory);
-	const projectRoot =
-		findProjectRoot(resolvedDir) ?? path.parse(resolvedDir).root;
-	const dirs: string[] = [];
-	let current = resolvedDir;
+  const resolvedDir = path.resolve(directory);
+  const projectRoot =
+    findProjectRoot(resolvedDir) ?? path.parse(resolvedDir).root;
+  const dirs: string[] = [];
+  let current = resolvedDir;
 
-	while (true) {
-		dirs.push(current);
-		if (current === projectRoot) break;
-		const parent = path.dirname(current);
-		if (parent === current) break;
-		current = parent;
-	}
+  while (true) {
+    dirs.push(current);
+    if (current === projectRoot) break;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
 
-	dirs.reverse();
+  dirs.reverse();
 
-	const configPaths: string[] = [];
-	for (const dir of dirs) {
-		const basePath = path.join(dir, ".opencode", "oh-my-opencode");
-		const detected = detectConfigFile(basePath);
-		if (detected.format !== "none") {
-			configPaths.push(detected.path);
-		}
-	}
+  const configPaths: string[] = [];
+  for (const dir of dirs) {
+    const basePath = path.join(dir, ".opencode", "oh-my-opencode");
+    const detected = detectConfigFile(basePath);
+    if (detected.format !== "none") {
+      configPaths.push(detected.path);
+    }
+  }
 
-	return configPaths;
+  return configPaths;
 }
 
 export function mergeConfigs(
-	base: OhMyOpenCodeConfig,
-	override: OhMyOpenCodeConfig,
+  base: OhMyOpenCodeConfig,
+  override: OhMyOpenCodeConfig
 ): OhMyOpenCodeConfig {
-	return {
-		...base,
-		...override,
-		agents: deepMerge(base.agents, override.agents),
-		categories: deepMerge(base.categories, override.categories),
-		disabled_agents: [
-			...new Set([
-				...(base.disabled_agents ?? []),
-				...(override.disabled_agents ?? []),
-			]),
-		],
-		disabled_mcps: [
-			...new Set([
-				...(base.disabled_mcps ?? []),
-				...(override.disabled_mcps ?? []),
-			]),
-		],
-		disabled_hooks: [
-			...new Set([
-				...(base.disabled_hooks ?? []),
-				...(override.disabled_hooks ?? []),
-			]),
-		],
-		disabled_commands: [
-			...new Set([
-				...(base.disabled_commands ?? []),
-				...(override.disabled_commands ?? []),
-			]),
-		],
-		disabled_skills: [
-			...new Set([
-				...(base.disabled_skills ?? []),
-				...(override.disabled_skills ?? []),
-			]),
-		],
-		claude_code: deepMerge(base.claude_code, override.claude_code),
-	};
+  return {
+    ...base,
+    ...override,
+    agents: deepMerge(base.agents, override.agents),
+    categories: deepMerge(base.categories, override.categories),
+    disabled_agents: [
+      ...new Set([
+        ...(base.disabled_agents ?? []),
+        ...(override.disabled_agents ?? []),
+      ]),
+    ],
+    disabled_mcps: [
+      ...new Set([
+        ...(base.disabled_mcps ?? []),
+        ...(override.disabled_mcps ?? []),
+      ]),
+    ],
+    disabled_hooks: [
+      ...new Set([
+        ...(base.disabled_hooks ?? []),
+        ...(override.disabled_hooks ?? []),
+      ]),
+    ],
+    disabled_commands: [
+      ...new Set([
+        ...(base.disabled_commands ?? []),
+        ...(override.disabled_commands ?? []),
+      ]),
+    ],
+    disabled_skills: [
+      ...new Set([
+        ...(base.disabled_skills ?? []),
+        ...(override.disabled_skills ?? []),
+      ]),
+    ],
+    claude_code: deepMerge(base.claude_code, override.claude_code),
+  };
 }
 
 export function loadPluginConfig(
-	directory: string,
-	_ctx: unknown,
+  directory: string,
+  _ctx: unknown
 ): OhMyOpenCodeConfig {
-	const configDir = getOhMyOpenCodeConfigDir();
-	const userBasePath = path.join(configDir, "oh-my-opencode");
-	const userConfigPath = getDetectedConfigPath(userBasePath);
-	const inlineConfigContent =
-		process.env.OH_MY_OPENCODE_CONFIG_CONTENT?.trim() ?? null;
-	const envConfigPath = process.env.OH_MY_OPENCODE_CONFIG?.trim() ?? null;
+  const configDir = getOhMyOpenCodeConfigDir();
+  const userBasePath = path.join(configDir, "oh-my-opencode");
+  const userConfigPath = getDetectedConfigPath(userBasePath);
+  const inlineConfigContent =
+    process.env.OH_MY_OPENCODE_CONFIG_CONTENT?.trim() ?? null;
+  const envConfigPath = process.env.OH_MY_OPENCODE_CONFIG?.trim() ?? null;
 
-	let config: OhMyOpenCodeConfig = loadConfigFromPath(userConfigPath) ?? {};
+  let config: OhMyOpenCodeConfig = loadConfigFromPath(userConfigPath) ?? {};
 
-	if (envConfigPath) {
-		const envConfig = loadConfigFromPath(envConfigPath);
-		if (envConfig) {
-			config = mergeConfigs(config, envConfig);
-		}
-	}
+  if (envConfigPath) {
+    const envConfig = loadConfigFromPath(envConfigPath);
+    if (envConfig) {
+      config = mergeConfigs(config, envConfig);
+    }
+  }
 
-	const projectConfigPaths = getProjectConfigPaths(directory);
-	for (const projectConfigPath of projectConfigPaths) {
-		const projectConfig = loadConfigFromPath(projectConfigPath);
-		if (projectConfig) {
-			config = mergeConfigs(config, projectConfig);
-		}
-	}
+  const projectConfigPaths = getProjectConfigPaths(directory);
+  for (const projectConfigPath of projectConfigPaths) {
+    const projectConfig = loadConfigFromPath(projectConfigPath);
+    if (projectConfig) {
+      config = mergeConfigs(config, projectConfig);
+    }
+  }
 
-	if (inlineConfigContent) {
-		const inlineConfig = loadConfigFromContent(
-			inlineConfigContent,
-			"OH_MY_OPENCODE_CONFIG_CONTENT",
-		);
-		if (inlineConfig) {
-			config = mergeConfigs(config, inlineConfig);
-		}
-	}
+  if (inlineConfigContent) {
+    const inlineConfig = loadConfigFromContent(
+      inlineConfigContent,
+      "OH_MY_OPENCODE_CONFIG_CONTENT"
+    );
+    if (inlineConfig) {
+      config = mergeConfigs(config, inlineConfig);
+    }
+  }
 
-	log("Final merged config", {
-		agents: config.agents,
-		disabled_agents: config.disabled_agents,
-		disabled_mcps: config.disabled_mcps,
-		disabled_hooks: config.disabled_hooks,
-		claude_code: config.claude_code,
-	});
-	return config;
+  log("Final merged config", {
+    agents: config.agents,
+    disabled_agents: config.disabled_agents,
+    disabled_mcps: config.disabled_mcps,
+    disabled_hooks: config.disabled_hooks,
+    claude_code: config.claude_code,
+  });
+  return config;
 }

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -1,132 +1,213 @@
-import * as fs from "fs";
-import * as path from "path";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { OhMyOpenCodeConfigSchema, type OhMyOpenCodeConfig } from "./config";
+import { findProjectRoot } from "./hooks/rules-injector/finder";
 import {
-  log,
-  deepMerge,
-  getOpenCodeConfigDir,
-  addConfigLoadError,
-  parseJsonc,
-  detectConfigFile,
-  migrateConfigFile,
+	addConfigLoadError,
+	deepMerge,
+	detectConfigFile,
+	getOpenCodeConfigDir,
+	log,
+	migrateConfig,
+	migrateConfigFile,
+	parseJsonc,
 } from "./shared";
 
 export function loadConfigFromPath(
-  configPath: string,
-  ctx: unknown
+	configPath: string,
 ): OhMyOpenCodeConfig | null {
-  try {
-    if (fs.existsSync(configPath)) {
-      const content = fs.readFileSync(configPath, "utf-8");
-      const rawConfig = parseJsonc<Record<string, unknown>>(content);
+	try {
+		if (fs.existsSync(configPath)) {
+			const content = fs.readFileSync(configPath, "utf-8");
+			const rawConfig = parseJsonc<Record<string, unknown>>(content);
 
-      migrateConfigFile(configPath, rawConfig);
+			migrateConfigFile(configPath, rawConfig);
 
-      const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
+			const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
 
-      if (!result.success) {
-        const errorMsg = result.error.issues
-          .map((i) => `${i.path.join(".")}: ${i.message}`)
-          .join(", ");
-        log(`Config validation error in ${configPath}:`, result.error.issues);
-        addConfigLoadError({
-          path: configPath,
-          error: `Validation error: ${errorMsg}`,
-        });
-        return null;
-      }
+			if (!result.success) {
+				const errorMsg = result.error.issues
+					.map((i) => `${i.path.join(".")}: ${i.message}`)
+					.join(", ");
+				log(`Config validation error in ${configPath}:`, result.error.issues);
+				addConfigLoadError({
+					path: configPath,
+					error: `Validation error: ${errorMsg}`,
+				});
+				return null;
+			}
 
-      log(`Config loaded from ${configPath}`, { agents: result.data.agents });
-      return result.data;
-    }
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err);
-    log(`Error loading config from ${configPath}:`, err);
-    addConfigLoadError({ path: configPath, error: errorMsg });
-  }
-  return null;
+			log(`Config loaded from ${configPath}`, { agents: result.data.agents });
+			return result.data;
+		}
+	} catch (err) {
+		const errorMsg = err instanceof Error ? err.message : String(err);
+		log(`Error loading config from ${configPath}:`, err);
+		addConfigLoadError({ path: configPath, error: errorMsg });
+	}
+	return null;
+}
+
+export function loadConfigFromContent(
+	content: string,
+	source: string,
+): OhMyOpenCodeConfig | null {
+	try {
+		const rawConfig = parseJsonc<Record<string, unknown>>(content);
+
+		migrateConfig(rawConfig);
+
+		const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
+
+		if (!result.success) {
+			const errorMsg = result.error.issues
+				.map((i) => `${i.path.join(".")}: ${i.message}`)
+				.join(", ");
+			log(`Config validation error in ${source}:`, result.error.issues);
+			addConfigLoadError({
+				path: source,
+				error: `Validation error: ${errorMsg}`,
+			});
+			return null;
+		}
+
+		log(`Config loaded from ${source}`, { agents: result.data.agents });
+		return result.data;
+	} catch (err) {
+		const errorMsg = err instanceof Error ? err.message : String(err);
+		log(`Error loading config from ${source}:`, err);
+		addConfigLoadError({ path: source, error: errorMsg });
+	}
+	return null;
+}
+
+function getOhMyOpenCodeConfigDir(): string {
+	const envDir = process.env.OH_MY_OPENCODE_CONFIG_DIR?.trim();
+	if (envDir) return envDir;
+	return getOpenCodeConfigDir({ binary: "opencode" });
+}
+
+function getDetectedConfigPath(basePath: string): string {
+	const detected = detectConfigFile(basePath);
+	return detected.format !== "none" ? detected.path : `${basePath}.json`;
+}
+
+function getProjectConfigPaths(directory: string): string[] {
+	const resolvedDir = path.resolve(directory);
+	const projectRoot =
+		findProjectRoot(resolvedDir) ?? path.parse(resolvedDir).root;
+	const dirs: string[] = [];
+	let current = resolvedDir;
+
+	while (true) {
+		dirs.push(current);
+		if (current === projectRoot) break;
+		const parent = path.dirname(current);
+		if (parent === current) break;
+		current = parent;
+	}
+
+	dirs.reverse();
+
+	const configPaths: string[] = [];
+	for (const dir of dirs) {
+		const basePath = path.join(dir, ".opencode", "oh-my-opencode");
+		const detected = detectConfigFile(basePath);
+		if (detected.format !== "none") {
+			configPaths.push(detected.path);
+		}
+	}
+
+	return configPaths;
 }
 
 export function mergeConfigs(
-  base: OhMyOpenCodeConfig,
-  override: OhMyOpenCodeConfig
+	base: OhMyOpenCodeConfig,
+	override: OhMyOpenCodeConfig,
 ): OhMyOpenCodeConfig {
-  return {
-    ...base,
-    ...override,
-    agents: deepMerge(base.agents, override.agents),
-    categories: deepMerge(base.categories, override.categories),
-    disabled_agents: [
-      ...new Set([
-        ...(base.disabled_agents ?? []),
-        ...(override.disabled_agents ?? []),
-      ]),
-    ],
-    disabled_mcps: [
-      ...new Set([
-        ...(base.disabled_mcps ?? []),
-        ...(override.disabled_mcps ?? []),
-      ]),
-    ],
-    disabled_hooks: [
-      ...new Set([
-        ...(base.disabled_hooks ?? []),
-        ...(override.disabled_hooks ?? []),
-      ]),
-    ],
-    disabled_commands: [
-      ...new Set([
-        ...(base.disabled_commands ?? []),
-        ...(override.disabled_commands ?? []),
-      ]),
-    ],
-    disabled_skills: [
-      ...new Set([
-        ...(base.disabled_skills ?? []),
-        ...(override.disabled_skills ?? []),
-      ]),
-    ],
-    claude_code: deepMerge(base.claude_code, override.claude_code),
-  };
+	return {
+		...base,
+		...override,
+		agents: deepMerge(base.agents, override.agents),
+		categories: deepMerge(base.categories, override.categories),
+		disabled_agents: [
+			...new Set([
+				...(base.disabled_agents ?? []),
+				...(override.disabled_agents ?? []),
+			]),
+		],
+		disabled_mcps: [
+			...new Set([
+				...(base.disabled_mcps ?? []),
+				...(override.disabled_mcps ?? []),
+			]),
+		],
+		disabled_hooks: [
+			...new Set([
+				...(base.disabled_hooks ?? []),
+				...(override.disabled_hooks ?? []),
+			]),
+		],
+		disabled_commands: [
+			...new Set([
+				...(base.disabled_commands ?? []),
+				...(override.disabled_commands ?? []),
+			]),
+		],
+		disabled_skills: [
+			...new Set([
+				...(base.disabled_skills ?? []),
+				...(override.disabled_skills ?? []),
+			]),
+		],
+		claude_code: deepMerge(base.claude_code, override.claude_code),
+	};
 }
 
 export function loadPluginConfig(
-  directory: string,
-  ctx: unknown
+	directory: string,
+	_ctx: unknown,
 ): OhMyOpenCodeConfig {
-  // User-level config path - prefer .jsonc over .json
-  const configDir = getOpenCodeConfigDir({ binary: "opencode" });
-  const userBasePath = path.join(configDir, "oh-my-opencode");
-  const userDetected = detectConfigFile(userBasePath);
-  const userConfigPath =
-    userDetected.format !== "none"
-      ? userDetected.path
-      : userBasePath + ".json";
+	const configDir = getOhMyOpenCodeConfigDir();
+	const userBasePath = path.join(configDir, "oh-my-opencode");
+	const userConfigPath = getDetectedConfigPath(userBasePath);
+	const inlineConfigContent =
+		process.env.OH_MY_OPENCODE_CONFIG_CONTENT?.trim() ?? null;
+	const envConfigPath = process.env.OH_MY_OPENCODE_CONFIG?.trim() ?? null;
 
-  // Project-level config path - prefer .jsonc over .json
-  const projectBasePath = path.join(directory, ".opencode", "oh-my-opencode");
-  const projectDetected = detectConfigFile(projectBasePath);
-  const projectConfigPath =
-    projectDetected.format !== "none"
-      ? projectDetected.path
-      : projectBasePath + ".json";
+	let config: OhMyOpenCodeConfig = loadConfigFromPath(userConfigPath) ?? {};
 
-  // Load user config first (base)
-  let config: OhMyOpenCodeConfig =
-    loadConfigFromPath(userConfigPath, ctx) ?? {};
+	if (envConfigPath) {
+		const envConfig = loadConfigFromPath(envConfigPath);
+		if (envConfig) {
+			config = mergeConfigs(config, envConfig);
+		}
+	}
 
-  // Override with project config
-  const projectConfig = loadConfigFromPath(projectConfigPath, ctx);
-  if (projectConfig) {
-    config = mergeConfigs(config, projectConfig);
-  }
+	const projectConfigPaths = getProjectConfigPaths(directory);
+	for (const projectConfigPath of projectConfigPaths) {
+		const projectConfig = loadConfigFromPath(projectConfigPath);
+		if (projectConfig) {
+			config = mergeConfigs(config, projectConfig);
+		}
+	}
 
-  log("Final merged config", {
-    agents: config.agents,
-    disabled_agents: config.disabled_agents,
-    disabled_mcps: config.disabled_mcps,
-    disabled_hooks: config.disabled_hooks,
-    claude_code: config.claude_code,
-  });
-  return config;
+	if (inlineConfigContent) {
+		const inlineConfig = loadConfigFromContent(
+			inlineConfigContent,
+			"OH_MY_OPENCODE_CONFIG_CONTENT",
+		);
+		if (inlineConfig) {
+			config = mergeConfigs(config, inlineConfig);
+		}
+	}
+
+	log("Final merged config", {
+		agents: config.agents,
+		disabled_agents: config.disabled_agents,
+		disabled_mcps: config.disabled_mcps,
+		disabled_hooks: config.disabled_hooks,
+		claude_code: config.claude_code,
+	});
+	return config;
 }

--- a/src/shared/migration.ts
+++ b/src/shared/migration.ts
@@ -1,230 +1,261 @@
-import * as fs from "fs"
-import { log } from "./logger"
+import * as fs from "node:fs";
+import { log } from "./logger";
 
 // Migration map: old keys → new keys (for backward compatibility)
 export const AGENT_NAME_MAP: Record<string, string> = {
-  // Sisyphus variants → "sisyphus"
-  omo: "sisyphus",
-  OmO: "sisyphus",
-  Sisyphus: "sisyphus",
-  sisyphus: "sisyphus",
+	// Sisyphus variants → "sisyphus"
+	omo: "sisyphus",
+	OmO: "sisyphus",
+	Sisyphus: "sisyphus",
+	sisyphus: "sisyphus",
 
-  // Prometheus variants → "prometheus"
-  "OmO-Plan": "prometheus",
-  "omo-plan": "prometheus",
-  "Planner-Sisyphus": "prometheus",
-  "planner-sisyphus": "prometheus",
-  "Prometheus (Planner)": "prometheus",
-  prometheus: "prometheus",
+	// Prometheus variants → "prometheus"
+	"OmO-Plan": "prometheus",
+	"omo-plan": "prometheus",
+	"Planner-Sisyphus": "prometheus",
+	"planner-sisyphus": "prometheus",
+	"Prometheus (Planner)": "prometheus",
+	prometheus: "prometheus",
 
-  // Atlas variants → "atlas"
-  "orchestrator-sisyphus": "atlas",
-  Atlas: "atlas",
-  atlas: "atlas",
+	// Atlas variants → "atlas"
+	"orchestrator-sisyphus": "atlas",
+	Atlas: "atlas",
+	atlas: "atlas",
 
-  // Metis variants → "metis"
-  "plan-consultant": "metis",
-  "Metis (Plan Consultant)": "metis",
-  metis: "metis",
+	// Metis variants → "metis"
+	"plan-consultant": "metis",
+	"Metis (Plan Consultant)": "metis",
+	metis: "metis",
 
-  // Momus variants → "momus"
-  "Momus (Plan Reviewer)": "momus",
-  momus: "momus",
+	// Momus variants → "momus"
+	"Momus (Plan Reviewer)": "momus",
+	momus: "momus",
 
-  // Sisyphus-Junior → "sisyphus-junior"
-  "Sisyphus-Junior": "sisyphus-junior",
-  "sisyphus-junior": "sisyphus-junior",
+	// Sisyphus-Junior → "sisyphus-junior"
+	"Sisyphus-Junior": "sisyphus-junior",
+	"sisyphus-junior": "sisyphus-junior",
 
-  // Already lowercase - passthrough
-  build: "build",
-  oracle: "oracle",
-  librarian: "librarian",
-  explore: "explore",
-  "multimodal-looker": "multimodal-looker",
-}
+	// Already lowercase - passthrough
+	build: "build",
+	oracle: "oracle",
+	librarian: "librarian",
+	explore: "explore",
+	"multimodal-looker": "multimodal-looker",
+};
 
 export const BUILTIN_AGENT_NAMES = new Set([
-  "sisyphus",           // was "Sisyphus"
-  "oracle",
-  "librarian",
-  "explore",
-  "multimodal-looker",
-  "metis",              // was "Metis (Plan Consultant)"
-  "momus",              // was "Momus (Plan Reviewer)"
-  "prometheus",         // was "Prometheus (Planner)"
-  "atlas",              // was "Atlas"
-  "build",
-])
+	"sisyphus", // was "Sisyphus"
+	"oracle",
+	"librarian",
+	"explore",
+	"multimodal-looker",
+	"metis", // was "Metis (Plan Consultant)"
+	"momus", // was "Momus (Plan Reviewer)"
+	"prometheus", // was "Prometheus (Planner)"
+	"atlas", // was "Atlas"
+	"build",
+]);
 
 // Migration map: old hook names → new hook names (for backward compatibility)
 // null means the hook was removed and should be filtered out from disabled_hooks
 export const HOOK_NAME_MAP: Record<string, string | null> = {
-  // Legacy names (backward compatibility)
-  "anthropic-auto-compact": "anthropic-context-window-limit-recovery",
-  "sisyphus-orchestrator": "atlas",
+	// Legacy names (backward compatibility)
+	"anthropic-auto-compact": "anthropic-context-window-limit-recovery",
+	"sisyphus-orchestrator": "atlas",
 
-  // Removed hooks (v3.0.0) - will be filtered out and user warned
-  "preemptive-compaction": null,
-  "empty-message-sanitizer": null,
-}
+	// Removed hooks (v3.0.0) - will be filtered out and user warned
+	"preemptive-compaction": null,
+	"empty-message-sanitizer": null,
+};
 
 /**
  * @deprecated LEGACY MIGRATION ONLY
- * 
+ *
  * This map exists solely for migrating old configs that used hardcoded model strings.
  * It maps legacy model strings to semantic category names, allowing users to migrate
  * from explicit model configs to category-based configs.
- * 
+ *
  * DO NOT add new entries here. New agents should use:
  * - Category-based config (preferred): { category: "unspecified-high" }
  * - Or inherit from OpenCode's config.model
- * 
+ *
  * This map will be removed in a future major version once migration period ends.
  */
 export const MODEL_TO_CATEGORY_MAP: Record<string, string> = {
-  "google/gemini-3-pro-preview": "visual-engineering",
-  "openai/gpt-5.2": "ultrabrain",
-  "anthropic/claude-haiku-4-5": "quick",
-  "anthropic/claude-opus-4-5": "unspecified-high",
-  "anthropic/claude-sonnet-4-5": "unspecified-low",
+	"google/gemini-3-pro-preview": "visual-engineering",
+	"openai/gpt-5.2": "ultrabrain",
+	"anthropic/claude-haiku-4-5": "quick",
+	"anthropic/claude-opus-4-5": "unspecified-high",
+	"anthropic/claude-sonnet-4-5": "unspecified-low",
+};
+
+export function migrateAgentNames(agents: Record<string, unknown>): {
+	migrated: Record<string, unknown>;
+	changed: boolean;
+} {
+	const migrated: Record<string, unknown> = {};
+	let changed = false;
+
+	for (const [key, value] of Object.entries(agents)) {
+		const newKey =
+			AGENT_NAME_MAP[key.toLowerCase()] ?? AGENT_NAME_MAP[key] ?? key;
+		if (newKey !== key) {
+			changed = true;
+		}
+		migrated[newKey] = value;
+	}
+
+	return { migrated, changed };
 }
 
-export function migrateAgentNames(agents: Record<string, unknown>): { migrated: Record<string, unknown>; changed: boolean } {
-  const migrated: Record<string, unknown> = {}
-  let changed = false
+export function migrateHookNames(hooks: string[]): {
+	migrated: string[];
+	changed: boolean;
+	removed: string[];
+} {
+	const migrated: string[] = [];
+	const removed: string[] = [];
+	let changed = false;
 
-  for (const [key, value] of Object.entries(agents)) {
-    const newKey = AGENT_NAME_MAP[key.toLowerCase()] ?? AGENT_NAME_MAP[key] ?? key
-    if (newKey !== key) {
-      changed = true
-    }
-    migrated[newKey] = value
-  }
+	for (const hook of hooks) {
+		const mapping = HOOK_NAME_MAP[hook];
 
-  return { migrated, changed }
-}
+		if (mapping === null) {
+			removed.push(hook);
+			changed = true;
+			continue;
+		}
 
-export function migrateHookNames(hooks: string[]): { migrated: string[]; changed: boolean; removed: string[] } {
-  const migrated: string[] = []
-  const removed: string[] = []
-  let changed = false
+		const newHook = mapping ?? hook;
+		if (newHook !== hook) {
+			changed = true;
+		}
+		migrated.push(newHook);
+	}
 
-  for (const hook of hooks) {
-    const mapping = HOOK_NAME_MAP[hook]
-
-    if (mapping === null) {
-      removed.push(hook)
-      changed = true
-      continue
-    }
-
-    const newHook = mapping ?? hook
-    if (newHook !== hook) {
-      changed = true
-    }
-    migrated.push(newHook)
-  }
-
-  return { migrated, changed, removed }
+	return { migrated, changed, removed };
 }
 
 export function migrateAgentConfigToCategory(config: Record<string, unknown>): {
-  migrated: Record<string, unknown>
-  changed: boolean
+	migrated: Record<string, unknown>;
+	changed: boolean;
 } {
-  const { model, ...rest } = config
-  if (typeof model !== "string") {
-    return { migrated: config, changed: false }
-  }
+	const { model, ...rest } = config;
+	if (typeof model !== "string") {
+		return { migrated: config, changed: false };
+	}
 
-  const category = MODEL_TO_CATEGORY_MAP[model]
-  if (!category) {
-    return { migrated: config, changed: false }
-  }
+	const category = MODEL_TO_CATEGORY_MAP[model];
+	if (!category) {
+		return { migrated: config, changed: false };
+	}
 
-  return {
-    migrated: { category, ...rest },
-    changed: true,
-  }
+	return {
+		migrated: { category, ...rest },
+		changed: true,
+	};
 }
 
 export function shouldDeleteAgentConfig(
-  config: Record<string, unknown>,
-  category: string
+	config: Record<string, unknown>,
+	category: string,
 ): boolean {
-  const { DEFAULT_CATEGORIES } = require("../tools/delegate-task/constants")
-  const defaults = DEFAULT_CATEGORIES[category]
-  if (!defaults) return false
+	const { DEFAULT_CATEGORIES } = require("../tools/delegate-task/constants");
+	const defaults = DEFAULT_CATEGORIES[category];
+	if (!defaults) return false;
 
-  const keys = Object.keys(config).filter((k) => k !== "category")
-  if (keys.length === 0) return true
+	const keys = Object.keys(config).filter((k) => k !== "category");
+	if (keys.length === 0) return true;
 
-  for (const key of keys) {
-    if (config[key] !== (defaults as Record<string, unknown>)[key]) {
-      return false
-    }
-  }
-  return true
+	for (const key of keys) {
+		if (config[key] !== (defaults as Record<string, unknown>)[key]) {
+			return false;
+		}
+	}
+	return true;
 }
 
-export function migrateConfigFile(configPath: string, rawConfig: Record<string, unknown>): boolean {
-  let needsWrite = false
+export function migrateConfig(rawConfig: Record<string, unknown>): {
+	migrated: Record<string, unknown>;
+	changed: boolean;
+} {
+	let changed = false;
 
-  if (rawConfig.agents && typeof rawConfig.agents === "object") {
-    const { migrated, changed } = migrateAgentNames(rawConfig.agents as Record<string, unknown>)
-    if (changed) {
-      rawConfig.agents = migrated
-      needsWrite = true
-    }
-  }
+	if (rawConfig.agents && typeof rawConfig.agents === "object") {
+		const { migrated, changed: agentChanged } = migrateAgentNames(
+			rawConfig.agents as Record<string, unknown>,
+		);
+		if (agentChanged) {
+			rawConfig.agents = migrated;
+			changed = true;
+		}
+	}
 
+	if (rawConfig.omo_agent) {
+		rawConfig.sisyphus_agent = rawConfig.omo_agent;
+		delete rawConfig.omo_agent;
+		changed = true;
+	}
 
+	if (rawConfig.disabled_agents && Array.isArray(rawConfig.disabled_agents)) {
+		const migrated: string[] = [];
+		let agentChanged = false;
+		for (const agent of rawConfig.disabled_agents as string[]) {
+			const newAgent =
+				AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent;
+			if (newAgent !== agent) {
+				agentChanged = true;
+			}
+			migrated.push(newAgent);
+		}
+		if (agentChanged) {
+			rawConfig.disabled_agents = migrated;
+			changed = true;
+		}
+	}
 
-  if (rawConfig.omo_agent) {
-    rawConfig.sisyphus_agent = rawConfig.omo_agent
-    delete rawConfig.omo_agent
-    needsWrite = true
-  }
+	if (rawConfig.disabled_hooks && Array.isArray(rawConfig.disabled_hooks)) {
+		const {
+			migrated,
+			changed: hookChanged,
+			removed,
+		} = migrateHookNames(rawConfig.disabled_hooks as string[]);
+		if (hookChanged) {
+			rawConfig.disabled_hooks = migrated;
+			changed = true;
+		}
+		if (removed.length > 0) {
+			log(
+				`Removed obsolete hooks from disabled_hooks: ${removed.join(", ")} (these hooks no longer exist in v3.0.0)`,
+			);
+		}
+	}
 
-  if (rawConfig.disabled_agents && Array.isArray(rawConfig.disabled_agents)) {
-    const migrated: string[] = []
-    let changed = false
-    for (const agent of rawConfig.disabled_agents as string[]) {
-      const newAgent = AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent
-      if (newAgent !== agent) {
-        changed = true
-      }
-      migrated.push(newAgent)
-    }
-    if (changed) {
-      rawConfig.disabled_agents = migrated
-      needsWrite = true
-    }
-  }
+	return { migrated: rawConfig, changed };
+}
 
-  if (rawConfig.disabled_hooks && Array.isArray(rawConfig.disabled_hooks)) {
-    const { migrated, changed, removed } = migrateHookNames(rawConfig.disabled_hooks as string[])
-    if (changed) {
-      rawConfig.disabled_hooks = migrated
-      needsWrite = true
-    }
-    if (removed.length > 0) {
-      log(`Removed obsolete hooks from disabled_hooks: ${removed.join(", ")} (these hooks no longer exist in v3.0.0)`)
-    }
-  }
+export function migrateConfigFile(
+	configPath: string,
+	rawConfig: Record<string, unknown>,
+): boolean {
+	const { migrated, changed } = migrateConfig(rawConfig);
 
-  if (needsWrite) {
-    try {
-      const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
-      const backupPath = `${configPath}.bak.${timestamp}`
-      fs.copyFileSync(configPath, backupPath)
+	if (changed) {
+		try {
+			const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+			const backupPath = `${configPath}.bak.${timestamp}`;
+			fs.copyFileSync(configPath, backupPath);
 
-      fs.writeFileSync(configPath, JSON.stringify(rawConfig, null, 2) + "\n", "utf-8")
-      log(`Migrated config file: ${configPath} (backup: ${backupPath})`)
-    } catch (err) {
-      log(`Failed to write migrated config to ${configPath}:`, err)
-    }
-  }
+			fs.writeFileSync(
+				configPath,
+				`${JSON.stringify(migrated, null, 2)}\n`,
+				"utf-8",
+			);
+			log(`Migrated config file: ${configPath} (backup: ${backupPath})`);
+		} catch (err) {
+			log(`Failed to write migrated config to ${configPath}:`, err);
+		}
+	}
 
-  return needsWrite
+	return changed;
 }

--- a/src/shared/migration.ts
+++ b/src/shared/migration.ts
@@ -1,263 +1,240 @@
-import * as fs from "node:fs";
-import { log } from "./logger";
+import * as fs from "fs"
+import { log } from "./logger"
 
 // Migration map: old keys → new keys (for backward compatibility)
 export const AGENT_NAME_MAP: Record<string, string> = {
-	// Sisyphus variants → "sisyphus"
-	omo: "sisyphus",
-	OmO: "sisyphus",
-	Sisyphus: "sisyphus",
-	sisyphus: "sisyphus",
+  // Sisyphus variants → "sisyphus"
+  omo: "sisyphus",
+  OmO: "sisyphus",
+  Sisyphus: "sisyphus",
+  sisyphus: "sisyphus",
 
-	// Prometheus variants → "prometheus"
-	"OmO-Plan": "prometheus",
-	"omo-plan": "prometheus",
-	"Planner-Sisyphus": "prometheus",
-	"planner-sisyphus": "prometheus",
-	"Prometheus (Planner)": "prometheus",
-	prometheus: "prometheus",
+  // Prometheus variants → "prometheus"
+  "OmO-Plan": "prometheus",
+  "omo-plan": "prometheus",
+  "Planner-Sisyphus": "prometheus",
+  "planner-sisyphus": "prometheus",
+  "Prometheus (Planner)": "prometheus",
+  prometheus: "prometheus",
 
-	// Atlas variants → "atlas"
-	"orchestrator-sisyphus": "atlas",
-	Atlas: "atlas",
-	atlas: "atlas",
+  // Atlas variants → "atlas"
+  "orchestrator-sisyphus": "atlas",
+  Atlas: "atlas",
+  atlas: "atlas",
 
-	// Metis variants → "metis"
-	"plan-consultant": "metis",
-	"Metis (Plan Consultant)": "metis",
-	metis: "metis",
+  // Metis variants → "metis"
+  "plan-consultant": "metis",
+  "Metis (Plan Consultant)": "metis",
+  metis: "metis",
 
-	// Momus variants → "momus"
-	"Momus (Plan Reviewer)": "momus",
-	momus: "momus",
+  // Momus variants → "momus"
+  "Momus (Plan Reviewer)": "momus",
+  momus: "momus",
 
-	// Sisyphus-Junior → "sisyphus-junior"
-	"Sisyphus-Junior": "sisyphus-junior",
-	"sisyphus-junior": "sisyphus-junior",
+  // Sisyphus-Junior → "sisyphus-junior"
+  "Sisyphus-Junior": "sisyphus-junior",
+  "sisyphus-junior": "sisyphus-junior",
 
-	// Already lowercase - passthrough
-	build: "build",
-	oracle: "oracle",
-	librarian: "librarian",
-	explore: "explore",
-	"multimodal-looker": "multimodal-looker",
-};
+  // Already lowercase - passthrough
+  build: "build",
+  oracle: "oracle",
+  librarian: "librarian",
+  explore: "explore",
+  "multimodal-looker": "multimodal-looker",
+}
 
 export const BUILTIN_AGENT_NAMES = new Set([
-	"sisyphus", // was "Sisyphus"
-	"oracle",
-	"librarian",
-	"explore",
-	"multimodal-looker",
-	"metis", // was "Metis (Plan Consultant)"
-	"momus", // was "Momus (Plan Reviewer)"
-	"prometheus", // was "Prometheus (Planner)"
-	"atlas", // was "Atlas"
-	"build",
-]);
+  "sisyphus",           // was "Sisyphus"
+  "oracle",
+  "librarian",
+  "explore",
+  "multimodal-looker",
+  "metis",              // was "Metis (Plan Consultant)"
+  "momus",              // was "Momus (Plan Reviewer)"
+  "prometheus",         // was "Prometheus (Planner)"
+  "atlas",              // was "Atlas"
+  "build",
+])
 
 // Migration map: old hook names → new hook names (for backward compatibility)
 // null means the hook was removed and should be filtered out from disabled_hooks
 export const HOOK_NAME_MAP: Record<string, string | null> = {
-	// Legacy names (backward compatibility)
-	"anthropic-auto-compact": "anthropic-context-window-limit-recovery",
-	"sisyphus-orchestrator": "atlas",
+  // Legacy names (backward compatibility)
+  "anthropic-auto-compact": "anthropic-context-window-limit-recovery",
+  "sisyphus-orchestrator": "atlas",
 
-	// Removed hooks (v3.0.0) - will be filtered out and user warned
-	"preemptive-compaction": null,
-	"empty-message-sanitizer": null,
-};
+  // Removed hooks (v3.0.0) - will be filtered out and user warned
+  "preemptive-compaction": null,
+  "empty-message-sanitizer": null,
+}
 
 /**
  * @deprecated LEGACY MIGRATION ONLY
- *
+ * 
  * This map exists solely for migrating old configs that used hardcoded model strings.
  * It maps legacy model strings to semantic category names, allowing users to migrate
  * from explicit model configs to category-based configs.
- *
+ * 
  * DO NOT add new entries here. New agents should use:
  * - Category-based config (preferred): { category: "unspecified-high" }
  * - Or inherit from OpenCode's config.model
- *
+ * 
  * This map will be removed in a future major version once migration period ends.
  */
 export const MODEL_TO_CATEGORY_MAP: Record<string, string> = {
-	"google/gemini-3-pro": "visual-engineering",
-	"google/gemini-3-pro-preview": "visual-engineering",
-	"google/gemini-3-flash": "writing",
-	"openai/gpt-5.2": "ultrabrain",
-	"anthropic/claude-haiku-4-5": "quick",
-	"anthropic/claude-opus-4-5": "unspecified-high",
-	"anthropic/claude-sonnet-4-5": "unspecified-low",
-};
-
-export function migrateAgentNames(agents: Record<string, unknown>): {
-	migrated: Record<string, unknown>;
-	changed: boolean;
-} {
-	const migrated: Record<string, unknown> = {};
-	let changed = false;
-
-	for (const [key, value] of Object.entries(agents)) {
-		const newKey =
-			AGENT_NAME_MAP[key.toLowerCase()] ?? AGENT_NAME_MAP[key] ?? key;
-		if (newKey !== key) {
-			changed = true;
-		}
-		migrated[newKey] = value;
-	}
-
-	return { migrated, changed };
+  "google/gemini-3-pro": "visual-engineering",
+  "google/gemini-3-pro-preview": "visual-engineering",
+  "google/gemini-3-flash": "writing",
+  "openai/gpt-5.2": "ultrabrain",
+  "anthropic/claude-haiku-4-5": "quick",
+  "anthropic/claude-opus-4-5": "unspecified-high",
+  "anthropic/claude-sonnet-4-5": "unspecified-low",
 }
 
-export function migrateHookNames(hooks: string[]): {
-	migrated: string[];
-	changed: boolean;
-	removed: string[];
-} {
-	const migrated: string[] = [];
-	const removed: string[] = [];
-	let changed = false;
+export function migrateAgentNames(agents: Record<string, unknown>): { migrated: Record<string, unknown>; changed: boolean } {
+  const migrated: Record<string, unknown> = {}
+  let changed = false
 
-	for (const hook of hooks) {
-		const mapping = HOOK_NAME_MAP[hook];
+  for (const [key, value] of Object.entries(agents)) {
+    const newKey = AGENT_NAME_MAP[key.toLowerCase()] ?? AGENT_NAME_MAP[key] ?? key
+    if (newKey !== key) {
+      changed = true
+    }
+    migrated[newKey] = value
+  }
 
-		if (mapping === null) {
-			removed.push(hook);
-			changed = true;
-			continue;
-		}
+  return { migrated, changed }
+}
 
-		const newHook = mapping ?? hook;
-		if (newHook !== hook) {
-			changed = true;
-		}
-		migrated.push(newHook);
-	}
+export function migrateHookNames(hooks: string[]): { migrated: string[]; changed: boolean; removed: string[] } {
+  const migrated: string[] = []
+  const removed: string[] = []
+  let changed = false
 
-	return { migrated, changed, removed };
+  for (const hook of hooks) {
+    const mapping = HOOK_NAME_MAP[hook]
+
+    if (mapping === null) {
+      removed.push(hook)
+      changed = true
+      continue
+    }
+
+    const newHook = mapping ?? hook
+    if (newHook !== hook) {
+      changed = true
+    }
+    migrated.push(newHook)
+  }
+
+  return { migrated, changed, removed }
 }
 
 export function migrateAgentConfigToCategory(config: Record<string, unknown>): {
-	migrated: Record<string, unknown>;
-	changed: boolean;
+  migrated: Record<string, unknown>
+  changed: boolean
 } {
-	const { model, ...rest } = config;
-	if (typeof model !== "string") {
-		return { migrated: config, changed: false };
-	}
+  const { model, ...rest } = config
+  if (typeof model !== "string") {
+    return { migrated: config, changed: false }
+  }
 
-	const category = MODEL_TO_CATEGORY_MAP[model];
-	if (!category) {
-		return { migrated: config, changed: false };
-	}
+  const category = MODEL_TO_CATEGORY_MAP[model]
+  if (!category) {
+    return { migrated: config, changed: false }
+  }
 
-	return {
-		migrated: { category, ...rest },
-		changed: true,
-	};
+  return {
+    migrated: { category, ...rest },
+    changed: true,
+  }
 }
 
 export function shouldDeleteAgentConfig(
-	config: Record<string, unknown>,
-	category: string,
+  config: Record<string, unknown>,
+  category: string
 ): boolean {
-	const { DEFAULT_CATEGORIES } = require("../tools/delegate-task/constants");
-	const defaults = DEFAULT_CATEGORIES[category];
-	if (!defaults) return false;
+  const { DEFAULT_CATEGORIES } = require("../tools/delegate-task/constants")
+  const defaults = DEFAULT_CATEGORIES[category]
+  if (!defaults) return false
 
-	const keys = Object.keys(config).filter((k) => k !== "category");
-	if (keys.length === 0) return true;
+  const keys = Object.keys(config).filter((k) => k !== "category")
+  if (keys.length === 0) return true
 
-	for (const key of keys) {
-		if (config[key] !== (defaults as Record<string, unknown>)[key]) {
-			return false;
-		}
-	}
-	return true;
+  for (const key of keys) {
+    if (config[key] !== (defaults as Record<string, unknown>)[key]) {
+      return false
+    }
+  }
+  return true
 }
 
 export function migrateConfig(rawConfig: Record<string, unknown>): {
-	migrated: Record<string, unknown>;
-	changed: boolean;
+  migrated: Record<string, unknown>
+  changed: boolean
 } {
-	let changed = false;
+  let changed = false
 
-	if (rawConfig.agents && typeof rawConfig.agents === "object") {
-		const { migrated, changed: agentChanged } = migrateAgentNames(
-			rawConfig.agents as Record<string, unknown>,
-		);
-		if (agentChanged) {
-			rawConfig.agents = migrated;
-			changed = true;
-		}
-	}
+  if (rawConfig.agents && typeof rawConfig.agents === "object") {
+    const { migrated, changed: agentChanged } = migrateAgentNames(rawConfig.agents as Record<string, unknown>)
+    if (agentChanged) {
+      rawConfig.agents = migrated
+      changed = true
+    }
+  }
 
-	if (rawConfig.omo_agent) {
-		rawConfig.sisyphus_agent = rawConfig.omo_agent;
-		delete rawConfig.omo_agent;
-		changed = true;
-	}
+  if (rawConfig.omo_agent) {
+    rawConfig.sisyphus_agent = rawConfig.omo_agent
+    delete rawConfig.omo_agent
+    changed = true
+  }
 
-	if (rawConfig.disabled_agents && Array.isArray(rawConfig.disabled_agents)) {
-		const migrated: string[] = [];
-		let agentChanged = false;
-		for (const agent of rawConfig.disabled_agents as string[]) {
-			const newAgent =
-				AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent;
-			if (newAgent !== agent) {
-				agentChanged = true;
-			}
-			migrated.push(newAgent);
-		}
-		if (agentChanged) {
-			rawConfig.disabled_agents = migrated;
-			changed = true;
-		}
-	}
+  if (rawConfig.disabled_agents && Array.isArray(rawConfig.disabled_agents)) {
+    const migrated: string[] = []
+    let agentChanged = false
+    for (const agent of rawConfig.disabled_agents as string[]) {
+      const newAgent = AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent
+      if (newAgent !== agent) {
+        agentChanged = true
+      }
+      migrated.push(newAgent)
+    }
+    if (agentChanged) {
+      rawConfig.disabled_agents = migrated
+      changed = true
+    }
+  }
 
-	if (rawConfig.disabled_hooks && Array.isArray(rawConfig.disabled_hooks)) {
-		const {
-			migrated,
-			changed: hookChanged,
-			removed,
-		} = migrateHookNames(rawConfig.disabled_hooks as string[]);
-		if (hookChanged) {
-			rawConfig.disabled_hooks = migrated;
-			changed = true;
-		}
-		if (removed.length > 0) {
-			log(
-				`Removed obsolete hooks from disabled_hooks: ${removed.join(", ")} (these hooks no longer exist in v3.0.0)`,
-			);
-		}
-	}
+  if (rawConfig.disabled_hooks && Array.isArray(rawConfig.disabled_hooks)) {
+    const { migrated, changed: hookChanged, removed } = migrateHookNames(rawConfig.disabled_hooks as string[])
+    if (hookChanged) {
+      rawConfig.disabled_hooks = migrated
+      changed = true
+    }
+    if (removed.length > 0) {
+      log(`Removed obsolete hooks from disabled_hooks: ${removed.join(", ")} (these hooks no longer exist in v3.0.0)`)
+    }
+  }
 
-	return { migrated: rawConfig, changed };
+  return { migrated: rawConfig, changed }
 }
 
-export function migrateConfigFile(
-	configPath: string,
-	rawConfig: Record<string, unknown>,
-): boolean {
-	const { migrated, changed } = migrateConfig(rawConfig);
+export function migrateConfigFile(configPath: string, rawConfig: Record<string, unknown>): boolean {
+  const { migrated, changed } = migrateConfig(rawConfig)
 
-	if (changed) {
-		try {
-			const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-			const backupPath = `${configPath}.bak.${timestamp}`;
-			fs.copyFileSync(configPath, backupPath);
+  if (changed) {
+    try {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
+      const backupPath = `${configPath}.bak.${timestamp}`
+      fs.copyFileSync(configPath, backupPath)
 
-			fs.writeFileSync(
-				configPath,
-				`${JSON.stringify(migrated, null, 2)}\n`,
-				"utf-8",
-			);
-			log(`Migrated config file: ${configPath} (backup: ${backupPath})`);
-		} catch (err) {
-			log(`Failed to write migrated config to ${configPath}:`, err);
-		}
-	}
+      fs.writeFileSync(configPath, JSON.stringify(migrated, null, 2) + "
+", "utf-8")
+      log(`Migrated config file: ${configPath} (backup: ${backupPath})`)
+    } catch (err) {
+      log(`Failed to write migrated config to ${configPath}:`, err)
+    }
+  }
 
-	return changed;
+  return changed
 }


### PR DESCRIPTION
## Summary
Adds deterministic config precedence and hierarchical project config discovery so repos can define shared defaults at the project root and override them in subdirectories.

## Behavior (lowest → highest precedence)
1. **User config**: `~/.config/opencode/oh-my-opencode.(jsonc|json)`
2. **Explicit config path** via `OH_MY_OPENCODE_CONFIG=/path/to/file.(jsonc|json)`
3. **Project configs**: `.opencode/oh-my-opencode.(jsonc|json)` discovered from **project root → current working directory** (applied in that order)
4. **Inline config** via `OH_MY_OPENCODE_CONFIG_CONTENT` (inline JSONC; highest precedence)

Notes:
- If both `.jsonc` and `.json` exist at the same location, **`.jsonc` is preferred**.
- `OH_MY_OPENCODE_CONFIG_DIR` can override the base config directory used for resolving user config.

## Implementation
- Added support for loading/validating inline JSONC content (`OH_MY_OPENCODE_CONFIG_CONTENT`).
- Reused migration logic for inline content via an in-memory migration step before validation.
- Refactored migration utilities to support in-memory migration while keeping file-based migration behavior unchanged.

## Tests / Docs
- Updated/added tests for precedence and project root → cwd discovery.
- Updated `docs/configurations.md` to document precedence and env vars.