### PR TITLE
fix(prometheus): add write permission and clarify workspace path

### DIFF
--- a/src/agents/prometheus-prompt.ts
+++ b/src/agents/prometheus-prompt.ts
@@ -122,8 +122,17 @@ You may ONLY create/edit markdown (.md) files. All other file types are FORBIDDE
 This constraint is enforced by the prometheus-md-only hook. Non-.md writes will be blocked.
 
 ### 4. PLAN OUTPUT LOCATION
+
+**ALWAYS use the current workspace's \`.sisyphus/\` directory.**
+
+**NEVER use paths like \`~/.sisyphus/\` or absolute paths to other directories.**
+
 Plans are saved to: \`.sisyphus/plans/{plan-name}.md\`
 Example: \`.sisyphus/plans/auth-refactor.md\`
+
+**Use relative paths only** - the Write tool will resolve them relative to the current workspace directory.
+**WRONG**: \`~/some/path/.sisyphus/plans/plan.md\` or \`/home/user/.sisyphus/plans/plan.md\`
+**CORRECT**: \`.sisyphus/plans/plan.md\`
 
 ### 5. SINGLE PLAN MANDATE (CRITICAL)
 **No matter how large the task, EVERYTHING goes into ONE work plan.**
@@ -1185,10 +1194,11 @@ This will:
 
 /**
  * Prometheus planner permission configuration.
- * Allows write/edit for plan files (.md only, enforced by prometheus-md-only hook).
+ * Allows write/edit for plan files (.md only in .sisyphus/, enforced by prometheus-md-only hook).
  * Question permission allows agent to ask user questions via OpenCode's QuestionTool.
  */
 export const PROMETHEUS_PERMISSION = {
+  write: "allow" as const,
   edit: "allow" as const,
   bash: "allow" as const,
   webfetch: "allow" as const,


### PR DESCRIPTION
- Add write: allow to PROMETHEUS_PERMISSION to enable plan file creation
- Clarify plan output location to use current workspace .sisyphus/ directory
- Add explicit guidance to avoid ~/.sisyphus/ and absolute paths

## Summary
Fixed #1105
When I tried to use with other un-recommended model (Minimax m2.1) it has some edge cases:
- Prometheus can't write plan file due to missing write tool in its allowed tool to use
- Prometheus actually tried to write tool in $HOME/.claude/.sysiphus/* instead of the current directory

This PR is to solve the issue, make it less ambiguous for promethus by:
- This give the missing permission to write the plan.md file. We already have post hook to check for the prometheus write file in case it tried to write to other location -> this is safe to add.
- Make the prompt more clear so prometheus always knows to create the plan file in the working dir of the current session. 

## Changes
- Add write: allow to PROMETHEUS_PERMISSION to enable plan file creation
- Clarify plan output location to use current workspace .sisyphus/ directory
- Add explicit guidance to avoid ~/.sisyphus/ and absolute paths

## Screenshots

## Testing
```
bun run typecheck
bun run build
bun test src/agents
```

All 38 tests passed
<img width="407" height="110" alt="image" src="https://github.com/user-attachments/assets/c542c546-1d3a-4c92-bb5f-76d362544ea6" />

## Related Issues
Related to #1105

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Prometheus to write plan .md files and clarify that plans must be saved under the current workspace’s .sisyphus/plans directory. This prevents failed writes and avoids accidental use of HOME or absolute paths.

- **Bug Fixes**
  - Enabled write permission in PROMETHEUS_PERMISSION (md-only still enforced).
  - Updated prompt to require relative paths like .sisyphus/plans/{name}.md and forbid ~/.sisyphus or absolute paths; notes that the Write tool resolves paths relative to the workspace.

<sup>Written for commit 02f3f5702903acf59bb571c310cda18e47e081ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



