### PR TITLE
Add title entry for gemini-3-flash in configurations

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -405,6 +405,7 @@ Each agent has a defined provider priority chain. The system tries providers in 
 | **oracle** | `gpt-5.2` | openai → anthropic → google → github-copilot → opencode |
 | **librarian** | `big-pickle` | opencode → github-copilot → anthropic |
 | **explore** | `gpt-5-nano` | opencode → anthropic → github-copilot |
+| **title** | `gemini-3-flash` | google → openai → zai-coding-plan → anthropic → opencode |
 | **multimodal-looker** | `gemini-3-flash` | google → openai → zai-coding-plan → anthropic → opencode |
 | **Prometheus (Planner)** | `claude-opus-4-5` | anthropic → github-copilot → opencode → antigravity → google |
 | **Metis (Plan Consultant)** | `claude-sonnet-4-5` | anthropic → github-copilot → opencode → antigravity → google |


### PR DESCRIPTION
## Summary

This is missing, since i get this in the opencode logs, so i got this knowledge hard way

```
ERROR 2026-01-25T03:01:10 +2ms service=llm providerID=google modelID=gemini-3-flash sessionID=ses_40ce8d19affeiNDbcYdkETMvS7 small=true agent=title mode=primary error=
```

since I'm not using the default models for the agents

## Changes

Add the agent to the list in the docs



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the missing "title" agent to the configurations docs with default model gemini-3-flash and provider chain: google → openai → zai-coding-plan → anthropic → opencode. This aligns the docs with current behavior and helps avoid errors when using non-default models.

<sup>Written for commit c2c29ab9de1829152800f8dfacd2170f55b6dda4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

