### PR TITLE
fix: use correct gh api command for starring repo

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -278,7 +278,7 @@ After everything is set up and working, ask the user:
 
 If the user agrees, run:
 ```bash
-gh repo star code-yeongyu/oh-my-opencode
+gh api --silent --method PUT /user/starred/code-yeongyu/oh-my-opencode >/dev/null 2>&1 || true
 ```
 
 **Important**: Only run the command if the user explicitly says yes. Never run it automatically without consent.

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -378,7 +378,7 @@ async function runNonTuiInstall(args: InstallArgs): Promise<number> {
   )
 
   console.log(`${SYMBOLS.star} ${color.yellow("If you found this helpful, consider starring the repo!")}`)
-  console.log(`  ${color.dim("gh repo star code-yeongyu/oh-my-opencode")}`)
+  console.log(`  ${color.dim("gh api --silent --method PUT /user/starred/code-yeongyu/oh-my-opencode >/dev/null 2>&1 || true")}`)
   console.log()
   console.log(color.dim("oMoMoMoMo... Enjoy!"))
   console.log()
@@ -496,7 +496,7 @@ export async function install(args: InstallArgs): Promise<number> {
   )
 
   p.log.message(`${color.yellow("★")} If you found this helpful, consider starring the repo!`)
-  p.log.message(`  ${color.dim("gh repo star code-yeongyu/oh-my-opencode")}`)
+  p.log.message(`  ${color.dim("gh api --silent --method PUT /user/starred/code-yeongyu/oh-my-opencode >/dev/null 2>&1 || true")}`)
 
   p.outro(color.green("oMoMoMoMo... Enjoy!"))
 


### PR DESCRIPTION
## Summary
- `gh repo star` is not a valid GitHub CLI command
- Replaced with `gh api --silent --method PUT /user/starred/code-yeongyu/oh-my-opencode >/dev/null 2>&1 || true`

## Changes
- `docs/guide/installation.md`: Updated star command in documentation
- `src/cli/install.ts`: Updated star command hints in CLI output (2 locations)