### PR TITLE
fix(doctor): respect user-configured agent variant

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.2.1",
-        "oh-my-opencode-darwin-x64": "3.2.1",
-        "oh-my-opencode-linux-arm64": "3.2.1",
-        "oh-my-opencode-linux-arm64-musl": "3.2.1",
-        "oh-my-opencode-linux-x64": "3.2.1",
-        "oh-my-opencode-linux-x64-musl": "3.2.1",
-        "oh-my-opencode-windows-x64": "3.2.1",
+        "oh-my-opencode-darwin-arm64": "3.2.2",
+        "oh-my-opencode-darwin-x64": "3.2.2",
+        "oh-my-opencode-linux-arm64": "3.2.2",
+        "oh-my-opencode-linux-arm64-musl": "3.2.2",
+        "oh-my-opencode-linux-x64": "3.2.2",
+        "oh-my-opencode-linux-x64-musl": "3.2.2",
+        "oh-my-opencode-windows-x64": "3.2.2",
       },
     },
   },
@@ -226,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-IvhHRUXTr/g/hJlkKTU2oCdgRl2BDl/Qre31Rukhs4NumlvME6iDmdnm8mM7bTxugfCBkfUUr7QJLxxLhzjdLA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-KyfoWcANfcvpfanrrX+Wc8vH8vr9mvr7dJMHBe2bkvuhdtHnLHOG18hQwLg6jk4HhdoZAeBEmkolOsK2k4XajA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-V2JbAdThAVfhBOcb+wBPZrAI0vBxPPRBdvmAixAxBOFC49CIJUrEFIRBUYFKhSQGHYWrNy8z0zJYoNQm4oQPog=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.2", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ajZ1E36Ixwdz6rvSUKUI08M2xOaNIl1ZsdVjknZTrPRtct9xgS+BEFCoSCov9bnV/9DrZD3mlZtO/+FFDbseUg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-SeT8P7Icq5YH/AIaEF28J4q+ifUnOqO2UgMFtdFusr8JLadYFy+6dTdeAuD2uGGToDQ3ZNKuaG+lo84KzEhA5w=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ItJsYfigXcOa8/ejTjopC4qk5BCeYioMQ693kPTpeYHK3ByugTjJk8aamE7bHlVnmrdgWldz91QFzaP82yOAdg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-wJUEVVUn1gyVIFNV4mxWg9cYo1rQdTKUXdGLfiqPiyQhWhZLRfPJ+9qpghvIVv7Dne6rzkbhYWdwdk/tew5RtQ=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/TvjYe/Kb//ZSHnJzgRj0QPKpS5Y2nermVTSaMTGS2btObXQyQWzuphDhsVRu60SVrNLbflHzfuTdqb3avDjyA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-p/XValXi1RRTZV8mEsdStXwZBkyQpgZjB41HLf0VfizPMAKRr6/bhuFZ9BDZFIhcDnLYcGV54MAVEsWms5yC2A=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Ka5j+tjuQkNnpESVzcTzW5tZMlBhOfP9F12+UaR72cIcwFpSoLMBp84rV6R0vXM0zUcrrN7mPeW66DvQ6A0XQQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-G7aNMqAMO2P+wUUaaAV8sXymm59cX4G9aVNXKAd/PM6RgFWh2F4HkXkOhOdHKYZzCl1QRhjh672mNillYsvebg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ISl0sTNShKCgPFO+rsDqEDsvVHQAMfOSAxO0KuWbHFKaH+KaRV4d3N/ihgxZ2M94CZjJLzZEuln+6kLZ93cvzQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-pyqTGlNxirKxQgXx9YJBq2y8KN/1oIygVupClmws7dDPj9etI1l8fs/SBEnMsYzMqTlGbLVeJ5+kj9p+yg7YDA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.2", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-KeiJLQvJuZ+UYf/+eMsQXvCiHDRPk6tD15lL+qruLvU19va62JqMNvTuOv97732uF19iG0ZMiiVhqIMbSyVPqQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/cli/doctor/checks/model-resolution.ts
+++ b/src/cli/doctor/checks/model-resolution.ts
@@ -182,17 +182,44 @@ function formatModelWithVariant(model: string, variant?: string): string {
   return variant ? `${model} (${variant})` : model
 }
 
