### PR TITLE
fix(model-availability): prefer exact model ID match in fuzzyMatchModel

### DIFF
--- a/src/shared/model-availability.test.ts
+++ b/src/shared/model-availability.test.ts
@@ -277,6 +277,30 @@ describe("fuzzyMatchModel", () => {
 		expect(result).toBe("anthropic/claude-opus-4-5")
 	})
 
+	// given available models with similar model IDs (e.g., glm-4.7 and glm-4.7-free)
+	// when searching for the longer variant (glm-4.7-free)
+	// then return exact model ID match, not the shorter one
+	it("should prefer exact model ID match over shorter substring match", () => {
+		const available = new Set([
+			"zai-coding-plan/glm-4.7",
+			"zai-coding-plan/glm-4.7-free",
+		])
+		const result = fuzzyMatchModel("glm-4.7-free", available)
+		expect(result).toBe("zai-coding-plan/glm-4.7-free")
+	})
+
+	// given available models with similar model IDs
+	// when searching for the shorter variant
+	// then return the shorter match (existing behavior preserved)
+	it("should still prefer shorter match when searching for shorter variant", () => {
+		const available = new Set([
+			"zai-coding-plan/glm-4.7",
+			"zai-coding-plan/glm-4.7-free",
+		])
+		const result = fuzzyMatchModel("glm-4.7", available)
+		expect(result).toBe("zai-coding-plan/glm-4.7")
+	})
+
 	// given available models with multiple providers
 	// when multiple providers are specified
 	// then search all specified providers

--- a/src/shared/model-availability.test.ts
+++ b/src/shared/model-availability.test.ts
@@ -301,6 +301,18 @@ describe("fuzzyMatchModel", () => {
 		expect(result).toBe("zai-coding-plan/glm-4.7")
 	})
 
+	// given same model ID from multiple providers
+	// when searching for exact model ID
+	// then return shortest full string (preserves tie-break behavior)
+	it("should use shortest tie-break when multiple providers have same model ID", () => {
+		const available = new Set([
+			"opencode/gpt-5.2",
+			"openai/gpt-5.2",
+		])
+		const result = fuzzyMatchModel("gpt-5.2", available)
+		expect(result).toBe("openai/gpt-5.2")
+	})
+
 	// given available models with multiple providers
 	// when multiple providers are specified
 	// then search all specified providers

--- a/src/shared/model-availability.ts
+++ b/src/shared/model-availability.ts
@@ -72,14 +72,25 @@ export function fuzzyMatchModel(
 		return null
 	}
 
-	// Priority 1: Exact match (normalized)
+	// Priority 1: Exact match (normalized full model string)
 	const exactMatch = matches.find((model) => normalizeModelName(model) === targetNormalized)
 	if (exactMatch) {
 		log("[fuzzyMatchModel] exact match found", { exactMatch })
 		return exactMatch
 	}
 
-	// Priority 2: Shorter model name (more specific)
+	// Priority 2: Exact model ID match (part after provider/)
+	// This ensures "glm-4.7-free" matches "zai-coding-plan/glm-4.7-free" over "zai-coding-plan/glm-4.7"
+	const exactModelIdMatch = matches.find((model) => {
+		const modelId = model.split("/").slice(1).join("/")
+		return normalizeModelName(modelId) === targetNormalized
+	})
+	if (exactModelIdMatch) {
+		log("[fuzzyMatchModel] exact model ID match found", { exactModelIdMatch })
+		return exactModelIdMatch
+	}
+
+	// Priority 3: Shorter model name (more specific)
 	const result = matches.reduce((shortest, current) =>
 		current.length < shortest.length ? current : shortest,
 	)

--- a/src/shared/model-availability.ts
+++ b/src/shared/model-availability.ts
@@ -81,16 +81,20 @@ export function fuzzyMatchModel(
 
 	// Priority 2: Exact model ID match (part after provider/)
 	// This ensures "glm-4.7-free" matches "zai-coding-plan/glm-4.7-free" over "zai-coding-plan/glm-4.7"
-	const exactModelIdMatch = matches.find((model) => {
+	// Use filter + shortest to handle multi-provider cases (e.g., openai/gpt-5.2 + opencode/gpt-5.2)
+	const exactModelIdMatches = matches.filter((model) => {
 		const modelId = model.split("/").slice(1).join("/")
 		return normalizeModelName(modelId) === targetNormalized
 	})
-	if (exactModelIdMatch) {
-		log("[fuzzyMatchModel] exact model ID match found", { exactModelIdMatch })
-		return exactModelIdMatch
+	if (exactModelIdMatches.length > 0) {
+		const result = exactModelIdMatches.reduce((shortest, current) =>
+			current.length < shortest.length ? current : shortest,
+		)
+		log("[fuzzyMatchModel] exact model ID match found", { result, candidateCount: exactModelIdMatches.length })
+		return result
 	}
 
-	// Priority 3: Shorter model name (more specific)
+	// Priority 3: Shorter model name (more specific, fallback for partial matches)
 	const result = matches.reduce((shortest, current) =>
 		current.length < shortest.length ? current : shortest,
 	)


### PR DESCRIPTION
## Summary

Fixes #1454 - Fuzzy model matcher now prefers exact model ID matches before falling back to shortest match.

## Problem

When searching for `glm-4.7-free`, the `fuzzyMatchModel` function would incorrectly return `glm-4.7` (the paid model) instead of `glm-4.7-free` (the free model). This happened because:

1. Both models matched as substrings
2. Neither was an exact full match (which includes the provider prefix)
3. The function fell back to "shortest match" which picked `glm-4.7`

## Solution

Added a new priority level to the matching algorithm:

1. **Priority 1**: Exact match (normalized full model string) 
2. **Priority 2**: **NEW** - Exact model ID match (part after `provider/`)
3. **Priority 3**: Shorter model name (fallback)

## Changes

- Modified `src/shared/model-availability.ts` to check for exact model ID matches before falling back to shortest match
- Added 2 new test cases to verify the fix:
  - Test that `glm-4.7-free` matches the correct model when both `glm-4.7` and `glm-4.7-free` exist
  - Test that searching for shorter variant (`glm-4.7`) still returns the shorter match (existing behavior preserved)

## Testing

All 44 tests pass:
- Existing fuzzy matching behavior is preserved
- New exact model ID match logic works correctly

Fixes #1454

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wrong model selection in fuzzyMatchModel by preferring an exact model ID match (e.g., glm-4.7-free) over a shorter substring (glm-4.7). Fixes #1454 and prevents returning paid models when a free variant is requested.

- **Bug Fixes**
  - Inserted new priority: exact model ID match after full normalized match, with a tie-break that prefers the shortest full string when multiple providers share the same model ID.
  - Updated src/shared/model-availability.ts to implement filter+reduce for multi-provider cases.
  - Added tests for glm-4.7-free vs glm-4.7, for the shorter-variant search, and for the multi-provider same model ID case.
  - Preserves previous behavior; all tests pass.

<sup>Written for commit f6238a68ad74f10d0f605b6d4da7fb65957f93ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

