### PR TITLE
refactor(tmux-subagent): state-first architecture with decision engine

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -71,6 +71,7 @@
           "interactive-bash-session",
           "thinking-block-validator",
           "ralph-loop",
+          "category-skill-reminder",
           "compaction-context-injector",
           "claude-code-hooks",
           "auto-slash-command",
@@ -2210,6 +2211,16 @@
           "type": "number",
           "minimum": 20,
           "maximum": 80
+        },
+        "main_pane_min_width": {
+          "default": 120,
+          "type": "number",
+          "minimum": 40
+        },
+        "agent_pane_min_width": {
+          "default": 40,
+          "type": "number",
+          "minimum": 20
         }
       }
     }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -320,9 +320,11 @@ export const TmuxLayoutSchema = z.enum([
 ])
 
 export const TmuxConfigSchema = z.object({
-  enabled: z.boolean().default(false),           // default: false (disabled)
-  layout: TmuxLayoutSchema.default('main-vertical'),  // default: main-vertical
-  main_pane_size: z.number().min(20).max(80).default(60),  // percentage, default: 60%
+  enabled: z.boolean().default(false),
+  layout: TmuxLayoutSchema.default('main-vertical'),
+  main_pane_size: z.number().min(20).max(80).default(60),
+  main_pane_min_width: z.number().min(40).default(120),
+  agent_pane_min_width: z.number().min(20).default(40),
 })
 export const OhMyOpenCodeConfigSchema = z.object({
   $schema: z.string().optional(),

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -776,7 +776,7 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
       parentModel: { providerID: "old", modelID: "old-model" },
     }
     const currentMessage: CurrentMessage = {
-      agent: "Sisyphus",
+      agent: "sisyphus",
       model: { providerID: "anthropic", modelID: "claude-opus-4-5" },
     }
 
@@ -784,7 +784,7 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
     const promptBody = buildNotificationPromptBody(task, currentMessage)
 
     // #then - uses currentMessage values, not task.parentModel/parentAgent
-    expect(promptBody.agent).toBe("Sisyphus")
+    expect(promptBody.agent).toBe("sisyphus")
     expect(promptBody.model).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-5" })
   })
 
@@ -827,11 +827,11 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-      parentAgent: "Sisyphus",
+      parentAgent: "sisyphus",
       parentModel: { providerID: "anthropic", modelID: "claude-opus" },
     }
     const currentMessage: CurrentMessage = {
-      agent: "Sisyphus",
+      agent: "sisyphus",
       model: { providerID: "anthropic" },
     }
 
@@ -839,7 +839,7 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
     const promptBody = buildNotificationPromptBody(task, currentMessage)
 
     // #then - model not passed due to incomplete data
-    expect(promptBody.agent).toBe("Sisyphus")
+    expect(promptBody.agent).toBe("sisyphus")
     expect("model" in promptBody).toBe(false)
   })
 
@@ -856,7 +856,7 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-      parentAgent: "Sisyphus",
+      parentAgent: "sisyphus",
       parentModel: { providerID: "anthropic", modelID: "claude-opus" },
     }
 
@@ -864,7 +864,7 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
     const promptBody = buildNotificationPromptBody(task, null)
 
     // #then - falls back to task.parentAgent, no model
-    expect(promptBody.agent).toBe("Sisyphus")
+    expect(promptBody.agent).toBe("sisyphus")
     expect("model" in promptBody).toBe(false)
   })
 })

--- a/src/features/tmux-subagent/action-executor.ts
+++ b/src/features/tmux-subagent/action-executor.ts
@@ -1,0 +1,66 @@
+import type { TmuxConfig } from "../../config/schema"
+import type { PaneAction } from "./types"
+import { spawnTmuxPane, closeTmuxPane } from "../../shared/tmux"
+import { log } from "../../shared"
+
+export interface ActionResult {
+  success: boolean
+  paneId?: string
+  error?: string
+}
+
+export interface ExecuteActionsResult {
+  success: boolean
+  spawnedPaneId?: string
+  results: Array<{ action: PaneAction; result: ActionResult }>
+}
+
+export async function executeAction(
+  action: PaneAction,
+  config: TmuxConfig,
+  serverUrl: string
+): Promise<ActionResult> {
+  if (action.type === "close") {
+    const success = await closeTmuxPane(action.paneId)
+    return { success }
+  }
+
+  const result = await spawnTmuxPane(
+    action.sessionId,
+    action.description,
+    config,
+    serverUrl,
+    action.targetPaneId
+  )
+
+  return {
+    success: result.success,
+    paneId: result.paneId,
+  }
+}
+
+export async function executeActions(
+  actions: PaneAction[],
+  config: TmuxConfig,
+  serverUrl: string
+): Promise<ExecuteActionsResult> {
+  const results: Array<{ action: PaneAction; result: ActionResult }> = []
+  let spawnedPaneId: string | undefined
+
+  for (const action of actions) {
+    log("[action-executor] executing", { type: action.type })
+    const result = await executeAction(action, config, serverUrl)
+    results.push({ action, result })
+
+    if (!result.success) {
+      log("[action-executor] action failed", { type: action.type, error: result.error })
+      return { success: false, results }
+    }
+
+    if (action.type === "spawn" && result.paneId) {
+      spawnedPaneId = result.paneId
+    }
+  }
+
+  return { success: true, spawnedPaneId, results }
+}

