### PR TITLE
fix: hide env export prefix in non-interactive hook

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -3020,6 +3020,17 @@
           }
         }
       }
+    },
+    "non_interactive_env": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "boolean"
+        },
+        "show_export_prefix": {
+          "type": "boolean"
+        }
+      }
     }
   }
 }

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -1228,3 +1228,21 @@ Tools that should never be pruned (default):
 | Variable              | Description                                                                                                                                     |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `OPENCODE_CONFIG_DIR` | Override the OpenCode configuration directory. Useful for profile isolation with tools like [OCX](https://github.com/kdcokenny/ocx) ghost mode. |
+
+## Non-interactive Env
+
+Configure how the non-interactive environment hook behaves:
+
+```json
+{
+  "non_interactive_env": {
+    "disabled": false,
+    "show_export_prefix": false
+  }
+}
+```
+
+| Option               | Default | Description |
+| -------------------- | ------- | ----------- |
+| `disabled`           | `false` | Disable non-interactive env injection for git commands. |
+| `show_export_prefix` | `false` | Show the `export ...;` prefix in the displayed command. When `false`, env vars are applied without rewriting the command. |

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -362,6 +362,13 @@ export const SisyphusTasksConfigSchema = z.object({
 export const SisyphusConfigSchema = z.object({
   tasks: SisyphusTasksConfigSchema.optional(),
 })
+
+export const NonInteractiveEnvConfigSchema = z.object({
+  /** Disable non-interactive env injection for git commands (default: false) */
+  disabled: z.boolean().optional(),
+  /** Show export prefix in displayed command (default: false) */
+  show_export_prefix: z.boolean().optional(),
+})
 export const OhMyOpenCodeConfigSchema = z.object({
   $schema: z.string().optional(),
   /** Enable new task system (default: false) */
@@ -389,6 +396,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
   browser_automation_engine: BrowserAutomationConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),
   sisyphus: SisyphusConfigSchema.optional(),
+  non_interactive_env: NonInteractiveEnvConfigSchema.optional(),
 })
 
 export type OhMyOpenCodeConfig = z.infer<typeof OhMyOpenCodeConfigSchema>
@@ -418,5 +426,6 @@ export type TmuxConfig = z.infer<typeof TmuxConfigSchema>
 export type TmuxLayout = z.infer<typeof TmuxLayoutSchema>
 export type SisyphusTasksConfig = z.infer<typeof SisyphusTasksConfigSchema>
 export type SisyphusConfig = z.infer<typeof SisyphusConfigSchema>
+export type NonInteractiveEnvConfig = z.infer<typeof NonInteractiveEnvConfigSchema>
 
 export { AnyMcpNameSchema, type AnyMcpName, McpNameSchema, type McpName } from "../mcp/types"

--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -9,12 +9,14 @@ describe("non-interactive-env hook", () => {
 
   beforeEach(() => {
     originalPlatform = process.platform
-    originalEnv = {
-      SHELL: process.env.SHELL,
-      PSModulePath: process.env.PSModulePath,
-      CI: process.env.CI,
-      OPENCODE_NON_INTERACTIVE: process.env.OPENCODE_NON_INTERACTIVE,
-    }
+    const envKeys = [
+      "SHELL",
+      "PSModulePath",
+      "CI",
+      "OPENCODE_NON_INTERACTIVE",
+      ...Object.keys(NON_INTERACTIVE_ENV),
+    ]
+    originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]))
     // given clean Unix-like environment for all tests
     // This prevents CI environments (which may have PSModulePath set) from
     // triggering PowerShell detection in tests that expect Unix behavior
@@ -35,7 +37,7 @@ describe("non-interactive-env hook", () => {
   })
 
   describe("git command modification", () => {
-    test("#given git command #when hook executes #then prepends export statement", async () => {
+    test("#given git command #when hook executes #then sets env without prefix", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git commit -m 'test'" },
@@ -47,14 +49,24 @@ describe("non-interactive-env hook", () => {
       )
 
       const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain("GIT_EDITOR=:")
-      expect(cmd).toContain("EDITOR=:")
-      expect(cmd).toContain("PAGER=cat")
-      expect(cmd).toContain("; git commit -m 'test'")
+      expect(cmd).toBe("git commit -m 'test'")
+      expect(process.env.GIT_EDITOR).toBe(":")
+      expect(process.env.EDITOR).toBe(":")
+      expect(process.env.PAGER).toBe("cat")
+      expect(process.env.VISUAL).toBe("")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
+
+      expect(process.env.GIT_EDITOR).toBe(originalEnv.GIT_EDITOR)
+      expect(process.env.EDITOR).toBe(originalEnv.EDITOR)
+      expect(process.env.PAGER).toBe(originalEnv.PAGER)
+      expect(process.env.VISUAL).toBe(originalEnv.VISUAL)
     })
 
-    test("#given chained git commands #when hook executes #then export applies to all", async () => {
+    test("#given chained git commands #when hook executes #then command unchanged", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git add file && git rebase --continue" },
@@ -66,8 +78,14 @@ describe("non-interactive-env hook", () => {
       )
 
       const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain("; git add file && git rebase --continue")
+      expect(cmd).toBe("git add file && git rebase --continue")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
+
+      expect(process.env.GIT_EDITOR).toBe(originalEnv.GIT_EDITOR)
     })
 
     test("#given non-git bash command #when hook executes #then command unchanged", async () => {
@@ -82,6 +100,13 @@ describe("non-interactive-env hook", () => {
       )
 
       expect(output.args.command).toBe("ls -la")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
+
+      expect(process.env.GIT_EDITOR).toBe(originalEnv.GIT_EDITOR)
     })
 
     test("#given non-bash tool #when hook executes #then command unchanged", async () => {
@@ -96,6 +121,11 @@ describe("non-interactive-env hook", () => {
       )
 
       expect(output.args.command).toBe("git status")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "Read", sessionID: "test", callID: "1" },
+        { title: "read", output: "", metadata: {} }
+      )
     })
 
     test("#given empty command #when hook executes #then no error", async () => {
@@ -110,11 +140,18 @@ describe("non-interactive-env hook", () => {
       )
 
       expect(output.args.command).toBeUndefined()
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
+
+      expect(process.env.GIT_EDITOR).toBe(originalEnv.GIT_EDITOR)
     })
   })
 
   describe("shell escaping", () => {
-    test("#given git command #when building prefix #then VISUAL properly escaped", async () => {
+    test("#given git command #when setting env #then VISUAL is empty string", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git status" },
@@ -125,11 +162,17 @@ describe("non-interactive-env hook", () => {
         output
       )
 
-      const cmd = output.args.command as string
-      expect(cmd).toContain("VISUAL=''")
+      expect(process.env.VISUAL).toBe("")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
+
+      expect(process.env.GIT_EDITOR).toBe(originalEnv.GIT_EDITOR)
     })
 
-    test("#given git command #when building prefix #then all NON_INTERACTIVE_ENV vars included", async () => {
+    test("#given git command #when setting env #then all NON_INTERACTIVE_ENV vars included", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git log" },
@@ -140,10 +183,77 @@ describe("non-interactive-env hook", () => {
         output
       )
 
-      const cmd = output.args.command as string
       for (const key of Object.keys(NON_INTERACTIVE_ENV)) {
-        expect(cmd).toContain(`${key}=`)
+        expect(process.env[key]).toBe(NON_INTERACTIVE_ENV[key])
       }
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
+    })
+  })
+
+  describe("env restoration", () => {
+    test("#given git command #when hook completes #then restores previous env", async () => {
+      process.env.GIT_EDITOR = "nano"
+      delete process.env.GIT_PAGER
+
+      const hook = createNonInteractiveEnvHook(mockCtx)
+      const output: { args: Record<string, unknown>; message?: string } = {
+        args: { command: "git status" },
+      }
+
+      await hook["tool.execute.before"](
+        { tool: "bash", sessionID: "test", callID: "restore-1" },
+        output
+      )
+
+      expect(process.env.GIT_EDITOR).toBe(":")
+      expect(process.env.GIT_PAGER).toBe("cat")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "restore-1" },
+        { title: "bash", output: "", metadata: {} }
+      )
+
+      expect(process.env.GIT_EDITOR).toBe("nano")
+      expect(process.env.GIT_PAGER).toBeUndefined()
+    })
+
+    test("#given parallel git commands #when hooks overlap #then env restores once", async () => {
+      process.env.GIT_EDITOR = "nano"
+
+      const hook = createNonInteractiveEnvHook(mockCtx)
+      const outputA: { args: Record<string, unknown>; message?: string } = {
+        args: { command: "git status" },
+      }
+      const outputB: { args: Record<string, unknown>; message?: string } = {
+        args: { command: "git log" },
+      }
+
+      await hook["tool.execute.before"](
+        { tool: "bash", sessionID: "test", callID: "a" },
+        outputA
+      )
+      await hook["tool.execute.before"](
+        { tool: "bash", sessionID: "test", callID: "b" },
+        outputB
+      )
+
+      expect(process.env.GIT_EDITOR).toBe(":")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "a" },
+        { title: "bash", output: "", metadata: {} }
+      )
+      expect(process.env.GIT_EDITOR).toBe(":")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "b" },
+        { title: "bash", output: "", metadata: {} }
+      )
+      expect(process.env.GIT_EDITOR).toBe("nano")
     })
   })
 
@@ -188,7 +298,7 @@ describe("non-interactive-env hook", () => {
       process.env.SHELL = "/bin/zsh"
       Object.defineProperty(process, "platform", { value: "darwin" })
 
-      const hook = createNonInteractiveEnvHook(mockCtx)
+      const hook = createNonInteractiveEnvHook(mockCtx, { show_export_prefix: true })
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git status" },
       }
@@ -203,6 +313,11 @@ describe("non-interactive-env hook", () => {
       expect(cmd).toContain(";")
       expect(cmd).not.toContain("$env:")
       expect(cmd).not.toContain("set ")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
     })
 
     test("#given Linux platform #when git command executes #then uses unix export syntax", async () => {
@@ -210,7 +325,7 @@ describe("non-interactive-env hook", () => {
       process.env.SHELL = "/bin/bash"
       Object.defineProperty(process, "platform", { value: "linux" })
 
-      const hook = createNonInteractiveEnvHook(mockCtx)
+      const hook = createNonInteractiveEnvHook(mockCtx, { show_export_prefix: true })
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git commit -m 'test'" },
       }
@@ -223,6 +338,11 @@ describe("non-interactive-env hook", () => {
       const cmd = output.args.command as string
       expect(cmd).toStartWith("export ")
       expect(cmd).toContain("; git commit")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
     })
 
     test("#given Windows with PowerShell env #when bash tool git command executes #then still uses unix export syntax", async () => {
@@ -231,7 +351,7 @@ describe("non-interactive-env hook", () => {
       process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
       Object.defineProperty(process, "platform", { value: "win32" })
 
-      const hook = createNonInteractiveEnvHook(mockCtx)
+      const hook = createNonInteractiveEnvHook(mockCtx, { show_export_prefix: true })
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git status" },
       }
@@ -247,6 +367,11 @@ describe("non-interactive-env hook", () => {
       expect(cmd).toContain("; git status")
       expect(cmd).not.toContain("$env:")
       expect(cmd).not.toContain("set ")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
     })
 
     test("#given Windows without SHELL env #when bash tool git command executes #then still uses unix export syntax", async () => {
@@ -256,7 +381,7 @@ describe("non-interactive-env hook", () => {
       delete process.env.SHELL
       Object.defineProperty(process, "platform", { value: "win32" })
 
-      const hook = createNonInteractiveEnvHook(mockCtx)
+      const hook = createNonInteractiveEnvHook(mockCtx, { show_export_prefix: true })
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git log" },
       }
@@ -273,6 +398,11 @@ describe("non-interactive-env hook", () => {
       expect(cmd).not.toContain("set ")
       expect(cmd).not.toContain("&&")
       expect(cmd).not.toContain("$env:")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
     })
 
     test("#given Windows Git Bash environment #when git command executes #then uses unix export syntax", async () => {
@@ -281,7 +411,7 @@ describe("non-interactive-env hook", () => {
       process.env.SHELL = "/usr/bin/bash"
       Object.defineProperty(process, "platform", { value: "win32" })
 
-      const hook = createNonInteractiveEnvHook(mockCtx)
+      const hook = createNonInteractiveEnvHook(mockCtx, { show_export_prefix: true })
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git status" },
       }
@@ -294,6 +424,11 @@ describe("non-interactive-env hook", () => {
       const cmd = output.args.command as string
       expect(cmd).toStartWith("export ")
       expect(cmd).toContain("; git status")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
     })
 
     test("#given any platform #when chained git commands via bash tool #then uses unix export syntax", async () => {
@@ -302,7 +437,7 @@ describe("non-interactive-env hook", () => {
       delete process.env.SHELL
       Object.defineProperty(process, "platform", { value: "win32" })
 
-      const hook = createNonInteractiveEnvHook(mockCtx)
+      const hook = createNonInteractiveEnvHook(mockCtx, { show_export_prefix: true })
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git add file && git commit -m 'test'" },
       }
@@ -315,6 +450,11 @@ describe("non-interactive-env hook", () => {
       const cmd = output.args.command as string
       expect(cmd).toStartWith("export ")
       expect(cmd).toContain("; git add file && git commit")
+
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "test", callID: "1" },
+        { title: "bash", output: "", metadata: {} }
+      )
     })
   })
 })

--- a/src/hooks/non-interactive-env/index.ts
+++ b/src/hooks/non-interactive-env/index.ts
@@ -2,10 +2,10 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import type { ShellType } from "../../shared"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
 import { log, buildEnvPrefix } from "../../shared"
+import type { NonInteractiveEnvConfig } from "../../config/schema"
 
 export * from "./constants"
 export * from "./detector"
-export * from "./types"
 
 const BANNED_COMMAND_PATTERNS = SHELL_COMMAND_PATTERNS.banned
   .filter((cmd) => !cmd.includes("("))
@@ -20,7 +20,35 @@ function detectBannedCommand(command: string): string | undefined {
   return undefined
 }
 
-export function createNonInteractiveEnvHook(_ctx: PluginInput) {
+type EnvSnapshot = Record<string, string | undefined>
+
+function applyEnv(env: Record<string, string>): EnvSnapshot {
+  const snapshot: EnvSnapshot = {}
+  for (const [key, value] of Object.entries(env)) {
+    snapshot[key] = process.env[key]
+    process.env[key] = value
+  }
+  return snapshot
+}
+
+function restoreEnv(snapshot: EnvSnapshot): void {
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function shouldShowExportPrefix(config?: NonInteractiveEnvConfig): boolean {
+  return config?.show_export_prefix === true
+}
+
+export function createNonInteractiveEnvHook(_ctx: PluginInput, config?: NonInteractiveEnvConfig) {
+  const activeCalls = new Set<string>()
+  let activeCount = 0
+  let baseSnapshot: EnvSnapshot | null = null
   return {
     "tool.execute.before": async (
       input: { tool: string; sessionID: string; callID: string },
@@ -46,24 +74,56 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
         return
       }
 
-      // NOTE: We intentionally removed the isNonInteractive() check here.
-      // Even when OpenCode runs in a TTY, the agent cannot interact with
-      // spawned bash processes. Git commands like `git rebase --continue`
-      // would open editors (vim/nvim) that hang forever.
-      // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
-      // for git commands to prevent interactive prompts.
+      if (config?.disabled) {
+        return
+      }
 
-      // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
-      // (via Git Bash, WSL, etc.), so we always use unix export syntax.
-      // This fixes GitHub issues #983 and #889.
-      const shellType: ShellType = "unix"
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
-      output.args.command = `${envPrefix} ${command}`
+      if (!activeCalls.has(input.callID)) {
+        activeCalls.add(input.callID)
+        if (activeCount === 0) {
+          baseSnapshot = applyEnv(NON_INTERACTIVE_ENV)
+        }
+        activeCount += 1
+      }
 
-      log(`[${HOOK_NAME}] Prepended non-interactive env vars to git command`, {
-        sessionID: input.sessionID,
-        envPrefix,
-      })
+      if (shouldShowExportPrefix(config)) {
+        // NOTE: We intentionally removed the isNonInteractive() check here.
+        // Even when OpenCode runs in a TTY, the agent cannot interact with
+        // spawned bash processes. Git commands like `git rebase --continue`
+        // would open editors (vim/nvim) that hang forever.
+        // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
+        // for git commands to prevent interactive prompts.
+
+        // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
+        // (via Git Bash, WSL, etc.), so we always use unix export syntax.
+        // This fixes GitHub issues #983 and #889.
+        const shellType: ShellType = "unix"
+        const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
+        output.args.command = `${envPrefix} ${command}`
+
+        log(`[${HOOK_NAME}] Prepended non-interactive env vars to git command`, {
+          sessionID: input.sessionID,
+          envPrefix,
+        })
+      }
+    },
+    "tool.execute.after": async (
+      input: { tool: string; sessionID: string; callID: string }
+    ): Promise<void> => {
+      if (input.tool.toLowerCase() !== "bash") {
+        return
+      }
+
+      if (!activeCalls.has(input.callID)) {
+        return
+      }
+
+      activeCalls.delete(input.callID)
+      activeCount = Math.max(0, activeCount - 1)
+      if (activeCount === 0 && baseSnapshot) {
+        restoreEnv(baseSnapshot)
+        baseSnapshot = null
+      }
     },
   }
 }

--- a/src/hooks/non-interactive-env/types.ts
+++ b/src/hooks/non-interactive-env/types.ts
@@ -1,3 +1,0 @@
-export interface NonInteractiveEnvConfig {
-  disabled?: boolean
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,7 +196,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     ? createAgentUsageReminderHook(ctx)
     : null;
   const nonInteractiveEnv = isHookEnabled("non-interactive-env")
-    ? createNonInteractiveEnvHook(ctx)
+    ? createNonInteractiveEnvHook(ctx, pluginConfig.non_interactive_env)
     : null;
   const interactiveBashSession = isHookEnabled("interactive-bash-session")
     ? createInteractiveBashSessionHook(ctx)


### PR DESCRIPTION
## Summary

resolves #1378


- hide non-interactive env export prefixes by default while still setting git-safe env vars
- add config to opt-in to showing export prefixes and document the new options
- update hook tests to cover env restoration and parallel call handling

commit made by hephaestus + gpt 5.2 mid

## Testing
- bun test src/hooks/non-interactive-env/index.test.ts
- bun run typecheck
- bun run build
- bun test (fails: mcp-oauth login/logout tests require --server-url; unstable-agent-babysitter tests expect prompt; delegate-task tools tests time out)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the non-interactive env export prefix by default. Env vars for git commands are applied directly and restored after execution, keeping the command unchanged and reducing noise.

- **New Features**
  - Apply NON_INTERACTIVE_ENV silently for bash git commands and restore previous env after; safe with parallel calls.
  - Add non_interactive_env config with disabled and show_export_prefix (opt-in). Schema and docs updated.
  - Tests expanded for env restoration, parallel execution, and platform-specific behavior when prefix is enabled.

- **Migration**
  - To keep the old behavior, set: non_interactive_env.show_export_prefix = true.

<sup>Written for commit 9164666c5b07c588ff8ed7a29189df82a7eeee52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