+function getAgentOverride(
+  agentName: string,
+  config: OmoConfig,
+): { variant?: string; category?: string } | undefined {
+  const agentOverrides = config.agents
+  if (!agentOverrides) return undefined
+
+  // Direct lookup first, then case-insensitive lookup (matches agent-variant.ts)
+  return (
+    agentOverrides[agentName] ??
+    Object.entries(agentOverrides).find(
+      ([key]) => key.toLowerCase() === agentName.toLowerCase()
+    )?.[1]
+  )
+}
+
 function getEffectiveVariant(
   name: string,
   requirement: ModelRequirement,
   config: OmoConfig,
 ): string | undefined {
-  // Check user config first
-  const userVariant = config.agents?.[name]?.variant
-  if (userVariant) {
-    return userVariant
+  const agentOverride = getAgentOverride(name, config)
+
+  // Priority 1: Agent's direct variant override
+  if (agentOverride?.variant) {
+    return agentOverride.variant
   }
-  // Fall back to requirement's fallback chain
+
+  // Priority 2: Agent's category -> category's variant (matches agent-variant.ts)
+  const categoryName = agentOverride?.category
+  if (categoryName) {
+    const categoryVariant = config.categories?.[categoryName]?.variant
+    if (categoryVariant) {
+      return categoryVariant
+    }
+  }
+
+  // Priority 3: Fall back to requirement's fallback chain
   const firstEntry = requirement.fallbackChain[0]
   return firstEntry?.variant ?? requirement.variant
 }
@@ -201,6 +228,19 @@ interface AvailableModelsInfo {
   providers: string[]
   modelCount: number
   cacheExists: boolean
+}
+
+function getCategoryEffectiveVariant(
+  categoryName: string,
+  requirement: ModelRequirement,
+  config: OmoConfig,
+): string | undefined {
+  const categoryVariant = config.categories?.[categoryName]?.variant
+  if (categoryVariant) {
+    return categoryVariant
+  }
+  const firstEntry = requirement.fallbackChain[0]
+  return firstEntry?.variant ?? requirement.variant
 }
 
 function buildDetailsArray(info: ModelResolutionInfo, available: AvailableModelsInfo, config: OmoConfig): string[] {
@@ -232,10 +272,9 @@ function buildDetailsArray(info: ModelResolutionInfo, available: AvailableModels
   details.push("Categories:")
   for (const category of info.categories) {
     const marker = category.userOverride ? "●" : "○"
-    const categoryVariant = config.categories?.[category.name]?.variant
     const display = formatModelWithVariant(
       category.effectiveModel,
-      categoryVariant ?? getEffectiveVariant(category.name, category.requirement, config)
+      getCategoryEffectiveVariant(category.name, category.requirement, config)
     )
     details.push(`  ${marker} ${category.name}: ${display}`)
   }

--- a/src/cli/doctor/checks/model-resolution.ts
+++ b/src/cli/doctor/checks/model-resolution.ts
@@ -69,8 +69,8 @@ export interface ModelResolutionInfo {
 }
 
 interface OmoConfig {
-  agents?: Record<string, { model?: string }>
-  categories?: Record<string, { model?: string }>
+  agents?: Record<string, { model?: string; variant?: string; category?: string }>
+  categories?: Record<string, { model?: string; variant?: string }>
 }
 
 function loadConfig(): OmoConfig | null {
@@ -182,7 +182,17 @@ function formatModelWithVariant(model: string, variant?: string): string {
   return variant ? `${model} (${variant})` : model
 }
 
-function getEffectiveVariant(requirement: ModelRequirement): string | undefined {
+function getEffectiveVariant(
+  name: string,
+  requirement: ModelRequirement,
+  config: OmoConfig,
+): string | undefined {
+  // Check user config first
+  const userVariant = config.agents?.[name]?.variant
+  if (userVariant) {
+    return userVariant
+  }
+  // Fall back to requirement's fallback chain
   const firstEntry = requirement.fallbackChain[0]
   return firstEntry?.variant ?? requirement.variant
 }
@@ -193,7 +203,7 @@ interface AvailableModelsInfo {
   cacheExists: boolean
 }
 
-function buildDetailsArray(info: ModelResolutionInfo, available: AvailableModelsInfo): string[] {
+function buildDetailsArray(info: ModelResolutionInfo, available: AvailableModelsInfo, config: OmoConfig): string[] {
   const details: string[] = []
 
   details.push("═══ Available Models (from cache) ═══")
@@ -215,14 +225,18 @@ function buildDetailsArray(info: ModelResolutionInfo, available: AvailableModels
   details.push("Agents:")
   for (const agent of info.agents) {
     const marker = agent.userOverride ? "●" : "○"
-    const display = formatModelWithVariant(agent.effectiveModel, getEffectiveVariant(agent.requirement))
+    const display = formatModelWithVariant(agent.effectiveModel, getEffectiveVariant(agent.name, agent.requirement, config))
     details.push(`  ${marker} ${agent.name}: ${display}`)
   }
   details.push("")
   details.push("Categories:")
   for (const category of info.categories) {
     const marker = category.userOverride ? "●" : "○"
-    const display = formatModelWithVariant(category.effectiveModel, getEffectiveVariant(category.requirement))
+    const categoryVariant = config.categories?.[category.name]?.variant
+    const display = formatModelWithVariant(
+      category.effectiveModel,
+      categoryVariant ?? getEffectiveVariant(category.name, category.requirement, config)
+    )
     details.push(`  ${marker} ${category.name}: ${display}`)
   }
   details.push("")
@@ -249,7 +263,7 @@ export async function checkModelResolution(): Promise<CheckResult> {
     name: CHECK_NAMES[CHECK_IDS.MODEL_RESOLUTION],
     status: available.cacheExists ? "pass" : "warn",
     message: `${agentCount} agents, ${categoryCount} categories${overrideNote}${cacheNote}`,
-    details: buildDetailsArray(info, available),
+    details: buildDetailsArray(info, available, config),
   }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes the doctor command's model resolution to respect user-configured agent variants from `oh-my-opencode.json`.

## Problem

The `doctor` command was ignoring user-defined variant settings in the configuration file. It only looked at `fallbackChain[0].variant`, completely bypassing `agents.<name>.variant` from user config.

## Changes

- Updated `OmoConfig` interface to include `variant` and `category` fields for agents
- Modified `getEffectiveVariant()` to check `config.agents?.[name]?.variant` first before falling back to the requirement's fallback chain
- Updated `buildDetailsArray()` to properly handle category-level variant overrides

## Fixes

Fixes #1429

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the doctor command respects user-configured agent and category variants from oh-my-opencode.json when resolving models. It now reads config overrides before the fallback chain so displayed variants match user settings. Fixes #1429.

- **Bug Fixes**
  - Extend OmoConfig to include variant fields (and agent category).
  - Resolve variant by checking agent override (case-insensitive), then agent.category -> categories[cat].variant, then requirement defaults.
  - Update details rendering to apply category overrides and pass config through.

<sup>Written for commit d0be91bab1d02f80c287ee705c2b8650704dc4ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

