### PR TITLE
feat: inject system reminder on agent switch

### DIFF
--- a/src/features/claude-code-session-state/state.test.ts
+++ b/src/features/claude-code-session-state/state.test.ts
@@ -7,6 +7,7 @@ import {
   setMainSession,
   getMainSessionID,
   _resetForTesting,
+  consumePreviousAgent,
 } from "./state"
 
 describe("claude-code-session-state", () => {
@@ -124,39 +125,116 @@ describe("claude-code-session-state", () => {
     })
   })
 
-  describe("issue #893: custom agent switch reset", () => {
-    test("should preserve custom agent when default agent is sent on subsequent messages", () => {
-      // #given - user switches to custom agent "MyCustomAgent"
-      const sessionID = "test-session-custom"
-      const customAgent = "MyCustomAgent"
-      const defaultAgent = "Sisyphus"
-
-      // User switches to custom agent (via UI)
-      setSessionAgent(sessionID, customAgent)
-      expect(getSessionAgent(sessionID)).toBe(customAgent)
-
-      // #when - first message after switch sends default agent
-      // This simulates the bug: input.agent = "Sisyphus" on first message
-      // Using setSessionAgent (first-write wins) should preserve custom agent
-      setSessionAgent(sessionID, defaultAgent)
-
-      // #then - custom agent should be preserved, NOT overwritten
-      expect(getSessionAgent(sessionID)).toBe(customAgent)
-    })
-
-    test("should allow explicit agent update via updateSessionAgent", () => {
-      // #given - custom agent is set
-      const sessionID = "test-session-explicit"
-      const customAgent = "MyCustomAgent"
-      const newAgent = "AnotherAgent"
-
-      setSessionAgent(sessionID, customAgent)
-
-      // #when - explicit update (user intentionally switches)
-      updateSessionAgent(sessionID, newAgent)
-
-      // #then - should be updated
-      expect(getSessionAgent(sessionID)).toBe(newAgent)
-    })
-  })
-})
+   describe("issue #893: custom agent switch reset", () => {
+     test("should preserve custom agent when default agent is sent on subsequent messages", () => {
+       // #given - user switches to custom agent "MyCustomAgent"
+       const sessionID = "test-session-custom"
+       const customAgent = "MyCustomAgent"
+       const defaultAgent = "Sisyphus"
+ 
+       // User switches to custom agent (via UI)
+       setSessionAgent(sessionID, customAgent)
+       expect(getSessionAgent(sessionID)).toBe(customAgent)
+ 
+       // #when - first message after switch sends default agent
+       // This simulates the bug: input.agent = "Sisyphus" on first message
+       // Using setSessionAgent (first-write wins) should preserve custom agent
+       setSessionAgent(sessionID, defaultAgent)
+ 
+       // #then - custom agent should be preserved, NOT overwritten
+       expect(getSessionAgent(sessionID)).toBe(customAgent)
+     })
+ 
+     test("should allow explicit agent update via updateSessionAgent", () => {
+       // #given - custom agent is set
+       const sessionID = "test-session-explicit"
+       const customAgent = "MyCustomAgent"
+       const newAgent = "AnotherAgent"
+ 
+       setSessionAgent(sessionID, customAgent)
+ 
+       // #when - explicit update (user intentionally switches)
+       updateSessionAgent(sessionID, newAgent)
+ 
+       // #then - should be updated
+       expect(getSessionAgent(sessionID)).toBe(newAgent)
+     })
+   })
+ 
+   describe("previousAgentMap for agent switch detection", () => {
+     test("updateSessionAgent() stores previous agent in previousAgentMap", () => {
+       // #given - session has agent "Sisyphus"
+       const sessionID = "test-session-1"
+       setSessionAgent(sessionID, "Sisyphus")
+       expect(getSessionAgent(sessionID)).toBe("Sisyphus")
+ 
+       // #when - update to "Oracle"
+       updateSessionAgent(sessionID, "Oracle")
+ 
+       // #then - consumePreviousAgent() returns "Sisyphus"
+       expect(consumePreviousAgent(sessionID)).toBe("Sisyphus")
+     })
+ 
+     test("consumePreviousAgent() returns previous agent and clears it", () => {
+       // #given - session has current and previous agent
+       const sessionID = "test-session-2"
+       setSessionAgent(sessionID, "Sisyphus")
+       updateSessionAgent(sessionID, "Oracle")
+       expect(consumePreviousAgent(sessionID)).toBe("Sisyphus")
+ 
+       // #when - call consumePreviousAgent() again
+       const secondCall = consumePreviousAgent(sessionID)
+ 
+       // #then - returns undefined (cleared after first call)
+       expect(secondCall).toBeUndefined()
+     })
+ 
+     test("same agent update does not store previous agent", () => {
+       // #given - session has agent "Sisyphus"
+       const sessionID = "test-session-1"
+       setSessionAgent(sessionID, "Sisyphus")
+       expect(getSessionAgent(sessionID)).toBe("Sisyphus")
+ 
+       // #when - update to "Sisyphus" again (same agent)
+       updateSessionAgent(sessionID, "Sisyphus")
+ 
+       // #then - consumePreviousAgent() returns undefined
+       expect(consumePreviousAgent(sessionID)).toBeUndefined()
+     })
+ 
+     test("clearSessionAgent() clears both current and previous agent", () => {
+       // #given - session has current and previous agent
+       const sessionID = "test-session-2"
+       setSessionAgent(sessionID, "Sisyphus")
+       updateSessionAgent(sessionID, "Oracle")
+       expect(getSessionAgent(sessionID)).toBe("Oracle")
+       expect(consumePreviousAgent(sessionID)).toBe("Sisyphus")
+ 
+       // #when - clearSessionAgent()
+       clearSessionAgent(sessionID)
+ 
+       // #then - both current and previous are undefined
+       expect(getSessionAgent(sessionID)).toBeUndefined()
+       expect(consumePreviousAgent(sessionID)).toBeUndefined()
+     })
+ 
+     test("_resetForTesting() clears previousAgentMap", () => {
+       // #given - multiple sessions with previous agents
+       const session1 = "test-session-1"
+       const session2 = "test-session-2"
+       setSessionAgent(session1, "Sisyphus")
+       updateSessionAgent(session1, "Oracle")
+       setSessionAgent(session2, "Prometheus")
+       updateSessionAgent(session2, "Librarian")
+       expect(consumePreviousAgent(session1)).toBe("Sisyphus")
+       expect(consumePreviousAgent(session2)).toBe("Prometheus")
+ 
+       // #when - _resetForTesting()
+       _resetForTesting()
+ 
+       // #then - all previous agents cleared
+       expect(consumePreviousAgent(session1)).toBeUndefined()
+       expect(consumePreviousAgent(session2)).toBeUndefined()
+     })
+   })
+ })

