### PR TITLE
feat: make systemDefaultModel optional for OpenCode fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,13 +27,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.0.1",
-        "oh-my-opencode-darwin-x64": "3.0.1",
-        "oh-my-opencode-linux-arm64": "3.0.1",
-        "oh-my-opencode-linux-arm64-musl": "3.0.1",
-        "oh-my-opencode-linux-x64": "3.0.1",
-        "oh-my-opencode-linux-x64-musl": "3.0.1",
-        "oh-my-opencode-windows-x64": "3.0.1",
+        "oh-my-opencode-darwin-arm64": "3.1.0",
+        "oh-my-opencode-darwin-x64": "3.1.0",
+        "oh-my-opencode-linux-arm64": "3.1.0",
+        "oh-my-opencode-linux-arm64-musl": "3.1.0",
+        "oh-my-opencode-linux-x64": "3.1.0",
+        "oh-my-opencode-linux-x64-musl": "3.1.0",
+        "oh-my-opencode-windows-x64": "3.1.0",
       },
     },
   },
@@ -225,19 +225,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.0.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-LRcLVi6DsmGh3ICFeN4yVJ0KinvCM5jotd2z7tZQ74n0sziHO7grjK1CmJaPV9eCv0clatoK5xfFCeEJ3FvXYg=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.1.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-8j7XI+n1bz7xIg35Zpjqp1AqoIoFWuVZdYyI9vTAZ0b6ta/mIlNOWPLAbFyEHfKelA9g3Xa+4sYnKPSxU5dQoA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.0.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ZaC0ZBe5M2f2aMncNsAMu9IZ3MjSPfNVcfUTCgJkp03db8lLPsajgjeG3556Er72hxignDPsEbrLkJBNlsDbAA=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.1.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Kd/3KpnF07cw+qBAyLwA0y8tp3S0X8b8HWH55WGlVp6m4gvQ432kKgDum/jat1vqP/3J8hm4P/sly5ibY5gMqw=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.0.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pcOvV6Y2GSwKr0exDndeB2BtFt297XhJFQgrq1cbeEJawoRONDRp7LNSpjwILSQpQ7YkkYnO2bIczBmxI5llNA=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.1.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-qy/QohHGM6eSQjHVEgibsDauUvlAgYPw5xrQqa9cVLo1hL4KMIhb+i4wGAxCK2p84rG2bfC2m8+IfZUxhhwcTg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.0.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7kXKaVbgFnOMSaw+j4JbZNs7O7mkvCekcfWPwh/9I/0WD21/n4PbAGl01ePhRoQh+u9MC6t8FH046hEjL2sk1g=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.1.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-HIO7zj3M5QAYOfgvFM7Djeuen9kdZD4RA51wzXcXiPj1FPAuBNAW9N7lTEGYBSgObgwX+vXnC3HwLSF7nqkw8w=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.0.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-1BOV1EnKa5BErhZmWiddnbriHwm1KFrPr+0BUCDdFX/d/hrMAJTo1733zaEnvKuXzvrdHSp/VznXheeUI1VjkA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.1.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-zcKaibnEhvbReiTsqbg+dog/Z3pnBx4v6R3AR5nVhGBO27hRSAXgA/fviYyE5bWD591WB7Pqwduf0t854ilKjw=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.0.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ASyTVatvU1nNJ0mk9o+A/GjybT5vOdgU172ystzCsnQ+12Mnv68GgaeMu/UFJgJNaZmKdhyUAP9XhnOKvEDBGQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.1.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-xmtHEyAhY93Djg5qEauvMqSF0x3tf8pzOGdKB6CuZmhCG69fZXk/dEwPrO0vKbOeGMV/T4K6HAg1+8Ue1N1ZaQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.0.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-QIuA564mVpwzCprhhAoyd8TSw0Rt2VM6M9y7H0fOoC/UjXuU+d7wIuUNuqUUMVaUnMedkctTZop0X0i2Q+Bvhg=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.1.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-pDgHd0mGWWVsiO0fT8C7bi6CziOXU38g+k2dWlGm1YXCMzyrrWZZCF7oIp+EzJB02saSCF/oJ2f1/uj/VPeLMA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/agents/atlas.ts
+++ b/src/agents/atlas.ts
@@ -523,9 +523,6 @@ function buildDynamicOrchestratorPrompt(ctx?: OrchestratorContext): string {
 }
 
 export function createAtlasAgent(ctx: OrchestratorContext): AgentConfig {
-  if (!ctx.model) {
-    throw new Error("createAtlasAgent requires a model in context")
-  }
   const restrictions = createAgentToolRestrictions([
     "task",
     "call_omo_agent",
@@ -534,7 +531,7 @@ export function createAtlasAgent(ctx: OrchestratorContext): AgentConfig {
     description:
       "Orchestrates work via delegate_task() to complete ALL tasks in a todo list until fully done",
     mode: "primary" as const,
-    model: ctx.model,
+    ...(ctx.model ? { model: ctx.model } : {}),
     temperature: 0.1,
     prompt: buildDynamicOrchestratorPrompt(ctx),
     thinking: { type: "enabled", budgetTokens: 32000 },

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -106,6 +106,30 @@ describe("createBuiltinAgents with model overrides", () => {
    })
 })
 
+describe("createBuiltinAgents without systemDefaultModel", () => {
+  test("creates agents successfully without systemDefaultModel", async () => {
+    // #given - no systemDefaultModel provided
+
+    // #when
+    const agents = await createBuiltinAgents([], {}, undefined, undefined)
+
+    // #then - agents should still be created using fallback chain
+    expect(agents.oracle).toBeDefined()
+    expect(agents.oracle.model).toBe("openai/gpt-5.2")
+  })
+
+  test("sisyphus uses fallback chain when systemDefaultModel undefined", async () => {
+    // #given - no systemDefaultModel
+
+    // #when
+    const agents = await createBuiltinAgents([], {}, undefined, undefined)
+
+    // #then - sisyphus should use its fallback chain
+    expect(agents.sisyphus).toBeDefined()
+    expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4-5")
+  })
+})
+
 describe("buildAgent with category and skills", () => {
   const { buildAgent } = require("./utils")
   const TEST_MODEL = "anthropic/claude-opus-4-5"

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -105,41 +105,6 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       log(`Plugin load errors`, { errors: pluginComponents.errors });
     }
 
-    if (!(config.model as string | undefined)?.trim()) {
-      let fallbackModel: string | undefined
-
-      for (const agentConfig of Object.values(pluginConfig.agents ?? {})) {
-        const model = (agentConfig as { model?: string })?.model
-        if (model && typeof model === 'string' && model.trim()) {
-          fallbackModel = model.trim()
-          break
-        }
-      }
-
-      if (!fallbackModel) {
-        for (const categoryConfig of Object.values(pluginConfig.categories ?? {})) {
-          const model = (categoryConfig as { model?: string })?.model
-          if (model && typeof model === 'string' && model.trim()) {
-            fallbackModel = model.trim()
-            break
-          }
-        }
-      }
-
-      if (fallbackModel) {
-        config.model = fallbackModel
-        log(`No default model specified, using fallback from config: ${fallbackModel}`)
-      } else {
-        const paths = getOpenCodeConfigPaths({ binary: "opencode", version: null })
-        throw new Error(
-          'oh-my-opencode requires a default model.\n\n' +
-          `Add this to ${paths.configJsonc}:\n\n` +
-          '  "model": "anthropic/claude-sonnet-4-5"\n\n' +
-          '(Replace with your preferred provider/model)'
-        )
-      }
-    }
-
     // Migrate disabled_agents from old names to new names
     const migratedDisabledAgents = (pluginConfig.disabled_agents ?? []).map(agent => {
       return AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent

--- a/src/shared/model-resolver.test.ts
+++ b/src/shared/model-resolver.test.ts
@@ -128,8 +128,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.model).toBe("anthropic/claude-opus-4-5")
-      expect(result.source).toBe("override")
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+      expect(result!.source).toBe("override")
       expect(logSpy).toHaveBeenCalledWith("Model resolved via override", { model: "anthropic/claude-opus-4-5" })
     })
 
@@ -148,8 +148,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.model).toBe("custom/my-model")
-      expect(result.source).toBe("override")
+      expect(result!.model).toBe("custom/my-model")
+      expect(result!.source).toBe("override")
     })
 
     test("whitespace-only userModel is treated as not provided", () => {
@@ -167,7 +167,7 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.source).not.toBe("override")
+      expect(result!.source).not.toBe("override")
     })
 
     test("empty string userModel is treated as not provided", () => {
@@ -185,7 +185,7 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.source).not.toBe("override")
+      expect(result!.source).not.toBe("override")
     })
   })
 
