### PR TITLE
fix(doctor): display user-configured variant in model resolution output

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -2877,6 +2877,13 @@
         },
         "state_dir": {
           "type": "string"
+        },
+        "context_strategy": {
+          "type": "string",
+          "enum": [
+            "reset",
+            "continue"
+          ]
         }
       }
     },

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -2878,7 +2878,7 @@
         "state_dir": {
           "type": "string"
         },
-        "context_strategy": {
+        "default_strategy": {
           "type": "string",
           "enum": [
             "reset",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "oh-my-opencode",
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.1.11",
-        "oh-my-opencode-darwin-x64": "3.1.11",
-        "oh-my-opencode-linux-arm64": "3.1.11",
-        "oh-my-opencode-linux-arm64-musl": "3.1.11",
-        "oh-my-opencode-linux-x64": "3.1.11",
-        "oh-my-opencode-linux-x64-musl": "3.1.11",
-        "oh-my-opencode-windows-x64": "3.1.11",
+        "oh-my-opencode-darwin-arm64": "3.1.10",
+        "oh-my-opencode-darwin-x64": "3.1.10",
+        "oh-my-opencode-linux-arm64": "3.1.10",
+        "oh-my-opencode-linux-arm64-musl": "3.1.10",
+        "oh-my-opencode-linux-x64": "3.1.10",
+        "oh-my-opencode-linux-x64-musl": "3.1.10",
+        "oh-my-opencode-windows-x64": "3.1.10",
       },
     },
   },
