### PR TITLE
feat(think-mode): add GLM-4.7 thinking mode support

### DIFF
--- a/src/hooks/think-mode/switcher.test.ts
+++ b/src/hooks/think-mode/switcher.test.ts
@@ -458,4 +458,71 @@ describe("think-mode switcher", () => {
       })
     })
   })
+
+  describe("Z.AI GLM-4.7 provider support", () => {
+    describe("getThinkingConfig for zai-coding-plan", () => {
+      it("should return thinking config for glm-4.7", () => {
+        // #given zai-coding-plan provider with glm-4.7 model
+        const config = getThinkingConfig("zai-coding-plan", "glm-4.7")
+
+        // #then should return zai-coding-plan thinking config
+        expect(config).not.toBeNull()
+        expect(config?.providerOptions).toBeDefined()
+        const zaiOptions = (config?.providerOptions as Record<string, unknown>)?.[
+          "zai-coding-plan"
+        ] as Record<string, unknown>
+        expect(zaiOptions?.extra_body).toBeDefined()
+        const extraBody = zaiOptions?.extra_body as Record<string, unknown>
+        expect(extraBody?.thinking).toBeDefined()
+        expect((extraBody?.thinking as Record<string, unknown>)?.type).toBe("enabled")
+        expect((extraBody?.thinking as Record<string, unknown>)?.clear_thinking).toBe(false)
+      })
+
+      it("should return thinking config for glm-4.6v (multimodal)", () => {
+        // #given zai-coding-plan provider with glm-4.6v model
+        const config = getThinkingConfig("zai-coding-plan", "glm-4.6v")
+
+        // #then should return zai-coding-plan thinking config
+        expect(config).not.toBeNull()
+        expect(config?.providerOptions).toBeDefined()
+      })
+
+      it("should return null for non-GLM models on zai-coding-plan", () => {
+        // #given zai-coding-plan provider with unknown model
+        const config = getThinkingConfig("zai-coding-plan", "some-other-model")
+
+        // #then should return null
+        expect(config).toBeNull()
+      })
+    })
+
+    describe("HIGH_VARIANT_MAP for GLM", () => {
+      it("should NOT have high variant for glm-4.7 (thinking enabled by default)", () => {
+        // #given glm-4.7 model
+        const variant = getHighVariant("glm-4.7")
+
+        // #then should return null (no high variant needed)
+        expect(variant).toBeNull()
+      })
+
+      it("should NOT have high variant for glm-4.6v", () => {
+        // #given glm-4.6v model
+        const variant = getHighVariant("glm-4.6v")
+
+        // #then should return null
+        expect(variant).toBeNull()
+      })
+    })
+  })
+
+  describe("THINKING_CONFIGS structure for zai-coding-plan", () => {
+    it("should have correct structure for zai-coding-plan", () => {
+      const config = THINKING_CONFIGS["zai-coding-plan"]
+      expect(config.providerOptions).toBeDefined()
+      const zaiOptions = (config.providerOptions as Record<string, unknown>)?.[
+        "zai-coding-plan"
+      ] as Record<string, unknown>
+      expect(zaiOptions?.extra_body).toBeDefined()
+    })
+  })
 })

--- a/src/hooks/think-mode/switcher.ts
+++ b/src/hooks/think-mode/switcher.ts
@@ -149,6 +149,18 @@ export const THINKING_CONFIGS = {
   openai: {
     reasoning_effort: "high",
   },
+  "zai-coding-plan": {
+    providerOptions: {
+      "zai-coding-plan": {
+        extra_body: {
+          thinking: {
+            type: "enabled",
+            clear_thinking: false,
+          },
+        },
+      },
+    },
+  },
 } as const satisfies Record<string, Record<string, unknown>>
 
 const THINKING_CAPABLE_MODELS = {
@@ -157,6 +169,7 @@ const THINKING_CAPABLE_MODELS = {
   google: ["gemini-2", "gemini-3"],
   "google-vertex": ["gemini-2", "gemini-3"],
   openai: ["gpt-5", "o1", "o3"],
+  "zai-coding-plan": ["glm"],
 } as const satisfies Record<string, readonly string[]>
 
 export function getHighVariant(modelID: string): string | null {


### PR DESCRIPTION
## Summary

Add thinking mode support for Z.AI's GLM-4.7 model via the `zai-coding-plan` provider.

## Changes

- Add `zai-coding-plan` to `THINKING_CONFIGS` with `extra_body.thinking` config format
- Add `glm` pattern to `THINKING_CAPABLE_MODELS` for model detection
- Add comprehensive tests for GLM thinking mode functionality

## Technical Details

GLM-4.7 uses OpenAI-compatible API format with `extra_body` wrapper:

```typescript
"zai-coding-plan": {
  providerOptions: {
    "zai-coding-plan": {
      extra_body: {
        thinking: {
          type: "enabled",
          clear_thinking: false,  // Preserved Thinking mode
        },
      },
    },
  },
}
```

**Key points:**
- `thinking.type: "enabled"` - Activates thinking mode
- `thinking.clear_thinking: false` - Preserves reasoning content in response (like Claude's `<thinking>` block)
- No HIGH_VARIANT_MAP entries needed since GLM-4.7 has thinking enabled by default

## Testing

- All 54 switcher tests pass (including 7 new GLM tests)
- All 71 think-mode tests pass
- TypeScript type check passes
- Build succeeds

Closes #1030

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds thinking mode support for Z.AI’s GLM-4.7 via the zai-coding-plan provider, preserving reasoning content in responses. Completes Linear #1030 by enabling GLM detection and configuration.

- **New Features**
  - Added zai-coding-plan entry to THINKING_CONFIGS with extra_body.thinking { type: "enabled", clear_thinking: false }.
  - Updated THINKING_CAPABLE_MODELS to detect GLM models via the "glm" pattern.
  - No high variant needed for GLM; getHighVariant returns null.
  - Added tests for GLM-4.7 and GLM-4.6v behavior and config structure.

<sup>Written for commit de6f4b2c91ceaea33b536612273754508ecf181d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

