### PR TITLE
feat(agents): respect uiSelectedModel in Atlas model resolution

### DIFF
--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -49,6 +49,36 @@ describe("createBuiltinAgents with model overrides", () => {
     expect(agents.sisyphus.thinking).toBeUndefined()
   })
 
+  test("Atlas uses uiSelectedModel when provided", async () => {
+    // #given
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
+      new Set(["openai/gpt-5.2", "anthropic/claude-sonnet-4-5"])
+    )
+    const uiSelectedModel = "openai/gpt-5.2"
+
+    try {
+      // #when
+      const agents = await createBuiltinAgents(
+        [],
+        {},
+        undefined,
+        TEST_DEFAULT_MODEL,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        uiSelectedModel
+      )
+
+      // #then
+      expect(agents.atlas).toBeDefined()
+      expect(agents.atlas.model).toBe("openai/gpt-5.2")
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   test("Sisyphus is created on first run when no availableModels or cache exist", async () => {
     // #given
     const systemDefaultModel = "anthropic/claude-opus-4-5"

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -446,17 +446,17 @@ export async function createBuiltinAgents(
      result[name] = config
    }
 
-   if (!disabledAgents.includes("atlas")) {
-     const orchestratorOverride = agentOverrides["atlas"]
-     const atlasRequirement = AGENT_MODEL_REQUIREMENTS["atlas"]
-    
-    const atlasResolution = applyModelResolution({
-      // NOTE: Atlas does NOT use uiSelectedModel - respects its own fallbackChain (k2p5 primary)
-      userModel: orchestratorOverride?.model,
-      requirement: atlasRequirement,
-      availableModels,
-      systemDefaultModel,
-    })
+    if (!disabledAgents.includes("atlas")) {
+      const orchestratorOverride = agentOverrides["atlas"]
+      const atlasRequirement = AGENT_MODEL_REQUIREMENTS["atlas"]
+
+      const atlasResolution = applyModelResolution({
+        uiSelectedModel,
+        userModel: orchestratorOverride?.model,
+        requirement: atlasRequirement,
+        availableModels,
+        systemDefaultModel,
+      })
     
     if (atlasResolution) {
       const { model: atlasModel, variant: atlasResolvedVariant } = atlasResolution


### PR DESCRIPTION
Atlas now respects uiSelectedModel when resolving model in createBuiltinAgents. Added test coverage for this behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Atlas now respects uiSelectedModel when resolving its model in createBuiltinAgents, so it uses the user’s selected model when available. Added a unit test to lock this behavior.

- **New Features**
  - Pass uiSelectedModel into Atlas applyModelResolution, with existing fallbacks if unavailable.
  - Added test verifying Atlas picks the provided uiSelectedModel when available.

<sup>Written for commit 1bc79dad7433a99a1fbf8a9ab0b11cc5c278cfaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