@@ -44,41 +44,41 @@
     "@code-yeongyu/comment-checker",
   ],
   "packages": {
-    "@ast-grep/cli": ["@ast-grep/cli@0.40.5", "", { "dependencies": { "detect-libc": "2.1.2" }, "optionalDependencies": { "@ast-grep/cli-darwin-arm64": "0.40.5", "@ast-grep/cli-darwin-x64": "0.40.5", "@ast-grep/cli-linux-arm64-gnu": "0.40.5", "@ast-grep/cli-linux-x64-gnu": "0.40.5", "@ast-grep/cli-win32-arm64-msvc": "0.40.5", "@ast-grep/cli-win32-ia32-msvc": "0.40.5", "@ast-grep/cli-win32-x64-msvc": "0.40.5" }, "bin": { "sg": "sg", "ast-grep": "ast-grep" } }, "sha512-yVXL7Gz0WIHerQLf+MVaVSkhIhidtWReG5akNVr/JS9OVCVkSdz7gWm7H8jVv2M9OO1tauuG76K3UaRGBPu5lQ=="],
+    "@ast-grep/cli": ["@ast-grep/cli@0.40.0", "", { "dependencies": { "detect-libc": "2.1.2" }, "optionalDependencies": { "@ast-grep/cli-darwin-arm64": "0.40.0", "@ast-grep/cli-darwin-x64": "0.40.0", "@ast-grep/cli-linux-arm64-gnu": "0.40.0", "@ast-grep/cli-linux-x64-gnu": "0.40.0", "@ast-grep/cli-win32-arm64-msvc": "0.40.0", "@ast-grep/cli-win32-ia32-msvc": "0.40.0", "@ast-grep/cli-win32-x64-msvc": "0.40.0" }, "bin": { "sg": "sg", "ast-grep": "ast-grep" } }, "sha512-L8AkflsfI2ZP70yIdrwqvjR02ScCuRmM/qNGnJWUkOFck+e6gafNVJ4e4jjGQlEul+dNdBpx36+O2Op629t47A=="],
 
-    "@ast-grep/cli-darwin-arm64": ["@ast-grep/cli-darwin-arm64@0.40.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-T9CzwJ1GqQhnANdsu6c7iT1akpvTVMK+AZrxnhIPv33Ze5hrXUUkqan+j4wUAukRJDqU7u94EhXLSLD+5tcJ8g=="],
+    "@ast-grep/cli-darwin-arm64": ["@ast-grep/cli-darwin-arm64@0.40.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UehY2MMUkdJbsriP7NKc6+uojrqPn7d1Cl0em+WAkee7Eij81VdyIjRsRxtZSLh440ZWQBHI3PALZ9RkOO8pKQ=="],
 
-    "@ast-grep/cli-darwin-x64": ["@ast-grep/cli-darwin-x64@0.40.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-ez9b2zKvXU8f4ghhjlqYvbx6tWCKJTuVlNVqDDfjqwwhGeiTYfnzMlSVat4ElYRMd21gLtXZIMy055v2f21Ztg=="],
+    "@ast-grep/cli-darwin-x64": ["@ast-grep/cli-darwin-x64@0.40.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-RFDJ2ZxUbT0+grntNlOLJx7wa9/ciVCeaVtQpQy8WJJTvXvkY0etl8Qlh2TmO2x2yr+i0Z6aMJi4IG/Yx5ghTQ=="],
 
-    "@ast-grep/cli-linux-arm64-gnu": ["@ast-grep/cli-linux-arm64-gnu@0.40.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-VXa2L1IEYD66AMb0GuG7VlMMbPmEGoJUySWDcwSZo/D9neiry3MJ41LQR5oTG2HyhIPBsf9umrXnmuRq66BviA=="],
+    "@ast-grep/cli-linux-arm64-gnu": ["@ast-grep/cli-linux-arm64-gnu@0.40.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-4p55gnTQ1mMFCyqjtM7bH9SB9r16mkwXtUcJQGX1YgFG4WD+QG8rC4GwSuNNZcdlYaOQuTWrgUEQ9z5K06UXfg=="],
 
-    "@ast-grep/cli-linux-x64-gnu": ["@ast-grep/cli-linux-x64-gnu@0.40.5", "", { "os": "linux", "cpu": "x64" }, "sha512-GQC5162eIOWXR2eQQ6Knzg7/8Trp5E1ODJkaErf0IubdQrZBGqj5AAcQPcWgPbbnmktjIp0H4NraPpOJ9eJ22A=="],
+    "@ast-grep/cli-linux-x64-gnu": ["@ast-grep/cli-linux-x64-gnu@0.40.0", "", { "os": "linux", "cpu": "x64" }, "sha512-u2MXFceuwvrO+OQ6zFGoJ6wbATXn46HWwW79j4UPrXYJzVl97jRyjJOIQTJOzTflsk02fjP98DQkfvbXt2dl3Q=="],
 
-    "@ast-grep/cli-win32-arm64-msvc": ["@ast-grep/cli-win32-arm64-msvc@0.40.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-YiZdnQZsSlXQTMsZJop/Ux9MmUGfuRvC2x/UbFgrt5OBSYxND+yoiMc0WcA3WG+wU+tt4ZkB5HUea3r/IkOLYA=="],
+    "@ast-grep/cli-win32-arm64-msvc": ["@ast-grep/cli-win32-arm64-msvc@0.40.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-E/I1xpF/RQL2fo1CQsQfTxyDLnChsbZ+ERrQHKuF1FI4WrkaPOBibpqda60QgVmUcgOGZyZ/GRb3iKEVWPsQNQ=="],
 
-    "@ast-grep/cli-win32-ia32-msvc": ["@ast-grep/cli-win32-ia32-msvc@0.40.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-MHkCxCITVTr8sY9CcVqNKbfUzMa3Hc6IilGXad0Clnw2vNmPfWqSky+hU/UTerr5YHWwWfAVURH7ANZgirtx0Q=="],
+    "@ast-grep/cli-win32-ia32-msvc": ["@ast-grep/cli-win32-ia32-msvc@0.40.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-9h12OQu1BR0GxHEtT+Z4QkJk3LLWLiKwjBkjXUGlASHYDPTyLcs85KwDLeFHs4BwarF8TDdF+KySvB9WPGl/nQ=="],
 
-    "@ast-grep/cli-win32-x64-msvc": ["@ast-grep/cli-win32-x64-msvc@0.40.5", "", { "os": "win32", "cpu": "x64" }, "sha512-/MJ5un7yxlClaaxou9eYl+Kr2xr/yTtYtTq5aLBWjPWA6dmmJ1nAJgx5zKHVuplFXFBrFDQk3paEgAETMTGcrA=="],
+    "@ast-grep/cli-win32-x64-msvc": ["@ast-grep/cli-win32-x64-msvc@0.40.0", "", { "os": "win32", "cpu": "x64" }, "sha512-n2+3WynEWFHhXg6KDgjwWQ0UEtIvqUITFbKEk5cDkUYrzYhg/A6kj0qauPwRbVMoJms49vtsNpLkzzqyunio5g=="],
 
-    "@ast-grep/napi": ["@ast-grep/napi@0.40.5", "", { "optionalDependencies": { "@ast-grep/napi-darwin-arm64": "0.40.5", "@ast-grep/napi-darwin-x64": "0.40.5", "@ast-grep/napi-linux-arm64-gnu": "0.40.5", "@ast-grep/napi-linux-arm64-musl": "0.40.5", "@ast-grep/napi-linux-x64-gnu": "0.40.5", "@ast-grep/napi-linux-x64-musl": "0.40.5", "@ast-grep/napi-win32-arm64-msvc": "0.40.5", "@ast-grep/napi-win32-ia32-msvc": "0.40.5", "@ast-grep/napi-win32-x64-msvc": "0.40.5" } }, "sha512-hJA62OeBKUQT68DD2gDyhOqJxZxycqg8wLxbqjgqSzYttCMSDL9tiAQ9abgekBYNHudbJosm9sWOEbmCDfpX2A=="],
+    "@ast-grep/napi": ["@ast-grep/napi@0.40.0", "", { "optionalDependencies": { "@ast-grep/napi-darwin-arm64": "0.40.0", "@ast-grep/napi-darwin-x64": "0.40.0", "@ast-grep/napi-linux-arm64-gnu": "0.40.0", "@ast-grep/napi-linux-arm64-musl": "0.40.0", "@ast-grep/napi-linux-x64-gnu": "0.40.0", "@ast-grep/napi-linux-x64-musl": "0.40.0", "@ast-grep/napi-win32-arm64-msvc": "0.40.0", "@ast-grep/napi-win32-ia32-msvc": "0.40.0", "@ast-grep/napi-win32-x64-msvc": "0.40.0" } }, "sha512-tq6nO/8KwUF/mHuk1ECaAOSOlz2OB/PmygnvprJzyAHGRVzdcffblaOOWe90M9sGz5MAasXoF+PTcayQj9TKKA=="],
 
-    "@ast-grep/napi-darwin-arm64": ["@ast-grep/napi-darwin-arm64@0.40.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2F072fGN0WTq7KI3okuEnkGJVEHLbi56Bw1H6NAMf7j2mJJeQWsRyGOMcyNnUXZDeNdvoMH0OB2a5wwUegY/nQ=="],
+    "@ast-grep/napi-darwin-arm64": ["@ast-grep/napi-darwin-arm64@0.40.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZMjl5yLhKjxdwbqEEdMizgQdWH2NrWsM6Px+JuGErgCDe6Aedq9yurEPV7veybGdLVJQhOah6htlSflXxjHnYA=="],
 
-    "@ast-grep/napi-darwin-x64": ["@ast-grep/napi-darwin-x64@0.40.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-dJMidHZhhxuLBYNi6/FKI812jQ7wcFPSKkVPwviez2D+KvYagapUMAV/4dJ7FCORfguVk8Y0jpPAlYmWRT5nvA=="],
+    "@ast-grep/napi-darwin-x64": ["@ast-grep/napi-darwin-x64@0.40.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-f9Ol5oQKNRMBkvDtzBK1WiNn2/3eejF2Pn9xwTj7PhXuSFseedOspPYllxQo0gbwUlw/DJqGFTce/jarhR/rBw=="],
 
-    "@ast-grep/napi-linux-arm64-gnu": ["@ast-grep/napi-linux-arm64-gnu@0.40.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-nBRCbyoS87uqkaw4Oyfe5VO+SRm2B+0g0T8ME69Qry9ShMf41a2bTdpcQx9e8scZPogq+CTwDHo3THyBV71l9w=="],
+    "@ast-grep/napi-linux-arm64-gnu": ["@ast-grep/napi-linux-arm64-gnu@0.40.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-+tO+VW5GDhT9jGkKOK+3b8+ohKjC98WTzn7wSskd/myyhK3oYL1WTKqCm07WSYBZOJvb3z+WaX+wOUrc4bvtyQ=="],
 
-    "@ast-grep/napi-linux-arm64-musl": ["@ast-grep/napi-linux-arm64-musl@0.40.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-/qKsmds5FMoaEj6FdNzepbmLMtlFuBLdrAn9GIWCqOIcVcYvM1Nka8+mncfeXB/MFZKOrzQsQdPTWqrrQzXLrA=="],
+    "@ast-grep/napi-linux-arm64-musl": ["@ast-grep/napi-linux-arm64-musl@0.40.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-MS9qalLRjUnF2PCzuTKTvCMVSORYHxxe3Qa0+SSaVULsXRBmuy5C/b1FeWwMFnwNnC0uie3VDet31Zujwi8q6A=="],
 
-    "@ast-grep/napi-linux-x64-gnu": ["@ast-grep/napi-linux-x64-gnu@0.40.5", "", { "os": "linux", "cpu": "x64" }, "sha512-DP4oDbq7f/1A2hRTFLhJfDFR6aI5mRWdEfKfHzRItmlKsR9WlcEl1qDJs/zX9R2EEtIDsSKRzuJNfJllY3/W8Q=="],
+    "@ast-grep/napi-linux-x64-gnu": ["@ast-grep/napi-linux-x64-gnu@0.40.0", "", { "os": "linux", "cpu": "x64" }, "sha512-BeHZVMNXhM3WV3XE2yghO0fRxhMOt8BTN972p5piYEQUvKeSHmS8oeGcs6Ahgx5znBclqqqq37ZfioYANiTqJA=="],
 
-    "@ast-grep/napi-linux-x64-musl": ["@ast-grep/napi-linux-x64-musl@0.40.5", "", { "os": "linux", "cpu": "x64" }, "sha512-BRZUvVBPUNpWPo6Ns8chXVzxHPY+k9gpsubGTHy92Q26ecZULd/dTkWWdnvfhRqttsSQ9Pe/XQdi5+hDQ6RYcg=="],
+    "@ast-grep/napi-linux-x64-musl": ["@ast-grep/napi-linux-x64-musl@0.40.0", "", { "os": "linux", "cpu": "x64" }, "sha512-rG1YujF7O+lszX8fd5u6qkFTuv4FwHXjWvt1CCvCxXwQLSY96LaCW88oVKg7WoEYQh54y++Fk57F+Wh9Gv9nVQ=="],
 
-    "@ast-grep/napi-win32-arm64-msvc": ["@ast-grep/napi-win32-arm64-msvc@0.40.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-y95zSEwc7vhxmcrcH0GnK4ZHEBQrmrszRBNQovzaciF9GUqEcCACNLoBesn4V47IaOp4fYgD2/EhGRTIBFb2Ug=="],
+    "@ast-grep/napi-win32-arm64-msvc": ["@ast-grep/napi-win32-arm64-msvc@0.40.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-9SqmnQqd4zTEUk6yx0TuW2ycZZs2+e569O/R0QnhSiQNpgwiJCYOe/yPS0BC9HkiaozQm6jjAcasWpFtz/dp+w=="],
 
-    "@ast-grep/napi-win32-ia32-msvc": ["@ast-grep/napi-win32-ia32-msvc@0.40.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-K/u8De62iUnFCzVUs7FBdTZ2Jrgc5/DLHqjpup66KxZ7GIM9/HGME/O8aSoPkpcAeCD4TiTZ11C1i5p5H98hTg=="],
+    "@ast-grep/napi-win32-ia32-msvc": ["@ast-grep/napi-win32-ia32-msvc@0.40.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-0JkdBZi5l9vZhGEO38A1way0LmLRDU5Vos6MXrLIOVkymmzDTDlCdY394J1LMmmsfwWcyJg6J7Yv2dw41MCxDQ=="],
 
-    "@ast-grep/napi-win32-x64-msvc": ["@ast-grep/napi-win32-x64-msvc@0.40.5", "", { "os": "win32", "cpu": "x64" }, "sha512-dqm5zg/o4Nh4VOQPEpMS23ot8HVd22gG0eg01t4CFcZeuzyuSgBlOL3N7xLbz3iH2sVkk7keuBwAzOIpTqziNQ=="],
+    "@ast-grep/napi-win32-x64-msvc": ["@ast-grep/napi-win32-x64-msvc@0.40.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Hk2IwfPqMFGZt5SRxsoWmGLxBXxprow4LRp1eG6V8EEiJCNHxZ9ZiEaIc5bNvMDBjHVSnqZAXT22dROhrcSKQg=="],
 
     "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
 
@@ -86,17 +86,17 @@
 
     "@code-yeongyu/comment-checker": ["@code-yeongyu/comment-checker@0.6.1", "", { "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "comment-checker": "bin/comment-checker" } }, "sha512-BBremX+Y5aW8sTzlhHrLsKParupYkPOVUYmq9STrlWvBvfAme6w5IWuZCLl6nHIQScRDdvGdrAjPycJC86EZFA=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
+    "@hono/node-server": ["@hono/node-server@1.19.7", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.47", "", { "dependencies": { "@opencode-ai/sdk": "1.1.47", "zod": "4.1.8" } }, "sha512-gNMPz72altieDfLhUw3VAT1xbduKi3w3wZ57GLeS7qU9W474HdvdIiLBnt2Xq3U7Ko0/0tvK3nzCker6IIDqmQ=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.19", "", { "dependencies": { "@opencode-ai/sdk": "1.1.19", "zod": "4.1.8" } }, "sha512-Q6qBEjHb/dJMEw4BUqQxEswTMxCCHUpFMMb6jR8HTTs8X/28XRkKt5pHNPA82GU65IlSoPRph+zd8LReBDN53Q=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.47", "", {}, "sha512-s3PBHwk1sP6Zt/lJxIWSBWZ1TnrI1nFxSP97LCODUytouAQgbygZ1oDH7O2sGMBEuGdA8B1nNSPla0aRSN3IpA=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.19", "", {}, "sha512-XhZhFuvlLCqDpvNtUEjOsi/wvFj3YCXb1dySp+OONQRMuHlorNYnNa7P2A2ntKuhRdGT1Xt5na0nFzlUyNw+4A=="],
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
-    "@types/node": ["@types/node@25.1.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA=="],
+    "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 
     "@types/picomatch": ["@types/picomatch@3.0.2", "", {}, "sha512-n0i8TD3UDB7paoMMxA3Y65vUncFJXjcUf7lQY7YyKGl6031FNjfsLs6pdLFCy2GNFxItPJG8GvvpbZc2skH7WA=="],
 
@@ -108,9 +108,9 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+    "body-parser": ["body-parser@2.2.1", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw=="],
 
-    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+    "bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -118,7 +118,7 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+    "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -128,7 +128,7 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+    "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -184,11 +184,11 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.11.7", "", {}, "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw=="],
+    "hono": ["hono@4.10.8", "", {}, "sha512-DDT0A0r6wzhe8zCGoYOmMeuGu3dyTAE40HHjwUsWFTEy5WxK1x2WDSsBPlEXgPbRIFY6miDualuUDbasPogIww=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -226,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.1.11", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-tMQJrMq2aY+EnfYLTqxQ16T4MzcmFO0tbUmr0ceMDtlGVks18Ro4mnPnFZXk6CyAInIi72pwYrjUlH38qxKfgQ=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.1.10", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-6qsZQtrtBYZLufcXTTuUUMEG9PoG9Y98pX+HFVn2xHIEc6GpwR6i5xY8McFHmqPkC388tzybD556JhKqPX7Pnw=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.1.11", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-hBbNvp5M2e8jI+6XexbbwiFuJWRfGLCheJKGK1+XbP4akhSoYjYdt2PO08LNfuFlryEMf/RWB43sZmjwSWOQlQ=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.1.10", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-I1tQQbcpSBvLGXTO652mBqlyIpwYhYuIlSJmrSM33YRGBiaUuhMASnHQsms+E0eC3U/TOyqomU/4KPnbWyxs4w=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.1.11", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-mnHmXXWzYt7s5qQ80HFaT+3hprdFucyn4HMRjZzA9oBoOn38ZhWbwPEzrGtjafMUeZUy0Sj3WYZ4CLChG26weA=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.1.10", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-r6Rm5Ru/WwcBKKuPIP0RreI0gnf+MYRV0mmzPBVhMZdPWSC/eTT3GdyqFDZ4cCN76n5aea0sa5PPW7iPF+Uw6Q=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.1.11", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-4dgXCU1By/1raClTJYhIhODomIB4l/5SRSgnj6lWwcqUijURH9HzN00QYzRfMI0phMV2jYAMklgCpGjuY9/gTA=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.1.10", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UVo5OWO92DPIFhoEkw0tj8IcZyUKOG6NlFs1+tSExz7qrgkr0IloxpLslGMmdc895xxpljrr/FobYktLxyJbcg=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.1.11", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-vfv4w4116lYFup5coSnsYG3cyeOE6QFYQz5fO3uq+90jCzl8nzVC6CkiAvD0+f8+8aml56z9+MznHmCT3tEg7Q=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.1.10", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-3g99z2FweMzHSUYuzgU0E2H0kjVmtOhPZdavwVqcHQtLQ9NNhwfnIvj3yFBif+kGJphP9RDnByC1oA8Q26UrCg=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.1.11", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-f7gvxG/GjuPqlsiXjXTVJU8oC28mQ0o8dwtnj1K2VHS1UTRNtIXskCwfc0EU4E+icAQYETxj3LfaGVfBlyJyzg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.1.10", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-2HS9Ju0Cr433lMFJtu/7bShApOJywp+zmVCduQUBWFi3xbX1nm5sJwWDhw1Wx+VcqHEuJl/SQzWPE4vaqkEQng=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.1.11", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-LevsDHYdYwD4a+St3wmwMbj4wVh9LfTVE3+fKQHBh70WAsRrV603gBq2NdN6JXTd3/zbm9ZbHLOZrLnJetKi3Q=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.1.10", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-QLncZJSlWmmcuXrAVKIH6a9Om1Ym6pkhG4hAxaD5K5aF1jw2QFsadjoT12VNq2WzQb+Pg5Y6IWvoow0ZR0aEvw=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
@@ -310,10 +310,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
-
-    "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
   }
 }

--- a/docs/features.md
+++ b/docs/features.md
@@ -257,7 +257,24 @@ project/
 - Auto-continues if agent stops without completion
 - Ends when: completion detected, max iterations reached (default 100), or `/cancel-ralph`
 
-**Configure**: `{ "ralph_loop": { "enabled": true, "default_max_iterations": 100 } }`
+**Configure**:
+```json
+{
+  "ralph_loop": {
+    "enabled": true,
+    "default_max_iterations": 100,
+    "context_strategy": "reset"
+  }
+}
+```
+
+**Context Strategy Options**:
+| Strategy | Description |
+|----------|-------------|
+| `"reset"` | Create a fresh session with clean context for each iteration (default) |
+| `"continue"` | Keep full context between iterations (accumulates context) |
+
+Use `"reset"` (default) to prevent context overflow on long-running loops. Use `"continue"` when you need full conversation history preserved.
 
 ### Command: /ulw-loop
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -243,13 +243,21 @@ project/
 
 **Purpose**: Self-referential development loop that runs until task completion
 
-**Named after**: Anthropic's Ralph Wiggum plugin
+**Named after**: [The Ralph Wiggum Loop](https://ghuntley.com/ralph/) - a technique for keeping LLMs in the "smart zone" by using fresh context per iteration
 
 **Usage**:
 ```
 /ralph-loop "Build a REST API with authentication"
 /ralph-loop "Refactor the payment module" --max-iterations=50
+/ralph-loop "Add test coverage" --strategy=continue
 ```
+
+**Flags**:
+| Flag | Description |
+|------|-------------|
+| `--max-iterations=N` | Maximum loop iterations (default: 100) |
+| `--completion-promise=TEXT` | Custom completion tag (default: "DONE") |
+| `--strategy=reset\|continue` | Override default strategy for this loop |
 
 **Behavior**:
 - Agent works continuously toward the goal
@@ -263,24 +271,30 @@ project/
   "ralph_loop": {
     "enabled": true,
     "default_max_iterations": 100,
-    "context_strategy": "reset"
+    "default_strategy": "reset"
   }
 }
 ```
 
-**Context Strategy Options**:
+**Strategy Options**:
 | Strategy | Description |
 |----------|-------------|
-| `"reset"` | Create a fresh session with clean context for each iteration (default) |
-| `"continue"` | Keep full context between iterations (accumulates context) |
+| `"reset"` (default) | Create a fresh session with clean context for each iteration - keeps LLM in "smart zone" |
+| `"continue"` | Keep same session, accumulates context - may enter "dumb zone" on long loops |
 
-Use `"reset"` (default) to prevent context overflow on long-running loops. Use `"continue"` when you need full conversation history preserved.
+Use `"reset"` (default) to prevent context overflow on long-running loops. This matches how the original bash-loop Ralph works where each iteration gets a fresh context window. Use `"continue"` only for short tasks where you need conversation history preserved.
 
 ### Command: /ulw-loop
 
 **Purpose**: Same as ralph-loop but with ultrawork mode active
 
-Everything runs at maximum intensity - parallel agents, background tasks, aggressive exploration.
+**Usage**:
+```
+/ulw-loop "Build complex feature"
+/ulw-loop "Major refactor" --strategy=reset --max-iterations=50
+```
+
+Everything runs at maximum intensity - parallel agents, background tasks, aggressive exploration. Supports the same flags as `/ralph-loop`.
 
 ### Command: /refactor
 

--- a/src/cli/doctor/checks/model-resolution.test.ts
+++ b/src/cli/doctor/checks/model-resolution.test.ts
@@ -90,6 +90,46 @@ describe("model-resolution check", () => {
       expect(sisyphus!.effectiveResolution).toContain("Provider fallback:")
       expect(sisyphus!.effectiveResolution).toContain("anthropic")
     })
+
+    it("captures user variant for agent when configured", async () => {
+      const { getModelResolutionInfoWithOverrides } = await import("./model-resolution")
+
+      //#given User has model with variant override for oracle agent
+      const mockConfig = {
+        agents: {
+          oracle: { model: "openai/gpt-5.2", variant: "xhigh" },
+        },
+      }
+
+      //#when getting resolution info with config
+      const info = getModelResolutionInfoWithOverrides(mockConfig)
+
+      //#then Oracle should have userVariant set
+      const oracle = info.agents.find((a) => a.name === "oracle")
+      expect(oracle).toBeDefined()
+      expect(oracle!.userOverride).toBe("openai/gpt-5.2")
+      expect(oracle!.userVariant).toBe("xhigh")
+    })
+
+    it("captures user variant for category when configured", async () => {
+      const { getModelResolutionInfoWithOverrides } = await import("./model-resolution")
+
+      //#given User has model with variant override for visual-engineering category
+      const mockConfig = {
+        categories: {
+          "visual-engineering": { model: "google/gemini-3-flash-preview", variant: "high" },
+        },
+      }
+
+      //#when getting resolution info with config
+      const info = getModelResolutionInfoWithOverrides(mockConfig)
+
+      //#then visual-engineering should have userVariant set
+      const visual = info.categories.find((c) => c.name === "visual-engineering")
+      expect(visual).toBeDefined()
+      expect(visual!.userOverride).toBe("google/gemini-3-flash-preview")
+      expect(visual!.userVariant).toBe("high")
+    })
   })
 
   describe("checkModelResolution", () => {

--- a/src/cli/doctor/checks/model-resolution.ts
+++ b/src/cli/doctor/checks/model-resolution.ts
@@ -51,6 +51,7 @@ export interface AgentResolutionInfo {
   name: string
   requirement: ModelRequirement
   userOverride?: string
+  userVariant?: string
   effectiveModel: string
   effectiveResolution: string
 }
@@ -59,6 +60,7 @@ export interface CategoryResolutionInfo {
   name: string
   requirement: ModelRequirement
   userOverride?: string
+  userVariant?: string
   effectiveModel: string
   effectiveResolution: string
 }
@@ -69,8 +71,8 @@ export interface ModelResolutionInfo {
 }
 
 interface OmoConfig {
-  agents?: Record<string, { model?: string }>
-  categories?: Record<string, { model?: string }>
+  agents?: Record<string, { model?: string; variant?: string }>
+  categories?: Record<string, { model?: string; variant?: string }>
 }
 
 function loadConfig(): OmoConfig | null {
@@ -152,10 +154,12 @@ export function getModelResolutionInfoWithOverrides(config: OmoConfig): ModelRes
   const agents: AgentResolutionInfo[] = Object.entries(AGENT_MODEL_REQUIREMENTS).map(
     ([name, requirement]) => {
       const userOverride = config.agents?.[name]?.model
+      const userVariant = config.agents?.[name]?.variant
       return {
         name,
         requirement,
         userOverride,
+        userVariant,
         effectiveModel: getEffectiveModel(requirement, userOverride),
         effectiveResolution: buildEffectiveResolution(requirement, userOverride),
       }
@@ -165,10 +169,12 @@ export function getModelResolutionInfoWithOverrides(config: OmoConfig): ModelRes
   const categories: CategoryResolutionInfo[] = Object.entries(CATEGORY_MODEL_REQUIREMENTS).map(
     ([name, requirement]) => {
       const userOverride = config.categories?.[name]?.model
+      const userVariant = config.categories?.[name]?.variant
       return {
         name,
         requirement,
         userOverride,
+        userVariant,
         effectiveModel: getEffectiveModel(requirement, userOverride),
         effectiveResolution: buildEffectiveResolution(requirement, userOverride),
       }
@@ -182,7 +188,10 @@ function formatModelWithVariant(model: string, variant?: string): string {
   return variant ? `${model} (${variant})` : model
 }
 
-function getEffectiveVariant(requirement: ModelRequirement): string | undefined {
+function getEffectiveVariant(requirement: ModelRequirement, userVariant?: string): string | undefined {
+  if (userVariant) {
+    return userVariant
+  }
   const firstEntry = requirement.fallbackChain[0]
   return firstEntry?.variant ?? requirement.variant
 }
@@ -215,14 +224,14 @@ function buildDetailsArray(info: ModelResolutionInfo, available: AvailableModels
   details.push("Agents:")
   for (const agent of info.agents) {
     const marker = agent.userOverride ? "●" : "○"
-    const display = formatModelWithVariant(agent.effectiveModel, getEffectiveVariant(agent.requirement))
+    const display = formatModelWithVariant(agent.effectiveModel, getEffectiveVariant(agent.requirement, agent.userVariant))
     details.push(`  ${marker} ${agent.name}: ${display}`)
   }
   details.push("")
   details.push("Categories:")
   for (const category of info.categories) {
     const marker = category.userOverride ? "●" : "○"
-    const display = formatModelWithVariant(category.effectiveModel, getEffectiveVariant(category.requirement))
+    const display = formatModelWithVariant(category.effectiveModel, getEffectiveVariant(category.requirement, category.userVariant))
     details.push(`  ${marker} ${category.name}: ${display}`)
   }
   details.push("")

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,6 +9,7 @@ export {
   SisyphusAgentConfigSchema,
   ExperimentalConfigSchema,
   RalphLoopConfigSchema,
+  ContextStrategySchema,
   TmuxConfigSchema,
   TmuxLayoutSchema,
 } from "./schema"
@@ -25,6 +26,7 @@ export type {
   ExperimentalConfig,
   DynamicContextPruningConfig,
   RalphLoopConfig,
+  ContextStrategy,
   TmuxConfig,
   TmuxLayout,
 } from "./schema"

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -300,11 +300,12 @@ export const RalphLoopConfigSchema = z.object({
   /** Custom state file directory relative to project root (default: .opencode/) */
   state_dir: z.string().optional(),
   /**
-   * Context management strategy between loop iterations (default: "reset")
+   * Default context management strategy between loop iterations (default: "reset")
+   * Can be overridden per-loop with --strategy flag
    * - "reset": Create a new session with fresh context for each iteration (recommended)
    * - "continue": Keep same session and accumulate context across iterations
    */
-  context_strategy: ContextStrategySchema.optional(),
+  default_strategy: ContextStrategySchema.optional(),
 })
 
 export const BackgroundTaskConfigSchema = z.object({

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -290,6 +290,8 @@ export const SkillsConfigSchema = z.union([
   }).partial()),
 ])
 
+export const ContextStrategySchema = z.enum(["reset", "continue"])
+
 export const RalphLoopConfigSchema = z.object({
   /** Enable ralph loop functionality (default: false - opt-in feature) */
   enabled: z.boolean().default(false),
@@ -297,6 +299,12 @@ export const RalphLoopConfigSchema = z.object({
   default_max_iterations: z.number().min(1).max(1000).default(100),
   /** Custom state file directory relative to project root (default: .opencode/) */
   state_dir: z.string().optional(),
+  /**
+   * Context management strategy between loop iterations (default: "reset")
+   * - "reset": Create a new session with fresh context for each iteration (recommended)
+   * - "continue": Keep same session and accumulate context across iterations
+   */
+  context_strategy: ContextStrategySchema.optional(),
 })
 
 export const BackgroundTaskConfigSchema = z.object({
@@ -413,6 +421,7 @@ export type DynamicContextPruningConfig = z.infer<typeof DynamicContextPruningCo
 export type SkillsConfig = z.infer<typeof SkillsConfigSchema>
 export type SkillDefinition = z.infer<typeof SkillDefinitionSchema>
 export type RalphLoopConfig = z.infer<typeof RalphLoopConfigSchema>
+export type ContextStrategy = z.infer<typeof ContextStrategySchema>
 export type NotificationConfig = z.infer<typeof NotificationConfigSchema>
 export type BabysittingConfig = z.infer<typeof BabysittingConfigSchema>
 export type CategoryConfig = z.infer<typeof CategoryConfigSchema>

--- a/src/features/builtin-commands/commands.ts
+++ b/src/features/builtin-commands/commands.ts
@@ -27,7 +27,7 @@ ${RALPH_LOOP_TEMPLATE}
 <user-task>
 $ARGUMENTS
 </user-task>`,
-     argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N]',
+     argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N] [--strategy=reset|continue]',
    },
    "ulw-loop": {
      description: "(builtin) Start ultrawork loop - continues until completion with ultrawork mode",
@@ -38,7 +38,7 @@ ${RALPH_LOOP_TEMPLATE}
 <user-task>
 $ARGUMENTS
 </user-task>`,
-     argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N]',
+     argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N] [--strategy=reset|continue]',
    },
   "cancel-ralph": {
     description: "(builtin) Cancel active Ralph Loop",

--- a/src/features/builtin-commands/templates/ralph-loop.ts
+++ b/src/features/builtin-commands/templates/ralph-loop.ts
@@ -24,9 +24,11 @@ export const RALPH_LOOP_TEMPLATE = `You are starting a Ralph Loop - a self-refer
 ## Your Task
 
 Parse the arguments below and begin working on the task. The format is:
-\`"task description" [--completion-promise=TEXT] [--max-iterations=N]\`
+\`"task description" [--completion-promise=TEXT] [--max-iterations=N] [--strategy=reset|continue]\`
 
-Default completion promise is "DONE" and default max iterations is 100.`
+Default completion promise is "DONE", default max iterations is 100, default strategy is "reset".
+- **reset**: Create a new session with fresh context for each iteration (recommended for long tasks)
+- **continue**: Keep same session and accumulate context across iterations`
 
 export const CANCEL_RALPH_TEMPLATE = `Cancel the currently active Ralph Loop.
 

--- a/src/hooks/ralph-loop/constants.ts
+++ b/src/hooks/ralph-loop/constants.ts
@@ -5,4 +5,4 @@ export const DEFAULT_STATE_FILE = ".sisyphus/ralph-loop.local.md"
 export const COMPLETION_TAG_PATTERN = /<promise>(.*?)<\/promise>/is
 export const DEFAULT_MAX_ITERATIONS = 100
 export const DEFAULT_COMPLETION_PROMISE = "DONE"
-export const DEFAULT_CONTEXT_STRATEGY: ContextStrategy = "reset"
+export const DEFAULT_STRATEGY: ContextStrategy = "reset"

--- a/src/hooks/ralph-loop/constants.ts
+++ b/src/hooks/ralph-loop/constants.ts
@@ -1,5 +1,8 @@
+import type { ContextStrategy } from "../../config"
+
 export const HOOK_NAME = "ralph-loop"
 export const DEFAULT_STATE_FILE = ".sisyphus/ralph-loop.local.md"
 export const COMPLETION_TAG_PATTERN = /<promise>(.*?)<\/promise>/is
 export const DEFAULT_MAX_ITERATIONS = 100
 export const DEFAULT_COMPLETION_PROMISE = "DONE"
+export const DEFAULT_CONTEXT_STRATEGY: ContextStrategy = "reset"

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -232,9 +232,9 @@ describe("ralph-loop", () => {
     })
 
     test("should inject continuation when loop active and no completion detected", async () => {
-      // #given - active loop state with context_strategy: continue to preserve session
+      // #given - active loop state with default_strategy: continue to preserve session
       const hook = createRalphLoopHook(createMockPluginInput(), {
-        config: { enabled: true, default_max_iterations: 100, context_strategy: "continue" },
+        config: { enabled: true, default_max_iterations: 100, default_strategy: "continue" },
       })
       hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
 
@@ -529,9 +529,9 @@ describe("ralph-loop", () => {
     })
 
     test("should handle multiple iterations correctly", async () => {
-      // #given - active loop with context_strategy: continue
+      // #given - active loop with default_strategy: continue
       const hook = createRalphLoopHook(createMockPluginInput(), {
-        config: { enabled: true, default_max_iterations: 100, context_strategy: "continue" },
+        config: { enabled: true, default_max_iterations: 100, default_strategy: "continue" },
       })
       hook.startLoop("session-123", "Build feature", { maxIterations: 5 })
 
@@ -663,9 +663,9 @@ describe("ralph-loop", () => {
     })
 
     test("should allow starting new loop while previous loop is active (different session)", async () => {
-      // #given - active loop in session A with context_strategy: continue
+      // #given - active loop in session A with default_strategy: continue
       const hook = createRalphLoopHook(createMockPluginInput(), {
-        config: { enabled: true, default_max_iterations: 100, context_strategy: "continue" },
+        config: { enabled: true, default_max_iterations: 100, default_strategy: "continue" },
       })
       hook.startLoop("session-A", "First task", { maxIterations: 10 })
       expect(hook.getState()?.session_id).toBe("session-A")
@@ -696,9 +696,9 @@ describe("ralph-loop", () => {
     })
 
     test("should allow starting new loop in same session (restart)", async () => {
-      // #given - active loop in session A at iteration 5 with context_strategy: continue
+      // #given - active loop in session A at iteration 5 with default_strategy: continue
       const hook = createRalphLoopHook(createMockPluginInput(), {
-        config: { enabled: true, default_max_iterations: 100, context_strategy: "continue" },
+        config: { enabled: true, default_max_iterations: 100, default_strategy: "continue" },
       })
       hook.startLoop("session-A", "First task", { maxIterations: 10 })
       
@@ -958,9 +958,9 @@ Original task: Build something`
     })
   })
 
-  describe("context_strategy", () => {
-    test("should create new session when context_strategy is 'reset' (default)", async () => {
-      // #given - hook with default context_strategy (reset)
+  describe("default_strategy", () => {
+    test("should create new session when default_strategy is 'reset' (default)", async () => {
+      // #given - hook with default strategy (reset)
       const hook = createRalphLoopHook(createMockPluginInput(), {
         config: { enabled: true, default_max_iterations: 10 },
       })
@@ -980,10 +980,10 @@ Original task: Build something`
       expect(hook.getState()?.session_id).toBe("created-session-new")
     })
 
-    test("should keep same session when context_strategy is 'continue'", async () => {
-      // #given - hook with context_strategy: continue
+    test("should keep same session when default_strategy is 'continue'", async () => {
+      // #given - hook with default_strategy: continue
       const hook = createRalphLoopHook(createMockPluginInput(), {
-        config: { enabled: true, default_max_iterations: 10, context_strategy: "continue" },
+        config: { enabled: true, default_max_iterations: 10, default_strategy: "continue" },
       })
       hook.startLoop("session-123", "Build something")
 
@@ -1002,10 +1002,10 @@ Original task: Build something`
     })
 
     test("should continue with original session if reset/create fails", async () => {
-      // #given - hook with context_strategy: reset but create fails
+      // #given - hook with default_strategy: reset but create fails
       mockCreateResult = { data: undefined }
       const hook = createRalphLoopHook(createMockPluginInput(), {
-        config: { enabled: true, default_max_iterations: 10, context_strategy: "reset" },
+        config: { enabled: true, default_max_iterations: 10, default_strategy: "reset" },
       })
       hook.startLoop("session-123", "Build something")
 
@@ -1019,6 +1019,23 @@ Original task: Build something`
       expect(promptCalls[0].sessionID).toBe("session-123")
       // #then - state retains original session ID
       expect(hook.getState()?.session_id).toBe("session-123")
+    })
+
+    test("should allow overriding strategy via startLoop option", async () => {
+      // #given - hook with default_strategy: reset, but startLoop overrides to continue
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        config: { enabled: true, default_max_iterations: 10, default_strategy: "reset" },
+      })
+      hook.startLoop("session-123", "Build something", { strategy: "continue" })
+
+      // #when - session goes idle
+      await hook.event({
+        event: { type: "session.idle", properties: { sessionID: "session-123" } },
+      })
+
+      // #then - no create called because strategy was overridden to continue
+      expect(createCalls.length).toBe(0)
+      expect(promptCalls[0].sessionID).toBe("session-123")
     })
   })
 })

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -11,7 +11,12 @@ describe("ralph-loop", () => {
   let promptCalls: Array<{ sessionID: string; text: string }>
   let toastCalls: Array<{ title: string; message: string; variant: string }>
   let messagesCalls: Array<{ sessionID: string }>
+  let summarizeCalls: Array<{ sessionID: string }>
+  let forkCalls: Array<{ sessionID: string }>
+  let createCalls: Array<{ title: string }>
   let mockSessionMessages: Array<{ info?: { role?: string }; parts?: Array<{ type: string; text?: string }> }>
+  let mockForkResult: { data?: { id: string } }
+  let mockCreateResult: { data?: { id: string } }
 
   function createMockPluginInput() {
     return {
@@ -27,6 +32,18 @@ describe("ralph-loop", () => {
           messages: async (opts: { path: { id: string } }) => {
             messagesCalls.push({ sessionID: opts.path.id })
             return { data: mockSessionMessages }
+          },
+          summarize: async (opts: { path: { id: string } }) => {
+            summarizeCalls.push({ sessionID: opts.path.id })
+            return {}
+          },
+          fork: async (opts: { path: { id: string } }) => {
+            forkCalls.push({ sessionID: opts.path.id })
+            return mockForkResult
+          },
+          create: async (opts: { body: { title: string } }) => {
+            createCalls.push({ title: opts.body.title })
+            return mockCreateResult
           },
         },
         tui: {
@@ -48,7 +65,12 @@ describe("ralph-loop", () => {
     promptCalls = []
     toastCalls = []
     messagesCalls = []
+    summarizeCalls = []
+    forkCalls = []
+    createCalls = []
     mockSessionMessages = []
+    mockForkResult = { data: { id: "forked-session-new" } }
+    mockCreateResult = { data: { id: "created-session-new" } }
 
     if (!existsSync(TEST_DIR)) {
       mkdirSync(TEST_DIR, { recursive: true })
@@ -66,7 +88,7 @@ describe("ralph-loop", () => {
 
   describe("storage", () => {
     test("should write and read state correctly", () => {
-      // given - a state object
+      // #given - a state object
       const state: RalphLoopState = {
         active: true,
         iteration: 1,
@@ -77,11 +99,11 @@ describe("ralph-loop", () => {
         session_id: "test-session-123",
       }
 
-      // when - write and read state
+      // #when - write and read state
       const writeSuccess = writeState(TEST_DIR, state)
       const readResult = readState(TEST_DIR)
 
-      // then - state should match
+      // #then - state should match
       expect(writeSuccess).toBe(true)
       expect(readResult).not.toBeNull()
       expect(readResult?.active).toBe(true)
@@ -93,7 +115,7 @@ describe("ralph-loop", () => {
     })
 
     test("should handle ultrawork field", () => {
-      // given - a state object with ultrawork enabled
+      // #given - a state object with ultrawork enabled
       const state: RalphLoopState = {
         active: true,
         iteration: 1,
@@ -105,25 +127,25 @@ describe("ralph-loop", () => {
         ultrawork: true,
       }
 
-      // when - write and read state
+      // #when - write and read state
       writeState(TEST_DIR, state)
       const readResult = readState(TEST_DIR)
 
-      // then - ultrawork field should be preserved
+      // #then - ultrawork field should be preserved
       expect(readResult?.ultrawork).toBe(true)
     })
 
     test("should return null for non-existent state", () => {
-      // given - no state file exists
-      // when - read state
+      // #given - no state file exists
+      // #when - read state
       const result = readState(TEST_DIR)
 
-      // then - should return null
+      // #then - should return null
       expect(result).toBeNull()
     })
 
     test("should clear state correctly", () => {
-      // given - existing state
+      // #given - existing state
       const state: RalphLoopState = {
         active: true,
         iteration: 1,
@@ -134,17 +156,17 @@ describe("ralph-loop", () => {
       }
       writeState(TEST_DIR, state)
 
-      // when - clear state
+      // #when - clear state
       const clearSuccess = clearState(TEST_DIR)
       const readResult = readState(TEST_DIR)
 
-      // then - state should be cleared
+      // #then - state should be cleared
       expect(clearSuccess).toBe(true)
       expect(readResult).toBeNull()
     })
 
     test("should handle multiline prompts", () => {
-      // given - state with multiline prompt
+      // #given - state with multiline prompt
       const state: RalphLoopState = {
         active: true,
         iteration: 1,
@@ -154,27 +176,27 @@ describe("ralph-loop", () => {
         prompt: "Build a feature\nwith multiple lines\nand requirements",
       }
 
-      // when - write and read
+      // #when - write and read
       writeState(TEST_DIR, state)
       const readResult = readState(TEST_DIR)
 
-      // then - multiline prompt preserved
+      // #then - multiline prompt preserved
       expect(readResult?.prompt).toBe("Build a feature\nwith multiple lines\nand requirements")
     })
   })
 
   describe("hook", () => {
     test("should start loop and write state", () => {
-      // given - hook instance
+      // #given - hook instance
       const hook = createRalphLoopHook(createMockPluginInput())
 
-      // when - start loop
+      // #when - start loop
       const success = hook.startLoop("session-123", "Build something", {
         maxIterations: 25,
         completionPromise: "FINISHED",
       })
 
-      // then - state should be written
+      // #then - state should be written
       expect(success).toBe(true)
       const state = hook.getState()
       expect(state?.active).toBe(true)
@@ -186,35 +208,37 @@ describe("ralph-loop", () => {
     })
 
     test("should accept ultrawork option in startLoop", () => {
-      // given - hook instance
+      // #given - hook instance
       const hook = createRalphLoopHook(createMockPluginInput())
 
-      // when - start loop with ultrawork
+      // #when - start loop with ultrawork
       hook.startLoop("session-123", "Build something", { ultrawork: true })
 
-      // then - state should have ultrawork=true
+      // #then - state should have ultrawork=true
       const state = hook.getState()
       expect(state?.ultrawork).toBe(true)
     })
 
     test("should handle missing ultrawork option in startLoop", () => {
-      // given - hook instance
+      // #given - hook instance
       const hook = createRalphLoopHook(createMockPluginInput())
 
-      // when - start loop without ultrawork
+      // #when - start loop without ultrawork
       hook.startLoop("session-123", "Build something")
 
-      // then - state should have ultrawork=undefined
+      // #then - state should have ultrawork=undefined
       const state = hook.getState()
       expect(state?.ultrawork).toBeUndefined()
     })
 
     test("should inject continuation when loop active and no completion detected", async () => {
-      // given - active loop state
-      const hook = createRalphLoopHook(createMockPluginInput())
+      // #given - active loop state with context_strategy: continue to preserve session
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        config: { enabled: true, default_max_iterations: 100, context_strategy: "continue" },
+      })
       hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -222,20 +246,20 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - continuation should be injected
+      // #then - continuation should be injected
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].sessionID).toBe("session-123")
       expect(promptCalls[0].text).toContain("RALPH LOOP")
       expect(promptCalls[0].text).toContain("Build a feature")
       expect(promptCalls[0].text).toContain("2/10")
 
-      // then - iteration should be incremented
+      // #then - iteration should be incremented
       const state = hook.getState()
       expect(state?.iteration).toBe(2)
     })
 
     test("should stop loop when max iterations reached", async () => {
-      // given - loop at max iteration
+      // #given - loop at max iteration
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Build something", { maxIterations: 2 })
 
@@ -243,7 +267,7 @@ describe("ralph-loop", () => {
       state.iteration = 2
       writeState(TEST_DIR, state)
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -251,46 +275,46 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - no continuation injected
+      // #then - no continuation injected
       expect(promptCalls.length).toBe(0)
 
-      // then - warning toast shown
+      // #then - warning toast shown
       expect(toastCalls.length).toBe(1)
       expect(toastCalls[0].title).toBe("Ralph Loop Stopped")
       expect(toastCalls[0].variant).toBe("warning")
 
-      // then - state should be cleared
+      // #then - state should be cleared
       expect(hook.getState()).toBeNull()
     })
 
     test("should cancel loop via cancelLoop", () => {
-      // given - active loop
+      // #given - active loop
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
-      // when - cancel loop
+      // #when - cancel loop
       const success = hook.cancelLoop("session-123")
 
-      // then - loop cancelled
+      // #then - loop cancelled
       expect(success).toBe(true)
       expect(hook.getState()).toBeNull()
     })
 
     test("should not cancel loop for different session", () => {
-      // given - active loop for session-123
+      // #given - active loop for session-123
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
-      // when - try to cancel for different session
+      // #when - try to cancel for different session
       const success = hook.cancelLoop("session-456")
 
-      // then - cancel should fail
+      // #then - cancel should fail
       expect(success).toBe(false)
       expect(hook.getState()).not.toBeNull()
     })
 
     test("should skip injection during recovery", async () => {
-      // given - active loop and session in recovery
+      // #given - active loop and session in recovery
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
@@ -301,7 +325,7 @@ describe("ralph-loop", () => {
         },
       })
 
-      // when - session goes idle immediately
+      // #when - session goes idle immediately
       await hook.event({
         event: {
           type: "session.idle",
@@ -309,16 +333,16 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - no continuation injected
+      // #then - no continuation injected
       expect(promptCalls.length).toBe(0)
     })
 
     test("should clear state on session deletion", async () => {
-      // given - active loop
+      // #given - active loop
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
-      // when - session deleted
+      // #when - session deleted
       await hook.event({
         event: {
           type: "session.deleted",
@@ -326,16 +350,16 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - state should be cleared
+      // #then - state should be cleared
       expect(hook.getState()).toBeNull()
     })
 
     test("should not inject for different session than loop owner", async () => {
-      // given - loop owned by session-123
+      // #given - loop owned by session-123
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Test task")
 
-      // when - different session goes idle
+      // #when - different session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -343,12 +367,12 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - no continuation injected
+      // #then - no continuation injected
       expect(promptCalls.length).toBe(0)
     })
 
     test("should clear orphaned state when original session no longer exists", async () => {
-      // given - state file exists from a previous session that no longer exists
+      // #given - state file exists from a previous session that no longer exists
       const state: RalphLoopState = {
         active: true,
         iteration: 3,
@@ -368,7 +392,7 @@ describe("ralph-loop", () => {
         },
       })
 
-      // when - a new session goes idle (different from the orphaned session in state)
+      // #when - a new session goes idle (different from the orphaned session in state)
       await hook.event({
         event: {
           type: "session.idle",
@@ -376,14 +400,14 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - orphaned state should be cleared
+      // #then - orphaned state should be cleared
       expect(hook.getState()).toBeNull()
-      // then - no continuation injected (state was cleared, not resumed)
+      // #then - no continuation injected (state was cleared, not resumed)
       expect(promptCalls.length).toBe(0)
     })
 
     test("should NOT clear state when original session still exists (different active session)", async () => {
-      // given - state file exists from a session that still exists
+      // #given - state file exists from a session that still exists
       const state: RalphLoopState = {
         active: true,
         iteration: 2,
@@ -403,7 +427,7 @@ describe("ralph-loop", () => {
         },
       })
 
-      // when - a different session goes idle
+      // #when - a different session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -411,15 +435,15 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - state should NOT be cleared (original session still active)
+      // #then - state should NOT be cleared (original session still active)
       expect(hook.getState()).not.toBeNull()
       expect(hook.getState()?.session_id).toBe("active-session-123")
-      // then - no continuation injected (it's a different session's loop)
+      // #then - no continuation injected (it's a different session's loop)
       expect(promptCalls.length).toBe(0)
     })
 
     test("should use default config values", () => {
-      // given - hook with config
+      // #given - hook with config
       const hook = createRalphLoopHook(createMockPluginInput(), {
         config: {
           enabled: true,
@@ -427,19 +451,19 @@ describe("ralph-loop", () => {
         },
       })
 
-      // when - start loop without options
+      // #when - start loop without options
       hook.startLoop("session-123", "Test task")
 
-      // then - should use config defaults
+      // #then - should use config defaults
       const state = hook.getState()
       expect(state?.max_iterations).toBe(200)
     })
 
     test("should not inject when no loop is active", async () => {
-      // given - no active loop
+      // #given - no active loop
       const hook = createRalphLoopHook(createMockPluginInput())
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -447,12 +471,12 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - no continuation injected
+      // #then - no continuation injected
       expect(promptCalls.length).toBe(0)
     })
 
     test("should detect completion promise and stop loop", async () => {
-      // given - active loop with transcript containing completion
+      // #given - active loop with transcript containing completion
       const transcriptPath = join(TEST_DIR, "transcript.jsonl")
       const hook = createRalphLoopHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
@@ -461,7 +485,7 @@ describe("ralph-loop", () => {
 
       writeFileSync(transcriptPath, JSON.stringify({ type: "tool_result", tool_name: "write", tool_output: { output: "Task done <promise>COMPLETE</promise>" } }) + "\n")
 
-      // when - session goes idle (transcriptPath now derived from sessionID via getTranscriptPath)
+      // #when - session goes idle (transcriptPath now derived from sessionID via getTranscriptPath)
       await hook.event({
         event: {
           type: "session.idle",
@@ -469,14 +493,14 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - loop completed, no continuation
+      // #then - loop completed, no continuation
       expect(promptCalls.length).toBe(0)
       expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
       expect(hook.getState()).toBeNull()
     })
 
     test("should detect completion promise via session messages API", async () => {
-      // given - active loop with assistant message containing completion promise
+      // #given - active loop with assistant message containing completion promise
       mockSessionMessages = [
         { info: { role: "user" }, parts: [{ type: "text", text: "Build something" }] },
         { info: { role: "assistant" }, parts: [{ type: "text", text: "I have completed the task. <promise>API_DONE</promise>" }] },
@@ -486,7 +510,7 @@ describe("ralph-loop", () => {
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "API_DONE" })
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -494,22 +518,24 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - loop completed via API detection, no continuation
+      // #then - loop completed via API detection, no continuation
       expect(promptCalls.length).toBe(0)
       expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
       expect(hook.getState()).toBeNull()
 
-      // then - messages API was called with correct session ID
+      // #then - messages API was called with correct session ID
       expect(messagesCalls.length).toBe(1)
       expect(messagesCalls[0].sessionID).toBe("session-123")
     })
 
     test("should handle multiple iterations correctly", async () => {
-      // given - active loop
-      const hook = createRalphLoopHook(createMockPluginInput())
+      // #given - active loop with context_strategy: continue
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        config: { enabled: true, default_max_iterations: 100, context_strategy: "continue" },
+      })
       hook.startLoop("session-123", "Build feature", { maxIterations: 5 })
 
-      // when - multiple idle events
+      // #when - multiple idle events
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-123" } },
       })
@@ -517,36 +543,36 @@ describe("ralph-loop", () => {
         event: { type: "session.idle", properties: { sessionID: "session-123" } },
       })
 
-      // then - iteration incremented correctly
+      // #then - iteration incremented correctly
       expect(hook.getState()?.iteration).toBe(3)
       expect(promptCalls.length).toBe(2)
     })
 
     test("should include prompt and promise in continuation message", async () => {
-      // given - loop with specific prompt and promise
+      // #given - loop with specific prompt and promise
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Create a calculator app", {
         completionPromise: "CALCULATOR_DONE",
         maxIterations: 10,
       })
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-123" } },
       })
 
-      // then - continuation includes original task and promise
+      // #then - continuation includes original task and promise
       expect(promptCalls[0].text).toContain("Create a calculator app")
       expect(promptCalls[0].text).toContain("<promise>CALCULATOR_DONE</promise>")
     })
 
     test("should clear loop state on user abort (MessageAbortedError)", async () => {
-      // given - active loop
+      // #given - active loop
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Build something")
       expect(hook.getState()).not.toBeNull()
 
-      // when - user aborts (Ctrl+C)
+      // #when - user aborts (Ctrl+C)
       await hook.event({
         event: {
           type: "session.error",
@@ -557,16 +583,16 @@ describe("ralph-loop", () => {
         },
       })
 
-      // then - loop state should be cleared immediately
+      // #then - loop state should be cleared immediately
       expect(hook.getState()).toBeNull()
     })
 
     test("should NOT set recovery mode on user abort", async () => {
-      // given - active loop
+      // #given - active loop
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Build something")
 
-      // when - user aborts (Ctrl+C)
+      // #when - user aborts (Ctrl+C)
       await hook.event({
         event: {
           type: "session.error",
@@ -580,17 +606,17 @@ describe("ralph-loop", () => {
       // Start a new loop
       hook.startLoop("session-123", "New task")
 
-      // when - session goes idle immediately (should work, no recovery mode)
+      // #when - session goes idle immediately (should work, no recovery mode)
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-123" } },
       })
 
-      // then - continuation should be injected (not blocked by recovery)
+      // #then - continuation should be injected (not blocked by recovery)
       expect(promptCalls.length).toBe(1)
     })
 
     test("should only check LAST assistant message for completion", async () => {
-      // given - multiple assistant messages, only first has completion promise
+      // #given - multiple assistant messages, only first has completion promise
       mockSessionMessages = [
         { info: { role: "user" }, parts: [{ type: "text", text: "Start task" }] },
         { info: { role: "assistant" }, parts: [{ type: "text", text: "I'll work on it. <promise>DONE</promise>" }] },
@@ -602,18 +628,18 @@ describe("ralph-loop", () => {
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-123" } },
       })
 
-      // then - loop should continue (last message has no completion promise)
+      // #then - loop should continue (last message has no completion promise)
       expect(promptCalls.length).toBe(1)
       expect(hook.getState()?.iteration).toBe(2)
     })
 
     test("should detect completion only in LAST assistant message", async () => {
-      // given - last assistant message has completion promise
+      // #given - last assistant message has completion promise
       mockSessionMessages = [
         { info: { role: "user" }, parts: [{ type: "text", text: "Start task" }] },
         { info: { role: "assistant" }, parts: [{ type: "text", text: "Starting work..." }] },
@@ -625,51 +651,55 @@ describe("ralph-loop", () => {
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-123" } },
       })
 
-      // then - loop should complete (last message has completion promise)
+      // #then - loop should complete (last message has completion promise)
       expect(promptCalls.length).toBe(0)
       expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
       expect(hook.getState()).toBeNull()
     })
 
     test("should allow starting new loop while previous loop is active (different session)", async () => {
-      // given - active loop in session A
-      const hook = createRalphLoopHook(createMockPluginInput())
+      // #given - active loop in session A with context_strategy: continue
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        config: { enabled: true, default_max_iterations: 100, context_strategy: "continue" },
+      })
       hook.startLoop("session-A", "First task", { maxIterations: 10 })
       expect(hook.getState()?.session_id).toBe("session-A")
       expect(hook.getState()?.prompt).toBe("First task")
 
-      // when - start new loop in session B (without completing A)
+      // #when - start new loop in session B (without completing A)
       hook.startLoop("session-B", "Second task", { maxIterations: 20 })
 
-      // then - state should be overwritten with session B's loop
+      // #then - state should be overwritten with session B's loop
       expect(hook.getState()?.session_id).toBe("session-B")
       expect(hook.getState()?.prompt).toBe("Second task")
       expect(hook.getState()?.max_iterations).toBe(20)
       expect(hook.getState()?.iteration).toBe(1)
 
-      // when - session B goes idle
+      // #when - session B goes idle
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-B" } },
       })
 
-      // then - continuation should be injected for session B
+      // #then - continuation should be injected for session B
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].sessionID).toBe("session-B")
       expect(promptCalls[0].text).toContain("Second task")
       expect(promptCalls[0].text).toContain("2/20")
 
-      // then - iteration incremented
+      // #then - iteration incremented
       expect(hook.getState()?.iteration).toBe(2)
     })
 
     test("should allow starting new loop in same session (restart)", async () => {
-      // given - active loop in session A at iteration 5
-      const hook = createRalphLoopHook(createMockPluginInput())
+      // #given - active loop in session A at iteration 5 with context_strategy: continue
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        config: { enabled: true, default_max_iterations: 100, context_strategy: "continue" },
+      })
       hook.startLoop("session-A", "First task", { maxIterations: 10 })
       
       // Simulate some iterations
@@ -682,29 +712,29 @@ describe("ralph-loop", () => {
       expect(hook.getState()?.iteration).toBe(3)
       expect(promptCalls.length).toBe(2)
 
-      // when - start NEW loop in same session (restart)
+      // #when - start NEW loop in same session (restart)
       hook.startLoop("session-A", "Restarted task", { maxIterations: 50 })
 
-      // then - state should be reset to iteration 1 with new prompt
+      // #then - state should be reset to iteration 1 with new prompt
       expect(hook.getState()?.session_id).toBe("session-A")
       expect(hook.getState()?.prompt).toBe("Restarted task")
       expect(hook.getState()?.max_iterations).toBe(50)
       expect(hook.getState()?.iteration).toBe(1)
 
-      // when - session goes idle
+      // #when - session goes idle
       promptCalls = [] // Reset to check new continuation
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-A" } },
       })
 
-      // then - continuation should use new task
+      // #then - continuation should use new task
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].text).toContain("Restarted task")
       expect(promptCalls[0].text).toContain("2/50")
     })
 
     test("should NOT detect completion from user message in transcript (issue #622)", async () => {
-      // given - transcript contains user message with template text that includes completion promise
+      // #given - transcript contains user message with template text that includes completion promise
       // This reproduces the bug where the RALPH_LOOP_TEMPLATE instructional text
       // containing `<promise>DONE</promise>` is recorded as a user message and
       // falsely triggers completion detection
@@ -723,7 +753,7 @@ Output <promise>DONE</promise> when fully complete`
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -731,13 +761,13 @@ Output <promise>DONE</promise> when fully complete`
         },
       })
 
-      // then - loop should CONTINUE (user message completion promise is instructional, not actual)
+      // #then - loop should CONTINUE (user message completion promise is instructional, not actual)
       expect(promptCalls.length).toBe(1)
       expect(hook.getState()?.iteration).toBe(2)
     })
 
     test("should NOT detect completion from continuation prompt in transcript (issue #622)", async () => {
-      // given - transcript contains continuation prompt (also a user message) with completion promise
+      // #given - transcript contains continuation prompt (also a user message) with completion promise
       const transcriptPath = join(TEST_DIR, "transcript.jsonl")
       const continuationText = `RALPH LOOP 2/100
 When FULLY complete, output: <promise>DONE</promise>
@@ -754,7 +784,7 @@ Original task: Build something`
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -762,13 +792,13 @@ Original task: Build something`
         },
       })
 
-      // then - loop should CONTINUE (continuation prompt text is not actual completion)
+      // #then - loop should CONTINUE (continuation prompt text is not actual completion)
       expect(promptCalls.length).toBe(1)
       expect(hook.getState()?.iteration).toBe(2)
     })
 
     test("should detect completion from tool_result entry in transcript", async () => {
-      // given - transcript contains a tool_result with completion promise
+      // #given - transcript contains a tool_result with completion promise
       const transcriptPath = join(TEST_DIR, "transcript.jsonl")
       const toolResultEntry = JSON.stringify({
         type: "tool_result",
@@ -784,7 +814,7 @@ Original task: Build something`
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -792,14 +822,14 @@ Original task: Build something`
         },
       })
 
-      // then - loop should complete (tool_result contains actual completion output)
+      // #then - loop should complete (tool_result contains actual completion output)
       expect(promptCalls.length).toBe(0)
       expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
       expect(hook.getState()).toBeNull()
     })
 
     test("should check transcript BEFORE API to optimize performance", async () => {
-      // given - transcript has completion promise
+      // #given - transcript has completion promise
       const transcriptPath = join(TEST_DIR, "transcript.jsonl")
       writeFileSync(transcriptPath, JSON.stringify({ type: "tool_result", tool_name: "write", tool_output: { output: "<promise>DONE</promise>" } }) + "\n")
       mockSessionMessages = [
@@ -810,7 +840,7 @@ Original task: Build something`
       })
       hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
 
-      // when - session goes idle
+      // #when - session goes idle
       await hook.event({
         event: {
           type: "session.idle",
@@ -818,7 +848,7 @@ Original task: Build something`
         },
       })
 
-      // then - should complete via transcript (API not called when transcript succeeds)
+      // #then - should complete via transcript (API not called when transcript succeeds)
       expect(promptCalls.length).toBe(0)
       expect(hook.getState()).toBeNull()
       // API should NOT be called since transcript found completion
@@ -826,7 +856,7 @@ Original task: Build something`
     })
 
     test("should show ultrawork completion toast", async () => {
-      // given - hook with ultrawork mode and completion in transcript
+      // #given - hook with ultrawork mode and completion in transcript
       const transcriptPath = join(TEST_DIR, "transcript.jsonl")
       const hook = createRalphLoopHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
@@ -834,17 +864,17 @@ Original task: Build something`
       writeFileSync(transcriptPath, JSON.stringify({ type: "tool_result", tool_name: "write", tool_output: { output: "<promise>DONE</promise>" } }) + "\n")
       hook.startLoop("test-id", "Build API", { ultrawork: true })
 
-      // when - idle event triggered
+      // #when - idle event triggered
       await hook.event({ event: { type: "session.idle", properties: { sessionID: "test-id" } } })
 
-      // then - ultrawork toast shown
+      // #then - ultrawork toast shown
       const completionToast = toastCalls.find(t => t.title === "ULTRAWORK LOOP COMPLETE!")
       expect(completionToast).toBeDefined()
       expect(completionToast!.message).toMatch(/JUST ULW ULW!/)
     })
 
     test("should show regular completion toast when ultrawork disabled", async () => {
-      // given - hook without ultrawork
+      // #given - hook without ultrawork
       const transcriptPath = join(TEST_DIR, "transcript.jsonl")
       const hook = createRalphLoopHook(createMockPluginInput(), {
         getTranscriptPath: () => transcriptPath,
@@ -852,39 +882,39 @@ Original task: Build something`
       writeFileSync(transcriptPath, JSON.stringify({ type: "tool_result", tool_name: "write", tool_output: { output: "<promise>DONE</promise>" } }) + "\n")
       hook.startLoop("test-id", "Build API")
 
-      // when - idle event triggered
+      // #when - idle event triggered
       await hook.event({ event: { type: "session.idle", properties: { sessionID: "test-id" } } })
 
-      // then - regular toast shown
+      // #then - regular toast shown
       expect(toastCalls.some(t => t.title === "Ralph Loop Complete!")).toBe(true)
     })
 
     test("should prepend ultrawork to continuation prompt when ultrawork=true", async () => {
-      // given - hook with ultrawork mode enabled
+      // #given - hook with ultrawork mode enabled
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Build API", { ultrawork: true })
 
-      // when - session goes idle (continuation triggered)
+      // #when - session goes idle (continuation triggered)
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-123" } },
       })
 
-      // then - prompt should start with "ultrawork "
+      // #then - prompt should start with "ultrawork "
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].text).toMatch(/^ultrawork /)
     })
 
     test("should NOT prepend ultrawork to continuation prompt when ultrawork=false", async () => {
-      // given - hook without ultrawork mode
+      // #given - hook without ultrawork mode
       const hook = createRalphLoopHook(createMockPluginInput())
       hook.startLoop("session-123", "Build API")
 
-      // when - session goes idle (continuation triggered)
+      // #when - session goes idle (continuation triggered)
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-123" } },
       })
 
-      // then - prompt should NOT start with "ultrawork "
+      // #then - prompt should NOT start with "ultrawork "
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].text).not.toMatch(/^ultrawork /)
     })
@@ -892,7 +922,7 @@ Original task: Build something`
 
   describe("API timeout protection", () => {
     test("should not hang when session.messages() throws", async () => {
-      // given - API that throws (simulates timeout error)
+      // #given - API that throws (simulates timeout error)
       let apiCallCount = 0
       const errorMock = {
         ...createMockPluginInput(),
@@ -913,18 +943,82 @@ Original task: Build something`
       })
       hook.startLoop("session-123", "Build something")
 
-      // when - session goes idle (API will throw)
+      // #when - session goes idle (API will throw)
       const startTime = Date.now()
       await hook.event({
         event: { type: "session.idle", properties: { sessionID: "session-123" } },
       })
       const elapsed = Date.now() - startTime
 
-      // then - should complete quickly (not hang for 10s)
+      // #then - should complete quickly (not hang for 10s)
       expect(elapsed).toBeLessThan(2000)
-      // then - loop should continue (API error = no completion detected)
+      // #then - loop should continue (API error = no completion detected)
       expect(promptCalls.length).toBe(1)
       expect(apiCallCount).toBeGreaterThan(0)
+    })
+  })
+
+  describe("context_strategy", () => {
+    test("should create new session when context_strategy is 'reset' (default)", async () => {
+      // #given - hook with default context_strategy (reset)
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        config: { enabled: true, default_max_iterations: 10 },
+      })
+      hook.startLoop("session-123", "Build something")
+
+      // #when - session goes idle
+      await hook.event({
+        event: { type: "session.idle", properties: { sessionID: "session-123" } },
+      })
+
+      // #then - create was called for new session
+      expect(createCalls.length).toBe(1)
+      // #then - continuation injected to NEW session
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].sessionID).toBe("created-session-new")
+      // #then - state updated with new session ID
+      expect(hook.getState()?.session_id).toBe("created-session-new")
+    })
+
+    test("should keep same session when context_strategy is 'continue'", async () => {
+      // #given - hook with context_strategy: continue
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        config: { enabled: true, default_max_iterations: 10, context_strategy: "continue" },
+      })
+      hook.startLoop("session-123", "Build something")
+
+      // #when - session goes idle
+      await hook.event({
+        event: { type: "session.idle", properties: { sessionID: "session-123" } },
+      })
+
+      // #then - no create called (same session)
+      expect(createCalls.length).toBe(0)
+      // #then - continuation injected to same session
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].sessionID).toBe("session-123")
+      // #then - state retains original session ID
+      expect(hook.getState()?.session_id).toBe("session-123")
+    })
+
+    test("should continue with original session if reset/create fails", async () => {
+      // #given - hook with context_strategy: reset but create fails
+      mockCreateResult = { data: undefined }
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        config: { enabled: true, default_max_iterations: 10, context_strategy: "reset" },
+      })
+      hook.startLoop("session-123", "Build something")
+
+      // #when - session goes idle
+      await hook.event({
+        event: { type: "session.idle", properties: { sessionID: "session-123" } },
+      })
+
+      // #then - continuation injected to ORIGINAL session as fallback
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].sessionID).toBe("session-123")
+      // #then - state retains original session ID
+      expect(hook.getState()?.session_id).toBe("session-123")
     })
   })
 })

--- a/src/hooks/ralph-loop/index.ts
+++ b/src/hooks/ralph-loop/index.ts
@@ -8,9 +8,10 @@ import {
   HOOK_NAME,
   DEFAULT_MAX_ITERATIONS,
   DEFAULT_COMPLETION_PROMISE,
-  DEFAULT_CONTEXT_STRATEGY,
+  DEFAULT_STRATEGY,
 } from "./constants"
 import type { RalphLoopState, RalphLoopOptions } from "./types"
+import type { ContextStrategy } from "../../config"
 import { getTranscriptPath as getDefaultTranscriptPath } from "../claude-code-hooks/transcript"
 import { findNearestMessageWithFields, MESSAGE_STORAGE } from "../../features/hook-message-injector"
 
@@ -44,9 +45,7 @@ interface OpenCodeSessionMessage {
   }>
 }
 
