### PR TITLE
fix(test): update builtin skills count from 3 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,32 @@ on:
   push:
     branches: [master, dev]
   pull_request:
-    branches: [dev]
+    branches: [master, dev]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Block PRs targeting master branch
+  block-master-pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Check PR target branch
+        run: |
+          if [ "${{ github.base_ref }}" = "master" ]; then
+            echo "::error::PRs to master branch are not allowed. Please target the 'dev' branch instead."
+            echo ""
+            echo "PULL REQUESTS TO MASTER ARE BLOCKED"
+            echo ""
+            echo "All PRs must target the 'dev' branch."
+            echo "Please close this PR and create a new one targeting 'dev'."
+            exit 1
+          else
+            echo "PR targets '${{ github.base_ref }}' branch - OK"
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/src/features/builtin-skills/skills.test.ts
+++ b/src/features/builtin-skills/skills.test.ts
@@ -75,7 +75,7 @@ describe("createBuiltinSkills", () => {
 		}
 	})
 
-	test("returns exactly 3 skills regardless of provider", () => {
+	test("returns exactly 4 skills regardless of provider", () => {
 		// #given
 
 		// #when
@@ -83,7 +83,7 @@ describe("createBuiltinSkills", () => {
 		const agentBrowserSkills = createBuiltinSkills({ browserProvider: "agent-browser" })
 
 		// #then
-		expect(defaultSkills).toHaveLength(3)
-		expect(agentBrowserSkills).toHaveLength(3)
+		expect(defaultSkills).toHaveLength(4)
+		expect(agentBrowserSkills).toHaveLength(4)
 	})
 })


### PR DESCRIPTION
## Summary
Update test expectation for `createBuiltinSkills` to expect 4 skills (dev-browser was added).

## Changes
- Update `skills.test.ts` to expect 4 skills instead of 3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update createBuiltinSkills test to expect 4 skills after adding dev-browser; counts are consistent across providers. Add CI check to block PRs to master and require targeting dev.

<sup>Written for commit c3844ab6436c9a2dfc83ec46554a440026283045. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

