### PR TITLE
fix: add missing gemini-3-flash to writing category migration

### DIFF
--- a/src/shared/migration.test.ts
+++ b/src/shared/migration.test.ts
@@ -468,13 +468,14 @@ describe("migrateAgentConfigToCategory", () => {
     // #given: Configs for each mapped model
     const configs = [
       { model: "google/gemini-3-pro" },
+      { model: "google/gemini-3-flash" },
       { model: "openai/gpt-5.2" },
       { model: "anthropic/claude-haiku-4-5" },
       { model: "anthropic/claude-opus-4-5" },
       { model: "anthropic/claude-sonnet-4-5" },
     ]
 
-    const expectedCategories = ["visual-engineering", "ultrabrain", "quick", "unspecified-high", "unspecified-low"]
+    const expectedCategories = ["visual-engineering", "writing", "ultrabrain", "quick", "unspecified-high", "unspecified-low"]
 
     // #when: Migrate each config
     const results = configs.map(migrateAgentConfigToCategory)

--- a/src/shared/migration.ts
+++ b/src/shared/migration.ts
@@ -83,6 +83,7 @@ export const HOOK_NAME_MAP: Record<string, string | null> = {
  */
 export const MODEL_TO_CATEGORY_MAP: Record<string, string> = {
   "google/gemini-3-pro": "visual-engineering",
+  "google/gemini-3-flash": "writing",
   "openai/gpt-5.2": "ultrabrain",
   "anthropic/claude-haiku-4-5": "quick",
   "anthropic/claude-opus-4-5": "unspecified-high",


### PR DESCRIPTION
## Summary

- Add missing `google/gemini-3-flash` → `writing` migration to `MODEL_TO_CATEGORY_MAP`
- Update tests to verify all category migrations are covered

## Problem

PR #1057 review comment identified that `writing` category migration was missing. Users who configured agents with `model: "google/gemini-3-flash"` would not get auto-migrated to `category: "writing"`.

## Solution

Added the missing mapping in `src/shared/migration.ts`:

```typescript
export const MODEL_TO_CATEGORY_MAP = {
  "google/gemini-3-pro": "visual-engineering",
  "google/gemini-3-flash": "writing",  // ← Added
  ...
}
```

## Testing

- All migration tests pass: `bun test src/shared/migration.test.ts` ✅
- Typecheck passes: `bun run typecheck` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing migration for google/gemini-3-flash so agents auto-migrate to the writing category. Updated migration tests to cover this mapping and ensure all category migrations are included.

<sup>Written for commit 187bc2fa504223f7ec16446664228dd93599d219. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

