### PR TITLE
refactor(background-agent): optimize lifecycle and simplify tools

### DIFF
--- a/src/tools/background-task/tools.test.ts
+++ b/src/tools/background-task/tools.test.ts
@@ -304,6 +304,30 @@ describe("background_cancel", () => {
     expect(cancelled).toEqual([taskA.id, taskB.id])
     expect(output).toContain("Cancelled 2 background task(s)")
   })
+
+  test("preserves original status in cancellation table", async () => {
+    // #given
+    const taskA = createTask({ id: "task-a", status: "running", sessionID: "ses-a", description: "running task" })
+    const taskB = createTask({ id: "task-b", status: "pending", sessionID: undefined, description: "pending task" })
+    const manager = {
+      getTask: () => undefined,
+      getAllDescendantTasks: () => [taskA, taskB],
+      cancelTask: async (taskId: string) => {
+        const task = taskId === taskA.id ? taskA : taskB
+        task.status = "cancelled"
+        return true
+      },
+    } as unknown as BackgroundManager
+    const client = { session: { abort: async () => ({}) } } as BackgroundCancelClient
+    const tool = createBackgroundCancel(manager, client)
+
+    // #when
+    const output = await tool.execute({ all: true }, mockContext)
+
+    // #then
+    expect(output).toContain("| `task-a` | running task | running | `ses-a` |")
+    expect(output).toContain("| `task-b` | pending task | pending | (not started) |")
+  })
 })
 type BackgroundOutputMessage = {
   id?: string

--- a/src/tools/background-task/tools.test.ts
+++ b/src/tools/background-task/tools.test.ts
@@ -1,7 +1,7 @@
-import { createBackgroundOutput } from "./tools"
-import type { BackgroundTask } from "../../features/background-agent"
+import { createBackgroundCancel, createBackgroundOutput } from "./tools"
+import type { BackgroundManager, BackgroundTask } from "../../features/background-agent"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
-import type { BackgroundOutputManager, BackgroundOutputClient } from "./tools"
+import type { BackgroundCancelClient, BackgroundOutputManager, BackgroundOutputClient } from "./tools"
 
 const projectDir = "/Users/yeongyu/local-workspaces/oh-my-opencode"
 
@@ -251,6 +251,58 @@ describe("background_output full_session", () => {
     // #then
     expect(output).toContain("[thinking] " + "y".repeat(2000) + "...")
     expect(output).not.toContain("y".repeat(2100))
+  })
+})
+
+describe("background_cancel", () => {
+  test("cancels a running task via manager", async () => {
+    // #given
+    const task = createTask({ status: "running" })
+    const cancelled: string[] = []
+    const manager = {
+      getTask: (id: string) => (id === task.id ? task : undefined),
+      getAllDescendantTasks: () => [task],
+      cancelTask: async (taskId: string) => {
+        cancelled.push(taskId)
+        task.status = "cancelled"
+        return true
+      },
+    } as unknown as BackgroundManager
+    const client = { session: { abort: async () => ({}) } } as BackgroundCancelClient
+    const tool = createBackgroundCancel(manager, client)
+
+    // #when
+    const output = await tool.execute({ taskId: task.id }, mockContext)
+
+    // #then
+    expect(cancelled).toEqual([task.id])
+    expect(output).toContain("Task cancelled successfully")
+  })
+
+  test("cancels all running or pending tasks", async () => {
+    // #given
+    const taskA = createTask({ id: "task-a", status: "running" })
+    const taskB = createTask({ id: "task-b", status: "pending" })
+    const cancelled: string[] = []
+    const manager = {
+      getTask: () => undefined,
+      getAllDescendantTasks: () => [taskA, taskB],
+      cancelTask: async (taskId: string) => {
+        cancelled.push(taskId)
+        const task = taskId === taskA.id ? taskA : taskB
+        task.status = "cancelled"
+        return true
+      },
+    } as unknown as BackgroundManager
+    const client = { session: { abort: async () => ({}) } } as BackgroundCancelClient
+    const tool = createBackgroundCancel(manager, client)
+
+    // #when
+    const output = await tool.execute({ all: true }, mockContext)
+
+    // #then
+    expect(cancelled).toEqual([taskA.id, taskB.id])
+    expect(output).toContain("Cancelled 2 background task(s)")
   })
 })
 type BackgroundOutputMessage = {

--- a/src/tools/background-task/tools.ts
+++ b/src/tools/background-task/tools.ts
@@ -638,15 +638,16 @@ export function createBackgroundCancel(manager: BackgroundManager, client: Backg
           }> = []
 
           for (const task of cancellableTasks) {
+            const originalStatus = task.status
             const cancelled = await manager.cancelTask(task.id, {
               source: "background_cancel",
-              abortSession: task.status === "running",
+              abortSession: originalStatus === "running",
             })
             if (!cancelled) continue
             cancelledInfo.push({
               id: task.id,
               description: task.description,
-              status: task.status === "pending" ? "pending" : "running",
+              status: originalStatus === "pending" ? "pending" : "running",
               sessionID: task.sessionID,
             })
           }
@@ -668,7 +669,7 @@ Continuable sessions:
 ${resumableTasks.map(t => `- \`${t.sessionID}\` (${t.description})`).join("\n")}`
              : ""
 
-          return `Cancelled ${cancellableTasks.length} background task(s):
+          return `Cancelled ${cancelledInfo.length} background task(s):
 
 | Task ID | Description | Status | Session ID |
 |---------|-------------|--------|------------|

--- a/src/tools/background-task/tools.ts
+++ b/src/tools/background-task/tools.ts
@@ -638,28 +638,17 @@ export function createBackgroundCancel(manager: BackgroundManager, client: Backg
           }> = []
 
           for (const task of cancellableTasks) {
-            if (task.status === "pending") {
-              manager.cancelPendingTask(task.id)
-              cancelledInfo.push({
-                id: task.id,
-                description: task.description,
-                status: "pending",
-                sessionID: undefined,
-              })
-            } else if (task.sessionID) {
-              client.session.abort({
-                path: { id: task.sessionID },
-              }).catch(() => {})
-
-              task.status = "cancelled"
-              task.completedAt = new Date()
-              cancelledInfo.push({
-                id: task.id,
-                description: task.description,
-                status: "running",
-                sessionID: task.sessionID,
-              })
-            }
+            const cancelled = await manager.cancelTask(task.id, {
+              source: "background_cancel",
+              abortSession: task.status === "running",
+            })
+            if (!cancelled) continue
+            cancelledInfo.push({
+              id: task.id,
+              description: task.description,
+              status: task.status === "pending" ? "pending" : "running",
+              sessionID: task.sessionID,
+            })
           }
 
           const tableRows = cancelledInfo
@@ -697,31 +686,21 @@ ${resumeSection}`
 Only running or pending tasks can be cancelled.`
         }
 
-        if (task.status === "pending") {
-          // Pending task: use manager method (no session to abort, no slot to release)
-          const cancelled = manager.cancelPendingTask(task.id)
-          if (!cancelled) {
-            return `[ERROR] Failed to cancel pending task: ${task.id}`
-          }
+        const cancelled = await manager.cancelTask(task.id, {
+          source: "background_cancel",
+          abortSession: task.status === "running",
+        })
+        if (!cancelled) {
+          return `[ERROR] Failed to cancel task: ${task.id}`
+        }
 
+        if (task.status === "pending") {
           return `Pending task cancelled successfully
 
 Task ID: ${task.id}
 Description: ${task.description}
 Status: ${task.status}`
         }
-
-        // Running task: abort session
-        // Fire-and-forget: abort 요청을 보내고 await 하지 않음
-        // await 하면 메인 세션까지 abort 되는 문제 발생
-        if (task.sessionID) {
-          client.session.abort({
-            path: { id: task.sessionID },
-          }).catch(() => {})
-        }
-
-        task.status = "cancelled"
-        task.completedAt = new Date()
 
         return `Task cancelled successfully
 


### PR DESCRIPTION
## Summary
- Optimize cache timer lifecycle and result handling in background-agent manager
- Simplify background-task tool implementation and expand test coverage
- Fix BackgroundCancel tool parameter handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies task cancellation in BackgroundManager with a new cancelTask that handles both pending and running tasks, releasing concurrency, clearing timers, and notifying parent sessions. Simplifies the background_cancel tool to delegate to the manager and adds focused tests.

- **Refactors**
  - Added BackgroundManager.cancelTask to cancel running/pending tasks, release concurrency, clear completion timers, clean pendingByParent, notify parent, optionally abort session, and record a reason.
  - cancelPendingTask now delegates to cancelTask.
  - background_cancel tool now uses manager.cancelTask for single/all cancellations and preserves each task’s original status in the summary table; tests cover single/all paths and output.

- **Bug Fixes**
  - Fixed BackgroundCancel tool parameter names and validation to match actual usage.
  - Corrected cancellation summary to count only successfully cancelled tasks.

<sup>Written for commit 7610611a548b322200260dede60d1729d2312d40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

