### PR TITLE
docs: update v3.x documentation (items 1, 3, 5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## OVERVIEW
 
-OpenCode plugin: multi-model agent orchestration (Claude Opus 4.5, GPT-5.2, Gemini 3 Flash, Grok Code, GLM-4.7). 31 lifecycle hooks, 20+ tools (LSP, AST-Grep, delegation), 10 specialized agents, full Claude Code compatibility. "oh-my-zsh" for OpenCode.
+OpenCode plugin: multi-model agent orchestration (Claude Opus 4.5, GPT-5.2, Gemini 3 Flash, Grok Code, GLM-4.7). 30 lifecycle hooks, 20+ tools (LSP, AST-Grep, delegation), 10 specialized agents, full Claude Code compatibility. "oh-my-zsh" for OpenCode.
 
 ## STRUCTURE
 
@@ -14,7 +14,7 @@ OpenCode plugin: multi-model agent orchestration (Claude Opus 4.5, GPT-5.2, Gemi
 oh-my-opencode/
 ├── src/
 │   ├── agents/        # 10 AI agents - see src/agents/AGENTS.md
-│   ├── hooks/         # 31 lifecycle hooks - see src/hooks/AGENTS.md
+│   ├── hooks/         # 30 lifecycle hooks - see src/hooks/AGENTS.md
 │   ├── tools/         # 20+ tools - see src/tools/AGENTS.md
 │   ├── features/      # Background agents, Claude Code compat - see src/features/AGENTS.md
 │   ├── shared/        # 50 cross-cutting utilities - see src/shared/AGENTS.md

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,8 +16,8 @@
 
 > [!TIP]
 >
-> [![The Orchestrator is now available in beta.](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.10)
-> > **オーケストレーターがベータ版で利用可能になりました。`oh-my-opencode@3.0.0-beta.10`を使用してインストールしてください。**
+> [![The Orchestrator is now available in beta.](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.16)
+> > **オーケストレーターがベータ版で利用可能になりました。`oh-my-opencode@3.0.0-beta.16`を使用してインストールしてください。**
 >
 > 一緒に歩みましょう！
 >

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,8 +16,8 @@
 >
 > [!TIP]
 >
-> [![The Orchestrator is now available in beta.](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.10)
-> > **오케스트레이터가 베타 버전으로 사용 가능합니다. 설치하려면 `oh-my-opencode@3.0.0-beta.10`을 사용하세요.**
+> [![The Orchestrator is now available in beta.](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.16)
+> > **오케스트레이터가 베타 버전으로 사용 가능합니다. 설치하려면 `oh-my-opencode@3.0.0-beta.16`을 사용하세요.**
 >
 > 함께해요!
 >

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 
 > [!TIP]
 >
-> [![The Orchestrator is now available in beta.](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.10)
-> > **The Orchestrator is now available in beta. Use `oh-my-opencode@3.0.0-beta.10` to install it.**
+> [![The Orchestrator is now available in beta.](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.16)
+> > **The Orchestrator is now available in beta. Use `oh-my-opencode@3.0.0-beta.16` to install it.**
 >
 > Be with us!
 >

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -16,8 +16,8 @@
 
 > [!TIP]
 >
-> [![Orchestrator 现已进入测试阶段。](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.10)
-> > **Orchestrator 现已进入测试阶段。使用 `oh-my-opencode@3.0.0-beta.10` 安装。**
+> [![Orchestrator 现已进入测试阶段。](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0-beta.16)
+> > **Orchestrator 现已进入测试阶段。使用 `oh-my-opencode@3.0.0-beta.16` 安装。**
 >
 > 加入我们！
 >

--- a/src/hooks/AGENTS.md
+++ b/src/hooks/AGENTS.md
@@ -2,33 +2,43 @@
 
 ## OVERVIEW
 
-31 lifecycle hooks intercepting/modifying agent behavior. Events: PreToolUse, PostToolUse, UserPromptSubmit, Stop, onSummarize.
+30 lifecycle hooks intercepting/modifying agent behavior. Events: PreToolUse, PostToolUse, UserPromptSubmit, Stop, onSummarize.
 
 ## STRUCTURE
 
 ```
 hooks/
 ├── atlas/                      # Main orchestration (773 lines)
-├── anthropic-context-window-limit-recovery/  # Auto-summarize
+├── anthropic-context-window-limit-recovery/  # Auto-summarize on context limit
 ├── todo-continuation-enforcer.ts # Force TODO completion
 ├── ralph-loop/                 # Self-referential dev loop
 ├── claude-code-hooks/          # settings.json compat layer - see AGENTS.md
-├── comment-checker/            # Prevents AI slop
+├── comment-checker/            # Prevents AI slop comments
 ├── auto-slash-command/         # Detects /command patterns
-├── rules-injector/             # Conditional rules
+├── rules-injector/             # Conditional rules injection
 ├── directory-agents-injector/  # Auto-injects AGENTS.md
 ├── directory-readme-injector/  # Auto-injects README.md
-├── edit-error-recovery/        # Recovers from failures
+├── edit-error-recovery/        # Recovers from Edit failures
 ├── thinking-block-validator/   # Ensures valid <thinking>
-├── context-window-monitor.ts   # Reminds of headroom
+├── context-window-monitor.ts   # Reminds of context headroom
 ├── session-recovery/           # Auto-recovers from crashes
 ├── think-mode/                 # Dynamic thinking budget
 ├── keyword-detector/           # ultrawork/search/analyze modes
-├── background-notification/    # OS notification
+├── background-notification/    # Routes events to BackgroundManager
 ├── prometheus-md-only/         # Planner read-only mode
 ├── agent-usage-reminder/       # Specialized agent hints
 ├── auto-update-checker/        # Plugin update check
-└── tool-output-truncator.ts    # Prevents context bloat
+├── tool-output-truncator.ts    # Prevents context bloat
+├── background-compaction/      # Preserves background task state during compaction
+├── compaction-context-injector/ # Injects critical context on summarize
+├── delegate-task-retry/        # Retry logic for delegate_task failures
+├── interactive-bash-session/   # Tmux integration for interactive terminals
+├── non-interactive-env/        # Prepends env vars for non-interactive git
+├── question-label-truncator/   # Truncates long AskUserQuestion labels
+├── start-work/                 # Initiates work from Prometheus plans
+├── task-resume-info/           # Appends resume instructions to delegate_task
+├── session-notification.ts     # Session state notifications
+└── empty-task-response-detector.ts # Detects empty task responses
 ```
 
 ## HOOK EVENTS


### PR DESCRIPTION
## Summary

Updates documentation for v3.x as requested in #1034.

### Changes

**Item 1 - Update version references:**
- Updated from `beta.10` to `beta.16` in all README files
- Files updated: README.md, README.ko.md, README.ja.md, README.zh-cn.md

**Item 3 - Update hook count:**
- Updated hook count from 31 to 30 (verified from `src/hooks/index.ts` exports)
- Files updated: AGENTS.md, src/hooks/AGENTS.md

**Item 5 - Document undocumented hooks:**
- Added 10 previously undocumented hooks to `src/hooks/AGENTS.md`:
  - `background-compaction` - Preserves background task state during compaction
  - `compaction-context-injector` - Injects critical context on summarize
  - `delegate-task-retry` - Retry logic for delegate_task failures
  - `interactive-bash-session` - Tmux integration for interactive terminals
  - `non-interactive-env` - Prepends env vars for non-interactive git
  - `question-label-truncator` - Truncates long AskUserQuestion labels
  - `start-work` - Initiates work from Prometheus plans
  - `task-resume-info` - Appends resume instructions to delegate_task
  - `session-notification.ts` - Session state notifications
  - `empty-task-response-detector.ts` - Detects empty task responses

---

Closes #1034 (items 1, 3, 5)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated v3.x docs to reflect the beta.16 release, correct the lifecycle hook count to 30, and add docs for 10 previously undocumented hooks. Aligns install instructions and hook inventory with the code; completes #1034 items 1, 3, and 5.

<sup>Written for commit bca9c7117d92451ac829dcd6cc86c0b306d4c84d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

