### PR TITLE
feat: support OPENCODE_SERVER_PORT and OPENCODE_SERVER_HOSTNAME env vars

### DIFF
--- a/src/cli/run/runner.ts
+++ b/src/cli/run/runner.ts
@@ -31,8 +31,18 @@ export async function run(options: RunOptions): Promise<number> {
   }
 
   try {
+    // Support custom OpenCode server port via environment variable
+    // This allows Open Agent and other orchestrators to run multiple
+    // concurrent missions without port conflicts
+    const serverPort = process.env.OPENCODE_SERVER_PORT
+      ? parseInt(process.env.OPENCODE_SERVER_PORT, 10)
+      : undefined
+    const serverHostname = process.env.OPENCODE_SERVER_HOSTNAME || undefined
+
     const { client, server } = await createOpencode({
       signal: abortController.signal,
+      ...(serverPort && !isNaN(serverPort) ? { port: serverPort } : {}),
+      ...(serverHostname ? { hostname: serverHostname } : {}),
     })
 
     const cleanup = () => {


### PR DESCRIPTION
## Summary
- Add support for customizing the OpenCode server port and hostname via environment variables
- Read `OPENCODE_SERVER_PORT` (default: 4096) and `OPENCODE_SERVER_HOSTNAME` (default: 127.0.0.1) in runner.ts

## Problem
When using orchestration tools like Open Agent that need to run an OpenCode server on a non-default port, oh-my-opencode currently hardcodes port 4096. This causes port conflicts when the main OpenCode server is already running on 4096.

## Solution
Check for environment variables before using defaults, allowing external configuration of the server connection parameters.

## Changes
- Modified `src/cli/run/runner.ts` to read `OPENCODE_SERVER_PORT` and `OPENCODE_SERVER_HOSTNAME` from environment
- Falls back to existing defaults (4096 and 127.0.0.1) if not set

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for configuring the OpenCode server port and hostname via environment variables. This prevents port conflicts with orchestrators like Open Agent by allowing custom values when needed.

Reads OPENCODE_SERVER_PORT and OPENCODE_SERVER_HOSTNAME in runner.ts, falling back to 4096 and 127.0.0.1 if unset.

<sup>Written for commit a2f49953d4b70e1b88fe7069537ec805fd80efca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