@@ -204,8 +204,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.model).toBe("github-copilot/claude-opus-4-5-preview")
-      expect(result.source).toBe("provider-fallback")
+      expect(result!.model).toBe("github-copilot/claude-opus-4-5-preview")
+      expect(result!.source).toBe("provider-fallback")
       expect(logSpy).toHaveBeenCalledWith("Model resolved via fallback chain (availability confirmed)", {
         provider: "github-copilot",
         model: "claude-opus-4-5",
@@ -228,8 +228,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.model).toBe("openai/gpt-5.2")
-      expect(result.source).toBe("provider-fallback")
+      expect(result!.model).toBe("openai/gpt-5.2")
+      expect(result!.source).toBe("provider-fallback")
     })
 
     test("tries next provider when first provider has no match", () => {
@@ -246,8 +246,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.model).toBe("opencode/gpt-5-nano")
-      expect(result.source).toBe("provider-fallback")
+      expect(result!.model).toBe("opencode/gpt-5-nano")
+      expect(result!.source).toBe("provider-fallback")
     })
 
     test("uses fuzzy matching within provider", () => {
@@ -264,8 +264,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.model).toBe("anthropic/claude-opus-4-5")
-      expect(result.source).toBe("provider-fallback")
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+      expect(result!.source).toBe("provider-fallback")
     })
 
     test("skips fallback chain when not provided", () => {
@@ -279,7 +279,7 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.source).toBe("system-default")
+      expect(result!.source).toBe("system-default")
     })
 
     test("skips fallback chain when empty", () => {
@@ -294,7 +294,7 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.source).toBe("system-default")
+      expect(result!.source).toBe("system-default")
     })
 
     test("case-insensitive fuzzy matching", () => {
@@ -311,8 +311,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.model).toBe("anthropic/claude-opus-4-5")
-      expect(result.source).toBe("provider-fallback")
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+      expect(result!.source).toBe("provider-fallback")
     })
   })
 