-const CONTINUATION_PROMPT = `${SYSTEM_DIRECTIVE_PREFIX} - RALPH LOOP {{ITERATION}}/{{MAX}}]
-
-Your previous attempt did not output the completion promise. Continue working on the task.
+const CONTINUATION_PROMPT_BASE = `Your previous attempt did not output the completion promise. Continue working on the task.
 
 IMPORTANT:
 - Review your progress so far
@@ -57,12 +56,25 @@ IMPORTANT:
 Original task:
 {{PROMPT}}`
 
+/**
+ * Generates the continuation prompt with appropriate prefix based on context strategy.
+ * - "reset": Uses plain prefix to allow keyword detection (new session needs mode injections)
+ * - "continue": Uses system directive prefix to skip keyword detection (mode already applied in iteration 1)
+ */
+function getContinuationPrompt(iteration: number, max: number, strategy: "reset" | "continue"): string {
+  const prefix =
+    strategy === "continue"
+      ? `${SYSTEM_DIRECTIVE_PREFIX} - RALPH LOOP ${iteration}/${max}]`
+      : `[RALPH LOOP - Iteration ${iteration}/${max}]`
+  return `${prefix}\n\n${CONTINUATION_PROMPT_BASE}`
+}
+
 export interface RalphLoopHook {
   event: (input: { event: { type: string; properties?: unknown } }) => Promise<void>
   startLoop: (
     sessionID: string,
     prompt: string,
-    options?: { maxIterations?: number; completionPromise?: string; ultrawork?: boolean }
+    options?: { maxIterations?: number; completionPromise?: string; ultrawork?: boolean; strategy?: ContextStrategy }
   ) => boolean
   cancelLoop: (sessionID: string) => boolean
   getState: () => RalphLoopState | null
@@ -162,7 +174,7 @@ export function createRalphLoopHook(
   const startLoop = (
     sessionID: string,
     prompt: string,
-    loopOptions?: { maxIterations?: number; completionPromise?: string; ultrawork?: boolean }
+    loopOptions?: { maxIterations?: number; completionPromise?: string; ultrawork?: boolean; strategy?: ContextStrategy }
   ): boolean => {
     const state: RalphLoopState = {
       active: true,
@@ -171,6 +183,7 @@ export function createRalphLoopHook(
         loopOptions?.maxIterations ?? config?.default_max_iterations ?? DEFAULT_MAX_ITERATIONS,
       completion_promise: loopOptions?.completionPromise ?? DEFAULT_COMPLETION_PROMISE,
       ultrawork: loopOptions?.ultrawork,
+      strategy: loopOptions?.strategy ?? config?.default_strategy ?? DEFAULT_STRATEGY,
       started_at: new Date().toISOString(),
       prompt,
       session_id: sessionID,
@@ -182,6 +195,7 @@ export function createRalphLoopHook(
         sessionID,
         maxIterations: state.max_iterations,
         completionPromise: state.completion_promise,
+        strategy: state.strategy,
       })
     }
     return success
@@ -319,10 +333,10 @@ export function createRalphLoopHook(
         max: newState.max_iterations,
       })
 
-      const contextStrategy = config?.context_strategy ?? DEFAULT_CONTEXT_STRATEGY
+      const strategy = newState.strategy ?? config?.default_strategy ?? DEFAULT_STRATEGY
       let targetSessionID = sessionID
 
-      if (contextStrategy === "reset") {
+      if (strategy === "reset") {
         try {
           log(`[${HOOK_NAME}] Creating new session for fresh context`, { sessionID })
           const createResp = await ctx.client.session.create({
@@ -363,8 +377,11 @@ export function createRalphLoopHook(
         }
       }
 
-      const continuationPrompt = CONTINUATION_PROMPT.replace("{{ITERATION}}", String(newState.iteration))
-        .replace("{{MAX}}", String(newState.max_iterations))
+      const continuationPrompt = getContinuationPrompt(
+        newState.iteration,
+        newState.max_iterations,
+        strategy
+      )
         .replace("{{PROMISE}}", newState.completion_promise)
         .replace("{{PROMPT}}", newState.prompt)
 

--- a/src/hooks/ralph-loop/index.ts
+++ b/src/hooks/ralph-loop/index.ts
@@ -8,6 +8,7 @@ import {
   HOOK_NAME,
   DEFAULT_MAX_ITERATIONS,
   DEFAULT_COMPLETION_PROMISE,
+  DEFAULT_CONTEXT_STRATEGY,
 } from "./constants"
 import type { RalphLoopState, RalphLoopOptions } from "./types"
 import { getTranscriptPath as getDefaultTranscriptPath } from "../claude-code-hooks/transcript"
@@ -318,6 +319,50 @@ export function createRalphLoopHook(
         max: newState.max_iterations,
       })
 
+      const contextStrategy = config?.context_strategy ?? DEFAULT_CONTEXT_STRATEGY
+      let targetSessionID = sessionID
+
+      if (contextStrategy === "reset") {
+        try {
+          log(`[${HOOK_NAME}] Creating new session for fresh context`, { sessionID })
+          const createResp = await ctx.client.session.create({
+            body: { title: `Ralph Loop - Iteration ${newState.iteration}` },
+            query: { directory: ctx.directory },
+          })
+          const newSessionID = (createResp as { data?: { id?: string } })?.data?.id
+          if (newSessionID) {
+            targetSessionID = newSessionID
+            const updatedState = { ...newState, session_id: newSessionID }
+            writeState(ctx.directory, updatedState, stateDir)
+            log(`[${HOOK_NAME}] Switched to new session`, { oldSessionID: sessionID, newSessionID })
+
+            // Switch TUI focus to the new session via raw API call
+            try {
+              const client = (ctx.client as unknown as { _client: { post: (opts: unknown) => Promise<unknown> } })._client
+              await client.post({
+                url: "/tui/select-session",
+                body: { sessionID: newSessionID },
+                query: { directory: ctx.directory },
+                headers: { "Content-Type": "application/json" },
+              })
+              log(`[${HOOK_NAME}] TUI switched to new session`, { newSessionID })
+            } catch (tuiErr) {
+              log(`[${HOOK_NAME}] TUI session switch failed (continuing anyway)`, {
+                newSessionID,
+                error: String(tuiErr),
+              })
+            }
+          } else {
+            log(`[${HOOK_NAME}] Failed to create new session, using original`, { sessionID })
+          }
+        } catch (err) {
+          log(`[${HOOK_NAME}] Session creation failed, using original session`, {
+            sessionID,
+            error: String(err),
+          })
+        }
+      }
+
       const continuationPrompt = CONTINUATION_PROMPT.replace("{{ITERATION}}", String(newState.iteration))
         .replace("{{MAX}}", String(newState.max_iterations))
         .replace("{{PROMISE}}", newState.completion_promise)
@@ -365,7 +410,7 @@ export function createRalphLoopHook(
         }
 
         await ctx.client.session.prompt({
-          path: { id: sessionID },
+          path: { id: targetSessionID },
           body: {
             ...(agent !== undefined ? { agent } : {}),
             ...(model !== undefined ? { model } : {}),
@@ -375,7 +420,7 @@ export function createRalphLoopHook(
         })
       } catch (err) {
         log(`[${HOOK_NAME}] Failed to inject continuation`, {
-          sessionID,
+          sessionID: targetSessionID,
           error: String(err),
         })
       }

--- a/src/hooks/ralph-loop/storage.ts
+++ b/src/hooks/ralph-loop/storage.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path"
 import { parseFrontmatter } from "../../shared/frontmatter"
 import type { RalphLoopState } from "./types"
 import { DEFAULT_STATE_FILE, DEFAULT_COMPLETION_PROMISE, DEFAULT_MAX_ITERATIONS } from "./constants"
+import type { ContextStrategy } from "../../config"
 
 export function getStateFilePath(directory: string, customPath?: string): string {
   return customPath
@@ -40,6 +41,11 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
       return str.replace(/^["']|["']$/g, "")
     }
 
+    const parseStrategy = (val: unknown): ContextStrategy | undefined => {
+      if (val === "reset" || val === "continue") return val
+      return undefined
+    }
+
     return {
       active: isActive,
       iteration: iterationNum,
@@ -49,6 +55,7 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
       prompt: body.trim(),
       session_id: data.session_id ? stripQuotes(data.session_id) : undefined,
       ultrawork: data.ultrawork === true || data.ultrawork === "true" ? true : undefined,
+      strategy: parseStrategy(data.strategy),
     }
   } catch {
     return null
@@ -70,13 +77,14 @@ export function writeState(
 
     const sessionIdLine = state.session_id ? `session_id: "${state.session_id}"\n` : ""
     const ultraworkLine = state.ultrawork !== undefined ? `ultrawork: ${state.ultrawork}\n` : ""
+    const strategyLine = state.strategy ? `strategy: "${state.strategy}"\n` : ""
     const content = `---
 active: ${state.active}
 iteration: ${state.iteration}
 max_iterations: ${state.max_iterations}
 completion_promise: "${state.completion_promise}"
 started_at: "${state.started_at}"
