### PR TITLE
docs: add Ollama streaming NDJSON issue guide and workaround

### DIFF
--- a/docs/troubleshooting/ollama-streaming-issue.md
+++ b/docs/troubleshooting/ollama-streaming-issue.md
@@ -76,7 +76,7 @@ Until the SDK is fixed, here's how to implement NDJSON parsing (for SDK maintain
 async function parseOllamaStreamResponse(response: string): Promise<object> {
   const lines = response.split('\n').filter(line => line.trim());
   const mergedMessage = { tool_calls: [] };
-  
+
   for (const line of lines) {
     try {
       const json = JSON.parse(line);
@@ -91,7 +91,7 @@ async function parseOllamaStreamResponse(response: string): Promise<object> {
       console.warn('Skipping malformed NDJSON line:', line);
     }
   }
-  
+
   return mergedMessage;
 }
 ```

--- a/docs/troubleshooting/ollama-streaming-issue.md
+++ b/docs/troubleshooting/ollama-streaming-issue.md
@@ -1,0 +1,126 @@
+# Ollama Streaming Issue - JSON Parse Error
+
+## Problem
+
+When using Ollama as a provider with oh-my-opencode agents, you may encounter:
+
+```
+JSON Parse error: Unexpected EOF
+```
+
+This occurs when agents attempt tool calls (e.g., `explore` agent using `mcp_grep_search`).
+
+## Root Cause
+
+Ollama returns **NDJSON** (newline-delimited JSON) when `stream: true` is used in API requests:
+
+```json
+{"message":{"tool_calls":[{"function":{"name":"read","arguments":{"filePath":"README.md"}}}]}, "done":false}
+{"message":{"content":""}, "done":true}
+```
+
+Claude Code SDK expects a single JSON object, not multiple NDJSON lines, causing the parse error.
+
+### Why This Happens
+
+- **Ollama API**: Returns streaming responses as NDJSON by design
+- **Claude Code SDK**: Doesn't properly handle NDJSON responses for tool calls
+- **oh-my-opencode**: Passes through the SDK's behavior (can't fix at this layer)
+
+## Solutions
+
+### Option 1: Disable Streaming (Recommended - Immediate Fix)
+
+Configure your Ollama provider to use `stream: false`:
+
+```json
+{
+  "provider": "ollama",
+  "model": "qwen3-coder",
+  "stream": false
+}
+```
+
+**Pros:**
+- Works immediately
+- No code changes needed
+- Simple configuration
+
+**Cons:**
+- Slightly slower response time (no streaming)
+- Less interactive feedback
+
+### Option 2: Use Non-Tool Agents Only
+
+If you need streaming, avoid agents that use tools:
+
+- ✅ **Safe**: Simple text generation, non-tool tasks
+- ❌ **Problematic**: Any agent with tool calls (explore, librarian, etc.)
+
+### Option 3: Wait for SDK Fix (Long-term)
+
+The proper fix requires Claude Code SDK to:
+
+1. Detect NDJSON responses
+2. Parse each line separately
+3. Merge `tool_calls` from multiple lines
+4. Return a single merged response
+
+**Tracking**: https://github.com/code-yeongyu/oh-my-opencode/issues/1124
+
+## Workaround Implementation
+
+Until the SDK is fixed, here's how to implement NDJSON parsing (for SDK maintainers):
+
+```typescript
+async function parseOllamaStreamResponse(response: string): Promise<object> {
+  const lines = response.split('\n').filter(line => line.trim());
+  const mergedMessage = { tool_calls: [] };
+  
+  for (const line of lines) {
+    try {
+      const json = JSON.parse(line);
+      if (json.message?.tool_calls) {
+        mergedMessage.tool_calls.push(...json.message.tool_calls);
+      }
+      if (json.message?.content) {
+        mergedMessage.content = json.message.content;
+      }
+    } catch (e) {
+      // Skip malformed lines
+      console.warn('Skipping malformed NDJSON line:', line);
+    }
+  }
+  
+  return mergedMessage;
+}
+```
+
+## Testing
+
+To verify the fix works:
+
+```bash
+# Test with curl (should work with stream: false)
+curl -s http://localhost:11434/api/chat \
+  -d '{
+    "model": "qwen3-coder",
+    "messages": [{"role": "user", "content": "Read file README.md"}],
+    "stream": false,
+    "tools": [{"type": "function", "function": {"name": "read", "description": "Read a file", "parameters": {"type": "object", "properties": {"filePath": {"type": "string"}}, "required": ["filePath"]}}}]
+  }'
+```
+
+## Related Issues
+
+- **oh-my-opencode**: https://github.com/code-yeongyu/oh-my-opencode/issues/1124
+- **Ollama API Docs**: https://github.com/ollama/ollama/blob/main/docs/api.md
+
+## Getting Help
+
+If you encounter this issue:
+
+1. Check your Ollama provider configuration
+2. Set `stream: false` as a workaround
+3. Report any additional errors to the issue tracker
+4. Provide your configuration (without secrets) for debugging

--- a/src/shared/ollama-ndjson-parser.ts
+++ b/src/shared/ollama-ndjson-parser.ts
@@ -1,0 +1,197 @@
+/**
+ * Ollama NDJSON Parser
+ *
+ * Parses newline-delimited JSON (NDJSON) responses from Ollama API.
+ *
+ * @module ollama-ndjson-parser
+ * @see https://github.com/code-yeongyu/oh-my-opencode/issues/1124
+ * @see https://github.com/ollama/ollama/blob/main/docs/api.md
+ */
+
+/**
+ * Ollama message structure
+ */
+export interface OllamaMessage {
+  tool_calls?: Array<{
+    function: {
+      name: string
+      arguments: Record<string, unknown>
+    }
+  }>
+  content?: string
+}
+
+/**
+ * Ollama NDJSON line structure
+ */
+export interface OllamaNDJSONLine {
+  message?: OllamaMessage
+  done: boolean
+  total_duration?: number
+  load_duration?: number
+  prompt_eval_count?: number
+  prompt_eval_duration?: number
+  eval_count?: number
+  eval_duration?: number
+}
+
+/**
+ * Merged Ollama response
+ */
+export interface OllamaMergedResponse {
+  message: OllamaMessage
+  done: boolean
+  stats?: {
+    total_duration?: number
+    load_duration?: number
+    prompt_eval_count?: number
+    prompt_eval_duration?: number
+    eval_count?: number
+    eval_duration?: number
+  }
+}
+
+/**
+ * Parse Ollama streaming NDJSON response into a single merged object.
+ *
+ * Ollama returns streaming responses as newline-delimited JSON (NDJSON):
+ * ```
+ * {"message":{"tool_calls":[...]}, "done":false}
+ * {"message":{"content":""}, "done":true}
+ * ```
+ *
+ * This function:
+ * 1. Splits the response by newlines
+ * 2. Parses each line as JSON
+ * 3. Merges tool_calls and content from all lines
+ * 4. Returns a single merged response
+ *
+ * @param response - Raw NDJSON response string from Ollama API
+ * @returns Merged response with all tool_calls and content combined
+ * @throws {Error} If no valid JSON lines are found
+ *
+ * @example
+ * ```typescript
+ * const ndjsonResponse = `
+ * {"message":{"tool_calls":[{"function":{"name":"read","arguments":{"filePath":"README.md"}}}]}, "done":false}
+ * {"message":{"content":""}, "done":true}
+ * `;
+ *
+ * const merged = parseOllamaStreamResponse(ndjsonResponse);
+ * // Result:
+ * // {
+ * //   message: {
+ * //     tool_calls: [{ function: { name: "read", arguments: { filePath: "README.md" } } }],
+ * //     content: ""
+ * //   },
+ * //   done: true
+ * // }
+ * ```
+ */
+export function parseOllamaStreamResponse(response: string): OllamaMergedResponse {
+  const lines = response.split("\n").filter((line) => line.trim())
+
+  if (lines.length === 0) {
+    throw new Error("No valid NDJSON lines found in response")
+  }
+
+  const mergedMessage: OllamaMessage = {
+    tool_calls: [],
+    content: "",
+  }
+
+  let done = false
+  let stats: OllamaMergedResponse["stats"] = {}
+
+  for (const line of lines) {
+    try {
+      const json = JSON.parse(line) as OllamaNDJSONLine
+
+      // Merge tool_calls
+      if (json.message?.tool_calls) {
+        mergedMessage.tool_calls = [
+          ...(mergedMessage.tool_calls || []),
+          ...json.message.tool_calls,
+        ]
+      }
+
+      // Merge content (concatenate)
+      if (json.message?.content) {
+        mergedMessage.content = (mergedMessage.content || "") + json.message.content
+      }
+
+      // Update done flag (final line has done: true)
+      if (json.done) {
+        done = true
+
+        // Capture stats from final line
+        stats = {
+          total_duration: json.total_duration,
+          load_duration: json.load_duration,
+          prompt_eval_count: json.prompt_eval_count,
+          prompt_eval_duration: json.prompt_eval_duration,
+          eval_count: json.eval_count,
+          eval_duration: json.eval_duration,
+        }
+      }
+    } catch (error) {
+      // Skip malformed lines with warning
+      console.warn(`[ollama-ndjson-parser] Skipping malformed NDJSON line: ${line}`, error)
+      continue
+    }
+  }
+
+  return {
+    message: mergedMessage,
+    done,
+    ...(Object.keys(stats).length > 0 ? { stats } : {}),
+  }
+}
+
+/**
+ * Check if a response string is NDJSON format.
+ *
+ * NDJSON is identified by:
+ * - Multiple lines
+ * - Each line is valid JSON
+ * - At least one line has "done" field
+ *
+ * @param response - Response string to check
+ * @returns true if response appears to be NDJSON
+ *
+ * @example
+ * ```typescript
+ * const ndjson = '{"done":false}\n{"done":true}';
+ * const singleJson = '{"done":true}';
+ *
+ * isNDJSONResponse(ndjson);     // true
+ * isNDJSONResponse(singleJson); // false
+ * ```
+ */
+export function isNDJSONResponse(response: string): boolean {
+  const lines = response.split("\n").filter((line) => line.trim())
+
+  // Single line is not NDJSON
+  if (lines.length <= 1) {
+    return false
+  }
+
+  let hasValidJSON = false
+  let hasDoneField = false
+
+  for (const line of lines) {
+    try {
+      const json = JSON.parse(line) as Record<string, unknown>
+      hasValidJSON = true
+
+      if ("done" in json) {
+        hasDoneField = true
+      }
+    } catch {
+      // If any line fails to parse, it's not NDJSON
+      return false
+    }
+  }
+
+  return hasValidJSON && hasDoneField
+}

--- a/src/shared/ollama-ndjson-parser.ts
+++ b/src/shared/ollama-ndjson-parser.ts
@@ -8,6 +8,8 @@
  * @see https://github.com/ollama/ollama/blob/main/docs/api.md
  */
 
+import { log } from "./logger"
+
 /**
  * Ollama message structure
  */
@@ -135,8 +137,7 @@ export function parseOllamaStreamResponse(response: string): OllamaMergedRespons
         }
       }
     } catch (error) {
-      // Skip malformed lines with warning
-      console.warn(`[ollama-ndjson-parser] Skipping malformed NDJSON line: ${line}`, error)
+      log(`[ollama-ndjson-parser] Skipping malformed NDJSON line: ${line}`, { error })
       continue
     }
   }


### PR DESCRIPTION
## Summary

Resolves #1124 - Ollama integration fails with streaming NDJSON responses

This PR provides documentation and utility code for the Ollama streaming issue.

## Problem

When using Ollama with oh-my-opencode agents that use tools, the error occurs:
```
JSON Parse error: Unexpected EOF
```

**Root Cause**: Ollama returns NDJSON when `stream: true`, but SDK expects single JSON.

## Solution

1. **Troubleshooting Guide** - Explains issue and provides immediate workaround
2. **Configuration Documentation** - Documents `stream: false` setting
3. **NDJSON Parser Utility** - For future SDK integration

## Verification

- ✅ Tested with real Ollama API (ministral-3:14b, qwen3-coder)
- ✅ NDJSON parser tested with real streaming data (9 lines)
- ✅ Tool calls verified working with stream=false
- ✅ No JSON parse errors

## Files Changed

- `docs/troubleshooting/ollama-streaming-issue.md` (NEW - 3.4 KB)
- `docs/configurations.md` (MODIFIED - +60 lines)
- `src/shared/ollama-ndjson-parser.ts` (NEW - 4.9 KB)

## Checklist

- [x] Code follows project conventions
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] Tested locally with OpenCode
- [x] Updated documentation
- [x] No version changes in package.json
- [x] Clear commit messages (present tense)
- [x] Issue #1124 referenced


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and works around Ollama’s streaming NDJSON responses that caused “JSON Parse error: Unexpected EOF” during tool calls. Adds an NDJSON parser utility and documents setting stream: false to restore stability (fixes #1124).

- **New Features**
  - NDJSON parser utility for Ollama streaming (parseOllamaStreamResponse, isNDJSONResponse).
  - Merges tool_calls and content, skips malformed lines, and collects basic stats.

- **Migration**
  - For Ollama agents, set "stream": false in config.

<sup>Written for commit c177f56d58ec5aa82a27d1f3070c63f8b5530f05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

