### PR TITLE
fix(delegate-task): honor explicit category model over sisyphus-junior

### DIFF
--- a/src/tools/delegate-task/executor.ts
+++ b/src/tools/delegate-task/executor.ts
@@ -794,18 +794,22 @@ export async function resolveCategoryExecution(
   let categoryModel: { providerID: string; modelID: string; variant?: string } | undefined
 
   const overrideModel = sisyphusJuniorModel
+  const explicitCategoryModel = userCategories?.[args.category!]?.model
 
   if (!requirement) {
-    actualModel = overrideModel ?? resolved.model
+    // Precedence: explicit category model > sisyphus-junior default > category resolved model
+    // This keeps `sisyphus-junior.model` useful as a global default while allowing
+    // per-category overrides via `categories[category].model`.
+    actualModel = explicitCategoryModel ?? overrideModel ?? resolved.model
     if (actualModel) {
-      modelInfo = overrideModel
+      modelInfo = explicitCategoryModel || overrideModel
         ? { model: actualModel, type: "user-defined", source: "override" }
         : { model: actualModel, type: "system-default", source: "system-default" }
     }
   } else {
     const resolution = resolveModelPipeline({
       intent: {
-        userModel: overrideModel ?? userCategories?.[args.category!]?.model,
+        userModel: explicitCategoryModel ?? overrideModel,
         categoryDefaultModel: resolved.model,
       },
       constraints: { availableModels },


### PR DESCRIPTION
## What
- Fix `delegate_task(category=...)` model precedence so `categories[category].model` wins over `agents.sisyphus-junior.model`.
- Keep `agents.sisyphus-junior.model` as a fallback when the category has no explicit model.

## Why
Users configure categories to route work to different models; the current precedence makes categories ineffective when `sisyphus-junior` has a model configured (common).

## How
- `src/tools/delegate-task/executor.ts`: prefer `userCategories[category].model` over `sisyphusJuniorModel` when resolving the effective model.
- `src/tools/delegate-task/tools.test.ts`: add regression test for explicit category model precedence.

## Verification
- `bun run typecheck`
- `bun test src/tools/delegate-task/tools.test.ts`
- `bun run build`

Fixes #1469

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor explicit category models in delegate_task so they override the sisyphus-junior default, ensuring per-category routing works as configured. Fixes #1469.

- **Bug Fixes**
  - Updated resolveCategoryExecution to prefer userCategories[category].model over agents.sisyphus-junior.model, keeping sisyphus-junior as fallback.
  - Added a regression test confirming category model precedence during task launch.

<sup>Written for commit 1411ca255af7af64fda3ad7d193c89a8362032b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

