### PR TITLE
fix: track agent in boulder state to fix session continuation (fixes #927)

### DIFF
--- a/src/features/boulder-state/storage.test.ts
+++ b/src/features/boulder-state/storage.test.ts
@@ -246,5 +246,33 @@ describe("boulder-state", () => {
       expect(state.plan_name).toBe("auth-refactor")
       expect(state.started_at).toBeDefined()
     })
+
+    test("should include agent field when provided", () => {
+      //#given - plan path, session id, and agent type
+      const planPath = "/path/to/feature.md"
+      const sessionId = "ses-xyz789"
+      const agent = "atlas"
+
+      //#when - createBoulderState is called with agent
+      const state = createBoulderState(planPath, sessionId, agent)
+
+      //#then - state should include the agent field
+      expect(state.agent).toBe("atlas")
+      expect(state.active_plan).toBe(planPath)
+      expect(state.session_ids).toEqual([sessionId])
+      expect(state.plan_name).toBe("feature")
+    })
+
+    test("should allow agent to be undefined", () => {
+      //#given - plan path and session id without agent
+      const planPath = "/path/to/legacy.md"
+      const sessionId = "ses-legacy"
+
+      //#when - createBoulderState is called without agent
+      const state = createBoulderState(planPath, sessionId)
+
+      //#then - state should not have agent field (backward compatible)
+      expect(state.agent).toBeUndefined()
+    })
   })
 })

