### PR TITLE
fix(claude-code-hooks): deduplicate settings paths to prevent double hook execution

### DIFF
--- a/src/hooks/claude-code-hooks/config.ts
+++ b/src/hooks/claude-code-hooks/config.ts
@@ -55,7 +55,9 @@ export function getClaudeSettingsPaths(customPath?: string): string[] {
     paths.unshift(customPath)
   }
 
-  return paths
+  // Deduplicate paths to prevent loading the same file multiple times
+  // (e.g., when cwd is the home directory)
+  return [...new Set(paths)]
 }
 
 function mergeHooksConfig(


### PR DESCRIPTION
## Summary

When the current working directory equals the home directory, `~/.claude/settings.json` was being loaded twice:
1. Once as the home config (`~/.claude/settings.json`)
2. Once as the cwd config (`process.cwd()/.claude/settings.json`)

This caused hooks like `Stop` to execute twice, resulting in sounds playing twice, notifications appearing twice, etc.

## Fix

Added deduplication using `Set` in `getClaudeSettingsPaths()` to ensure each config file path is only included once.

## Testing

Verified locally that Stop hooks now execute only once when cwd is the home directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double execution of Claude Code hooks by deduplicating settings file paths. Fixes the case where ~/.claude/settings.json was loaded twice when the cwd is the home directory.

- **Bug Fixes**
  - Deduplicate paths in getClaudeSettingsPaths using Set so each config loads once.
  - Hooks (e.g., Stop) now fire once when cwd equals home.

<sup>Written for commit 4c40c3adb1026cf822c257f49cea3c93bdd21559. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

