### PR TITLE
feat(#1389): Add Kimi Auto-Review Hook

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -87,7 +87,8 @@
           "atlas",
           "unstable-agent-babysitter",
           "stop-continuation-guard",
-          "tasks-todowrite-disabler"
+          "tasks-todowrite-disabler",
+          "kimi-auto-review"
         ]
       }
     },
@@ -3018,6 +3019,49 @@
               "type": "boolean"
             }
           }
+        }
+      }
+    },
+    "kimi_review": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "model": {
+          "default": "moonshot/kimi-k2.5",
+          "type": "string"
+        },
+        "blockOnCritical": {
+          "default": true,
+          "type": "boolean"
+        },
+        "reviewThreshold": {
+          "default": "code-only",
+          "type": "string",
+          "enum": [
+            "all",
+            "code-only"
+          ]
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignorePatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "timeoutMs": {
+          "default": 30000,
+          "type": "number",
+          "minimum": 5000,
+          "maximum": 120000
         }
       }
     }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -93,6 +93,7 @@ export const HookNameSchema = z.enum([
   "unstable-agent-babysitter",
   "stop-continuation-guard",
   "tasks-todowrite-disabler",
+  "kimi-auto-review",
 ])
 
 export const BuiltinCommandNameSchema = z.enum([
@@ -300,6 +301,23 @@ export const RalphLoopConfigSchema = z.object({
   state_dir: z.string().optional(),
 })
 
+export const KimiReviewConfigSchema = z.object({
+  /** Enable Kimi auto-review (default: true) */
+  enabled: z.boolean().default(true),
+  /** Model to use for review (default: moonshot/kimi-k2.5) */
+  model: z.string().default("moonshot/kimi-k2.5"),
+  /** Block execution on critical issues (default: true) */
+  blockOnCritical: z.boolean().default(true),
+  /** Review threshold: 'all' or 'code-only' (default: code-only) */
+  reviewThreshold: z.enum(["all", "code-only"]).default("code-only"),
+  /** File extensions to review (default: common code extensions) */
+  extensions: z.array(z.string()).optional(),
+  /** Glob patterns to ignore (default: test files) */
+  ignorePatterns: z.array(z.string()).optional(),
+  /** Timeout in milliseconds (default: 30000) */
+  timeoutMs: z.number().min(5000).max(120000).default(30000),
+})
+
 export const BackgroundTaskConfigSchema = z.object({
   defaultConcurrency: z.number().min(1).optional(),
   providerConcurrency: z.record(z.string(), z.number().min(0)).optional(),
@@ -389,6 +407,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
   browser_automation_engine: BrowserAutomationConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),
   sisyphus: SisyphusConfigSchema.optional(),
+  kimi_review: KimiReviewConfigSchema.optional(),
 })
 
 export type OhMyOpenCodeConfig = z.infer<typeof OhMyOpenCodeConfigSchema>
@@ -418,5 +437,6 @@ export type TmuxConfig = z.infer<typeof TmuxConfigSchema>
 export type TmuxLayout = z.infer<typeof TmuxLayoutSchema>
 export type SisyphusTasksConfig = z.infer<typeof SisyphusTasksConfigSchema>
 export type SisyphusConfig = z.infer<typeof SisyphusConfigSchema>
+export type KimiReviewConfig = z.infer<typeof KimiReviewConfigSchema>
 
 export { AnyMcpNameSchema, type AnyMcpName, McpNameSchema, type McpName } from "../mcp/types"

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -36,3 +36,5 @@ export { createSubagentQuestionBlockerHook } from "./subagent-question-blocker";
 export { createStopContinuationGuardHook, type StopContinuationGuard } from "./stop-continuation-guard";
 export { createCompactionContextInjector, type SummarizeContext } from "./compaction-context-injector";
 export { createUnstableAgentBabysitterHook } from "./unstable-agent-babysitter";
+export { createKimiAutoReviewHook, parseReviewResponse } from "./kimi-auto-review";
+export type { KimiReviewConfig, KimiReviewOptions, KimiReviewResult } from "./kimi-auto-review/types";

--- a/src/hooks/kimi-auto-review/constants.ts
+++ b/src/hooks/kimi-auto-review/constants.ts
@@ -1,0 +1,109 @@
+import type { KimiReviewConfig } from "./types"
+
+export const DEFAULT_MODEL = "moonshot/kimi-k2.5"
+
+export const DEFAULT_CONFIG: Required<KimiReviewConfig> = {
+  enabled: true,
+  model: DEFAULT_MODEL,
+  blockOnCritical: true,
+  reviewThreshold: "all",
+  extensions: [
+    ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java", ".cpp", ".c", ".kt", ".swift",
+    ".json", ".yaml", ".yml", ".toml", ".xml", ".ini", ".env",
+    ".sh", ".bash", ".zsh",
+    ".md", ".mdx",
+  ],
+  ignorePatterns: [
+    "**/test/**", "**/*.test.ts", "**/*.spec.ts", "**/node_modules/**", "**/__tests__/**",
+    "**/package-lock.json", "**/bun.lock", "**/yarn.lock", "**/pnpm-lock.yaml",
+  ],
+  timeoutMs: 30000,
+}
+
+export const CODE_EXTENSIONS = new Set(DEFAULT_CONFIG.extensions)
+
+export const TRIGGER_TOOLS = ["write", "edit"] as const
+export type TriggerTool = typeof TRIGGER_TOOLS[number]
+
+export const REVIEW_PROMPT_TEMPLATE = `You are a meticulous reviewer. Review the following change and identify issues.
+
+File: {{filePath}}
+Operation: {{operation}}
+
+{{#if oldContent}}
+Previous content:
+\`\`\`
+{{oldContent}}
+\`\`\`
+{{/if}}
+
+{{#if newContent}}
+New content:
+\`\`\`
+{{newContent}}
+\`\`\`
+{{/if}}
+
+{{#if content}}
+Content:
+\`\`\`
+{{content}}
+\`\`\`
+{{/if}}
+
+Respond in this EXACT format:
+
+REVIEW: [APPROVED or ISSUES_FOUND]
+
+[CRITICAL] (only if critical issues exist)
+- Issue description
+  File: path:line (if applicable)
+  Fix: How to resolve
+
+[WARNING] (only if warnings exist)
+- Issue description
+  Suggestion: Recommended improvement
+
+[STYLE] (only if style issues exist)
+- Minor style/convention issue
+
+For CODE files, focus on:
+1. Security vulnerabilities (injection, XSS, secrets exposure)
+2. Logic errors and bugs
+3. Type safety issues
+4. Error handling gaps
+5. Performance problems
+
+For CONFIG files (.json, .yaml, .toml, .env), focus on:
+1. Secrets/credentials accidentally committed
+2. Invalid syntax or structure
+3. Missing required fields
+4. Inconsistent or conflicting settings
+5. Security misconfigurations
+
+For DOCUMENTATION (.md), focus on:
+1. Accuracy of technical claims
+2. Outdated or misleading information
+3. Missing critical warnings
+
+Use the SESSION CONTEXT (if provided) to understand:
+1. What the user is trying to accomplish
+2. Whether the change aligns with the stated goal
+3. Potential conflicts with other recent changes
+
+Be concise and specific. Only flag REAL issues, not preferences.
+CRITICAL = must fix before proceeding
+WARNING = should fix but not blocking
+STYLE = optional improvements`
+
+export const APPROVED_RESPONSE = "[KIMI REVIEW] APPROVED - No issues found."
+
+export const buildReviewBlockMessage = (issues: string[]): string => {
+  return `[KIMI REVIEW - BLOCKING]
+
+Critical issues found. You MUST fix these before proceeding:
+
+${issues.join("\n")}
+
+DO NOT continue until these issues are resolved.`
+}

--- a/src/hooks/kimi-auto-review/index.test.ts
+++ b/src/hooks/kimi-auto-review/index.test.ts
@@ -1,0 +1,380 @@
+import { describe, test, expect, beforeEach, mock, spyOn } from "bun:test"
+import type { KimiReviewConfig, KimiReviewResult, ToolExecuteInput, ToolExecuteOutput } from "./types"
+import { DEFAULT_CONFIG, TRIGGER_TOOLS } from "./constants"
+
+const createMockPluginInput = (overrides: {
+  promptMock?: ReturnType<typeof mock>
+  messagesMock?: ReturnType<typeof mock>
+  createMock?: ReturnType<typeof mock>
+  getMock?: ReturnType<typeof mock>
+  reviewResponse?: string
+} = {}) => {
+  const promptCalls: Array<{ sessionID: string; agent: string; text: string }> = []
+  
+  const getMock = overrides.getMock ?? mock(async () => ({
+    data: { directory: "/test/project" }
+  }))
+
+  const createMock = overrides.createMock ?? mock(async () => ({
+    data: { id: "review-session-123" }
+  }))
+
+  const promptMock = overrides.promptMock ?? mock(async (opts: {
+    path: { id: string }
+    body: { agent: string; parts: Array<{ type: string; text: string }> }
+  }) => {
+    promptCalls.push({
+      sessionID: opts.path.id,
+      agent: opts.body.agent,
+      text: opts.body.parts[0]?.text ?? "",
+    })
+    return {}
+  })
+
+  const defaultReviewResponse = overrides.reviewResponse ?? "REVIEW: APPROVED\n\nNo issues found."
+  const messagesMock = overrides.messagesMock ?? mock(async () => ({
+    data: [{ 
+      info: { 
+        role: "assistant",
+        time: { created: Date.now() }
+      },
+      parts: [{ type: "text", text: defaultReviewResponse }]
+    }]
+  }))
+
+  return {
+    ctx: {
+      client: {
+        session: {
+          get: getMock,
+          create: createMock,
+          prompt: promptMock,
+          messages: messagesMock,
+        },
+        app: {
+          agents: mock(async () => ({ data: [] })),
+        },
+        tui: {
+          showToast: mock(async () => ({})),
+        },
+      },
+      directory: "/test/project",
+    },
+    promptCalls,
+    promptMock,
+    messagesMock,
+    createMock,
+    getMock,
+  }
+}
+
+describe("kimi-auto-review hook", () => {
+  describe("hook creation", () => {
+    test("should create hook with default config", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+
+      expect(hook).toBeDefined()
+      expect(hook["tool.execute.after"]).toBeDefined()
+      expect(typeof hook["tool.execute.after"]).toBe("function")
+    })
+
+    test("should create hook with custom config", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx } = createMockPluginInput()
+
+      const customConfig: KimiReviewConfig = {
+        enabled: false,
+        model: "custom/model",
+        blockOnCritical: false,
+      }
+
+      const hook = createKimiAutoReviewHook(ctx as any, { config: customConfig })
+
+      expect(hook).toBeDefined()
+    })
+  })
+
+  describe("trigger conditions", () => {
+    test("should trigger on 'write' tool", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+      const input: ToolExecuteInput = { tool: "write", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { title: "Write", output: "Wrote file", metadata: { filePath: "/src/file.ts" } }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).toHaveBeenCalled()
+    })
+
+    test("should trigger on 'edit' tool", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+      const input: ToolExecuteInput = { tool: "edit", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { title: "Edit", output: "Edited file", metadata: { filePath: "/src/file.ts" } }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).toHaveBeenCalled()
+    })
+
+    test("should trigger on 'Write' tool (case insensitive)", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+      const input: ToolExecuteInput = { tool: "Write", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { title: "Write", output: "Wrote file", metadata: { filePath: "/src/file.ts" } }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).toHaveBeenCalled()
+    })
+
+    test("should NOT trigger on 'read' tool", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+      const input: ToolExecuteInput = { tool: "read", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { title: "Read", output: "File content", metadata: {} }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).not.toHaveBeenCalled()
+    })
+
+    test("should NOT trigger on 'bash' tool", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+      const input: ToolExecuteInput = { tool: "bash", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { title: "Bash", output: "Command output", metadata: {} }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("file filtering", () => {
+    test("should review .ts files by default", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+      const input: ToolExecuteInput = { tool: "write", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { 
+        title: "Write", 
+        output: "Wrote file", 
+        metadata: { filePath: "/src/file.ts" } 
+      }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).toHaveBeenCalled()
+    })
+
+    test("should skip .txt files when reviewThreshold is code-only", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any, {
+        config: { reviewThreshold: "code-only" }
+      })
+      const input: ToolExecuteInput = { tool: "write", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { 
+        title: "Write", 
+        output: "Wrote file", 
+        metadata: { filePath: "/src/notes.txt" } 
+      }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).not.toHaveBeenCalled()
+    })
+
+    test("should skip test files matching ignorePatterns", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+      const input: ToolExecuteInput = { tool: "write", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { 
+        title: "Write", 
+        output: "Wrote file", 
+        metadata: { filePath: "/src/file.test.ts" } 
+      }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).not.toHaveBeenCalled()
+    })
+
+    test("should respect custom extensions config", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any, {
+        config: { extensions: [".md"], ignorePatterns: [] }
+      })
+      const input: ToolExecuteInput = { tool: "write", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { 
+        title: "Write", 
+        output: "Wrote file", 
+        metadata: { filePath: "/src/README.md" } 
+      }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).toHaveBeenCalled()
+    })
+  })
+
+  describe("disabled state", () => {
+    test("should skip review when enabled=false", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const { ctx, promptMock } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any, { config: { enabled: false } })
+      const input: ToolExecuteInput = { tool: "write", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { 
+        title: "Write", 
+        output: "Wrote file", 
+        metadata: { filePath: "/src/file.ts" } 
+      }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(promptMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("output injection", () => {
+    test("should inject review summary into output.output for approved review", async () => {
+      const { createKimiAutoReviewHook, parseReviewResponse } = await import("./index")
+      const { ctx } = createMockPluginInput()
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+      const input: ToolExecuteInput = { tool: "write", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { 
+        title: "Write", 
+        output: "Wrote file", 
+        metadata: { filePath: "/src/file.ts" } 
+      }
+
+      await hook["tool.execute.after"]?.(input, output)
+
+      expect(output.output).toContain("[KIMI REVIEW]")
+    })
+  })
+
+  describe("error handling", () => {
+    test("should handle API errors gracefully", async () => {
+      const { createKimiAutoReviewHook } = await import("./index")
+      const errorMock = mock(async () => {
+        throw new Error("API Error")
+      })
+      const { ctx } = createMockPluginInput({ promptMock: errorMock })
+
+      const hook = createKimiAutoReviewHook(ctx as any)
+      const input: ToolExecuteInput = { tool: "write", sessionID: "test-session", callID: "call-1" }
+      const output: ToolExecuteOutput = { 
+        title: "Write", 
+        output: "Wrote file", 
+        metadata: { filePath: "/src/file.ts" } 
+      }
+
+      const result = await hook["tool.execute.after"]?.(input, output)
+      expect(result).toBeUndefined()
+    })
+  })
+})
+
+describe("parseReviewResponse", () => {
+  test("should parse APPROVED verdict", async () => {
+    const { parseReviewResponse } = await import("./index")
+
+    const response = "REVIEW: APPROVED\n\nNo issues found."
+    const result = parseReviewResponse(response)
+
+    expect(result.verdict).toBe("APPROVED")
+    expect(result.issues).toHaveLength(0)
+  })
+
+  test("should parse ISSUES_FOUND with CRITICAL issues", async () => {
+    const { parseReviewResponse } = await import("./index")
+
+    const response = `REVIEW: ISSUES_FOUND
+
+[CRITICAL]
+- SQL injection vulnerability in query builder
+  File: src/db.ts:42
+  Fix: Use parameterized queries`
+
+    const result = parseReviewResponse(response)
+
+    expect(result.verdict).toBe("ISSUES_FOUND")
+    expect(result.issues.some(i => i.severity === "CRITICAL")).toBe(true)
+    expect(result.issues[0].file).toBe("src/db.ts")
+    expect(result.issues[0].line).toBe(42)
+    expect(result.issues[0].suggestion).toBe("Use parameterized queries")
+  })
+
+  test("should parse ISSUES_FOUND with WARNING issues", async () => {
+    const { parseReviewResponse } = await import("./index")
+
+    const response = `REVIEW: ISSUES_FOUND
+
+[WARNING]
+- Missing error handling for async operation
+  Suggestion: Add try-catch block`
+
+    const result = parseReviewResponse(response)
+
+    expect(result.verdict).toBe("ISSUES_FOUND")
+    expect(result.issues.some(i => i.severity === "WARNING")).toBe(true)
+    expect(result.issues[0].suggestion).toBe("Add try-catch block")
+  })
+
+  test("should parse ISSUES_FOUND with STYLE issues", async () => {
+    const { parseReviewResponse } = await import("./index")
+
+    const response = `REVIEW: ISSUES_FOUND
+
+[STYLE]
+- Inconsistent naming convention`
+
+    const result = parseReviewResponse(response)
+
+    expect(result.verdict).toBe("ISSUES_FOUND")
+    expect(result.issues.some(i => i.severity === "STYLE")).toBe(true)
+  })
+
+  test("should parse mixed severity issues", async () => {
+    const { parseReviewResponse } = await import("./index")
+
+    const response = `REVIEW: ISSUES_FOUND
+
+[CRITICAL]
+- Security issue
+
+[WARNING]
+- Performance concern
+
+[STYLE]
+- Naming convention`
+
+    const result = parseReviewResponse(response)
+
+    expect(result.verdict).toBe("ISSUES_FOUND")
+    expect(result.issues).toHaveLength(3)
+  })
+})

--- a/src/hooks/kimi-auto-review/index.ts
+++ b/src/hooks/kimi-auto-review/index.ts
@@ -1,0 +1,431 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import type { 
+  KimiReviewConfig, 
+  KimiReviewOptions, 
+  KimiReviewResult, 
+  ReviewIssue, 
+  ReviewSeverity,
+  ToolExecuteInput,
+  ToolExecuteOutput 
+} from "./types"
+import { 
+  DEFAULT_CONFIG, 
+  TRIGGER_TOOLS, 
+  REVIEW_PROMPT_TEMPLATE,
+  APPROVED_RESPONSE,
+  buildReviewBlockMessage 
+} from "./constants"
+import { log, promptWithModelSuggestionRetry } from "../../shared"
+import { minimatch } from "minimatch"
+import { extname } from "node:path"
+
+const KIMI_REVIEWER_AGENT = "kimi-reviewer"
+
+export function parseReviewResponse(response: string): KimiReviewResult {
+  const lines = response.split("\n")
+  const issues: ReviewIssue[] = []
+  let verdict: "APPROVED" | "ISSUES_FOUND" = "APPROVED"
+  let currentSeverity: ReviewSeverity | null = null
+  let currentIssueLines: string[] = []
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    if (trimmed.startsWith("REVIEW:")) {
+      const verdictMatch = trimmed.match(/REVIEW:\s*(APPROVED|ISSUES_FOUND)/i)
+      if (verdictMatch) {
+        verdict = verdictMatch[1].toUpperCase() as "APPROVED" | "ISSUES_FOUND"
+      }
+      continue
+    }
+
+    const severityMatch = trimmed.match(/^\[(CRITICAL|WARNING|STYLE)\]$/)
+    if (severityMatch) {
+      if (currentSeverity && currentIssueLines.length > 0) {
+        issues.push(createIssue(currentSeverity, currentIssueLines))
+      }
+      currentSeverity = severityMatch[1] as ReviewSeverity
+      currentIssueLines = []
+      continue
+    }
+
+    if (currentSeverity && trimmed.startsWith("-")) {
+      if (currentIssueLines.length > 0) {
+        issues.push(createIssue(currentSeverity, currentIssueLines))
+      }
+      currentIssueLines = [trimmed.slice(1).trim()]
+    } else if (currentSeverity && trimmed && currentIssueLines.length > 0) {
+      currentIssueLines.push(trimmed)
+    }
+  }
+
+  if (currentSeverity && currentIssueLines.length > 0) {
+    issues.push(createIssue(currentSeverity, currentIssueLines))
+  }
+
+  return {
+    verdict,
+    issues,
+    summary: verdict === "APPROVED" 
+      ? "No issues found." 
+      : `Found ${issues.length} issue(s).`,
+    rawResponse: response,
+  }
+}
+
+function createIssue(severity: ReviewSeverity, lines: string[]): ReviewIssue {
+  const message = lines[0] ?? ""
+  let file: string | undefined
+  let line: number | undefined
+  let suggestion: string | undefined
+
+  for (const l of lines.slice(1)) {
+    if (l.startsWith("File:")) {
+      const match = l.match(/File:\s*(.+?)(?::(\d+))?$/)
+      if (match) {
+        file = match[1].trim()
+        line = match[2] ? parseInt(match[2], 10) : undefined
+      }
+    } else if (l.startsWith("Fix:") || l.startsWith("Suggestion:")) {
+      suggestion = l.replace(/^(Fix|Suggestion):\s*/, "").trim()
+    }
+  }
+
+  return { severity, message, file, line, suggestion }
+}
+
+function shouldReviewFile(
+  filePath: string, 
+  config: Required<KimiReviewConfig>
+): boolean {
+  for (const pattern of config.ignorePatterns) {
+    if (minimatch(filePath, pattern)) {
+      return false
+    }
+  }
+
+  if (config.reviewThreshold === "all") {
+    return true
+  }
+
+  const ext = extname(filePath)
+  const extensions = new Set(config.extensions)
+  return extensions.has(ext)
+}
+
+function extractFilePath(output: ToolExecuteOutput): string | undefined {
+  const metadata = output.metadata as Record<string, unknown> | undefined
+  
+  if (metadata?.filePath && typeof metadata.filePath === "string") {
+    return metadata.filePath
+  }
+  if (metadata?.file_path && typeof metadata.file_path === "string") {
+    return metadata.file_path
+  }
+  
+  const outputText = output.output
+  const writeMatch = outputText.match(/(?:Wrote|Edited|Created)\s+(?:file\s+)?['"]?([^\s'"]+)['"]?/i)
+  if (writeMatch) {
+    return writeMatch[1]
+  }
+
+  return undefined
+}
+
+function buildReviewPrompt(
+  filePath: string,
+  operation: string,
+  content?: string,
+  oldContent?: string,
+  newContent?: string,
+  sessionContext?: string
+): string {
+  let prompt = REVIEW_PROMPT_TEMPLATE
+    .replace("{{filePath}}", filePath)
+    .replace("{{operation}}", operation)
+
+  if (oldContent) {
+    prompt = prompt.replace("{{#if oldContent}}", "").replace("{{/if}}", "")
+    prompt = prompt.replace("{{oldContent}}", oldContent)
+  } else {
+    prompt = prompt.replace(/\{\{#if oldContent\}\}[\s\S]*?\{\{\/if\}\}/g, "")
+  }
+
+  if (newContent) {
+    prompt = prompt.replace("{{#if newContent}}", "").replace("{{/if}}", "")
+    prompt = prompt.replace("{{newContent}}", newContent)
+  } else {
+    prompt = prompt.replace(/\{\{#if newContent\}\}[\s\S]*?\{\{\/if\}\}/g, "")
+  }
+
+  if (content) {
+    prompt = prompt.replace("{{#if content}}", "").replace("{{/if}}", "")
+    prompt = prompt.replace("{{content}}", content)
+  } else {
+    prompt = prompt.replace(/\{\{#if content\}\}[\s\S]*?\{\{\/if\}\}/g, "")
+  }
+
+  if (sessionContext) {
+    prompt += `\n\n${sessionContext}`
+  }
+
+  return prompt
+}
+
+function formatReviewOutput(result: KimiReviewResult): string {
+  if (result.verdict === "APPROVED") {
+    return APPROVED_RESPONSE
+  }
+
+  const lines = [`[KIMI REVIEW] ISSUES_FOUND - ${result.summary}`]
+  
+  const criticals = result.issues.filter(i => i.severity === "CRITICAL")
+  const warnings = result.issues.filter(i => i.severity === "WARNING")
+  const styles = result.issues.filter(i => i.severity === "STYLE")
+
+  if (criticals.length > 0) {
+    lines.push("\n[CRITICAL]")
+    for (const issue of criticals) {
+      lines.push(`- ${issue.message}`)
+      if (issue.file) lines.push(`  File: ${issue.file}${issue.line ? `:${issue.line}` : ""}`)
+      if (issue.suggestion) lines.push(`  Fix: ${issue.suggestion}`)
+    }
+  }
+
+  if (warnings.length > 0) {
+    lines.push("\n[WARNING]")
+    for (const issue of warnings) {
+      lines.push(`- ${issue.message}`)
+      if (issue.suggestion) lines.push(`  Suggestion: ${issue.suggestion}`)
+    }
+  }
+
+  if (styles.length > 0) {
+    lines.push("\n[STYLE]")
+    for (const issue of styles) {
+      lines.push(`- ${issue.message}`)
+    }
+  }
+
+  return lines.join("\n")
+}
+
+async function fetchSessionContext(
+  ctx: PluginInput,
+  sessionID: string,
+  maxMessages = 10
+): Promise<string> {
+  try {
+    const messagesResult = await ctx.client.session.messages({
+      path: { id: sessionID },
+    })
+
+    if (messagesResult.error || !messagesResult.data) {
+      return ""
+    }
+
+    const messages = messagesResult.data
+      .slice(-maxMessages)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .filter((m: any) => m.info.role === "user" || m.info.role === "assistant")
+
+    if (messages.length === 0) {
+      return ""
+    }
+
+    const contextLines: string[] = ["## Session Context (recent conversation)"]
+    
+    for (const msg of messages) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const role = (msg as any).info.role === "user" ? "User" : "Assistant"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const textParts = (msg as any).parts
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .filter((p: any) => p.type === "text")
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .map((p: any) => p.text)
+        .join("\n")
+      
+      if (textParts) {
+        const truncated = textParts.length > 500 
+          ? textParts.slice(0, 500) + "..." 
+          : textParts
+        contextLines.push(`\n**${role}**: ${truncated}`)
+      }
+    }
+
+    return contextLines.join("\n")
+  } catch (error) {
+    log(`[kimi-auto-review] Failed to fetch session context: ${error}`)
+    return ""
+  }
+}
+
+async function invokeKimiReview(
+  ctx: PluginInput,
+  parentSessionID: string,
+  reviewPrompt: string,
+  config: Required<KimiReviewConfig>
+): Promise<KimiReviewResult> {
+  const parentSession = await ctx.client.session.get({
+    path: { id: parentSessionID },
+  }).catch(() => null)
+  const parentDirectory = parentSession?.data?.directory ?? ctx.directory
+
+  const createResult = await ctx.client.session.create({
+    body: {
+      parentID: parentSessionID,
+      title: `kimi-review: code review`,
+      permission: [
+        { permission: "question", action: "deny" as const, pattern: "*" },
+      ],
+    } as any,
+    query: {
+      directory: parentDirectory,
+    },
+  })
+
+  if (createResult.error) {
+    log(`[kimi-auto-review] Session create error:`, createResult.error)
+    throw new Error(`Failed to create review session: ${createResult.error}`)
+  }
+
+  const sessionID = createResult.data.id
+  log(`[kimi-auto-review] Created review session: ${sessionID}`)
+
+  let agentModel: { providerID: string; modelID: string } | undefined
+  if (config.model) {
+    const modelParts = config.model.split("/")
+    if (modelParts.length >= 2) {
+      agentModel = {
+        providerID: modelParts[0],
+        modelID: modelParts.slice(1).join("/"),
+      }
+      log(`[kimi-auto-review] Using model: ${config.model}`)
+    }
+  }
+
+  const promptPromise = promptWithModelSuggestionRetry(ctx.client, {
+    path: { id: sessionID },
+    body: {
+      agent: KIMI_REVIEWER_AGENT,
+      tools: {
+        task: false,
+        call_omo_agent: false,
+        look_at: false,
+        read: true,
+        glob: true,
+        grep: true,
+      },
+      parts: [{ type: "text", text: reviewPrompt }],
+      ...(agentModel ? { model: { providerID: agentModel.providerID, modelID: agentModel.modelID } } : {}),
+    },
+  })
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(`Review timed out after ${config.timeoutMs}ms`)), config.timeoutMs)
+  })
+
+  await Promise.race([promptPromise, timeoutPromise])
+
+  const messagesResult = await ctx.client.session.messages({
+    path: { id: sessionID },
+  })
+
+  if (messagesResult.error) {
+    log(`[kimi-auto-review] Messages error:`, messagesResult.error)
+    throw new Error(`Failed to get review messages: ${messagesResult.error}`)
+  }
+
+  const messages = messagesResult.data
+  log(`[kimi-auto-review] Got ${messages.length} messages from review session`)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const lastAssistantMessage = messages
+    .filter((m: any) => m.info.role === "assistant")
+    .sort((a: any, b: any) => (b.info.time?.created || 0) - (a.info.time?.created || 0))[0]
+
+  if (!lastAssistantMessage) {
+    log(`[kimi-auto-review] No assistant message found in review session`)
+    return {
+      verdict: "APPROVED",
+      issues: [],
+      summary: "Review agent did not respond.",
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const textParts = lastAssistantMessage.parts.filter((p: any) => p.type === "text")
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const responseText = textParts.map((p: any) => p.text).join("\n")
+
+  log(`[kimi-auto-review] Got review response, length: ${responseText.length}`)
+
+  return parseReviewResponse(responseText)
+}
+
+export function createKimiAutoReviewHook(
+  ctx: PluginInput,
+  options?: KimiReviewOptions
+) {
+  const config: Required<KimiReviewConfig> = {
+    ...DEFAULT_CONFIG,
+    ...options?.config,
+    extensions: options?.config?.extensions ?? DEFAULT_CONFIG.extensions,
+    ignorePatterns: options?.config?.ignorePatterns ?? DEFAULT_CONFIG.ignorePatterns,
+  }
+
+  return {
+    "tool.execute.after": async (
+      input: ToolExecuteInput,
+      output: ToolExecuteOutput
+    ): Promise<{ block?: boolean; reason?: string } | void> => {
+      if (!config.enabled) {
+        return
+      }
+
+      const toolLower = input.tool.toLowerCase()
+      if (!TRIGGER_TOOLS.includes(toolLower as typeof TRIGGER_TOOLS[number])) {
+        return
+      }
+
+      const filePath = extractFilePath(output)
+      if (!filePath) {
+        log("[kimi-auto-review] Could not extract file path from output")
+        return
+      }
+
+      if (!shouldReviewFile(filePath, config)) {
+        log(`[kimi-auto-review] Skipping non-code file: ${filePath}`)
+        return
+      }
+
+      try {
+        const operation = toolLower === "write" ? "Write (create/overwrite)" : "Edit (modify)"
+        
+        const sessionContext = await fetchSessionContext(ctx, input.sessionID)
+        const reviewPrompt = buildReviewPrompt(filePath, operation, undefined, undefined, undefined, sessionContext)
+
+        log(`[kimi-auto-review] Invoking review for: ${filePath}`)
+        const reviewResult = await invokeKimiReview(ctx, input.sessionID, reviewPrompt, config)
+
+        const reviewOutput = formatReviewOutput(reviewResult)
+        output.output += `\n\n${reviewOutput}`
+
+        if (config.blockOnCritical && reviewResult.issues.some(i => i.severity === "CRITICAL")) {
+          const criticalMessages = reviewResult.issues
+            .filter(i => i.severity === "CRITICAL")
+            .map(i => `- ${i.message}`)
+          
+          return {
+            block: true,
+            reason: buildReviewBlockMessage(criticalMessages),
+          }
+        }
+      } catch (err) {
+        log(`[kimi-auto-review] Error invoking review: ${err}`)
+        // Don't block on review errors - fail open
+      }
+    },
+  }
+}

--- a/src/hooks/kimi-auto-review/types.ts
+++ b/src/hooks/kimi-auto-review/types.ts
@@ -1,0 +1,43 @@
+export interface KimiReviewConfig {
+  enabled?: boolean
+  model?: string
+  blockOnCritical?: boolean
+  reviewThreshold?: "all" | "code-only"
+  extensions?: string[]
+  ignorePatterns?: string[]
+  timeoutMs?: number
+}
+
+export interface KimiReviewOptions {
+  config?: KimiReviewConfig
+}
+
+export type ReviewSeverity = "CRITICAL" | "WARNING" | "STYLE"
+export type ReviewVerdict = "APPROVED" | "ISSUES_FOUND"
+
+export interface ReviewIssue {
+  severity: ReviewSeverity
+  message: string
+  file?: string
+  line?: number
+  suggestion?: string
+}
+
+export interface KimiReviewResult {
+  verdict: ReviewVerdict
+  issues: ReviewIssue[]
+  summary: string
+  rawResponse?: string
+}
+
+export interface ToolExecuteInput {
+  tool: string
+  sessionID: string
+  callID: string
+}
+
+export interface ToolExecuteOutput {
+  title: string
+  output: string
+  metadata: unknown
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   createStopContinuationGuardHook,
   createCompactionContextInjector,
   createUnstableAgentBabysitterHook,
+  createKimiAutoReviewHook,
 } from "./hooks";
 import {
   contextCollector,
@@ -319,6 +320,10 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
           }
         )
       : null;
+
+  const kimiAutoReview = isHookEnabled("kimi-auto-review")
+    ? createKimiAutoReviewHook(ctx, { config: pluginConfig.kimi_review })
+    : null;
 
   if (sessionRecovery && todoContinuationEnforcer) {
     sessionRecovery.setOnAbortCallback(todoContinuationEnforcer.markRecovering);
@@ -757,6 +762,16 @@ await editErrorRecovery?.["tool.execute.after"](input, output);
         await delegateTaskRetry?.["tool.execute.after"](input, output);
         await atlasHook?.["tool.execute.after"]?.(input, output);
       await taskResumeInfo["tool.execute.after"](input, output);
+      const kimiResult = await kimiAutoReview?.["tool.execute.after"]?.(input, output);
+      if (kimiResult?.block && kimiResult.reason) {
+        ctx.client.session
+          .prompt({
+            path: { id: input.sessionID },
+            body: { parts: [{ type: "text", text: kimiResult.reason }] },
+            query: { directory: ctx.directory },
+          })
+          .catch((err: unknown) => log("[kimi-auto-review] Failed to inject block prompt", err));
+      }
     },
 
     "experimental.session.compacting": async (input: { sessionID: string }) => {


### PR DESCRIPTION
## Summary
Adds a PostToolUse hook that automatically invokes Kimi model to review code changes after Write/Edit operations.

## Changes
- **New hook**: `src/hooks/kimi-auto-review/` with full TDD test coverage (19 tests)
- **Config schema**: `KimiReviewConfigSchema` added to support configuration
- **Integration**: Hook registered in main plugin, conditionally enabled

## Features
- Triggers on Write/Edit operations
- Reviews code files (configurable extensions)
- Skips test files and non-code files
- Parses review responses (APPROVED/ISSUES_FOUND)
- Blocks on CRITICAL issues when configured
- Injects review feedback into conversation

## Configuration
```json
{
  "kimi_review": {
    "enabled": true,
    "model": "moonshot/kimi-k2.5",
    "blockOnCritical": true,
    "reviewThreshold": "code-only"
  }
}
```

## Testing
- 19 comprehensive tests covering all scenarios
- TDD workflow: RED → GREEN → REFACTOR

Closes #1389

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Kimi auto-review hook that runs after Write/Edit to review changes, use recent session context, and optionally block on critical issues. Registers the hook, isolates reviews in a child session, and adds config to enable and tune behavior, aligning with #1389.

- **New Features**
  - Runs after Write/Edit; reviews code, config, and docs; skips tests and lockfiles by pattern.
  - Parses results (APPROVED/ISSUES_FOUND), injects feedback, blocks on CRITICAL when enabled.
  - Runs review in an isolated child session, pulls recent session context, and uses kimi_review.model directly; supports timeout.
  - New kimi_review config (enabled, model: moonshot/kimi-k2.5, blockOnCritical, reviewThreshold: all by default, extensions, ignorePatterns, timeoutMs).
  - Hook exported and wired into tool.execute.after; 19 tests cover triggers, filtering, parsing, and errors.

- **Migration**
  - Enabled by default; to disable set kimi_review.enabled=false or add to disabled_hooks.
  - To limit scope to code only, set kimi_review.reviewThreshold=code-only; customize extensions, ignorePatterns, or model via the kimi_review block.

<sup>Written for commit 36bd4c044d02cc6818debb3bba8cd1db12fa15e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

