### PR TITLE
fix: prevent config handler deadlock on fresh installs

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1394,6 +1394,15 @@ function registerProcessSignal(
   exitAfter: boolean
 ): () => void {
   const listener = () => {
+    // DEADLOCK FIX: If cleanup involves API calls to a deadlocked server,
+    // the handler() call may hang forever. Set a force-exit timeout so
+    // Ctrl+C always works even when the server is unresponsive.
+    if (exitAfter) {
+      const forceExitTimer = setTimeout(() => {
+        process.exit(1)
+      }, 3000)
+      forceExitTimer.unref()
+    }
     handler()
     if (exitAfter) {
       process.exit(0)

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -26,6 +26,14 @@ import { loadAllPluginComponents } from "../features/claude-code-plugin-loader";
 import { createBuiltinMcps } from "../mcp";
 import type { OhMyOpenCodeConfig } from "../config";
 import { log, fetchAvailableModels, readConnectedProvidersCache } from "../shared";
+
+// DEADLOCK FIX: The config handler is called by OpenCode during startup, before
+// the TUI/web UI renders. If the handler calls back to the OpenCode server via
+// client API (e.g., client.provider.list() inside fetchAvailableModels), it creates
+// a circular dependency: server waits for config → config waits for server.
+// To break this, we avoid passing the client for model fetching in the config handler
+// and rely on cache-based resolution instead.
+const CONFIG_HANDLER_CLIENT = undefined;
 import { getOpenCodeConfigPaths } from "../shared/opencode-config-dir";
 import { migrateAgentConfig } from "../shared/permission-compat";
 import { AGENT_NAME_MAP } from "../shared/migration";
@@ -144,7 +152,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       pluginConfig.categories,
       pluginConfig.git_master,
       allDiscoveredSkills,
-      ctx.client,
+      CONFIG_HANDLER_CLIENT, // DEADLOCK FIX: use cache-only model resolution
       browserProvider,
       currentModel // uiSelectedModel - takes highest priority
     );
@@ -249,9 +257,10 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
 
         const prometheusRequirement = AGENT_MODEL_REQUIREMENTS["prometheus"];
         const connectedProviders = readConnectedProvidersCache();
-        const availableModels = ctx.client
-          ? await fetchAvailableModels(ctx.client, { connectedProviders: connectedProviders ?? undefined })
-          : new Set<string>();
+        // DEADLOCK FIX: use cache-only resolution to avoid calling back to server
+        const availableModels = await fetchAvailableModels(CONFIG_HANDLER_CLIENT, {
+          connectedProviders: connectedProviders ?? undefined,
+        });
 
         const modelResolution = resolveModelWithFallback({
           uiSelectedModel: currentModel,


### PR DESCRIPTION
## Summary

- The config handler calls `fetchAvailableModels(ctx.client)` during OpenCode bootstrap, before the server is ready to handle requests
- On fresh installs with no cache files, this triggers `client.provider.list()` which sends an HTTP request back to the OpenCode server
- The server is blocked waiting for the config handler to return → **circular dependency / deadlock**
- The TUI/web UI never renders (black screen), and Ctrl+C can also hang because cleanup calls hit the same deadlocked server

### Root cause

This is a regression from 80ee52f which re-introduced client API calls as a fallback in `fetchAvailableModels`, undoing the fix in ab3e622 ("fix: use cache file for model availability instead of SDK calls") that explicitly made the client parameter unused (`_client`) to prevent this exact deadlock.

### Why it appears platform-specific

The issue was reported as Linux-only, but it's actually a **fresh-install problem**:

1. The `connected-providers.json` cache is only written by the `session.created` event handler
2. On a fresh install, no cache exists → `readConnectedProvidersCache()` returns `null` → `connectedProvidersUnknown = true` → client API call → deadlock
3. Since the session never starts, the cache is never written — the bug is **permanent** once hit
4. Users with existing cache files (e.g. from before the regression in 80ee52f) skip the client call path entirely and never encounter the issue

### Changes

- **`config-handler.ts`**: Pass `undefined` instead of `ctx.client` to `createBuiltinAgents()` and `fetchAvailableModels()` during the config phase, forcing cache-only model resolution (same approach as ab3e622)
- **`manager.ts`**: Add 3-second force-exit timeout to SIGINT handler so Ctrl+C always terminates even when cleanup API calls hang on a deadlocked server

## Test plan

- [x] Verified fix on Linux (Pop!_OS 22.04, OpenCode v1.1.44, oh-my-opencode v3.1.9)
- [x] Confirmed `~/.cache/oh-my-opencode/connected-providers.json` does not exist on fresh install
- [x] Pre-fix log shows `/provider` request stuck at "started" indefinitely (deadlock)
- [x] Post-fix log shows all server requests completing, plugins loading, MCP servers connecting
- [ ] Verify no regression on macOS (should be no-op since cache files exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a startup deadlock on fresh installs by avoiding client API calls during config bootstrap. Adds a 3s force-exit on SIGINT so Ctrl+C still works if cleanup hangs.

- **Bug Fixes**
  - Config handler now uses cache-only model resolution by passing undefined client to createBuiltinAgents and fetchAvailableModels, avoiding circular server calls before the server is ready.
  - Background agent adds a 3s force-exit timer in the SIGINT handler to ensure the process exits even if cleanup API calls hang.

<sup>Written for commit b21e42d1615f1c03589a810cc1595a95f798b753. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

