### PR TITLE
fix(background-agent): prevent zombie processes by aborting sessions on shutdown (#1240)

### DIFF
--- a/src/hooks/interactive-bash-session/index.ts
+++ b/src/hooks/interactive-bash-session/index.ts
@@ -6,6 +6,7 @@ import {
 } from "./storage";
 import { OMO_SESSION_PREFIX, buildSessionReminderMessage } from "./constants";
 import type { InteractiveBashSessionState } from "./types";
+import { subagentSessions } from "../../features/claude-code-session-state";
 
 interface ToolExecuteInput {
   tool: string;
@@ -146,7 +147,7 @@ function findSubcommand(tokens: string[]): string {
   return ""
 }
 
-export function createInteractiveBashSessionHook(_ctx: PluginInput) {
+export function createInteractiveBashSessionHook(ctx: PluginInput) {
   const sessionStates = new Map<string, InteractiveBashSessionState>();
 
   function getOrCreateState(sessionID: string): InteractiveBashSessionState {
@@ -177,6 +178,10 @@ export function createInteractiveBashSessionHook(_ctx: PluginInput) {
         });
         await proc.exited;
       } catch {}
+    }
+
+    for (const sessionId of subagentSessions) {
+      ctx.client.session.abort({ path: { id: sessionId } }).catch(() => {})
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,6 +264,11 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       });
       log("[index] onSubagentSessionCreated callback completed");
     },
+    onShutdown: () => {
+      tmuxSessionManager.cleanup().catch((error) => {
+        log("[index] tmux cleanup error during shutdown:", error)
+      })
+    },
   });
 
   const atlasHook = isHookEnabled("atlas")


### PR DESCRIPTION
## Summary

Fixes #1240 — Zombie opencode processes remain after tmux visual multi-agent sessions are closed.

### Root Cause

When using the tmux-based visual multi-agent feature, child `opencode` processes were never terminated because:

1. `BackgroundManager.shutdown()` released concurrency and cleared state, but **never called `session.abort()`** on running child sessions
2. `TmuxSessionManager.cleanup()` was never invoked on process exit signals
3. `killAllTrackedSessions` in the interactive-bash-session hook only killed tmux sessions via `tmux kill-session`, not the underlying opencode processes

### Changes

| File | Change |
|------|--------|
| `src/features/background-agent/manager.ts` | `shutdown()` now aborts all running child sessions via `client.session.abort()` before clearing state. Added `onShutdown` callback to constructor options for tmux cleanup integration. |
| `src/features/background-agent/manager.test.ts` | 4 new tests: abort on shutdown for running tasks, skip abort for non-running tasks, onShutdown callback invocation, onShutdown error resilience. Fixed existing mock clients to include `abort` method. |
| `src/hooks/interactive-bash-session/index.ts` | `killAllTrackedSessions` now also aborts tracked subagent opencode sessions (defense-in-depth). |
| `src/index.ts` | Wired `TmuxSessionManager.cleanup()` into BackgroundManager's `onShutdown` callback. |

### Design Decisions

- **Fire-and-forget abort pattern**: `session.abort()` calls use `.catch(() => {})` because `shutdown()` is synchronous (called from signal handlers). This matches the existing pattern at `checkAndInterruptStaleTasks`.
- **No PID tracking**: OpenCode's `session.abort()` API is the correct termination mechanism — we don't spawn OS-level processes directly.
- **No startup orphan cleanup**: Deferred as low priority — the main fix (aborting on shutdown) prevents the problem going forward.

### Verification

- `bun run typecheck` ✅ (0 errors)
- `bun test src/features/background-agent/manager.test.ts` ✅ (59/59 pass)
- `bun test` ✅ (1627 pass, 17 pre-existing failures unchanged)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort all running child sessions on shutdown and trigger tmux cleanup to stop zombie opencode processes after visual multi-agent sessions. Fixes #1240.

- **Bug Fixes**
  - BackgroundManager.shutdown aborts running sessions via client.session.abort before clearing state.
  - Added onShutdown callback; wired to TmuxSessionManager.cleanup so panes/processes are cleaned on exit.
  - Interactive bash hook now also aborts tracked subagent sessions when killing tmux sessions.
  - Added tests for abort-on-shutdown, skip for non-running tasks, onShutdown invocation, and error resilience.

<sup>Written for commit ac0383f5b78ae35a4b8368ab5216f2f9bd3a21ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

