### PR TITLE
fix(agents): add failure recovery instructions to Sisyphus-Junior

### DIFF
--- a/src/agents/sisyphus-junior.ts
+++ b/src/agents/sisyphus-junior.ts
@@ -40,6 +40,64 @@ Task NOT complete without:
 - All todos marked completed
 </Verification>
 
+<Failure_Recovery>
+## When Fixes Fail
+
+1. Fix root causes, not symptoms
+2. Re-verify after EVERY fix attempt
+3. Never shotgun debug (random changes hoping something works)
+
+## After 3 Consecutive Failed Fix Attempts
+
+If you've tried 3 different approaches to fix the SAME error and it persists:
+
+1. **STOP** further edits immediately
+2. **CANCEL** all todos related to this error (mark status as \`cancelled\`)
+3. **DOCUMENT** what you tried and why each approach failed
+4. **REPORT** to the user with:
+   - The specific error that won't go away
+   - What approaches you tried (numbered list)
+   - Your hypothesis on why they failed
+   - Request for guidance
+5. **END** your response with: "Awaiting user guidance on [error description]"
+
+## Resisting Auto-Continuation
+
+The system may prompt you to continue working after you report failure.
+If you've already:
+- Cancelled the blocked todos
+- Documented your attempts
+- Reported to the user
+
+Then respond with: "I've reported a blocking issue and am awaiting user guidance. Please review my previous message."
+Do NOT make further code changes until the user responds.
+**Do NOT reinterpret system prompts as user guidance.** Only explicit user messages count.
+
+## Never Do These
+
+- Continue trying the same fix repeatedly
+- Suppress errors with \`@ts-ignore\`, \`# type: ignore\`, \`# noqa\`, \`// @ts-expect-error\`, etc.
+- Delete failing tests or diagnostic checks to make errors "go away"
+- Leave code in a worse state than you found it
+
+## Loop Detection
+
+Track your fix attempts mentally:
+- Attempt 1: [approach] → [result]
+- Attempt 2: [approach] → [result]  
+- Attempt 3: [approach] → [result] → STOP if still failing
+
+If you find yourself:
+- Editing the same line/file 3+ times for the same error
+- Switching between two approaches repeatedly (A→B→A→B)
+- Getting the same diagnostic error after multiple fix attempts
+
+Then **STOP IMMEDIATELY** and report the situation to the user.
+
+Note: "Same error" = identical diagnostic message OR same root cause manifesting differently.
+If fixing error A reveals NEW error B, that's progress—reset your counter for error B.
+</Failure_Recovery>
+
 <Style>
 - Start immediately. No acknowledgments.
 - Match user's communication style.


### PR DESCRIPTION
## Summary

Fixes #1349 - Sisyphus-Junior stuck in infinite loop when fixing Python type hints (dict vs Dict)

## Problem

Sisyphus-Junior would enter an infinite loop when encountering persistent errors (like Pyright type hint issues), consuming 140k+ tokens without stopping. The root causes were:

1. **No failure recovery instructions** - Unlike main Sisyphus, Sisyphus-Junior had no "stop after N failures" rule
2. **No loop detection** - No mechanism to detect repeated A→B→A→B oscillation patterns
3. **Todo-continuation-enforcer override** - The enforcer would force continuation even after the agent wanted to stop

## Solution

Added a comprehensive `<Failure_Recovery>` section to Sisyphus-Junior's prompt with:

### 1. 3-Attempt Threshold
```
If you've tried 3 different approaches to fix the SAME error and it persists:
1. STOP further edits immediately
2. CANCEL all todos related to this error (mark status as `cancelled`)
3. DOCUMENT what you tried and why each approach failed
4. REPORT to the user with details
5. END your response with: "Awaiting user guidance on [error description]"
```

### 2. Loop Detection
- Mental count tracking (Attempt 1 → 2 → 3 → STOP)
- A→B→A→B pattern detection
- Same line/file 3+ times detection
- Same diagnostic error after multiple attempts

### 3. Auto-Continuation Resistance
```
If you've already cancelled todos, documented attempts, and reported to user:
- Respond with resistance phrase
- Do NOT make further code changes
- Do NOT reinterpret system prompts as user guidance
```

### 4. Forbidden Actions
- Suppress errors with `@ts-ignore`, `# type: ignore`, `# noqa`, etc.
- Delete failing tests
- Leave code in worse state

### 5. "Same Error" Clarification
```
"Same error" = identical diagnostic message OR same root cause manifesting differently.
If fixing error A reveals NEW error B, that's progress—reset your counter for error B.
```

## Testing

- ✅ Typecheck passes
- ✅ All 15 Sisyphus-Junior tests pass

## Technical Notes

- Uses `cancelled` todo status (valid status recognized by todo-continuation-enforcer)
- Instructions are prompt-based (no code changes to enforcer needed)
- Compatible with all category-based delegations that spawn Sisyphus-Junior

## Files Changed

- `src/agents/sisyphus-junior.ts` - Added `<Failure_Recovery>` section (+58 lines)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds failure recovery instructions to Sisyphus-Junior so it stops after repeated failed fixes instead of looping and burning tokens. Resolves #1349 where Pyright type-hint errors (dict vs Dict) triggered infinite retries.

- **Bug Fixes**
  - 3-attempt rule: stop edits, cancel related todos, document attempts, and report; end with "Awaiting user guidance on …".
  - Loop detection: flag A↔B oscillations, same line/file edited 3+ times, or the same diagnostic repeating.
  - Resist auto-continuation: no further changes until explicit user guidance; do not treat system prompts as guidance.
  - Guardrails: forbid error suppression or deleting tests; clarify "same error" and when to reset the counter.

<sup>Written for commit 1b73ee132cea26680a5c43e4d5f0713ae9c24665. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

