### PR TITLE
fix(delegate-task): extract tool_result content from subagent messages

### DIFF
--- a/src/tools/delegate-task/executor.ts
+++ b/src/tools/delegate-task/executor.ts
@@ -37,9 +37,54 @@ export interface ParentContext {
   model?: { providerID: string; modelID: string; variant?: string }
 }
 
+interface SessionMessagePart {
+  type?: string
+  text?: string
+  content?: string | Array<{ type: string; text?: string }>
+  output?: string
+}
+
 interface SessionMessage {
   info?: { role?: string; time?: { created?: number }; agent?: string; model?: { providerID: string; modelID: string }; modelID?: string; providerID?: string }
-  parts?: Array<{ type?: string; text?: string }>
+  parts?: SessionMessagePart[]
+}
+
+function isTextOrReasoningPart(part: { type?: string; text?: string }): boolean {
+  return (part.type === "text" || part.type === "reasoning") && !!part.text
+}
+
+function extractToolResultContent(part: SessionMessagePart): string[] {
+  const results: string[] = []
+
+  if (typeof part.content === "string" && part.content) {
+    results.push(part.content)
+  } else if (Array.isArray(part.content)) {
+    for (const block of part.content) {
+      if (isTextOrReasoningPart(block)) {
+        results.push(block.text!)
+      }
+    }
+  }
+
+  if (part.output && part.output.length > 0) {
+    results.push(part.output)
+  }
+
+  return results
+}
+
+function extractMessageContent(message: SessionMessage): string {
+  const extractedContent: string[] = []
+
+  for (const part of message.parts ?? []) {
+    if (isTextOrReasoningPart(part)) {
+      extractedContent.push(part.text!)
+    } else if (part.type === "tool_result") {
+      extractedContent.push(...extractToolResultContent(part))
+    }
+  }
+
+  return extractedContent.filter(text => text.length > 0).join("\n\n")
 }
 
 export async function resolveSkillContent(
@@ -274,8 +319,7 @@ export async function executeSyncContinuation(
     return `No assistant response found.\n\nSession ID: ${args.session_id}`
   }
 
-  const textParts = lastMessage?.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
-  const textContent = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+  const textContent = extractMessageContent(lastMessage)
   const duration = formatDuration(startTime)
 
   return `Task continued and completed in ${duration}.
@@ -400,8 +444,7 @@ export async function executeUnstableAgentTask(
       return `No assistant response found (task ran in background mode).\n\nSession ID: ${sessionID}`
     }
 
-    const textParts = lastMessage?.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
-    const textContent = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+    const textContent = extractMessageContent(lastMessage)
     const duration = formatDuration(startTime)
 
     return `SUPERVISED TASK COMPLETED SUCCESSFULLY
@@ -707,8 +750,7 @@ export async function executeSyncTask(
       return `No assistant response found.\n\nSession ID: ${sessionID}`
     }
 
-    const textParts = lastMessage?.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
-    const textContent = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+    const textContent = extractMessageContent(lastMessage)
 
     const duration = formatDuration(startTime)
 

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -2721,4 +2721,180 @@ describe("sisyphus-task", () => {
       expect(result).toContain("</task_metadata>")
     }, { timeout: 10000 })
   })
