### PR TITLE
docs: clarify category model resolution priority and fallback behavior

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -301,27 +301,96 @@ Configure concurrency limits for background agent tasks. This controls how many 
 
 Categories enable domain-specific task delegation via the `delegate_task` tool. Each category applies runtime presets (model, temperature, prompt additions) when calling the `Sisyphus-Junior` agent.
 
-**Default Categories:**
+### Built-in Categories
 
-| Category         | Model                         | Description                                                                  |
-| ---------------- | ----------------------------- | ---------------------------------------------------------------------------- |
-| `visual`         | `google/gemini-3-pro` | Frontend, UI/UX, design-focused tasks. High creativity (temp 0.7).           |
-| `business-logic` | `openai/gpt-5.2`              | Backend logic, architecture, strategic reasoning. Low creativity (temp 0.1). |
+All 7 categories come with optimal model defaults, but **you must configure them to use those defaults**:
 
-**Usage:**
+| Category             | Built-in Default Model             | Description                                                          |
+| -------------------- | ---------------------------------- | -------------------------------------------------------------------- |
+| `visual-engineering` | `google/gemini-3-pro-preview`      | Frontend, UI/UX, design, styling, animation                          |
+| `ultrabrain`         | `openai/gpt-5.2-codex` (xhigh)     | Deep logical reasoning, complex architecture decisions               |
+| `artistry`           | `google/gemini-3-pro-preview` (max)| Highly creative/artistic tasks, novel ideas                          |
+| `quick`              | `anthropic/claude-haiku-4-5`       | Trivial tasks - single file changes, typo fixes, simple modifications|
+| `unspecified-low`    | `anthropic/claude-sonnet-4-5`      | Tasks that don't fit other categories, low effort required           |
+| `unspecified-high`   | `anthropic/claude-opus-4-5` (max)  | Tasks that don't fit other categories, high effort required          |
+| `writing`            | `google/gemini-3-flash-preview`    | Documentation, prose, technical writing                              |
+
+### ⚠️ Critical: Model Resolution Priority
+
+**Categories DO NOT use their built-in defaults unless configured.** Model resolution follows this priority:
 
 ```
-// Via delegate_task tool
-delegate_task(category="visual", prompt="Create a responsive dashboard component")
-delegate_task(category="business-logic", prompt="Design the payment processing flow")
+1. User-configured model (in oh-my-opencode.json)
+2. Category's built-in default (if you add category to config)
+3. System default model (from opencode.json)
+```
 
-// Or target a specific agent directly
+**Example Problem:**
+
+```json
+// opencode.json
+{ "model": "anthropic/claude-sonnet-4-5" }
+
+// oh-my-opencode.json (empty categories section)
+{}
+
+// Result: ALL categories use claude-sonnet-4-5 (wasteful!)
+// - quick tasks use Sonnet instead of Haiku (expensive)
+// - ultrabrain uses Sonnet instead of GPT-5.2 (inferior reasoning)
+// - visual tasks use Sonnet instead of Gemini (suboptimal for UI)
+```
+
+### Recommended Configuration
+
+**To use optimal models for each category, add them to your config:**
+
+```json
+{
+  "categories": {
+    "visual-engineering": { 
+      "model": "google/gemini-3-pro-preview"
+    },
+    "ultrabrain": { 
+      "model": "openai/gpt-5.2-codex",
+      "variant": "xhigh"
+    },
+    "artistry": { 
+      "model": "google/gemini-3-pro-preview",
+      "variant": "max"
+    },
+    "quick": { 
+      "model": "anthropic/claude-haiku-4-5"  // Fast + cheap for trivial tasks
+    },
+    "unspecified-low": { 
+      "model": "anthropic/claude-sonnet-4-5"
+    },
+    "unspecified-high": { 
+      "model": "anthropic/claude-opus-4-5",
+      "variant": "max"
+    },
+    "writing": { 
+      "model": "google/gemini-3-flash-preview"
+    }
+  }
+}
+```
+
+**Only configure categories you have access to.** Unconfigured categories fall back to your system default model.
+
+### Usage
+
+```javascript
+// Via delegate_task tool
+delegate_task(category="visual-engineering", prompt="Create a responsive dashboard component")
+delegate_task(category="ultrabrain", prompt="Design the payment processing flow")
+
+// Or target a specific agent directly (bypasses categories)
 delegate_task(agent="oracle", prompt="Review this architecture")
 ```
 
