### PR TITLE
feat(explore): add github-copilot/gpt-5-mini to fallback chain

### DIFF
--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -712,7 +712,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
       "model": "github-copilot/claude-sonnet-4.5",
     },
     "explore": {
-      "model": "opencode/gpt-5-nano",
+      "model": "github-copilot/gpt-5-mini",
     },
     "librarian": {
       "model": "github-copilot/claude-sonnet-4.5",
@@ -776,7 +776,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
       "model": "github-copilot/claude-sonnet-4.5",
     },
     "explore": {
-      "model": "opencode/gpt-5-nano",
+      "model": "github-copilot/gpt-5-mini",
     },
     "librarian": {
       "model": "github-copilot/claude-sonnet-4.5",
@@ -1022,7 +1022,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
       "model": "github-copilot/claude-sonnet-4.5",
     },
     "explore": {
-      "model": "opencode/gpt-5-nano",
+      "model": "github-copilot/gpt-5-mini",
     },
     "librarian": {
       "model": "github-copilot/claude-sonnet-4.5",

--- a/src/cli/model-fallback.test.ts
+++ b/src/cli/model-fallback.test.ts
@@ -353,6 +353,17 @@ describe("generateModelConfig", () => {
       // #then explore should use gpt-5-nano (fallback)
       expect(result.agents?.explore?.model).toBe("opencode/gpt-5-nano")
     })
+
+    test("explore uses gpt-5-mini when only Copilot available", () => {
+      // #given only Copilot is available
+      const config = createConfig({ hasCopilot: true })
+
+      // #when generateModelConfig is called
+      const result = generateModelConfig(config)
+
+      // #then explore should use gpt-5-mini (Copilot fallback)
+      expect(result.agents?.explore?.model).toBe("github-copilot/gpt-5-mini")
+    })
   })
 
   describe("Sisyphus agent special cases", () => {

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -139,12 +139,14 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
       continue
     }
 
-    // Special case: explore uses Claude haiku → OpenCode gpt-5-nano
+    // Special case: explore uses Claude haiku → GitHub Copilot gpt-5-mini → OpenCode gpt-5-nano
     if (role === "explore") {
       if (avail.native.claude) {
         agents[role] = { model: "anthropic/claude-haiku-4-5" }
       } else if (avail.opencodeZen) {
         agents[role] = { model: "opencode/claude-haiku-4-5" }
+      } else if (avail.copilot) {
+        agents[role] = { model: "github-copilot/gpt-5-mini" }
       } else {
         agents[role] = { model: "opencode/gpt-5-nano" }
       }

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -59,14 +59,23 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     const explore = AGENT_MODEL_REQUIREMENTS["explore"]
 
     // #when - accessing explore requirement
-    // #then - fallbackChain exists with claude-haiku-4-5 as first entry
+    // #then - fallbackChain exists with claude-haiku-4-5 as first entry, gpt-5-mini as second, gpt-5-nano as third
     expect(explore).toBeDefined()
     expect(explore.fallbackChain).toBeArray()
-    expect(explore.fallbackChain.length).toBeGreaterThan(0)
+    expect(explore.fallbackChain).toHaveLength(3)
 
     const primary = explore.fallbackChain[0]
     expect(primary.providers).toContain("anthropic")
+    expect(primary.providers).toContain("opencode")
     expect(primary.model).toBe("claude-haiku-4-5")
+
+    const secondary = explore.fallbackChain[1]
+    expect(secondary.providers).toContain("github-copilot")
+    expect(secondary.model).toBe("gpt-5-mini")
+
+    const tertiary = explore.fallbackChain[2]
+    expect(tertiary.providers).toContain("opencode")
+    expect(tertiary.model).toBe("gpt-5-nano")
   })
 
   test("multimodal-looker has valid fallbackChain with gemini-3-flash as primary", () => {

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -35,6 +35,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   explore: {
     fallbackChain: [
       { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
+      { providers: ["github-copilot"], model: "gpt-5-mini" },
       { providers: ["opencode"], model: "gpt-5-nano" },
     ],
   },


### PR DESCRIPTION
## Summary

- Add `github-copilot/gpt-5-mini` as second fallback in explore agent's fallback chain
- Falls back to Copilot's gpt-5-mini when Claude haiku unavailable, then to opencode/gpt-5-nano

## Changes

### New Fallback Chain

```typescript
explore: {
  fallbackChain: [
    { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
    { providers: ["github-copilot"], model: "gpt-5-mini" },      // NEW
    { providers: ["opencode"], model: "gpt-5-nano" },
  ],
}
```

### Modified Files

- `src/shared/model-requirements.ts` - Update fallbackChain definition
- `src/cli/model-fallback.ts` - Add Copilot fallback to explore special case logic
- `src/shared/model-requirements.test.ts` - Expand test cases for 3-step chain
- `src/cli/model-fallback.test.ts` - Add Copilot-only test case
- Update snapshots

## Test

```
bun test src/shared/model-requirements.test.ts src/cli/model-fallback.test.ts
# 56 pass, 0 fail
```