### PR TITLE
fix(agent-variant): resolve variant based on current model, not static config

### DIFF
--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { OhMyOpenCodeConfig } from "../config"
-import { applyAgentVariant, resolveAgentVariant } from "./agent-variant"
+import { applyAgentVariant, resolveAgentVariant, resolveVariantForModel } from "./agent-variant"
 
 describe("resolveAgentVariant", () => {
   test("returns undefined when agent name missing", () => {
@@ -79,5 +79,119 @@ describe("applyAgentVariant", () => {
 
     // #then
     expect(message.variant).toBe("max")
+  })
+})
+
+describe("resolveVariantForModel", () => {
+  test("returns correct variant for anthropic provider", () => {
+    // #given
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "anthropic", modelID: "claude-opus-4-5" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "sisyphus", model)
+
+    // #then
+    expect(variant).toBe("max")
+  })
+
+  test("returns correct variant for openai provider", () => {
+    // #given
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "openai", modelID: "gpt-5.2" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "sisyphus", model)
+
+    // #then
+    expect(variant).toBe("medium")
+  })
+
+  test("returns undefined for provider with no variant in chain", () => {
+    // #given
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "google", modelID: "gemini-3-pro" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "sisyphus", model)
+
+    // #then
+    expect(variant).toBeUndefined()
+  })
+
+  test("returns undefined for provider not in chain", () => {
+    // #given
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "unknown-provider", modelID: "some-model" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "sisyphus", model)
+
+    // #then
+    expect(variant).toBeUndefined()
+  })
+
+  test("returns undefined for unknown agent", () => {
+    // #given
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "anthropic", modelID: "claude-opus-4-5" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "nonexistent-agent", model)
+
+    // #then
+    expect(variant).toBeUndefined()
+  })
+
+  test("returns variant for zai-coding-plan provider without variant", () => {
+    // #given
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "zai-coding-plan", modelID: "glm-4.7" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "sisyphus", model)
+
+    // #then
+    expect(variant).toBeUndefined()
+  })
+
+  test("falls back to category chain when agent has no requirement", () => {
+    // #given
+    const config = {
+      agents: {
+        "custom-agent": { category: "ultrabrain" },
+      },
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "openai", modelID: "gpt-5.2-codex" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "custom-agent", model)
+
+    // #then
+    expect(variant).toBe("xhigh")
+  })
+
+  test("returns correct variant for oracle agent with openai", () => {
+    // #given
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "openai", modelID: "gpt-5.2" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "oracle", model)
+
+    // #then
+    expect(variant).toBe("high")
+  })
+
+  test("returns correct variant for oracle agent with anthropic", () => {
+    // #given
+    const config = {} as OhMyOpenCodeConfig
+    const model = { providerID: "anthropic", modelID: "claude-opus-4-5" }
+
+    // #when
+    const variant = resolveVariantForModel(config, "oracle", model)
+
+    // #then
+    expect(variant).toBe("max")
   })
 })


### PR DESCRIPTION
## Summary

- Fix variant sticking to static agent config (e.g. "max") when user switches models at runtime, causing silent degradation (variant resolves to undefined for non-matching providers)
- Add `resolveVariantForModel()` that looks up the correct variant from `AGENT_MODEL_REQUIREMENTS` / `CATEGORY_MODEL_REQUIREMENTS` fallback chains based on the current model's provider
- Update `chat.message` hook to use model-aware resolution when `input.model` is available

## Problem

When using Sisyphus (defaults to `claude-opus-4-5` with variant `"max"`), sometimes you want to switch to a different model for quick questions. When you change the model in the UI to e.g. `openai/gpt-5.2`, the thinking variant stays stuck on `"max"` (a Claude-only variant). For GPT-5.2, `"max"` resolves to `undefined` in the backend (`model.variants["max"]` → `undefined`), so no reasoning effort is applied at all. Silent degradation, not an error.

Switching models with Ctrl+T correctly shows the new model's valid variants in the UI, but the plugin's `chat.message` hook still injects the old variant from static agent config, overriding the user's selection.

## Root Cause

`resolveAgentVariant()` reads variant from static config (`config.agents[agentName].variant`) without knowing what model is currently active. The `chat.message` hook blindly applies this result regardless of model.

## Fix

- New `resolveVariantForModel(config, agentName, currentModel)` function that matches `currentModel.providerID` against `AGENT_MODEL_REQUIREMENTS` fallback chains
- Falls back to `CATEGORY_MODEL_REQUIREMENTS` when agent has a category but no agent-level requirement
- Returns `undefined` when no match (correct — don't force a variant)
- `chat.message` hook prefers model-aware resolution when `input.model` is available

## Testing

- 8 new BDD-style tests covering: anthropic→"max", openai→"medium", google→undefined, unknown provider→undefined, unknown agent→undefined, zai-coding-plan→undefined, category fallback, cross-agent (oracle)
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test src/shared/agent-variant.test.ts` — 14/14 pass ✅
- Tested locally with opencode — variant now correctly resolves per active model

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes variant selection to use the active model/provider instead of a static agent setting. Switching models now picks a valid reasoning variant and avoids silent degradation.

- Bug Fixes
  - Added resolveVariantForModel using AGENT_MODEL_REQUIREMENTS with CATEGORY_MODEL_REQUIREMENTS fallback to map provider → variant.
  - Updated chat.message to prefer model-aware resolution when input.model is present; otherwise use applyAgentVariant.
  - Return undefined when no match to avoid forcing invalid variants.
  - Added tests across providers, unknown agents, and category fallback.

<sup>Written for commit f084dad27b6af3734f90bd8dfef4d298880be7ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

