### PR TITLE
fix: resolve version detection for npm global installations

### DIFF
--- a/src/hooks/auto-update-checker/checker.ts
+++ b/src/hooks/auto-update-checker/checker.ts
@@ -170,6 +170,20 @@ export function getCachedVersion(): string | null {
     log("[auto-update-checker] Failed to resolve version from current directory:", err)
   }
 
+  // Fallback for compiled binaries (npm global install)
+  // process.execPath points to the actual binary location
+  try {
+    const execDir = path.dirname(fs.realpathSync(process.execPath))
+    const pkgPath = findPackageJsonUp(execDir)
+    if (pkgPath) {
+      const content = fs.readFileSync(pkgPath, "utf-8")
+      const pkg = JSON.parse(content) as PackageJson
+      if (pkg.version) return pkg.version
+    }
+  } catch (err) {
+    log("[auto-update-checker] Failed to resolve version from execPath:", err)
+  }
+
   return null
 }
 


### PR DESCRIPTION
## Summary

Fixes #1182

## Problem

After a fresh `npm install -g oh-my-opencode`, the `get-local-version` command returns 'unknown' instead of the actual version. This is because the version detection logic only looks for `package.json` relative to the current directory or the source file location, which doesn't work for globally installed npm packages.

## Solution

Added a fallback mechanism in `getCachedVersion()` that:
1. Resolves the actual path of the running binary using `process.execPath`
2. Searches for `package.json` starting from that location

This ensures version detection works correctly for:
- Local development (existing behavior)
- Project-specific installations (existing behavior)
- **Global npm installations (new fallback)**

## Testing

1. Fresh install: `npm install -g oh-my-opencode`
2. Run: `oh-my-opencode get-local-version`
3. Should now show the correct version instead of 'unknown'

## Changes

- `src/hooks/auto-update-checker/checker.ts`: Added execPath-based version detection fallback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix version detection for npm global installs so get-local-version shows the correct version instead of “unknown” (Fixes #1182). Adds an execPath-based fallback in getCachedVersion to locate package.json from the running binary.

<sup>Written for commit 95ef055edeae62c9e9fc2b922db9bd128940649e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

