### PR TITLE
fix(tools): add permission field to session.create() for consistency (#1192)

### DIFF
--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -163,7 +163,10 @@ async function executeSync(
       body: {
         parentID: toolContext.sessionID,
         title: `${args.description} (@${args.subagent_type} subagent)`,
-      },
+        permission: [
+          { permission: "question", action: "deny" as const, pattern: "*" },
+        ],
+      } as any,
       query: {
         directory: parentDirectory,
       },
@@ -171,6 +174,17 @@ async function executeSync(
 
     if (createResult.error) {
       log(`[call_omo_agent] Session create error:`, createResult.error)
+      const errorStr = String(createResult.error)
+      if (errorStr.toLowerCase().includes("unauthorized")) {
+        return `Error: Failed to create session (Unauthorized). This may be due to:
+1. OAuth token restrictions (e.g., Claude Code credentials are restricted to Claude Code only)
+2. Provider authentication issues
+3. Session permission inheritance problems
+
+Try using a different provider or API key authentication.
+
+Original error: ${createResult.error}`
+      }
       return `Error: Failed to create session: ${createResult.error}`
     }
 

--- a/src/tools/look-at/tools.ts
+++ b/src/tools/look-at/tools.ts
@@ -102,7 +102,10 @@ If the requested information is not found, clearly state what is missing.`
         body: {
           parentID: toolContext.sessionID,
           title: `look_at: ${args.goal.substring(0, 50)}`,
-        },
+          permission: [
+            { permission: "question", action: "deny" as const, pattern: "*" },
+          ],
+        } as any,
         query: {
           directory: parentDirectory,
         },
@@ -110,6 +113,17 @@ If the requested information is not found, clearly state what is missing.`
 
       if (createResult.error) {
         log(`[look_at] Session create error:`, createResult.error)
+        const errorStr = String(createResult.error)
+        if (errorStr.toLowerCase().includes("unauthorized")) {
+          return `Error: Failed to create session (Unauthorized). This may be due to:
+1. OAuth token restrictions (e.g., Claude Code credentials are restricted to Claude Code only)
+2. Provider authentication issues
+3. Session permission inheritance problems
+
+Try using a different provider or API key authentication.
+
+Original error: ${createResult.error}`
+        }
         return `Error: Failed to create session: ${createResult.error}`
       }
 


### PR DESCRIPTION
## Summary

Fixes #1192 - look_at tool fails with 'Unauthorized' error

This PR adds consistency to session creation across all tools by:
- Adding `permission` field to `look_at` and `call_omo_agent` session.create() calls
- Matching the pattern already used in `delegate_task` and `background-agent`
- Adding better error messages for Unauthorized failures with actionable guidance

## Changes

- **src/tools/look-at/tools.ts**: Add permission field and improved error handling
- **src/tools/call-omo-agent/tools.ts**: Add permission field and improved error handling

## Root Cause Analysis

The `look_at` and `call_omo_agent` tools were creating sessions WITHOUT the `permission` field, while `delegate_task` and `background-agent` included it:

```typescript
// Before (look_at/call_omo_agent)
const createResult = await ctx.client.session.create({
  body: {
    parentID: toolContext.sessionID,
    title: `...`,
  },
  query: { directory: parentDirectory },
})

// After (consistent with delegate_task/background-agent)
const createResult = await ctx.client.session.create({
  body: {
    parentID: toolContext.sessionID,
    title: `...`,
    permission: [
      { permission: "question", action: "deny" as const, pattern: "*" },
    ],
  } as any,
  query: { directory: parentDirectory },
})
```

## Note on #1198

Issue #1198 ("This credential is only authorized for use with Claude Code") is a **separate issue** caused by Anthropic restricting Claude Code OAuth tokens. This is not a code bug but an Anthropic ToS enforcement - users need to use a different auth method or provider.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes session creation consistent across tools to prevent Unauthorized errors in look_at and call_omo_agent. Addresses #1192.

- **Bug Fixes**
  - Added permission field to child sessions in look_at and call_omo_agent (deny "question" with pattern "*").
  - Matched session.create payload with delegate_task and background-agent.
  - Improved Unauthorized error messages with clear guidance on auth/provider issues.

<sup>Written for commit 1525fd3b14a9480ad1136e2d6e2b2c4c3c99aab1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

