### PR TITLE
fix(hooks): add null guard for tool.execute.after output

### DIFF
--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -66,6 +66,20 @@ describe("atlas hook", () => {
   })
 
   describe("tool.execute.after handler", () => {
+    test("should handle undefined output gracefully (issue #1035)", async () => {
+      // #given - hook and undefined output (e.g., from /review command)
+      const hook = createAtlasHook(createMockPluginInput())
+
+      // #when - calling with undefined output
+      const result = await hook["tool.execute.after"](
+        { tool: "delegate_task", sessionID: "session-123" },
+        undefined as unknown as { title: string; output: string; metadata: Record<string, unknown> }
+      )
+
+      // #then - returns undefined without throwing
+      expect(result).toBeUndefined()
+    })
+
     test("should ignore non-delegate_task tools", async () => {
       // #given - hook and non-delegate_task tool
       const hook = createAtlasHook(createMockPluginInput())

--- a/src/hooks/atlas/index.ts
+++ b/src/hooks/atlas/index.ts
@@ -684,6 +684,11 @@ export function createAtlasHook(
       input: ToolExecuteAfterInput,
       output: ToolExecuteAfterOutput
     ): Promise<void> => {
+      // Guard against undefined output (e.g., from /review command - see issue #1035)
+      if (!output) {
+        return
+      }
+
       if (!isCallerOrchestrator(input.sessionID)) {
         return
       }

--- a/src/hooks/claude-code-hooks/index.ts
+++ b/src/hooks/claude-code-hooks/index.ts
@@ -237,6 +237,11 @@ export function createClaudeCodeHooksHook(
       input: { tool: string; sessionID: string; callID: string },
       output: { title: string; output: string; metadata: unknown }
     ): Promise<void> => {
+      // Guard against undefined output (e.g., from /review command - see issue #1035)
+      if (!output) {
+        return
+      }
+
       const claudeConfig = await loadClaudeHooksConfig()
       const extendedConfig = await loadPluginExtendedConfig()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -565,6 +565,10 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     },
 
     "tool.execute.after": async (input, output) => {
+      // Guard against undefined output (e.g., from /review command - see issue #1035)
+      if (!output) {
+        return;
+      }
       await claudeCodeHooks["tool.execute.after"](input, output);
       await toolOutputTruncator?.["tool.execute.after"](input, output);
       await contextWindowMonitor?.["tool.execute.after"](input, output);


### PR DESCRIPTION
## Summary

- Adds defensive null checks for `output` parameter in `tool.execute.after` hooks
- Fixes crash when `/review` command (and other Claude Code built-in commands) trigger hooks with `undefined` output

## Problem

Claude Code's `/review` command triggers `tool.execute.after` hooks but passes `output` as `undefined` instead of the expected object with `output`, `metadata`, and `title` properties. This causes crashes when hooks try to access `output.metadata`.

## Solution

Added early return guards in three locations (defense-in-depth):
1. **Main orchestrator** (`src/index.ts`): Guards all downstream hooks
2. **Claude Code hooks** (`src/hooks/claude-code-hooks/index.ts`): Additional safety layer
3. **Atlas hook** (`src/hooks/atlas/index.ts`): Additional safety layer

## Changes

- `src/index.ts`: Add `if (!output) return` guard at start of `tool.execute.after` handler
- `src/hooks/claude-code-hooks/index.ts`: Add `if (!output) return` guard
- `src/hooks/atlas/index.ts`: Add `if (!output) return` guard
- `src/hooks/atlas/index.test.ts`: Add test for undefined output handling

## Testing

- Added test case for undefined output in atlas hook tests
- All existing tests pass
- TypeScript typecheck passes

Fixes #1035

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add null guards in tool.execute.after to handle undefined output from /review and other Claude Code commands, preventing crashes. Fixes #1035.

- **Bug Fixes**
  - Guard against undefined output in the orchestrator and Claude Code/Atlas hooks.
  - Prevent metadata/output access when output is missing.
  - Add a unit test for undefined output handling in the Atlas hook.

<sup>Written for commit e9412bd0e98d0b3629895ea2d33c1c1f8e24ffa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

