### PR TITLE
fix(delegate-task): honor sisyphus-junior model override precedence

### DIFF
--- a/src/tools/delegate-task/executor.ts
+++ b/src/tools/delegate-task/executor.ts
@@ -793,16 +793,20 @@ export async function resolveCategoryExecution(
   let modelInfo: ModelFallbackInfo | undefined
   let categoryModel: { providerID: string; modelID: string; variant?: string } | undefined
 
+  const overrideModel = sisyphusJuniorModel
+
   if (!requirement) {
-    actualModel = resolved.model
+    actualModel = overrideModel ?? resolved.model
     if (actualModel) {
-      modelInfo = { model: actualModel, type: "system-default", source: "system-default" }
+      modelInfo = overrideModel
+        ? { model: actualModel, type: "user-defined", source: "override" }
+        : { model: actualModel, type: "system-default", source: "system-default" }
     }
   } else {
     const resolution = resolveModelPipeline({
       intent: {
-        userModel: userCategories?.[args.category!]?.model,
-        categoryDefaultModel: resolved.model ?? sisyphusJuniorModel,
+        userModel: overrideModel ?? userCategories?.[args.category!]?.model,
+        categoryDefaultModel: resolved.model,
       },
       constraints: { availableModels },
       policy: {


### PR DESCRIPTION
## Summary
- ensure sisyphus-junior model override takes precedence over category defaults
- keep model resolution metadata aligned with override usage
- add regression test covering override precedence

## Testing
- bun test src/tools/delegate-task/tools.test.ts
- bun run typecheck
- bun run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritize the sisyphus-junior model override over category defaults in delegate-task execution, and mark override usage correctly in model resolution metadata. Adds a regression test to lock this behavior.

- **Bug Fixes**
  - Use sisyphus-junior override as the selected model before category defaults.
  - Tag override usage as user-defined with source "override" in modelInfo.
  - Add regression test verifying override beats category model in ultrabrain.

<sup>Written for commit 6230ecef37f2f8550d807deeb29897132a2ca0ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

