### PR TITLE
fix(ralph-loop): skip user messages in transcript completion detection (#622)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,13 +27,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.0.0-beta.16",
-        "oh-my-opencode-darwin-x64": "3.0.0-beta.16",
-        "oh-my-opencode-linux-arm64": "3.0.0-beta.16",
-        "oh-my-opencode-linux-arm64-musl": "3.0.0-beta.16",
-        "oh-my-opencode-linux-x64": "3.0.0-beta.16",
-        "oh-my-opencode-linux-x64-musl": "3.0.0-beta.16",
-        "oh-my-opencode-windows-x64": "3.0.0-beta.16",
+        "oh-my-opencode-darwin-arm64": "3.0.0",
+        "oh-my-opencode-darwin-x64": "3.0.0",
+        "oh-my-opencode-linux-arm64": "3.0.0",
+        "oh-my-opencode-linux-arm64-musl": "3.0.0",
+        "oh-my-opencode-linux-x64": "3.0.0",
+        "oh-my-opencode-linux-x64-musl": "3.0.0",
+        "oh-my-opencode-windows-x64": "3.0.0",
       },
     },
   },
@@ -225,19 +225,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.0.0-beta.16", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-1gfnTsKpYxTMXpbuV98wProR3RMe6BI/muuSVa3Xy68EEkBJsuRAne6IzFq/yxIMbx9OiQaS5cTE0mxFtxcCGA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.0.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-zelvb7qz5GsS+Dhyz9rACZrkUMtWbAZGijiHSQqmRcjlN/sRPNhXtsL55VheDjlPM3VP+t3+psv+se0WA/aw5w=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.0.0-beta.16", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/h7kBZAN5Ut9kL7gEtwVVZ49Kw4gZoSVJdrpnh7Wij0a3mlOwqbkgGilK7oUiJ2N8fsxvxEBbTscYOLAdhyVBw=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.0.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-dRMD1U5zIrb6BsiKQJZtAFtuD8clAQquZyU2LajMoFTHBNhcBDIgsaBBwvMBIq7dTe8rnFq91ExiFA8OfdrzBA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.0.0-beta.16", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jW7pl76WerBa7FucKCYcthpbKbhJQSVe6rqUFSbVobjOP9VWslrGdxc9Y8BeiMx9SJEFYwA8/2ROhnOHpH3TxA=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.0.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Wx6Cx2Nu2T69mfZa3FQ3gk0OFONvMh48rMVYK0Cp8VX5W4Zb/GZgTUFmZlYsApyxqP+7J9m18skd46qPOhzuEQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.0.0-beta.16", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-cXXka0zQDBiFu9mmxa45o3g812w8q/jZRYgdwJsLbj3nm24WXv6uRP7nnVVoZiVmJ2GQbLE1nyGCMkBXFwRGGA=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.0.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-mfOlptgLoXLVuhFRcXgZU7BYGuL1axZOMOOjONgncNzOp/BQYU5B9BRFihBUXdDsWGmeMiLowrYGBhVpSv3NlA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.0.0-beta.16", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-4VS1V6DiXdWHQ/AGc3rB1sCxFUlD1REex0Ai/y4tEgA2M0FD0Bu+tjXHhDghUvC8f0kQBRfijnTrtc1Lh7hIrA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.0.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-vVjshfaz0UC9NrGD9FfjlYK5NvckIW0sZaE/wRv/LKjrukHFH1jJpJa5KKXxBWLsEJjt6ooJRguXXxtfNXpAWw=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.0.0-beta.16", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-PGVe7vyUK3hjSNfvu1fBXTbgbe0OPh7JgB/TZR2U5R54X1k3NBkb1VHX9yxEUSA0VsNR+inE2x+DfEA+7KIruQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.0.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-N6cNJ7+Dj0a5dWqPf6OKfB39o8HWw5HQ3hB4omgYqc6Gzo6nChA4KIiVefEC3+tIL98x4XvMeD7OU+UYgwxHnQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.0.0-beta.16", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-1lN/8y4laQnSJDvyARuV5YaETAwBb+PK06QHQzpoK/0asiFoEIBcKNgjaRwau+nBsdRUrQocE2xc6g2ZNH4HUw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.0.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-TaC0hiHpnsS42GWTVUKoTwCb+QzNLBlQtTkIQ0PjlkDYFjlEC2LuR2FFcscik055PRRIGishyB9A1n/8XAgcvA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/features/builtin-commands/templates/ralph-loop.ts
+++ b/src/features/builtin-commands/templates/ralph-loop.ts
@@ -17,7 +17,7 @@ export const RALPH_LOOP_TEMPLATE = `You are starting a Ralph Loop - a self-refer
 
 ## Exit Conditions
 
-1. **Completion**: Output \`<promise>DONE</promise>\` (or custom promise text) when fully complete
+1. **Completion**: Output your completion promise tag when fully complete
 2. **Max Iterations**: Loop stops automatically at limit
 3. **Cancel**: User runs \`/cancel-ralph\` command
 

--- a/src/hooks/ralph-loop/index.ts
+++ b/src/hooks/ralph-loop/index.ts
@@ -100,7 +100,18 @@ export function createRalphLoopHook(
 
       const content = readFileSync(transcriptPath, "utf-8")
       const pattern = new RegExp(`<promise>\\s*${escapeRegex(promise)}\\s*</promise>`, "is")
-      return pattern.test(content)
+      const lines = content.split("\n").filter(l => l.trim())
+
+      for (const line of lines) {
+        try {
+          const entry = JSON.parse(line)
+          if (entry.type === "user") continue
+          if (pattern.test(line)) return true
+        } catch {
+          continue
+        }
+      }
+      return false
     } catch {
       return false
     }


### PR DESCRIPTION
## Summary

Fixes #622 — Ralph loop iteration count always stays at 1 instead of incrementing.

## Root Cause

The `detectCompletionPromise()` function in `src/hooks/ralph-loop/index.ts` reads the **entire** transcript JSONL file and searches for `<promise>DONE</promise>`. The `RALPH_LOOP_TEMPLATE` instructional text contains this literal pattern:

```
1. **Completion**: Output `<promise>DONE</promise>` (or custom promise text) when fully complete
```

When the user runs `/ralph-loop`, this template is sent as the user's message and recorded to the transcript via `recordUserMessage()`. On `session.idle`, the completion detection finds the pattern in the template text and falsely reports completion at iteration 1.

The same issue affects iteration 2+ because the `CONTINUATION_PROMPT` also contains `<promise>DONE</promise>` as an instruction to the model.

## Fix

**Primary fix** (`src/hooks/ralph-loop/index.ts`):
- Parse transcript JSONL entries line-by-line
- Skip entries with `type: "user"` (these contain template/continuation prompt text)
- Only check non-user entries (e.g., `tool_result`, `assistant`) for the completion promise

**Defense-in-depth** (`src/features/builtin-commands/templates/ralph-loop.ts`):
- Removed the hardcoded `<promise>DONE</promise>` from the Exit Conditions section of the template
- The instruction in line 6 (`output: <promise>{{COMPLETION_PROMISE}}</promise>`) already tells the model what to output

## Test Coverage

Added 3 new regression tests:
- `should NOT detect completion from user message in transcript (issue #622)` — reproduces the exact bug
- `should NOT detect completion from continuation prompt in transcript (issue #622)` — covers iteration 2+ case
- `should detect completion from tool_result entry in transcript` — verifies real completion still works

Updated 4 existing transcript tests to use proper JSONL format with `type` fields.

## Verification

- ✅ 37 tests pass, 1 skipped (known flaky CI timeout test)
- ✅ TypeScript type check passes (`bun run typecheck`)
- ✅ Build passes (`bun run build`)
- ✅ No regressions in related test suites (74 pass across 3 files)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false completion detection in Ralph Loop by ignoring user messages in transcript parsing, so the loop increments correctly and only completes on actual outputs. Addresses #622.

- **Bug Fixes**
  - Parse transcript JSONL line-by-line and skip entries with type "user"; only check assistant/tool_result entries for the completion promise.
  - Remove hardcoded "<promise>DONE</promise>" from the template’s exit conditions; rely on the configured completion promise tag.

<sup>Written for commit d4f0d10b70ae9c3034050b8077651638ef6c0d10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

