### PR TITLE
fix(model-requirements): use supported variant for gemini-3-pro

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.2.1",
-        "oh-my-opencode-darwin-x64": "3.2.1",
-        "oh-my-opencode-linux-arm64": "3.2.1",
-        "oh-my-opencode-linux-arm64-musl": "3.2.1",
-        "oh-my-opencode-linux-x64": "3.2.1",
-        "oh-my-opencode-linux-x64-musl": "3.2.1",
-        "oh-my-opencode-windows-x64": "3.2.1",
+        "oh-my-opencode-darwin-arm64": "3.2.2",
+        "oh-my-opencode-darwin-x64": "3.2.2",
+        "oh-my-opencode-linux-arm64": "3.2.2",
+        "oh-my-opencode-linux-arm64-musl": "3.2.2",
+        "oh-my-opencode-linux-x64": "3.2.2",
+        "oh-my-opencode-linux-x64-musl": "3.2.2",
+        "oh-my-opencode-windows-x64": "3.2.2",
       },
     },
   },
@@ -226,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-IvhHRUXTr/g/hJlkKTU2oCdgRl2BDl/Qre31Rukhs4NumlvME6iDmdnm8mM7bTxugfCBkfUUr7QJLxxLhzjdLA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-KyfoWcANfcvpfanrrX+Wc8vH8vr9mvr7dJMHBe2bkvuhdtHnLHOG18hQwLg6jk4HhdoZAeBEmkolOsK2k4XajA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-V2JbAdThAVfhBOcb+wBPZrAI0vBxPPRBdvmAixAxBOFC49CIJUrEFIRBUYFKhSQGHYWrNy8z0zJYoNQm4oQPog=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.2", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ajZ1E36Ixwdz6rvSUKUI08M2xOaNIl1ZsdVjknZTrPRtct9xgS+BEFCoSCov9bnV/9DrZD3mlZtO/+FFDbseUg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-SeT8P7Icq5YH/AIaEF28J4q+ifUnOqO2UgMFtdFusr8JLadYFy+6dTdeAuD2uGGToDQ3ZNKuaG+lo84KzEhA5w=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ItJsYfigXcOa8/ejTjopC4qk5BCeYioMQ693kPTpeYHK3ByugTjJk8aamE7bHlVnmrdgWldz91QFzaP82yOAdg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-wJUEVVUn1gyVIFNV4mxWg9cYo1rQdTKUXdGLfiqPiyQhWhZLRfPJ+9qpghvIVv7Dne6rzkbhYWdwdk/tew5RtQ=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/TvjYe/Kb//ZSHnJzgRj0QPKpS5Y2nermVTSaMTGS2btObXQyQWzuphDhsVRu60SVrNLbflHzfuTdqb3avDjyA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-p/XValXi1RRTZV8mEsdStXwZBkyQpgZjB41HLf0VfizPMAKRr6/bhuFZ9BDZFIhcDnLYcGV54MAVEsWms5yC2A=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Ka5j+tjuQkNnpESVzcTzW5tZMlBhOfP9F12+UaR72cIcwFpSoLMBp84rV6R0vXM0zUcrrN7mPeW66DvQ6A0XQQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-G7aNMqAMO2P+wUUaaAV8sXymm59cX4G9aVNXKAd/PM6RgFWh2F4HkXkOhOdHKYZzCl1QRhjh672mNillYsvebg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ISl0sTNShKCgPFO+rsDqEDsvVHQAMfOSAxO0KuWbHFKaH+KaRV4d3N/ihgxZ2M94CZjJLzZEuln+6kLZ93cvzQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-pyqTGlNxirKxQgXx9YJBq2y8KN/1oIygVupClmws7dDPj9etI1l8fs/SBEnMsYzMqTlGbLVeJ5+kj9p+yg7YDA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.2", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-KeiJLQvJuZ+UYf/+eMsQXvCiHDRPk6tD15lL+qruLvU19va62JqMNvTuOv97732uF19iG0ZMiiVhqIMbSyVPqQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -335,18 +335,18 @@ exports[`generateModelConfig single native provider uses Gemini models when only
     },
     "metis": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "momus": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "multimodal-looker": {
       "model": "google/gemini-3-flash",
     },
     "oracle": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "prometheus": {
       "model": "google/gemini-3-pro",
@@ -355,14 +355,14 @@ exports[`generateModelConfig single native provider uses Gemini models when only
   "categories": {
     "artistry": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "quick": {
       "model": "google/gemini-3-flash",
     },
     "ultrabrain": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "unspecified-high": {
       "model": "google/gemini-3-flash",
@@ -395,18 +395,18 @@ exports[`generateModelConfig single native provider uses Gemini models with isMa
     },
     "metis": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "momus": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "multimodal-looker": {
       "model": "google/gemini-3-flash",
     },
     "oracle": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "prometheus": {
       "model": "google/gemini-3-pro",
@@ -415,14 +415,14 @@ exports[`generateModelConfig single native provider uses Gemini models with isMa
   "categories": {
     "artistry": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "quick": {
       "model": "google/gemini-3-flash",
     },
     "ultrabrain": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "unspecified-high": {
       "model": "google/gemini-3-pro",
@@ -484,7 +484,7 @@ exports[`generateModelConfig all native providers uses preferred models from fal
   "categories": {
     "artistry": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "openai/gpt-5.2-codex",
@@ -557,7 +557,7 @@ exports[`generateModelConfig all native providers uses preferred models with isM
   "categories": {
     "artistry": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "openai/gpt-5.2-codex",
@@ -631,7 +631,7 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models when on
   "categories": {
     "artistry": {
       "model": "opencode/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "opencode/gpt-5.2-codex",
@@ -704,7 +704,7 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models with is
   "categories": {
     "artistry": {
       "model": "opencode/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "opencode/gpt-5.2-codex",
@@ -778,7 +778,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
   "categories": {
     "artistry": {
       "model": "github-copilot/gemini-3-pro-preview",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "github-copilot/gpt-5.2-codex",
@@ -851,7 +851,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
   "categories": {
     "artistry": {
       "model": "github-copilot/gemini-3-pro-preview",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "github-copilot/gpt-5.2-codex",
@@ -1035,7 +1035,7 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + OpenCode Zen
   "categories": {
     "artistry": {
       "model": "opencode/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "opencode/gpt-5.2-codex",
@@ -1108,7 +1108,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
   "categories": {
     "artistry": {
       "model": "github-copilot/gemini-3-pro-preview",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "openai/gpt-5.2-codex",
@@ -1225,7 +1225,7 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
     },
     "oracle": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "prometheus": {
       "model": "anthropic/claude-opus-4-5",
@@ -1239,14 +1239,14 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
   "categories": {
     "artistry": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "quick": {
       "model": "anthropic/claude-haiku-4-5",
     },
     "ultrabrain": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "unspecified-high": {
       "model": "anthropic/claude-sonnet-4-5",
@@ -1308,7 +1308,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
   "categories": {
     "artistry": {
       "model": "github-copilot/gemini-3-pro-preview",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "github-copilot/gpt-5.2-codex",
@@ -1381,7 +1381,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
   "categories": {
     "artistry": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "openai/gpt-5.2-codex",
@@ -1454,7 +1454,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
   "categories": {
     "artistry": {
       "model": "google/gemini-3-pro",
-      "variant": "max",
+      "variant": "high",
     },
     "deep": {
       "model": "openai/gpt-5.2-codex",

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -313,7 +313,7 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
 
     const primary = artistry.fallbackChain[0]
     expect(primary.model).toBe("gemini-3-pro")
-    expect(primary.variant).toBe("max")
+    expect(primary.variant).toBe("high")
     expect(primary.providers[0]).toBe("google")
   })
 

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -31,7 +31,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   oracle: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
     ],
   },
@@ -75,14 +75,14 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode"], model: "kimi-k2.5-free" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
   },
   momus: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "medium" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
   },
   atlas: {
@@ -107,7 +107,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   ultrabrain: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "xhigh" },
-      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
     ],
   },
@@ -115,18 +115,18 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
      fallbackChain: [
        { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "medium" },
        { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
+       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
      ],
      requiresModel: "gpt-5.2-codex",
    },
-   artistry: {
-     fallbackChain: [
-       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "max" },
-       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
-     ],
-     requiresModel: "gemini-3-pro",
-   },
+    artistry: {
+      fallbackChain: [
+        { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
+        { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+        { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
+      ],
+      requiresModel: "gemini-3-pro",
+    },
   quick: {
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-haiku-4-5" },

--- a/src/tools/delegate-task/constants.ts
+++ b/src/tools/delegate-task/constants.ts
@@ -196,7 +196,7 @@ export const DEFAULT_CATEGORIES: Record<string, CategoryConfig> = {
   "visual-engineering": { model: "google/gemini-3-pro" },
   ultrabrain: { model: "openai/gpt-5.2-codex", variant: "xhigh" },
   deep: { model: "openai/gpt-5.2-codex", variant: "medium" },
-  artistry: { model: "google/gemini-3-pro", variant: "max" },
+  artistry: { model: "google/gemini-3-pro", variant: "high" },
   quick: { model: "anthropic/claude-haiku-4-5" },
   "unspecified-low": { model: "anthropic/claude-sonnet-4-5" },
   "unspecified-high": { model: "anthropic/claude-opus-4-5", variant: "max" },

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -1492,7 +1492,7 @@ describe("sisyphus-task", () => {
         abort: new AbortController().signal,
       }
       
-      // when - artistry category (gemini-3-pro with max variant)
+      // when - artistry category (gemini-3-pro with high variant)
       const result = await tool.execute(
         {
           description: "Test artistry forced background",


### PR DESCRIPTION
## Summary

Fixes #1433

Changed `variant: "max"` to `variant: "high"` for `gemini-3-pro` fallback entries across agents and categories.

According to [Google's Gemini API documentation](https://ai.google.dev/gemini-api/docs/thinking-mode), Gemini 3 Pro only supports `"low"` and `"high"` thinking levels:

> `thinkingLevel` (string) - Controls the model's reasoning depth.
> - **Gemini 3 Pro**: `"low"`, `"high"` (default: `"high"`)

Using `"max"` results in API errors (400 Bad Request) when the fallback resolves to Gemini 3 Pro.

## Changes

| Location | Type | Change |
|----------|------|--------|
| `oracle` | Agent | `variant: "max"` → `variant: "high"` |
| `metis` | Agent | `variant: "max"` → `variant: "high"` |
| `momus` | Agent | `variant: "max"` → `variant: "high"` |
| `ultrabrain` | Category | `variant: "max"` → `variant: "high"` |
| `deep` | Category | `variant: "max"` → `variant: "high"` |
| `artistry` | Category | `variant: "max"` → `variant: "high"` |

## Notes

- `"high"` is already the maximum thinking level supported by Gemini 3 Pro
- Other models (`claude-opus-4-5` with `max`, `gpt-5.2` with `high`) correctly use their respective variants
- Tests and snapshots updated to reflect the change

## Related

- PR #1434 attempted a similar fix from another fork

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix 400 errors by switching Gemini 3 Pro fallbacks from variant "max" to "high" so thinking mode is valid. Aligns with Google’s docs and addresses #1433.

- **Bug Fixes**
  - Changed gemini-3-pro fallback variant to "high" for oracle, metis, and momus agents, and ultrabrain, deep, and artistry categories.
  - Updated delegate-task default artistry category to "high".
  - Updated tests and snapshots to match the new variant.

<sup>Written for commit 7a8a84d20f2ab16556bce8396a182495b9c6c949. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

