### PR TITLE
fix(delegate-task): pass registered agent model explicitly for subagent_type (#1225)

### DIFF
--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -784,7 +784,7 @@ Create the work plan directly - that's your job as the planning agent.`
         // Uses case-insensitive matching to allow "Oracle", "oracle", "ORACLE" etc.
         try {
           const agentsResult = await client.app.agents()
-          type AgentInfo = { name: string; mode?: "subagent" | "primary" | "all" }
+          type AgentInfo = { name: string; mode?: "subagent" | "primary" | "all"; model?: { providerID: string; modelID: string } }
           const agents = (agentsResult as { data?: AgentInfo[] }).data ?? agentsResult as unknown as AgentInfo[]
 
           const callableAgents = agents.filter((a) => a.mode !== "primary")
@@ -807,6 +807,14 @@ Create the work plan directly - that's your job as the planning agent.`
           }
           // Use the canonical agent name from registration
           agentToUse = matchedAgent.name
+
+          // Extract registered agent's model to pass explicitly to session.prompt.
+          // This ensures the model is always in the correct object format ({providerID, modelID})
+          // regardless of how OpenCode handles string→object conversion for plugin-registered agents.
+          // See: https://github.com/code-yeongyu/oh-my-opencode/issues/1225
+          if (matchedAgent.model) {
+            categoryModel = matchedAgent.model
+          }
         } catch {
           // If we can't fetch agents, proceed anyway - the session.prompt will fail with a clearer error
         }


### PR DESCRIPTION
## Summary

- When `delegate_task` uses `subagent_type`, extract the matched agent's registered model (`{providerID, modelID}`) and pass it explicitly to `session.prompt()` / `manager.launch()`, making the code path consistent with category-based delegation
- Previously, `subagent_type` delegation relied on OpenCode internally resolving the registered agent's model, which could fail with `ProviderModelNotFoundError` if OpenCode didn't properly convert string→object format for plugin-registered agents

## Root Cause

`delegate_task` had two code paths with different model handling:
- **Category-based** (`category="ultrabrain"`): Model resolved explicitly → parsed to `{providerID, modelID}` → passed to `session.prompt`/`manager.launch` ✅
- **Subagent-based** (`subagent_type="explore"`): No model passed → relied on OpenCode's internal agent registration model resolution → could fail ❌

## Fix

After matching the agent by name, extract its `model` object from the agents list and set it as `categoryModel` so both sync and background paths receive it.

## Tests

3 new tests:
1. Background mode: matched agent's model passed to `manager.launch`
2. Sync mode: matched agent's model passed to `session.prompt`
3. Edge case: agent without model does not override `categoryModel`

Closes #1225


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subagent delegation model handling. The matched subagent’s model is now passed explicitly to session.prompt and manager.launch, preventing ProviderModelNotFoundError and aligning with the category-based path.

- **Bug Fixes**
  - Extract the matched subagent’s model ({providerID, modelID}) and set it as categoryModel.
  - Applies to both background and sync paths; ignores override when the agent has no model.
  - Adds tests for background, sync, and no-model cases to cover regressions.

<sup>Written for commit 99d809461607d87604a598f12d7a14774c6e9628. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