-${sessionIdLine}${ultraworkLine}---
+${sessionIdLine}${ultraworkLine}${strategyLine}---
 ${state.prompt}
 `
 

--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -1,4 +1,4 @@
-import type { RalphLoopConfig } from "../../config"
+import type { ContextStrategy, RalphLoopConfig } from "../../config"
 
 export interface RalphLoopState {
   active: boolean
@@ -9,6 +9,7 @@ export interface RalphLoopState {
   prompt: string
   session_id?: string
   ultrawork?: boolean
+  strategy?: ContextStrategy
 }
 
 export interface RalphLoopOptions {

--- a/src/hooks/todo-continuation-enforcer.ts
+++ b/src/hooks/todo-continuation-enforcer.ts
@@ -10,6 +10,7 @@ import {
 } from "../features/hook-message-injector"
 import { log } from "../shared/logger"
 import { createSystemDirective, SystemDirectiveTypes } from "../shared/system-directive"
+import { readState as readRalphLoopState } from "./ralph-loop"
 
 const HOOK_NAME = "todo-continuation-enforcer"
 
@@ -19,6 +20,8 @@ export interface TodoContinuationEnforcerOptions {
   backgroundManager?: BackgroundManager
   skipAgents?: string[]
   isContinuationStopped?: (sessionID: string) => boolean
+  directory?: string
+  ralphLoopStateDir?: string
 }
 
 export interface TodoContinuationEnforcer {
@@ -97,7 +100,13 @@ export function createTodoContinuationEnforcer(
   ctx: PluginInput,
   options: TodoContinuationEnforcerOptions = {}
 ): TodoContinuationEnforcer {
-  const { backgroundManager, skipAgents = DEFAULT_SKIP_AGENTS, isContinuationStopped } = options
+  const { 
+    backgroundManager, 
+    skipAgents = DEFAULT_SKIP_AGENTS, 
+    isContinuationStopped,
+    directory,
+    ralphLoopStateDir,
+  } = options
   const sessions = new Map<string, SessionState>()
 
   function getState(sessionID: string): SessionState {
@@ -349,6 +358,14 @@ ${todoList}`
       if (hasRunningBgTasks) {
         log(`[${HOOK_NAME}] Skipped: background tasks running`, { sessionID })
         return
+      }
+
+      if (directory) {
+        const ralphLoopState = readRalphLoopState(directory, ralphLoopStateDir)
+        if (ralphLoopState?.active) {
+          log(`[${HOOK_NAME}] Skipped: ralph-loop is active`, { sessionID, ralphLoopSessionID: ralphLoopState.session_id })
+          return
+        }
       }
 
       // Check 2: API-based abort detection (fallback, for cases where event was missed)