@@ -331,8 +331,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.model).toBe("google/gemini-3-pro")
-      expect(result.source).toBe("system-default")
+      expect(result!.model).toBe("google/gemini-3-pro")
+      expect(result!.source).toBe("system-default")
       expect(logSpy).toHaveBeenCalledWith("No available model found in fallback chain, falling through to system default")
     })
 
@@ -350,8 +350,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then - should use first fallback entry, not system default
-      expect(result.model).toBe("anthropic/claude-opus-4-5")
-      expect(result.source).toBe("provider-fallback")
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+      expect(result!.source).toBe("provider-fallback")
     })
 
     test("returns system default when fallbackChain is not provided", () => {
@@ -365,8 +365,8 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // #then
-      expect(result.model).toBe("google/gemini-3-pro")
-      expect(result.source).toBe("system-default")
+      expect(result!.model).toBe("google/gemini-3-pro")
+      expect(result!.source).toBe("system-default")
     })
   })
 
@@ -386,8 +386,8 @@ describe("resolveModelWithFallback", () => {
       })
 
       // #then
-      expect(result.model).toBe("anthropic/claude-opus-4-5")
-      expect(result.source).toBe("provider-fallback")
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+      expect(result!.source).toBe("provider-fallback")
     })
 
     test("tries all providers in first entry before moving to second entry", () => {
@@ -405,8 +405,8 @@ describe("resolveModelWithFallback", () => {
       })
 
       // #then
-      expect(result.model).toBe("google/gemini-3-pro")
-      expect(result.source).toBe("provider-fallback")
+      expect(result!.model).toBe("google/gemini-3-pro")
+      expect(result!.source).toBe("provider-fallback")
     })
 
     test("returns first matching entry even if later entries have better matches", () => {
@@ -427,8 +427,8 @@ describe("resolveModelWithFallback", () => {
       })
 
       // #then
-      expect(result.model).toBe("openai/gpt-5.2")
-      expect(result.source).toBe("provider-fallback")
+      expect(result!.model).toBe("openai/gpt-5.2")
+      expect(result!.source).toBe("provider-fallback")
     })
 
     test("falls through to system default when none match availability", () => {
@@ -447,8 +447,8 @@ describe("resolveModelWithFallback", () => {
       })
 
       // #then
-      expect(result.model).toBe("system/default")
-      expect(result.source).toBe("system-default")
+      expect(result!.model).toBe("system/default")
+      expect(result!.source).toBe("system-default")
     })
   })
 
