### PR TITLE
refactor(ultrawork): simplify workflow and apply parallel context gathering

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -8,6 +8,9 @@
     "$schema": {
       "type": "string"
     },
+    "new_task_system_enabled": {
+      "type": "boolean"
+    },
     "default_run_agent": {
       "type": "string"
     },

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -8,9 +8,6 @@
     "$schema": {
       "type": "string"
     },
-    "new_task_system_enabled": {
-      "type": "boolean"
-    },
     "default_run_agent": {
       "type": "string"
     },
@@ -2754,6 +2751,9 @@
               }
             }
           }
+        },
+        "task_system": {
+          "type": "boolean"
         }
       }
     },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -368,8 +368,6 @@ export const SisyphusConfigSchema = z.object({
 })
 export const OhMyOpenCodeConfigSchema = z.object({
   $schema: z.string().optional(),
-  /** Enable new task system (default: false) */
-  new_task_system_enabled: z.boolean().optional(),
   /** Default agent name for `oh-my-opencode run` (env: OPENCODE_DEFAULT_AGENT) */
   default_run_agent: z.string().optional(),
   disabled_mcps: z.array(AnyMcpNameSchema).optional(),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -368,6 +368,8 @@ export const SisyphusConfigSchema = z.object({
 })
 export const OhMyOpenCodeConfigSchema = z.object({
   $schema: z.string().optional(),
+  /** Enable new task system (default: false) */
+  new_task_system_enabled: z.boolean().optional(),
   /** Default agent name for `oh-my-opencode run` (env: OPENCODE_DEFAULT_AGENT) */
   default_run_agent: z.string().optional(),
   disabled_mcps: z.array(AnyMcpNameSchema).optional(),

--- a/src/hooks/keyword-detector/ultrawork/default.ts
+++ b/src/hooks/keyword-detector/ultrawork/default.ts
@@ -2,9 +2,9 @@
  * Default ultrawork message optimized for Claude series models.
  *
  * Key characteristics:
- * - Optimized for Claude's tendency to be "helpful" by forcing explicit delegation
- * - "DELEGATE. ALWAYS." instruction counters Claude's natural inclination to do everything
- * - Strong emphasis on parallel agent usage and category+skills delegation
+ * - Natural tool-like usage of explore/librarian agents (background=true)
+ * - Parallel execution emphasized - fire agents and continue working
+ * - Simple workflow: EXPLORES → GATHER → PLAN → DELEGATE
  */
 
 export const ULTRAWORK_DEFAULT_MESSAGE = `<ultrawork-mode>
@@ -44,12 +44,9 @@ export const ULTRAWORK_DEFAULT_MESSAGE = `<ultrawork-mode>
 
 **WHEN IN DOUBT:**
 \`\`\`
-delegate_task(subagent_type="explore", load_skills=[], prompt="Find [X] patterns in codebase", run_in_background=true)
-delegate_task(subagent_type="librarian", load_skills=[], prompt="Find docs/examples for [Y]", run_in_background=true)
-
-// Hard problem? DON'T struggle alone:
-delegate_task(subagent_type="oracle", load_skills=[], run_in_background=false, prompt="...")         // conventional: architecture, debugging
-delegate_task(category="artistry", load_skills=[], run_in_background=false, prompt="...")    // non-conventional: needs different approach
+delegate_task(agent="explore", prompt="Find [X] patterns in codebase", background=true)
+delegate_task(agent="librarian", prompt="Find docs/examples for [Y]", background=true)
+delegate_task(agent="oracle", prompt="Review my approach: [describe plan]")
 \`\`\`
 
 **ONLY AFTER YOU HAVE:**
@@ -178,83 +175,18 @@ delegate_task(category="quick", load_skills=["git-master"])
 
 ---
 
-## EXECUTION RULES (PARALLELIZATION)
+## EXECUTION RULES
+- **TODO**: Track EVERY step. Mark complete IMMEDIATELY after each.
+- **PARALLEL**: Fire independent agent calls simultaneously via delegate_task(background=true) - NEVER wait sequentially.
+- **BACKGROUND FIRST**: Use delegate_task for exploration/research agents (10+ concurrent if needed).
+- **VERIFY**: Re-read request after completion. Check ALL requirements met before reporting done.
+- **DELEGATE**: Don't do everything yourself - orchestrate specialized agents for their strengths.
 
-| Rule | Implementation |
-|------|----------------|
-| **PARALLEL FIRST** | Fire ALL **truly independent** agents simultaneously via delegate_task(run_in_background=true) |
-| **DATA DEPENDENCY CHECK** | If task B requires output FROM task A, B MUST wait for A to complete |
-| **10+ CONCURRENT** | Use 10+ background agents if needed for comprehensive exploration |
-| **COLLECT BEFORE DEPENDENT** | Collect results with background_output() BEFORE invoking dependent tasks |
-
-### DEPENDENCY EXCEPTIONS (OVERRIDES PARALLEL FIRST)
-
-| Agent | Dependency | Must Wait For |
-|-------|------------|---------------|
-| plan | explore/librarian results | Collect explore outputs FIRST |
-| execute | plan output | Finalized work plan |
-
-**CRITICAL: Plan agent REQUIRES explore results as input. This is a DATA DEPENDENCY, not parallelizable.**
-
-\`\`\`
-// WRONG: Launching plan without explore results
-delegate_task(subagent_type="explore", run_in_background=true, prompt="...")
-delegate_task(subagent_type="plan", prompt="...")  // BAD - no context yet!
-
-// CORRECT: Collect explore results BEFORE plan
-delegate_task(subagent_type="explore", run_in_background=true, prompt="...")  // task_id_1
-// ... wait or continue other work ...
-context = background_output(task_id="task_id_1")  // COLLECT FIRST
-delegate_task(subagent_type="plan", prompt="<collected context + request>")  // NOW plan has context
-\`\`\`
-
----
-
-## WORKFLOW (MANDATORY SEQUENCE - STEPS HAVE DATA DEPENDENCIES)
-
-**CRITICAL: Steps 1→2→3 have DATA DEPENDENCIES. Each step REQUIRES output from the previous step.**
-
-\`\`\`
-[Step 1: EXPLORE] → output: context
-      ↓ (data dependency)
-[Step 2: COLLECT] → input: task_ids, output: gathered_context  
-      ↓ (data dependency)
-[Step 3: PLAN] → input: gathered_context + request
-\`\`\`
-
-1. **GATHER CONTEXT** (parallel background agents):
-   \`\`\`
-   task_id_1 = delegate_task(subagent_type="explore", run_in_background=true, prompt="...")
-   task_id_2 = delegate_task(subagent_type="librarian", run_in_background=true, prompt="...")
-   \`\`\`
-
-2. **COLLECT EXPLORE RESULTS** (REQUIRED before step 3):
-   \`\`\`
-   // You MUST collect results before invoking plan agent
-   explore_result = background_output(task_id=task_id_1)
-   librarian_result = background_output(task_id=task_id_2)
-   gathered_context = explore_result + librarian_result
-   \`\`\`
-
-3. **INVOKE PLAN AGENT** (input: gathered_context from step 2):
-   \`\`\`
-   result = delegate_task(subagent_type="plan", prompt="<gathered_context from step 2> + <user request>")
-   // STORE the session_id for follow-ups!
-   plan_session_id = result.session_id
-   \`\`\`
-
-4. **ITERATE WITH PLAN AGENT** (if clarification needed):
-   \`\`\`
-   // Use session_id to continue the conversation
-   delegate_task(session_id=plan_session_id, prompt="<answer to plan agent's question>")
-   \`\`\`
-
-5. **EXECUTE VIA DELEGATION** (category + skills from plan agent's output):
-   \`\`\`
-   delegate_task(category="...", load_skills=[...], run_in_background=false, prompt="<task from plan>")
-   \`\`\`
-
-6. **VERIFY** against original requirements
+## WORKFLOW
+1. Analyze the request and identify required capabilities
+2. Spawn exploration/librarian agents via delegate_task(background=true) in PARALLEL (10+ if needed)
+3. Use Plan agent with gathered context to create detailed work breakdown
+4. Execute with continuous verification against original requirements
 
 ## VERIFICATION GUARANTEE (NON-NEGOTIABLE)
 
@@ -327,11 +259,9 @@ Write these criteria explicitly. Share with user if scope is non-trivial.
 
 THE USER ASKED FOR X. DELIVER EXACTLY X. NOT A SUBSET. NOT A DEMO. NOT A STARTING POINT.
 
-1. EXPLORES + LIBRARIANS (background) → get task_ids
-2. COLLECT explore results via background_output() → gathered_context
-3. INVOKE PLAN with gathered_context: delegate_task(subagent_type="plan", prompt="<gathered_context + request>")
-4. ITERATE WITH PLAN AGENT (session_id resume) UNTIL PLAN IS FINALIZED
-5. WORK BY DELEGATING TO CATEGORY + SKILLS AGENTS (following plan agent's parallel task graph)
+1. EXPLORES + LIBRARIANS
+2. GATHER -> PLAN AGENT SPAWN
+3. WORK BY DELEGATING TO ANOTHER AGENTS
 
 NOW.
 

--- a/src/hooks/keyword-detector/ultrawork/default.ts
+++ b/src/hooks/keyword-detector/ultrawork/default.ts
@@ -44,9 +44,9 @@ export const ULTRAWORK_DEFAULT_MESSAGE = `<ultrawork-mode>
 
 **WHEN IN DOUBT:**
 \`\`\`
-delegate_task(agent="explore", prompt="Find [X] patterns in codebase", background=true)
-delegate_task(agent="librarian", prompt="Find docs/examples for [Y]", background=true)
-delegate_task(agent="oracle", prompt="Review my approach: [describe plan]")
+delegate_task(subagent_type="explore", load_skills=[], prompt="Find [X] patterns in codebase", run_in_background=true)
+delegate_task(subagent_type="librarian", load_skills=[], prompt="Find docs/examples for [Y]", run_in_background=true)
+delegate_task(subagent_type="oracle", load_skills=[], prompt="Review my approach: [describe plan]", run_in_background=false)
 \`\`\`
 
 **ONLY AFTER YOU HAVE:**

--- a/src/hooks/keyword-detector/ultrawork/gpt5.2.ts
+++ b/src/hooks/keyword-detector/ultrawork/gpt5.2.ts
@@ -97,12 +97,12 @@ Use these when they provide clear value based on the decision framework above:
 **ALWAYS run both tracks in parallel:**
 \`\`\`
 // Fire background agents for deep exploration
-delegate_task(agent="explore", prompt="Find X patterns...", background=true)
-delegate_task(agent="librarian", prompt="Find docs for Y...", background=true)
+delegate_task(subagent_type="explore", load_skills=[], prompt="Find X patterns...", run_in_background=true)
+delegate_task(subagent_type="librarian", load_skills=[], prompt="Find docs for Y...", run_in_background=true)
 
 // WHILE THEY RUN - use direct tools for immediate context
-Grep(pattern="relevant_pattern", path="src/")
-Read(filePath="known/important/file.ts")
+grep(pattern="relevant_pattern", path="src/")
+read_file(filePath="known/important/file.ts")
 
 // Collect background results when ready
 deep_context = background_output(task_id=...)

--- a/src/hooks/keyword-detector/ultrawork/gpt5.2.ts
+++ b/src/hooks/keyword-detector/ultrawork/gpt5.2.ts
@@ -4,13 +4,12 @@
  * Key characteristics (from GPT 5.2 Prompting Guide):
  * - "Stronger instruction adherence" - follows instructions more literally
  * - "Conservative grounding bias" - prefers correctness over speed
- * - "More deliberate scaffolding" - builds clearer plans by default
- * - Explicit decision criteria needed (model won't infer)
+ * - "Parallelize independent reads to reduce latency" - official guidance
  *
  * Design principles:
- * - Provide explicit complexity-based decision criteria
- * - Use conditional logic, not absolute commands
- * - Enable autonomous judgment with clear guidelines
+ * - Two-track parallel context gathering (Direct tools + Background agents)
+ * - Fire background agents, then use direct tools while waiting
+ * - Explicit complexity-based decision criteria
  */
 
 export const ULTRAWORK_GPT_MESSAGE = `<ultrawork-mode>
@@ -81,41 +80,47 @@ Use these when they provide clear value based on the decision framework above:
 | delegate_task category | Specialized work matching a category | \`delegate_task(category="...", load_skills=[...])\` |
 
 <tool_usage_rules>
-- Prefer tools over internal knowledge for fresh/user-specific data
-- Parallelize independent reads (explore, librarian) when gathering context
-- After any write/update, briefly restate: What changed, Where, Any follow-up needed
+- Prefer tools over internal knowledge for fresh or user-specific data
+- Parallelize independent reads (read_file, grep, explore, librarian) to reduce latency
+- After any write/update, briefly restate: What changed, Where (path), Follow-up needed
 </tool_usage_rules>
 
-## EXECUTION APPROACH
+## EXECUTION PATTERN
 
-### Step 1: Assess Complexity
-Before starting, classify the task using the decision framework above.
+**Context gathering uses TWO parallel tracks:**
 
-### Step 2: Gather Context (if needed)
-For non-trivial tasks, fire explore/librarian in parallel as background:
+| Track | Tools | Speed | Purpose |
+|-------|-------|-------|---------|
+| **Direct** | Grep, Read, LSP, AST-grep | Instant | Quick wins, known locations |
+| **Background** | explore, librarian agents | Async | Deep search, external docs |
+
+**ALWAYS run both tracks in parallel:**
 \`\`\`
-delegate_task(subagent_type="explore", run_in_background=true, prompt="Find patterns for X...")
-delegate_task(subagent_type="librarian", run_in_background=true, prompt="Find docs for Y...")
-// Continue working - collect results when needed with background_output()
+// Fire background agents for deep exploration
+delegate_task(agent="explore", prompt="Find X patterns...", background=true)
+delegate_task(agent="librarian", prompt="Find docs for Y...", background=true)
+
+// WHILE THEY RUN - use direct tools for immediate context
+Grep(pattern="relevant_pattern", path="src/")
+Read(filePath="known/important/file.ts")
+
+// Collect background results when ready
+deep_context = background_output(task_id=...)
+
+// Merge ALL findings for comprehensive understanding
 \`\`\`
 
-### Step 3: Plan (for complex tasks only)
-Only invoke plan agent if task has 5+ interdependent steps:
-\`\`\`
-// Collect context first
-context = background_output(task_id=task_id)
-// Then plan with context
-delegate_task(subagent_type="plan", prompt="<context> + <request>")
-\`\`\`
+**Plan agent (complex tasks only):**
+- Only if 5+ interdependent steps
+- Invoke AFTER gathering context from both tracks
 
-### Step 4: Execute
-- If doing yourself: make surgical, minimal changes matching existing patterns
+**Execute:**
+- Surgical, minimal changes matching existing patterns
 - If delegating: provide exhaustive context and success criteria
 
-### Step 5: Verify
-- Run \`lsp_diagnostics\` on modified files
+**Verify:**
+- \`lsp_diagnostics\` on modified files
 - Run tests if available
-- Confirm all success criteria met
 
 ## QUALITY STANDARDS
 


### PR DESCRIPTION
## Summary
- Simplify ultrawork workflow to natural tool-like agent usage (beta.16 style)
- Apply GPT-5.2 Prompting Guide two-track parallel context gathering
- Fire background agents + direct tools simultaneously for comprehensive context

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors ultrawork to a simpler, tool-like workflow that runs background agents in parallel with direct tools to cut latency. Adds a task_system setting to enable the new task API.

- **Refactors**
  - Simplified ultrawork default flow: EXPLORES → GATHER → PLAN → DELEGATE.
  - Restored beta.16-style delegate_task usage: subagent_type=..., run_in_background=true.
  - GPT-5.2 profile now uses two-track context gathering (background explore/librarian + direct grep/read_file/LSP) in parallel.
  - Condensed execution rules; removed verbose data-dependency sections.

- **Migration**
  - Add task_system in config (ExperimentalConfigSchema and schema JSON); new_task_system_enabled remains supported.
  - task_system enables the new task API (TaskCreate/Update/List/Get) and blocks TodoRead/TodoWrite; default is false.

<sup>Written for commit 72adc4302ce32d0034577b0afc6258f6ec000658. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

