### PR TITLE
refactor(config-handler): separate plan prompt into dedicated configuration

### DIFF
--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -176,10 +176,12 @@ describe("Plan agent demote behavior", () => {
     await handler(config)
 
     // then
-    const agents = config.agent as Record<string, { mode?: string; name?: string }>
+    const agents = config.agent as Record<string, { mode?: string; name?: string; prompt?: string }>
     expect(agents.plan).toBeDefined()
     expect(agents.plan.mode).toBe("subagent")
     expect(agents.plan.name).toBe("plan")
+    expect(agents.plan.prompt).toBe("original plan prompt")
+    expect(agents.plan.prompt).not.toBe(agents.prometheus?.prompt)
   })
 
   test("prometheus should have mode 'all' to be callable via delegate_task", async () => {


### PR DESCRIPTION
## Summary
- Separate plan prompt configuration into its own dedicated field
- Improves maintainability and clarity of config handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated the plan agent prompt into its own config and preserved it when plan is demoted to a subagent. Prevents the plan prompt from being overwritten by the prometheus config.

- **Refactors**
  - Split plan prompt handling from name/mode and pass it explicitly during plan demotion.

- **Bug Fixes**
  - Plan now keeps its original prompt when replaced by prometheus; no longer inherits the prometheus prompt.

<sup>Written for commit 7df7a9cd942ca57b83ce582f86135df97c224552. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

