### PR TITLE
fix(start-work): prevent overwriting session agent if already set; inherit parent model for subagent types

### DIFF
--- a/src/features/builtin-commands/commands.ts
+++ b/src/features/builtin-commands/commands.ts
@@ -55,7 +55,6 @@ ${REFACTOR_TEMPLATE}
   },
   "start-work": {
     description: "(builtin) Start Sisyphus work session from Prometheus plan",
-    agent: "atlas",
     template: `<command-instruction>
 ${START_WORK_TEMPLATE}
 </command-instruction>

--- a/src/features/hook-message-injector/injector.ts
+++ b/src/features/hook-message-injector/injector.ts
@@ -5,7 +5,7 @@ import type { MessageMeta, OriginalMessageContext, TextPart, ToolPermission } fr
 
 export interface StoredMessage {
   agent?: string
-  model?: { providerID?: string; modelID?: string }
+  model?: { providerID?: string; modelID?: string; variant?: string }
   tools?: Record<string, ToolPermission>
 }
 

--- a/src/features/hook-message-injector/injector.ts
+++ b/src/features/hook-message-injector/injector.ts
@@ -141,9 +141,17 @@ export function injectHookMessage(
   const resolvedAgent = originalMessage.agent ?? fallback?.agent ?? "general"
   const resolvedModel =
     originalMessage.model?.providerID && originalMessage.model?.modelID
-      ? { providerID: originalMessage.model.providerID, modelID: originalMessage.model.modelID }
+      ? { 
+          providerID: originalMessage.model.providerID, 
+          modelID: originalMessage.model.modelID,
+          ...(originalMessage.model.variant ? { variant: originalMessage.model.variant } : {})
+        }
       : fallback?.model?.providerID && fallback?.model?.modelID
-        ? { providerID: fallback.model.providerID, modelID: fallback.model.modelID }
+        ? { 
+            providerID: fallback.model.providerID, 
+            modelID: fallback.model.modelID,
+            ...(fallback.model.variant ? { variant: fallback.model.variant } : {})
+          }
         : undefined
   const resolvedTools = originalMessage.tools ?? fallback?.tools
 

--- a/src/features/hook-message-injector/types.ts
+++ b/src/features/hook-message-injector/types.ts
@@ -12,6 +12,7 @@ export interface MessageMeta {
   model?: {
     providerID: string
     modelID: string
+    variant?: string
   }
   path?: {
     cwd: string
@@ -25,6 +26,7 @@ export interface OriginalMessageContext {
   model?: {
     providerID?: string
     modelID?: string
+    variant?: string
   }
   path?: {
     cwd?: string

--- a/src/hooks/start-work/index.ts
+++ b/src/hooks/start-work/index.ts
@@ -10,7 +10,7 @@ import {
   clearBoulderState,
 } from "../../features/boulder-state"
 import { log } from "../../shared/logger"
-import { updateSessionAgent } from "../../features/claude-code-session-state"
+import { getSessionAgent, updateSessionAgent } from "../../features/claude-code-session-state"
 
 export const HOOK_NAME = "start-work"
 
@@ -71,7 +71,10 @@ export function createStartWorkHook(ctx: PluginInput) {
         sessionID: input.sessionID,
       })
 
-      updateSessionAgent(input.sessionID, "atlas")
+      const currentAgent = getSessionAgent(input.sessionID)
+      if (!currentAgent) {
+        updateSessionAgent(input.sessionID, "atlas")
+      }
 
       const existingState = readBoulderState(ctx.directory)
       const sessionId = input.sessionID

--- a/src/hooks/todo-continuation-enforcer.ts
+++ b/src/hooks/todo-continuation-enforcer.ts
@@ -205,7 +205,11 @@ export function createTodoContinuationEnforcer(
       const prevMessage = messageDir ? findNearestMessageWithFields(messageDir) : null
       agentName = agentName ?? prevMessage?.agent
       model = model ?? (prevMessage?.model?.providerID && prevMessage?.model?.modelID
-        ? { providerID: prevMessage.model.providerID, modelID: prevMessage.model.modelID }
+        ? { 
+            providerID: prevMessage.model.providerID, 
+            modelID: prevMessage.model.modelID,
+            ...(prevMessage.model.variant ? { variant: prevMessage.model.variant } : {})
+          }
         : undefined)
       tools = tools ?? prevMessage?.tools
     }

--- a/src/tools/background-task/tools.ts
+++ b/src/tools/background-task/tools.ts
@@ -80,7 +80,11 @@ export function createBackgroundTask(manager: BackgroundManager): ToolDefinition
         })
         
         const parentModel = prevMessage?.model?.providerID && prevMessage?.model?.modelID
-          ? { providerID: prevMessage.model.providerID, modelID: prevMessage.model.modelID }
+          ? { 
+              providerID: prevMessage.model.providerID, 
+              modelID: prevMessage.model.modelID,
+              ...(prevMessage.model.variant ? { variant: prevMessage.model.variant } : {})
+            }
           : undefined
 
         const task = await manager.launch({

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -800,6 +800,13 @@ Sisyphus-Junior is spawned automatically when you specify a category. Pick the a
         } catch {
           // If we can't fetch agents, proceed anyway - the session.prompt will fail with a clearer error
         }
+
+        // When using subagent_type directly, inherit parent model so agents don't default
+        // to their hardcoded models (like grok-code) which may not be available
+        if (parentModel) {
+          categoryModel = parentModel
+          modelInfo = { model: `${parentModel.providerID}/${parentModel.modelID}`, type: "inherited" }
+        }
       }
 
       const systemContent = buildSystemContent({ skillContent, categoryPromptAppend, agentName: agentToUse })

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -287,7 +287,11 @@ Prompts MUST be in English.`
         resolvedParentAgent: parentAgent,
       })
       const parentModel = prevMessage?.model?.providerID && prevMessage?.model?.modelID
-        ? { providerID: prevMessage.model.providerID, modelID: prevMessage.model.modelID }
+        ? { 
+            providerID: prevMessage.model.providerID, 
+            modelID: prevMessage.model.modelID,
+            ...(prevMessage.model.variant ? { variant: prevMessage.model.variant } : {})
+          }
         : undefined
 
       if (args.session_id) {


### PR DESCRIPTION

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->
- /start-work will use model in current session instead of default model


## Changes

<!-- What was changed and how. List specific modifications. -->
- When subagent_type is used, the parent session's model is inherited
- categoryModel is set to parentModel
- modelInfo is set to { type: "inherited" } for toast display
- The parent's model (e.g., anthropic/claude-opus-4-5) is passed to the subagent
- Subagent uses the same model as the parent session
- 
## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->
https://github.com/code-yeongyu/oh-my-opencode/issues/1200
<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
/start-work no longer overwrites the session agent, and subagents inherit the parent session’s model (including variant). This keeps model selection consistent and avoids defaulting to unavailable hardcoded models.

- **Bug Fixes**
  - Only set the session agent to atlas if no agent is set; removed the default agent from the command config.
  - For subagent_type, inherit the parent model (categoryModel = parentModel) and mark modelInfo as "inherited" for display.
  - Preserve model.variant in StoredMessage and propagate it to subagents and background tasks.

<sup>Written for commit a544e80fc44563e13e065cf1b656f06cd2dc472b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