--- a/src/features/tmux-subagent/decision-engine.ts
+++ b/src/features/tmux-subagent/decision-engine.ts
@@ -1,0 +1,130 @@
+import type { WindowState, PaneAction, SpawnDecision, CapacityConfig } from "./types"
+
+export interface SessionMapping {
+  sessionId: string
+  paneId: string
+  createdAt: Date
+}
+
+export function calculateCapacity(
+  windowWidth: number,
+  config: CapacityConfig
+): number {
+  const availableForAgents = windowWidth - config.mainPaneMinWidth
+  if (availableForAgents <= 0) return 0
+  return Math.floor(availableForAgents / config.agentPaneWidth)
+}
+
+function calculateAvailableWidth(
+  windowWidth: number,
+  mainPaneMinWidth: number,
+  agentPaneCount: number,
+  agentPaneWidth: number
+): number {
+  const usedByAgents = agentPaneCount * agentPaneWidth
+  return windowWidth - mainPaneMinWidth - usedByAgents
+}
+
+function findOldestSession(mappings: SessionMapping[]): SessionMapping | null {
+  if (mappings.length === 0) return null
+  return mappings.reduce((oldest, current) =>
+    current.createdAt < oldest.createdAt ? current : oldest
+  )
+}
+
+function getRightmostPane(state: WindowState): string {
+  if (state.agentPanes.length > 0) {
+    const rightmost = state.agentPanes.reduce((r, p) => (p.left > r.left ? p : r))
+    return rightmost.paneId
+  }
+  return state.mainPane?.paneId ?? ""
+}
+
+export function decideSpawnActions(
+  state: WindowState,
+  sessionId: string,
+  description: string,
+  config: CapacityConfig,
+  sessionMappings: SessionMapping[]
+): SpawnDecision {
+  if (!state.mainPane) {
+    return { canSpawn: false, actions: [], reason: "no main pane found" }
+  }
+
+  const availableWidth = calculateAvailableWidth(
+    state.windowWidth,
+    config.mainPaneMinWidth,
+    state.agentPanes.length,
+    config.agentPaneWidth
+  )
+
+  if (availableWidth >= config.agentPaneWidth) {
+    const targetPaneId = getRightmostPane(state)
+    return {
+      canSpawn: true,
+      actions: [
+        {
+          type: "spawn",
+          sessionId,
+          description,
+          targetPaneId,
+        },
+      ],
+    }
+  }
+
+  if (state.agentPanes.length > 0) {
+    const oldest = findOldestSession(sessionMappings)
+    
+    if (oldest) {
+      return {
+        canSpawn: true,
+        actions: [
+          { type: "close", paneId: oldest.paneId, sessionId: oldest.sessionId },
+          {
+            type: "spawn",
+            sessionId,
+            description,
+            targetPaneId: state.mainPane.paneId,
+          },
+        ],
+        reason: "closing oldest session to make room",
+      }
+    }
+    
+    const leftmostPane = state.agentPanes.reduce((l, p) => (p.left < l.left ? p : l))
+    return {
+      canSpawn: true,
+      actions: [
+        { type: "close", paneId: leftmostPane.paneId, sessionId: "" },
+        {
+          type: "spawn",
+          sessionId,
+          description,
+          targetPaneId: state.mainPane.paneId,
+        },
+      ],
+      reason: "closing leftmost pane to make room",
+    }
+  }
+
+  return {
+    canSpawn: false,
+    actions: [],
+    reason: `window too narrow: available=${availableWidth}, needed=${config.agentPaneWidth}`,
+  }
+}
+
+export function decideCloseAction(
+  state: WindowState,
+  sessionId: string,
+  sessionMappings: SessionMapping[]
+): PaneAction | null {
+  const mapping = sessionMappings.find((m) => m.sessionId === sessionId)
+  if (!mapping) return null
+
+  const paneExists = state.agentPanes.some((p) => p.paneId === mapping.paneId)
+  if (!paneExists) return null
+
+  return { type: "close", paneId: mapping.paneId, sessionId }
+}

--- a/src/features/tmux-subagent/index.ts
+++ b/src/features/tmux-subagent/index.ts
@@ -1,2 +1,5 @@
 export * from "./manager"
 export * from "./types"
