### PR TITLE
feat(delegate-task): add empty response retry for Gemini models

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,13 +27,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.0.0-beta.11",
-        "oh-my-opencode-darwin-x64": "3.0.0-beta.11",
-        "oh-my-opencode-linux-arm64": "3.0.0-beta.11",
-        "oh-my-opencode-linux-arm64-musl": "3.0.0-beta.11",
-        "oh-my-opencode-linux-x64": "3.0.0-beta.11",
-        "oh-my-opencode-linux-x64-musl": "3.0.0-beta.11",
-        "oh-my-opencode-windows-x64": "3.0.0-beta.11",
+        "oh-my-opencode-darwin-arm64": "3.0.0-beta.16",
+        "oh-my-opencode-darwin-x64": "3.0.0-beta.16",
+        "oh-my-opencode-linux-arm64": "3.0.0-beta.16",
+        "oh-my-opencode-linux-arm64-musl": "3.0.0-beta.16",
+        "oh-my-opencode-linux-x64": "3.0.0-beta.16",
+        "oh-my-opencode-linux-x64-musl": "3.0.0-beta.16",
+        "oh-my-opencode-windows-x64": "3.0.0-beta.16",
       },
     },
   },
@@ -225,19 +225,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.0.0-beta.11", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7cFv2bbz9HTY7sshgVTu+IhvYf7CT0czDYqHEB+dYfEqFU6TaoSMimq6uHqcWegUUR1T7PNmc0dyjYVw69FeVA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.0.0-beta.16", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-1gfnTsKpYxTMXpbuV98wProR3RMe6BI/muuSVa3Xy68EEkBJsuRAne6IzFq/yxIMbx9OiQaS5cTE0mxFtxcCGA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.0.0-beta.11", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-rGAbDdUySWITIdm2yiuNFB9lFYaSXT8LMtg97LTlOO5vZbI3M+obIS3QlIkBtAhgOTIPB7Ni+T0W44OmJpHoYA=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.0.0-beta.16", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/h7kBZAN5Ut9kL7gEtwVVZ49Kw4gZoSVJdrpnh7Wij0a3mlOwqbkgGilK7oUiJ2N8fsxvxEBbTscYOLAdhyVBw=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.0.0-beta.11", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-F9dqwWwGAdqeSkE7Tre5DmHQXwDpU2Z8Jk0lwTJMLj+kMqYFDVPjLPo4iVUdwPpxpmm0pR84u/oonG/2+84/zw=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.0.0-beta.16", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jW7pl76WerBa7FucKCYcthpbKbhJQSVe6rqUFSbVobjOP9VWslrGdxc9Y8BeiMx9SJEFYwA8/2ROhnOHpH3TxA=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.0.0-beta.11", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-H+zOtHkHd+TmdPj64M1A0zLOk7OHIK4C8yqfLFhfizOIBffT1yOhAs6EpK3EqPhfPLu54ADgcQcu8W96VP24UA=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.0.0-beta.16", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-cXXka0zQDBiFu9mmxa45o3g812w8q/jZRYgdwJsLbj3nm24WXv6uRP7nnVVoZiVmJ2GQbLE1nyGCMkBXFwRGGA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.0.0-beta.11", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-IG+KODTJ8rs6cEJ2wN6Zpr6YtvCS5OpYP6jBdGJltmUpjQdMhdMsaY3ysZk+9Vxpx2KC3xj5KLHV1USg3uBTeg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.0.0-beta.16", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-4VS1V6DiXdWHQ/AGc3rB1sCxFUlD1REex0Ai/y4tEgA2M0FD0Bu+tjXHhDghUvC8f0kQBRfijnTrtc1Lh7hIrA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.0.0-beta.11", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-irV+AuWrHqNm7VT7HO56qgymR0+vEfJbtB3vCq68kprH2V4NQmGp2MNKIYPnUCYL7NEK3H2NX+h06YFZJ/8ELQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.0.0-beta.16", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-PGVe7vyUK3hjSNfvu1fBXTbgbe0OPh7JgB/TZR2U5R54X1k3NBkb1VHX9yxEUSA0VsNR+inE2x+DfEA+7KIruQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.0.0-beta.11", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-exZ/NEwGBlxyWszN7dvOfzbYX0cuhBZXftqAAFOlVP26elDHdo+AmSmLR/4cJyzpR9nCWz4xvl/RYF84bY6OEA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.0.0-beta.16", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-1lN/8y4laQnSJDvyARuV5YaETAwBb+PK06QHQzpoK/0asiFoEIBcKNgjaRwau+nBsdRUrQocE2xc6g2ZNH4HUw=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -109,6 +109,157 @@ type ToolContextWithMetadata = {
   metadata?: (input: { title?: string; metadata?: Record<string, unknown> }) => void
 }
 
