### PR TITLE
feat: add Cursor-style Debug Mode with hypothesis-driven instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .sisyphus/
 node_modules/
 
+# Debug mode artifacts
+.opencode/debug/
+
 # Build output
 dist/
 

--- a/src/features/builtin-commands/commands.test.ts
+++ b/src/features/builtin-commands/commands.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "bun:test"
+import { loadBuiltinCommands } from "./commands"
+
+describe("loadBuiltinCommands", () => {
+  test("should include debug command", () => {
+    // #given - default loading (no disabled commands)
+    // #when
+    const commands = loadBuiltinCommands()
+
+    // #then - debug command should exist with correct structure
+    expect(commands["debug"]).toBeDefined()
+    expect(commands["debug"].name).toBe("debug")
+    expect(commands["debug"].description).toContain("Debug runtime issues")
+    expect(commands["debug"].template).toContain("DEBUG MODE")
+  })
+
+  test("should respect disabled commands", () => {
+    // #given - debug command disabled
+    // #when
+    const commands = loadBuiltinCommands(["debug"])
+
+    // #then - debug command should not exist
+    expect(commands["debug"]).toBeUndefined()
+  })
+
+  test("should have 7 builtin commands total", () => {
+    // #given / #when
+    const commands = loadBuiltinCommands()
+
+    // #then - all 7 commands present
+    const commandNames = Object.keys(commands)
+    expect(commandNames).toHaveLength(7)
+    expect(commandNames).toContain("init-deep")
+    expect(commandNames).toContain("ralph-loop")
+    expect(commandNames).toContain("ulw-loop")
+    expect(commandNames).toContain("cancel-ralph")
+    expect(commandNames).toContain("refactor")
+    expect(commandNames).toContain("start-work")
+    expect(commandNames).toContain("debug")
+  })
+})

--- a/src/features/builtin-commands/commands.ts
+++ b/src/features/builtin-commands/commands.ts
@@ -4,6 +4,7 @@ import { INIT_DEEP_TEMPLATE } from "./templates/init-deep"
 import { RALPH_LOOP_TEMPLATE, CANCEL_RALPH_TEMPLATE } from "./templates/ralph-loop"
 import { REFACTOR_TEMPLATE } from "./templates/refactor"
 import { START_WORK_TEMPLATE } from "./templates/start-work"
