### PR TITLE
fix(model-availability): honor connected providers for fallback

### DIFF
--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -228,11 +228,12 @@ describe("createBuiltinAgents without systemDefaultModel", () => {
 })
 
 describe("createBuiltinAgents with requiresModel gating", () => {
-  test("hephaestus is not created when gpt-5.2-codex is unavailable", async () => {
+  test("hephaestus is not created when gpt-5.2-codex is unavailable and provider not connected", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
       new Set(["anthropic/claude-opus-4-5"])
     )
+    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue([])
 
     try {
       // #when
@@ -242,6 +243,7 @@ describe("createBuiltinAgents with requiresModel gating", () => {
       expect(agents.hephaestus).toBeUndefined()
     } finally {
       fetchSpy.mockRestore()
+      cacheSpy.mockRestore()
     }
   })
 
@@ -355,11 +357,12 @@ describe("createBuiltinAgents with requiresAnyModel gating (sisyphus)", () => {
     }
   })
 
-  test("sisyphus is not created when no fallback model is available (unrelated model only)", async () => {
+  test("sisyphus is not created when no fallback model is available and provider not connected", async () => {
     // #given - only openai/gpt-5.2 available, not in sisyphus fallback chain
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
       new Set(["openai/gpt-5.2"])
     )
+    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue([])
 
     try {
       // #when
@@ -369,6 +372,7 @@ describe("createBuiltinAgents with requiresAnyModel gating (sisyphus)", () => {
       expect(agents.sisyphus).toBeUndefined()
     } finally {
       fetchSpy.mockRestore()
+      cacheSpy.mockRestore()
     }
   })
 })

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -395,7 +395,7 @@ export async function createBuiltinAgents(
       !hephaestusRequirement?.requiresModel ||
       hasHephaestusExplicitConfig ||
       isFirstRunNoCache ||
-      (availableModels.size > 0 && isModelAvailable(hephaestusRequirement.requiresModel, availableModels))
+      isAnyFallbackModelAvailable(hephaestusRequirement.fallbackChain, availableModels)
 
     if (hasRequiredModel) {
       let hephaestusResolution = applyModelResolution({

--- a/src/shared/agent-tool-restrictions.ts
+++ b/src/shared/agent-tool-restrictions.ts
@@ -22,6 +22,7 @@ const AGENT_RESTRICTIONS: Record<string, Record<string, boolean>> = {
     edit: false,
     task: false,
     delegate_task: false,
+    call_omo_agent: false,
   },
 
   metis: {


### PR DESCRIPTION
## Summary
- Treat connected providers as valid fallback when model list is empty
- Use fallback chain check for Hephaestus gating
- Align agent restrictions and tests with connected provider checks

## Testing
- bun test src/agents/utils.test.ts
- bun run typecheck
- bun run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor connected provider state in model availability checks to prevent agents from being skipped when the model list is empty. Hephaestus now gates on its fallback chain.

- **Bug Fixes**
  - isAnyFallbackModelAvailable checks connectedProvidersCache when availableModels is empty.
  - Hephaestus creation uses fallback chain availability instead of a single model check.
  - Added call_omo_agent: false to agent restrictions and updated tests to cover non-connected providers.

<sup>Written for commit 80297f890e2a7553cb64c85953dbee5afb88fb49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

