### PR TITLE
fix: resolve deadlock in config handler during plugin initialization

### DIFF
--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -3,6 +3,7 @@ import { createBuiltinAgents } from "./utils"
 import type { AgentConfig } from "@opencode-ai/sdk"
 import { clearSkillCache } from "../features/opencode-skill-loader/skill-content"
 import * as connectedProvidersCache from "../shared/connected-providers-cache"
+import * as modelAvailability from "../shared/model-availability"
 
 const TEST_DEFAULT_MODEL = "anthropic/claude-opus-4-5"
 
@@ -521,5 +522,42 @@ describe("override.category expansion in createBuiltinAgents", () => {
     expect(agents.oracle).toBeDefined()
     const agentsWithoutOverride = await createBuiltinAgents([], {}, undefined, TEST_DEFAULT_MODEL)
     expect(agents.oracle.model).toBe(agentsWithoutOverride.oracle.model)
+  })
+})
+
+describe("Deadlock prevention - fetchAvailableModels must not receive client", () => {
+  test("createBuiltinAgents should call fetchAvailableModels with undefined client to prevent deadlock", async () => {
+    // #given - This test ensures we don't regress on issue #1301
+    // Passing client to fetchAvailableModels during createBuiltinAgents (called from config handler)
+    // causes deadlock:
+    // - Plugin init waits for server response (client.provider.list())
+    // - Server waits for plugin init to complete before handling requests
+    const fetchSpy = spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(new Set<string>())
+    spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+
+    const mockClient = {
+      provider: { list: () => Promise.resolve({ data: { connected: [] } }) },
+      model: { list: () => Promise.resolve({ data: [] }) },
+    }
+
+    // #when - Even when client is provided, fetchAvailableModels must be called with undefined
+    await createBuiltinAgents(
+      [],
+      {},
+      undefined,
+      TEST_DEFAULT_MODEL,
+      undefined,
+      undefined,
+      [],
+      mockClient // client is passed but should NOT be forwarded to fetchAvailableModels
+    )
+
+    // #then - fetchAvailableModels must be called with undefined as first argument (no client)
+    // This prevents the deadlock described in issue #1301
+    expect(fetchSpy).toHaveBeenCalled()
+    const firstCallArgs = fetchSpy.mock.calls[0]
+    expect(firstCallArgs[0]).toBeUndefined()
+
+    fetchSpy.mockRestore()
   })
 })

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -48,32 +48,32 @@ describe("createBuiltinAgents with model overrides", () => {
     expect(agents.sisyphus.reasoningEffort).toBeUndefined()
   })
 