+import { DEBUG_TEMPLATE } from "./templates/debug"
 
 const BUILTIN_COMMAND_DEFINITIONS: Record<BuiltinCommandName, Omit<CommandDefinition, "name">> = {
   "init-deep": {
@@ -53,10 +54,10 @@ ${REFACTOR_TEMPLATE}
 </command-instruction>`,
     argumentHint: "<refactoring-target> [--scope=<file|module|project>] [--strategy=<safe|aggressive>]",
   },
-  "start-work": {
-    description: "(builtin) Start Sisyphus work session from Prometheus plan",
-    agent: "atlas",
-    template: `<command-instruction>
+   "start-work": {
+     description: "(builtin) Start Sisyphus work session from Prometheus plan",
+     agent: "atlas",
+     template: `<command-instruction>
 ${START_WORK_TEMPLATE}
 </command-instruction>
 
@@ -68,9 +69,15 @@ Timestamp: $TIMESTAMP
 <user-request>
 $ARGUMENTS
 </user-request>`,
-    argumentHint: "[plan-name]",
-  },
-}
+     argumentHint: "[plan-name]",
+   },
+   debug: {
+     description: "(builtin) Debug runtime issues with hypothesis-driven instrumentation",
+     template: `<command-instruction>
+${DEBUG_TEMPLATE}
+</command-instruction>`,
+   },
+ }
 
 export function loadBuiltinCommands(
   disabledCommands?: BuiltinCommandName[]

--- a/src/features/builtin-commands/templates/debug.ts
+++ b/src/features/builtin-commands/templates/debug.ts
@@ -1,0 +1,29 @@
+export const DEBUG_TEMPLATE = `
+# Debug Mode
+
+You are now in DEBUG MODE for hypothesis-driven runtime debugging.
+
+## Quick Start Workflow
+1. Ask the user to describe the bug they're experiencing
+2. Generate 3-5 specific, testable hypotheses (labeled A, B, C, D, E)
+3. Create the debug server: .opencode/debug/server.js (port 7777)
+4. Start the server: \`node .opencode/debug/server.js &\`
+5. Instrument code with __debugLog(hypothesisId, label, location, message, data?) calls
+6. Ask user to reproduce the bug
+7. Read and analyze .opencode/debug/debug.log (NDJSON format)
+8. Propose a fix based on the evidence
+9. After user verifies fix: remove instrumentation and cleanup
+
+## Detailed Implementation Reference
+For complete details (server code, NDJSON schema, instrumentation patterns for JS/TS/Python/Go), load the **runtime-debugging** skill:
+\`\`\`
+/runtime-debugging
+\`\`\`
+
+## Important
+- Each hypothesis gets its own hypothesisId (A, B, C, etc.)
+- Artifacts go in .opencode/debug/ (NOT tracked by git - ensure cleanup before commits)
+- Cleanup: remove instrumentation calls, stop server, delete .opencode/debug/
+
+Start by asking: "What bug are you experiencing? Please describe what happens and what you expected to happen."
+`

--- a/src/features/builtin-commands/templates/debug.ts
+++ b/src/features/builtin-commands/templates/debug.ts
@@ -36,5 +36,8 @@ For complete details (server code, NDJSON schema, instrumentation patterns for J
 - Artifacts go in .opencode/debug/ (automatically added to .gitignore)
 - Cleanup: remove instrumentation calls, stop server, delete .opencode/debug/
 
+## Frontend CSP Note
+If debugging browser code, Content Security Policy (CSP) may block connections to localhost:7777. Check browser console for "Refused to connect" errors. The runtime-debugging skill includes detailed CSP detection and handling instructions.
+
 Start by updating .gitignore (if needed), then ask: "What bug are you experiencing? Please describe what happens and what you expected to happen."
 `

--- a/src/features/builtin-commands/templates/debug.ts
+++ b/src/features/builtin-commands/templates/debug.ts
@@ -3,6 +3,17 @@ export const DEBUG_TEMPLATE = `
 
 You are now in DEBUG MODE for hypothesis-driven runtime debugging.
 
+## FIRST: Ensure .gitignore is Updated (DO THIS IMMEDIATELY)
+
+Before anything else, check if \`.opencode/debug/\` is in the project's .gitignore:
+1. Read the project's .gitignore file (create if it doesn't exist)
+2. If \`.opencode/debug/\` is NOT present, append it:
+   \`\`\`
+   # Debug mode artifacts (oh-my-opencode)
+   .opencode/debug/
+   \`\`\`
+3. Confirm to user: "✓ Updated .gitignore to exclude debug artifacts"
+
 ## Quick Start Workflow
 1. Ask the user to describe the bug they're experiencing
 2. Generate 3-5 specific, testable hypotheses (labeled A, B, C, D, E)
@@ -22,8 +33,8 @@ For complete details (server code, NDJSON schema, instrumentation patterns for J
 
 ## Important
 - Each hypothesis gets its own hypothesisId (A, B, C, etc.)
-- Artifacts go in .opencode/debug/ (NOT tracked by git - ensure cleanup before commits)
+- Artifacts go in .opencode/debug/ (automatically added to .gitignore)
 - Cleanup: remove instrumentation calls, stop server, delete .opencode/debug/
 
-Start by asking: "What bug are you experiencing? Please describe what happens and what you expected to happen."
+Start by updating .gitignore (if needed), then ask: "What bug are you experiencing? Please describe what happens and what you expected to happen."
 `

--- a/src/features/builtin-commands/types.ts
+++ b/src/features/builtin-commands/types.ts
@@ -1,6 +1,6 @@
 import type { CommandDefinition } from "../claude-code-command-loader"
 
-export type BuiltinCommandName = "init-deep" | "ralph-loop" | "cancel-ralph" | "ulw-loop" | "refactor" | "start-work"
+export type BuiltinCommandName = "init-deep" | "ralph-loop" | "cancel-ralph" | "ulw-loop" | "refactor" | "start-work" | "debug"
 
 export interface BuiltinCommandConfig {
   disabled_commands?: BuiltinCommandName[]

--- a/src/features/builtin-skills/skills.test.ts
+++ b/src/features/builtin-skills/skills.test.ts
@@ -75,7 +75,7 @@ describe("createBuiltinSkills", () => {
 		}
 	})
 
-	test("returns exactly 3 skills regardless of provider", () => {
+	test("returns exactly 4 skills regardless of provider", () => {
 		// #given
 
 		// #when
@@ -83,7 +83,7 @@ describe("createBuiltinSkills", () => {
 		const agentBrowserSkills = createBuiltinSkills({ browserProvider: "agent-browser" })
 
 		// #then
-		expect(defaultSkills).toHaveLength(3)
-		expect(agentBrowserSkills).toHaveLength(3)
+		expect(defaultSkills).toHaveLength(4)
+		expect(agentBrowserSkills).toHaveLength(4)
 	})
 })

--- a/src/features/builtin-skills/skills.test.ts
+++ b/src/features/builtin-skills/skills.test.ts
@@ -75,7 +75,7 @@ describe("createBuiltinSkills", () => {
 		}
 	})
 
-	test("returns exactly 4 skills regardless of provider", () => {
+	test("returns exactly 5 skills regardless of provider", () => {
 		// #given
 
 		// #when
@@ -83,7 +83,22 @@ describe("createBuiltinSkills", () => {
 		const agentBrowserSkills = createBuiltinSkills({ browserProvider: "agent-browser" })
 
 		// #then
-		expect(defaultSkills).toHaveLength(4)
-		expect(agentBrowserSkills).toHaveLength(4)
+		expect(defaultSkills).toHaveLength(5)
+		expect(agentBrowserSkills).toHaveLength(5)
+	})
+
+	test("includes runtime-debugging skill", () => {
+		// #given
+
+		// #when
+		const skills = createBuiltinSkills()
+
+		// #then
+		const runtimeDebuggingSkill = skills.find((s) => s.name === "runtime-debugging")
+		expect(runtimeDebuggingSkill).toBeDefined()
+		expect(runtimeDebuggingSkill!.description).toContain("runtime")
+		expect(runtimeDebuggingSkill!.template).toContain("Debug Server")
+		expect(runtimeDebuggingSkill!.template).toContain("NDJSON")
+		expect(runtimeDebuggingSkill!.template).toContain("hypothesisId")
 	})
 })

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -1988,7 +1988,11 @@ Insert \`__debugLog\` / \`debug_log\` / \`DebugLog\` calls at strategic points:
 
 ### Step 5: Reproduce the Issue
 1. Ensure debug server is running
-2. Clear previous logs: \`> .opencode/debug/debug.log\`
+2. **Clear previous logs** (MANDATORY before each debug session):
+   \`\`\`bash
+   > .opencode/debug/debug.log
+   \`\`\`
+   This ensures you only see logs from the current reproduction attempt.
 3. Trigger the problematic behavior
 4. Collect logs
 
@@ -2026,8 +2030,14 @@ Look for:
 After debugging is complete:
 
 1. **Remove instrumentation code** from all modified files
-2. **Stop the debug server**: \`pkill -f "node .opencode/debug/server.js"\`
-3. **Delete debug artifacts**:
+2. **Revert any CSP changes** (if you modified CSP for frontend debugging):
+   \`\`\`bash
+   # Check for CSP modifications
+   git diff | grep -E "Content-Security-Policy|contentSecurityPolicy|helmet|connect-src"
+   # Revert if found (unless using environment-based CSP)
+   \`\`\`
+3. **Stop the debug server**: \`pkill -f "node .opencode/debug/server.js"\`
+4. **Delete debug artifacts**:
    \`\`\`bash
    rm -rf .opencode/debug/
    \`\`\`
@@ -2195,10 +2205,11 @@ If modifying source code is not feasible, use a browser extension like [Requestl
 |--------|---------|
 | Start server | \`node .opencode/debug/server.js &\` |
 | Check server | \`curl http://localhost:7777/health\` |
-| Clear logs | \`> .opencode/debug/debug.log\` |
+| **Clear logs (before each run)** | \`> .opencode/debug/debug.log\` |
 | View logs | \`cat .opencode/debug/debug.log \\| jq .\` |
 | Stop server | \`pkill -f "node .opencode/debug/server.js"\` |
-| Cleanup | \`rm -rf .opencode/debug/\` |
+| Check CSP changes | \`git diff \\| grep -E "Content-Security-Policy\\|connect-src"\` |
+| **Full cleanup** | \`pkill -f "node .opencode/debug/server.js"; rm -rf .opencode/debug/\` |
 `,
 }
 

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -2048,6 +2048,147 @@ git status | grep -E "debug|__debugLog|debug_log"
 
 If you see any debug-related changes, remove them before committing.
 
+## CSP Handling for Frontend Debugging
+
+### The Problem
+
+When debugging frontend code, Content Security Policy (CSP) may block connections to the debug server at \`localhost:7777\`. CSP violations appear in the browser console as:
+
+\`\`\`
+Refused to connect to 'http://localhost:7777/ingest' because it violates 
+the following Content Security Policy directive: "connect-src 'self'"
+\`\`\`
+
+### Step 1: Detect CSP Configuration
+
+Search the project for CSP settings:
+
+\`\`\`bash
+# HTML meta tags
+grep -r "Content-Security-Policy" . --include="*.html" --include="*.htm"
+
+# Next.js config
+grep -r "contentSecurityPolicy\\|headers()" . --include="next.config.*"
+
+# Express/Node (helmet middleware)
+grep -r "helmet\\|contentSecurityPolicy" . --include="*.ts" --include="*.js"
+
+# Nginx
+grep -r "add_header.*Content-Security-Policy" . --include="nginx.conf" --include="*.conf"
+
+# Apache
+grep -r "Header set Content-Security-Policy" . --include=".htaccess"
+
+# Vite/Webpack plugins
+grep -r "csp\\|ContentSecurityPolicy" . --include="vite.config.*" --include="webpack.config.*"
+\`\`\`
+
+### Step 2: Modify CSP for Debugging
+
+**Option A: HTML Meta Tag**
+\`\`\`html
+<!-- Find and modify connect-src to include localhost -->
+<meta http-equiv="Content-Security-Policy" 
+      content="default-src 'self'; connect-src 'self' localhost:* http://localhost:* ws://localhost:*">
+\`\`\`
+
+**Option B: Next.js (next.config.js)**
+\`\`\`javascript
+// Add to headers() function
+async headers() {
+  const isDev = process.env.NODE_ENV === 'development';
+  return [{
+    source: '/:path*',
+    headers: [{
+      key: isDev ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy',
+      value: isDev 
+        ? "default-src 'self'; connect-src 'self' localhost:* http://localhost:* ws://localhost:*; script-src 'self' 'unsafe-eval'"
+        : "default-src 'self'; connect-src 'self' api.example.com"
+    }]
+  }];
+}
+\`\`\`
+
+**Option C: Express/Helmet**
+\`\`\`javascript
+const helmet = require('helmet');
+const isDev = process.env.NODE_ENV === 'development';
+
+app.use(helmet.contentSecurityPolicy({
+  reportOnly: isDev, // Report violations but don't block in dev
+  directives: {
+    defaultSrc: ["'self'"],
+    connectSrc: isDev 
+      ? ["'self'", "localhost:*", "http://localhost:*", "ws://localhost:*"]
+      : ["'self'", "api.example.com"],
+    scriptSrc: isDev 
+      ? ["'self'", "'unsafe-eval'"] // unsafe-eval needed for DevTools console
+      : ["'self'"]
+  }
+}));
+\`\`\`
+
+**Option D: Nginx**
+\`\`\`nginx
+# In development server block
+add_header Content-Security-Policy-Report-Only 
+    "default-src 'self'; connect-src 'self' localhost:* http://localhost:* ws://localhost:*";
+\`\`\`
+
+### Step 3: Verify CSP Changes
+
+After modifying CSP:
+
+1. **Check browser console** for CSP violation messages (should disappear)
+2. **Test debug server connection**:
+   \`\`\`javascript
+   // Run in browser console
+   fetch('http://localhost:7777/health')
+     .then(r => r.json())
+     .then(console.log)
+     .catch(e => console.error('CSP still blocking:', e));
+   \`\`\`
+3. **Monitor violations programmatically** (optional):
+   \`\`\`javascript
+   document.addEventListener('securitypolicyviolation', (e) => {
+     console.warn('CSP Violation:', {
+       blockedURI: e.blockedURI,
+       violatedDirective: e.violatedDirective
+     });
+   });
+   \`\`\`
+
+### Step 4: Restore CSP After Debugging
+
+**CRITICAL**: Revert CSP changes before committing!
+
+\`\`\`bash
+# Check for CSP modifications in staged files
+git diff --cached | grep -E "Content-Security-Policy|contentSecurityPolicy|helmet|connect-src"
+\`\`\`
+
+If you used environment-based CSP (Options B, C above), changes are safe to commit as they only affect development mode.
+
+### Browser Extension Alternative (Last Resort)
+
+If modifying source code is not feasible, use a browser extension like [Requestly](https://requestly.io/) to override CSP headers locally:
+
+1. Install Requestly browser extension
+2. Create "Modify Headers" rule:
+   - **URL Pattern**: Your app's URL
+   - **Header**: Content-Security-Policy
+   - **Action**: Remove or modify to allow localhost
+
+**WARNING**: Only use for local debugging. Never rely on extensions in production testing.
+
+### CSP Directives Reference
+
+| Directive | Controls | Debug Value |
+|-----------|----------|-------------|
+| \`connect-src\` | fetch, XHR, WebSocket | \`'self' localhost:* http://localhost:* ws://localhost:*\` |
+| \`script-src\` | Script execution | \`'self' 'unsafe-eval'\` (for DevTools console) |
+| \`default-src\` | Fallback for all | \`'self' localhost:*\` |
+
 ## Quick Reference
 
 | Action | Command |

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -1838,12 +1838,41 @@ Each log entry is a JSON object on its own line:
 | level | string | No | Log level: debug, info, warn, error (default: info) |
 | timestamp | number | No | Unix ms timestamp (server adds if missing) |
 
+## Region Markers for Instrumentation
+
+**CRITICAL**: ALL debug instrumentation MUST be wrapped with region markers for systematic removal.
+
+### Region Marker Format
+
+| Language | Start Marker | End Marker |
+|----------|--------------|------------|
+| JavaScript/TypeScript | \`// @DEBUG:START\` | \`// @DEBUG:END\` |
+| Python | \`# @DEBUG:START\` | \`# @DEBUG:END\` |
+| Go | \`// @DEBUG:START\` | \`// @DEBUG:END\` |
+| Rust | \`// @DEBUG:START\` | \`// @DEBUG:END\` |
+| Ruby | \`# @DEBUG:START\` | \`# @DEBUG:END\` |
+| Java/Kotlin | \`// @DEBUG:START\` | \`// @DEBUG:END\` |
+| C/C++ | \`// @DEBUG:START\` | \`// @DEBUG:END\` |
+| Shell/Bash | \`# @DEBUG:START\` | \`# @DEBUG:END\` |
+| HTML | \`<!-- @DEBUG:START -->\` | \`<!-- @DEBUG:END -->\` |
+| CSS | \`/* @DEBUG:START */\` | \`/* @DEBUG:END */\` |
+
+### Find All Debug Regions
+
+\`\`\`bash
+# Find all files with debug instrumentation
+grep -rn "@DEBUG:START" . --include="*.ts" --include="*.js" --include="*.py" --include="*.go"
+
+# Count debug regions
+grep -c "@DEBUG:START" . -r --include="*.ts" --include="*.js" --include="*.py" --include="*.go" 2>/dev/null | grep -v ":0$"
+\`\`\`
+
 ## Instrumentation Functions
 
 ### JavaScript/TypeScript
 
 \`\`\`typescript
-// Add to instrumented file or a shared utils file
+// @DEBUG:START - Debug logging utility
 async function __debugLog(
   hypothesisId: string,
   label: string,
@@ -1870,16 +1899,23 @@ async function __debugLog(
     // Silent fail - don't break app if debug server is down
   }
 }
+// @DEBUG:END
 
-// Usage examples:
+// Usage examples (wrap each instrumentation block):
+// @DEBUG:START - Hypothesis A: async timing
 await __debugLog("A", "fn-entry", "src/api.ts:42", "processOrder called", { orderId: 123 });
+// @DEBUG:END
+
+// @DEBUG:START - Hypothesis A: state tracking
 await __debugLog("A", "state-change", "src/api.ts:55", "Order status updated", { from: "pending", to: "processing" });
 await __debugLog("A", "fn-exit", "src/api.ts:78", "processOrder completed", { result: "success" });
+// @DEBUG:END
 \`\`\`
 
 ### Python
 
 \`\`\`python
+# @DEBUG:START - Debug logging utility
 import requests
 import time
 from typing import Any, Optional
@@ -1909,14 +1945,18 @@ def debug_log(
         )
     except Exception:
         pass  # Silent fail
+# @DEBUG:END
 
-# Usage:
+# Usage (wrap each instrumentation block):
+# @DEBUG:START - Hypothesis A
 debug_log("A", "fn-entry", "api.py:42", "process_order called", {"order_id": 123})
+# @DEBUG:END
 \`\`\`
 
 ### Go
 
 \`\`\`go
+// @DEBUG:START - Debug logging utility
 package debug
 
 import (
@@ -1950,9 +1990,12 @@ func DebugLog(hypothesisID, label, location, message string, data map[string]int
     client := &http.Client{Timeout: time.Second}
     client.Post("http://localhost:7777/ingest", "application/json", bytes.NewReader(body))
 }
+// @DEBUG:END
 
-// Usage:
+// Usage (wrap each instrumentation block):
+// @DEBUG:START - Hypothesis A
 // debug.DebugLog("A", "fn-entry", "api.go:42", "ProcessOrder called", map[string]interface{}{"orderID": 123})
+// @DEBUG:END
 \`\`\`
 
 ## 7-Step Debugging Workflow
@@ -1977,6 +2020,15 @@ For each hypothesis, identify:
 - What sequence of events would confirm/refute the hypothesis
 
 ### Step 4: Add Instrumentation
+
+**CRITICAL: Always wrap instrumentation with region markers!**
+
+\`\`\`typescript
+// @DEBUG:START - Hypothesis A: [description]
+await __debugLog("A", "fn-entry", "src/api.ts:42", "processOrder called", { orderId });
+// @DEBUG:END
+\`\`\`
+
 Insert \`__debugLog\` / \`debug_log\` / \`DebugLog\` calls at strategic points:
 - Function entry/exit
 - State changes
@@ -1985,6 +2037,7 @@ Insert \`__debugLog\` / \`debug_log\` / \`DebugLog\` calls at strategic points:
 - Branch points
 
 **Keep instrumentation minimal and targeted.** Don't log everything.
+**Every debug block MUST have \`@DEBUG:START\` and \`@DEBUG:END\` markers.**
 
 ### Step 5: Reproduce the Issue
 1. Ensure debug server is running
@@ -2029,7 +2082,20 @@ Look for:
 
 After debugging is complete:
 
-1. **Remove instrumentation code** from all modified files
+1. **Remove instrumentation code systematically using region markers**:
+   \`\`\`bash
+   # Step 1: Find all files with debug instrumentation
+   grep -rn "@DEBUG:START" . --include="*.ts" --include="*.js" --include="*.tsx" --include="*.jsx" --include="*.py" --include="*.go" --include="*.rs" --include="*.rb" --include="*.java" --include="*.kt"
+   
+   # Step 2: For each file, remove all content between @DEBUG:START and @DEBUG:END (inclusive)
+   # The agent should open each file and delete the marked regions
+   \`\`\`
+   
+   **Systematic removal process:**
+   - Search for \`@DEBUG:START\` in all source files
+   - For each match, delete from \`@DEBUG:START\` line through \`@DEBUG:END\` line (inclusive)
+   - Verify no \`@DEBUG\` markers remain: \`grep -r "@DEBUG:" . --include="*.ts" --include="*.js" --include="*.py" --include="*.go"\`
+
 2. **Revert any CSP changes** (if you modified CSP for frontend debugging):
    \`\`\`bash
    # Check for CSP modifications
@@ -2040,6 +2106,11 @@ After debugging is complete:
 4. **Delete debug artifacts**:
    \`\`\`bash
    rm -rf .opencode/debug/
+   \`\`\`
+5. **Final verification**:
+   \`\`\`bash
+   # Ensure no debug markers remain
+   grep -r "@DEBUG:" . --include="*.ts" --include="*.js" --include="*.py" --include="*.go" && echo "WARNING: Debug markers still present!" || echo "✓ All debug instrumentation removed"
    \`\`\`
 
 ## Git Safety
@@ -2053,6 +2124,8 @@ Add to \`.gitignore\`:
 
 Before committing, verify:
 \`\`\`bash
+# Check for any remaining debug code
+grep -r "@DEBUG:" . --include="*.ts" --include="*.js" --include="*.py" --include="*.go"
 git status | grep -E "debug|__debugLog|debug_log"
 \`\`\`
 
@@ -2207,6 +2280,8 @@ If modifying source code is not feasible, use a browser extension like [Requestl
 | Check server | \`curl http://localhost:7777/health\` |
 | **Clear logs (before each run)** | \`> .opencode/debug/debug.log\` |
 | View logs | \`cat .opencode/debug/debug.log \\| jq .\` |
+| **Find debug regions** | \`grep -rn "@DEBUG:START" . --include="*.ts" --include="*.js" --include="*.py" --include="*.go"\` |
+| **Verify cleanup** | \`grep -r "@DEBUG:" . --include="*.ts" --include="*.js" --include="*.py" --include="*.go"\` |
 | Stop server | \`pkill -f "node .opencode/debug/server.js"\` |
 | Check CSP changes | \`git diff \\| grep -E "Content-Security-Policy\\|connect-src"\` |
 | **Full cleanup** | \`pkill -f "node .opencode/debug/server.js"; rm -rf .opencode/debug/\` |

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -1716,6 +1716,351 @@ EOF
 \`\`\``,
 }
 
+const runtimeDebuggingSkill: BuiltinSkill = {
+  name: "runtime-debugging",
+  description:
+    "Debug runtime issues with hypothesis-driven instrumentation. Use for async issues, state problems, race conditions.",
+  template: `# Runtime Debugging Skill
+
+Debug runtime issues systematically using hypothesis-driven instrumentation and a lightweight debug server.
+
+## Overview
+
+This skill helps you debug runtime issues (async problems, state corruption, race conditions) by:
+1. Forming hypotheses about what's wrong
+2. Adding targeted instrumentation to verify/refute hypotheses
+3. Analyzing logs to find root cause
+4. Fixing and verifying the fix
+
+## Debug Server Contract
+
+Create \`.opencode/debug/server.js\` with this content:
+
+\`\`\`javascript
+// Debug Server - Port 7777 (or pass custom port as CLI arg)
+// Usage: node .opencode/debug/server.js [port]
+// Requires: Node.js (or Bun)
+
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const PORT = parseInt(process.argv[2]) || 7777;
+const LOG_DIR = path.join(process.cwd(), ".opencode", "debug");
+const LOG_FILE = path.join(LOG_DIR, "debug.log");
+
+// Ensure log directory exists
+if (!fs.existsSync(LOG_DIR)) {
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+}
+
+const server = http.createServer((req, res) => {
+  // CORS headers
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (req.method === "GET" && req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok", port: PORT }));
+    return;
+  }
+
+  if (req.method === "POST" && req.url === "/ingest") {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      try {
+        const entry = JSON.parse(body);
+        // Add server timestamp if not present
+        if (!entry.timestamp) {
+          entry.timestamp = Date.now();
+        }
+        // Append as NDJSON
+        fs.appendFileSync(LOG_FILE, JSON.stringify(entry) + "\\n");
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ success: true }));
+      } catch (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Invalid JSON" }));
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404);
+  res.end("Not Found");
+});
+
+server.listen(PORT, () => {
+  console.log(\\\`Debug server listening on http://localhost:\\\${PORT}\\\`);
+  console.log(\\\`Log file: \\\${LOG_FILE}\\\`);
+  console.log("Endpoints:");
+  console.log("  POST /ingest - Send debug log entries");
+  console.log("  GET /health  - Health check");
+});
+\`\`\`
+
+**Start the server:**
+\`\`\`bash
+mkdir -p .opencode/debug && node .opencode/debug/server.js &
+\`\`\`
+
+## NDJSON Log Entry Schema
+
+Each log entry is a JSON object on its own line:
+
+\`\`\`json
+{
+  "hypothesisId": "A",
+  "label": "fn-entry",
+  "location": "src/api.ts:42",
+  "message": "Function called",
+  "data": { "arg1": 123, "arg2": "test" },
+  "level": "info",
+  "timestamp": 1704067925123
+}
+\`\`\`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| hypothesisId | string | Yes | Links log to hypothesis (A, B, C...) |
+| label | string | Yes | Semantic label (fn-entry, fn-exit, state-change, error, checkpoint) |
+| location | string | Yes | Source location (file:line) |
+| message | string | Yes | Human-readable description |
+| data | object | No | Arbitrary payload (args, state, etc.) |
+| level | string | No | Log level: debug, info, warn, error (default: info) |
+| timestamp | number | No | Unix ms timestamp (server adds if missing) |
+
+## Instrumentation Functions
+
+### JavaScript/TypeScript
+
+\`\`\`typescript
+// Add to instrumented file or a shared utils file
+async function __debugLog(
+  hypothesisId: string,
+  label: string,
+  location: string,
+  message: string,
+  data?: Record<string, unknown>,
+  level: string = "info"
+): Promise<void> {
+  try {
+    await fetch("http://localhost:7777/ingest", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        hypothesisId,
+        label,
+        location,
+        message,
+        data,
+        level,
+        timestamp: Date.now(),
+      }),
+    });
+  } catch {
+    // Silent fail - don't break app if debug server is down
+  }
+}
+
+// Usage examples:
+await __debugLog("A", "fn-entry", "src/api.ts:42", "processOrder called", { orderId: 123 });
+await __debugLog("A", "state-change", "src/api.ts:55", "Order status updated", { from: "pending", to: "processing" });
+await __debugLog("A", "fn-exit", "src/api.ts:78", "processOrder completed", { result: "success" });
+\`\`\`
+
+### Python
+
+\`\`\`python
+import requests
+import time
+from typing import Any, Optional
+
+def debug_log(
+    hypothesis_id: str,
+    label: str,
+    location: str,
+    message: str,
+    data: Optional[dict[str, Any]] = None,
+    level: str = "info"
+) -> None:
+    """Send debug log entry to debug server."""
+    try:
+        requests.post(
+            "http://localhost:7777/ingest",
+            json={
+                "hypothesisId": hypothesis_id,
+                "label": label,
+                "location": location,
+                "message": message,
+                "data": data,
+                "level": level,
+                "timestamp": int(time.time() * 1000),
+            },
+            timeout=1,
+        )
+    except Exception:
+        pass  # Silent fail
+
+# Usage:
+debug_log("A", "fn-entry", "api.py:42", "process_order called", {"order_id": 123})
+\`\`\`
+
+### Go
+
+\`\`\`go
+package debug
+
+import (
+    "bytes"
+    "encoding/json"
+    "net/http"
+    "time"
+)
+
+type LogEntry struct {
+    HypothesisID string                 \\\`json:"hypothesisId"\\\`
+    Label        string                 \\\`json:"label"\\\`
+    Location     string                 \\\`json:"location"\\\`
+    Message      string                 \\\`json:"message"\\\`
+    Data         map[string]interface{} \\\`json:"data,omitempty"\\\`
+    Level        string                 \\\`json:"level"\\\`
+    Timestamp    int64                  \\\`json:"timestamp"\\\`
+}
+
+func DebugLog(hypothesisID, label, location, message string, data map[string]interface{}) {
+    entry := LogEntry{
+        HypothesisID: hypothesisID,
+        Label:        label,
+        Location:     location,
+        Message:      message,
+        Data:         data,
+        Level:        "info",
+        Timestamp:    time.Now().UnixMilli(),
+    }
+    body, _ := json.Marshal(entry)
+    client := &http.Client{Timeout: time.Second}
+    client.Post("http://localhost:7777/ingest", "application/json", bytes.NewReader(body))
+}
+
+// Usage:
+// debug.DebugLog("A", "fn-entry", "api.go:42", "ProcessOrder called", map[string]interface{}{"orderID": 123})
+\`\`\`
+
+## 7-Step Debugging Workflow
+
+### Step 1: Describe the Problem
+Clearly articulate:
+- What behavior is expected?
+- What behavior is observed?
+- When does it happen? (Always? Sometimes? Under specific conditions?)
+- Any error messages or symptoms?
+
+### Step 2: Form Hypotheses
+List 2-4 possible causes, labeled A, B, C, etc.:
+- **Hypothesis A**: "The async callback fires before state is initialized"
+- **Hypothesis B**: "Race condition between two concurrent requests"
+- **Hypothesis C**: "Stale closure captures old state value"
+
+### Step 3: Design Instrumentation
+For each hypothesis, identify:
+- What code paths to instrument
+- What data to capture
+- What sequence of events would confirm/refute the hypothesis
+
+### Step 4: Add Instrumentation
+Insert \`__debugLog\` / \`debug_log\` / \`DebugLog\` calls at strategic points:
+- Function entry/exit
+- State changes
+- Async boundaries (before/after await, callback entry)
+- Error handlers
+- Branch points
+
+**Keep instrumentation minimal and targeted.** Don't log everything.
+
+### Step 5: Reproduce the Issue
+1. Ensure debug server is running
+2. Clear previous logs: \`> .opencode/debug/debug.log\`
+3. Trigger the problematic behavior
+4. Collect logs
+
+### Step 6: Analyze Logs
+\`\`\`bash
+# View all logs
+cat .opencode/debug/debug.log | jq .
+
+# Filter by hypothesis
+cat .opencode/debug/debug.log | jq 'select(.hypothesisId == "A")'
+
+# View timeline
+cat .opencode/debug/debug.log | jq -r '[.timestamp, .hypothesisId, .label, .message] | @tsv' | sort -n
+
+# Find errors
+cat .opencode/debug/debug.log | jq 'select(.level == "error")'
+\`\`\`
+
+Look for:
+- Unexpected ordering of events
+- Missing expected log entries
+- Unexpected data values
+- Timing gaps
+
+### Step 7: Fix and Verify
+1. Implement the fix based on findings
+2. Keep instrumentation in place
+3. Reproduce the scenario
+4. Verify logs show correct behavior
+5. Remove instrumentation
+6. Run full test suite
+
+## Cleanup Instructions
+
+After debugging is complete:
+
+1. **Remove instrumentation code** from all modified files
+2. **Stop the debug server**: \`pkill -f "node .opencode/debug/server.js"\`
+3. **Delete debug artifacts**:
+   \`\`\`bash
+   rm -rf .opencode/debug/
+   \`\`\`
+
+## Git Safety
+
+**IMPORTANT**: Never commit debug artifacts!
+
+Add to \`.gitignore\`:
+\`\`\`
+.opencode/debug/
+\`\`\`
+
+Before committing, verify:
+\`\`\`bash
+git status | grep -E "debug|__debugLog|debug_log"
+\`\`\`
+
+If you see any debug-related changes, remove them before committing.
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Start server | \`node .opencode/debug/server.js &\` |
+| Check server | \`curl http://localhost:7777/health\` |
+| Clear logs | \`> .opencode/debug/debug.log\` |
+| View logs | \`cat .opencode/debug/debug.log \\| jq .\` |
+| Stop server | \`pkill -f "node .opencode/debug/server.js"\` |
+| Cleanup | \`rm -rf .opencode/debug/\` |
+`,
+}
+
 export interface CreateBuiltinSkillsOptions {
   browserProvider?: BrowserAutomationProvider
 }
@@ -1725,5 +2070,5 @@ export function createBuiltinSkills(options: CreateBuiltinSkillsOptions = {}): B
 
   const browserSkill = browserProvider === "agent-browser" ? agentBrowserSkill : playwrightSkill
 
-  return [browserSkill, frontendUiUxSkill, gitMasterSkill, devBrowserSkill]
+  return [browserSkill, frontendUiUxSkill, gitMasterSkill, devBrowserSkill, runtimeDebuggingSkill]
 }

--- a/src/hooks/keyword-detector/constants.ts
+++ b/src/hooks/keyword-detector/constants.ts
@@ -298,7 +298,7 @@ NEVER stop at first result - be exhaustive.`,
   // ANALYZE: EN/KO/JP/CN/VN
   {
     pattern:
-      /\b(analyze|analyse|investigate|examine|research|study|deep[\s-]?dive|inspect|audit|evaluate|assess|review|diagnose|scrutinize|dissect|debug|comprehend|interpret|breakdown|understand)\b|why\s+is|how\s+does|how\s+to|분석|조사|파악|연구|검토|진단|이해|설명|원인|이유|뜯어봐|따져봐|평가|해석|디버깅|디버그|어떻게|왜|살펴|分析|調査|解析|検討|研究|診断|理解|説明|検証|精査|究明|デバッグ|なぜ|どう|仕組み|调查|检查|剖析|深入|诊断|解释|调试|为什么|原理|搞清楚|弄明白|phân tích|điều tra|nghiên cứu|kiểm tra|xem xét|chẩn đoán|giải thích|tìm hiểu|gỡ lỗi|tại sao/i,
+      /\b(analyze|analyse|investigate|examine|research|study|deep[\s-]?dive|inspect|audit|evaluate|assess|review|diagnose|scrutinize|dissect|comprehend|interpret|breakdown|understand)\b|why\s+is|how\s+does|how\s+to|분석|조사|파악|연구|검토|진단|이해|설명|원인|이유|뜯어봐|따져봐|평가|해석|어떻게|왜|살펴|分析|調査|解析|検討|研究|診断|理解|説明|検証|精査|究明|なぜ|どう|仕組み|调查|检查|剖析|深入|诊断|解释|为什么|原理|搞清楚|弄明白|phân tích|điều tra|nghiên cứu|kiểm tra|xem xét|chẩn đoán|giải thích|tìm hiểu|tại sao/i,
     message: `[analyze-mode]
 ANALYSIS MODE. Gather context before diving deep:
 
@@ -311,5 +311,18 @@ IF COMPLEX (architecture, multi-system, debugging after 2+ failures):
 - Consult oracle for strategic guidance
 
 SYNTHESIZE findings before proceeding.`,
+  },
+  // DEBUG (index 3)
+  {
+    pattern: /\b(debug|debugging|debugger|breakpoint)\b|디버그|デバッグ|调试|gỡ lỗi/i,
+    message: `[debug-mode]
+DEBUG MODE. Use /debug command or follow runtime-debugging skill:
+1. Describe the bug
+2. Generate hypotheses
+3. Instrument code
+4. Reproduce issue
+5. Analyze logs
+6. Fix based on evidence
+7. Verify and cleanup`,
   },
 ]

--- a/src/hooks/keyword-detector/detector.test.ts
+++ b/src/hooks/keyword-detector/detector.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "bun:test"
+import { detectKeywordsWithType } from "./detector"
+import { KEYWORD_DETECTORS } from "./constants"
+
+describe("detectKeywordsWithType", () => {
+  test("types array length matches KEYWORD_DETECTORS length (sync check)", () => {
+    // #given - various keyword inputs
+    const ultraworkResult = detectKeywordsWithType("ultrawork")
+    const searchResult = detectKeywordsWithType("search for")
+    const analyzeResult = detectKeywordsWithType("analyze this")
+    const debugResult = detectKeywordsWithType("debug this")
+
+    // #then - each keyword type is detected correctly
+    expect(ultraworkResult).toHaveLength(1)
+    expect(ultraworkResult[0].type).toBe("ultrawork")
+
+    expect(searchResult).toHaveLength(1)
+    expect(searchResult[0].type).toBe("search")
+
+    expect(analyzeResult).toHaveLength(1)
+    expect(analyzeResult[0].type).toBe("analyze")
+
+    expect(debugResult).toHaveLength(1)
+    expect(debugResult[0].type).toBe("debug")
+
+    expect(KEYWORD_DETECTORS.length).toBe(4)
+  })
+
+  test("'debug' triggers debug-mode only, not analyze-mode", () => {
+    // #given - input with debug keyword
+    const result = detectKeywordsWithType("debug this issue")
+
+    // #then - only debug-mode is triggered
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe("debug")
+    expect(result[0].message).toContain("[debug-mode]")
+  })
+
+  test("'analyze' triggers analyze-mode only, not debug-mode", () => {
+    // #given - input with analyze keyword
+    const result = detectKeywordsWithType("analyze the performance")
+
+    // #then - only analyze-mode is triggered
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe("analyze")
+    expect(result[0].message).toContain("[analyze-mode]")
+  })
+
+  test("multilingual debug keywords trigger debug-mode", () => {
+    // #given - multilingual debug keywords
+    for (const word of ["디버그", "デバッグ", "调试", "gỡ lỗi"]) {
+      // #when - detecting keywords
+      const result = detectKeywordsWithType(word)
+
+      // #then - debug-mode is triggered
+      expect(result.some(r => r.type === "debug")).toBe(true)
+    }
+  })
+})

--- a/src/hooks/keyword-detector/detector.ts
+++ b/src/hooks/keyword-detector/detector.ts
@@ -5,7 +5,7 @@ import {
 } from "./constants"
 
 export interface DetectedKeyword {
-  type: "ultrawork" | "search" | "analyze"
+  type: "ultrawork" | "search" | "analyze" | "debug"
   message: string
 }
 
@@ -32,7 +32,7 @@ export function detectKeywords(text: string, agentName?: string): string[] {
 
 export function detectKeywordsWithType(text: string, agentName?: string): DetectedKeyword[] {
   const textWithoutCode = removeCodeBlocks(text)
-  const types: Array<"ultrawork" | "search" | "analyze"> = ["ultrawork", "search", "analyze"]
+  const types: Array<"ultrawork" | "search" | "analyze" | "debug"> = ["ultrawork", "search", "analyze", "debug"]
   return KEYWORD_DETECTORS.map(({ pattern, message }, index) => ({
     matches: pattern.test(textWithoutCode),
     type: types[index],

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -539,3 +539,128 @@ describe("keyword-detector agent-specific ultrawork messages", () => {
     expect(textPart!.text).toContain("plan this")
   })
 })
+
+describe("keyword-detector debug keyword detection", () => {
+  let logCalls: Array<{ msg: string; data?: unknown }>
+  let logSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    _resetForTesting()
+    logCalls = []
+    logSpy = spyOn(sharedModule, "log").mockImplementation((msg: string, data?: unknown) => {
+      logCalls.push({ msg, data })
+    })
+  })
+
+  afterEach(() => {
+    logSpy?.mockRestore()
+  })
+
+  function createMockPluginInput() {
+    return {
+      client: {
+        tui: {
+          showToast: async () => {},
+        },
+      },
+    } as any
+  }
+
+  test("should prepend debug message to text part", async () => {
+    // #given - a fresh ContextCollector and keyword-detector hook
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "test-session-debug"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "debug this issue" }],
+    }
+
+    // #when - keyword detection runs
+    await hook["chat.message"]({ sessionID }, output)
+
+    // #then - debug message should be prepended to text part
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("[debug-mode]")
+    expect(textPart!.text).toContain("---")
+    expect(textPart!.text).toContain("this issue")
+  })
+
+  test("should detect 'debugging' keyword", async () => {
+    // #given - text with 'debugging' keyword
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "test-session-debugging"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "I'm debugging the application" }],
+    }
+
+    // #when - keyword detection runs
+    await hook["chat.message"]({ sessionID }, output)
+
+    // #then - debug message should be prepended
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("[debug-mode]")
+  })
+
+  test("should detect 'breakpoint' keyword", async () => {
+    // #given - text with 'breakpoint' keyword
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "test-session-breakpoint"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "set a breakpoint here" }],
+    }
+
+    // #when - keyword detection runs
+    await hook["chat.message"]({ sessionID }, output)
+
+    // #then - debug message should be prepended
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("[debug-mode]")
+  })
+
+  test("should detect Korean debug keyword '디버그'", async () => {
+    // #given - text with Korean debug keyword
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "test-session-korean-debug"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "디버그 해줘" }],
+    }
+
+    // #when - keyword detection runs
+    await hook["chat.message"]({ sessionID }, output)
+
+    // #then - debug message should be prepended
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("[debug-mode]")
+  })
+
+  test("should NOT trigger analyze-mode for 'debug' keyword", async () => {
+    // #given - text with only 'debug' keyword
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "test-session-debug-only"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "debug this code" }],
+    }
+
+    // #when - keyword detection runs
+    await hook["chat.message"]({ sessionID }, output)
+
+    // #then - only debug-mode should be triggered, not analyze-mode
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toContain("[debug-mode]")
+    expect(textPart!.text).not.toContain("[analyze-mode]")
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Cursor-style Debug Mode for hypothesis-driven runtime debugging with lightweight instrumentation and a local NDJSON log server. Adds frontend CSP guidance to enable localhost logging during browser debugging.

- New Features
  - /debug command with a 7-step workflow and guided template.
  - runtime-debugging skill with server code (port 7777), NDJSON schema, JS/TS/Python/Go instrumentation, region markers for cleanup, and verification steps.
  - CSP detection and handling instructions for frontend debugging.
  - Keyword detection for debug terms (English, Korean, Japanese, Chinese, Vietnamese) that injects a [debug-mode] message.
  - .gitignore updated to exclude .opencode/debug/.
  - 37 tests added/updated across commands, skills, and keyword detector; all passing.

<sup>Written for commit 165e673268e54058bf0d746e8f394689f204ee4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



