### PR TITLE
feat(look_at): add image_data parameter for clipboard/pasted image support

### DIFF
--- a/src/tools/look-at/types.ts
+++ b/src/tools/look-at/types.ts
@@ -1,4 +1,5 @@
 export interface LookAtArgs {
-  file_path: string
+  file_path?: string
+  image_data?: string  // base64 encoded image data (for clipboard images)
   goal: string
 }


### PR DESCRIPTION
## Summary

Closes #704

This PR adds support for base64-encoded image data in the `look_at` tool, enabling analysis of clipboard/pasted images without requiring a file path.

## Problem

When users paste a clipboard image into Oh My OpenCode, the interface renders it as `[Image 1]` placeholder. The agent then attempts to use this as a file path with the `look_at` tool, which fails because:
1. The `look_at` tool only accepts `file_path` parameter
2. `[Image 1]` is not a valid file path - the image exists only as clipboard/embedded data

## Solution

Extend the `look_at` tool to accept an optional `image_data` parameter (base64-encoded) as an alternative to `file_path`. This allows:
- Direct analysis of clipboard/pasted images via data URLs
- Backward compatibility with existing file path usage
- Automatic MIME type detection from base64 headers

## Changes

### `src/tools/look-at/types.ts`
- Add optional `image_data?: string` field to `LookAtArgs` interface

### `src/tools/look-at/tools.ts`
- Update `normalizeArgs` to preserve `image_data`
- Update `validateArgs` to accept either `file_path` OR `image_data` (mutually exclusive)
- Add `inferMimeTypeFromBase64()` function to detect image format from base64 data
- Add `extractBase64Data()` helper to handle data URL prefix stripping
- Update `execute()` to construct data URL when `image_data` is provided

### `src/tools/look-at/tools.test.ts`
- Add tests for `image_data` parameter in `normalizeArgs`
- Add validation tests for `image_data` scenarios
- Add integration tests for base64 image handling

## Testing

```bash
bun run typecheck  # ✅ Pass
bun test src/tools/look-at/tools.test.ts  # ✅ 16 tests pass
```

## Usage

After this change, the tool can be called in two ways:

```typescript
// File path (existing behavior)
look_at(file_path="/path/to/image.png", goal="describe this image")

// Base64 data (new)
look_at(image_data="data:image/png;base64,iVBORw0KGgo...", goal="describe this image")
```

## Note

This PR addresses the tool-side of the issue. For complete clipboard image support, the frontend may also need to pass the base64 data when images are pasted. However, this change enables the backend capability that was missing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds base64 image_data support to the look_at tool so pasted/clipboard images can be analyzed without a file path. Keeps existing file_path behavior and auto-detects MIME types.

- **New Features**
  - Accepts image_data (base64 or data URL) as an alternative to file_path; validation enforces only one.
  - Infers MIME type from base64 header/content and builds a data URL for the model.
  - Improves error messages to reference images when relevant.
  - Adds tests for normalization, validation, and base64 handling.

- **Migration**
  - No breaking changes.
  - To enable clipboard image flow end-to-end, the frontend should pass the pasted image’s base64 as image_data.

<sup>Written for commit d099b0255f1a74abde55a5ed7e958ecaa9a398ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

