### PR TITLE
fix(run): prevent premature exit on idle before meaningful work

### DIFF
--- a/src/cli/run/events.ts
+++ b/src/cli/run/events.ts
@@ -63,6 +63,8 @@ export interface EventState {
   lastOutput: string
   lastPartText: string
   currentTool: string | null
+  /** Set to true when the main session has produced meaningful work (text, tool call, or tool result) */
+  hasReceivedMeaningfulWork: boolean
 }
 
 export function createEventState(): EventState {
@@ -73,6 +75,7 @@ export function createEventState(): EventState {
     lastOutput: "",
     lastPartText: "",
     currentTool: null,
+    hasReceivedMeaningfulWork: false,
   }
 }
 
@@ -241,6 +244,7 @@ function handleMessagePartUpdated(
     const newText = part.text.slice(state.lastPartText.length)
     if (newText) {
       process.stdout.write(newText)
+      state.hasReceivedMeaningfulWork = true
     }
     state.lastPartText = part.text
   }
@@ -267,6 +271,7 @@ function handleMessageUpdated(
     }
   }
   state.lastOutput = content
+  state.hasReceivedMeaningfulWork = true
 }
 
 function handleToolExecute(
@@ -296,6 +301,7 @@ function handleToolExecute(
     }
   }
 
+  state.hasReceivedMeaningfulWork = true
   process.stdout.write(`\n${pc.cyan(">")} ${pc.bold(toolName)}${inputPreview}\n`)
 }
 

--- a/src/cli/run/runner.ts
+++ b/src/cli/run/runner.ts
@@ -143,6 +143,14 @@ export async function run(options: RunOptions): Promise<number> {
           process.exit(1)
         }
 
+        // Guard against premature completion: don't check completion until the
+        // session has produced meaningful work (text output, tool call, or tool result).
+        // Without this, a session that goes busy->idle before the LLM responds
+        // would exit immediately because 0 todos + 0 children = "complete".
+        if (!eventState.hasReceivedMeaningfulWork) {
+          continue
+        }
+
         const shouldExit = await checkCompletionConditions(ctx)
         if (shouldExit) {
           console.log(pc.green("\n\nAll tasks completed."))


### PR DESCRIPTION
## Problem

The `oh-my-opencode run` command has a race condition in its completion detection logic. When a session transitions `busy -> idle` before the LLM generates any meaningful output (e.g., empty API response or network delay), `checkCompletionConditions()` returns `true` because:

- `areAllTodosComplete()`: 0 incomplete todos → `true`
- `areAllChildrenIdle()`: 0 children → `true`

This causes the runner to print "All tasks completed" and `process.exit(0)` before any actual work is done.

## Root Cause

`runner.ts` poll loop:
```
while (!aborted) {
  await sleep(500)
  if (!eventState.mainSessionIdle) continue
  // ← Session went idle before LLM responded
  const shouldExit = await checkCompletionConditions(ctx)
  // ← Returns true: 0 todos + 0 children = "complete"
  if (shouldExit) process.exit(0) // ← Premature exit
}
```

## Fix

1. **`events.ts`**: Added `hasReceivedMeaningfulWork` flag to `EventState`. Set to `true` when the main session produces:
   - Assistant text content (`message.part.updated` with text)
   - Assistant message with content (`message.updated`)
   - Tool execution (`tool.execute`)

2. **`runner.ts`**: Added guard before completion check:
   ```typescript
   if (!eventState.hasReceivedMeaningfulWork) {
     continue  // Don't check completion until real work observed
   }
   ```

## Tests

Added 6 new test cases in `events.test.ts`:
- `hasReceivedMeaningfulWork` is false after bare `session.idle`
- `message.updated` with content sets the flag
- `message.updated` with empty content does NOT set the flag  
- `tool.execute` from main session sets the flag
- `tool.execute` from different session does NOT set the flag
- Initial state has `hasReceivedMeaningfulWork: false`

All 330 existing tests pass. Typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition in the run command that caused premature "All tasks completed" exits. The runner now waits for real output or tool activity before checking completion.

- **Bug Fixes**
  - Added hasReceivedMeaningfulWork flag to EventState (default false).
  - Set the flag on assistant text, message.updated with content, and tool.execute from the main session.
  - Skipped completion checks until the flag is true to prevent idle-before-output exits.
  - Added tests covering idle-without-output, empty assistant content, and cross-session tool calls.

<sup>Written for commit b269830d35d2ec9011ceb5832ea87b44f82ddf83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

