### PR TITLE
fix(model-fallback): transform gemini-3 models to -preview for google provider

### DIFF
--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -325,7 +325,7 @@ exports[`generateModelConfig single native provider uses Gemini models when only
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
   "agents": {
     "atlas": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "explore": {
       "model": "opencode/gpt-5-nano",
@@ -334,47 +334,47 @@ exports[`generateModelConfig single native provider uses Gemini models when only
       "model": "opencode/glm-4.7-free",
     },
     "metis": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "momus": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "multimodal-looker": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "prometheus": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "quick": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "ultrabrain": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "unspecified-high": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "unspecified-low": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "writing": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
   },
 }
@@ -385,7 +385,7 @@ exports[`generateModelConfig single native provider uses Gemini models with isMa
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
   "agents": {
     "atlas": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "explore": {
       "model": "opencode/gpt-5-nano",
@@ -394,47 +394,47 @@ exports[`generateModelConfig single native provider uses Gemini models with isMa
       "model": "opencode/glm-4.7-free",
     },
     "metis": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "momus": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "multimodal-looker": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "prometheus": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "quick": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "ultrabrain": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "unspecified-high": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "unspecified-low": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "writing": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
   },
 }
@@ -466,7 +466,7 @@ exports[`generateModelConfig all native providers uses preferred models from fal
       "variant": "medium",
     },
     "multimodal-looker": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
       "model": "openai/gpt-5.2",
@@ -483,7 +483,7 @@ exports[`generateModelConfig all native providers uses preferred models from fal
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "deep": {
@@ -504,10 +504,10 @@ exports[`generateModelConfig all native providers uses preferred models from fal
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "writing": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
   },
 }
@@ -539,7 +539,7 @@ exports[`generateModelConfig all native providers uses preferred models with isM
       "variant": "medium",
     },
     "multimodal-looker": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
       "model": "openai/gpt-5.2",
@@ -556,7 +556,7 @@ exports[`generateModelConfig all native providers uses preferred models with isM
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "deep": {
@@ -578,10 +578,10 @@ exports[`generateModelConfig all native providers uses preferred models with isM
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "writing": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
   },
 }
@@ -1221,10 +1221,10 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
       "variant": "max",
     },
     "multimodal-looker": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "prometheus": {
@@ -1238,14 +1238,14 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "quick": {
       "model": "anthropic/claude-haiku-4-5",
     },
     "ultrabrain": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "unspecified-high": {
@@ -1255,10 +1255,10 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "writing": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
   },
 }
@@ -1363,7 +1363,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "variant": "medium",
     },
     "multimodal-looker": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
       "model": "openai/gpt-5.2",
@@ -1380,7 +1380,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "deep": {
@@ -1401,10 +1401,10 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "writing": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
   },
 }
@@ -1436,7 +1436,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "variant": "medium",
     },
     "multimodal-looker": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
       "model": "openai/gpt-5.2",
@@ -1453,7 +1453,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
       "variant": "max",
     },
     "deep": {
@@ -1475,10 +1475,10 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3-pro-preview",
     },
     "writing": {
-      "model": "google/gemini-3-flash",
+      "model": "google/gemini-3-flash-preview",
     },
   },
 }

--- a/src/cli/model-fallback.test.ts
+++ b/src/cli/model-fallback.test.ts
@@ -97,6 +97,34 @@ describe("generateModelConfig", () => {
       // #then should use higher capability models
       expect(result).toMatchSnapshot()
     })
