### PR TITLE
fix: honor agent variant overrides

### DIFF
--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -84,13 +84,14 @@ describe("applyAgentVariant", () => {
 
 describe("resolveVariantForModel", () => {
   test("returns agent override variant when configured", () => {
-    // given
+    // given - use a model in sisyphus chain (claude-opus-4-5 has default variant "max")
+    // to verify override takes precedence over fallback chain
     const config = {
       agents: {
         sisyphus: { variant: "high" },
       },
     } as OhMyOpenCodeConfig
-    const model = { providerID: "github-copilot", modelID: "gpt-5.2" }
+    const model = { providerID: "anthropic", modelID: "claude-opus-4-5" }
 
     // when
     const variant = resolveVariantForModel(config, "sisyphus", model)

--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -83,6 +83,22 @@ describe("applyAgentVariant", () => {
 })
 
 describe("resolveVariantForModel", () => {
+  test("returns agent override variant when configured", () => {
+    // given
+    const config = {
+      agents: {
+        sisyphus: { variant: "high" },
+      },
+    } as OhMyOpenCodeConfig
+    const model = { providerID: "github-copilot", modelID: "gpt-5.2" }
+
+    // when
+    const variant = resolveVariantForModel(config, "sisyphus", model)
+
+    // then
+    expect(variant).toBe("high")
+  })
+
   test("returns correct variant for anthropic provider", () => {
     // given
     const config = {} as OhMyOpenCodeConfig


### PR DESCRIPTION
## Summary
- honor agent-level variant overrides before fallback-chain resolution
- require provider+model match when resolving variants to avoid cross-model leakage
- add coverage for override variant behavior

## Testing
- bun test src/shared/agent-variant.test.ts
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes variant resolution by using the agent’s override variant before any fallback chain and by requiring both provider and model to match, preventing cross-model leakage. Adds support for variant in agent config and a unit test for override behavior.

<sup>Written for commit 5546859c9e8a359145495edf48464ab5dd27c5ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

