### PR TITLE
fix: apply user agent config and fallback chain to subagent_type delegation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -346,6 +346,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     gitMasterConfig: pluginConfig.git_master,
     sisyphusJuniorModel: pluginConfig.agents?.["sisyphus-junior"]?.model,
     browserProvider,
+    agentOverrides: pluginConfig.agents,
     onSyncSessionCreated: async (event) => {
       log("[index] onSyncSessionCreated callback", {
         sessionID: event.sessionID,

--- a/src/tools/delegate-task/executor.ts
+++ b/src/tools/delegate-task/executor.ts
@@ -15,7 +15,7 @@ import { subagentSessions, getSessionAgent } from "../../features/claude-code-se
 import { log, getAgentToolRestrictions, resolveModelPipeline, promptWithModelSuggestionRetry } from "../../shared"
 import { fetchAvailableModels, isModelAvailable } from "../../shared/model-availability"
 import { readConnectedProvidersCache } from "../../shared/connected-providers-cache"
-import { CATEGORY_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
+import { CATEGORY_MODEL_REQUIREMENTS, AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
 
 const SISYPHUS_JUNIOR_AGENT = "sisyphus-junior"
 
@@ -27,6 +27,7 @@ export interface ExecutorContext {
   gitMasterConfig?: GitMasterConfig
   sisyphusJuniorModel?: string
   browserProvider?: BrowserAutomationProvider
+  agentOverrides?: Record<string, { model?: string; variant?: string }>
   onSyncSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
 }
 
@@ -897,7 +898,7 @@ export async function resolveSubagentExecution(
   executorCtx: ExecutorContext,
   parentAgent: string | undefined,
   categoryExamples: string
-): Promise<{ agentToUse: string; categoryModel: { providerID: string; modelID: string } | undefined; error?: string }> {
+): Promise<{ agentToUse: string; categoryModel: { providerID: string; modelID: string; variant?: string } | undefined; error?: string }> {
   const { client } = executorCtx
 
   if (!args.subagent_type?.trim()) {
@@ -927,7 +928,7 @@ Create the work plan directly - that's your job as the planning agent.`,
   }
 
   let agentToUse = agentName
-  let categoryModel: { providerID: string; modelID: string } | undefined
+  let categoryModel: { providerID: string; modelID: string; variant?: string } | undefined
 
   try {
     const agentsResult = await client.app.agents()
@@ -963,12 +964,40 @@ Create the work plan directly - that's your job as the planning agent.`,
     }
 
     agentToUse = matchedAgent.name
-
-    if (matchedAgent.model) {
-      categoryModel = matchedAgent.model
-    }
   } catch {
     // Proceed anyway - session.prompt will fail with clearer error if agent doesn't exist
+  }
+
+  const { agentOverrides } = executorCtx
+  const agentNameLower = agentToUse.toLowerCase()
+  const agentOverride = agentOverrides?.[agentNameLower] 
+    ?? Object.entries(agentOverrides ?? {}).find(([key]) => key.toLowerCase() === agentNameLower)?.[1]
+  
+  const agentRequirement = AGENT_MODEL_REQUIREMENTS[agentNameLower as keyof typeof AGENT_MODEL_REQUIREMENTS]
+  const connectedProviders = readConnectedProvidersCache()
+  const availableModels = await fetchAvailableModels(undefined, {
+    connectedProviders: connectedProviders ?? undefined
+  })
+
+  const resolution = resolveModelPipeline({
+    intent: {
+      userModel: agentOverride?.model,
+    },
+    constraints: {
+      availableModels,
+    },
+    policy: {
+      fallbackChain: agentRequirement?.fallbackChain,
+      systemDefaultModel: undefined,
+    },
+  })
+
+  if (resolution) {
+    const parsed = parseModelString(resolution.model)
+    if (parsed) {
+      const variantToUse = agentOverride?.variant ?? resolution.variant
+      categoryModel = variantToUse ? { ...parsed, variant: variantToUse } : parsed
+    }
   }
 
   return { agentToUse, categoryModel }

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
-import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider } from "../../config/schema"
+import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider, AgentOverrideConfig } from "../../config/schema"
 
 export type OpencodeClient = PluginInput["client"]
 
@@ -41,6 +41,7 @@ export interface DelegateTaskToolOptions {
   gitMasterConfig?: GitMasterConfig
   sisyphusJuniorModel?: string
   browserProvider?: BrowserAutomationProvider
+  agentOverrides?: Record<string, AgentOverrideConfig>
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>
 }
 


### PR DESCRIPTION
## Summary

- Fix `delegate_task(subagent_type=...)` ignoring user's agent model configuration
- Add proper fallback chain support when user config is not set

## Changes

### 1. `src/tools/delegate-task/types.ts`
- Add `agentOverrides` to `DelegateTaskToolOptions`

### 2. `src/tools/delegate-task/executor.ts`
- Add `agentOverrides` to `ExecutorContext`
- Import `AGENT_MODEL_REQUIREMENTS` for fallback chains
- Update `resolveSubagentExecution` to:
  - Look up user's model from `agentOverrides` (highest priority)
  - Use `resolveModelPipeline` with agent's fallback chain
  - Apply user's variant override if specified

### 3. `src/index.ts`
- Pass `pluginConfig.agents` as `agentOverrides` to `createDelegateTask`

## Model Resolution Priority

1. **User Config** (`oh-my-opencode.json` agents) → Immediate use, no availability check
2. **Fallback Chain** (`AGENT_MODEL_REQUIREMENTS`) → When user config not set
3. **System Default** → Last resort

## Testing

```typescript
// Before: Always uses system default
delegate_task(subagent_type="oracle", prompt="What model are you?")
// → system default ❌

// After: Uses user config
delegate_task(subagent_type="oracle", prompt="What model are you?")
// → openai/gpt-5.2 ✅ (from oh-my-opencode.json)
```

Fixes #1357

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subagent model resolution so delegate_task(subagent_type=...) uses the user’s configured agent model and variant, with a proper fallback when not set. Prevents unintended fallback to the system default.

- **Bug Fixes**
  - Apply agentOverrides (pluginConfig.agents) to subagent delegation, including variant.
  - Use AGENT_MODEL_REQUIREMENTS with resolveModelPipeline for fallback when no user config.
  - Model selection order: user config (no availability check) → agent fallback chain → system default.

<sup>Written for commit 468dad7d11518a1047386c541a2cf0a879d6498c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

