### PR TITLE
fix(agents): emphasize user-installed custom skills in delegation prompts

### DIFF
--- a/src/agents/atlas/utils.ts
+++ b/src/agents/atlas/utils.ts
@@ -56,21 +56,66 @@ export function buildSkillsSection(skills: AvailableSkill[]): string {
     return ""
   }
 
-  const skillRows = skills.map((s) => {
+  const builtinSkills = skills.filter((s) => s.location === "plugin")
+  const customSkills = skills.filter((s) => s.location !== "plugin")
+
+  const builtinRows = builtinSkills.map((s) => {
     const shortDesc = s.description.split(".")[0] || s.description
     return `| \`${s.name}\` | ${shortDesc} |`
   })
+
+  const customRows = customSkills.map((s) => {
+    const shortDesc = s.description.split(".")[0] || s.description
+    const source = s.location === "project" ? "project" : "user"
+    return `| \`${s.name}\` | ${shortDesc} | ${source} |`
+  })
+
+  const customSkillNames = customSkills.map((s) => `"${s.name}"`).join(", ")
+
+  let skillsTable: string
+
+  if (customSkills.length > 0 && builtinSkills.length > 0) {
+    skillsTable = `**Built-in Skills:**
+
+| Skill | When to Use |
+|-------|-------------|
+${builtinRows.join("\n")}
+
+**User-Installed Skills (HIGH PRIORITY):**
+
+The user installed these for their workflow. They MUST be evaluated for EVERY delegation.
+
+| Skill | When to Use | Source |
+|-------|-------------|--------|
+${customRows.join("\n")}
+
+> **CRITICAL**: The user installed ${customSkillNames} for a reason — USE THEM when the task overlaps with their domain.
+> When in doubt, INCLUDE a user-installed skill rather than omit it.`
+  } else if (customSkills.length > 0) {
+    skillsTable = `**User-Installed Skills (HIGH PRIORITY):**
+
+The user installed these for their workflow. They MUST be evaluated for EVERY delegation.
+
+| Skill | When to Use | Source |
+|-------|-------------|--------|
+${customRows.join("\n")}
+
+> **CRITICAL**: The user installed ${customSkillNames} for a reason — USE THEM when the task overlaps with their domain.
+> When in doubt, INCLUDE a user-installed skill rather than omit it.`
+  } else {
+    skillsTable = `| Skill | When to Use |
+|-------|-------------|
+${builtinRows.join("\n")}`
+  }
 
   return `
 #### 3.2.2: Skill Selection (PREPEND TO PROMPT)
 
 **Skills are specialized instructions that guide subagent behavior. Consider them alongside category selection.**
 
-| Skill | When to Use |
-|-------|-------------|
-${skillRows.join("\n")}
+${skillsTable}
 
-**MANDATORY: Evaluate ALL skills for relevance to your task.**
+**MANDATORY: Evaluate ALL skills (built-in AND user-installed) for relevance to your task.**
 
 Read each skill's description and ask: "Does this skill's domain overlap with my task?"
 - If YES: INCLUDE in load_skills=[...]

--- a/src/agents/dynamic-agent-prompt-builder.test.ts
+++ b/src/agents/dynamic-agent-prompt-builder.test.ts
@@ -1,0 +1,161 @@
+/// <reference types="bun-types" />
+
+import { describe, it, expect } from "bun:test"
+import {
+  buildCategorySkillsDelegationGuide,
+  buildUltraworkSection,
+  type AvailableSkill,
+  type AvailableCategory,
+  type AvailableAgent,
+} from "./dynamic-agent-prompt-builder"
+
+describe("buildCategorySkillsDelegationGuide", () => {
+  const categories: AvailableCategory[] = [
+    { name: "visual-engineering", description: "Frontend, UI/UX" },
+    { name: "quick", description: "Trivial tasks" },
+  ]
+
+  const builtinSkills: AvailableSkill[] = [
+    { name: "playwright", description: "Browser automation via Playwright", location: "plugin" },
+    { name: "frontend-ui-ux", description: "Designer-turned-developer", location: "plugin" },
+  ]
+
+  const customUserSkills: AvailableSkill[] = [
+    { name: "react-19", description: "React 19 patterns and best practices", location: "user" },
+    { name: "tailwind-4", description: "Tailwind CSS v4 utilities", location: "user" },
+  ]
+
+  const customProjectSkills: AvailableSkill[] = [
+    { name: "our-design-system", description: "Internal design system components", location: "project" },
+  ]
+
+  it("should separate builtin and custom skills into distinct sections", () => {
+    //#given: mix of builtin and custom skills
+    const allSkills = [...builtinSkills, ...customUserSkills]
+
+    //#when: building the delegation guide
+    const result = buildCategorySkillsDelegationGuide(categories, allSkills)
+
+    //#then: should have separate sections
+    expect(result).toContain("Built-in Skills")
+    expect(result).toContain("User-Installed Skills")
+    expect(result).toContain("HIGH PRIORITY")
+  })
+
+  it("should include custom skill names in CRITICAL warning", () => {
+    //#given: custom skills installed
+    const allSkills = [...builtinSkills, ...customUserSkills]
+
+    //#when: building the delegation guide
+    const result = buildCategorySkillsDelegationGuide(categories, allSkills)
+
+    //#then: should mention custom skills by name in the warning
+    expect(result).toContain('"react-19"')
+    expect(result).toContain('"tailwind-4"')
+    expect(result).toContain("CRITICAL")
+  })
+
+  it("should show source column for custom skills (user vs project)", () => {
+    //#given: both user and project custom skills
+    const allSkills = [...builtinSkills, ...customUserSkills, ...customProjectSkills]
+
+    //#when: building the delegation guide
+    const result = buildCategorySkillsDelegationGuide(categories, allSkills)
+
+    //#then: should show source for each custom skill
+    expect(result).toContain("| user |")
+    expect(result).toContain("| project |")
+  })
+
+  it("should not show custom skill section when only builtin skills exist", () => {
+    //#given: only builtin skills
+    const allSkills = [...builtinSkills]
+
+    //#when: building the delegation guide
+    const result = buildCategorySkillsDelegationGuide(categories, allSkills)
+
+    //#then: should not contain custom skill emphasis
+    expect(result).not.toContain("User-Installed Skills")
+    expect(result).not.toContain("HIGH PRIORITY")
+    expect(result).toContain("Available Skills")
+  })
+
+  it("should handle only custom skills (no builtins)", () => {
+    //#given: only custom skills, no builtins
+    const allSkills = [...customUserSkills]
+
+    //#when: building the delegation guide
+    const result = buildCategorySkillsDelegationGuide(categories, allSkills)
+
+    //#then: should show custom skills with emphasis, no builtin section
+    expect(result).toContain("User-Installed Skills")
+    expect(result).toContain("HIGH PRIORITY")
+    expect(result).not.toContain("Built-in Skills")
+  })
+
+  it("should include priority note for custom skills in evaluation step", () => {
+    //#given: custom skills present
+    const allSkills = [...builtinSkills, ...customUserSkills]
+
+    //#when: building the delegation guide
+    const result = buildCategorySkillsDelegationGuide(categories, allSkills)
+
+    //#then: evaluation section should mention user-installed priority
+    expect(result).toContain("User-installed skills get PRIORITY")
+    expect(result).toContain("INCLUDE it rather than omit it")
+  })
+
+  it("should NOT include priority note when no custom skills", () => {
+    //#given: only builtin skills
+    const allSkills = [...builtinSkills]
+
+    //#when: building the delegation guide
+    const result = buildCategorySkillsDelegationGuide(categories, allSkills)
+
+    //#then: no priority note for custom skills
+    expect(result).not.toContain("User-installed skills get PRIORITY")
+  })
+
+  it("should return empty string when no categories and no skills", () => {
+    //#given: no categories and no skills
+    //#when: building the delegation guide
+    const result = buildCategorySkillsDelegationGuide([], [])
+
+    //#then: should return empty string
+    expect(result).toBe("")
+  })
+})
+
+describe("buildUltraworkSection", () => {
+  const agents: AvailableAgent[] = []
+
+  it("should separate builtin and custom skills", () => {
+    //#given: mix of builtin and custom skills
+    const skills: AvailableSkill[] = [
+      { name: "playwright", description: "Browser automation", location: "plugin" },
+      { name: "react-19", description: "React 19 patterns", location: "user" },
+    ]
+
+    //#when: building ultrawork section
+    const result = buildUltraworkSection(agents, [], skills)
+
+    //#then: should have separate sections
+    expect(result).toContain("Built-in Skills")
+    expect(result).toContain("User-Installed Skills")
+    expect(result).toContain("HIGH PRIORITY")
+  })
+
+  it("should not separate when only builtin skills", () => {
+    //#given: only builtin skills
+    const skills: AvailableSkill[] = [
+      { name: "playwright", description: "Browser automation", location: "plugin" },
+    ]
+
+    //#when: building ultrawork section
+    const result = buildUltraworkSection(agents, [], skills)
+
+    //#then: should have single section
+    expect(result).toContain("Built-in Skills")
+    expect(result).not.toContain("User-Installed Skills")
+  })
+})


### PR DESCRIPTION
## Summary

Custom skills installed in `.config/opencode/skills/` (e.g., `react-19`, `tailwind-4`, `typescript-strict`) were visible in agent prompts but **consistently ignored by the model when delegating** via `delegate_task(load_skills=[...])`. The root cause is that all skills were rendered in a single flat table with no distinction between built-in and user-installed skills, causing the model to default to built-in ones only.

This is a known pattern — Claude Code has the same issue documented in [anthropics/claude-code#18784](https://github.com/anthropics/claude-code/issues/18784) where agent frontmatter constraints (including skills) are ignored during delegation.

## Root Cause Analysis

The backend already supports custom skills end-to-end:
- ✅ `discoverSkills()` finds custom skills from all directories
- ✅ `getAllSkills()` merges builtin + custom skills
- ✅ `resolveMultipleSkillsAsync()` can resolve custom skill names to content
- ✅ `createBuiltinAgents()` passes discovered skills to agent factories

**The problem is purely in the prompt layer.** The model sees custom skills listed alongside built-in ones but doesn't recognize them as important enough to include in `load_skills` when delegating.

## Changes

### `src/agents/dynamic-agent-prompt-builder.ts`

**`buildCategorySkillsDelegationGuide()`** — Used by Sisyphus, Hephaestus, and Atlas:
- Separate skills by `location` field: `plugin` = built-in, `user`/`project` = custom
- When custom skills exist, render two distinct sections:
  - **"Built-in Skills"** — standard table
  - **"User-Installed Skills (HIGH PRIORITY)"** — with source column (user/project)
- Add **CRITICAL warning** that names each custom skill explicitly
- Add priority note in evaluation step: *"When in doubt about a user-installed skill, INCLUDE it rather than omit it"*
- When only built-in skills exist: no change to existing behavior (zero overhead)

**`buildUltraworkSection()`** — Same separation applied

### `src/agents/atlas/utils.ts`

**`buildSkillsSection()`** — Atlas had its own skill renderer that also used a flat table. Applied the same HIGH PRIORITY emphasis and CRITICAL warning pattern.

### `src/agents/dynamic-agent-prompt-builder.test.ts` (NEW)

10 unit tests covering:
- Mixed builtin + custom skills → separate sections
- Custom skill names appear in CRITICAL warning
- Source column (user vs project) rendered correctly
- Only builtin skills → no custom section, no overhead
- Only custom skills → no builtin section
- Priority note present/absent based on custom skills
- Empty skills → empty string
- `buildUltraworkSection` separation

## Before / After

**Before** (flat table — model ignores custom skills):
```
| Skill | Expertise Domain |
|-------|------------------|
| `playwright` | Browser automation |
| `frontend-ui-ux` | Designer-turned-developer |
| `git-master` | Git operations |
| `react-19` | React 19 patterns |     ← model ignores these
| `tailwind-4` | Tailwind CSS v4 |      ← model ignores these
```

**After** (separated with emphasis — model picks them up):
```
#### Built-in Skills
| Skill | Expertise Domain |
| `playwright` | Browser automation |
| `frontend-ui-ux` | Designer-turned-developer |

#### User-Installed Skills (HIGH PRIORITY)
**The user has installed these custom skills. They MUST be evaluated for EVERY delegation.**

| Skill | Expertise Domain | Source |
| `react-19` | React 19 patterns | user |
| `tailwind-4` | Tailwind CSS v4 | user |

> **CRITICAL**: The user installed "react-19", "tailwind-4" for a reason — USE THEM.
```

## Testing

### Unit Tests
```
bun test src/agents/
→ 90 tests, 0 failures (including 10 new tests)
```

### Deep Integration Test (50 assertions)
Verified the full pipeline with real custom skills in `~/.config/opencode/skills/`:

| Layer | Test | Status |
|-------|------|--------|
| Discovery | Custom skills from `~/.config/opencode/skills/` found | ✅ |
| Merge | `getAllSkills()` returns builtin + custom | ✅ |
| Resolution | `resolveMultipleSkillsAsync("react-19")` → content | ✅ |
| Resolution | 6 mixed skills (3 builtin + 3 custom) simultaneously | ✅ |
| Resolution | Non-existent skill → correctly in `notFound` | ✅ |
| Sisyphus | Prompt has HIGH PRIORITY + CRITICAL + all custom skill names | ✅ |
| Hephaestus | Prompt has HIGH PRIORITY + CRITICAL + all custom skill names | ✅ |
| Atlas | `buildSkillsSection()` separates builtin/custom | ✅ |
| Ultrawork | `buildUltraworkSection()` separates builtin/custom | ✅ |

### Existing Tests
```
bun test src/agents/ src/features/opencode-skill-loader/
→ 159 tests, 0 failures
```

## Affected Agents

| Agent | Function | Impact |
|-------|----------|--------|
| **Sisyphus** | `buildCategorySkillsDelegationGuide()` | Custom skills now emphasized |
| **Hephaestus** | `buildCategorySkillsDelegationGuide()` | Custom skills now emphasized |
| **Atlas** | `buildCategorySkillsDelegationGuide()` + `buildSkillsSection()` | Both functions updated |
| **Sisyphus-Junior** | N/A | No change needed — receives skill content directly via `resolveMultipleSkillsAsync` |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix prompts so user-installed custom skills are evaluated and included during delegate_task, instead of being ignored. This improves delegation accuracy by clearly prioritizing user-installed skills over built-ins when relevant.

- **Bug Fixes**
  - Split skills into “Built-in Skills” and “User-Installed Skills (HIGH PRIORITY)” with a Source column (user/project).
  - Add a CRITICAL warning that names each custom skill and a note to include them when in doubt.
  - Apply changes in buildCategorySkillsDelegationGuide, buildUltraworkSection, and Atlas buildSkillsSection; no change when only built-ins exist.
  - Add 10 unit tests covering mixed and edge cases; all tests pass.

<sup>Written for commit a298a2f06302dffbd01a373f6456de7fbf23294c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

