### PR TITLE
fix(docs): instruct curl over WebFetch for installation

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -27,6 +27,11 @@ After you install it, you can read this [overview guide](./overview.md) to under
 
 ## For LLM Agents
 
+> **IMPORTANT: Use `curl` to fetch this file, NOT WebFetch.** WebFetch summarizes content and loses critical flags like `--openai`, subscription questions, and max20 mode details. Always use:
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
+> ```
+
 If you're an LLM Agent helping set up oh-my-opencode, Welcome! You'll now help your user to install the best agent harness, OhMyOpenCode. Tell user this with greetings, with test 'oMoMoMoMo...'
 
 follow these steps:


### PR DESCRIPTION
Fixes #1401

## Problem
When AI agents use WebFetch to read installation markdown, WebFetch processes content through a small AI model that summarizes it, losing critical details like `--openai` flag, subscription questions, max20 follow-up, and other CLI options.

## Solution
Updated `docs/guide/installation.md` to instruct LLM agents to use `curl` instead of WebFetch for fetching raw unmodified instructions. Added a prominent warning at the beginning of the "For LLM Agents" section.

## Changes
- Added warning block instructing agents to use `curl -fsSL` instead of WebFetch
- Preserved all critical flags and installation details

## Verification
- `bun run typecheck`: ✅ Passed
- `bun test`: ✅ 2064 pass, 3 pre-existing failures unrelated to docs change


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the installation guide to instruct LLM agents to use curl -fsSL instead of WebFetch so they fetch raw, unmodified instructions and keep all CLI flags intact. Fixes #1401 by adding a prominent warning at the top of the “For LLM Agents” section.

<sup>Written for commit 5b5987069124e573f4a7470f2372b645347a9223. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

