### PR TITLE
fix(model-resolver): respect UI model selection in agent initialization

### DIFF
--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -149,7 +149,8 @@ export async function createBuiltinAgents(
   gitMasterConfig?: GitMasterConfig,
   discoveredSkills: LoadedSkill[] = [],
   client?: any,
-  browserProvider?: BrowserAutomationProvider
+  browserProvider?: BrowserAutomationProvider,
+  uiSelectedModel?: string
 ): Promise<Record<string, AgentConfig>> {
   const connectedProviders = readConnectedProvidersCache()
   const availableModels = client 
@@ -198,6 +199,7 @@ export async function createBuiltinAgents(
     const requirement = AGENT_MODEL_REQUIREMENTS[agentName]
     
     const resolution = resolveModelWithFallback({
+      uiSelectedModel,
       userModel: override?.model,
       fallbackChain: requirement?.fallbackChain,
       availableModels,
@@ -241,6 +243,7 @@ export async function createBuiltinAgents(
      const sisyphusRequirement = AGENT_MODEL_REQUIREMENTS["sisyphus"]
     
     const sisyphusResolution = resolveModelWithFallback({
+      uiSelectedModel,
       userModel: sisyphusOverride?.model,
       fallbackChain: sisyphusRequirement?.fallbackChain,
       availableModels,
@@ -282,6 +285,7 @@ export async function createBuiltinAgents(
      const atlasRequirement = AGENT_MODEL_REQUIREMENTS["atlas"]
     
     const atlasResolution = resolveModelWithFallback({
+      uiSelectedModel,
       userModel: orchestratorOverride?.model,
       fallbackChain: atlasRequirement?.fallbackChain,
       availableModels,

--- a/src/shared/model-resolver.test.ts
+++ b/src/shared/model-resolver.test.ts
@@ -112,7 +112,80 @@ describe("resolveModelWithFallback", () => {
     logSpy.mockRestore()
   })
 
-  describe("Step 1: Override", () => {
+  describe("Step 1: UI Selection (highest priority)", () => {
+    test("returns uiSelectedModel with override source when provided", () => {
+      // #given
+      const input: ExtendedModelResolutionInput = {
+        uiSelectedModel: "opencode/glm-4.7-free",
+        userModel: "anthropic/claude-opus-4-5",
+        fallbackChain: [
+          { providers: ["anthropic", "github-copilot"], model: "claude-opus-4-5" },
+        ],
+        availableModels: new Set(["anthropic/claude-opus-4-5", "github-copilot/claude-opus-4-5-preview"]),
+        systemDefaultModel: "google/gemini-3-pro",
+      }
+
+      // #when
+      const result = resolveModelWithFallback(input)
+
+      // #then
+      expect(result!.model).toBe("opencode/glm-4.7-free")
+      expect(result!.source).toBe("override")
+      expect(logSpy).toHaveBeenCalledWith("Model resolved via UI selection", { model: "opencode/glm-4.7-free" })
+    })
+
+    test("UI selection takes priority over config override", () => {
+      // #given
+      const input: ExtendedModelResolutionInput = {
+        uiSelectedModel: "opencode/glm-4.7-free",
+        userModel: "anthropic/claude-opus-4-5",
+        availableModels: new Set(["anthropic/claude-opus-4-5"]),
+        systemDefaultModel: "google/gemini-3-pro",
+      }
+
+      // #when
+      const result = resolveModelWithFallback(input)
+
+      // #then
+      expect(result!.model).toBe("opencode/glm-4.7-free")
+      expect(result!.source).toBe("override")
+    })
+
+    test("whitespace-only uiSelectedModel is treated as not provided", () => {
+      // #given
+      const input: ExtendedModelResolutionInput = {
+        uiSelectedModel: "   ",
+        userModel: "anthropic/claude-opus-4-5",
+        availableModels: new Set(["anthropic/claude-opus-4-5"]),
+        systemDefaultModel: "google/gemini-3-pro",
+      }
+
+      // #when
+      const result = resolveModelWithFallback(input)
+
+      // #then
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+      expect(logSpy).toHaveBeenCalledWith("Model resolved via config override", { model: "anthropic/claude-opus-4-5" })
+    })
+
+    test("empty string uiSelectedModel falls through to config override", () => {
+      // #given
+      const input: ExtendedModelResolutionInput = {
+        uiSelectedModel: "",
+        userModel: "anthropic/claude-opus-4-5",
+        availableModels: new Set(["anthropic/claude-opus-4-5"]),
+        systemDefaultModel: "google/gemini-3-pro",
+      }
+
+      // #when
+      const result = resolveModelWithFallback(input)
+
+      // #then
+      expect(result!.model).toBe("anthropic/claude-opus-4-5")
+    })
+  })
+
+  describe("Step 2: Config Override", () => {
     test("returns userModel with override source when userModel is provided", () => {
       // #given
       const input: ExtendedModelResolutionInput = {
@@ -130,7 +203,7 @@ describe("resolveModelWithFallback", () => {
       // #then
       expect(result!.model).toBe("anthropic/claude-opus-4-5")
       expect(result!.source).toBe("override")
-      expect(logSpy).toHaveBeenCalledWith("Model resolved via override", { model: "anthropic/claude-opus-4-5" })
+      expect(logSpy).toHaveBeenCalledWith("Model resolved via config override", { model: "anthropic/claude-opus-4-5" })
     })
 
     test("override takes priority even if model not in availableModels", () => {
@@ -189,7 +262,7 @@ describe("resolveModelWithFallback", () => {
     })
   })
 
-  describe("Step 2: Provider fallback chain", () => {
+  describe("Step 3: Provider fallback chain", () => {
     test("tries providers in order within entry and returns first match", () => {
       // #given
       const input: ExtendedModelResolutionInput = {
@@ -316,7 +389,7 @@ describe("resolveModelWithFallback", () => {
     })
   })
 
-  describe("Step 3: System default fallback (no availability match)", () => {
+  describe("Step 4: System default fallback (no availability match)", () => {
     test("returns system default when no availability match found in fallback chain", () => {
       // #given
       const input: ExtendedModelResolutionInput = {

--- a/src/shared/model-resolver.ts
+++ b/src/shared/model-resolver.ts
@@ -21,6 +21,7 @@ export type ModelResolutionResult = {
 }
 
 export type ExtendedModelResolutionInput = {
+	uiSelectedModel?: string
 	userModel?: string
 	fallbackChain?: FallbackEntry[]
 	availableModels: Set<string>
@@ -43,16 +44,23 @@ export function resolveModel(input: ModelResolutionInput): string | undefined {
 export function resolveModelWithFallback(
 	input: ExtendedModelResolutionInput,
 ): ModelResolutionResult | undefined {
-	const { userModel, fallbackChain, availableModels, systemDefaultModel } = input
+	const { uiSelectedModel, userModel, fallbackChain, availableModels, systemDefaultModel } = input
 
-	// Step 1: Override
+	// Step 1: UI Selection (highest priority - respects user's model choice in OpenCode UI)
+	const normalizedUiModel = normalizeModel(uiSelectedModel)
+	if (normalizedUiModel) {
+		log("Model resolved via UI selection", { model: normalizedUiModel })
+		return { model: normalizedUiModel, source: "override" }
+	}
+
+	// Step 2: Config Override (from oh-my-opencode.json)
 	const normalizedUserModel = normalizeModel(userModel)
 	if (normalizedUserModel) {
-		log("Model resolved via override", { model: normalizedUserModel })
+		log("Model resolved via config override", { model: normalizedUserModel })
 		return { model: normalizedUserModel, source: "override" }
 	}
 
-	// Step 2: Provider fallback chain (with availability check)
+	// Step 3: Provider fallback chain (with availability check)
 	if (fallbackChain && fallbackChain.length > 0) {
 		if (availableModels.size === 0) {
 			const connectedProviders = readConnectedProvidersCache()
@@ -92,7 +100,7 @@ export function resolveModelWithFallback(
 		log("No available model found in fallback chain, falling through to system default")
 	}
 
-	// Step 3: System default (if provided)
+	// Step 4: System default (if provided)
 	if (systemDefaultModel === undefined) {
 		log("No model resolved - systemDefaultModel not configured")
 		return undefined


### PR DESCRIPTION
- Add uiSelectedModel parameter to resolveModelWithFallback()
- Update model resolution priority: UI Selection → Config Override → Fallback → System Default
- Pass config.model as uiSelectedModel in createBuiltinAgents()
- Fix ProviderModelNotFoundError when model is unset in config but selected in UI

## Summary

- Fix Sisyphus and other agents ignoring UI model selection when model is not set in config
- Prevent `ProviderModelNotFoundError` crash when user selects model in OpenCode UI but config has no model override

## Changes

- `src/shared/model-resolver.ts`: Add `uiSelectedModel` parameter to `ExtendedModelResolutionInput` type and `resolveModelWithFallback()` function. UI selection now takes highest priority (Step 1) in model resolution chain.
- `src/agents/utils.ts`: Add `uiSelectedModel` parameter to `createBuiltinAgents()` and pass it to all `resolveModelWithFallback()` calls for Sisyphus, Atlas, and other agents.
- `src/plugin-handlers/config-handler.ts`: Pass `config.model` (OpenCode's active model including UI selection) as `uiSelectedModel` to `createBuiltinAgents()` and Prometheus model resolution.
- `src/shared/model-resolver.test.ts`: Add test cases for UI model selection priority, including edge cases for empty/whitespace values.

## Screenshots

N/A - Backend logic change, no UI modifications.

## Testing

bun run typecheck
bun test model-resolver
bun run build**Manual testing:**
1. Start OpenCode with oh-my-opencode plugin
2. Select a model in OpenCode UI (e.g., `opencode/some-model`)
3. Do NOT set model in `oh-my-opencode.json` config
4. Send a message - Sisyphus should now use the UI-selected model instead of throwing `ProviderModelNotFoundError`

## Related Issues
https://github.com/code-yeongyu/oh-my-opencode/issues/959


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agents ignoring the model chosen in the OpenCode UI by making UI selection the top priority. Prevents ProviderModelNotFoundError when config has no model.

- **Bug Fixes**
  - Added uiSelectedModel to resolveModelWithFallback and createBuiltinAgents.
  - Updated resolution order: UI selection → config override → provider fallback → system default.
  - Passed OpenCode’s active model (config.model) as uiSelectedModel for Sisyphus, Atlas, and Prometheus.
  - Added tests for UI priority and empty/whitespace edge cases.

<sup>Written for commit 01dd89919968c8ad11e6fe0173d6f63b6c8eb689. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

