### PR TITLE
fix: remove redundant removeCodeBlocks call

### DIFF
--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -31,7 +31,7 @@ export function createKeywordDetectorHook(ctx: PluginInput, collector?: ContextC
       }
 
       const currentAgent = getSessionAgent(input.sessionID) ?? input.agent
-      let detectedKeywords = detectKeywordsWithType(removeCodeBlocks(promptText), currentAgent)
+      let detectedKeywords = detectKeywordsWithType(promptText, currentAgent)
 
       if (detectedKeywords.length === 0) {
         return


### PR DESCRIPTION
Remove duplicate removeCodeBlocks() call in keyword-detector/index.ts.

The detectKeywordsWithType() function already calls removeCodeBlocks() internally, so calling it before passing the text was redundant and caused unnecessary double processing.

## Summary

- Remove redundant `removeCodeBlocks()` call to avoid duplicate text processing

## Changes

- Removed `removeCodeBlocks()` wrapper in `index.ts` when calling `detectKeywordsWithType()`
- `detectKeywordsWithType()` already handles code block removal internally, making the external call unnecessary

## Screenshots

<!-- Not applicable for this change - delete this section -->

## Testing

```bash
bun run typecheck
bun test
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a redundant removeCodeBlocks() call in keyword-detector to avoid double processing and reduce minor overhead. Behavior stays the same since detectKeywordsWithType() already removes code blocks internally.

<sup>Written for commit 9b26703e00f13afca6432729990bd27d92a895e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

