### PR TITLE
fix: redirect native task tool to delegate_task for problematic agents

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -34,3 +34,4 @@ export { createAtlasHook } from "./atlas";
 export { createDelegateTaskRetryHook } from "./delegate-task-retry";
 export { createQuestionLabelTruncatorHook } from "./question-label-truncator";
 export { createSubagentQuestionBlockerHook } from "./subagent-question-blocker";
+export { createTaskToDelegateRedirectHook } from "./task-to-delegate-redirect";

--- a/src/hooks/task-to-delegate-redirect/index.ts
+++ b/src/hooks/task-to-delegate-redirect/index.ts
@@ -1,0 +1,56 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { log } from "../../shared"
+
+/**
+ * Hook to redirect native OpenCode `task` tool calls to `delegate_task`.
+ * 
+ * The native `task` tool has known issues with token refresh and empty responses
+ * for certain agents (metis, oracle, momus, etc.). This hook intercepts `task` calls
+ * and transforms them to use `delegate_task` which has more robust error handling.
+ * 
+ * See: https://github.com/code-yeongyu/oh-my-opencode/issues/1281
+ */
+
+// Agents that have issues with native `task` tool
+const PROBLEMATIC_AGENTS = ["metis", "momus", "oracle", "atlas"]
+
+export function createTaskToDelegateRedirectHook(_ctx: PluginInput) {
+  return {
+    "tool.execute.before": async (
+      input: { tool: string; sessionID: string; callID: string },
+      output: { 
+        tool: string
+        args: Record<string, unknown>
+        title?: string
+        metadata?: unknown 
+      }
+    ) => {
+      if (input.tool.toLowerCase() !== "task") return
+
+      const args = output.args
+      const subagentType = (args.subagent_type as string)?.toLowerCase() ?? ""
+
+      const isProblematic = PROBLEMATIC_AGENTS.some(
+        (agent) => subagentType === agent.toLowerCase()
+      )
+
+      if (!isProblematic) return
+
+      log("[task-to-delegate-redirect] Redirecting task to delegate_task", {
+        sessionID: input.sessionID,
+        subagentType,
+      })
+
+      // Transform to delegate_task format
+      output.tool = "delegate_task"
+      output.args = {
+        subagent_type: args.subagent_type,
+        description: args.description ?? "Redirected task",
+        prompt: args.prompt ?? "",
+        session_id: args.session_id,
+        run_in_background: false,
+        load_skills: [],
+      }
+    },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import {
   createSisyphusJuniorNotepadHook,
   createQuestionLabelTruncatorHook,
   createSubagentQuestionBlockerHook,
+  createTaskToDelegateRedirectHook,
 } from "./hooks";
 import {
   contextCollector,
@@ -241,6 +242,10 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   const subagentQuestionBlocker = createSubagentQuestionBlockerHook();
 
   const taskResumeInfo = createTaskResumeInfoHook();
+
+  const taskToDelegateRedirect = isHookEnabled("task-to-delegate-redirect")
+    ? createTaskToDelegateRedirectHook(ctx)
+    : null;
 
   const tmuxSessionManager = new TmuxSessionManager(ctx, tmuxConfig);
 
@@ -606,6 +611,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
       await prometheusMdOnly?.["tool.execute.before"]?.(input, output);
       await sisyphusJuniorNotepad?.["tool.execute.before"]?.(input, output);
       await atlasHook?.["tool.execute.before"]?.(input, output);
+      await taskToDelegateRedirect?.["tool.execute.before"]?.(input, output);
 
       if (input.tool === "task") {
         const args = output.args as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Adds `task-to-delegate-redirect` hook to intercept native `task` tool calls
- Redirects to `delegate_task` for agents with known issues (metis, oracle, momus, atlas)
- Preserves original task arguments while adding required delegate_task parameters

## Problem
The native OpenCode `task` tool returns empty responses (only session_id metadata) for certain agents due to token refresh issues. `delegate_task` works correctly for the same agents.

**Diagnostic evidence from issue #1281:**

| Agent | mcp_task | mcp_delegate_task |
|-------|----------|-------------------|
| metis | Empty response | Full response |
| oracle | Empty response | Full response |
| explore | Works | Works |
| librarian | Works | Works |

Fixes #1281

## Changes
- `src/hooks/task-to-delegate-redirect/index.ts` - New hook implementation
- `src/hooks/index.ts` - Export new hook  
- `src/index.ts` - Import, instantiate, and wire up hook

## Implementation Details
- Hook is conditionally enabled via `isHookEnabled("task-to-delegate-redirect")`
- Only affects problematic agents (metis, momus, oracle, atlas)
- Non-breaking: explore/librarian and other agents pass through unchanged
- Follows existing hook patterns (like `delegate-task-retry`)

## Testing
- Verified hook pattern matches existing hooks
- Hook runs BEFORE the existing `if (input.tool === "task")` block to ensure redirect happens first

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects native task tool calls to delegate_task for problematic agents to prevent empty responses. Adds a pre-execution hook for metis, momus, oracle, and atlas. Fixes #1281.

- **Bug Fixes**
  - Added task-to-delegate-redirect hook to map task → delegate_task on tool.execute.before for affected agents.
  - Preserves task args and sets delegate_task fields (description, prompt, session_id, run_in_background=false, load_skills=[]).
  - Gated by isHookEnabled("task-to-delegate-redirect") and runs before the task handler; other agents are unchanged.

<sup>Written for commit 825e6c2e3b932967cc231a32930c901c3178d102. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