+export * from "./pane-state-querier"
+export * from "./decision-engine"
+export * from "./action-executor"

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -1,21 +1,69 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test'
 import type { TmuxConfig } from '../../config/schema'
+import type { WindowState, PaneAction } from './types'
+import type { ActionResult } from './action-executor'
 
-// Mock setup - tmux-utils functions
-const mockSpawnTmuxPane = mock(async () => ({ success: true, paneId: '%mock' }))
-const mockCloseTmuxPane = mock(async () => true)
-const mockIsInsideTmux = mock(() => true)
+type ExecuteActionsResult = {
+  success: boolean
+  spawnedPaneId?: string
+  results: Array<{ action: PaneAction; result: ActionResult }>
+}
+
+const mockQueryWindowState = mock<(paneId: string) => Promise<WindowState | null>>(
+  async () => ({
+    windowWidth: 200,
+    mainPane: { paneId: '%0', width: 120, left: 0, title: 'main', isActive: true },
+    agentPanes: [],
+  })
+)
+const mockPaneExists = mock<(paneId: string) => Promise<boolean>>(async () => true)
+const mockExecuteActions = mock<(
+  actions: PaneAction[],
+  config: TmuxConfig,
+  serverUrl: string
+) => Promise<ExecuteActionsResult>>(async () => ({
+  success: true,
+  spawnedPaneId: '%mock',
+  results: [],
+}))
+const mockExecuteAction = mock<(
+  action: PaneAction,
+  config: TmuxConfig,
+  serverUrl: string
+) => Promise<ActionResult>>(async () => ({ success: true }))
+const mockIsInsideTmux = mock<() => boolean>(() => true)
+const mockGetCurrentPaneId = mock<() => string | undefined>(() => '%0')
+
+mock.module('./pane-state-querier', () => ({
+  queryWindowState: mockQueryWindowState,
+  paneExists: mockPaneExists,
+  getRightmostAgentPane: (state: WindowState) =>
+    state.agentPanes.length > 0
+      ? state.agentPanes.reduce((r, p) => (p.left > r.left ? p : r))
+      : null,
+  getOldestAgentPane: (state: WindowState) =>
+    state.agentPanes.length > 0
+      ? state.agentPanes.reduce((o, p) => (p.left < o.left ? p : o))
+      : null,
+}))
+
+mock.module('./action-executor', () => ({
+  executeActions: mockExecuteActions,
+  executeAction: mockExecuteAction,
+}))
 
 mock.module('../../shared/tmux', () => ({
-  spawnTmuxPane: mockSpawnTmuxPane,
-  closeTmuxPane: mockCloseTmuxPane,
   isInsideTmux: mockIsInsideTmux,
+  getCurrentPaneId: mockGetCurrentPaneId,
   POLL_INTERVAL_BACKGROUND_MS: 2000,
   SESSION_TIMEOUT_MS: 600000,
   SESSION_MISSING_GRACE_MS: 6000,
+  SESSION_READY_POLL_INTERVAL_MS: 100,
+  SESSION_READY_TIMEOUT_MS: 500,
 }))
 
