### PR TITLE
fix(lsp): prevent stale diagnostics by syncing didChange

### DIFF
--- a/src/tools/lsp/client.test.ts
+++ b/src/tools/lsp/client.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+import { describe, it, expect, spyOn, mock } from "bun:test"
+
+mock.module("vscode-jsonrpc/node", () => ({
+  createMessageConnection: () => {
+    throw new Error("not used in unit test")
+  },
+  StreamMessageReader: function StreamMessageReader() {},
+  StreamMessageWriter: function StreamMessageWriter() {},
+}))
+
+import { LSPClient } from "./client"
+import type { ResolvedServer } from "./types"
+
+describe("LSPClient", () => {
+  describe("openFile", () => {
+    it("sends didChange when a previously opened file changes on disk", async () => {
+      // #given
+      const dir = mkdtempSync(join(tmpdir(), "lsp-client-test-"))
+      const filePath = join(dir, "test.ts")
+      writeFileSync(filePath, "const a = 1\n")
+
+      const originalSetTimeout = globalThis.setTimeout
+      globalThis.setTimeout = ((fn: (...args: unknown[]) => void, _ms?: number) => {
+        fn()
+        return 0 as unknown as ReturnType<typeof setTimeout>
+      }) as typeof setTimeout
+
+      const server: ResolvedServer = {
+        id: "typescript",
+        command: ["typescript-language-server", "--stdio"],
+        extensions: [".ts"],
+        priority: 0,
+      }
+
+      const client = new LSPClient(dir, server)
+
+      // Stub protocol output: we only want to assert notifications.
+      const sendNotificationSpy = spyOn(
+        client as unknown as { sendNotification: (m: string, p?: unknown) => void },
+        "sendNotification"
+      )
+
+      try {
+        // #when
+        await client.openFile(filePath)
+        writeFileSync(filePath, "const a = 2\n")
+        await client.openFile(filePath)
+
+        // #then
+        const methods = sendNotificationSpy.mock.calls.map((c) => c[0])
+        expect(methods).toContain("textDocument/didOpen")
+        expect(methods).toContain("textDocument/didChange")
+      } finally {
+        globalThis.setTimeout = originalSetTimeout
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  })
+})

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -215,6 +215,8 @@ export class LSPClient {
   private proc: Subprocess<"pipe", "pipe", "pipe"> | null = null
   private connection: MessageConnection | null = null
   private openedFiles = new Set<string>()
+  private documentVersions = new Map<string, number>()
+  private lastSyncedText = new Map<string, string>()
   private stderrBuffer: string[] = []
   private processExited = false
   private diagnosticsStore = new Map<string, Diagnostic[]>()
@@ -432,23 +434,50 @@ export class LSPClient {
 
   async openFile(filePath: string): Promise<void> {
     const absPath = resolve(filePath)
-    if (this.openedFiles.has(absPath)) return
 
+    const uri = pathToFileURL(absPath).href
     const text = readFileSync(absPath, "utf-8")
-    const ext = extname(absPath)
-    const languageId = getLanguageId(ext)
 
-    this.sendNotification("textDocument/didOpen", {
-      textDocument: {
-        uri: pathToFileURL(absPath).href,
-        languageId,
-        version: 1,
-        text,
-      },
+    if (!this.openedFiles.has(absPath)) {
+      const ext = extname(absPath)
+      const languageId = getLanguageId(ext)
+      const version = 1
+
+      this.sendNotification("textDocument/didOpen", {
+        textDocument: {
+          uri,
+          languageId,
+          version,
+          text,
+        },
+      })
+
+      this.openedFiles.add(absPath)
+      this.documentVersions.set(uri, version)
+      this.lastSyncedText.set(uri, text)
+      await new Promise((r) => setTimeout(r, 1000))
+      return
+    }
+
+    const prevText = this.lastSyncedText.get(uri)
+    if (prevText === text) {
+      return
+    }
+
+    const nextVersion = (this.documentVersions.get(uri) ?? 1) + 1
+    this.documentVersions.set(uri, nextVersion)
+    this.lastSyncedText.set(uri, text)
+
+    this.sendNotification("textDocument/didChange", {
+      textDocument: { uri, version: nextVersion },
+      contentChanges: [{ text }],
     })
-    this.openedFiles.add(absPath)
 
-    await new Promise((r) => setTimeout(r, 1000))
+    // Some servers update diagnostics only after save
+    this.sendNotification("textDocument/didSave", {
+      textDocument: { uri },
+      text,
+    })
   }
 
   async definition(filePath: string, line: number, character: number): Promise<unknown> {


### PR DESCRIPTION
## Summary
- Fix stale LSP diagnostics by syncing updated on-disk file contents to the language server after edits.
- Add a focused unit test to ensure a previously opened file triggers a content update notification.

## Changes
- Updated src/tools/lsp/client.ts to:
  - Track per-document version numbers and last-synced text.
  - Send textDocument/didChange (full text) when a file that was already didOpen’d changes on disk.
  - Send textDocument/didSave after didChange to improve compatibility with servers that refresh diagnostics on save.
- Added src/tools/lsp/client.test.ts to verify didChange is emitted when a previously opened file’s content changes.

## Testing
bun run typecheck
bun test src/tools/lsp/*.test.ts

## Related Issues

#1272
<!-- Closes #1272  -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale LSP diagnostics by syncing file changes for already-opened files via didChange and didSave. Addresses #1272.

- **Bug Fixes**
  - Track per-document version and last-synced text.
  - Emit textDocument/didChange (full text) when an opened file’s content changes on disk.
  - Emit textDocument/didSave after didChange for servers that refresh on save.
  - Add a unit test that asserts didChange is sent for a previously opened file.

<sup>Written for commit 3bb4289b186c4a76ac93297e1c0142282d9f9182. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

