### PR TITLE
ci(cla): add repository owner to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,7 +25,7 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/code-yeongyu/oh-my-opencode/blob/master/CLA.md'
           branch: 'dev'
-          allowlist: bot*,dependabot*,github-actions*,*[bot],sisyphus-dev-ai
+          allowlist: code-yeongyu,bot*,dependabot*,github-actions*,*[bot],sisyphus-dev-ai
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, we need you to sign our [Contributor License Agreement (CLA)](https://github.com/code-yeongyu/oh-my-opencode/blob/master/CLA.md).
             


### PR DESCRIPTION
## Problem

The repository owner (`code-yeongyu`) was not included in the CLA allowlist, causing the CLA Assistant to require signature even on the owner's own PRs.

## Solution

Added `code-yeongyu` to the CLA allowlist in `.github/workflows/cla.yml`.

## Changes

```yaml
# Before
allowlist: bot*,dependabot*,github-actions*,*[bot],sisyphus-dev-ai

# After  
allowlist: code-yeongyu,bot*,dependabot*,github-actions*,*[bot],sisyphus-dev-ai
```

This ensures the repository owner can merge their own PRs without CLA signature requirement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated .github/workflows/cla.yml to add the repository owner (code-yeongyu) to the CLA allowlist. This stops CLA prompts on owner PRs and allows merging without extra steps.

<sup>Written for commit e1765153020ce191047349b5a8adde6ed653fd48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