-// Mock context helper
+const trackedSessions = new Set<string>()
+
 function createMockContext(overrides?: {
   sessionStatusResult?: { data?: Record<string, { type: string }> }
 }) {
@@ -23,23 +71,71 @@ function createMockContext(overrides?: {
     serverUrl: new URL('http://localhost:4096'),
     client: {
       session: {
-        status: mock(async () => overrides?.sessionStatusResult ?? { data: {} }),
+        status: mock(async () => {
+          if (overrides?.sessionStatusResult) {
+            return overrides.sessionStatusResult
+          }
+          const data: Record<string, { type: string }> = {}
+          for (const sessionId of trackedSessions) {
+            data[sessionId] = { type: 'running' }
+          }
+          return { data }
+        }),
       },
     },
   } as any
 }
 
+function createSessionCreatedEvent(
+  id: string,
+  parentID: string | undefined,
+  title: string
+) {
+  return {
+    type: 'session.created',
+    properties: {
+      info: { id, parentID, title },
+    },
+  }
+}
+
+function createWindowState(overrides?: Partial<WindowState>): WindowState {
+  return {
+    windowWidth: 200,
+    mainPane: { paneId: '%0', width: 120, left: 0, title: 'main', isActive: true },
+    agentPanes: [],
+    ...overrides,
+  }
+}
+
 describe('TmuxSessionManager', () => {
   beforeEach(() => {
-    // Reset mocks before each test
-    mockSpawnTmuxPane.mockClear()
-    mockCloseTmuxPane.mockClear()
+    mockQueryWindowState.mockClear()
+    mockPaneExists.mockClear()
+    mockExecuteActions.mockClear()
+    mockExecuteAction.mockClear()
     mockIsInsideTmux.mockClear()
+    mockGetCurrentPaneId.mockClear()
+    trackedSessions.clear()
+
+    mockQueryWindowState.mockImplementation(async () => createWindowState())
+    mockExecuteActions.mockImplementation(async (actions) => {
+      for (const action of actions) {
+        if (action.type === 'spawn') {
+          trackedSessions.add(action.sessionId)
+        }
+      }
+      return {
+        success: true,
+        spawnedPaneId: '%mock',
+        results: [],
+      }
+    })
   })
 
   describe('constructor', () => {
     test('enabled when config.enabled=true and isInsideTmux=true', async () => {
-      // #given
+      //#given
       mockIsInsideTmux.mockReturnValue(true)
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
@@ -47,17 +143,19 @@ describe('TmuxSessionManager', () => {
         enabled: true,
         layout: 'main-vertical',
         main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
       }
 
-      // #when
+      //#when
       const manager = new TmuxSessionManager(ctx, config)
 
-      // #then
+      //#then
       expect(manager).toBeDefined()
     })
 
     test('disabled when config.enabled=true but isInsideTmux=false', async () => {
-      // #given
+      //#given
       mockIsInsideTmux.mockReturnValue(false)
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
@@ -65,17 +163,19 @@ describe('TmuxSessionManager', () => {
         enabled: true,
         layout: 'main-vertical',
         main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
       }
 
-      // #when
+      //#when
       const manager = new TmuxSessionManager(ctx, config)
 
-      // #then
+      //#then
       expect(manager).toBeDefined()
     })
 
     test('disabled when config.enabled=false', async () => {
-      // #given
+      //#given
       mockIsInsideTmux.mockReturnValue(true)
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
@@ -83,50 +183,120 @@ describe('TmuxSessionManager', () => {
         enabled: false,
         layout: 'main-vertical',
         main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
       }
 
-      // #when
+      //#when
       const manager = new TmuxSessionManager(ctx, config)
 
-      // #then
+      //#then
       expect(manager).toBeDefined()
     })
   })
 
   describe('onSessionCreated', () => {
-    test('spawns pane when session has parentID', async () => {
-      // #given
+    test('first agent spawns from source pane via decision engine', async () => {
+      //#given
       mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () => createWindowState())
+
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
       const config: TmuxConfig = {
         enabled: true,
         layout: 'main-vertical',
         main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config)
+      const event = createSessionCreatedEvent(
+        'ses_child',
+        'ses_parent',
+        'Background: Test Task'
+      )
+
+      //#when
+      await manager.onSessionCreated(event)
+
+      //#then
+      expect(mockQueryWindowState).toHaveBeenCalledTimes(1)
+      expect(mockExecuteActions).toHaveBeenCalledTimes(1)
+
+      const call = mockExecuteActions.mock.calls[0]
+      expect(call).toBeDefined()
+      const actionsArg = call![0]
+      expect(actionsArg).toHaveLength(1)
+      expect(actionsArg[0]).toEqual({
+        type: 'spawn',
+        sessionId: 'ses_child',
+        description: 'Background: Test Task',
+        targetPaneId: '%0',
+      })
+    })
+
+    test('second agent spawns from last agent pane', async () => {
+      //#given
+      mockIsInsideTmux.mockReturnValue(true)
+
+      let callCount = 0
+      mockQueryWindowState.mockImplementation(async () => {
+        callCount++
+        if (callCount === 1) {
+          return createWindowState()
+        }
+        return createWindowState({
+          agentPanes: [
+            {
+              paneId: '%1',
+              width: 40,
+              left: 120,
+              title: 'omo-subagent-Task 1',
+              isActive: false,
+            },
+          ],
+        })
+      })
+
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = createMockContext()
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
       }
       const manager = new TmuxSessionManager(ctx, config)
 
-      const event = {
-        sessionID: 'ses_child',
-        parentID: 'ses_parent',
-        title: 'Background: Test Task',
-      }
-
-      // #when
-      await manager.onSessionCreated(event)
-
-      // #then
-      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(1)
-      expect(mockSpawnTmuxPane).toHaveBeenCalledWith(
-        'ses_child',
-        'Background: Test Task',
-        config,
-        'http://localhost:4096'
+      //#when - first agent
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_1', 'ses_parent', 'Task 1')
       )
+      mockExecuteActions.mockClear()
+
+      //#when - second agent
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_2', 'ses_parent', 'Task 2')
+      )
+
+      //#then - second agent targets the last agent pane (%1)
+      expect(mockExecuteActions).toHaveBeenCalledTimes(1)
+      const call = mockExecuteActions.mock.calls[0]
+      expect(call).toBeDefined()
+      const actionsArg = call![0]
+      expect(actionsArg).toHaveLength(1)
+      expect(actionsArg[0]).toEqual({
+        type: 'spawn',
+        sessionId: 'ses_2',
+        description: 'Task 2',
+        targetPaneId: '%1',
+      })
     })
 
     test('does NOT spawn pane when session has no parentID', async () => {
-      // #given
+      //#given
       mockIsInsideTmux.mockReturnValue(true)
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
@@ -134,24 +304,21 @@ describe('TmuxSessionManager', () => {
         enabled: true,
         layout: 'main-vertical',
         main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
       }
       const manager = new TmuxSessionManager(ctx, config)
+      const event = createSessionCreatedEvent('ses_root', undefined, 'Root Session')
 
-      const event = {
-        sessionID: 'ses_root',
-        parentID: undefined,
-        title: 'Root Session',
-      }
-
-      // #when
+      //#when
       await manager.onSessionCreated(event)
 
-      // #then
-      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(0)
+      //#then
+      expect(mockExecuteActions).toHaveBeenCalledTimes(0)
     })
 
     test('does NOT spawn pane when disabled', async () => {
-      // #given
+      //#given
       mockIsInsideTmux.mockReturnValue(true)
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
@@ -159,52 +326,160 @@ describe('TmuxSessionManager', () => {
         enabled: false,
         layout: 'main-vertical',
         main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config)
+      const event = createSessionCreatedEvent(
+        'ses_child',
+        'ses_parent',
+        'Background: Test Task'
+      )
+
+      //#when
+      await manager.onSessionCreated(event)
+
+      //#then
+      expect(mockExecuteActions).toHaveBeenCalledTimes(0)
+    })
+
+    test('does NOT spawn pane for non session.created event type', async () => {
+      //#given
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = createMockContext()
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config)
+      const event = {
+        type: 'session.deleted',
+        properties: {
+          info: { id: 'ses_child', parentID: 'ses_parent', title: 'Task' },
+        },
+      }
+
+      //#when
+      await manager.onSessionCreated(event)
+
+      //#then
+      expect(mockExecuteActions).toHaveBeenCalledTimes(0)
+    })
+
+    test('closes oldest agent when at max capacity', async () => {
+      //#given
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () =>
+        createWindowState({
+          windowWidth: 160,
+          agentPanes: [
+            {
+              paneId: '%1',
+              width: 40,
+              left: 120,
+              title: 'omo-subagent-Task 1',
+              isActive: false,
+            },
+          ],
+        })
+      )
+
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = createMockContext()
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 120,
+        agent_pane_min_width: 40,
       }
       const manager = new TmuxSessionManager(ctx, config)
 
-      const event = {
-        sessionID: 'ses_child',
-        parentID: 'ses_parent',
-        title: 'Background: Test Task',
-      }
+      //#when
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_new', 'ses_parent', 'New Task')
+      )
 
-      // #when
-      await manager.onSessionCreated(event)
+      //#then
+      expect(mockExecuteActions).toHaveBeenCalledTimes(1)
+      const call = mockExecuteActions.mock.calls[0]
+      expect(call).toBeDefined()
+      const actionsArg = call![0]
+      expect(actionsArg.length).toBeGreaterThanOrEqual(1)
 
-      // #then
-      expect(mockSpawnTmuxPane).toHaveBeenCalledTimes(0)
+      const closeActions = actionsArg.filter((a) => a.type === 'close')
+      const spawnActions = actionsArg.filter((a) => a.type === 'spawn')
+
+      expect(closeActions).toHaveLength(1)
+      expect((closeActions[0] as any).paneId).toBe('%1')
+      expect(spawnActions).toHaveLength(1)
     })
   })
 
   describe('onSessionDeleted', () => {
     test('closes pane when tracked session is deleted', async () => {
-      // #given
+      //#given
       mockIsInsideTmux.mockReturnValue(true)
+
+      let stateCallCount = 0
+      mockQueryWindowState.mockImplementation(async () => {
+        stateCallCount++
+        if (stateCallCount === 1) {
+          return createWindowState()
+        }
+        return createWindowState({
+          agentPanes: [
+            {
+              paneId: '%mock',
+              width: 40,
+              left: 120,
+              title: 'omo-subagent-Task',
+              isActive: false,
+            },
+          ],
+        })
+      })
+
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
       const config: TmuxConfig = {
         enabled: true,
         layout: 'main-vertical',
         main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
       }
       const manager = new TmuxSessionManager(ctx, config)
 
-      // First create a session (to track it)
-      await manager.onSessionCreated({
-        sessionID: 'ses_child',
-        parentID: 'ses_parent',
-        title: 'Background: Test Task',
-      })
+      await manager.onSessionCreated(
+        createSessionCreatedEvent(
+          'ses_child',
+          'ses_parent',
+          'Background: Test Task'
+        )
+      )
+      mockExecuteAction.mockClear()
 
-      // #when
+      //#when
       await manager.onSessionDeleted({ sessionID: 'ses_child' })
 
-      // #then
-      expect(mockCloseTmuxPane).toHaveBeenCalledTimes(1)
+      //#then
+      expect(mockExecuteAction).toHaveBeenCalledTimes(1)
+      const call = mockExecuteAction.mock.calls[0]
+      expect(call).toBeDefined()
+      expect(call![0]).toEqual({
+        type: 'close',
+        paneId: '%mock',
+        sessionId: 'ses_child',
+      })
     })
 
     test('does nothing when untracked session is deleted', async () => {
-      // #given
+      //#given
       mockIsInsideTmux.mockReturnValue(true)
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
@@ -212,88 +487,208 @@ describe('TmuxSessionManager', () => {
         enabled: true,
         layout: 'main-vertical',
         main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
       }
       const manager = new TmuxSessionManager(ctx, config)
 
-      // #when
+      //#when
       await manager.onSessionDeleted({ sessionID: 'ses_unknown' })
 
-      // #then
-      expect(mockCloseTmuxPane).toHaveBeenCalledTimes(0)
-    })
-  })
-
-  describe('pollSessions', () => {
-    test('closes pane when session becomes idle', async () => {
-      // #given
-      mockIsInsideTmux.mockReturnValue(true)
-      const { TmuxSessionManager } = await import('./manager')
-
-      // Mock session.status to return idle session
-      const ctx = createMockContext({
-        sessionStatusResult: {
-          data: {
-            ses_child: { type: 'idle' },
-          },
-        },
-      })
-
-      const config: TmuxConfig = {
-        enabled: true,
-        layout: 'main-vertical',
-        main_pane_size: 60,
-      }
-      const manager = new TmuxSessionManager(ctx, config)
-
-      // Create tracked session
-      await manager.onSessionCreated({
-        sessionID: 'ses_child',
-        parentID: 'ses_parent',
-        title: 'Background: Test Task',
-      })
-
-      mockCloseTmuxPane.mockClear() // Clear spawn call
-
-      // #when
-      await manager.pollSessions()
-
-      // #then
-      expect(mockCloseTmuxPane).toHaveBeenCalledTimes(1)
+      //#then
+      expect(mockExecuteAction).toHaveBeenCalledTimes(0)
     })
   })
 
   describe('cleanup', () => {
     test('closes all tracked panes', async () => {
-      // #given
+      //#given
       mockIsInsideTmux.mockReturnValue(true)
+
+      let callCount = 0
+      mockExecuteActions.mockImplementation(async () => {
+        callCount++
+        return {
+          success: true,
+          spawnedPaneId: `%${callCount}`,
+          results: [],
+        }
+      })
+
       const { TmuxSessionManager } = await import('./manager')
       const ctx = createMockContext()
       const config: TmuxConfig = {
         enabled: true,
         layout: 'main-vertical',
         main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
       }
       const manager = new TmuxSessionManager(ctx, config)
 
-      // Track multiple sessions
-      await manager.onSessionCreated({
-        sessionID: 'ses_1',
-        parentID: 'ses_parent',
-        title: 'Task 1',
-      })
-      await manager.onSessionCreated({
-        sessionID: 'ses_2',
-        parentID: 'ses_parent',
-        title: 'Task 2',
-      })
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_1', 'ses_parent', 'Task 1')
+      )
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_2', 'ses_parent', 'Task 2')
+      )
 
-      mockCloseTmuxPane.mockClear()
+      mockExecuteAction.mockClear()
 
-      // #when
+      //#when
       await manager.cleanup()
 
-      // #then
-      expect(mockCloseTmuxPane).toHaveBeenCalledTimes(2)
+      //#then
+      expect(mockExecuteAction).toHaveBeenCalledTimes(2)
+    })
+  })
+})
+
+describe('DecisionEngine', () => {
+  describe('calculateCapacity', () => {
+    test('calculates correct max agents for given window width', async () => {
+      //#given
+      const { calculateCapacity } = await import('./decision-engine')
+
+      //#when
+      const result = calculateCapacity(200, {
+        mainPaneMinWidth: 120,
+        agentPaneWidth: 40,
+      })
+
+      //#then
+      expect(result).toBe(2)
+    })
+
+    test('returns 0 when window is too narrow', async () => {
+      //#given
+      const { calculateCapacity } = await import('./decision-engine')
+
+      //#when
+      const result = calculateCapacity(100, {
+        mainPaneMinWidth: 120,
+        agentPaneWidth: 40,
+      })
+
+      //#then
+      expect(result).toBe(0)
+    })
+  })
+
+  describe('decideSpawnActions', () => {
+    test('returns spawn action when under capacity', async () => {
+      //#given
+      const { decideSpawnActions } = await import('./decision-engine')
+      const state: WindowState = {
+        windowWidth: 200,
+        mainPane: {
+          paneId: '%0',
+          width: 120,
+          left: 0,
+          title: 'main',
+          isActive: true,
+        },
+        agentPanes: [],
+      }
+
+      //#when
+      const decision = decideSpawnActions(
+        state,
+        'ses_1',
+        'Test Task',
+        { mainPaneMinWidth: 120, agentPaneWidth: 40 },
+        []
+      )
+
+      //#then
+      expect(decision.canSpawn).toBe(true)
+      expect(decision.actions).toHaveLength(1)
+      expect(decision.actions[0]).toEqual({
+        type: 'spawn',
+        sessionId: 'ses_1',
+        description: 'Test Task',
+        targetPaneId: '%0',
+      })
+    })
+
+    test('returns close + spawn when at capacity', async () => {
+      //#given
+      const { decideSpawnActions } = await import('./decision-engine')
+      const state: WindowState = {
+        windowWidth: 160,
+        mainPane: {
+          paneId: '%0',
+          width: 120,
+          left: 0,
+          title: 'main',
+          isActive: true,
+        },
+        agentPanes: [
+          {
+            paneId: '%1',
+            width: 40,
+            left: 120,
+            title: 'omo-subagent-Old',
+            isActive: false,
+          },
+        ],
+      }
+      const sessionMappings = [
+        { sessionId: 'ses_old', paneId: '%1', createdAt: new Date('2024-01-01') },
+      ]
+
+      //#when
+      const decision = decideSpawnActions(
+        state,
+        'ses_new',
+        'New Task',
+        { mainPaneMinWidth: 120, agentPaneWidth: 40 },
+        sessionMappings
+      )
+
+      //#then
+      expect(decision.canSpawn).toBe(true)
+      expect(decision.actions).toHaveLength(2)
+      expect(decision.actions[0]).toEqual({
+        type: 'close',
+        paneId: '%1',
+        sessionId: 'ses_old',
+      })
+      expect(decision.actions[1]).toEqual({
+        type: 'spawn',
+        sessionId: 'ses_new',
+        description: 'New Task',
+        targetPaneId: '%0',
+      })
+    })
+
+    test('returns canSpawn=false when window too narrow', async () => {
+      //#given
+      const { decideSpawnActions } = await import('./decision-engine')
+      const state: WindowState = {
+        windowWidth: 100,
+        mainPane: {
+          paneId: '%0',
+          width: 100,
+          left: 0,
+          title: 'main',
+          isActive: true,
+        },
+        agentPanes: [],
+      }
+
+      //#when
+      const decision = decideSpawnActions(
+        state,
+        'ses_1',
+        'Test Task',
+        { mainPaneMinWidth: 120, agentPaneWidth: 40 },
+        []
+      )
+
+      //#then
+      expect(decision.canSpawn).toBe(false)
+      expect(decision.reason).toContain('too narrow')
     })
   })
 })

