### PR TITLE
fix(non-interactive-env): use detectShellType() instead of hardcoded 'unix'

### DIFF
--- a/src/hooks/non-interactive-env/index.ts
+++ b/src/hooks/non-interactive-env/index.ts
@@ -1,7 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import type { ShellType } from "../../shared"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
-import { log, buildEnvPrefix } from "../../shared"
+import { log, buildEnvPrefix, detectShellType } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -53,10 +52,10 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
       // for git commands to prevent interactive prompts.
 
-      // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
-      // (via Git Bash, WSL, etc.), so we always use unix export syntax.
-      // This fixes GitHub issues #983 and #889.
-      const shellType: ShellType = "unix"
+      // Detect the shell type dynamically to support native Windows shells
+      // (cmd.exe, PowerShell) in addition to Unix-like shells (bash, zsh).
+      // Fixes Windows compatibility issues when running without Git Bash/WSL.
+      const shellType = detectShellType()
       const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
       output.args.command = `${envPrefix} ${command}`
 


### PR DESCRIPTION
## Summary

- Use `detectShellType()` instead of hardcoded `"unix"` for shell type detection
- Fixes Windows compatibility when running without Git Bash or WSL

## Problem

The `shellType` was hardcoded to `"unix"` in `src/hooks/non-interactive-env/index.ts`:

```typescript
const shellType: ShellType = "unix"
```

This breaks on native Windows shells (cmd.exe, PowerShell) because the `export` command syntax only works in Unix-like shells.

## Solution

Use the existing `detectShellType()` function from `src/shared/shell-env.ts` to dynamically determine the correct shell type:

```typescript
const shellType = detectShellType()
```

This enables proper environment variable syntax for all supported shell environments:
- Unix shells (bash, zsh): `export VAR=value`
- PowerShell: `$env:VAR="value"`
- cmd.exe: `set VAR=value`

## Testing

- All existing tests pass (`bun test src/hooks/non-interactive-env/`)
- The `detectShellType()` function has comprehensive tests in `src/shared/shell-env.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the non-interactive env hook to use detectShellType() so env vars use the right syntax per shell. Fixes Windows runs in cmd.exe/PowerShell without Git Bash or WSL.

- **Bug Fixes**
  - Replaced hardcoded "unix" shell type with detectShellType() in the hook.
  - Ensures correct env var syntax across bash/zsh, PowerShell, and cmd.exe.

<sup>Written for commit 3c1396e9b36d7ff7afa5a9eea54b95842ce94bae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