--- a/src/features/claude-code-session-state/state.ts
+++ b/src/features/claude-code-session-state/state.ts
@@ -14,9 +14,12 @@ export function getMainSessionID(): string | undefined {
 export function _resetForTesting(): void {
   _mainSessionID = undefined
   subagentSessions.clear()
+  sessionAgentMap.clear()
+  previousAgentMap.clear()
 }
 
 const sessionAgentMap = new Map<string, string>()
+const previousAgentMap = new Map<string, string>()
 
 export function setSessionAgent(sessionID: string, agent: string): void {
   if (!sessionAgentMap.has(sessionID)) {
@@ -25,6 +28,10 @@ export function setSessionAgent(sessionID: string, agent: string): void {
 }
 
 export function updateSessionAgent(sessionID: string, agent: string): void {
+  const currentAgent = sessionAgentMap.get(sessionID)
+  if (currentAgent !== undefined && currentAgent !== agent) {
+    previousAgentMap.set(sessionID, currentAgent)
+  }
   sessionAgentMap.set(sessionID, agent)
 }
 
@@ -32,6 +39,13 @@ export function getSessionAgent(sessionID: string): string | undefined {
   return sessionAgentMap.get(sessionID)
 }
 
+export function consumePreviousAgent(sessionID: string): string | undefined {
+  const previous = previousAgentMap.get(sessionID)
+  previousAgentMap.delete(sessionID)
+  return previous
+}
+
 export function clearSessionAgent(sessionID: string): void {
   sessionAgentMap.delete(sessionID)
+  previousAgentMap.delete(sessionID)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,8 @@ import {
   setSessionAgent,
   updateSessionAgent,
   clearSessionAgent,
+  consumePreviousAgent,
+  subagentSessions,
 } from "./features/claude-code-session-state";
 import {
   builtinTools,
@@ -318,6 +320,23 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     "chat.message": async (input, output) => {
       if (input.agent) {
         setSessionAgent(input.sessionID, input.agent);
+      }
+
+      // Agent switch reminder injection
+      if (!subagentSessions.has(input.sessionID)) {
+        const previousAgent = consumePreviousAgent(input.sessionID)
+        if (previousAgent !== undefined && previousAgent !== input.agent) {
+          const reminder = `<system-reminder>
+[AGENT SWITCH] ${previousAgent} → ${input.agent}
+You are now operating as ${input.agent}. Adjust your behavior accordingly.
+</system-reminder>
+
+`
+          const idx = output.parts.findIndex((p) => p.type === "text" && "text" in p && p.text)
+          if (idx >= 0 && "text" in output.parts[idx] && output.parts[idx].text) {
+            (output.parts[idx] as { text: string }).text = reminder + (output.parts[idx] as { text: string }).text
+          }
+        }
       }
 
       const message = (output as { message: { variant?: string } }).message


### PR DESCRIPTION
## Summary
- Automatically injects `[AGENT SWITCH]` system reminder when users switch between agents
- Reminder only shows when previous agent differs from current agent
- Skips: subagent sessions, first message, same agent continuation

## Changes
- `src/features/claude-code-session-state/state.ts`: Add `previousAgentMap` and `consumePreviousAgent()`
- `src/index.ts`: Add agent switch detection logic in `chat.message` hook
- `src/features/claude-code-session-state/state.test.ts`: Add 5 test cases

## Testing
- `bun test state.test.ts` → 15 pass, 1 skip, 0 fail
- `bun run build` → success

## How it works
1. User sends message with Agent A
2. User switches to Agent B via UI
3. First message after switch shows:
   ```
   <system-reminder>
   [AGENT SWITCH] Agent A → Agent B
   You are now operating as Agent B. Adjust your behavior accordingly.
   </system-reminder>
   ```
4. Subsequent messages with same agent have no reminder

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)