### PR TITLE
feat(doctor): detect OpenCode desktop GUI installations on all platforms

### DIFF
--- a/src/cli/doctor/checks/opencode.test.ts
+++ b/src/cli/doctor/checks/opencode.test.ts
@@ -1,6 +1,4 @@
 import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test"
-import { join } from "node:path"
-import { homedir } from "node:os"
 import * as opencode from "./opencode"
 import { MIN_OPENCODE_VERSION } from "../constants"
 

--- a/src/cli/doctor/checks/opencode.test.ts
+++ b/src/cli/doctor/checks/opencode.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test"
+import { join } from "node:path"
+import { homedir } from "node:os"
 import * as opencode from "./opencode"
 import { MIN_OPENCODE_VERSION } from "../constants"
 
@@ -222,6 +224,81 @@ describe("opencode check", () => {
       expect(def.category).toBe("installation")
       expect(def.critical).toBe(true)
       expect(typeof def.check).toBe("function")
+    })
+  })
+
+  describe("getDesktopAppPaths", () => {
+    it("returns macOS desktop app paths for darwin platform", () => {
+      // given darwin platform
+      const platform: NodeJS.Platform = "darwin"
+
+      // when getting desktop paths
+      const paths = opencode.getDesktopAppPaths(platform)
+
+      // then should include macOS app bundle paths
+      expect(paths).toContain("/Applications/OpenCode.app/Contents/MacOS/opencode")
+      expect(paths.some((p) => p.includes("Applications/OpenCode.app"))).toBe(true)
+    })
+
+    it("returns Windows desktop app paths for win32 platform", () => {
+      // given win32 platform
+      const platform: NodeJS.Platform = "win32"
+
+      // when getting desktop paths
+      const paths = opencode.getDesktopAppPaths(platform)
+
+      // then should include Windows program paths
+      expect(paths.some((p) => p.includes("Program Files"))).toBe(true)
+      expect(paths.some((p) => p.endsWith("opencode.exe"))).toBe(true)
+    })
+
+    it("returns Linux desktop app paths for linux platform", () => {
+      // given linux platform
+      const platform: NodeJS.Platform = "linux"
+
+      // when getting desktop paths
+      const paths = opencode.getDesktopAppPaths(platform)
+
+      // then should include Linux installation paths
+      expect(paths.some((p) => p.includes("/opt/opencode"))).toBe(true)
+      expect(paths.some((p) => p.includes("/snap/bin"))).toBe(true)
+    })
+
+    it("returns empty array for unsupported platforms", () => {
+      // given unsupported platform
+      const platform = "freebsd" as NodeJS.Platform
+
+      // when getting desktop paths
+      const paths = opencode.getDesktopAppPaths(platform)
+
+      // then should return empty array
+      expect(paths).toEqual([])
+    })
+  })
+
+  describe("findOpenCodeBinary with desktop fallback", () => {
+    it("falls back to desktop paths when PATH binary not found", async () => {
+      // given no binary in PATH but desktop app exists
+      const existsSyncMock = (p: string) =>
+        p === "/Applications/OpenCode.app/Contents/MacOS/opencode"
+
+      // when finding binary with mocked filesystem
+      const result = await opencode.findDesktopBinary("darwin", existsSyncMock)
+
+      // then should find desktop app
+      expect(result).not.toBeNull()
+      expect(result?.path).toBe("/Applications/OpenCode.app/Contents/MacOS/opencode")
+    })
+
+    it("returns null when no desktop binary found", async () => {
+      // given no binary exists
+      const existsSyncMock = () => false
+
+      // when finding binary
+      const result = await opencode.findDesktopBinary("darwin", existsSyncMock)
+
+      // then should return null
+      expect(result).toBeNull()
     })
   })
 })

--- a/src/cli/doctor/checks/opencode.test.ts
+++ b/src/cli/doctor/checks/opencode.test.ts
@@ -235,21 +235,49 @@ describe("opencode check", () => {
       // when getting desktop paths
       const paths = opencode.getDesktopAppPaths(platform)
 
-      // then should include macOS app bundle paths
-      expect(paths).toContain("/Applications/OpenCode.app/Contents/MacOS/opencode")
+      // then should include macOS app bundle paths with correct binary name
+      expect(paths).toContain("/Applications/OpenCode.app/Contents/MacOS/OpenCode")
       expect(paths.some((p) => p.includes("Applications/OpenCode.app"))).toBe(true)
     })
 
