### PR TITLE
fix(mcp): add optional Context7 `Authorization` header

### DIFF
--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -21,7 +21,7 @@ mcp/
 | Name | URL | Purpose | Auth |
 |------|-----|---------|------|
 | websearch | mcp.exa.ai/mcp?tools=web_search_exa | Real-time web search | EXA_API_KEY |
-| context7 | mcp.context7.com/mcp | Library docs | None |
+| context7 | mcp.context7.com/mcp | Library docs | CONTEXT7_API_KEY |
 | grep_app | mcp.grep.app | GitHub code search | None |
 
 ## THREE-TIER MCP SYSTEM
@@ -61,4 +61,5 @@ const mcps = createBuiltinMcps(["websearch"])  // Disable specific
 
 - **Remote only**: HTTP/SSE, no stdio
 - **Disable**: User can set `disabled_mcps: ["name"]` in config
-- **Exa**: Requires `EXA_API_KEY` env var
+- **Context7**: Optional auth using `CONTEXT7_API_KEY` env var
+- **Exa**: Optional auth using `EXA_API_KEY` env var

--- a/src/mcp/context7.ts
+++ b/src/mcp/context7.ts
@@ -2,5 +2,9 @@ export const context7 = {
   type: "remote" as const,
   url: "https://mcp.context7.com/mcp",
   enabled: true,
+  headers: process.env.CONTEXT7_API_KEY
+    ? { Authorization: `Bearer ${process.env.CONTEXT7_API_KEY}` }
+    : undefined,
+  // Disable OAuth auto-detection - Context7 uses API key header, not OAuth
   oauth: false as const,
 }


### PR DESCRIPTION
## Summary

Context7 should mirror `websearch` by only sending auth when `CONTEXT7_API_KEY` is set.

## Changes

Set bearer auth in `headers` using `CONTEXT7_API_KEY` if said environment variable is set, otherwise leave `headers` to `undefined`.

## Related Issues

Closes #1130.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Context7 now sends a Bearer Authorization header only when CONTEXT7_API_KEY is set, mirroring websearch and addressing #1130.

- **Bug Fixes**
  - Set Authorization header when CONTEXT7_API_KEY is present; otherwise no headers, and OAuth auto-detection is disabled.
  - Update AGENTS.md to mark Context7 auth as optional.

<sup>Written for commit 3cf1eaf2061938ab6454c7f14e1f548428f1334f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

