### PR TITLE
fix(model-resolver): use connected providers cache when model cache is empty

### DIFF
--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -537,7 +537,7 @@ To continue this session: session_id="${args.session_id}"`
            }
           } else {
           const resolution = resolveModelWithFallback({
-              userModel: userCategories?.[args.category]?.model ?? resolved.model ?? sisyphusJuniorModel,
+              userModel: userCategories?.[args.category]?.model ?? sisyphusJuniorModel,
               fallbackChain: requirement.fallbackChain,
               availableModels,
               systemDefaultModel,


### PR DESCRIPTION
## Summary

- Fixes delegate_task with category (e.g., `visual-engineering`) always using first provider (google) instead of connected provider (github-copilot)
- When model cache is empty but connected providers cache exists, use it to find valid providers from fallback chain
- Remove `resolved.model` from userModel fallback in tools.ts (was bypassing the fallback chain entirely)

## Root Cause

The upstream fix (30ed086) passed `resolved.model` as `userModel`, which bypassed the fallback chain. This caused categories to always use the hardcoded default provider (e.g., `google/gemini-3-pro`) even when user only has `github-copilot` connected.

## Changes

1. **tools.ts**: Remove `resolved.model` from userModel fallback chain
2. **model-resolver.ts**: When `availableModels.size === 0`, check connected providers cache and use it to find valid providers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider selection when the model cache is empty. The resolver now uses the connected providers cache so category tasks pick the correct provider (e.g., GitHub Copilot instead of Google).

- **Bug Fixes**
  - Use connected providers cache to walk the fallback chain when availableModels is empty; choose the first connected provider, else use system default.
  - Remove resolved.model from userModel in delegate_task tools to avoid bypassing the fallback chain.

<sup>Written for commit 49bb7a80638fb2899d2399bd1b4bf163c856a563. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

