### PR TITLE
fix(doctor): display user-configured variant in model resolution output

### DIFF
--- a/src/cli/doctor/checks/model-resolution.test.ts
+++ b/src/cli/doctor/checks/model-resolution.test.ts
@@ -90,6 +90,46 @@ describe("model-resolution check", () => {
       expect(sisyphus!.effectiveResolution).toContain("Provider fallback:")
       expect(sisyphus!.effectiveResolution).toContain("anthropic")
     })
+
+    it("captures user variant for agent when configured", async () => {
+      const { getModelResolutionInfoWithOverrides } = await import("./model-resolution")
+
+      //#given User has model with variant override for oracle agent
+      const mockConfig = {
+        agents: {
+          oracle: { model: "openai/gpt-5.2", variant: "xhigh" },
+        },
+      }
+
+      //#when getting resolution info with config
+      const info = getModelResolutionInfoWithOverrides(mockConfig)
+
+      //#then Oracle should have userVariant set
+      const oracle = info.agents.find((a) => a.name === "oracle")
+      expect(oracle).toBeDefined()
+      expect(oracle!.userOverride).toBe("openai/gpt-5.2")
+      expect(oracle!.userVariant).toBe("xhigh")
+    })
+
+    it("captures user variant for category when configured", async () => {
+      const { getModelResolutionInfoWithOverrides } = await import("./model-resolution")
+
+      //#given User has model with variant override for visual-engineering category
+      const mockConfig = {
+        categories: {
+          "visual-engineering": { model: "google/gemini-3-flash-preview", variant: "high" },
+        },
+      }
+
+      //#when getting resolution info with config
+      const info = getModelResolutionInfoWithOverrides(mockConfig)
+
+      //#then visual-engineering should have userVariant set
+      const visual = info.categories.find((c) => c.name === "visual-engineering")
+      expect(visual).toBeDefined()
+      expect(visual!.userOverride).toBe("google/gemini-3-flash-preview")
+      expect(visual!.userVariant).toBe("high")
+    })
   })
 
   describe("checkModelResolution", () => {

--- a/src/cli/doctor/checks/model-resolution.ts
+++ b/src/cli/doctor/checks/model-resolution.ts
@@ -51,6 +51,7 @@ export interface AgentResolutionInfo {
   name: string
   requirement: ModelRequirement
   userOverride?: string
+  userVariant?: string
   effectiveModel: string
   effectiveResolution: string
 }
@@ -59,6 +60,7 @@ export interface CategoryResolutionInfo {
   name: string
   requirement: ModelRequirement
   userOverride?: string
+  userVariant?: string
   effectiveModel: string
   effectiveResolution: string
 }
@@ -152,10 +154,12 @@ export function getModelResolutionInfoWithOverrides(config: OmoConfig): ModelRes
   const agents: AgentResolutionInfo[] = Object.entries(AGENT_MODEL_REQUIREMENTS).map(
     ([name, requirement]) => {
       const userOverride = config.agents?.[name]?.model
+      const userVariant = config.agents?.[name]?.variant
       return {
         name,
         requirement,
         userOverride,
+        userVariant,
         effectiveModel: getEffectiveModel(requirement, userOverride),
         effectiveResolution: buildEffectiveResolution(requirement, userOverride),
       }
@@ -165,10 +169,12 @@ export function getModelResolutionInfoWithOverrides(config: OmoConfig): ModelRes
   const categories: CategoryResolutionInfo[] = Object.entries(CATEGORY_MODEL_REQUIREMENTS).map(
     ([name, requirement]) => {
       const userOverride = config.categories?.[name]?.model
+      const userVariant = config.categories?.[name]?.variant
       return {
         name,
         requirement,
         userOverride,
+        userVariant,
         effectiveModel: getEffectiveModel(requirement, userOverride),
         effectiveResolution: buildEffectiveResolution(requirement, userOverride),
       }


### PR DESCRIPTION
## Summary

- Fix doctor command showing incorrect/missing variants in model resolution output
- `OmoConfig` interface was missing `variant` property, causing doctor to display variants from `ModelRequirement` fallback chain instead of user's config

## Changes

- Add `variant` to `OmoConfig` agent/category entries
- Add `userVariant` to `AgentResolutionInfo` and `CategoryResolutionInfo`
- Update `getEffectiveVariant()` to prioritize user variant over requirement defaults
- Add 2 tests verifying variant capture for agents and categories

## Before/After

| Agent | Config | Before | After |
|-------|--------|--------|-------|
| oracle | xhigh | high | xhigh ✓ |
| metis | xhigh | max | xhigh ✓ |
| momus | max | medium | max ✓ |
| librarian | high | (missing) | high ✓ |
| explore | high | (missing) | high ✓ |
| multimodal-looker | high | (missing) | high ✓ |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the doctor command to correctly display user-configured model variants in the model resolution output. Captures user variants for agents and categories and prioritizes them over fallback defaults; adds tests to cover both cases.

<sup>Written for commit 81a2317f51446d2fa59bc70e77cf58e822d202d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