--- a/src/index.ts
+++ b/src/index.ts
@@ -521,7 +521,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
               ? parseInt(maxIterMatch[1], 10)
               : undefined,
             completionPromise: promiseMatch?.[1],
-            strategy: strategyMatch?.[1] as "reset" | "continue" | undefined,
+            strategy: strategyMatch?.[1]?.toLowerCase() as "reset" | "continue" | undefined,
           });
         } else if (isCancelRalphTemplate) {
           log("[ralph-loop] Cancelling loop from chat.message", {
@@ -695,7 +695,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
               ? parseInt(maxIterMatch[1], 10)
               : undefined,
             completionPromise: promiseMatch?.[1],
-            strategy: strategyMatch?.[1] as "reset" | "continue" | undefined,
+            strategy: strategyMatch?.[1]?.toLowerCase() as "reset" | "continue" | undefined,
           });
          } else if (command === "cancel-ralph" && sessionID) {
            ralphLoop.cancelLoop(sessionID);
@@ -716,12 +716,12 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
 
            ralphLoop.startLoop(sessionID, prompt, {
               ultrawork: true,
-              maxIterations: maxIterMatch
-                ? parseInt(maxIterMatch[1], 10)
-                : undefined,
-              completionPromise: promiseMatch?.[1],
-              strategy: strategyMatch?.[1] as "reset" | "continue" | undefined,
-            });
+            maxIterations: maxIterMatch
+              ? parseInt(maxIterMatch[1], 10)
+              : undefined,
+            completionPromise: promiseMatch?.[1],
+            strategy: strategyMatch?.[1]?.toLowerCase() as "reset" | "continue" | undefined,
+          });
          }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,8 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     ? createTodoContinuationEnforcer(ctx, {
         backgroundManager,
         isContinuationStopped: stopContinuationGuard?.isStopped,
+        directory: ctx.directory,
+        ralphLoopStateDir: pluginConfig.ralph_loop?.state_dir,
       })
     : null;
 