-**Custom Categories:**
+### Custom Categories
 
-Add custom categories in `oh-my-opencode.json`:
+Add your own categories or override built-in ones:
 
 ```json
 {
@@ -331,15 +400,15 @@ Add custom categories in `oh-my-opencode.json`:
       "temperature": 0.2,
       "prompt_append": "Focus on data analysis, ML pipelines, and statistical methods."
     },
-    "visual": {
-      "model": "google/gemini-3-pro",
+    "visual-engineering": {
+      "model": "google/gemini-3-pro-preview",
       "prompt_append": "Use shadcn/ui components and Tailwind CSS."
     }
   }
 }
 ```
 
-Each category supports: `model`, `temperature`, `top_p`, `maxTokens`, `thinking`, `reasoningEffort`, `textVerbosity`, `tools`, `prompt_append`.
+Each category supports: `model`, `temperature`, `top_p`, `maxTokens`, `thinking`, `reasoningEffort`, `textVerbosity`, `tools`, `prompt_append`, `variant`.
 
 ## Model Resolution System
 


### PR DESCRIPTION
## Summary

Fixes misleading documentation about category model resolution. The previous docs implied categories automatically use their built-in defaults (e.g., Gemini for visual, GPT-5.2 for ultrabrain), when in reality they fall back to the system default model unless explicitly configured.

## Problem

Users configure their system default model but don't add categories to their config:

```json
// opencode.json
{ "model": "anthropic/claude-sonnet-4-5" }

// oh-my-opencode.json (empty)
{}
```

**Result**: All category delegations use Sonnet 4.5 instead of optimal models:
- `quick` tasks: Sonnet instead of Haiku (expensive for trivial work)
- `ultrabrain` tasks: Sonnet instead of GPT-5.2 (inferior reasoning)
- `visual-engineering`: Sonnet instead of Gemini (suboptimal for UI)

This wastes money and delivers suboptimal results.

## Changes

### Documentation Improvements

1. **Added explicit warning** about model resolution priority:
   ```
   1. User-configured model (in oh-my-opencode.json)
   2. Category's built-in default (if you add category to config)
   3. System default model (from opencode.json)
   ```

2. **Documented all 7 built-in categories** (was only showing 2):
   - `visual-engineering` → Gemini 3 Pro
   - `ultrabrain` → GPT-5.2 Codex (xhigh variant)
   - `artistry` → Gemini 3 Pro (max variant)
   - `quick` → Haiku 4.5
   - `unspecified-low` → Sonnet 4.5
   - `unspecified-high` → Opus 4.5 (max variant)
   - `writing` → Gemini 3 Flash

3. **Added complete example config** showing all categories configured

4. **Explained the wasteful fallback scenario** with concrete examples

5. **Added `variant` to supported category options** (was missing)

## Testing

- Verified documentation renders correctly in markdown viewers
- Confirmed all 7 category names match constants in `src/tools/delegate-task/constants.ts`
- Cross-referenced with model resolution code in `src/tools/delegate-task/tools.ts` (lines 127-133)

## Impact

Users will now understand:
- Categories don't auto-optimize unless configured
- How to configure categories for optimal model selection
- Why their category delegations might not be using expected models

Closes: N/A (documentation improvement)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies category model resolution and fallback behavior so users configure categories to get optimal models and avoid unexpected costs and weaker results.

- **Bug Fixes**
  - Added clear model resolution priority and warning.
  - Documented all 7 built-in categories and their default models.
  - Included a complete example config, including the new variant option.
  - Explained the wasteful fallback scenario with a simple example.

- **Migration**
  - Add the categories you use to oh-my-opencode.json to apply built-in defaults.
  - Configure only categories you have access to; others will fall back to the system default.

<sup>Written for commit b6dd1f02675433fd0a64087c45b9777247f59cf4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