+
+    test("transforms gemini-3-flash to gemini-3-flash-preview for google provider", () => {
+      // #given only Gemini is available
+      const config = createConfig({ hasGemini: true })
+
+      // #when generateModelConfig is called
+      const result = generateModelConfig(config)
+
+      // #then gemini-3-flash models should be transformed to gemini-3-flash-preview
+      // This is required because Google provider only has gemini-3-flash-preview, not gemini-3-flash
+      expect(result.categories?.quick?.model).toBe("google/gemini-3-flash-preview")
+      expect(result.categories?.writing?.model).toBe("google/gemini-3-flash-preview")
+      expect(result.agents?.["multimodal-looker"]?.model).toBe("google/gemini-3-flash-preview")
+    })
+
+    test("transforms gemini-3-pro to gemini-3-pro-preview for google provider", () => {
+      // #given Gemini is available with Max 20 plan
+      const config = createConfig({ hasGemini: true, isMax20: true })
+
+      // #when generateModelConfig is called
+      const result = generateModelConfig(config)
+
+      // #then gemini-3-pro models should be transformed to gemini-3-pro-preview
+      // This is required because Google provider only has gemini-3-pro-preview, not gemini-3-pro
+      expect(result.agents?.oracle?.model).toBe("google/gemini-3-pro-preview")
+      expect(result.agents?.prometheus?.model).toBe("google/gemini-3-pro-preview")
+      expect(result.categories?.["visual-engineering"]?.model).toBe("google/gemini-3-pro-preview")
+    })
   })
 
   describe("all native providers", () => {

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -75,13 +75,13 @@ function transformModelForProvider(provider: string, model: string): string {
       .replace("claude-sonnet-4-5", "claude-sonnet-4.5")
       .replace("claude-haiku-4-5", "claude-haiku-4.5")
       .replace("claude-sonnet-4", "claude-sonnet-4")
-      .replace("gemini-3-pro", "gemini-3-pro-preview")
-      .replace("gemini-3-flash", "gemini-3-flash-preview")
+      .replace(/gemini-3-pro(?!-)/g, "gemini-3-pro-preview")
+      .replace(/gemini-3-flash(?!-)/g, "gemini-3-flash-preview")
   }
   if (provider === "google") {
     return model
-      .replace("gemini-3-pro", "gemini-3-pro-preview")
-      .replace("gemini-3-flash", "gemini-3-flash-preview")
+      .replace(/gemini-3-pro(?!-)/g, "gemini-3-pro-preview")
+      .replace(/gemini-3-flash(?!-)/g, "gemini-3-flash-preview")
   }
   return model
 }

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -78,6 +78,11 @@ function transformModelForProvider(provider: string, model: string): string {
       .replace("gemini-3-pro", "gemini-3-pro-preview")
       .replace("gemini-3-flash", "gemini-3-flash-preview")
   }
+  if (provider === "google") {
+    return model
+      .replace("gemini-3-pro", "gemini-3-pro-preview")
+      .replace("gemini-3-flash", "gemini-3-flash-preview")
+  }
   return model
 }
 

--- a/src/shared/model-resolution-pipeline.ts
+++ b/src/shared/model-resolution-pipeline.ts
@@ -6,8 +6,8 @@ import type { FallbackEntry } from "./model-requirements"
 function transformModelForProvider(provider: string, model: string): string {
   if (provider === "google" || provider === "github-copilot") {
     return model
-      .replace("gemini-3-pro", "gemini-3-pro-preview")
-      .replace("gemini-3-flash", "gemini-3-flash-preview")
+      .replace(/gemini-3-pro(?!-)/g, "gemini-3-pro-preview")
+      .replace(/gemini-3-flash(?!-)/g, "gemini-3-flash-preview")
   }
   return model
 }

--- a/src/shared/model-resolution-pipeline.ts
+++ b/src/shared/model-resolution-pipeline.ts
@@ -3,6 +3,15 @@ import { readConnectedProvidersCache } from "./connected-providers-cache"
 import { fuzzyMatchModel } from "./model-availability"
 import type { FallbackEntry } from "./model-requirements"
 
