### PR TITLE
fix(config): properly handle prompt_append for Prometheus agent

### DIFF
--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -298,9 +298,19 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
             : {}),
         };
 
-        agentConfig["prometheus"] = prometheusOverride
-          ? { ...prometheusBase, ...prometheusOverride }
-          : prometheusBase;
+        // Properly handle prompt_append for Prometheus
+        // Extract prompt_append and append it to prompt instead of shallow spread
+        // Fixes: https://github.com/code-yeongyu/oh-my-opencode/issues/723
+        if (prometheusOverride) {
+          const { prompt_append, ...restOverride } = prometheusOverride as Record<string, unknown> & { prompt_append?: string };
+          const merged = { ...prometheusBase, ...restOverride };
+          if (prompt_append && merged.prompt) {
+            merged.prompt = merged.prompt + "\n" + prompt_append;
+          }
+          agentConfig["prometheus"] = merged;
+        } else {
+          agentConfig["prometheus"] = prometheusBase;
+        }
       }
 
     const filteredConfigAgents = configAgent


### PR DESCRIPTION
## Summary
Fixes #723 — `prompt_append` in agent overrides is ignored for Prometheus agent.

## Problem
When using `prompt_append` in `oh-my-opencode.json` for Prometheus:
```json
{
  "agents": {
    "prometheus": {
      "prompt_append": "## Custom Rules\nUse max 2 commits."
    }
  }
}
```
The `prompt_append` was ignored because `config-handler.ts` used shallow spread:
```typescript
agentConfig["prometheus"] = { ...prometheusBase, ...prometheusOverride }
```
This leaves `prompt_append` as a separate property instead of appending it to the `prompt` field.

## Solution
Extract `prompt_append` from the override and explicitly append it to the base prompt:
```typescript
const { prompt_append, ...restOverride } = prometheusOverride;
const merged = { ...prometheusBase, ...restOverride };
if (prompt_append && merged.prompt) {
  merged.prompt = merged.prompt + "\n" + prompt_append;
}
```

## Changes
- `src/plugin-handlers/config-handler.ts`: Handle `prompt_append` properly for Prometheus
- `src/plugin-handlers/config-handler.test.ts`: Add test verifying `prompt_append` is appended

## Testing
- All 12 existing tests pass
- New test verifies `prompt_append` content appears at end of prompt
- Typecheck passes

## Related
- Fixes #723
- Related to #1219 (agent overrides not applied)
- Supersedes stalled PR #719 (which had test import issues and malformed code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Properly appends prompt_append from Prometheus agent overrides to the base prompt instead of ignoring it. Fixes #723 and ensures custom rules appear at the end of the final prompt.

- **Bug Fixes**
  - Extracts prompt_append from the override and appends it to merged.prompt.
  - Replaces shallow spread that discarded prompt_append.
  - Adds a test to confirm base prompt is preserved and ends with the custom instructions.

<sup>Written for commit 2094b3395d4f5740722ca6cf621a5a79daf75ac5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