@@ -462,11 +462,81 @@ describe("resolveModelWithFallback", () => {
       }
 
       // #when
-      const result: ModelResolutionResult = resolveModelWithFallback(input)
+      const result = resolveModelWithFallback(input)
 
       // #then
-      expect(typeof result.model).toBe("string")
-      expect(["override", "provider-fallback", "system-default"]).toContain(result.source)
+      expect(result).toBeDefined()
+      expect(typeof result!.model).toBe("string")
+      expect(["override", "provider-fallback", "system-default"]).toContain(result!.source)
+    })
+  })
+
+  describe("Optional systemDefaultModel", () => {
+    test("returns undefined when systemDefaultModel is undefined and no fallback found", () => {
+      // #given
+      const input: ExtendedModelResolutionInput = {
+        fallbackChain: [
+          { providers: ["anthropic"], model: "nonexistent-model" },
+        ],
+        availableModels: new Set(["openai/gpt-5.2"]),
+        systemDefaultModel: undefined,
+      }
+
+      // #when
+      const result = resolveModelWithFallback(input)
+
+      // #then
+      expect(result).toBeUndefined()
+    })
+
+    test("returns undefined when no fallbackChain and systemDefaultModel is undefined", () => {
+      // #given
+      const input: ExtendedModelResolutionInput = {
+        availableModels: new Set(["openai/gpt-5.2"]),
+        systemDefaultModel: undefined,
+      }
+
+      // #when
+      const result = resolveModelWithFallback(input)
+
+      // #then
+      expect(result).toBeUndefined()
+    })
+
+    test("still returns override when userModel provided even if systemDefaultModel undefined", () => {
+      // #given
+      const input: ExtendedModelResolutionInput = {
+        userModel: "anthropic/claude-opus-4-5",
+        availableModels: new Set(),
+        systemDefaultModel: undefined,
+      }
+
+      // #when
+      const result = resolveModelWithFallback(input)
+
+      // #then
+      expect(result).toBeDefined()
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+      expect(result!.source).toBe("override")
+    })
+
+    test("still returns fallback match when systemDefaultModel undefined", () => {
+      // #given
+      const input: ExtendedModelResolutionInput = {
+        fallbackChain: [
+          { providers: ["anthropic"], model: "claude-opus-4-5" },
+        ],
+        availableModels: new Set(["anthropic/claude-opus-4-5"]),
+        systemDefaultModel: undefined,
+      }
+
+      // #when
+      const result = resolveModelWithFallback(input)
+
+      // #then
+      expect(result).toBeDefined()
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+      expect(result!.source).toBe("provider-fallback")
     })
   })
 })

--- a/src/shared/model-resolver.ts
+++ b/src/shared/model-resolver.ts
@@ -6,7 +6,7 @@ import { readConnectedProvidersCache } from "./connected-providers-cache"
 export type ModelResolutionInput = {
 	userModel?: string
 	inheritedModel?: string
-	systemDefault: string
+	systemDefault?: string
 }
 
 export type ModelSource =
