### PR TITLE
fix(background-agent): add deadlock detection to prevent infinite stability reset loop

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -283,6 +283,8 @@ export const BackgroundTaskConfigSchema = z.object({
   modelConcurrency: z.record(z.string(), z.number().min(0)).optional(),
   /** Stale timeout in milliseconds - interrupt tasks with no activity for this duration (default: 180000 = 3 minutes, minimum: 60000 = 1 minute) */
   staleTimeoutMs: z.number().min(60000).optional(),
+  /** Maximum stability resets before force-completing a deadlocked task (default: 10, range: 1-100) */
+  maxStabilityResets: z.number().min(1).max(100).optional(),
 })
 
 export const NotificationConfigSchema = z.object({

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -1676,6 +1676,417 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
   })
 })
 
+describe("BackgroundManager.deadlockDetection", () => {
+  function createMockClientWithTracking() {
+    const abortCalls: string[] = []
+    const statusResponses: Record<string, { type: string }> = {}
+    const messagesResponses: Record<string, Array<{ info?: { role?: string }; parts?: Array<{ type?: string; text?: string }> }>> = {}
+
+    return {
+      abortCalls,
+      statusResponses,
+      messagesResponses,
+      client: {
+        session: {
+          prompt: async () => ({}),
+          abort: async (args: { path: { id: string } }) => {
+            abortCalls.push(args.path.id)
+            return {}
+          },
+          status: async () => ({ data: statusResponses }),
+          messages: async (args: { path: { id: string } }) => ({
+            data: messagesResponses[args.path.id] ?? [
+              { info: { role: "assistant" }, parts: [{ type: "text", text: "response" }] }
+            ]
+          }),
+          todo: async () => ({ data: [] }),
+        },
+      },
+    }
+  }
+
+  test("should force-cancel task after maxStabilityResets when session stuck in non-idle", async () => {
+    // #given
+    const { client, abortCalls, statusResponses, messagesResponses } = createMockClientWithTracking()
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { maxStabilityResets: 3 })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-deadlock",
+      sessionID: "session-deadlock",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "Deadlock test",
+      prompt: "Test",
+      agent: "test-agent",
+      status: "running",
+      startedAt: new Date(Date.now() - 60_000), // Started 60s ago
+      lastMsgCount: 5,
+      stablePolls: 2, // Already at 2 stable polls
+      stabilityResets: 2, // Already reset twice
+      progress: {
+        toolCalls: 1,
+        lastUpdate: new Date(),
+      },
+    }
+
+    // Session stuck in "busy" state
+    statusResponses["session-deadlock"] = { type: "busy" }
+    messagesResponses["session-deadlock"] = [
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "response" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "response2" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "response3" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "response4" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "response5" }] },
+    ]
+
+    getTaskMap(manager).set(task.id, task)
+
+    // #when - simulate polling cycle that will trigger 3rd stable poll → 3rd reset → deadlock
+    await manager["pollRunningTasks"]()
+
+    // #then
+    expect(task.status).toBe("cancelled")
+    expect(task.error).toContain("Deadlock detected")
+    expect(task.error).toContain("stability resets")
+    expect(task.completedAt).toBeDefined()
+    expect(abortCalls).toContain("session-deadlock")
+
+    manager.shutdown()
+  })
+
+  test("should set status to cancelled (not completed) on deadlock", async () => {
+    // #given
+    const { client, statusResponses, messagesResponses } = createMockClientWithTracking()
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { maxStabilityResets: 1 })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-cancelled-status",
+      sessionID: "session-cancelled",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "Cancelled status test",
+      prompt: "Test",
+      agent: "test-agent",
+      status: "running",
+      startedAt: new Date(Date.now() - 60_000),
+      lastMsgCount: 3,
+      stablePolls: 2, // Will trigger stability on next poll
+      stabilityResets: 0,
+      progress: {
+        toolCalls: 1,
+        lastUpdate: new Date(),
+      },
+    }
+
+    statusResponses["session-cancelled"] = { type: "processing" }
+    messagesResponses["session-cancelled"] = [
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "a" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "b" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "c" }] },
+    ]
+
+    getTaskMap(manager).set(task.id, task)
+
+    // #when
+    await manager["pollRunningTasks"]()
+
+    // #then - specifically verify status is "cancelled" not "completed"
+    expect(task.status).toBe("cancelled")
+    expect(task.status).not.toBe("completed")
+
+    manager.shutdown()
+  })
+
+  test("should call session.abort() on deadlock", async () => {
+    // #given
+    const { client, abortCalls, statusResponses, messagesResponses } = createMockClientWithTracking()
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { maxStabilityResets: 1 })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-abort-test",
+      sessionID: "session-abort",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "Abort test",
+      prompt: "Test",
+      agent: "test-agent",
+      status: "running",
+      startedAt: new Date(Date.now() - 60_000),
+      lastMsgCount: 2,
+      stablePolls: 2,
+      stabilityResets: 0,
+      progress: {
+        toolCalls: 1,
+        lastUpdate: new Date(),
+      },
+    }
+
+    statusResponses["session-abort"] = { type: "busy" }
+    messagesResponses["session-abort"] = [
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "x" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "y" }] },
+    ]
+
+    getTaskMap(manager).set(task.id, task)
+
+    // #when
+    await manager["pollRunningTasks"]()
+
+    // #then - verify abort was called with correct session ID
+    expect(abortCalls).toContain("session-abort")
+    expect(abortCalls.length).toBe(1)
+
+    manager.shutdown()
+  })
+
+  test("should release concurrency slot on deadlock", async () => {
+    // #given
+    const { client, statusResponses, messagesResponses } = createMockClientWithTracking()
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { maxStabilityResets: 1 })
+    stubNotifyParentSession(manager)
+
+    const concurrencyKey = "test-agent"
+    const concurrencyManager = getConcurrencyManager(manager)
+    await concurrencyManager.acquire(concurrencyKey)
+
+    const task: BackgroundTask = {
+      id: "task-concurrency",
+      sessionID: "session-concurrency",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "Concurrency test",
+      prompt: "Test",
+      agent: "test-agent",
+      status: "running",
+      startedAt: new Date(Date.now() - 60_000),
+      lastMsgCount: 1,
+      stablePolls: 2,
+      stabilityResets: 0,
+      concurrencyKey,
+      progress: {
+        toolCalls: 1,
+        lastUpdate: new Date(),
+      },
+    }
+
+    statusResponses["session-concurrency"] = { type: "busy" }
+    messagesResponses["session-concurrency"] = [
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "z" }] },
+    ]
+
+    getTaskMap(manager).set(task.id, task)
+
+    // #when
+    await manager["pollRunningTasks"]()
+
+    // #then
+    expect(task.concurrencyKey).toBeUndefined()
+    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
+
+    manager.shutdown()
+  })
+
+  test("should reset stabilityResets counter when session becomes idle via stability detection", async () => {
+    // #given - need to simulate: first status check returns busy, recheck returns idle
+    let statusCallCount = 0
+    const abortCalls: string[] = []
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        abort: async (args: { path: { id: string } }) => {
+          abortCalls.push(args.path.id)
+          return {}
+        },
+        status: async () => {
+          statusCallCount++
+          // First call (line 1144): return busy so we go through stability detection
+          // Second call (line 1231 recheck): return idle so stabilityResets gets reset
+          if (statusCallCount === 1) {
+            return { data: { "session-reset-idle": { type: "busy" } } }
+          }
+          return { data: { "session-reset-idle": { type: "idle" } } }
+        },
+        messages: async () => ({
+          data: [
+            { info: { role: "assistant" }, parts: [{ type: "text", text: "done" }] },
+            { info: { role: "assistant" }, parts: [{ type: "text", text: "finished" }] },
+          ]
+        }),
+        todo: async () => ({ data: [] }),
+      },
+    }
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { maxStabilityResets: 10 })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-reset-idle",
+      sessionID: "session-reset-idle",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "Reset on idle test",
+      prompt: "Test",
+      agent: "test-agent",
+      status: "running",
+      startedAt: new Date(Date.now() - 60_000),
+      lastMsgCount: 2,
+      stablePolls: 2, // Will trigger stability check (hits 3 on this poll)
+      stabilityResets: 5, // Has 5 resets already
+      progress: {
+        toolCalls: 1,
+        lastUpdate: new Date(),
+      },
+    }
+
+    getTaskMap(manager).set(task.id, task)
+
+    // #when
+    await manager["pollRunningTasks"]()
+
+    // #then - task should complete normally and stabilityResets should be reset
+    expect(task.status).toBe("completed")
+    expect(task.stabilityResets).toBe(0)
+
+    manager.shutdown()
+  })
+
+  test("should reset stabilityResets counter when message count changes", async () => {
+    // #given
+    const { client, statusResponses, messagesResponses } = createMockClientWithTracking()
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { maxStabilityResets: 10 })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-reset-activity",
+      sessionID: "session-reset-activity",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "Reset on activity test",
+      prompt: "Test",
+      agent: "test-agent",
+      status: "running",
+      startedAt: new Date(Date.now() - 60_000),
+      lastMsgCount: 2, // Previous count was 2
+      stablePolls: 1,
+      stabilityResets: 5, // Has 5 resets already
+      progress: {
+        toolCalls: 1,
+        lastUpdate: new Date(),
+      },
+    }
+
+    statusResponses["session-reset-activity"] = { type: "busy" }
+    // Now has 3 messages (count changed from 2)
+    messagesResponses["session-reset-activity"] = [
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "a" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "b" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "c" }] },
+    ]
+
+    getTaskMap(manager).set(task.id, task)
+
+    // #when
+    await manager["pollRunningTasks"]()
+
+    // #then - stabilityResets should be reset due to message count change
+    expect(task.status).toBe("running")
+    expect(task.stabilityResets).toBe(0)
+    expect(task.stablePolls).toBe(0) // Also reset
+    expect(task.lastMsgCount).toBe(3) // Updated to new count
+
+    manager.shutdown()
+  })
+
+  test("should increment stabilityResets when stability reached but session not idle", async () => {
+    // #given
+    const { client, statusResponses, messagesResponses } = createMockClientWithTracking()
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { maxStabilityResets: 10 })
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-increment",
+      sessionID: "session-increment",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "Increment test",
+      prompt: "Test",
+      agent: "test-agent",
+      status: "running",
+      startedAt: new Date(Date.now() - 60_000),
+      lastMsgCount: 2,
+      stablePolls: 2, // Will hit 3 on this poll
+      stabilityResets: 3, // Has 3 resets already
+      progress: {
+        toolCalls: 1,
+        lastUpdate: new Date(),
+      },
+    }
+
+    // Session stuck in busy
+    statusResponses["session-increment"] = { type: "busy" }
+    messagesResponses["session-increment"] = [
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "a" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "b" }] },
+    ]
+
+    getTaskMap(manager).set(task.id, task)
+
+    // #when
+    await manager["pollRunningTasks"]()
+
+    // #then - should increment stabilityResets and reset stablePolls
+    expect(task.status).toBe("running")
+    expect(task.stabilityResets).toBe(4) // Incremented from 3 to 4
+    expect(task.stablePolls).toBe(0) // Reset
+
+    manager.shutdown()
+  })
+
+  test("should use default maxStabilityResets of 10 when not configured", async () => {
+    // #given
+    const { client, statusResponses, messagesResponses } = createMockClientWithTracking()
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput) // No config
+    stubNotifyParentSession(manager)
+
+    const task: BackgroundTask = {
+      id: "task-default",
+      sessionID: "session-default",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "Default max test",
+      prompt: "Test",
+      agent: "test-agent",
+      status: "running",
+      startedAt: new Date(Date.now() - 60_000),
+      lastMsgCount: 1,
+      stablePolls: 2,
+      stabilityResets: 9, // At 9, will hit 10 and trigger deadlock
+      progress: {
+        toolCalls: 1,
+        lastUpdate: new Date(),
+      },
+    }
+
+    statusResponses["session-default"] = { type: "busy" }
+    messagesResponses["session-default"] = [
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "x" }] },
+    ]
+
+    getTaskMap(manager).set(task.id, task)
+
+    // #when
+    await manager["pollRunningTasks"]()
+
+    // #then - should trigger deadlock at 10 resets (default)
+    expect(task.status).toBe("cancelled")
+    expect(task.error).toContain("Deadlock detected")
+
+    manager.shutdown()
+  })
+})
+
 describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
   test("should NOT interrupt task running less than 30 seconds (min runtime guard)", async () => {
     const client = {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1233,13 +1233,29 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
                 const currentStatus = recheckData[sessionID]
                 
                 if (currentStatus?.type !== "idle") {
+                  task.stabilityResets = (task.stabilityResets ?? 0) + 1
+                  const maxResets = this.config?.maxStabilityResets ?? 10
+
+                  if (task.stabilityResets >= maxResets) {
+                    log("[background-agent] DEADLOCK - Force completing after max stability resets:", {
+                      taskId: task.id,
+                      stabilityResets: task.stabilityResets,
+                      sessionStatus: currentStatus?.type ?? "not_in_status"
+                    })
+                    task.error = `Force-completed after ${task.stabilityResets} stability resets (deadlock detected)`
+                    await this.tryCompleteTask(task, "deadlock detection")
+                    continue
+                  }
+
                   log("[background-agent] Stability reached but session not idle, resetting:", { 
-                    taskId: task.id, 
+                    taskId: task.id,
+                    stabilityResets: task.stabilityResets,
                     sessionStatus: currentStatus?.type ?? "not_in_status" 
                   })
                   task.stablePolls = 0
                   continue
                 }
+                task.stabilityResets = 0
 
                 // Edge guard: Validate session has actual output before completing
                 const hasValidOutput = await this.validateSessionHasOutput(sessionID)
@@ -1259,6 +1275,7 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
               }
             } else {
               task.stablePolls = 0
+              task.stabilityResets = 0
             }
           }
           task.lastMsgCount = currentMsgCount

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1237,13 +1237,36 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
                   const maxResets = this.config?.maxStabilityResets ?? 10
 
                   if (task.stabilityResets >= maxResets) {
-                    log("[background-agent] DEADLOCK - Force completing after max stability resets:", {
+                    log("[background-agent] DEADLOCK - Force cancelling after max stability resets:", {
                       taskId: task.id,
                       stabilityResets: task.stabilityResets,
                       sessionStatus: currentStatus?.type ?? "not_in_status"
                     })
-                    task.error = `Force-completed after ${task.stabilityResets} stability resets (deadlock detected)`
-                    await this.tryCompleteTask(task, "deadlock detection")
+
+                    // Guard: Check if task is still running (could have been completed by another path)
+                    if (task.status !== "running") continue
+
+                    // Use "cancelled" status for abnormal termination (matching stale timeout pattern)
+                    task.status = "cancelled"
+                    task.error = `Deadlock detected: force-terminated after ${task.stabilityResets} stability resets (session stuck in "${currentStatus?.type ?? "unknown"}")`
+                    task.completedAt = new Date()
+
+                    // Release concurrency BEFORE any async operations to prevent slot leaks
+                    if (task.concurrencyKey) {
+                      this.concurrencyManager.release(task.concurrencyKey)
+                      task.concurrencyKey = undefined
+                    }
+
+                    // Abort the server-side session to stop resource consumption
+                    this.client.session.abort({ path: { id: sessionID } }).catch(() => {})
+
+                    this.markForNotification(task)
+
+                    try {
+                      await this.notifyParentSession(task)
+                    } catch (err) {
+                      log("[background-agent] Error notifying parent for deadlocked task:", { taskId: task.id, error: err })
+                    }
                     continue
                   }
 

--- a/src/features/background-agent/types.ts
+++ b/src/features/background-agent/types.ts
@@ -41,6 +41,8 @@ export interface BackgroundTask {
   lastMsgCount?: number
   /** Number of consecutive polls with stable message count */
   stablePolls?: number
+  /** Number of times stability was reached but session was not idle (for deadlock detection) */
+  stabilityResets?: number
 }
 
 export interface LaunchInput {


### PR DESCRIPTION
## Summary

Fixes #1079

When stability is reached (3 polls with same message count) but session status remains non-idle, the code previously reset `stablePolls` to 0 and continued polling indefinitely. This created an infinite loop observed to iterate 18,000+ times.

## Root Cause

The bug was introduced in commit `bf3f8e5` ("fix(background-agent): prevent premature task completion when agent still running").

**The loop mechanism:**
1. `stablePolls` increments: 0 → 1 → 2 → 3
2. At 3, check session status → not idle
3. Reset `stablePolls = 0`, continue
4. Next 3 polls: `stablePolls` back to 3
5. Session still not idle → reset again
6. **INFINITE LOOP** - no exit condition

## Changes

- Add `stabilityResets` counter to track consecutive stability resets
- After `maxStabilityResets` (default 10), force-complete task with error
- Reset counter on success (session becomes idle) or progress (message count changes)
- Add `maxStabilityResets` config option (1-100) to `BackgroundTaskConfigSchema`
- Add `stabilityResets` field to `BackgroundTask` interface

## Files Changed

| File | Change |
|------|--------|
| `src/features/background-agent/manager.ts` | Add deadlock detection logic |
| `src/features/background-agent/types.ts` | Add `stabilityResets` field |
| `src/config/schema.ts` | Add `maxStabilityResets` config option |

## Testing

After 10 stability resets (~30 polls), stuck tasks are force-completed with error:
```
Force-completed after 10 stability resets (deadlock detected)
```

Log output clearly indicates deadlock was detected:
```
[background-agent] DEADLOCK - Force completing after max stability resets: { taskId, stabilityResets, sessionStatus }
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deadlock detection to the background agent to stop the infinite stability reset loop. Stuck tasks now auto-cancel with an error after a configurable number of cycles.

- **Bug Fixes**
  - Track consecutive stabilityResets; reset on idle or when message count changes.
  - Force-cancel after maxStabilityResets (default 10, configurable 1–100) with a clear error and deadlock log.
  - Abort the server-side session and release concurrency on deadlock; add maxStabilityResets to the config schema and stabilityResets to the BackgroundTask type.

<sup>Written for commit e653f665ee61acd5fe4230bae6450eeca21736c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

