### PR TITLE
fix(tmux): send Ctrl+C before kill-pane and respawn-pane to prevent orphaned processes

### DIFF
--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -75,6 +75,7 @@ const trackedSessions = new Set<string>()
 
 function createMockContext(overrides?: {
   sessionStatusResult?: { data?: Record<string, { type: string }> }
+  sessionMessagesResult?: { data?: unknown[] }
 }) {
   return {
     serverUrl: new URL('http://localhost:4096'),
@@ -89,6 +90,12 @@ function createMockContext(overrides?: {
             data[sessionId] = { type: 'running' }
           }
           return { data }
+        }),
+        messages: mock(async () => {
+          if (overrides?.sessionMessagesResult) {
+            return overrides.sessionMessagesResult
+          }
+          return { data: [] }
         }),
       },
     },
@@ -547,6 +554,212 @@ describe('TmuxSessionManager', () => {
 
       //#then
       expect(mockExecuteAction).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('Stability Detection (Issue #1330)', () => {
+    test('does NOT close session immediately when idle - waits for stability', async () => {
+      //#given - session that just became idle
+      mockIsInsideTmux.mockReturnValue(true)
+      
+      const { TmuxSessionManager } = await import('./manager')
+      
+      // Create context where session is idle but we haven't reached stability
+      const statusMock = mock(async () => ({
+        data: { 'ses_child': { type: 'idle' } }
+      }))
+      const messagesMock = mock(async () => ({
+        data: [{ id: 'msg1' }]  // 1 message
+      }))
+      
+      const ctx = {
+        serverUrl: new URL('http://localhost:4096'),
+        client: {
+          session: {
+            status: statusMock,
+            messages: messagesMock,
+          },
+        },
+      } as any
+      
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      // Spawn a session first
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
+      )
+      mockExecuteAction.mockClear()
+
+      //#when - poll once (should NOT close - need 3 stable polls)
+      await (manager as any).pollSessions()
+
+      //#then - should NOT have closed the session yet
+      expect(mockExecuteAction).not.toHaveBeenCalled()
+    })
+
+    test('closes session after 3 consecutive stable idle polls', async () => {
+      //#given
+      mockIsInsideTmux.mockReturnValue(true)
+      
+      const { TmuxSessionManager } = await import('./manager')
+      
+      const statusMock = mock(async () => ({
+        data: { 'ses_child': { type: 'idle' } }
+      }))
+      const messagesMock = mock(async () => ({
+        data: [{ id: 'msg1' }]  // Same message count each time
+      }))
+      
+      const ctx = {
+        serverUrl: new URL('http://localhost:4096'),
+        client: {
+          session: {
+            status: statusMock,
+            messages: messagesMock,
+          },
+        },
+      } as any
+      
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
+      )
+      
+      // Simulate session being old enough (>10s) by manipulating createdAt
+      const sessions = (manager as any).sessions as Map<string, any>
+      const tracked = sessions.get('ses_child')
+      tracked.createdAt = new Date(Date.now() - 15000)  // 15 seconds ago
+      
+      mockExecuteAction.mockClear()
+
+      //#when - poll 4 times (1st sets lastMessageCount, then 3 stable polls)
+      await (manager as any).pollSessions()  // sets lastMessageCount = 1
+      await (manager as any).pollSessions()  // stableIdlePolls = 1
+      await (manager as any).pollSessions()  // stableIdlePolls = 2
+      await (manager as any).pollSessions()  // stableIdlePolls = 3 -> close
+
+      //#then - should have closed the session
+      expect(mockExecuteAction).toHaveBeenCalled()
+      const call = mockExecuteAction.mock.calls[0]
+      expect(call![0].type).toBe('close')
+    })
+
+    test('resets stability counter when new messages arrive', async () => {
+      //#given
+      mockIsInsideTmux.mockReturnValue(true)
+      
+      const { TmuxSessionManager } = await import('./manager')
+      
+      let messageCount = 1
+      const statusMock = mock(async () => ({
+        data: { 'ses_child': { type: 'idle' } }
+      }))
+      const messagesMock = mock(async () => {
+        // Simulate new messages arriving each poll
+        messageCount++
+        return { data: Array(messageCount).fill({ id: 'msg' }) }
+      })
+      
+      const ctx = {
+        serverUrl: new URL('http://localhost:4096'),
+        client: {
+          session: {
+            status: statusMock,
+            messages: messagesMock,
+          },
+        },
+      } as any
+      
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
+      )
+      
+      const sessions = (manager as any).sessions as Map<string, any>
+      const tracked = sessions.get('ses_child')
+      tracked.createdAt = new Date(Date.now() - 15000)
+      
+      mockExecuteAction.mockClear()
+
+      //#when - poll multiple times (message count keeps changing)
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+
+      //#then - should NOT have closed (stability never reached due to changing messages)
+      expect(mockExecuteAction).not.toHaveBeenCalled()
+    })
+
+    test('does NOT apply stability detection for sessions younger than 10s', async () => {
+      //#given - freshly created session
+      mockIsInsideTmux.mockReturnValue(true)
+      
+      const { TmuxSessionManager } = await import('./manager')
+      
+      const statusMock = mock(async () => ({
+        data: { 'ses_child': { type: 'idle' } }
+      }))
+      const messagesMock = mock(async () => ({
+        data: [{ id: 'msg1' }]
+      }))
+      
+      const ctx = {
+        serverUrl: new URL('http://localhost:4096'),
+        client: {
+          session: {
+            status: statusMock,
+            messages: messagesMock,
+          },
+        },
+      } as any
+      
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
+      )
+      
+      // Session is fresh (createdAt is now) - don't manipulate it
+      mockExecuteAction.mockClear()
+
+      //#when - poll multiple times
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+
+      //#then - should NOT have closed (session too young for stability detection)
+      expect(mockExecuteAction).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -558,18 +558,17 @@ describe('TmuxSessionManager', () => {
   })
 
   describe('Stability Detection (Issue #1330)', () => {
-    test('does NOT close session immediately when idle - waits for stability', async () => {
-      //#given - session that just became idle
+    test('does NOT close session immediately when idle - requires 4 polls (1 baseline + 3 stable)', async () => {
+      //#given - session that is old enough (>10s) and idle
       mockIsInsideTmux.mockReturnValue(true)
       
       const { TmuxSessionManager } = await import('./manager')
       
-      // Create context where session is idle but we haven't reached stability
       const statusMock = mock(async () => ({
         data: { 'ses_child': { type: 'idle' } }
       }))
       const messagesMock = mock(async () => ({
-        data: [{ id: 'msg1' }]  // 1 message
+        data: [{ id: 'msg1' }]  // Same message count each time
       }))
       
       const ctx = {
@@ -595,12 +594,20 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionCreated(
         createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
       )
+      
+      // Make session old enough for stability detection (>10s)
+      const sessions = (manager as any).sessions as Map<string, any>
+      const tracked = sessions.get('ses_child')
+      tracked.createdAt = new Date(Date.now() - 15000)  // 15 seconds ago
+      
       mockExecuteAction.mockClear()
 
-      //#when - poll once (should NOT close - need 3 stable polls)
-      await (manager as any).pollSessions()
+      //#when - poll only 3 times (need 4: 1 baseline + 3 stable)
+      await (manager as any).pollSessions()  // sets lastMessageCount = 1
+      await (manager as any).pollSessions()  // stableIdlePolls = 1
+      await (manager as any).pollSessions()  // stableIdlePolls = 2
 
-      //#then - should NOT have closed the session yet
+      //#then - should NOT have closed yet (need one more poll)
       expect(mockExecuteAction).not.toHaveBeenCalled()
     })
 
@@ -715,7 +722,7 @@ describe('TmuxSessionManager', () => {
     })
 
     test('does NOT apply stability detection for sessions younger than 10s', async () => {
-      //#given - freshly created session
+      //#given - freshly created session (age < 10s)
       mockIsInsideTmux.mockReturnValue(true)
       
       const { TmuxSessionManager } = await import('./manager')
@@ -724,7 +731,7 @@ describe('TmuxSessionManager', () => {
         data: { 'ses_child': { type: 'idle' } }
       }))
       const messagesMock = mock(async () => ({
-        data: [{ id: 'msg1' }]
+        data: [{ id: 'msg1' }]  // Same message count - would trigger close if age check wasn't there
       }))
       
       const ctx = {
@@ -751,12 +758,15 @@ describe('TmuxSessionManager', () => {
       )
       
       // Session is fresh (createdAt is now) - don't manipulate it
+      // This tests the 10s age gate - stability detection should NOT activate
       mockExecuteAction.mockClear()
 
-      //#when - poll multiple times
-      await (manager as any).pollSessions()
-      await (manager as any).pollSessions()
-      await (manager as any).pollSessions()
+      //#when - poll 5 times (more than enough to close if age check wasn't there)
+      await (manager as any).pollSessions()  // Would set lastMessageCount if age check passed
+      await (manager as any).pollSessions()  // Would be stableIdlePolls = 1
+      await (manager as any).pollSessions()  // Would be stableIdlePolls = 2
+      await (manager as any).pollSessions()  // Would be stableIdlePolls = 3 -> would close
+      await (manager as any).pollSessions()  // Extra poll to be sure
 
       //#then - should NOT have closed (session too young for stability detection)
       expect(mockExecuteAction).not.toHaveBeenCalled()

--- a/src/features/tmux-subagent/types.ts
+++ b/src/features/tmux-subagent/types.ts
@@ -4,6 +4,9 @@ export interface TrackedSession {
   description: string
   createdAt: Date
   lastSeenAt: Date
+  // Stability detection fields (prevents premature closure)
+  lastMessageCount?: number
+  stableIdlePolls?: number
 }
 
 export const MIN_PANE_WIDTH = 52


### PR DESCRIPTION
## Summary

Fixes orphaned `opencode attach` processes that remain alive and consume CPU after tmux subpanes are closed.

## Problem

When tmux subagent panes are closed via `kill-pane` or replaced via `respawn-pane -k`:
- tmux sends `SIGHUP` to the running process
- OpenCode TUI has **no SIGHUP handler** (it sets `exitOnCtrlC: false` and uses custom keyboard handling)
- The `opencode attach` process ignores SIGHUP and continues running as an orphan
- Over time, dozens of orphaned processes accumulate, consuming CPU resources

## Solution

Send `Ctrl+C` via `tmux send-keys` before executing destructive pane operations:

1. **closeTmuxPane()**: Send `Ctrl+C` → wait 250ms → `kill-pane`
2. **replaceTmuxPane()**: Send `Ctrl+C` → wait 250ms → `respawn-pane -k`

This triggers OpenCode's graceful exit sequence:
```
Ctrl+C → renderer.destroy() → onExit?.() → process.exit(0)
```

## Changes

- `src/shared/tmux/tmux-utils.ts`
  - Modified `closeTmuxPane()`: Added Ctrl+C send before kill-pane
  - Modified `replaceTmuxPane()`: Added Ctrl+C send before respawn-pane -k
  - Added 250ms delay after Ctrl+C for graceful shutdown
  - Added logging for debugging

## Testing

### Manual Test Procedure
```bash
# 1. List tmux panes to find subagent
tmux list-panes -a -F "#{pane_id} :: #{pane_title}"
# Example output:
# %58 :: OC | Codebase test search
# %60 :: OC | Background: Search for "test" patterns

# 2. Set pane ID
PANE="%60"

# 3. Count processes before
echo "Before:" && pgrep -f "opencode attach" | wc -l
# Output: 1

# 4. Send Ctrl+C then kill pane
tmux send-keys -t "$PANE" C-c
sleep 0.3
tmux kill-pane -t "$PANE"
# Output: can't find pane: %60 (pane already closed - process exited gracefully!)

# 5. Count processes after
echo "After:" && pgrep -f "opencode attach" | wc -l
# Output: 0
```

### Test Results

**Before fix**: Panes close but `opencode attach` processes remain as orphans (observed 56+ orphaned processes)

**After fix**: 
- Ctrl+C triggers graceful shutdown
- Process exits cleanly
- Pane auto-closes (because process exited)
- **0 orphaned processes**

The "can't find pane" message is actually a success indicator - the pane was already gone because the graceful shutdown worked!

## Research

Investigated OpenCode source code:
- `exit.tsx`: Exit handler calls `renderer.destroy()` then `process.exit(0)`
- `app.tsx`: Sets `exitOnCtrlC: false`, implements custom Ctrl+C handling
- `config.ts`: Default exit keybindings are `ctrl+c, ctrl+d, <leader>q`

Reference: https://github.com/sst/opencode

## Checklist

- [x] Code follows existing patterns in codebase
- [x] Function signatures unchanged
- [x] Return types unchanged
- [x] Error handling preserved
- [x] Logging added for debugging
- [x] Typecheck passes (`bun run typecheck`)
- [x] Manual testing verified fix works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send Ctrl+C to tmux panes before kill/respawn to stop orphaned opencode processes, and add stability detection so tmux subagent panes don’t close while work continues.

- **Bug Fixes**
  - closeTmuxPane: send Ctrl+C, wait 250ms, then kill-pane.
  - replaceTmuxPane: send Ctrl+C, then respawn-pane -k.
  - Subagent: add stability detection (10s min age, 3 idle polls with same message count, double-check status) before auto-close (fixes #1330).
  - Updates in tmux-utils, tmux-subagent manager/types; tests added and light logs.

<sup>Written for commit 4168b5a5b1742e0260c46b7b6d7fd52997832390. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

