### PR TITLE
fix(cli): remove antigravity auto-injection from install

### DIFF
--- a/src/cli/config-manager.test.ts
+++ b/src/cli/config-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test"
 
-import { ANTIGRAVITY_PROVIDER_CONFIG, getPluginNameWithVersion, fetchNpmDistTags, generateOmoConfig } from "./config-manager"
+import { getPluginNameWithVersion, fetchNpmDistTags, generateOmoConfig } from "./config-manager"
 import type { InstallConfig } from "./types"
 
 describe("getPluginNameWithVersion", () => {
@@ -166,37 +166,6 @@ describe("fetchNpmDistTags", () => {
 
     // #then should return null
     expect(result).toBeNull()
-  })
-})
-
-describe("config-manager ANTIGRAVITY_PROVIDER_CONFIG", () => {
-  test("Gemini models include full spec (limit + modalities)", () => {
-    const google = (ANTIGRAVITY_PROVIDER_CONFIG as any).google
-    expect(google).toBeTruthy()
-
-    const models = google.models as Record<string, any>
-    expect(models).toBeTruthy()
-
-    const required = [
-      "antigravity-gemini-3-pro-high",
-      "antigravity-gemini-3-pro-low",
-      "antigravity-gemini-3-flash",
-    ]
-
-    for (const key of required) {
-      const model = models[key]
-      expect(model).toBeTruthy()
-      expect(typeof model.name).toBe("string")
-      expect(model.name.includes("(Antigravity)")).toBe(true)
-
-      expect(model.limit).toBeTruthy()
-      expect(typeof model.limit.context).toBe("number")
-      expect(typeof model.limit.output).toBe("number")
-
-      expect(model.modalities).toBeTruthy()
-      expect(Array.isArray(model.modalities.input)).toBe(true)
-      expect(Array.isArray(model.modalities.output)).toBe(true)
-    }
   })
 })
 

--- a/src/cli/config-manager.ts
+++ b/src/cli/config-manager.ts
@@ -394,46 +394,6 @@ export async function getOpenCodeVersion(): Promise<string | null> {
   return result?.version ?? null
 }
 