--- a/src/features/tmux-subagent/pane-state-querier.ts
+++ b/src/features/tmux-subagent/pane-state-querier.ts
@@ -1,0 +1,68 @@
+import { spawn } from "bun"
+import type { WindowState, TmuxPaneInfo } from "./types"
+import { getTmuxPath } from "../../tools/interactive-bash/utils"
+import { log } from "../../shared"
+
+/**
+ * Query the current window state from tmux.
+ * This is the source of truth - not our internal cache.
+ */
+export async function queryWindowState(sourcePaneId: string): Promise<WindowState | null> {
+  const tmux = await getTmuxPath()
+  if (!tmux) return null
+
+  // Get window width and all panes in the current window
+  const proc = spawn(
+    [
+      tmux,
+      "list-panes",
+      "-t",
+      sourcePaneId,
+      "-F",
+      "#{pane_id},#{pane_width},#{pane_left},#{pane_title},#{pane_active},#{window_width}",
+    ],
+    { stdout: "pipe", stderr: "pipe" }
+  )
+
+  const exitCode = await proc.exited
+  const stdout = await new Response(proc.stdout).text()
+
+  if (exitCode !== 0) {
+    log("[pane-state-querier] list-panes failed", { exitCode })
+    return null
+  }
+
+  const lines = stdout.trim().split("\n").filter(Boolean)
+  if (lines.length === 0) return null
+
+  let windowWidth = 0
+  const panes: TmuxPaneInfo[] = []
+
+  for (const line of lines) {
+    const [paneId, widthStr, leftStr, title, activeStr, windowWidthStr] = line.split(",")
+    const width = parseInt(widthStr, 10)
+    const left = parseInt(leftStr, 10)
+    const isActive = activeStr === "1"
+    windowWidth = parseInt(windowWidthStr, 10)
+
+    if (!isNaN(width) && !isNaN(left)) {
+      panes.push({ paneId, width, left, title, isActive })
+    }
+  }
+
+  // Sort panes by left position (leftmost first)
+  panes.sort((a, b) => a.left - b.left)
+
+  // The main pane is the leftmost pane (where opencode runs)
+  // Agent panes are all other panes to the right
+  const mainPane = panes.find((p) => p.paneId === sourcePaneId) ?? panes[0] ?? null
+  const agentPanes = panes.filter((p) => p.paneId !== mainPane?.paneId)
+
+  log("[pane-state-querier] window state", {
+    windowWidth,
+    mainPane: mainPane?.paneId,
+    agentPaneCount: agentPanes.length,
+  })
+
+  return { windowWidth, mainPane, agentPanes }
+}

