### PR TITLE
✨ feat(keyword-detector): improve session title handling on ultrawork activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ packages/*/bin/oh-my-opencode.exe
 .vscode/
 *.swp
 *.swo
+.ace-tool/
 
 # OS
 .DS_Store

--- a/src/hooks/keyword-detector/detector.ts
+++ b/src/hooks/keyword-detector/detector.ts
@@ -50,3 +50,22 @@ export function extractPromptText(
     .map((p) => p.text || "")
     .join(" ")
 }
+
+export function cleanTitleFromPrompt(promptText: string): string {
+  const ULTRAWORK_KEYWORD_PATTERN = /\b(ultrawork|ulw)\b/gi
+  let result = promptText.replace(ULTRAWORK_KEYWORD_PATTERN, "")
+  
+  result = result.replace(/\s+/g, " ")
+  
+  result = result.trim()
+  
+  if (!result) {
+    return ""
+  }
+  
+  if (result.length > 80) {
+    return result.slice(0, 77) + "..."
+  }
+  
+  return result
+}

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -4,6 +4,7 @@ import { setMainSession, updateSessionAgent, clearSessionAgent, _resetForTesting
 import { ContextCollector } from "../../features/context-injector"
 import * as sharedModule from "../../shared"
 import * as sessionState from "../../features/claude-code-session-state"
+import { cleanTitleFromPrompt } from "./detector"
 
 describe("keyword-detector message transform", () => {
   let logCalls: Array<{ msg: string; data?: unknown }>
@@ -15,13 +16,52 @@ describe("keyword-detector message transform", () => {
     logCalls = []
     logSpy = spyOn(sharedModule, "log").mockImplementation((msg: string, data?: unknown) => {
       logCalls.push({ msg, data })
-    })
+  })
+})
+
+describe("cleanTitleFromPrompt", () => {
+  test("should remove ultrawork keyword from start", () => {
+    // #given - prompt with ulw at start
+    // #when - cleanTitleFromPrompt is called
+    // #then - keyword is removed, text is trimmed
+    expect(cleanTitleFromPrompt("ulw fix the login bug")).toBe("fix the login bug")
   })
 
-  afterEach(() => {
-    logSpy?.mockRestore()
-    getMainSessionSpy?.mockRestore()
+  test("should remove ultrawork keyword case-insensitively", () => {
+    expect(cleanTitleFromPrompt("ultrawork refactor auth")).toBe("refactor auth")
   })
+
+  test("should remove keyword from middle of text", () => {
+    expect(cleanTitleFromPrompt("fix ULW bug")).toBe("fix bug")
+  })
+
+  test("should handle multiple keywords globally", () => {
+    expect(cleanTitleFromPrompt("ulw ultrawork test ulw")).toBe("test")
+  })
+
+  test("should return empty string when only keywords", () => {
+    expect(cleanTitleFromPrompt("   ulw   ")).toBe("")
+    expect(cleanTitleFromPrompt("ulw")).toBe("")
+  })
+
+  test("should return empty string for empty input", () => {
+    expect(cleanTitleFromPrompt("")).toBe("")
+  })
+
+  test("should NOT truncate 80-char string", () => {
+    const exactly80 = "a".repeat(80)
+    expect(cleanTitleFromPrompt(exactly80)).toBe(exactly80)
+    expect(cleanTitleFromPrompt(exactly80).length).toBe(80)
+  })
+
+  test("should truncate string over 80 chars to 77 + ellipsis", () => {
+    const chars81 = "a".repeat(81)
+    const result = cleanTitleFromPrompt(chars81)
+    expect(result.length).toBe(80)
+    expect(result).toBe("a".repeat(77) + "...")
+  })
+})
+
 
   function createMockPluginInput() {
     return {

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -16,8 +16,13 @@ describe("keyword-detector message transform", () => {
     logCalls = []
     logSpy = spyOn(sharedModule, "log").mockImplementation((msg: string, data?: unknown) => {
       logCalls.push({ msg, data })
+    })
   })
-})
+
+  afterEach(() => {
+    logSpy?.mockRestore()
+    getMainSessionSpy?.mockRestore()
+  })
 
 describe("cleanTitleFromPrompt", () => {
   test("should remove ultrawork keyword from start", () => {

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -765,3 +765,146 @@ describe("keyword-detector agent-specific ultrawork messages", () => {
     expect(textPart!.text).not.toContain("YOU ARE A PLANNER, NOT AN IMPLEMENTER")
   })
 })
+
+describe("session title update", () => {
+  let logCalls: Array<{ msg: string; data?: unknown }>
+  let logSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    _resetForTesting()
+    logCalls = []
+    logSpy = spyOn(sharedModule, "log").mockImplementation((msg: string, data?: unknown) => {
+      logCalls.push({ msg, data })
+    })
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+  })
+
+  function createMockPluginInputWithSession(options: {
+    sessionUpdateCalls?: Array<{ path: any; body: any; query: any }>
+    sessionUpdateError?: Error
+  } = {}) {
+    const sessionUpdateCalls = options.sessionUpdateCalls ?? []
+    return {
+      client: {
+        tui: {
+          showToast: async () => {},
+        },
+        session: {
+          update: async (opts: any) => {
+            if (options.sessionUpdateError) {
+              throw options.sessionUpdateError
+            }
+            sessionUpdateCalls.push(opts)
+          },
+        },
+      },
+      directory: "/test/dir",
+    } as any
+  }
+
+  test("should call session.update with cleaned title when ultrawork detected", async () => {
+    // #given - ultrawork prompt with meaningful content
+    const sessionUpdateCalls: Array<{ path: any; body: any; query: any }> = []
+    const ctx = createMockPluginInputWithSession({ sessionUpdateCalls })
+    const hook = createKeywordDetectorHook(ctx)
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ulw fix the login bug" }],
+    }
+
+    // #when - hook processes ultrawork message
+    await hook["chat.message"]!({ sessionID: "test-session-123" }, output)
+
+    // #then - session.update called with cleaned title
+    await new Promise((resolve) => setTimeout(resolve, 0)) // flush microtasks
+    expect(sessionUpdateCalls.length).toBe(1)
+    expect(sessionUpdateCalls[0].body.title).toBe("fix the login bug")
+  })
+
+  test("should call session.update with input.sessionID as path.id", async () => {
+    // #given - ultrawork prompt with specific session ID
+    const sessionUpdateCalls: Array<{ path: any; body: any; query: any }> = []
+    const ctx = createMockPluginInputWithSession({ sessionUpdateCalls })
+    const hook = createKeywordDetectorHook(ctx)
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ulw implement feature X" }],
+    }
+
+    // #when - hook processes ultrawork message
+    await hook["chat.message"]!({ sessionID: "test-session-456" }, output)
+
+    // #then - session.update called with correct session ID
+    await new Promise((resolve) => setTimeout(resolve, 0)) // flush microtasks
+    expect(sessionUpdateCalls.length).toBe(1)
+    expect(sessionUpdateCalls[0].path.id).toBe("test-session-456")
+    expect(sessionUpdateCalls[0].query.directory).toBe("/test/dir")
+  })
+
+  test("should not call session.update when cleaned title is empty", async () => {
+    // #given - ultrawork prompt with only keyword (no meaningful content)
+    const sessionUpdateCalls: Array<{ path: any; body: any; query: any }> = []
+    const ctx = createMockPluginInputWithSession({ sessionUpdateCalls })
+    const hook = createKeywordDetectorHook(ctx)
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ulw" }],
+    }
+
+    // #when - hook processes ultrawork-only message
+    await hook["chat.message"]!({ sessionID: "test-session-789" }, output)
+
+    // #then - session.update NOT called
+    await new Promise((resolve) => setTimeout(resolve, 0)) // flush microtasks
+    expect(sessionUpdateCalls.length).toBe(0)
+  })
+
+  test("should log error and not crash when session.update fails", async () => {
+    // #given - session.update that throws error
+    const sessionUpdateCalls: Array<{ path: any; body: any; query: any }> = []
+    const ctx = createMockPluginInputWithSession({
+      sessionUpdateCalls,
+      sessionUpdateError: new Error("API error"),
+    })
+    const hook = createKeywordDetectorHook(ctx)
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ulw add new feature" }],
+    }
+
+    // #when - hook processes ultrawork message
+    await hook["chat.message"]!({ sessionID: "test-session-error" }, output)
+
+    // #then - error logged, hook doesn't throw
+    await new Promise((resolve) => setTimeout(resolve, 0)) // flush microtasks
+    expect(logCalls.length).toBeGreaterThan(0)
+    const errorLog = logCalls.find((call) =>
+      call.msg?.includes("[keyword-detector] Failed to update session title"),
+    )
+    expect(errorLog).toBeDefined()
+    expect(errorLog?.data).toBeDefined()
+  })
+
+  test("should update title even in non-main session with ultrawork", async () => {
+    // #given - non-main session with ultrawork
+    const sessionUpdateCalls: Array<{ path: any; body: any; query: any }> = []
+    const ctx = createMockPluginInputWithSession({ sessionUpdateCalls })
+    const hook = createKeywordDetectorHook(ctx)
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ulw refactor authentication" }],
+    }
+
+    // #when - hook processes ultrawork in non-main session
+    await hook["chat.message"]!({ sessionID: "non-main-session" }, output)
+
+    // #then - session.update still called (ultrawork passes through non-main filter)
+    await new Promise((resolve) => setTimeout(resolve, 0)) // flush microtasks
+    expect(sessionUpdateCalls.length).toBe(1)
+    expect(sessionUpdateCalls[0].body.title).toBe("refactor authentication")
+    expect(sessionUpdateCalls[0].path.id).toBe("non-main-session")
+  })
+})

--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { detectKeywordsWithType, extractPromptText, removeCodeBlocks } from "./detector"
+import { detectKeywordsWithType, extractPromptText, removeCodeBlocks, cleanTitleFromPrompt } from "./detector"
 import { isPlannerAgent } from "./constants"
 import { log } from "../../shared"
 import { hasSystemReminder, isSystemDirective, removeSystemReminders } from "../../shared/system-directive"
@@ -69,6 +69,16 @@ export function createKeywordDetectorHook(ctx: PluginInput, collector?: ContextC
       const hasUltrawork = detectedKeywords.some((k) => k.type === "ultrawork")
       if (hasUltrawork) {
         log(`[keyword-detector] Ultrawork mode activated`, { sessionID: input.sessionID })
+
+        // Proactively set session title to avoid "Ultrawork mode enabled!" issue (#1156)
+        const cleanedTitle = cleanTitleFromPrompt(promptText)
+        if (cleanedTitle && ctx.client.session?.update) {
+          void ctx.client.session.update({
+            path: { id: input.sessionID },
+            body: { title: cleanedTitle },
+            query: { directory: ctx.directory }
+          }).catch((err) => log("[keyword-detector] Failed to update session title", { error: err }))
+        }
 
         if (output.message.variant === undefined) {
           output.message.variant = "max"


### PR DESCRIPTION
## Summary
- Add `cleanTitleFromPrompt` utility to extract clean session titles from ultrawork prompts
- Fix session title not being set when ultrawork mode is activated via keyword detection
- Add comprehensive test coverage for session title update functionality

## Changes
- `src/hooks/keyword-detector/`: Add `cleanTitleFromPrompt` utility function
- `src/hooks/keyword-detector/`: Set session title on ultrawork activation
- `src/hooks/keyword-detector/*.test.ts`: Add session title update tests
- `.gitignore`: Add `.ace-tool/` to ignored files

## Testing
```bash
bun run typecheck
bun test
```

## Related Issues
Closes #1156

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves session title handling when ultrawork is activated via keyword detection so prompts produce clean, meaningful titles. Fixes #1156 to prevent empty or noisy titles like “Ultrawork mode enabled!”.

- **New Features**
  - Added cleanTitleFromPrompt to strip ultrawork keywords, normalize whitespace, and cap titles at 80 chars.

- **Bug Fixes**
  - Set the session title on ultrawork activation using the cleaned prompt, with correct session ID and safe error handling; added tests for title cleaning and session.update behavior.

<sup>Written for commit 115af0aefb78f0369dd80b0fc23a0f0bc42c2bb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

