### PR TITLE
fix(multimodal-looker): update fallback chain order

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -405,7 +405,7 @@ Each agent has a defined provider priority chain. The system tries providers in 
 | **oracle** | `gpt-5.2` | openai → anthropic → google → github-copilot → opencode |
 | **librarian** | `big-pickle` | opencode → github-copilot → anthropic |
 | **explore** | `gpt-5-nano` | opencode → anthropic → github-copilot |
-| **multimodal-looker** | `gemini-3-flash` | google → anthropic → zai → openai → github-copilot → opencode |
+| **multimodal-looker** | `gemini-3-flash` | google → openai → zai-coding-plan → anthropic → opencode |
 | **Prometheus (Planner)** | `claude-opus-4-5` | anthropic → github-copilot → opencode → antigravity → google |
 | **Metis (Plan Consultant)** | `claude-sonnet-4-5` | anthropic → github-copilot → opencode → antigravity → google |
 | **Momus (Plan Reviewer)** | `claude-opus-4-5` | anthropic → github-copilot → opencode → antigravity → google |

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -112,9 +112,9 @@ Each agent has a **provider priority chain**. The system tries providers in orde
 
 ```
 Example: multimodal-looker
-google → anthropic → zai → openai → github-copilot → opencode
-   ↓         ↓         ↓        ↓           ↓            ↓
-gemini   haiku     glm-4.6  gpt-5.2    fallback     fallback
+google → openai → zai-coding-plan → anthropic → opencode
+   ↓        ↓           ↓              ↓           ↓
+gemini   gpt-5.2     glm-4.6v       haiku     gpt-5-nano
 ```
 
 If you have Gemini, it uses `google/gemini-3-flash`. No Gemini but have Claude? Uses `anthropic/claude-haiku-4-5`. And so on.
@@ -131,7 +131,7 @@ Here's a real-world config for a user with **Claude, OpenAI, Gemini, and Z.ai** 
     "Atlas": { "model": "anthropic/claude-sonnet-4-5", "variant": "max" },
     "librarian": { "model": "zai-coding-plan/glm-4.7" },
     "explore": { "model": "opencode/gpt-5-nano" },
-    "multimodal-looker": { "model": "zai-coding-plan/glm-4.6" }
+    "multimodal-looker": { "model": "zai-coding-plan/glm-4.6v" }
   },
   "categories": {
     // Override categories for cost optimization

--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -854,7 +854,7 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian whe
       "model": "opencode/big-pickle",
     },
     "multimodal-looker": {
-      "model": "zai-coding-plan/glm-4.6",
+      "model": "zai-coding-plan/glm-4.6v",
     },
     "oracle": {
       "model": "opencode/big-pickle",
@@ -912,7 +912,7 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian wit
       "model": "opencode/big-pickle",
     },
     "multimodal-looker": {
-      "model": "zai-coding-plan/glm-4.6",
+      "model": "zai-coding-plan/glm-4.6v",
     },
     "oracle": {
       "model": "opencode/big-pickle",
@@ -1099,7 +1099,7 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + ZAI combinat
       "model": "anthropic/claude-opus-4-5",
     },
     "multimodal-looker": {
-      "model": "anthropic/claude-haiku-4-5",
+      "model": "zai-coding-plan/glm-4.6v",
     },
     "oracle": {
       "model": "anthropic/claude-opus-4-5",

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -41,10 +41,10 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   "multimodal-looker": {
     fallbackChain: [
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-flash" },
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-haiku-4-5" },
-      { providers: ["zai-coding-plan"], model: "glm-4.6v" },
-      { providers: ["opencode"], model: "gpt-5-nano" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
+      { providers: ["zai-coding-plan"], model: "glm-4.6v" },
+      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-haiku-4-5" },
+      { providers: ["opencode"], model: "gpt-5-nano" },
     ],
   },
   prometheus: {


### PR DESCRIPTION
## Summary

Updates the `multimodal-looker` agent's fallback chain to the requested order:

1. `google/gemini-3-flash`
2. `openai/gpt-5.2`
3. `zai-coding-plan/glm-4.6v`
4. `anthropic/claude-haiku-4-5`
5. `opencode/gpt-5-nano` (FREE, ultimate fallback)

## Changes

- **src/shared/model-requirements.ts**: Updated fallback chain order
- **src/cli/__snapshots__/model-fallback.test.ts.snap**: Regenerated snapshots
- **docs/configurations.md**: Updated provider chain table
- **docs/guide/overview.md**: Updated ASCII diagram and JSON example

## Testing

- All 55 tests passing
- Snapshots regenerated

Closes follow-up from #1048

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the multimodal-looker agent’s fallback chain to prioritize: google/gemini-3-flash → openai/gpt-5.2 → zai-coding-plan/glm-4.6v → anthropic/claude-haiku-4-5 → opencode/gpt-5-nano. This fixes incorrect fallback behavior and aligns code and docs with the requested order.

- **Bug Fixes**
  - Updated src/shared/model-requirements.ts with the new chain.
  - Adjusted docs/configurations.md and docs/guide/overview.md to match.
  - Regenerated model-fallback snapshots; all tests pass.

<sup>Written for commit 56da1b017090c18f5afddccaa741c4107b4e58b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

