### PR TITLE
docs(cla): restrict relicensing to open source and clarify terms

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,13 +1,17 @@
-# Contributor License Agreement
+# Contributor License Agreement (CLA)
 
 Thank you for your interest in contributing to oh-my-opencode ("Project"), owned by YeonGyu Kim ("Owner").
 
-By signing this Contributor License Agreement ("Agreement"), you agree to the following terms:
+By submitting a Contribution to the Project, you agree to the following terms:
+
+---
 
 ## 1. Definitions
 
 - **"Contribution"** means any original work of authorship, including any modifications or additions to existing work, that you submit to the Project.
 - **"Submit"** means any form of communication sent to the Project, including but not limited to pull requests, issues, commits, and documentation changes.
+
+---
 
 ## 2. Grant of Rights
 
@@ -17,7 +21,13 @@ By submitting a Contribution, you grant the Owner:
 
 2. **Patent License**: A perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution.
 
-3. **Relicensing Rights**: The right to relicense the Contribution under any license, including proprietary licenses, without requiring additional permission from you.
+3. **Relicensing Rights (Open-Source Only)**: The Owner may relicense Contributions only under licenses that are OSI-approved or otherwise widely recognized open-source licenses, provided such relicensing does not materially reduce the permissions granted to the public for the Project.
+
+4. **Contributor Ownership**: You retain copyright in your Contribution. This Agreement only grants the licenses described above.
+
+5. **Patent Termination**: If you initiate patent litigation alleging that the Project or a Contribution infringes a patent, then any patent licenses granted to you under this Agreement for the Project terminate as of the date such litigation is filed.
+
+---
 
 ## 3. Representations
 
@@ -28,6 +38,8 @@ You represent that:
 3. Your Contribution does not violate any third party's intellectual property rights.
 4. If your employer has rights to intellectual property that you create, you have received permission to make Contributions on behalf of that employer.
 
+---
+
 ## 4. No Obligation
 
 You understand that:
@@ -36,23 +48,36 @@ You understand that:
 2. The decision to include any Contribution is at the sole discretion of the Owner.
 3. You are not entitled to any compensation for your Contributions.
 
+---
+
 ## 5. Future License Changes
 
 You acknowledge and agree that:
 
 1. The Project may change its license in the future.
-2. Your Contributions may be distributed under a different license than the one in effect at the time of your Contribution.
-3. This includes, but is not limited to, relicensing under source-available or proprietary licenses.
+2. Your Contributions may be distributed under a different open-source license than the one in effect at the time of your Contribution, consistent with Section 2.3.
+
+---
 
 ## 6. Miscellaneous
 
-- This Agreement is governed by the laws of the Republic of Korea.
+- This Agreement is governed by the laws of the Republic of Korea, without regard to conflict of law principles.
 - This Agreement represents the entire agreement between you and the Owner concerning Contributions.
 
 ---
 
 ## How to Sign
 
-By submitting a pull request to this repository, you agree to the terms of this Contributor License Agreement. The CLA Assistant bot will automatically track your agreement.
+By submitting a pull request to this repository, you agree to the terms of this Contributor License Agreement.
 
-If you have any questions, please open an issue or contact the Owner.
+If the repository uses a CLA bot, your agreement may be recorded automatically. Otherwise, maintainers may ask you to confirm your agreement in the pull request.
+
+---
+
+## Where to Put This File
+
+Create a file named **CLA.md** in the **root of your GitHub repository** and paste this content there.
+
+(Optional but recommended) Add a note in **CONTRIBUTING.md**:
+
+> By submitting a PR, you agree to the CLA in `CLA.md`.


### PR DESCRIPTION
Refines the Contributor License Agreement to be more standard, contributor-friendly, and reusable as a template.

- Restrict relicensing rights to only OSI-approved or widely recognized open-source licenses, removing the previous clause that allowed for proprietary relicensing.
- Explicitly state that contributors retain copyright ownership of their contributions.
- Add a standard patent termination clause.
- Improve definitions and add instructions for use, making the CLA a self-contained template.

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Contributor License Agreement to allow relicensing only under OSI-approved open-source licenses and to clarify contributor rights. Adds a patent termination clause, explicit copyright retention, improved definitions, and usage instructions to make the CLA reusable.

<sup>Written for commit 286b36841334bc60d2f47bc5fae14b5bed5020d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

