### PR TITLE
fix: guard JSON.parse(result.stdout) with || "{}" fallback in hook ha…

### DIFF
--- a/src/hooks/claude-code-hooks/post-tool-use.ts
+++ b/src/hooks/claude-code-hooks/post-tool-use.ts
@@ -123,7 +123,7 @@ export async function executePostToolUseHooks(
 
         if (result.exitCode === 0 && result.stdout) {
           try {
-            const output = JSON.parse(result.stdout) as PostToolUseOutput
+            const output = JSON.parse(result.stdout || "{}") as PostToolUseOutput
             if (output.decision === "block") {
               return {
                 block: true,

--- a/src/hooks/claude-code-hooks/pre-compact.ts
+++ b/src/hooks/claude-code-hooks/pre-compact.ts
@@ -73,7 +73,7 @@ export async function executePreCompactHooks(
 
       if (result.stdout) {
         try {
-          const output = JSON.parse(result.stdout) as PreCompactOutput
+          const output = JSON.parse(result.stdout || "{}") as PreCompactOutput
 
           if (output.hookSpecificOutput?.additionalContext) {
             collectedContext.push(...output.hookSpecificOutput.additionalContext)

--- a/src/hooks/claude-code-hooks/pre-tool-use.ts
+++ b/src/hooks/claude-code-hooks/pre-tool-use.ts
@@ -117,7 +117,7 @@ export async function executePreToolUseHooks(
 
       if (result.stdout) {
         try {
-          const output = JSON.parse(result.stdout) as PreToolUseOutput
+          const output = JSON.parse(result.stdout || "{}") as PreToolUseOutput
 
           // Handle deprecated decision/reason fields (Claude Code backward compat)
           let decision: PermissionDecision | undefined

--- a/src/hooks/claude-code-hooks/stop.ts
+++ b/src/hooks/claude-code-hooks/stop.ts
@@ -93,7 +93,7 @@ export async function executeStopHooks(
 
        if (result.stdout) {
          try {
-           const output = JSON.parse(result.stdout) as StopOutput
+           const output = JSON.parse(result.stdout || "{}") as StopOutput
            if (output.stop_hook_active !== undefined) {
              stopHookActiveState.set(ctx.sessionId, output.stop_hook_active)
            }


### PR DESCRIPTION
To solve the following promlem:

Send prompt failed


Error: JSON Parse error: Unexpected EOF

Session ID: ses_400294fd1ffeqk5hzKBELv0hkS

Agent: plan


Arguments:



description: "Plan LSP syntax check workflow"

category: (none)

subagent_type: plan

run_in_background: false

load_skills: []


Stack Trace:


SyntaxError: JSON Parse error: Unexpected EOF
    at <parse> (:0)
    at parse (unknown)
    at processTicksAndRejections (native:7:39)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded JSON.parse calls in Claude Code hook handlers with a "{}" fallback to prevent crashes when hook scripts return empty or partial stdout. This fixes the "JSON Parse error: Unexpected EOF" that caused prompt sends to fail.

- **Bug Fixes**
  - Use JSON.parse(result.stdout || "{}") in pre-tool-use, post-tool-use, pre-compact, and stop hooks.
  - Gracefully handles empty/truncated stdout, avoiding Unexpected EOF errors.
  - Preserves default behavior when no structured output is provided.

<sup>Written for commit 1a3ca12c30e517def093001d3ea47968c179bc4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

