### PR TITLE
fix: generate skill/slashcommand descriptions synchronously when pre-provided

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,13 +27,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.0.0-beta.16",
-        "oh-my-opencode-darwin-x64": "3.0.0-beta.16",
-        "oh-my-opencode-linux-arm64": "3.0.0-beta.16",
-        "oh-my-opencode-linux-arm64-musl": "3.0.0-beta.16",
-        "oh-my-opencode-linux-x64": "3.0.0-beta.16",
-        "oh-my-opencode-linux-x64-musl": "3.0.0-beta.16",
-        "oh-my-opencode-windows-x64": "3.0.0-beta.16",
+        "oh-my-opencode-darwin-arm64": "3.0.0",
+        "oh-my-opencode-darwin-x64": "3.0.0",
+        "oh-my-opencode-linux-arm64": "3.0.0",
+        "oh-my-opencode-linux-arm64-musl": "3.0.0",
+        "oh-my-opencode-linux-x64": "3.0.0",
+        "oh-my-opencode-linux-x64-musl": "3.0.0",
+        "oh-my-opencode-windows-x64": "3.0.0",
       },
     },
   },
@@ -225,19 +225,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.0.0-beta.16", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-1gfnTsKpYxTMXpbuV98wProR3RMe6BI/muuSVa3Xy68EEkBJsuRAne6IzFq/yxIMbx9OiQaS5cTE0mxFtxcCGA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.0.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-zelvb7qz5GsS+Dhyz9rACZrkUMtWbAZGijiHSQqmRcjlN/sRPNhXtsL55VheDjlPM3VP+t3+psv+se0WA/aw5w=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.0.0-beta.16", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/h7kBZAN5Ut9kL7gEtwVVZ49Kw4gZoSVJdrpnh7Wij0a3mlOwqbkgGilK7oUiJ2N8fsxvxEBbTscYOLAdhyVBw=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.0.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-dRMD1U5zIrb6BsiKQJZtAFtuD8clAQquZyU2LajMoFTHBNhcBDIgsaBBwvMBIq7dTe8rnFq91ExiFA8OfdrzBA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.0.0-beta.16", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jW7pl76WerBa7FucKCYcthpbKbhJQSVe6rqUFSbVobjOP9VWslrGdxc9Y8BeiMx9SJEFYwA8/2ROhnOHpH3TxA=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.0.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Wx6Cx2Nu2T69mfZa3FQ3gk0OFONvMh48rMVYK0Cp8VX5W4Zb/GZgTUFmZlYsApyxqP+7J9m18skd46qPOhzuEQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.0.0-beta.16", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-cXXka0zQDBiFu9mmxa45o3g812w8q/jZRYgdwJsLbj3nm24WXv6uRP7nnVVoZiVmJ2GQbLE1nyGCMkBXFwRGGA=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.0.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-mfOlptgLoXLVuhFRcXgZU7BYGuL1axZOMOOjONgncNzOp/BQYU5B9BRFihBUXdDsWGmeMiLowrYGBhVpSv3NlA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.0.0-beta.16", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-4VS1V6DiXdWHQ/AGc3rB1sCxFUlD1REex0Ai/y4tEgA2M0FD0Bu+tjXHhDghUvC8f0kQBRfijnTrtc1Lh7hIrA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.0.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-vVjshfaz0UC9NrGD9FfjlYK5NvckIW0sZaE/wRv/LKjrukHFH1jJpJa5KKXxBWLsEJjt6ooJRguXXxtfNXpAWw=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.0.0-beta.16", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-PGVe7vyUK3hjSNfvu1fBXTbgbe0OPh7JgB/TZR2U5R54X1k3NBkb1VHX9yxEUSA0VsNR+inE2x+DfEA+7KIruQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.0.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-N6cNJ7+Dj0a5dWqPf6OKfB39o8HWw5HQ3hB4omgYqc6Gzo6nChA4KIiVefEC3+tIL98x4XvMeD7OU+UYgwxHnQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.0.0-beta.16", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-1lN/8y4laQnSJDvyARuV5YaETAwBb+PK06QHQzpoK/0asiFoEIBcKNgjaRwau+nBsdRUrQocE2xc6g2ZNH4HUw=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.0.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-TaC0hiHpnsS42GWTVUKoTwCb+QzNLBlQtTkIQ0PjlkDYFjlEC2LuR2FFcscik055PRRIGishyB9A1n/8XAgcvA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/tools/skill/tools.test.ts
+++ b/src/tools/skill/tools.test.ts
@@ -57,6 +57,45 @@ const mockContext = {
   abort: new AbortController().signal,
 }
 