@@ -24,7 +24,7 @@ export type ExtendedModelResolutionInput = {
 	userModel?: string
 	fallbackChain?: FallbackEntry[]
 	availableModels: Set<string>
-	systemDefaultModel: string
+	systemDefaultModel?: string
 }
 
 function normalizeModel(model?: string): string | undefined {
@@ -32,7 +32,7 @@ function normalizeModel(model?: string): string | undefined {
 	return trimmed || undefined
 }
 
-export function resolveModel(input: ModelResolutionInput): string {
+export function resolveModel(input: ModelResolutionInput): string | undefined {
 	return (
 		normalizeModel(input.userModel) ??
 		normalizeModel(input.inheritedModel) ??
@@ -42,7 +42,7 @@ export function resolveModel(input: ModelResolutionInput): string {
 
 export function resolveModelWithFallback(
 	input: ExtendedModelResolutionInput,
-): ModelResolutionResult {
+): ModelResolutionResult | undefined {
 	const { userModel, fallbackChain, availableModels, systemDefaultModel } = input
 
 	// Step 1: Override
@@ -92,7 +92,12 @@ export function resolveModelWithFallback(
 		log("No available model found in fallback chain, falling through to system default")
 	}
 
-	// Step 4: System default
+	// Step 3: System default (if provided)
+	if (systemDefaultModel === undefined) {
+		log("No model resolved - systemDefaultModel not configured")
+		return undefined
+	}
+
 	log("Model resolved via system default", { model: systemDefaultModel })
 	return { model: systemDefaultModel, source: "system-default" }
 }

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -78,11 +78,11 @@ describe("sisyphus-task", () => {
   })
 
   describe("category delegation config validation", () => {
-    test("returns error when systemDefaultModel is not configured", async () => {
+    test("proceeds without error when systemDefaultModel is undefined", async () => {
       // #given a mock client with no model in config
       const { createDelegateTask } = require("./tools")
       
-      const mockManager = { launch: async () => ({}) }
+      const mockManager = { launch: async () => ({ id: "task-123" }) }
       const mockClient = {
         app: { agents: async () => ({ data: [] }) },
         config: { get: async () => ({}) }, // No model configured
@@ -111,14 +111,14 @@ describe("sisyphus-task", () => {
           description: "Test task",
           prompt: "Do something",
           category: "ultrabrain",
-          run_in_background: false,
-          load_skills: ["git-master"],
+          run_in_background: true,
+          load_skills: [],
         },
         toolContext
       )
       
-      // #then returns descriptive error message
-      expect(result).toContain("oh-my-opencode requires a default model")
+      // #then proceeds without error - uses fallback chain
+      expect(result).not.toContain("oh-my-opencode requires a default model")
     })
   })
 


### PR DESCRIPTION
## Summary

Make `systemDefaultModel` optional throughout the plugin, allowing OpenCode's built-in model fallback to work when user doesn't explicitly configure a default model.

## Problem

Previously, the plugin threw an error when no default model was configured:
```
oh-my-opencode requires a default model.

Add this to ~/.config/opencode/opencode.jsonc:

  "model": "anthropic/claude-sonnet-4-5"
```

However, OpenCode has its own fallback mechanism that automatically picks the best available model when none is specified. The plugin was blocking this behavior unnecessarily.

## Changes

### Core Changes
- **model-resolver.ts**: Made `systemDefaultModel` optional in types, returns `undefined` when no model can be resolved
- **config-handler.ts**: Removed the entire throw block (lines 108-141) that required a default model
- **delegate-task/tools.ts**: Removed the guard that blocked category delegation without `systemDefaultModel`
- **agents/utils.ts**: Removed throw, agents are created only if model resolution succeeds
- **agents/atlas.ts**: Made `ctx.model` optional

### Test Updates
- Added tests for optional `systemDefaultModel` scenarios
- Updated existing tests to use non-null assertions where appropriate

## Verification
- `bun run typecheck` passes
- All modified test files pass (50+ tests)
- Backward compatible: if user specifies model, it's used; if not, OpenCode decides

Closes #1129


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the default model optional so OpenCode can use its own fallback when a user doesn’t configure one. This removes hard errors and lets agents and category delegation run without a pre-set model. Closes #1129.

- **New Features**
  - Made systemDefaultModel optional in the resolver; returns undefined when no override or fallback is found so OpenCode can pick the model.
  - Removed throws in config-handler, agents/utils, atlas, and delegate-task; Sisyphus and Atlas now use fallback chains and proceed without a default model.
  - Added tests for optional model scenarios and bumped optional oh-my-opencode binaries to 3.1.0.

<sup>Written for commit 840a76d62a9734e74cddd96406c1af6414ab7393. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

