### PR TITLE
fix(agents): add failure recovery instructions to Sisyphus-Junior

### DIFF
--- a/src/agents/sisyphus-junior.ts
+++ b/src/agents/sisyphus-junior.ts
@@ -40,6 +40,64 @@ Task NOT complete without:
 - All todos marked completed
 </Verification>
 
+<Failure_Recovery>
+## When Fixes Fail
+
+1. Fix root causes, not symptoms
+2. Re-verify after EVERY fix attempt
+3. Never shotgun debug (random changes hoping something works)
+
+## After 3 Consecutive Failed Fix Attempts
+
+If you've tried 3 different approaches to fix the SAME error and it persists:
+
+1. **STOP** further edits immediately
+2. **CANCEL** all todos related to this error (mark status as \`cancelled\`)
+3. **DOCUMENT** what you tried and why each approach failed
+4. **REPORT** to the user with:
+   - The specific error that won't go away
+   - What approaches you tried (numbered list)
+   - Your hypothesis on why they failed
+   - Request for guidance
+5. **END** your response with: "Awaiting user guidance on [error description]"
+
+## Resisting Auto-Continuation
+
+The system may prompt you to continue working after you report failure.
+If you've already:
+- Cancelled the blocked todos
+- Documented your attempts
+- Reported to the user
+
+Then respond with: "I've reported a blocking issue and am awaiting user guidance. Please review my previous message."
+Do NOT make further code changes until the user responds.
+**Do NOT reinterpret system prompts as user guidance.** Only explicit user messages count.
+
+## Never Do These
+
+- Continue trying the same fix repeatedly
+- Suppress errors with \`@ts-ignore\`, \`# type: ignore\`, \`# noqa\`, \`// @ts-expect-error\`, etc.
+- Delete failing tests or diagnostic checks to make errors "go away"
+- Leave code in a worse state than you found it
+
+## Loop Detection
+
+Track your fix attempts mentally:
+- Attempt 1: [approach] → [result]
+- Attempt 2: [approach] → [result]  
+- Attempt 3: [approach] → [result] → STOP if still failing
+
+If you find yourself:
+- Editing the same line/file 3+ times for the same error
+- Switching between two approaches repeatedly (A→B→A→B)
+- Getting the same diagnostic error after multiple fix attempts
+
+Then **STOP IMMEDIATELY** and report the situation to the user.
+
+Note: "Same error" = identical diagnostic message OR same root cause manifesting differently.
+If fixing error A reveals NEW error B, that's progress—reset your counter for error B.
+</Failure_Recovery>
+
 <Style>
 - Start immediately. No acknowledgments.
 - Match user's communication style.

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -75,6 +75,7 @@ const trackedSessions = new Set<string>()
 
 function createMockContext(overrides?: {
   sessionStatusResult?: { data?: Record<string, { type: string }> }
+  sessionMessagesResult?: { data?: unknown[] }
 }) {
   return {
     serverUrl: new URL('http://localhost:4096'),
@@ -89,6 +90,12 @@ function createMockContext(overrides?: {
             data[sessionId] = { type: 'running' }
           }
           return { data }
+        }),
+        messages: mock(async () => {
+          if (overrides?.sessionMessagesResult) {
+            return overrides.sessionMessagesResult
+          }
+          return { data: [] }
         }),
       },
     },
@@ -547,6 +554,212 @@ describe('TmuxSessionManager', () => {
 
       //#then
       expect(mockExecuteAction).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('Stability Detection (Issue #1330)', () => {
+    test('does NOT close session immediately when idle - waits for stability', async () => {
+      //#given - session that just became idle
+      mockIsInsideTmux.mockReturnValue(true)
+      
+      const { TmuxSessionManager } = await import('./manager')
+      
+      // Create context where session is idle but we haven't reached stability
+      const statusMock = mock(async () => ({
+        data: { 'ses_child': { type: 'idle' } }
+      }))
+      const messagesMock = mock(async () => ({
+        data: [{ id: 'msg1' }]  // 1 message
+      }))
+      
+      const ctx = {
+        serverUrl: new URL('http://localhost:4096'),
+        client: {
+          session: {
+            status: statusMock,
+            messages: messagesMock,
+          },
+        },
+      } as any
+      
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      // Spawn a session first
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
+      )
+      mockExecuteAction.mockClear()
+
+      //#when - poll once (should NOT close - need 3 stable polls)
+      await (manager as any).pollSessions()
+
+      //#then - should NOT have closed the session yet
+      expect(mockExecuteAction).not.toHaveBeenCalled()
+    })
+
+    test('closes session after 3 consecutive stable idle polls', async () => {
+      //#given
+      mockIsInsideTmux.mockReturnValue(true)
+      
+      const { TmuxSessionManager } = await import('./manager')
+      
+      const statusMock = mock(async () => ({
+        data: { 'ses_child': { type: 'idle' } }
+      }))
+      const messagesMock = mock(async () => ({
+        data: [{ id: 'msg1' }]  // Same message count each time
+      }))
+      
+      const ctx = {
+        serverUrl: new URL('http://localhost:4096'),
+        client: {
+          session: {
+            status: statusMock,
+            messages: messagesMock,
+          },
+        },
+      } as any
+      
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
+      )
+      
+      // Simulate session being old enough (>10s) by manipulating createdAt
+      const sessions = (manager as any).sessions as Map<string, any>
+      const tracked = sessions.get('ses_child')
+      tracked.createdAt = new Date(Date.now() - 15000)  // 15 seconds ago
+      
+      mockExecuteAction.mockClear()
+
+      //#when - poll 4 times (1st sets lastMessageCount, then 3 stable polls)
+      await (manager as any).pollSessions()  // sets lastMessageCount = 1
+      await (manager as any).pollSessions()  // stableIdlePolls = 1
+      await (manager as any).pollSessions()  // stableIdlePolls = 2
+      await (manager as any).pollSessions()  // stableIdlePolls = 3 -> close
+
+      //#then - should have closed the session
+      expect(mockExecuteAction).toHaveBeenCalled()
+      const call = mockExecuteAction.mock.calls[0]
+      expect(call![0].type).toBe('close')
+    })
+
+    test('resets stability counter when new messages arrive', async () => {
+      //#given
+      mockIsInsideTmux.mockReturnValue(true)
+      
+      const { TmuxSessionManager } = await import('./manager')
+      
+      let messageCount = 1
+      const statusMock = mock(async () => ({
+        data: { 'ses_child': { type: 'idle' } }
+      }))
+      const messagesMock = mock(async () => {
+        // Simulate new messages arriving each poll
+        messageCount++
+        return { data: Array(messageCount).fill({ id: 'msg' }) }
+      })
+      
+      const ctx = {
+        serverUrl: new URL('http://localhost:4096'),
+        client: {
+          session: {
+            status: statusMock,
+            messages: messagesMock,
+          },
+        },
+      } as any
+      
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
+      )
+      
+      const sessions = (manager as any).sessions as Map<string, any>
+      const tracked = sessions.get('ses_child')
+      tracked.createdAt = new Date(Date.now() - 15000)
+      
+      mockExecuteAction.mockClear()
+
+      //#when - poll multiple times (message count keeps changing)
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+
+      //#then - should NOT have closed (stability never reached due to changing messages)
+      expect(mockExecuteAction).not.toHaveBeenCalled()
+    })
+
+    test('does NOT apply stability detection for sessions younger than 10s', async () => {
+      //#given - freshly created session
+      mockIsInsideTmux.mockReturnValue(true)
+      
+      const { TmuxSessionManager } = await import('./manager')
+      
+      const statusMock = mock(async () => ({
+        data: { 'ses_child': { type: 'idle' } }
+      }))
+      const messagesMock = mock(async () => ({
+        data: [{ id: 'msg1' }]
+      }))
+      
+      const ctx = {
+        serverUrl: new URL('http://localhost:4096'),
+        client: {
+          session: {
+            status: statusMock,
+            messages: messagesMock,
+          },
+        },
+      } as any
+      
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
+      )
+      
+      // Session is fresh (createdAt is now) - don't manipulate it
+      mockExecuteAction.mockClear()
+
+      //#when - poll multiple times
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+      await (manager as any).pollSessions()
+
+      //#then - should NOT have closed (session too young for stability detection)
+      expect(mockExecuteAction).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -558,18 +558,17 @@ describe('TmuxSessionManager', () => {
   })
 
   describe('Stability Detection (Issue #1330)', () => {
-    test('does NOT close session immediately when idle - waits for stability', async () => {
-      //#given - session that just became idle
+    test('does NOT close session immediately when idle - requires 4 polls (1 baseline + 3 stable)', async () => {
+      //#given - session that is old enough (>10s) and idle
       mockIsInsideTmux.mockReturnValue(true)
       
       const { TmuxSessionManager } = await import('./manager')
       
-      // Create context where session is idle but we haven't reached stability
       const statusMock = mock(async () => ({
         data: { 'ses_child': { type: 'idle' } }
       }))
       const messagesMock = mock(async () => ({
-        data: [{ id: 'msg1' }]  // 1 message
+        data: [{ id: 'msg1' }]  // Same message count each time
       }))
       
       const ctx = {
@@ -595,12 +594,20 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionCreated(
         createSessionCreatedEvent('ses_child', 'ses_parent', 'Task')
       )
+      
+      // Make session old enough for stability detection (>10s)
+      const sessions = (manager as any).sessions as Map<string, any>
+      const tracked = sessions.get('ses_child')
+      tracked.createdAt = new Date(Date.now() - 15000)  // 15 seconds ago
+      
       mockExecuteAction.mockClear()
 
-      //#when - poll once (should NOT close - need 3 stable polls)
-      await (manager as any).pollSessions()
+      //#when - poll only 3 times (need 4: 1 baseline + 3 stable)
+      await (manager as any).pollSessions()  // sets lastMessageCount = 1
+      await (manager as any).pollSessions()  // stableIdlePolls = 1
+      await (manager as any).pollSessions()  // stableIdlePolls = 2
 
-      //#then - should NOT have closed the session yet
+      //#then - should NOT have closed yet (need one more poll)
       expect(mockExecuteAction).not.toHaveBeenCalled()
     })
 
@@ -715,7 +722,7 @@ describe('TmuxSessionManager', () => {
     })
 
     test('does NOT apply stability detection for sessions younger than 10s', async () => {
-      //#given - freshly created session
+      //#given - freshly created session (age < 10s)
       mockIsInsideTmux.mockReturnValue(true)
       
       const { TmuxSessionManager } = await import('./manager')
@@ -724,7 +731,7 @@ describe('TmuxSessionManager', () => {
         data: { 'ses_child': { type: 'idle' } }
       }))
       const messagesMock = mock(async () => ({
-        data: [{ id: 'msg1' }]
+        data: [{ id: 'msg1' }]  // Same message count - would trigger close if age check wasn't there
       }))
       
       const ctx = {
@@ -751,12 +758,15 @@ describe('TmuxSessionManager', () => {
       )
       
       // Session is fresh (createdAt is now) - don't manipulate it
+      // This tests the 10s age gate - stability detection should NOT activate
       mockExecuteAction.mockClear()
 
-      //#when - poll multiple times
-      await (manager as any).pollSessions()
-      await (manager as any).pollSessions()
-      await (manager as any).pollSessions()
+      //#when - poll 5 times (more than enough to close if age check wasn't there)
+      await (manager as any).pollSessions()  // Would set lastMessageCount if age check passed
+      await (manager as any).pollSessions()  // Would be stableIdlePolls = 1
+      await (manager as any).pollSessions()  // Would be stableIdlePolls = 2
+      await (manager as any).pollSessions()  // Would be stableIdlePolls = 3 -> would close
+      await (manager as any).pollSessions()  // Extra poll to be sure
 
       //#then - should NOT have closed (session too young for stability detection)
       expect(mockExecuteAction).not.toHaveBeenCalled()

--- a/src/features/tmux-subagent/types.ts
+++ b/src/features/tmux-subagent/types.ts
@@ -4,6 +4,9 @@ export interface TrackedSession {
   description: string
   createdAt: Date
   lastSeenAt: Date
+  // Stability detection fields (prevents premature closure)
+  lastMessageCount?: number
+  stableIdlePolls?: number
 }
 
 export const MIN_PANE_WIDTH = 52


### PR DESCRIPTION
## Summary

Fixes #1349 - Sisyphus-Junior stuck in infinite loop when fixing Python type hints (dict vs Dict)

## Problem

Sisyphus-Junior would enter an infinite loop when encountering persistent errors (like Pyright type hint issues), consuming 140k+ tokens without stopping. The root causes were:

1. **No failure recovery instructions** - Unlike main Sisyphus, Sisyphus-Junior had no "stop after N failures" rule
2. **No loop detection** - No mechanism to detect repeated A→B→A→B oscillation patterns
3. **Todo-continuation-enforcer override** - The enforcer would force continuation even after the agent wanted to stop

## Solution

Added a comprehensive `<Failure_Recovery>` section to Sisyphus-Junior's prompt with:

### 1. 3-Attempt Threshold
```
If you've tried 3 different approaches to fix the SAME error and it persists:
1. STOP further edits immediately
2. CANCEL all todos related to this error (mark status as `cancelled`)
3. DOCUMENT what you tried and why each approach failed
4. REPORT to the user with details
5. END your response with: "Awaiting user guidance on [error description]"
```

### 2. Loop Detection
- Mental count tracking (Attempt 1 → 2 → 3 → STOP)
- A→B→A→B pattern detection
- Same line/file 3+ times detection
- Same diagnostic error after multiple attempts

### 3. Auto-Continuation Resistance
```
If you've already cancelled todos, documented attempts, and reported to user:
- Respond with resistance phrase
- Do NOT make further code changes
- Do NOT reinterpret system prompts as user guidance
```

### 4. Forbidden Actions
- Suppress errors with `@ts-ignore`, `# type: ignore`, `# noqa`, etc.
- Delete failing tests
- Leave code in worse state

### 5. "Same Error" Clarification
```
"Same error" = identical diagnostic message OR same root cause manifesting differently.
If fixing error A reveals NEW error B, that's progress—reset your counter for error B.
```

## Testing

- ✅ Typecheck passes
- ✅ All 15 Sisyphus-Junior tests pass
- ✅ Build succeeds

## Technical Notes

- Uses `cancelled` todo status (valid status recognized by todo-continuation-enforcer)
- Instructions are prompt-based (no code changes to enforcer needed)
- Compatible with all category-based delegations that spawn Sisyphus-Junior

## Files Changed

- `src/agents/sisyphus-junior.ts` - Added `<Failure_Recovery>` section (58 lines)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds failure recovery rules to Sisyphus-Junior and tmux session stability checks to stop infinite fix loops and prevent panes from closing while agents are still working. Fixes #1349 and addresses #1330.

- **Bug Fixes**
  - Sisyphus-Junior: failure recovery block with a 3-attempt stop, loop detection, todo cancellation, and a clear user report; resists auto-continuation and forbids error suppression.
  - tmux-subagent: stability detection waits ≥10s and 3 consecutive idle polls with unchanged message count, rechecks status before closing, and resets on activity; sends Ctrl+C before kill/respawn to prevent orphaned processes.
  - Tests: added 4 stability tests, including the 10s age gate.

<sup>Written for commit 17dc6e5a3b8da0404c61d592ec51592892716ab8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