+describe("skill tool - synchronous description", () => {
+  it("includes available_skills immediately when skills are pre-provided", () => {
+    // #given
+    const loadedSkills = [createMockSkill("test-skill")]
+
+    // #when
+    const tool = createSkillTool({ skills: loadedSkills })
+
+    // #then
+    expect(tool.description).toContain("<available_skills>")
+    expect(tool.description).toContain("test-skill")
+  })
+
+  it("includes all pre-provided skills in available_skills immediately", () => {
+    // #given
+    const loadedSkills = [
+      createMockSkill("playwright"),
+      createMockSkill("frontend-ui-ux"),
+      createMockSkill("git-master"),
+    ]
+
+    // #when
+    const tool = createSkillTool({ skills: loadedSkills })
+
+    // #then
+    expect(tool.description).toContain("playwright")
+    expect(tool.description).toContain("frontend-ui-ux")
+    expect(tool.description).toContain("git-master")
+  })
+
+  it("shows no-skills message immediately when empty skills are pre-provided", () => {
+    // #given / #when
+    const tool = createSkillTool({ skills: [] })
+
+    // #then
+    expect(tool.description).toContain("No skills are currently available")
+  })
+})
+
 describe("skill tool - agent restriction", () => {
   it("allows skill without agent restriction to any agent", async () => {
     // #given

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -147,7 +147,14 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
     return cachedDescription
   }
 
-  getDescription()
+  if (options.skills) {
+    const skillInfos = options.skills.map(loadedSkillToInfo)
+    cachedDescription = skillInfos.length === 0
+      ? TOOL_DESCRIPTION_NO_SKILLS
+      : TOOL_DESCRIPTION_PREFIX + formatSkillsXml(skillInfos)
+  } else {
+    getDescription()
+  }
 
   return tool({
     get description() {

--- a/src/tools/slashcommand/tools.test.ts
+++ b/src/tools/slashcommand/tools.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "bun:test"
+import { createSlashcommandTool } from "./tools"
+import type { CommandInfo } from "./types"
+import type { LoadedSkill } from "../../features/opencode-skill-loader"
+
+function createMockCommand(name: string, description = ""): CommandInfo {
+  return {
+    name,
+    metadata: {
+      name,
+      description: description || `Test command ${name}`,
+    },
+    scope: "builtin",
+  }
+}
+
+function createMockSkill(name: string, description = ""): LoadedSkill {
+  return {
+    name,
+    path: `/test/skills/${name}/SKILL.md`,
+    resolvedPath: `/test/skills/${name}`,
+    definition: {
+      name,
+      description: description || `Test skill ${name}`,
+      template: "Test template",
+    },
+    scope: "opencode-project",
+  }
+}
+
+describe("slashcommand tool - synchronous description", () => {
+  it("includes available_skills immediately when commands and skills are pre-provided", () => {
+    // #given
+    const commands = [createMockCommand("commit", "Create a git commit")]
+    const skills = [createMockSkill("playwright", "Browser automation via Playwright MCP")]
+
+    // #when
+    const tool = createSlashcommandTool({ commands, skills })
+
+    // #then
+    expect(tool.description).toContain("<available_skills>")
+    expect(tool.description).toContain("commit")
+    expect(tool.description).toContain("playwright")
+  })
+
+  it("includes all pre-provided commands and skills in description immediately", () => {
+    // #given
+    const commands = [
+      createMockCommand("commit", "Git commit"),
+      createMockCommand("plan", "Create plan"),
+    ]
+    const skills = [
+      createMockSkill("playwright", "Browser automation"),
+      createMockSkill("frontend-ui-ux", "Frontend design"),
+      createMockSkill("git-master", "Git operations"),
+    ]
+
+    // #when
+    const tool = createSlashcommandTool({ commands, skills })
+
+    // #then
+    expect(tool.description).toContain("commit")
+    expect(tool.description).toContain("plan")
+    expect(tool.description).toContain("playwright")
+    expect(tool.description).toContain("frontend-ui-ux")
+    expect(tool.description).toContain("git-master")
+  })
+
+  it("shows prefix-only description when both commands and skills are empty", () => {
+    // #given / #when
+    const tool = createSlashcommandTool({ commands: [], skills: [] })
+
+    // #then - even with no items, description should be built synchronously (not just prefix)
+    expect(tool.description).toContain("Load a skill")
+  })
+})

--- a/src/tools/slashcommand/tools.ts
+++ b/src/tools/slashcommand/tools.ts
@@ -210,8 +210,12 @@ export function createSlashcommandTool(options: SlashcommandToolOptions = {}): T
     return cachedDescription
   }
 
-  // Pre-warm the cache immediately
-  buildDescription()
+  if (options.commands !== undefined && options.skills !== undefined) {
+    const allItems = [...options.commands, ...options.skills.map(skillToCommandInfo)]
+    cachedDescription = buildDescriptionFromItems(allItems)
+  } else {
+    buildDescription()
+  }
 
   return tool({
     get description() {


### PR DESCRIPTION
## Summary

Fixes #1039 — Skills are not visible in `<available_skills>` XML.

## Root Cause

Both `createSkillTool()` and `createSlashcommandTool()` generate their `<available_skills>` description **asynchronously via fire-and-forget**, even when skills are already pre-resolved synchronously via `options.skills`. The description getter returns the bare prefix before the async cache-warming microtask completes, so the LLM never sees skill names.

## Fix

When `options.skills` (and `options.commands` for slashcommand) are provided (pre-resolved), build the tool description **synchronously** instead of calling the async `getDescription()`/`buildDescription()`. The async fallback is kept only for the default export path (no pre-provided skills).

### `src/tools/skill/tools.ts`
```typescript
// Before: getDescription()  // fire-and-forget async
// After:
if (options.skills) {
  const skillInfos = options.skills.map(loadedSkillToInfo)
  cachedDescription = skillInfos.length === 0
    ? TOOL_DESCRIPTION_NO_SKILLS
    : TOOL_DESCRIPTION_PREFIX + formatSkillsXml(skillInfos)
} else {
  getDescription()
}
```

### `src/tools/slashcommand/tools.ts`
```typescript
// Before: buildDescription()  // fire-and-forget async
// After:
if (options.commands !== undefined && options.skills !== undefined) {
  const allItems = [...options.commands, ...options.skills.map(skillToCommandInfo)]
  cachedDescription = buildDescriptionFromItems(allItems)
} else {
  buildDescription()
}
```

## Tests

- **6 new tests** (3 in `skill/tools.test.ts`, 3 in new `slashcommand/tools.test.ts`)
- RED → GREEN TDD cycle confirmed
- Full suite: **1382 pass, 0 fail, 2 skip** (96 files)
- Typecheck: clean

## Files Changed

| File | Change |
|------|--------|
| `src/tools/skill/tools.ts` | Sync description when `options.skills` provided |
| `src/tools/slashcommand/tools.ts` | Sync description when both `options.commands` and `options.skills` provided |
| `src/tools/skill/tools.test.ts` | 3 new tests for synchronous description |
| `src/tools/slashcommand/tools.test.ts` | New file — 3 tests for synchronous description |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1039 by generating skill and slashcommand tool descriptions synchronously when pre-provided lists are passed. This removes the race that hid names in <available_skills> and makes them visible immediately.

- **Bug Fixes**
  - Skill tool: when options.skills is provided, build the full description synchronously (including the no-skills message when empty).
  - Slashcommand tool: when both options.commands and options.skills are provided, build the full description synchronously from all items.
  - Keep async fallback only when lists aren’t pre-provided.
  - Added 6 tests to verify immediate description content.

<sup>Written for commit 374f696a9e57668e351bfd801f3cc68325175e4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

