### PR TITLE
fix: improve Windows compatibility and fix event listener issues

### DIFF
--- a/src/cli/doctor/checks/dependencies.ts
+++ b/src/cli/doctor/checks/dependencies.ts
@@ -3,11 +3,9 @@ import { CHECK_IDS, CHECK_NAMES } from "../constants"
 
 async function checkBinaryExists(binary: string): Promise<{ exists: boolean; path: string | null }> {
   try {
-    const proc = Bun.spawn(["which", binary], { stdout: "pipe", stderr: "pipe" })
-    const output = await new Response(proc.stdout).text()
-    await proc.exited
-    if (proc.exitCode === 0) {
-      return { exists: true, path: output.trim() }
+    const path = Bun.which(binary)
+    if (path) {
+      return { exists: true, path }
     }
   } catch {
     // intentionally empty - binary not found

--- a/src/cli/doctor/checks/opencode.ts
+++ b/src/cli/doctor/checks/opencode.ts
@@ -55,16 +55,9 @@ export function buildVersionCommand(
 export async function findOpenCodeBinary(): Promise<{ binary: string; path: string } | null> {
   for (const binary of OPENCODE_BINARIES) {
     try {
-      const lookupCommand = getBinaryLookupCommand(process.platform)
-      const proc = Bun.spawn([lookupCommand, binary], { stdout: "pipe", stderr: "pipe" })
-      const output = await new Response(proc.stdout).text()
-      await proc.exited
-      if (proc.exitCode === 0) {
-        const paths = parseBinaryPaths(output)
-        const selectedPath = selectBinaryPath(paths, process.platform)
-        if (selectedPath) {
-          return { binary, path: selectedPath }
-        }
+      const path = Bun.which(binary)
+      if (path) {
+        return { binary, path }
       }
     } catch {
       continue

--- a/src/hooks/comment-checker/cli.ts
+++ b/src/hooks/comment-checker/cli.ts
@@ -165,7 +165,7 @@ export async function runCommentChecker(input: HookInput, cliPath?: string, cust
   debugLog("running comment-checker with input:", jsonInput.substring(0, 200))
 
   try {
-    const args = [binaryPath]
+    const args = [binaryPath, "check"]
     if (customPrompt) {
       args.push("--prompt", customPrompt)
     }

--- a/src/hooks/session-notification-utils.ts
+++ b/src/hooks/session-notification-utils.ts
@@ -21,28 +21,8 @@ let aplayPath: string | null = null
 let aplayPromise: Promise<string | null> | null = null
 
 async function findCommand(commandName: string): Promise<string | null> {
-  const isWindows = process.platform === "win32"
-  const cmd = isWindows ? "where" : "which"
-
   try {
-    const proc = spawn([cmd, commandName], {
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-
-    const exitCode = await proc.exited
-    if (exitCode !== 0) {
-      return null
-    }
-
-    const stdout = await new Response(proc.stdout).text()
-    const path = stdout.trim().split("\n")[0]
-
-    if (!path) {
-      return null
-    }
-
-    return path
+    return Bun.which(commandName)
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary

This PR improves cross-platform compatibility (especially for Windows) and fixes several event listener issues by replacing platform-specific commands with cross-platform APIs.

## Issues Fixed

- Fixes #1027: Comment-checker binary crashes on Windows (missing 'check' subcommand + TUI mode issue)
- Fixes #1036: Session-notification listens to non-existent events (`session.updated`, `message.created`)
- Fixes #1033: Infinite loop in session notifications (notification commands reset their own state)
- Fixes #599: Doctor incorrectly reports OpenCode as not installed on Windows
- Fixes #1005: PowerShell path detection corruption on Windows

## Changes

### 1. Replace `which`/`where` with `Bun.which()` API
- **Files:** `src/cli/doctor/checks/dependencies.ts`, `src/cli/doctor/checks/opencode.ts`, `src/hooks/session-notification-utils.ts`
- **Why:** The `which` command doesn't exist on Windows, causing Doctor to fail. `Bun.which()` is a cross-platform built-in API that handles executable extensions (.exe, .cmd, .bat, .ps1) automatically.

### 2. Add `check` subcommand to comment-checker
- **File:** `src/hooks/comment-checker/cli.ts`
- **Why:** Without the subcommand, the Go binary defaults to TUI mode, causing hangs/crashes on Windows.

### 3. Remove non-existent event listeners
- **File:** `src/hooks/session-notification.ts`
- **Why:** `session.updated` and `message.created` are not emitted by OpenCode SDK, causing unnecessary overhead.

### 4. Fix infinite notification loop
- **File:** `src/hooks/session-notification.ts`
- **Why:** Notification commands were resetting `notifiedSessions` state, causing them to trigger themselves infinitely.

## Testing

All tests pass on Windows:
- ✅ `doctor/checks/dependencies`: 8/8 pass
- ✅ `doctor/checks/opencode`: 17/17 pass
- ✅ `hooks/comment-checker`: 4/4 pass
- ✅ `hooks/session-notification`: 11/11 pass
- ✅ TypeScript typecheck: PASS

## Cross-Platform Compatibility

- ✅ **Windows**: Tested on Windows 10
- ✅ **Linux**: `Bun.which()` is documented as cross-platform
- ✅ **macOS**: `Bun.which()` is documented as cross-platform

## Additional Notes

- All changes are minimal and focused on fixing specific bugs
- No core technology changes
- Code is cleaner and more maintainable (removed complex platform detection logic)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Windows compatibility and fixes session notification bugs by switching to Bun.which for cross-platform executable lookup and tightening event handling. Prevents comment-checker crashes, false Doctor failures, and infinite notification loops.

- **Bug Fixes**
  - Doctor correctly detects OpenCode and dependencies on Windows using Bun.which; resolves false “not installed” reports and PowerShell path issues (fixes #599, #1005).
  - Comment-checker runs with the "check" subcommand to avoid TUI mode crashes on Windows (fixes #1027).
  - Removed listeners for non-existent events (session.updated, message.created) to reduce noise and errors (fixes #1036).
  - Stopped notifications from resetting their own state to prevent infinite loops, and clear notified state if activity occurs during a notification to avoid missed alerts (fixes #1033).

<sup>Written for commit c655c357daffb003d7a8138e959ca3c92822b545. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