@@ -508,6 +510,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
           const promiseMatch = rawTask.match(
             /--completion-promise=["']?([^"'\s]+)["']?/i
           );
+          const strategyMatch = rawTask.match(/--strategy=(reset|continue)/i);
 
           log("[ralph-loop] Starting loop from chat.message", {
             sessionID: input.sessionID,
@@ -518,6 +521,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
               ? parseInt(maxIterMatch[1], 10)
               : undefined,
             completionPromise: promiseMatch?.[1],
+            strategy: strategyMatch?.[1] as "reset" | "continue" | undefined,
           });
         } else if (isCancelRalphTemplate) {
           log("[ralph-loop] Cancelling loop from chat.message", {
@@ -673,7 +677,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
 
         if (command === "ralph-loop" && sessionID) {
           const rawArgs =
-            args?.command?.replace(/^\/?(ralph-loop)\s*/i, "") || "";
+            args?.command?.replace(/^\/?(?:ralph-loop)\s*/i, "") || "";
           const taskMatch = rawArgs.match(/^["'](.+?)["']/);
           const prompt =
             taskMatch?.[1] ||
@@ -684,18 +688,20 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
           const promiseMatch = rawArgs.match(
             /--completion-promise=["']?([^"'\s]+)["']?/i
           );
+          const strategyMatch = rawArgs.match(/--strategy=(reset|continue)/i);
 
           ralphLoop.startLoop(sessionID, prompt, {
             maxIterations: maxIterMatch
               ? parseInt(maxIterMatch[1], 10)
               : undefined,
             completionPromise: promiseMatch?.[1],
+            strategy: strategyMatch?.[1] as "reset" | "continue" | undefined,
           });
          } else if (command === "cancel-ralph" && sessionID) {
            ralphLoop.cancelLoop(sessionID);
          } else if (command === "ulw-loop" && sessionID) {
            const rawArgs =
-             args?.command?.replace(/^\/?(ulw-loop)\s*/i, "") || "";
+             args?.command?.replace(/^\/?(?:ulw-loop)\s*/i, "") || "";
            const taskMatch = rawArgs.match(/^["'](.+?)["']/);
            const prompt =
              taskMatch?.[1] ||
@@ -706,6 +712,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
            const promiseMatch = rawArgs.match(
              /--completion-promise=["']?([^"'\s]+)["']?/i
            );
+           const strategyMatch = rawArgs.match(/--strategy=(reset|continue)/i);
 
            ralphLoop.startLoop(sessionID, prompt, {
               ultrawork: true,
@@ -713,6 +720,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
                 ? parseInt(maxIterMatch[1], 10)
                 : undefined,
               completionPromise: promiseMatch?.[1],
+              strategy: strategyMatch?.[1] as "reset" | "continue" | undefined,
             });
          }
       }


### PR DESCRIPTION
## Summary

- Fix doctor command showing incorrect/missing variants in model resolution output
- `OmoConfig` interface was missing `variant` property, causing doctor to display variants from `ModelRequirement` fallback chain instead of user's config

## Changes

- Add `variant` to `OmoConfig` agent/category entries
- Add `userVariant` to `AgentResolutionInfo` and `CategoryResolutionInfo`
- Update `getEffectiveVariant()` to prioritize user variant over requirement defaults
- Add 2 tests verifying variant capture for agents and categories

## Before/After

| Agent | Config | Before | After |
|-------|--------|--------|-------|
| oracle | xhigh | high | xhigh ✓ |
| metis | xhigh | max | xhigh ✓ |
| momus | max | medium | max ✓ |
| librarian | high | (missing) | high ✓ |
| explore | high | (missing) | high ✓ |
| multimodal-looker | high | (missing) | high ✓ |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes doctor output to show user-configured model variants and adds a context strategy to Ralph Loop that defaults to fresh context each iteration. Includes a --strategy flag, updated docs, and safeguards to avoid conflicts with the TODO continuation enforcer.

- **New Features**
  - Ralph Loop context strategy:
    - Config: ralph_loop.default_strategy = "reset" | "continue" (default "reset").
    - Per-iteration session reset with TUI focus; fallback to original session if creation fails.
    - Override per run with --strategy=reset|continue on /ralph-loop and /ulw-loop.
    - Strategy stored in loop state; templates and argument hints updated; docs expanded.
  - Prevent interference: todo-continuation-enforcer skips when ralph-loop is active.

- **Bug Fixes**
  - Doctor model resolution now displays the user’s variant when set.
    - Added variant to OmoConfig entries; userVariant to resolution info.
    - getEffectiveVariant prioritizes user-configured variant over defaults.
    - Tests added for agents and categories.

<sup>Written for commit 16bc14c73df3fdd9fdb02f531a7268b01ab57fc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