--- a/src/features/boulder-state/storage.ts
+++ b/src/features/boulder-state/storage.ts
@@ -139,12 +139,14 @@ export function getPlanName(planPath: string): string {
  */
 export function createBoulderState(
   planPath: string,
-  sessionId: string
+  sessionId: string,
+  agent?: string
 ): BoulderState {
   return {
     active_plan: planPath,
     started_at: new Date().toISOString(),
     session_ids: [sessionId],
     plan_name: getPlanName(planPath),
+    ...(agent !== undefined ? { agent } : {}),
   }
 }

--- a/src/features/boulder-state/types.ts
+++ b/src/features/boulder-state/types.ts
@@ -14,6 +14,8 @@ export interface BoulderState {
   session_ids: string[]
   /** Plan name derived from filename */
   plan_name: string
+  /** Agent type to use when resuming (e.g., 'atlas') */
+  agent?: string
 }
 
 export interface PlanProgress {

--- a/src/hooks/atlas/index.ts
+++ b/src/hooks/atlas/index.ts
@@ -26,6 +26,13 @@ function isSisyphusPath(filePath: string): boolean {
 
 const WRITE_EDIT_TOOLS = ["Write", "Edit", "write", "edit"]
 
+function getLastAgentFromSession(sessionID: string): string | null {
+  const messageDir = getMessageDir(sessionID)
+  if (!messageDir) return null
+  const nearest = findNearestMessageWithFields(messageDir)
+  return nearest?.agent?.toLowerCase() ?? null
+}
+
 const DIRECT_WORK_REMINDER = `
 
 ---
@@ -549,8 +556,14 @@ export function createAtlasHook(
           return
         }
 
-        if (!isCallerOrchestrator(sessionID)) {
-          log(`[${HOOK_NAME}] Skipped: last agent is not Atlas`, { sessionID })
+        const requiredAgent = (boulderState.agent ?? "atlas").toLowerCase()
+        const lastAgent = getLastAgentFromSession(sessionID)
+        if (!lastAgent || lastAgent !== requiredAgent) {
+          log(`[${HOOK_NAME}] Skipped: last agent does not match boulder agent`, {
+            sessionID,
+            lastAgent: lastAgent ?? "unknown",
+            requiredAgent,
+          })
           return
         }
 

--- a/src/hooks/atlas/index.ts
+++ b/src/hooks/atlas/index.ts
@@ -431,7 +431,7 @@ export function createAtlasHook(
     return state
   }
 
-  async function injectContinuation(sessionID: string, planName: string, remaining: number, total: number): Promise<void> {
+  async function injectContinuation(sessionID: string, planName: string, remaining: number, total: number, agent?: string): Promise<void> {
     const hasRunningBgTasks = backgroundManager
       ? backgroundManager.getTasksByParentSession(sessionID).some(t => t.status === "running")
       : false
@@ -477,7 +477,7 @@ export function createAtlasHook(
        await ctx.client.session.prompt({
          path: { id: sessionID },
          body: {
-            agent: "atlas",
+            agent: agent ?? "atlas",
            ...(model !== undefined ? { model } : {}),
            parts: [{ type: "text", text: prompt }],
          },
@@ -568,7 +568,7 @@ export function createAtlasHook(
 
         state.lastContinuationInjectedAt = now
         const remaining = progress.total - progress.completed
-        injectContinuation(sessionID, boulderState.plan_name, remaining, progress.total)
+        injectContinuation(sessionID, boulderState.plan_name, remaining, progress.total, boulderState.agent)
         return
       }
 

--- a/src/hooks/start-work/index.ts
+++ b/src/hooks/start-work/index.ts
@@ -102,7 +102,7 @@ All ${progress.total} tasks are done. Create a new plan with: /plan "your task"`
             if (existingState) {
               clearBoulderState(ctx.directory)
             }
-            const newState = createBoulderState(matchedPlan, sessionId)
+            const newState = createBoulderState(matchedPlan, sessionId, "atlas")
             writeBoulderState(ctx.directory, newState)
             
             contextInfo = `
@@ -187,7 +187,7 @@ All ${plans.length} plan(s) are complete. Create a new plan with: /plan "your ta
         } else if (incompletePlans.length === 1) {
           const planPath = incompletePlans[0]
           const progress = getPlanProgress(planPath)
-          const newState = createBoulderState(planPath, sessionId)
+          const newState = createBoulderState(planPath, sessionId, "atlas")
           writeBoulderState(ctx.directory, newState)
 
           contextInfo += `


### PR DESCRIPTION
## Summary

Fixes #927 - After session interruption during `/start-work`, when user types "continue", Prometheus (planner) was resuming instead of Sisyphus (executor), causing all subsequent `delegate_task` calls to get READ-ONLY directive injected.

## Root Cause

The `boulder.json` file was missing an `agent` field to specify which agent should resume on continuation. The atlas hook hardcoded `agent: "atlas"` but this wasn't being persisted when the boulder state was created.

## Changes

- Add optional `agent` field to `BoulderState` interface in `types.ts`
- Update `createBoulderState()` in `storage.ts` to accept optional `agent` parameter
- Update `start-work` hook to set `agent: 'atlas'` when creating boulder state
- Update `atlas` hook to use stored `boulderState.agent` (defaults to 'atlas') on continuation
- Add tests for new agent field functionality

## Testing

- Added 2 new tests for `createBoulderState` with agent field
- All 59 related tests pass
- Full test suite: 2099 pass (10 pre-existing failures in MCP OAuth tests)
- Typecheck passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the active agent in boulder.json so “continue” resumes the correct executor (atlas/sisyphus) instead of the planner (Prometheus). Fixes #927 and prevents READ-ONLY mode from being injected into delegate_task calls.

- **Bug Fixes**
  - Added optional agent to BoulderState and createBoulderState(plan, session, agent?)
  - Set agent="atlas" when /start-work initializes boulder state
  - Idle handler now checks the last session agent against boulderState.agent (defaults to "atlas") and uses it for continuation; supports non-Atlas agents
  - Prometheus MD-only: prioritize boulder state agent over message files so sessions resume with the executor even after restarts
  - Added tests for agent field, backward compatibility, non-Atlas continuation, and boulder-over-message priority

<sup>Written for commit 38b40bca04e37976cc39089ca04da39ad03cfb1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

