### PR TITLE
fix: return friendly error when file not found in look_at

### DIFF
--- a/src/tools/look-at/tools.ts
+++ b/src/tools/look-at/tools.ts
@@ -1,4 +1,5 @@
 import { extname, basename } from "node:path"
+import { existsSync } from "node:fs"
 import { pathToFileURL } from "node:url"
 import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin"
 import { LOOK_AT_DESCRIPTION, MULTIMODAL_LOOKER_AGENT } from "./constants"
@@ -80,6 +81,12 @@ export function createLookAt(ctx: PluginInput): ToolDefinition {
       }
 
       log(`[look_at] Analyzing file: ${args.file_path}, goal: ${args.goal}`)
+
+      if (!existsSync(args.file_path)) {
+        const errorMsg = `Error: File not found: ${args.file_path}`
+        log(`[look_at] ${errorMsg}`)
+        return errorMsg
+      }
 
       const mimeType = inferMimeType(args.file_path)
       const filename = basename(args.file_path)


### PR DESCRIPTION
## Summary

When using the `look_at` tool with a non-existent file path, it previously threw a cryptic `SyntaxError: JSON Parse error: Unexpected EOF` error. This PR adds a file existence check that returns a clear, user-friendly error message instead.

## Changes

- Added `existsSync` check before processing the file
- Returns clear error message: `Error: File not found: <path>`
- Added logging for debugging purposes

## Testing

- All existing tests pass (`bun test src/tools/look-at` - 7 tests)
- Build succeeds (`bun run build`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
look_at now checks for file existence and returns "Error: File not found: <path>" for invalid paths, instead of a cryptic JSON parse error. Adds an existsSync guard and logs the error for easier debugging.

<sup>Written for commit 727b762b01073c34bbed9c51bcc27749da98da0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