+// Empty response retry configuration
+const EMPTY_RESPONSE_MAX_RETRIES = 2
+const EMPTY_RESPONSE_RETRY_DELAY_MS = 2000
+const EMPTY_RESPONSE_MIN_LENGTH = 10
+
+/**
+ * Check if the response content is empty or too short to be valid.
+ * Gemini models sometimes return empty responses that need retry.
+ */
+function isEmptyResponse(textContent: string | undefined): boolean {
+  if (!textContent) return true
+  const trimmed = textContent.trim()
+  return trimmed.length < EMPTY_RESPONSE_MIN_LENGTH
+}
+
+/**
+ * Extract text content from session messages.
+ * Returns both the text content and the last assistant message for inspection.
+ */
+function extractTextFromMessages(
+  messages: Array<{
+    info?: { role?: string; time?: { created?: number } }
+    parts?: Array<{ type?: string; text?: string }>
+  }>
+): { textContent: string; lastMessage: typeof messages[0] | undefined } {
+  const assistantMessages = messages
+    .filter((m) => m.info?.role === "assistant")
+    .sort((a, b) => (b.info?.time?.created ?? 0) - (a.info?.time?.created ?? 0))
+  const lastMessage = assistantMessages[0]
+  
+  if (!lastMessage) {
+    return { textContent: "", lastMessage: undefined }
+  }
+  
+  // Extract text from both "text" and "reasoning" parts (thinking models use "reasoning")
+  const textParts = lastMessage?.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
+  const textContent = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+  
+  return { textContent, lastMessage }
+}
+
+interface EmptyResponseRetryContext {
+  sessionID: string
+  client: OpencodeClient
+  isGeminiModel?: boolean
+  agent?: string
+  model?: { providerID: string; modelID: string }
+  abortSignal?: AbortSignal
+}
+
+/**
+ * Retry logic for empty responses from Gemini models.
+ * Sends a "continue" prompt to nudge the model to produce output.
+ */
+async function retryOnEmptyResponse(
+  ctx: EmptyResponseRetryContext,
+  currentTextContent: string,
+  retryCount: number
+): Promise<{ textContent: string; retried: boolean; finalRetryCount: number }> {
+  // Only retry for Gemini models or if explicitly flagged
+  const modelString = ctx.model ? `${ctx.model.providerID}/${ctx.model.modelID}` : ""
+  const isGemini = ctx.isGeminiModel ?? modelString.toLowerCase().includes("gemini")
+  
+  if (!isGemini || !isEmptyResponse(currentTextContent)) {
+    return { textContent: currentTextContent, retried: false, finalRetryCount: retryCount }
+  }
+  
+  let textContent = currentTextContent
+  let currentRetry = retryCount
+  
+  while (currentRetry < EMPTY_RESPONSE_MAX_RETRIES && isEmptyResponse(textContent)) {
+    if (ctx.abortSignal?.aborted) {
+      break
+    }
+    
+    currentRetry++
+    log(`[delegate_task] Empty response detected, retry ${currentRetry}/${EMPTY_RESPONSE_MAX_RETRIES}`, {
+      sessionID: ctx.sessionID,
+      agent: ctx.agent,
+      model: modelString,
+      previousContentLength: textContent.length,
+    })
+    
+    await new Promise(resolve => setTimeout(resolve, EMPTY_RESPONSE_RETRY_DELAY_MS))
+    
+    try {
+      // Send a continue prompt to nudge the model
+      await ctx.client.session.prompt({
+        path: { id: ctx.sessionID },
+        body: {
+          parts: [{ type: "text", text: "continue" }],
+        },
+      })
+      
+      // Wait for response to stabilize
+      const RETRY_POLL_INTERVAL_MS = 500
+      const RETRY_STABILITY_TIME_MS = 3000
+      const RETRY_MAX_WAIT_MS = 30000
+      const retryStart = Date.now()
+      let stablePolls = 0
+      let lastMsgCount = 0
+      
+      while (Date.now() - retryStart < RETRY_MAX_WAIT_MS) {
+        if (ctx.abortSignal?.aborted) break
+        
+        await new Promise(resolve => setTimeout(resolve, RETRY_POLL_INTERVAL_MS))
+        
+        if (Date.now() - retryStart < RETRY_STABILITY_TIME_MS) continue
+        
+        const messagesCheck = await ctx.client.session.messages({ path: { id: ctx.sessionID } })
+        const msgs = ((messagesCheck as { data?: unknown }).data ?? messagesCheck) as Array<unknown>
+        
+        if (msgs.length === lastMsgCount) {
+          stablePolls++
+          if (stablePolls >= 3) break
+        } else {
+          stablePolls = 0
+          lastMsgCount = msgs.length
+        }
+      }
+      
+      // Fetch updated messages
+      const messagesResult = await ctx.client.session.messages({ path: { id: ctx.sessionID } })
+      const messages = ((messagesResult as { data?: unknown }).data ?? messagesResult) as Array<{
+        info?: { role?: string; time?: { created?: number } }
+        parts?: Array<{ type?: string; text?: string }>
+      }>
+      
+      const extracted = extractTextFromMessages(messages)
+      textContent = extracted.textContent
+      
+      if (!isEmptyResponse(textContent)) {
+        log(`[delegate_task] Empty response retry succeeded`, {
+          sessionID: ctx.sessionID,
+          retryCount: currentRetry,
+          newContentLength: textContent.length,
+        })
+      }
+    } catch (retryError) {
+      log(`[delegate_task] Empty response retry failed`, {
+        sessionID: ctx.sessionID,
+        retryCount: currentRetry,
+        error: retryError instanceof Error ? retryError.message : String(retryError),
+      })
+      // Continue to next retry or exit
+    }
+  }
+  
+  return { textContent, retried: currentRetry > retryCount, finalRetryCount: currentRetry }
+}
+
 export function resolveCategoryConfig(
   categoryName: string,
   options: {
@@ -424,10 +575,7 @@ Use \`background_output\` with task_id="${task.id}" to check progress.`
           parts?: Array<{ type?: string; text?: string }>
         }>
 
-        const assistantMessages = messages
-          .filter((m) => m.info?.role === "assistant")
-          .sort((a, b) => (b.info?.time?.created ?? 0) - (a.info?.time?.created ?? 0))
-        const lastMessage = assistantMessages[0]
+        let { textContent, lastMessage } = extractTextFromMessages(messages)
 
         if (toastManager) {
           toastManager.removeTask(taskId)
@@ -437,9 +585,17 @@ Use \`background_output\` with task_id="${task.id}" to check progress.`
           return `No assistant response found.\n\nSession ID: ${args.resume}`
         }
 
-        // Extract text from both "text" and "reasoning" parts (thinking models use "reasoning")
-        const textParts = lastMessage?.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
-        const textContent = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+        // Retry on empty response for Gemini models
+        const retryResult = await retryOnEmptyResponse(
+          {
+            sessionID: args.resume,
+            client,
+            abortSignal: ctx.abort,
+          },
+          textContent,
+          0
+        )
+        textContent = retryResult.textContent
 
         const duration = formatDuration(startTime)
 
@@ -670,17 +826,26 @@ To resume this session: resume="${args.resume}"`
               parts?: Array<{ type?: string; text?: string }>
             }>
 
-            const assistantMessages = messages
-              .filter((m) => m.info?.role === "assistant")
-              .sort((a, b) => (b.info?.time?.created ?? 0) - (a.info?.time?.created ?? 0))
-            const lastMessage = assistantMessages[0]
+            let { textContent, lastMessage } = extractTextFromMessages(messages)
 
             if (!lastMessage) {
               return `No assistant response found (task ran in background mode).\n\nSession ID: ${sessionID}`
             }
 
-            const textParts = lastMessage?.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
-            const textContent = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+            // Retry on empty response for Gemini models (this is the unstable agent path)
+            const retryResult = await retryOnEmptyResponse(
+              {
+                sessionID,
+                client,
+                isGeminiModel: true, // This path is specifically for unstable/Gemini models
+                agent: agentToUse,
+                model: categoryModel,
+                abortSignal: ctx.abort,
+              },
+              textContent,
+              0
+            )
+            textContent = retryResult.textContent
             const duration = formatDuration(startTime)
 
             return `SUPERVISED TASK COMPLETED SUCCESSFULLY
@@ -987,18 +1152,25 @@ To resume this session: resume="${task.sessionID}"`
           parts?: Array<{ type?: string; text?: string }>
         }>
 
-        const assistantMessages = messages
-          .filter((m) => m.info?.role === "assistant")
-          .sort((a, b) => (b.info?.time?.created ?? 0) - (a.info?.time?.created ?? 0))
-        const lastMessage = assistantMessages[0]
+        let { textContent, lastMessage } = extractTextFromMessages(messages)
 
         if (!lastMessage) {
           return `No assistant response found.\n\nSession ID: ${sessionID}`
         }
 
-        // Extract text from both "text" and "reasoning" parts (thinking models use "reasoning")
-        const textParts = lastMessage?.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
-        const textContent = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+        // Retry on empty response for Gemini models
+        const retryResult = await retryOnEmptyResponse(
+          {
+            sessionID,
+            client,
+            agent: agentToUse,
+            model: categoryModel,
+            abortSignal: ctx.abort,
+          },
+          textContent,
+          0
+        )
+        textContent = retryResult.textContent
 
         const duration = formatDuration(startTime)
 


### PR DESCRIPTION
## Summary

Gemini models frequently return empty responses, causing `delegate_task` to report `(No text output)` without any retry attempt. This PR adds automatic retry logic to handle this issue.

## Problem

When using Gemini 3 Pro (or other Gemini models) via `delegate_task`, the model sometimes returns empty responses. The current implementation simply reports "(No text output)" and moves on, which leads to:
- Failed task delegations
- Lost work context
- User frustration with manual retries

## Solution

Added automatic retry logic for empty responses in `delegate_task`:

### Key Changes

1. **New helper functions**:
   - `isEmptyResponse()`: Detects responses shorter than 10 characters
   - `extractTextFromMessages()`: Shared extraction logic (reduces duplication)
   - `retryOnEmptyResponse()`: Core retry logic with configurable parameters

2. **Retry behavior**:
   - Sends "continue" prompt to nudge the model
   - Waits 2 seconds between retry attempts
   - Maximum 2 retries (configurable via constants)
   - Waits for response stability before checking result
   - Only activates for Gemini models (detected by model name containing "gemini")

3. **Applied to all execution paths**:
   - Resume sync mode
   - Unstable agent monitoring mode
   - Normal sync mode

### Configuration Constants

```typescript
const EMPTY_RESPONSE_MAX_RETRIES = 2
const EMPTY_RESPONSE_RETRY_DELAY_MS = 2000
const EMPTY_RESPONSE_MIN_LENGTH = 10
```

## Testing

- [x] TypeScript compilation passes
- [x] Type checking passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)

## Related Issues

This addresses the common issue of Gemini models returning empty responses during task delegation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic retries for empty Gemini responses in delegate_task to reduce “No text output” and improve task reliability. Applies to resume mode, unstable agent monitoring, and normal sync paths.

- **New Features**
  - Detects empty/short replies and retries up to 2 times with a 2s delay.
  - Sends a “continue” prompt and waits briefly for a stable response.
  - Active only for Gemini models; respects abort signals.

- **Refactors**
  - Added extractTextFromMessages and isEmptyResponse helpers to consolidate parsing and checks.
  - Centralized retry logic via retryOnEmptyResponse and applied across execution paths.

<sup>Written for commit c3a42f868292433836622cf299fda379bb8fea11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

