### PR TITLE
feat(config): support fallback_models for agents/categories

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,8 @@ export {
   OhMyOpenCodeConfigSchema,
   AgentOverrideConfigSchema,
   AgentOverridesSchema,
+  FallbackModelsSchema,
+  RuntimeFallbackConfigSchema,
   McpNameSchema,
   AgentNameSchema,
   HookNameSchema,
@@ -11,12 +13,16 @@ export {
   RalphLoopConfigSchema,
   TmuxConfigSchema,
   TmuxLayoutSchema,
+  DynamicContextPruningConfigSchema,
+  CommentCheckerConfigSchema,
 } from "./schema"
 
 export type {
   OhMyOpenCodeConfig,
   AgentOverrideConfig,
   AgentOverrides,
+  FallbackModels,
+  RuntimeFallbackConfig,
   McpName,
   AgentName,
   HookName,
@@ -27,4 +33,5 @@ export type {
   RalphLoopConfig,
   TmuxConfig,
   TmuxLayout,
+  CommentCheckerConfig,
 } from "./schema"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,6 +4,7 @@ export {
   AgentOverridesSchema,
   FallbackModelsSchema,
   RuntimeFallbackConfigSchema,
+  CategoriesConfigSchema,
   McpNameSchema,
   AgentNameSchema,
   HookNameSchema,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -95,9 +95,14 @@ export const BuiltinCommandNameSchema = z.enum([
   "start-work",
 ])
 
+export const FallbackModelsSchema = z.union([
+  z.string(),
+  z.array(z.string()),
+])
+
 export const AgentOverrideConfigSchema = z.object({
-  /** @deprecated Use `category` instead. Model is inherited from category defaults. */
   model: z.string().optional(),
+  fallback_models: FallbackModelsSchema.optional(),
   variant: z.string().optional(),
   /** Category name to inherit model and other settings from CategoryConfig */
   category: z.string().optional(),
@@ -195,6 +200,14 @@ export const BuiltinCategoryNameSchema = z.enum([
 ])
 
 export const CategoriesConfigSchema = z.record(z.string(), CategoryConfigSchema)
+
+export const RuntimeFallbackConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  retry_on_errors: z.array(z.number()).default([429, 503, 529]),
+  max_fallback_attempts: z.number().min(1).max(10).default(3),
+  cooldown_seconds: z.number().min(0).default(60),
+  notify_on_fallback: z.boolean().default(true),
+})
 
 export const CommentCheckerConfigSchema = z.object({
   /** Custom prompt to replace the default warning message. Use {{comments}} placeholder for detected comments XML. */


### PR DESCRIPTION
## Summary
- Add `fallback_models` configuration for agents and categories
- Support both string and array of strings for fallback models
- Evaluate fallback models at agent initialization time
- Add `runtime_fallback` schema for future runtime model switching

## Changes
- **Schema**: Add `FallbackModelsSchema` and `RuntimeFallbackConfigSchema`
- **Model Resolution**: Implement fallback_models in `model-resolver.ts`
- **Agent Config**: Support fallback_models and category defaults
- **Documentation**: Update configurations.md with examples
- **Tests**: Add comprehensive test coverage for fallback logic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fallback_models to agents and categories so the system selects a backup model at startup when the preferred model isn’t available. Also adds a runtime_fallback schema to prepare for future automatic switching on transient errors.

- New Features
  - Support fallback_models (string or array) in agent and category configs.
  - Resolver tries fallback_models first and picks the first available via available models or connected providers.
  - Agents inherit category model, fallback_models, and defaults; delegate-task uses the resolved model and variant.
  - Added runtime_fallback config schema; updated docs with examples.

<sup>Written for commit 812a944214072464d9377c626a534f8b1c24aacb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