-export async function addAuthPlugins(config: InstallConfig): Promise<ConfigMergeResult> {
-  try {
-    ensureConfigDir()
-  } catch (err) {
-    return { success: false, configPath: getConfigDir(), error: formatErrorWithSuggestion(err, "create config directory") }
-  }
-
-  const { format, path } = detectConfigFormat()
-
-  try {
-    let existingConfig: OpenCodeConfig | null = null
-    if (format !== "none") {
-      const parseResult = parseConfigWithError(path)
-      if (parseResult.error && !parseResult.config) {
-        existingConfig = {}
-      } else {
-        existingConfig = parseResult.config
-      }
-    }
-
-    const plugins: string[] = existingConfig?.plugin ?? []
-
-    if (config.hasGemini) {
-      const version = await fetchLatestVersion("opencode-antigravity-auth")
-      const pluginEntry = version ? `opencode-antigravity-auth@${version}` : "opencode-antigravity-auth"
-      if (!plugins.some((p) => p.startsWith("opencode-antigravity-auth"))) {
-        plugins.push(pluginEntry)
-      }
-    }
-
-
-
-    const newConfig = { ...(existingConfig ?? {}), plugin: plugins }
-    writeFileSync(path, JSON.stringify(newConfig, null, 2) + "\n")
-    return { success: true, configPath: path }
-  } catch (err) {
-    return { success: false, configPath: path, error: formatErrorWithSuggestion(err, "add auth plugins to config") }
-  }
-}
-
 export interface BunInstallResult {
   success: boolean
   timedOut?: boolean
@@ -489,89 +449,6 @@ export async function runBunInstallWithDetails(): Promise<BunInstallResult> {
       success: false,
       error: `bun install failed: ${message}. Is bun installed? Try: curl -fsSL https://bun.sh/install | bash`,
     }
-  }
-}
-
-/**
- * Antigravity Provider Configuration
- *
- * IMPORTANT: Model names MUST use `antigravity-` prefix for stability.
- *
- * The opencode-antigravity-auth plugin supports two naming conventions:
- * - `antigravity-gemini-3-pro-high` (RECOMMENDED, explicit Antigravity quota routing)
- * - `gemini-3-pro-high` (LEGACY, backward compatible but may break in future)
- *
- * Legacy names rely on Gemini CLI using `-preview` suffix for disambiguation.
- * If Google removes `-preview`, legacy names may route to wrong quota.
- *
- * @see https://github.com/NoeFabris/opencode-antigravity-auth#migration-guide-v127
- */
-export const ANTIGRAVITY_PROVIDER_CONFIG = {
-  google: {
-    name: "Google",
-    models: {
-      "antigravity-gemini-3-pro-high": {
-        name: "Gemini 3 Pro High (Antigravity)",
-        thinking: true,
-        attachment: true,
-        limit: { context: 1048576, output: 65535 },
-        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
-      },
-      "antigravity-gemini-3-pro-low": {
-        name: "Gemini 3 Pro Low (Antigravity)",
-        thinking: true,
-        attachment: true,
-        limit: { context: 1048576, output: 65535 },
-        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
-      },
-      "antigravity-gemini-3-flash": {
-        name: "Gemini 3 Flash (Antigravity)",
-        attachment: true,
-        limit: { context: 1048576, output: 65536 },
-        modalities: { input: ["text", "image", "pdf"], output: ["text"] },
-      },
-    },
-  },
-}
-
-
-
-export function addProviderConfig(config: InstallConfig): ConfigMergeResult {
-  try {
-    ensureConfigDir()
-  } catch (err) {
-    return { success: false, configPath: getConfigDir(), error: formatErrorWithSuggestion(err, "create config directory") }
-  }
-
-  const { format, path } = detectConfigFormat()
-
-  try {
-    let existingConfig: OpenCodeConfig | null = null
-    if (format !== "none") {
-      const parseResult = parseConfigWithError(path)
-      if (parseResult.error && !parseResult.config) {
-        existingConfig = {}
-      } else {
-        existingConfig = parseResult.config
-      }
-    }
-
-    const newConfig = { ...(existingConfig ?? {}) }
-
-    const providers = (newConfig.provider ?? {}) as Record<string, unknown>
-
-    if (config.hasGemini) {
-      providers.google = ANTIGRAVITY_PROVIDER_CONFIG.google
-    }
-
-    if (Object.keys(providers).length > 0) {
-      newConfig.provider = providers
-    }
-
-    writeFileSync(path, JSON.stringify(newConfig, null, 2) + "\n")
-    return { success: true, configPath: path }
-  } catch (err) {
-    return { success: false, configPath: path, error: formatErrorWithSuggestion(err, "add provider config") }
   }
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -6,8 +6,6 @@ import {
   writeOmoConfig,
   isOpenCodeInstalled,
   getOpenCodeVersion,
-  addAuthPlugins,
-  addProviderConfig,
   detectCurrentConfig,
 } from "./config-manager"
 import { shouldShowChatGPTOnlyWarning } from "./model-fallback"
@@ -290,7 +288,7 @@ async function runNonTuiInstall(args: InstallArgs): Promise<number> {
 
   printHeader(isUpdate)
 
-  const totalSteps = 6
+  const totalSteps = 4
   let step = 1
 
   printStep(step++, totalSteps, "Checking OpenCode installation...")
@@ -317,26 +315,6 @@ async function runNonTuiInstall(args: InstallArgs): Promise<number> {
     return 1
   }
   printSuccess(`Plugin ${isUpdate ? "verified" : "added"} ${SYMBOLS.arrow} ${color.dim(pluginResult.configPath)}`)
-
-  if (config.hasGemini) {
-    printStep(step++, totalSteps, "Adding auth plugins...")
-    const authResult = await addAuthPlugins(config)
-    if (!authResult.success) {
-      printError(`Failed: ${authResult.error}`)
-      return 1
-    }
-    printSuccess(`Auth plugins configured ${SYMBOLS.arrow} ${color.dim(authResult.configPath)}`)
-
-    printStep(step++, totalSteps, "Adding provider configurations...")
-    const providerResult = addProviderConfig(config)
-    if (!providerResult.success) {
-      printError(`Failed: ${providerResult.error}`)
-      return 1
-    }
-    printSuccess(`Providers configured ${SYMBOLS.arrow} ${color.dim(providerResult.configPath)}`)
-  } else {
-    step += 2
-  }
 
   printStep(step++, totalSteps, "Writing oh-my-opencode configuration...")
   const omoResult = writeOmoConfig(config)
@@ -387,7 +365,7 @@ async function runNonTuiInstall(args: InstallArgs): Promise<number> {
     printBox(
       `Run ${color.cyan("opencode auth login")} and select your provider:\n` +
       (config.hasClaude ? `  ${SYMBOLS.bullet} Anthropic ${color.gray("→ Claude Pro/Max")}\n` : "") +
-      (config.hasGemini ? `  ${SYMBOLS.bullet} Google ${color.gray("→ OAuth with Antigravity")}\n` : "") +
+      (config.hasGemini ? `  ${SYMBOLS.bullet} Google ${color.gray("→ Install opencode-antigravity-auth first")}\n` : "") +
       (config.hasCopilot ? `  ${SYMBOLS.bullet} GitHub ${color.gray("→ Copilot")}` : ""),
       "Authenticate Your Providers"
     )
@@ -436,26 +414,6 @@ export async function install(args: InstallArgs): Promise<number> {
   }
   s.stop(`Plugin added to ${color.cyan(pluginResult.configPath)}`)
 
-  if (config.hasGemini) {
-    s.start("Adding auth plugins (fetching latest versions)")
-    const authResult = await addAuthPlugins(config)
-    if (!authResult.success) {
-      s.stop(`Failed to add auth plugins: ${authResult.error}`)
-      p.outro(color.red("Installation failed."))
-      return 1
-    }
-    s.stop(`Auth plugins added to ${color.cyan(authResult.configPath)}`)
-
-    s.start("Adding provider configurations")
-    const providerResult = addProviderConfig(config)
-    if (!providerResult.success) {
-      s.stop(`Failed to add provider config: ${providerResult.error}`)
-      p.outro(color.red("Installation failed."))
-      return 1
-    }
-    s.stop(`Provider config added to ${color.cyan(providerResult.configPath)}`)
-  }
-
   s.start("Writing oh-my-opencode configuration")
   const omoResult = writeOmoConfig(config)
   if (!omoResult.success) {
@@ -503,7 +461,7 @@ export async function install(args: InstallArgs): Promise<number> {
   if ((config.hasClaude || config.hasGemini || config.hasCopilot) && !args.skipAuth) {
     const providers: string[] = []
     if (config.hasClaude) providers.push(`Anthropic ${color.gray("→ Claude Pro/Max")}`)
-    if (config.hasGemini) providers.push(`Google ${color.gray("→ OAuth with Antigravity")}`)
+    if (config.hasGemini) providers.push(`Google ${color.gray("→ Install opencode-antigravity-auth first")}`)
     if (config.hasCopilot) providers.push(`GitHub ${color.gray("→ Copilot")}`)
 
     console.log()


### PR DESCRIPTION
## Summary

- Remove automatic antigravity plugin and provider configuration injection from install process
- Users upgrading to v3 were experiencing their existing antigravity configs being overwritten
- Installation docs already guide LLM/users through manual configuration at the OpenCode level

## Changes

- **config-manager.ts**: Remove `ANTIGRAVITY_PROVIDER_CONFIG` constant, `addProviderConfig()`, and `addAuthPlugins()` functions
- **install.ts**: Remove injection calls, update `totalSteps` from 6 to 4, change Gemini hint to `"Install opencode-antigravity-auth first"`
- **config-manager.test.ts**: Remove related test block

**Background**: While upgrading to v3, my existing `opencode-antigravity-auth` provider/model configs were overwritten by hardcoded values. Found [PR #812](https://github.com/code-yeongyu/oh-my-opencode/pull/812) was closed with maintainer comment: *"Antigravity is no longer supported directly in oMo. It will still work but config will happen in OpenCode itself."*

This PR takes the complete approach by removing auto-injection entirely. The [installation guide](https://github.com/code-yeongyu/oh-my-opencode/blob/dev/docs/guide/installation.md#google-gemini-antigravity-oauth) already provides complete instructions for manual setup.

## Testing

```bash
bun run typecheck  # pass
bun test src/cli/  # 181 pass, 0 fail
```

**Manual verification:**
```bash
# Backup existing config
cp ~/.config/opencode/opencode.json ~/.config/opencode/opencode.json.bak

# Run install with --gemini=yes
bun ./src/cli/index.ts install --no-tui --claude=yes --gemini=yes --copilot=no --skip-auth

# Verify provider config unchanged
diff ~/.config/opencode/opencode.json.bak ~/.config/opencode/opencode.json
# (no output = identical)
```

## Related Issues

Related to #812

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Antigravity auto-injection from the CLI install to stop overwriting user configs. Gemini setup is now manual; the installer only points users to install opencode-antigravity-auth.

- **Bug Fixes**
  - Removed Antigravity provider/auth auto-writes (deleted ANTIGRAVITY_PROVIDER_CONFIG, addProviderConfig, addAuthPlugins).
  - Simplified install flow: steps reduced 6→4; Gemini hint now says “Install opencode-antigravity-auth first.”

- **Migration**
  - No config changes are written automatically; existing settings stay intact.
  - For Gemini, install and configure opencode-antigravity-auth manually following the docs.

<sup>Written for commit 5d9ab3bfe03b9561c8e3f1683d2365ceb15b0dc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

