### PR TITLE
fix(lsp): add Bun version check for Windows LSP segfault bug

### DIFF
--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -5,6 +5,37 @@ import { pathToFileURL } from "node:url"
 import { getLanguageId } from "./config"
 import type { Diagnostic, ResolvedServer } from "./types"
 
+/**
+ * Check if the current Bun version is affected by Windows LSP crash bug.
+ * Bun v1.3.5 and earlier have a known segmentation fault issue on Windows
+ * when spawning LSP servers. This was fixed in Bun v1.3.6.
+ * See: https://github.com/oven-sh/bun/issues/25798
+ */
+function checkWindowsBunVersion(): { isAffected: boolean; message: string } | null {
+  if (process.platform !== "win32") return null
+
+  const version = Bun.version
+  const [major, minor, patch] = version.split(".").map((v) => parseInt(v.split("-")[0], 10))
+
+  // Bun v1.3.5 and earlier are affected
+  if (major < 1 || (major === 1 && minor < 3) || (major === 1 && minor === 3 && patch < 6)) {
+    return {
+      isAffected: true,
+      message:
+        `⚠️  Windows + Bun v${version} detected: Known segmentation fault bug with LSP.\n` +
+        `   This causes crashes when using LSP tools (lsp_diagnostics, lsp_goto_definition, etc.).\n` +
+        `   \n` +
+        `   SOLUTION: Upgrade to Bun v1.3.6 or later:\n` +
+        `   powershell -c "irm bun.sh/install.ps1|iex"\n` +
+        `   \n` +
+        `   WORKAROUND: Use WSL instead of native Windows.\n` +
+        `   See: https://github.com/oven-sh/bun/issues/25798`,
+    }
+  }
+
+  return null
+}
+
 interface ManagedClient {
   client: LSPClient
   lastUsedAt: number
@@ -223,6 +254,13 @@ export class LSPClient {
   ) {}
 
   async start(): Promise<void> {
+    const windowsCheck = checkWindowsBunVersion()
+    if (windowsCheck?.isAffected) {
+      throw new Error(
+        `LSP server cannot be started safely.\n\n${windowsCheck.message}`
+      )
+    }
+
     this.proc = spawn(this.server.command, {
       stdin: "pipe",
       stdout: "pipe",


### PR DESCRIPTION
## Summary

Fixes #1047 - Bun crashes when using LSP tools (like `lsp_diagnostics`) on Windows.

## Root Cause Analysis

This is a **known Bun bug**, not an oh-my-opencode issue:

- **Bun v1.3.5 and earlier** on Windows have a segmentation fault bug when spawning processes via `Bun.spawn()`
- LSP tools trigger this by spawning language server processes
- **Fix was released in Bun v1.3.6** (January 13, 2026)
- Related issues:
  - https://github.com/oven-sh/bun/issues/25798
  - https://github.com/oven-sh/bun/issues/21044

## Solution

Added a version check before spawning LSP servers on Windows:
- Detects Windows + affected Bun versions (< 1.3.6)
- Throws a helpful error with upgrade instructions instead of crashing
- Provides workaround suggestion (use WSL)

## User Experience

**Before:** Bun crashes with segmentation fault, user sees cryptic crash message

**After:** User sees clear error with actionable solution:
```
LSP server cannot be started safely.

⚠️  Windows + Bun v1.3.5 detected: Known segmentation fault bug with LSP.
   This causes crashes when using LSP tools (lsp_diagnostics, lsp_goto_definition, etc.).
   
   SOLUTION: Upgrade to Bun v1.3.6 or later:
   powershell -c "irm bun.sh/install.ps1|iex"
   
   WORKAROUND: Use WSL instead of native Windows.
   See: https://github.com/oven-sh/bun/issues/25798
```

## Testing

- [x] TypeScript type check passes
- [x] LSP tests pass (3/3)
- [x] Non-Windows users unaffected (check returns null early)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Windows LSP crashes by adding a Bun version check before starting language servers. If Bun is older than 1.3.6, the client stops and shows a clear upgrade message instead of segfaulting.

- **Bug Fixes**
  - Detects Windows + Bun <1.3.6 and blocks LSP start with actionable error (includes upgrade steps and WSL workaround).
  - No changes for other platforms or for Bun >=1.3.6.

<sup>Written for commit d15794004e25cfc07db7e2b346ef91b96d936bb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