+function transformModelForProvider(provider: string, model: string): string {
+  if (provider === "google" || provider === "github-copilot") {
+    return model
+      .replace("gemini-3-pro", "gemini-3-pro-preview")
+      .replace("gemini-3-flash", "gemini-3-flash-preview")
+  }
+  return model
+}
+
 export type ModelResolutionRequest = {
   intent?: {
     uiSelectedModel?: string
@@ -84,10 +93,13 @@ export function resolveModelPipeline(
       if (parts.length >= 2) {
         const provider = parts[0]
         if (connectedProviders.includes(provider)) {
+          const modelName = parts.slice(1).join("/")
+          const transformedModel = `${provider}/${transformModelForProvider(provider, modelName)}`
           log("Model resolved via category default (connected provider)", {
-            model: normalizedCategoryDefault,
+            model: transformedModel,
+            original: normalizedCategoryDefault,
           })
-          return { model: normalizedCategoryDefault, provenance: "category-default", attempted }
+          return { model: transformedModel, provenance: "category-default", attempted }
         }
       }
     }
@@ -107,10 +119,12 @@ export function resolveModelPipeline(
         for (const entry of fallbackChain) {
           for (const provider of entry.providers) {
             if (connectedSet.has(provider)) {
-              const model = `${provider}/${entry.model}`
+              const transformedModelName = transformModelForProvider(provider, entry.model)
+              const model = `${provider}/${transformedModelName}`
               log("Model resolved via fallback chain (connected provider)", {
                 provider,
-                model: entry.model,
+                model: transformedModelName,
+                original: entry.model,
                 variant: entry.variant,
               })
               return {

--- a/src/shared/model-resolver.test.ts
+++ b/src/shared/model-resolver.test.ts
@@ -543,7 +543,7 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // then - should use github-copilot (second provider) since google not connected
-      expect(result!.model).toBe("github-copilot/gemini-3-pro")
+      expect(result!.model).toBe("github-copilot/gemini-3-pro-preview")
       expect(result!.source).toBe("provider-fallback")
       cacheSpy.mockRestore()
     })
@@ -795,8 +795,8 @@ describe("resolveModelWithFallback", () => {
       // when
       const result = resolveModelWithFallback(input)
 
-      // then - should use categoryDefaultModel since google is connected
-      expect(result!.model).toBe("google/gemini-3-pro")
+      // then - should use transformed categoryDefaultModel since google is connected
+      expect(result!.model).toBe("google/gemini-3-pro-preview")
       expect(result!.source).toBe("category-default")
       cacheSpy.mockRestore()
     })


### PR DESCRIPTION
## Summary

Fix ProviderModelNotFoundError when subagents try to use Gemini 3 models via the Google provider.

## Problem

When a subagent attempts to use `google/gemini-3-flash` or `google/gemini-3-pro`, opencode throws:

```
ProviderModelNotFoundError: ProviderModelNotFoundError
providerID: "google",
modelID: "gemini-3-flash",
suggestions: [ "gemini-3-flash-preview", "antigravity-gemini-3-flash" ]
```

This happens because the Google provider only has `gemini-3-flash-preview` and `gemini-3-pro-preview` registered - not the base model names without the `-preview` suffix.

## Solution

Add the same model name transformation for the `google` provider that was already implemented for the `github-copilot` provider:

- `gemini-3-flash` → `gemini-3-flash-preview`
- `gemini-3-pro` → `gemini-3-pro-preview`

## Changes

- **src/cli/model-fallback.ts**: Added google provider to `transformModelForProvider()` function
- **src/cli/model-fallback.test.ts**: Added tests for the new transformations (TDD approach)
- **Updated snapshots**: Reflect the new model names for google provider

## Testing

- [x] Added unit tests (TDD RED → GREEN)
- [x] All existing tests pass
- [x] Snapshots updated
- [x] Typecheck passes
- [x] LSP diagnostics clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ProviderModelNotFoundError by mapping Google Gemini 3 model names to their preview variants across config generation and runtime resolution. Subagents can now use Google Gemini 3 without errors.

- **Bug Fixes**
  - Added idempotent transformation in transformModelForProvider and resolveModelPipeline to map gemini-3-pro → gemini-3-pro-preview and gemini-3-flash → gemini-3-flash-preview (prevents -preview-preview; covers category defaults and fallback chain).
  - Updated unit tests and snapshots for both config generation and runtime resolution.

<sup>Written for commit 72481a3f05f34da78c7cb32b6f06c0bfbb787993. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