-  test("Oracle uses connected provider fallback when availableModels is empty and cache exists", async () => {
-    // #given - connected providers cache has "openai", which matches oracle's first fallback entry
-    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+   test("Oracle uses connected provider fallback when availableModels is empty and cache exists", async () => {
+     // #given - connected providers cache has "openai", which matches oracle's first fallback entry
+     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
 
-    // #when
-    const agents = await createBuiltinAgents([], {}, undefined, TEST_DEFAULT_MODEL)
+     // #when
+     const agents = await createBuiltinAgents([], {}, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - oracle resolves via connected cache fallback to openai/gpt-5.2 (not system default)
-    expect(agents.oracle.model).toBe("openai/gpt-5.2")
-    expect(agents.oracle.reasoningEffort).toBe("medium")
-    expect(agents.oracle.thinking).toBeUndefined()
-    cacheSpy.mockRestore()
-  })
+     // #then - oracle resolves via connected cache fallback to openai/gpt-5.2 (not system default)
+     expect(agents.oracle.model).toBe("openai/gpt-5.2")
+     expect(agents.oracle.reasoningEffort).toBe("medium")
+     expect(agents.oracle.thinking).toBeUndefined()
+     cacheSpy.mockRestore?.()
+   })
 
-  test("Oracle created without model field when no cache exists (first run scenario)", async () => {
-    // #given - no cache at all (first run)
-    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+   test("Oracle created without model field when no cache exists (first run scenario)", async () => {
+     // #given - no cache at all (first run)
+     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
 
-    // #when
-    const agents = await createBuiltinAgents([], {}, undefined, TEST_DEFAULT_MODEL)
+     // #when
+     const agents = await createBuiltinAgents([], {}, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - oracle should be created with system default model (fallback to systemDefaultModel)
-    expect(agents.oracle).toBeDefined()
-    expect(agents.oracle.model).toBe(TEST_DEFAULT_MODEL)
-    cacheSpy.mockRestore()
-  })
+     // #then - oracle should be created with system default model (fallback to systemDefaultModel)
+     expect(agents.oracle).toBeDefined()
+     expect(agents.oracle.model).toBe(TEST_DEFAULT_MODEL)
+     cacheSpy.mockRestore?.()
+   })
 
   test("Oracle with GPT model override has reasoningEffort, no thinking", async () => {
     // #given
@@ -123,43 +123,43 @@ describe("createBuiltinAgents with model overrides", () => {
 })
 
 describe("createBuiltinAgents without systemDefaultModel", () => {
-  test("agents created via connected cache fallback even without systemDefaultModel", async () => {
-    // #given - connected cache has "openai", which matches oracle's fallback chain
-    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+   test("agents created via connected cache fallback even without systemDefaultModel", async () => {
+     // #given - connected cache has "openai", which matches oracle's fallback chain
+     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
 
-    // #when
-    const agents = await createBuiltinAgents([], {}, undefined, undefined)
+     // #when
+     const agents = await createBuiltinAgents([], {}, undefined, undefined)
 
-    // #then - connected cache enables model resolution despite no systemDefaultModel
-    expect(agents.oracle).toBeDefined()
-    expect(agents.oracle.model).toBe("openai/gpt-5.2")
-    cacheSpy.mockRestore()
-  })
+     // #then - connected cache enables model resolution despite no systemDefaultModel
+     expect(agents.oracle).toBeDefined()
+     expect(agents.oracle.model).toBe("openai/gpt-5.2")
+     cacheSpy.mockRestore?.()
+   })
 
-  test("agents NOT created when no cache and no systemDefaultModel (first run without defaults)", async () => {
-    // #given
-    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+   test("agents NOT created when no cache and no systemDefaultModel (first run without defaults)", async () => {
+     // #given
+     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
 
-    // #when
-    const agents = await createBuiltinAgents([], {}, undefined, undefined)
+     // #when
+     const agents = await createBuiltinAgents([], {}, undefined, undefined)
 
-    // #then
-    expect(agents.oracle).toBeUndefined()
-    cacheSpy.mockRestore()
-  })
+     // #then
+     expect(agents.oracle).toBeUndefined()
+     cacheSpy.mockRestore?.()
+   })
 
-  test("sisyphus created via connected cache fallback even without systemDefaultModel", async () => {
-    // #given - connected cache has "anthropic", which matches sisyphus's first fallback entry
-    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["anthropic"])
+   test("sisyphus created via connected cache fallback even without systemDefaultModel", async () => {
+     // #given - connected cache has "anthropic", which matches sisyphus's first fallback entry
+     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["anthropic"])
 
-    // #when
-    const agents = await createBuiltinAgents([], {}, undefined, undefined)
+     // #when
+     const agents = await createBuiltinAgents([], {}, undefined, undefined)
 
-    // #then - connected cache enables model resolution despite no systemDefaultModel
-    expect(agents.sisyphus).toBeDefined()
-    expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4-5")
-    cacheSpy.mockRestore()
-  })
+     // #then - connected cache enables model resolution despite no systemDefaultModel
+     expect(agents.sisyphus).toBeDefined()
+     expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4-5")
+     cacheSpy.mockRestore?.()
+   })
 })
 
 describe("buildAgent with category and skills", () => {
@@ -526,38 +526,39 @@ describe("override.category expansion in createBuiltinAgents", () => {
 })
 
 describe("Deadlock prevention - fetchAvailableModels must not receive client", () => {
-  test("createBuiltinAgents should call fetchAvailableModels with undefined client to prevent deadlock", async () => {
-    // #given - This test ensures we don't regress on issue #1301
-    // Passing client to fetchAvailableModels during createBuiltinAgents (called from config handler)
-    // causes deadlock:
-    // - Plugin init waits for server response (client.provider.list())
-    // - Server waits for plugin init to complete before handling requests
-    const fetchSpy = spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(new Set<string>())
-    spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+   test("createBuiltinAgents should call fetchAvailableModels with undefined client to prevent deadlock", async () => {
+     // #given - This test ensures we don't regress on issue #1301
+     // Passing client to fetchAvailableModels during createBuiltinAgents (called from config handler)
+     // causes deadlock:
+     // - Plugin init waits for server response (client.provider.list())
+     // - Server waits for plugin init to complete before handling requests
+     const fetchSpy = spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(new Set<string>())
+     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
 
-    const mockClient = {
-      provider: { list: () => Promise.resolve({ data: { connected: [] } }) },
-      model: { list: () => Promise.resolve({ data: [] }) },
-    }
+     const mockClient = {
+       provider: { list: () => Promise.resolve({ data: { connected: [] } }) },
+       model: { list: () => Promise.resolve({ data: [] }) },
+     }
 
-    // #when - Even when client is provided, fetchAvailableModels must be called with undefined
-    await createBuiltinAgents(
-      [],
-      {},
-      undefined,
-      TEST_DEFAULT_MODEL,
-      undefined,
-      undefined,
-      [],
-      mockClient // client is passed but should NOT be forwarded to fetchAvailableModels
-    )
+     // #when - Even when client is provided, fetchAvailableModels must be called with undefined
+     await createBuiltinAgents(
+       [],
+       {},
+       undefined,
+       TEST_DEFAULT_MODEL,
+       undefined,
+       undefined,
+       [],
+       mockClient // client is passed but should NOT be forwarded to fetchAvailableModels
+     )
 
-    // #then - fetchAvailableModels must be called with undefined as first argument (no client)
-    // This prevents the deadlock described in issue #1301
-    expect(fetchSpy).toHaveBeenCalled()
-    const firstCallArgs = fetchSpy.mock.calls[0]
-    expect(firstCallArgs[0]).toBeUndefined()
+     // #then - fetchAvailableModels must be called with undefined as first argument (no client)
+     // This prevents the deadlock described in issue #1301
+     expect(fetchSpy).toHaveBeenCalled()
+     const firstCallArgs = fetchSpy.mock.calls[0]
+     expect(firstCallArgs[0]).toBeUndefined()
 
-    fetchSpy.mockRestore()
-  })
+     fetchSpy.mockRestore?.()
+     cacheSpy.mockRestore?.()
+   })
 })

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -180,9 +180,12 @@ export async function createBuiltinAgents(
   uiSelectedModel?: string
 ): Promise<Record<string, AgentConfig>> {
   const connectedProviders = readConnectedProvidersCache()
-  const availableModels = client 
-    ? await fetchAvailableModels(client, { connectedProviders: connectedProviders ?? undefined }) 
-    : new Set<string>()
+  // IMPORTANT: Do NOT pass client to fetchAvailableModels during plugin initialization.
+  // This function is called from config handler, and calling client API causes deadlock.
+  // See: https://github.com/code-yeongyu/oh-my-opencode/issues/1301
+  const availableModels = await fetchAvailableModels(undefined, {
+    connectedProviders: connectedProviders ?? undefined,
+  })
 
   const result: Record<string, AgentConfig> = {}
   const availableAgents: AvailableAgent[] = []

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -435,5 +435,7 @@ describe("Deadlock prevention - fetchAvailableModels must not receive client", (
     expect(fetchSpy).toHaveBeenCalled()
     const firstCallArgs = fetchSpy.mock.calls[0]
     expect(firstCallArgs[0]).toBeUndefined()
+
+    fetchSpy.mockRestore?.()
   })
 })

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -396,3 +396,44 @@ describe("Prometheus direct override priority over category", () => {
     expect(agents.prometheus.temperature).toBe(0.1)
   })
 })
+
+describe("Deadlock prevention - fetchAvailableModels must not receive client", () => {
+  test("fetchAvailableModels should be called with undefined client to prevent deadlock during plugin init", async () => {
+    // #given - This test ensures we don't regress on issue #1301
+    // Passing client to fetchAvailableModels during config handler causes deadlock:
+    // - Plugin init waits for server response (client.provider.list())
+    // - Server waits for plugin init to complete before handling requests
+    const fetchSpy = spyOn(shared, "fetchAvailableModels" as any).mockResolvedValue(new Set<string>())
+
+    const pluginConfig: OhMyOpenCodeConfig = {
+      sisyphus_agent: {
+        planner_enabled: true,
+      },
+    }
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-5",
+      agent: {},
+    }
+    const mockClient = {
+      provider: { list: () => Promise.resolve({ data: { connected: [] } }) },
+      model: { list: () => Promise.resolve({ data: [] }) },
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp", client: mockClient },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler(config)
+
+    // #then - fetchAvailableModels must be called with undefined as first argument (no client)
+    // This prevents the deadlock described in issue #1301
+    expect(fetchSpy).toHaveBeenCalled()
+    const firstCallArgs = fetchSpy.mock.calls[0]
+    expect(firstCallArgs[0]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
The config handler and createBuiltinAgents were calling fetchAvailableModels with client, which triggers client.provider.list() API call to OpenCode server. This caused a deadlock because:
- Plugin initialization waits for server response
- Server waits for plugin init to complete before handling requests

Now using cache-only mode by passing undefined instead of client. If cache is unavailable, the fallback chain will use the first model.

Fixes #1301

## Summary

- Fix deadlock that causes blank screen when loading oh-my-opencode plugin
- Remove client API calls during plugin initialization to prevent circular wait

## Changes

- `src/plugin-handlers/config-handler.ts`: Pass `undefined` instead of `ctx.client` to `fetchAvailableModels()` to avoid server API call during config handler execution
- `src/agents/utils.ts`: Same fix in `createBuiltinAgents()` which is called from config handler
- `src/plugin-handlers/config-handler.test.ts`: Add regression test to prevent reintroducing client parameter
- `src/agents/utils.test.ts`: Add regression test for createBuiltinAgents

## Screenshots

N/A - This is a deadlock fix. Before: TUI hangs on blank screen. After: TUI renders normally.

## Testing

Automated:
- `bun run typecheck`
- `bun test`

### Manual Testing Done

1. Built local version: `bun run build`
2. Linked to opencode cache: `bun link && cd ~/.cache/opencode && bun link oh-my-opencode`
3. Ran `opencode` - TUI renders normally without blank screen hang

**Environment:**
- macOS (Apple Silicon)
- opencode 1.1.47
- oh-my-opencode local build (this PR)

## Related Issues
Closes #1301


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve startup deadlock by removing server API calls from plugin initialization. Uses cache-only model discovery with fallback, fixing the blank screen hang (fixes #1301).

- **Bug Fixes**
  - Pass undefined to fetchAvailableModels in config handler and createBuiltinAgents to avoid client.provider.list() during init.
  - Use connectedProviders cache only; no network calls in initialization path.
  - Fallback selects the first model when cache is missing, preventing circular waits.
  - Add regression tests to ensure fetchAvailableModels is called with undefined during init.

<sup>Written for commit ea8c4c73582c7fb30fc8cc9b2a6e563062ac11fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



