### PR TITLE
fix: grep and glob tools usage without path param under Opencode Desktop

### DIFF
--- a/src/tools/glob/tools.ts
+++ b/src/tools/glob/tools.ts
@@ -20,10 +20,12 @@ export const glob: ToolDefinition = tool({
           "simply omit it for the default behavior. Must be a valid directory path if provided."
       ),
   },
-  execute: async (args) => {
+  execute: async (args, ctx) => {
     try {
       const cli = await resolveGrepCliWithAutoInstall()
-      const paths = args.path ? [args.path] : undefined
+      // Use ctx.directory as the default search path when no path is provided
+      const searchPath = args.path ?? ctx.directory
+      const paths = [searchPath]
 
       const result = await runRgFiles(
         {

--- a/src/tools/grep/tools.ts
+++ b/src/tools/grep/tools.ts
@@ -20,10 +20,12 @@ export const grep: ToolDefinition = tool({
       .optional()
       .describe("The directory to search in. Defaults to the current working directory."),
   },
-  execute: async (args) => {
+  execute: async (args, ctx) => {
     try {
       const globs = args.include ? [args.include] : undefined
-      const paths = args.path ? [args.path] : undefined
+      // Use ctx.directory as the default search path when no path is provided
+      const searchPath = args.path ?? ctx.directory
+      const paths = [searchPath]
 
       const result = await runRg({
         pattern: args.pattern,


### PR DESCRIPTION
Fixes grep and glob tools usage without path param under Opencode Desktop

## Summary

Grep and Glob now uses ctx.directory when no path data is given. In OpenCode Desktop, the cwd is "/" when run via Finder or Dock, this causes the tools to run under "/" instead of the project directory. This small change fixes the problem as opencode pushed changes so that ctx receives the correct directory now (via Instance.directory) 

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->
https://github.com/code-yeongyu/oh-my-opencode/issues/658
https://github.com/code-yeongyu/oh-my-opencode/issues/588

-- also probably from opencode 
https://github.com/anomalyco/opencode/issues/7143

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes grep and glob running under “/” in OpenCode Desktop by defaulting the search path to ctx.directory when no path is provided. Searches now run in the project directory even when Desktop launches with cwd set to “/”.

<sup>Written for commit 527c21ea90e348f415570112c85cc77fdcb2a4bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

