### PR TITLE
fix(config-handler): preserve plan prompt when demoted

### DIFF
--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -184,6 +184,117 @@ describe("Plan agent demote behavior", () => {
     expect(agents.plan.prompt).not.toBe(agents.prometheus?.prompt)
   })
 
+  test("plan agent should not be demoted when replacePlan is false", async () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {
+      sisyphus_agent: {
+        planner_enabled: true,
+        replace_plan: false,
+      },
+    }
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-5",
+      agent: {
+        plan: {
+          name: "plan",
+          mode: "primary",
+          prompt: "original plan prompt",
+        },
+      },
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // when
+    await handler(config)
+
+    // then
+    const agents = config.agent as Record<string, { mode?: string; name?: string; prompt?: string }>
+    expect(agents.plan).toBeDefined()
+    expect(agents.plan.mode).toBe("primary")
+    expect(agents.plan.name).toBe("plan")
+    expect(agents.plan.prompt).toBe("original plan prompt")
+  })
+
+  test("plan agent should not be demoted when planner is disabled", async () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {
+      sisyphus_agent: {
+        planner_enabled: false,
+        replace_plan: true,
+      },
+    }
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-5",
+      agent: {
+        plan: {
+          name: "plan",
+          mode: "primary",
+          prompt: "original plan prompt",
+        },
+      },
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // when
+    await handler(config)
+
+    // then
+    const agents = config.agent as Record<string, { mode?: string; name?: string; prompt?: string }>
+    expect(agents.prometheus).toBeUndefined()
+    expect(agents.plan).toBeDefined()
+    expect(agents.plan.mode).toBe("primary")
+  })
+
+  test("preserves empty plan prompt when demoting", async () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {
+      sisyphus_agent: {
+        planner_enabled: true,
+        replace_plan: true,
+      },
+    }
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-5",
+      agent: {
+        plan: {
+          name: "plan",
+          mode: "primary",
+          prompt: "",
+        },
+      },
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // when
+    await handler(config)
+
+    // then
+    const agents = config.agent as Record<string, { prompt?: string }>
+    expect(agents.plan).toBeDefined()
+    expect(agents.plan.prompt).toBe("")
+  })
+
   test("prometheus should have mode 'all' to be callable via delegate_task", async () => {
     // given
     const pluginConfig: OhMyOpenCodeConfig = {

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -195,6 +195,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     const plannerEnabled =
       pluginConfig.sisyphus_agent?.planner_enabled ?? true;
     const replacePlan = pluginConfig.sisyphus_agent?.replace_plan ?? true;
+    const shouldReplacePlan = plannerEnabled && replacePlan;
 
     type AgentConfig = Record<
       string,
@@ -344,7 +345,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
           Object.entries(configAgent)
             .filter(([key]) => {
               if (key === "build") return false;
-              if (key === "plan" && replacePlan) return false;
+              if (key === "plan" && shouldReplacePlan) return false;
               // Filter out agents that oh-my-opencode provides to prevent
               // OpenCode defaults from overwriting user config in oh-my-opencode.json
               // See: https://github.com/code-yeongyu/oh-my-opencode/issues/472
@@ -362,12 +363,12 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
         ? migrateAgentConfig(configAgent.build as Record<string, unknown>)
         : {};
 
-      const planDemoteConfig = replacePlan && agentConfig["prometheus"]
+      const planDemoteConfig = shouldReplacePlan && agentConfig["prometheus"]
         ? {
             ...agentConfig["prometheus"],
             name: "plan",
             mode: "subagent" as const,
-            ...(planPrompt ? { prompt: planPrompt } : {}),
+            ...(typeof planPrompt === "string" ? { prompt: planPrompt } : {}),
           }
         : undefined;
 


### PR DESCRIPTION
## Summary
- Preserve empty plan prompts when demoting to subagent
- Avoid removing plan agent when planner is disabled
- Add demotion behavior regression tests

## Testing
- bun test src/plugin-handlers/config-handler.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix config-handler to only demote/replace the plan agent when the planner is enabled and configured, and preserve the plan prompt even when it’s an empty string. Prevents unintended removal of the plan agent when the planner is disabled.

- **Bug Fixes**
  - Preserve empty plan prompt when demoting to subagent.
  - Do not demote/replace plan when replace_plan is false.
  - Do not remove the plan agent when planner_enabled is false.
  - Add regression tests for demotion behavior.

<sup>Written for commit f5077c774b2dbfc29b2e11a49d22f6dfb7cfd7a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

