### PR TITLE
fix: block bash commands in Prometheus mode to respect permission config

### DIFF
--- a/src/hooks/prometheus-md-only/constants.ts
+++ b/src/hooks/prometheus-md-only/constants.ts
@@ -9,7 +9,7 @@ export const ALLOWED_EXTENSIONS = [".md"]
 
 export const ALLOWED_PATH_PREFIX = ".sisyphus"
 
-export const BLOCKED_TOOLS = ["Write", "Edit", "write", "edit"]
+export const BLOCKED_TOOLS = ["Write", "Edit", "write", "edit", "bash"]
 
 export const PLANNING_CONSULT_WARNING = `
 

--- a/src/hooks/prometheus-md-only/index.test.ts
+++ b/src/hooks/prometheus-md-only/index.test.ts
@@ -173,7 +173,25 @@ describe("prometheus-md-only", () => {
       ).rejects.toThrow("can only write/edit .md files")
     })
 
-    test("should not affect non-Write/Edit tools", async () => {
+    test("should block bash commands from Prometheus", async () => {
+      // given
+      const hook = createPrometheusMdOnlyHook(createMockPluginInput())
+      const input = {
+        tool: "bash",
+        sessionID: TEST_SESSION_ID,
+        callID: "call-1",
+      }
+      const output = {
+        args: { command: "echo test" },
+      }
+
+      // when / #then
+      await expect(
+        hook["tool.execute.before"](input, output)
+      ).rejects.toThrow("cannot execute bash commands")
+    })
+
+    test("should not affect non-blocked tools", async () => {
       // given
       const hook = createPrometheusMdOnlyHook(createMockPluginInput())
       const input = {

--- a/src/hooks/prometheus-md-only/index.ts
+++ b/src/hooks/prometheus-md-only/index.ts
@@ -106,6 +106,20 @@ export function createPrometheusMdOnlyHook(ctx: PluginInput) {
         return
       }
 
+      // Block bash commands completely - Prometheus is read-only
+      if (toolName === "bash") {
+        log(`[${HOOK_NAME}] Blocked: Prometheus cannot execute bash commands`, {
+          sessionID: input.sessionID,
+          tool: toolName,
+          agent: agentName,
+        })
+        throw new Error(
+          `[${HOOK_NAME}] ${getAgentDisplayName("prometheus")} cannot execute bash commands. ` +
+          `${getAgentDisplayName("prometheus")} is a READ-ONLY planner. Use /start-work to execute the plan. ` +
+          `APOLOGIZE TO THE USER, REMIND OF YOUR PLAN WRITING PROCESSES, TELL USER WHAT YOU WILL GOING TO DO AS THE PROCESS, WRITE THE PLAN`
+        )
+      }
+
       const filePath = (output.args.filePath ?? output.args.path ?? output.args.file) as string | undefined
       if (!filePath) {
         return


### PR DESCRIPTION
## Summary

Fixes #1428 - Prometheus mode was bypassing the bash permission setting in `opencode.jsonc`.

## Problem

When users configured `"bash": "ask"` in their `opencode.jsonc` permission config, Prometheus (Plan Builder) mode could still execute bash commands without user confirmation. This posed a security risk since Prometheus is designed as a read-only planner that should only analyze and create plans, not execute commands.

## Root Cause

The `prometheus-md-only` hook only blocked `write` and `edit` tools but did NOT include `bash` in the `BLOCKED_TOOLS` list. Since Prometheus has `bash: "allow"` in its default permission configuration, bash commands executed directly without respecting the user's global permission settings.

## Solution

Added `bash` to the `BLOCKED_TOOLS` array in the prometheus-md-only hook, making Prometheus truly read-only as intended.

### Changes

1. **`src/hooks/prometheus-md-only/constants.ts`**: Added `"bash"` to `BLOCKED_TOOLS`
2. **`src/hooks/prometheus-md-only/index.ts`**: Added specific handling for bash commands with a clear error message
3. **`src/hooks/prometheus-md-only/index.test.ts`**: Added test case to verify bash blocking behavior

## Security Impact

This fix ensures Prometheus respects the security model by:
- Blocking all bash command execution in Prometheus mode
- Providing clear error messages explaining Prometheus is read-only
- Directing users to use `/start-work` for plan execution

## Testing

- All 26 prometheus-md-only tests pass including the new bash blocking test
- Full test suite: 2050 pass, 10 fail (pre-existing failures unrelated to this change)

## Checklist

- [x] Fix implemented
- [x] Tests added
- [x] All tests pass
- [x] Security concern addressed
- [x] PR targets `dev` branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block bash command execution in Prometheus (Plan Builder) mode to honor opencode.jsonc permissions and keep Prometheus read-only. Fixes #1428.

- **Bug Fixes**
  - Added "bash" to BLOCKED_TOOLS in the prometheus-md-only hook.
  - Throw a clear error when bash is invoked in Prometheus, directing users to use /start-work for execution.
  - Added a test to verify bash is blocked.

<sup>Written for commit 8515ad7164fb44a5da57082bd4caddf8e7ac05d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