--- a/src/features/tmux-subagent/types.ts
+++ b/src/features/tmux-subagent/types.ts
@@ -5,3 +5,49 @@ export interface TrackedSession {
   createdAt: Date
   lastSeenAt: Date
 }
+
+/**
+ * Raw pane info from tmux list-panes command
+ * Source of truth - queried directly from tmux
+ */
+export interface TmuxPaneInfo {
+  paneId: string
+  width: number
+  left: number
+  title: string
+  isActive: boolean
+}
+
+/**
+ * Current window state queried from tmux
+ * This is THE source of truth, not our internal Map
+ */
+export interface WindowState {
+  windowWidth: number
+  mainPane: TmuxPaneInfo | null
+  agentPanes: TmuxPaneInfo[]
+}
+
+/**
+ * Actions that can be executed on tmux panes
+ */
+export type PaneAction =
+  | { type: "close"; paneId: string; sessionId: string }
+  | { type: "spawn"; sessionId: string; description: string; targetPaneId: string }
+
+/**
+ * Decision result from the decision engine
+ */
+export interface SpawnDecision {
+  canSpawn: boolean
+  actions: PaneAction[]
+  reason?: string
+}
+
+/**
+ * Config needed for capacity calculation
+ */
+export interface CapacityConfig {
+  mainPaneMinWidth: number
+  agentPaneWidth: number
+}