-    it("returns Windows desktop app paths for win32 platform", () => {
-      // given win32 platform
+    it("returns Windows desktop app paths for win32 platform when env vars set", () => {
+      // given win32 platform with env vars set
       const platform: NodeJS.Platform = "win32"
+      const originalProgramFiles = process.env.ProgramFiles
+      const originalLocalAppData = process.env.LOCALAPPDATA
+      process.env.ProgramFiles = "C:\\Program Files"
+      process.env.LOCALAPPDATA = "C:\\Users\\Test\\AppData\\Local"
 
       // when getting desktop paths
       const paths = opencode.getDesktopAppPaths(platform)
 
-      // then should include Windows program paths
+      // then should include Windows program paths with correct binary name
       expect(paths.some((p) => p.includes("Program Files"))).toBe(true)
-      expect(paths.some((p) => p.endsWith("opencode.exe"))).toBe(true)
+      expect(paths.some((p) => p.endsWith("OpenCode.exe"))).toBe(true)
+      expect(paths.every((p) => p.startsWith("C:\\"))).toBe(true)
+
+      // cleanup
+      process.env.ProgramFiles = originalProgramFiles
+      process.env.LOCALAPPDATA = originalLocalAppData
+    })
+
+    it("returns empty array for win32 when all env vars undefined", () => {
+      // given win32 platform with no env vars
+      const platform: NodeJS.Platform = "win32"
+      const originalProgramFiles = process.env.ProgramFiles
+      const originalLocalAppData = process.env.LOCALAPPDATA
+      delete process.env.ProgramFiles
+      delete process.env.LOCALAPPDATA
+
+      // when getting desktop paths
+      const paths = opencode.getDesktopAppPaths(platform)
+
+      // then should return empty array (no relative paths)
+      expect(paths).toEqual([])
+
+      // cleanup
+      process.env.ProgramFiles = originalProgramFiles
+      process.env.LOCALAPPDATA = originalLocalAppData
     })
 
     it("returns Linux desktop app paths for linux platform", () => {
@@ -259,9 +287,10 @@ describe("opencode check", () => {
       // when getting desktop paths
       const paths = opencode.getDesktopAppPaths(platform)
 
-      // then should include Linux installation paths
-      expect(paths.some((p) => p.includes("/opt/opencode"))).toBe(true)
-      expect(paths.some((p) => p.includes("/snap/bin"))).toBe(true)
+      // then should include verified Linux installation paths
+      expect(paths).toContain("/usr/bin/opencode")
+      expect(paths).toContain("/usr/lib/opencode/opencode")
+      expect(paths.some((p) => p.includes("AppImage"))).toBe(true)
     })
 
     it("returns empty array for unsupported platforms", () => {
@@ -280,14 +309,14 @@ describe("opencode check", () => {
     it("falls back to desktop paths when PATH binary not found", async () => {
       // given no binary in PATH but desktop app exists
       const existsSyncMock = (p: string) =>
-        p === "/Applications/OpenCode.app/Contents/MacOS/opencode"
+        p === "/Applications/OpenCode.app/Contents/MacOS/OpenCode"
 
       // when finding binary with mocked filesystem
       const result = await opencode.findDesktopBinary("darwin", existsSyncMock)
 
       // then should find desktop app
       expect(result).not.toBeNull()
-      expect(result?.path).toBe("/Applications/OpenCode.app/Contents/MacOS/opencode")
+      expect(result?.path).toBe("/Applications/OpenCode.app/Contents/MacOS/OpenCode")
     })
 
     it("returns null when no desktop binary found", async () => {

--- a/src/cli/doctor/checks/opencode.ts
+++ b/src/cli/doctor/checks/opencode.ts
@@ -12,19 +12,28 @@ export function getDesktopAppPaths(platform: NodeJS.Platform): string[] {
   switch (platform) {
     case "darwin":
       return [
-        "/Applications/OpenCode.app/Contents/MacOS/opencode",
-        join(home, "Applications/OpenCode.app/Contents/MacOS/opencode"),
+        "/Applications/OpenCode.app/Contents/MacOS/OpenCode",
+        join(home, "Applications", "OpenCode.app", "Contents", "MacOS", "OpenCode"),
       ]
-    case "win32":
-      return [
-        "C:\\Program Files\\OpenCode\\opencode.exe",
-        join(process.env.LOCALAPPDATA ?? "", "Programs\\OpenCode\\opencode.exe"),
-      ]
+    case "win32": {
+      const programFiles = process.env.ProgramFiles
+      const localAppData = process.env.LOCALAPPDATA
+
+      const paths: string[] = []
+      if (programFiles) {
+        paths.push(join(programFiles, "OpenCode", "OpenCode.exe"))
+      }
+      if (localAppData) {
+        paths.push(join(localAppData, "OpenCode", "OpenCode.exe"))
+      }
+      return paths
+    }
     case "linux":
       return [
-        "/opt/opencode/bin/opencode",
-        "/snap/bin/opencode",
-        join(home, ".local/bin/opencode"),
+        "/usr/bin/opencode",
+        "/usr/lib/opencode/opencode",
+        join(home, "Applications", "opencode-desktop-linux-x86_64.AppImage"),
+        join(home, "Applications", "opencode-desktop-linux-aarch64.AppImage"),
       ]
     default:
       return []

--- a/src/cli/doctor/checks/opencode.ts
+++ b/src/cli/doctor/checks/opencode.ts
@@ -1,7 +1,35 @@
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
 import type { CheckResult, CheckDefinition, OpenCodeInfo } from "../types"
 import { CHECK_IDS, CHECK_NAMES, MIN_OPENCODE_VERSION, OPENCODE_BINARIES } from "../constants"
 
 const WINDOWS_EXECUTABLE_EXTS = [".exe", ".cmd", ".bat", ".ps1"]
+
+export function getDesktopAppPaths(platform: NodeJS.Platform): string[] {
+  const home = homedir()
+
+  switch (platform) {
+    case "darwin":
+      return [
+        "/Applications/OpenCode.app/Contents/MacOS/opencode",
+        join(home, "Applications/OpenCode.app/Contents/MacOS/opencode"),
+      ]
+    case "win32":
+      return [
+        "C:\\Program Files\\OpenCode\\opencode.exe",
+        join(process.env.LOCALAPPDATA ?? "", "Programs\\OpenCode\\opencode.exe"),
+      ]
+    case "linux":
+      return [
+        "/opt/opencode/bin/opencode",
+        "/snap/bin/opencode",
+        join(home, ".local/bin/opencode"),
+      ]
+    default:
+      return []
+  }
+}
 
 export function getBinaryLookupCommand(platform: NodeJS.Platform): "which" | "where" {
   return platform === "win32" ? "where" : "which"
@@ -52,6 +80,19 @@ export function buildVersionCommand(
   return [binaryPath, "--version"]
 }
 
+export function findDesktopBinary(
+  platform: NodeJS.Platform = process.platform,
+  checkExists: (path: string) => boolean = existsSync
+): { binary: string; path: string } | null {
+  const desktopPaths = getDesktopAppPaths(platform)
+  for (const desktopPath of desktopPaths) {
+    if (checkExists(desktopPath)) {
+      return { binary: "opencode", path: desktopPath }
+    }
+  }
+  return null
+}
+
 export async function findOpenCodeBinary(): Promise<{ binary: string; path: string } | null> {
   for (const binary of OPENCODE_BINARIES) {
     try {
@@ -63,6 +104,12 @@ export async function findOpenCodeBinary(): Promise<{ binary: string; path: stri
       continue
     }
   }
+
+  const desktopResult = findDesktopBinary()
+  if (desktopResult) {
+    return desktopResult
+  }
+
   return null
 }
 


### PR DESCRIPTION
## Summary

- Add `getDesktopAppPaths()` function that returns platform-specific paths for desktop GUI installations
- Add `findDesktopBinary()` helper for testable desktop path detection with dependency injection
- Modify `findOpenCodeBinary()` to check desktop paths as fallback when PATH lookup fails

## Problem

The doctor check only detected OpenCode binaries in PATH via `which`/`where` commands. Desktop GUI apps installed in standard locations were not detected:
- **macOS**: `/Applications/OpenCode.app/Contents/MacOS/opencode`
- **Windows**: `C:\Program Files\OpenCode\opencode.exe`
- **Linux**: `/opt/opencode/bin/opencode`, `/snap/bin/opencode`

## Solution

When `Bun.which()` fails to find OpenCode in PATH, fall back to checking platform-specific desktop installation paths using `existsSync()`.

## Testing

Added 6 new tests covering:
- macOS desktop paths detection
- Windows desktop paths detection
- Linux desktop paths detection
- Unsupported platform handling
- Desktop fallback when PATH binary not found
- Null return when no binary found anywhere

All 23 tests pass. Typecheck passes.

Fixes #1310

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects OpenCode desktop GUI installations on macOS, Windows, and Linux using verified install paths, so the doctor check finds the binary even when it's not on PATH. Addresses #1310.

- **New Features**
  - Added getDesktopAppPaths(platform) returning verified desktop install paths per OS.
  - Added findDesktopBinary(platform, checkExists) for testable desktop detection.
  - Updated findOpenCodeBinary() to fall back to desktop paths when PATH lookup fails.

<sup>Written for commit 65cf000e804bd9619fdfaaf26ea87ba6109f9d4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

