### PR TITLE
fix(model-requirements): use supported variant for gemini-3-pro

### DIFF
--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -31,7 +31,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   oracle: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
     ],
   },
@@ -75,14 +75,14 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode"], model: "kimi-k2.5-free" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
   },
   momus: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "medium" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
   },
   atlas: {
@@ -107,7 +107,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   ultrabrain: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "xhigh" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
     ],
   },
@@ -115,13 +115,13 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
      fallbackChain: [
        { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "medium" },
        { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
-     ],
-     requiresModel: "gpt-5.2-codex",
-   },
+        { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
+      ],
+      requiresModel: "gpt-5.2-codex",
+    },
    artistry: {
-     fallbackChain: [
-       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      fallbackChain: [
+        { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
        { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
        { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
      ],


### PR DESCRIPTION
## Summary

Fixes `gemini-3-pro` fallback entries that use unsupported `variant: "max"`.

According to [Google's official Gemini API documentation](https://ai.google.dev/gemini-api/docs/thinking-mode), Gemini 3 Pro only supports `"low"` and `"high"` thinking levels:

> `thinkingLevel` (string) - Controls the model's reasoning depth.
> - **Gemini 3 Pro**: `"low"`, `"high"` (default: `"high"`)
> - **Gemini 3 Flash**: `"minimal"`, `"low"`, `"medium"`, `"high"` (default: `"high"`)

Using `"max"` results in API errors (400 Bad Request) when the fallback resolves to Gemini 3 Pro.

## Changes

Changed `variant: "max"` → `variant: "high"` for `gemini-3-pro` in:

| Type | Name |
|------|------|
| Agent | `oracle` |
| Agent | `metis` |
| Agent | `momus` |
| Category | `ultrabrain` |
| Category | `deep` |
| Category | `artistry` |

## Notes

- `"high"` is already the maximum thinking level for Gemini 3 Pro
- Other models (`claude-opus-4-5`, `gpt-5.2`) correctly use their respective max variants
- No behavioral change since `"high"` = maximum reasoning for this model

Closes #1433

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced gemini-3-pro fallback variant "max" with "high" to match Google’s supported thinking levels. This prevents 400 errors when fallbacks resolve to Gemini 3 Pro.

- **Bug Fixes**
  - Updated gemini-3-pro variant to "high" in oracle, metis, momus agents and ultrabrain, deep, artistry categories.

<sup>Written for commit dfcfcfa12a17fe1e4394dd87164831af57cc7ba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