--- a/src/shared/tmux/constants.ts
+++ b/src/shared/tmux/constants.ts
@@ -7,5 +7,6 @@ export const SESSION_TIMEOUT_MS = 10 * 60 * 1000  // 10 minutes
 // Grace period for missing session before cleanup
 export const SESSION_MISSING_GRACE_MS = 6000  // 6 seconds
 
-// Delay after pane spawn before sending prompt
-export const PANE_SPAWN_DELAY_MS = 500
+// Session readiness polling config
+export const SESSION_READY_POLL_INTERVAL_MS = 500
+export const SESSION_READY_TIMEOUT_MS = 10_000  // 10 seconds max wait


### PR DESCRIPTION
## Summary
Major refactor of tmux-subagent to use state-first architecture (Query → Decide → Execute pattern).

## Architecture Changes
- **pane-state-querier**: Queries actual tmux pane state (source of truth)
- **decision-engine**: Pure functions to decide spawn/close actions
- **action-executor**: Executes actions with verification
- **manager**: Orchestrates the flow, maintains sessionId↔paneId cache

## New Config Options
- `main_pane_min_width`: Minimum width for main pane (default: 120)
- `agent_pane_min_width`: Minimum width for agent panes (default: 40)

## Callback Integration
- BackgroundManager now uses `onSubagentSessionCreated` callback
- DelegateTask sync sessions use `onSyncSessionCreated` callback
- Both callbacks invoke TmuxSessionManager.onSessionCreated

## Testing
- Comprehensive unit tests for decision engine
- Updated manager tests with mocked state querier

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored tmux-subagent to a state-first architecture with a Query → Decide → Execute flow, improving reliable pane spawning/closing and capacity handling. Added session-created callbacks so panes spawn immediately for background and sync sessions.

- **New Features**
  - Pure decision engine chooses spawn/close actions from real tmux state.
  - Pane spawn callbacks: onSubagentSessionCreated (BackgroundManager) and onSyncSessionCreated (DelegateTask) routed to TmuxSessionManager.
  - New config: main_pane_min_width (default 120) and agent_pane_min_width (default 40) to control capacity.
  - Session readiness polling (up to 10s) before tracking spawned panes.

- **Refactors**
  - TmuxSessionManager rewritten to query tmux state, decide actions, execute with verification; caches sessionId↔paneId only after success.
  - New modules: pane-state-querier, decision-engine, action-executor.
  - tmux-utils: targeted splits with min width, improved logging, getCurrentPaneId; close-pane now logs success/failure.
  - Expanded tests for manager and decision engine.

<sup>Written for commit dcc4404703bac55971ce4a8848e8681765b2cded. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