+
+  describe("tool_result content extraction", () => {
+    test("sync task extracts tool_result content from messages", async () => {
+      //#given
+      const { createDelegateTask } = require("./tools")
+      const mockManager = { launch: async () => ({}) }
+
+      const mockClient = {
+        app: { agents: async () => ({ data: [] }) },
+        config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
+        model: { list: async () => [{ provider: "anthropic", id: "claude-haiku-4-5" }] },
+        session: {
+          get: async () => ({ data: { directory: "/project" } }),
+          create: async () => ({ data: { id: "ses_tool_result_test" } }),
+          prompt: async () => ({ data: {} }),
+          messages: async () => ({
+            data: [{
+              info: { role: "assistant", time: { created: 1 } },
+              parts: [
+                { type: "tool", tool: "bash" },
+                { type: "tool_result", content: "On branch main\nYour branch is up to date with 'origin/main'.\n\nnothing to commit, working tree clean" },
+                { type: "text", text: "Git status shows clean working tree." }
+              ]
+            }]
+          }),
+          status: async () => ({ data: { "ses_tool_result_test": { type: "idle" } } }),
+        },
+      }
+
+      const tool = createDelegateTask({
+        manager: mockManager,
+        client: mockClient,
+      })
+
+      const toolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "sisyphus",
+        abort: new AbortController().signal,
+      }
+
+      //#when
+      const result = await tool.execute(
+        {
+          description: "Git status task",
+          prompt: "Run git status",
+          category: "quick",
+          run_in_background: false,
+          load_skills: [],
+        },
+        toolContext
+      )
+
+      //#then
+      expect(result).toContain("On branch main")
+      expect(result).toContain("nothing to commit, working tree clean")
+      expect(result).toContain("Git status shows clean working tree.")
+    }, { timeout: 20000 })
+
+    test("sync task extracts tool_result with array content", async () => {
+      //#given
+      const { createDelegateTask } = require("./tools")
+      const mockManager = { launch: async () => ({}) }
+
+      const mockClient = {
+        app: { agents: async () => ({ data: [] }) },
+        config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
+        model: { list: async () => [{ provider: "anthropic", id: "claude-haiku-4-5" }] },
+        session: {
+          get: async () => ({ data: { directory: "/project" } }),
+          create: async () => ({ data: { id: "ses_array_content_test" } }),
+          prompt: async () => ({ data: {} }),
+          messages: async () => ({
+            data: [{
+              info: { role: "assistant", time: { created: 1 } },
+              parts: [
+                { 
+                  type: "tool_result", 
+                  content: [
+                    { type: "text", text: "File created: test.txt" },
+                    { type: "text", text: "Lines written: 10" }
+                  ]
+                }
+              ]
+            }]
+          }),
+          status: async () => ({ data: { "ses_array_content_test": { type: "idle" } } }),
+        },
+      }
+
+      const tool = createDelegateTask({
+        manager: mockManager,
+        client: mockClient,
+      })
+
+      const toolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "sisyphus",
+        abort: new AbortController().signal,
+      }
+
+      //#when
+      const result = await tool.execute(
+        {
+          description: "Create file task",
+          prompt: "Create a file",
+          category: "quick",
+          run_in_background: false,
+          load_skills: [],
+        },
+        toolContext
+      )
+
+      //#then
+      expect(result).toContain("File created: test.txt")
+      expect(result).toContain("Lines written: 10")
+    }, { timeout: 20000 })
+
+    test("sync task extracts tool_result with output property", async () => {
+      //#given
+      const { createDelegateTask } = require("./tools")
+      const mockManager = { launch: async () => ({}) }
+
+      const mockClient = {
+        app: { agents: async () => ({ data: [] }) },
+        config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
+        model: { list: async () => [{ provider: "anthropic", id: "claude-haiku-4-5" }] },
+        session: {
+          get: async () => ({ data: { directory: "/project" } }),
+          create: async () => ({ data: { id: "ses_output_prop_test" } }),
+          prompt: async () => ({ data: {} }),
+          messages: async () => ({
+            data: [{
+              info: { role: "assistant", time: { created: 1 } },
+              parts: [
+                { 
+                  type: "tool_result", 
+                  output: "commit abc123\nAuthor: Test User\nDate: Mon Jan 1 00:00:00 2024\n\n    Initial commit"
+                }
+              ]
+            }]
+          }),
+          status: async () => ({ data: { "ses_output_prop_test": { type: "idle" } } }),
+        },
+      }
+
+      const tool = createDelegateTask({
+        manager: mockManager,
+        client: mockClient,
+      })
+
+      const toolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "sisyphus",
+        abort: new AbortController().signal,
+      }
+
+      //#when
+      const result = await tool.execute(
+        {
+          description: "Git log task",
+          prompt: "Run git log",
+          category: "quick",
+          run_in_background: false,
+          load_skills: [],
+        },
+        toolContext
+      )
+
+      //#then
+      expect(result).toContain("commit abc123")
+      expect(result).toContain("Initial commit")
+    }, { timeout: 20000 })
+  })
 })


### PR DESCRIPTION
## Summary

- Fix #1261 where git-master tasks return empty output
- Add extraction of `tool_result` content from assistant messages in `delegate_task`
- Match the extraction behavior of `background_output` for consistency

## Changes

- Add helper functions to extract content from all relevant message part types:
  - `isTextOrReasoningPart()` - Check for text/reasoning content
  - `extractToolResultContent()` - Extract content from tool_result parts (string, array, or output property)
  - `extractMessageContent()` - Combine both to extract all relevant content from a message
- Update all three output extraction locations in `executor.ts`:
  - `executeSyncContinuation` (line 322)
  - `executeUnstableAgentTask` (line 447)
  - `executeSyncTask` (line 753)
- Add 3 new tests covering tool_result content extraction

## Testing

```bash
bun test src/tools/delegate-task/tools.test.ts --test-name-pattern "tool_result"
# 3 pass, 0 fail
```

## Related Issues

Closes #1261

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include tool_result output in delegate_task responses so subagent tool results (e.g., git output) are visible. Resolves #1261 where git-master tasks returned empty output.

- **Bug Fixes**
  - Parse tool_result parts (string, array, or output) alongside text/reasoning.
  - Added helpers: isTextOrReasoningPart, extractToolResultContent, extractMessageContent.
  - Applied unified extraction in executeSyncContinuation, executeUnstableAgentTask, and executeSyncTask.
  - Added 3 tests covering string, array, and output cases; aligns with background_output behavior.

<sup>Written for commit fdde945d2e6fff9ce117d07c25528d5003bce17a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

