### PR TITLE
fix: expand override.category and explicit reasoningEffort priority (#1219)

### DIFF
--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -140,7 +140,7 @@ function applyCategoryOverride(
   if (categoryConfig.temperature !== undefined) result.temperature = categoryConfig.temperature
   if (categoryConfig.reasoningEffort !== undefined) result.reasoningEffort = categoryConfig.reasoningEffort
   if (categoryConfig.textVerbosity !== undefined) result.textVerbosity = categoryConfig.textVerbosity
-  if (categoryConfig.thinking) result.thinking = categoryConfig.thinking
+  if (categoryConfig.thinking !== undefined) result.thinking = categoryConfig.thinking
   if (categoryConfig.top_p !== undefined) result.top_p = categoryConfig.top_p
   if (categoryConfig.maxTokens !== undefined) result.maxTokens = categoryConfig.maxTokens
 

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -120,6 +120,33 @@ export function createEnvContext(): string {
 </omo-env>`
 }
 
+/**
+ * Expands a category reference from an agent override into concrete config properties.
+ * Category properties are applied unconditionally (overwriting factory defaults),
+ * because the user's chosen category should take priority over factory base values.
+ * Direct override properties applied later via mergeAgentConfig() will supersede these.
+ */
+function applyCategoryOverride(
+  config: AgentConfig,
+  categoryName: string,
+  mergedCategories: Record<string, CategoryConfig>
+): AgentConfig {
+  const categoryConfig = mergedCategories[categoryName]
+  if (!categoryConfig) return config
+
+  const result = { ...config } as AgentConfig & Record<string, unknown>
+  if (categoryConfig.model) result.model = categoryConfig.model
+  if (categoryConfig.variant !== undefined) result.variant = categoryConfig.variant
+  if (categoryConfig.temperature !== undefined) result.temperature = categoryConfig.temperature
+  if (categoryConfig.reasoningEffort !== undefined) result.reasoningEffort = categoryConfig.reasoningEffort
+  if (categoryConfig.textVerbosity !== undefined) result.textVerbosity = categoryConfig.textVerbosity
+  if (categoryConfig.thinking) result.thinking = categoryConfig.thinking
+  if (categoryConfig.top_p !== undefined) result.top_p = categoryConfig.top_p
+  if (categoryConfig.maxTokens !== undefined) result.maxTokens = categoryConfig.maxTokens
+
+  return result as AgentConfig
+}
+
 function mergeAgentConfig(
   base: AgentConfig,
   override: AgentOverrideConfig
@@ -210,11 +237,15 @@ export async function createBuiltinAgents(
 
     let config = buildAgent(source, model, mergedCategories, gitMasterConfig, browserProvider)
     
-    // Apply variant from override or resolved fallback chain
-    if (override?.variant) {
-      config = { ...config, variant: override.variant }
-    } else if (resolvedVariant) {
+    // Apply resolved variant from model fallback chain
+    if (resolvedVariant) {
       config = { ...config, variant: resolvedVariant }
+    }
+
+    // Expand override.category into concrete properties (higher priority than factory/resolved)
+    const overrideCategory = (override as Record<string, unknown> | undefined)?.category as string | undefined
+    if (overrideCategory) {
+      config = applyCategoryOverride(config, overrideCategory, mergedCategories)
     }
 
     if (agentName === "librarian" && directory && config.prompt) {
@@ -222,6 +253,7 @@ export async function createBuiltinAgents(
       config = { ...config, prompt: config.prompt + envContext }
     }
 
+    // Direct override properties take highest priority
     if (override) {
       config = mergeAgentConfig(config, override)
     }
@@ -261,10 +293,13 @@ export async function createBuiltinAgents(
         availableCategories
       )
       
-      if (sisyphusOverride?.variant) {
-        sisyphusConfig = { ...sisyphusConfig, variant: sisyphusOverride.variant }
-      } else if (sisyphusResolvedVariant) {
+      if (sisyphusResolvedVariant) {
         sisyphusConfig = { ...sisyphusConfig, variant: sisyphusResolvedVariant }
+      }
+
+      const sisOverrideCategory = (sisyphusOverride as Record<string, unknown> | undefined)?.category as string | undefined
+      if (sisOverrideCategory) {
+        sisyphusConfig = applyCategoryOverride(sisyphusConfig, sisOverrideCategory, mergedCategories)
       }
 
       if (directory && sisyphusConfig.prompt) {
@@ -302,10 +337,13 @@ export async function createBuiltinAgents(
         userCategories: categories,
       })
       
-      if (orchestratorOverride?.variant) {
-        orchestratorConfig = { ...orchestratorConfig, variant: orchestratorOverride.variant }
-      } else if (atlasResolvedVariant) {
+      if (atlasResolvedVariant) {
         orchestratorConfig = { ...orchestratorConfig, variant: atlasResolvedVariant }
+      }
+
+      const atlasOverrideCategory = (orchestratorOverride as Record<string, unknown> | undefined)?.category as string | undefined
+      if (atlasOverrideCategory) {
+        orchestratorConfig = applyCategoryOverride(orchestratorConfig, atlasOverrideCategory, mergedCategories)
       }
 
       if (orchestratorOverride) {


### PR DESCRIPTION
## Summary

Fixes #1219 — Agent overrides for `reasoningEffort`/`variant` not applied when using `category` in agent overrides.

## Changes

### Bug 1: `override.category` not expanded (`src/agents/utils.ts`)

`createBuiltinAgents()` called `buildAgent()` with only the factory's base category. When a user override contained `category: "ultrabrain"`, it was merged as a raw string via `mergeAgentConfig()` — its referenced settings (model, variant, reasoningEffort, etc.) were never expanded.

**Fix**: Added `applyCategoryOverride()` helper that expands a category reference into concrete config properties. Applied in all three code paths:
- Standard agent loop (metis, momus, oracle, librarian, explore, multimodal-looker)
- Sisyphus special path
- Atlas special path

### Bug 2: Prometheus `reasoningEffort` priority (`src/plugin-handlers/config-handler.ts`)

Made `reasoningEffort`, `textVerbosity`, `thinking`, `temperature`, `top_p`, and `maxTokens` use explicit `??` priority chains (direct override > category) — matching the existing `variant` pattern instead of relying on object spread ordering.

### Priority order (highest → lowest)

1. Direct override properties (`agents.oracle.variant`)
2. Override category properties (`categories[agents.oracle.category].variant`)
3. Resolved variant from model fallback chain
4. Factory base defaults

## Tests

- 7 new tests in `utils.test.ts` covering category expansion for standard agents, Sisyphus, Atlas, with direct override priority
- 3 new tests in `config-handler.test.ts` covering Prometheus reasoningEffort/temperature direct override priority
- All 41 tests pass, typecheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1219 by expanding agent override.category into concrete settings and making direct overrides take clear priority in Prometheus config. Ensures overrides work consistently across all agents.

- Bug Fixes
  - Expanded override.category into model, variant, reasoningEffort, textVerbosity, thinking, temperature, top_p, and maxTokens via applyCategoryOverride across standard agents, Sisyphus, and Atlas paths.
  - Prometheus handler now uses explicit priority chains for variant, reasoningEffort, textVerbosity, thinking, temperature, top_p, and maxTokens:
    - direct override > category > resolved model-fallback variant > factory defaults.

<sup>Written for commit c243fe8c3d920f691159fa646c9a6768257ff713. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

