### PR TITLE
 fix: remove redundant removeCodeBlocks call

### DIFF
--- a/src/hooks/keyword-detector/index.ts
+++ b/src/hooks/keyword-detector/index.ts
@@ -36,7 +36,7 @@ export function createKeywordDetectorHook(ctx: PluginInput, collector?: ContextC
       // Remove system-reminder content to prevent automated system messages from triggering mode keywords
       const cleanText = removeSystemReminders(promptText)
       const modelID = input.model?.modelID
-      let detectedKeywords = detectKeywordsWithType(removeCodeBlocks(cleanText), currentAgent, modelID)
+      let detectedKeywords = detectKeywordsWithType(cleanText, currentAgent, modelID)
 
       if (isPlannerAgent(currentAgent)) {
         detectedKeywords = detectedKeywords.filter((k) => k.type !== "ultrawork")


### PR DESCRIPTION
Remove duplicate removeCodeBlocks() call in keyword-detector/index.ts.

The detectKeywordsWithType() function already calls removeCodeBlocks() internally, so calling it before passing the text was redundant and caused unnecessary double processing.

## Summary

- Remove redundant `removeCodeBlocks()` call to avoid duplicate text processing

## Changes

- Removed `removeCodeBlocks()` wrapper in `index.ts` when calling `detectKeywordsWithType()`
- `detectKeywordsWithType()` already handles code block removal internally, making the external call unnecessary

## Screenshots

<!-- Not applicable for this change - delete this section -->

## Testing

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the extra removeCodeBlocks() call in keyword-detector/index.ts. detectKeywordsWithType() already strips code blocks, so this avoids double processing while keeping behavior unchanged.

<sup>Written for commit f68a6f7d1b3f0a2ef3c3601243f6c7954bd213ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

