### PR TITLE
refactor(agents): extract formatCustomSkillsBlock to eliminate duplication

### DIFF
--- a/src/agents/atlas/utils.ts
+++ b/src/agents/atlas/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CategoryConfig } from "../../config/schema"
-import type { AvailableAgent, AvailableSkill } from "../dynamic-agent-prompt-builder"
+import { formatCustomSkillsBlock, type AvailableAgent, type AvailableSkill } from "../dynamic-agent-prompt-builder"
 import { DEFAULT_CATEGORIES, CATEGORY_DESCRIPTIONS } from "../../tools/delegate-task/constants"
 
 export const getCategoryDescription = (name: string, userCategories?: Record<string, CategoryConfig>) =>
@@ -70,7 +70,7 @@ export function buildSkillsSection(skills: AvailableSkill[]): string {
     return `| \`${s.name}\` | ${shortDesc} | ${source} |`
   })
 
-  const customSkillNames = customSkills.map((s) => `"${s.name}"`).join(", ")
+  const customSkillBlock = formatCustomSkillsBlock(customRows, customSkills, "**")
 
   let skillsTable: string
 
@@ -81,27 +81,9 @@ export function buildSkillsSection(skills: AvailableSkill[]): string {
 |-------|-------------|
 ${builtinRows.join("\n")}
 
-**User-Installed Skills (HIGH PRIORITY):**
-
-The user installed these for their workflow. They MUST be evaluated for EVERY delegation.
-
-| Skill | When to Use | Source |
-|-------|-------------|--------|
-${customRows.join("\n")}
-
-> **CRITICAL**: The user installed ${customSkillNames} for a reason — USE THEM when the task overlaps with their domain.
-> When in doubt, INCLUDE a user-installed skill rather than omit it.`
+${customSkillBlock}`
   } else if (customSkills.length > 0) {
-    skillsTable = `**User-Installed Skills (HIGH PRIORITY):**
-
-The user installed these for their workflow. They MUST be evaluated for EVERY delegation.
-
-| Skill | When to Use | Source |
-|-------|-------------|--------|
-${customRows.join("\n")}
-
-> **CRITICAL**: The user installed ${customSkillNames} for a reason — USE THEM when the task overlaps with their domain.
-> When in doubt, INCLUDE a user-installed skill rather than omit it.`
+    skillsTable = customSkillBlock
   } else {
     skillsTable = `| Skill | When to Use |
 |-------|-------------|

--- a/src/agents/dynamic-agent-prompt-builder.test.ts
+++ b/src/agents/dynamic-agent-prompt-builder.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from "bun:test"
 import {
   buildCategorySkillsDelegationGuide,
   buildUltraworkSection,
+  formatCustomSkillsBlock,
   type AvailableSkill,
   type AvailableCategory,
   type AvailableAgent,
@@ -157,5 +158,48 @@ describe("buildUltraworkSection", () => {
     //#then: should have single section
     expect(result).toContain("Built-in Skills")
     expect(result).not.toContain("User-Installed Skills")
+  })
+})
+
+describe("formatCustomSkillsBlock", () => {
+  const customSkills: AvailableSkill[] = [
+    { name: "react-19", description: "React 19 patterns", location: "user" },
+    { name: "tailwind-4", description: "Tailwind v4", location: "project" },
+  ]
+
+  const customRows = customSkills.map((s) => {
+    const source = s.location === "project" ? "project" : "user"
+    return `| \`${s.name}\` | ${s.description} | ${source} |`
+  })
+
+  it("should produce consistent output used by both builders", () => {
+    //#given: custom skills and rows
+    //#when: formatting with default header level
+    const result = formatCustomSkillsBlock(customRows, customSkills)
+
+    //#then: contains all expected elements
+    expect(result).toContain("User-Installed Skills (HIGH PRIORITY)")
+    expect(result).toContain("CRITICAL")
+    expect(result).toContain('"react-19"')
+    expect(result).toContain('"tailwind-4"')
+    expect(result).toContain("| user |")
+    expect(result).toContain("| project |")
+  })
+
+  it("should use #### header by default", () => {
+    //#given: default header level
+    const result = formatCustomSkillsBlock(customRows, customSkills)
+
+    //#then: uses markdown h4
+    expect(result).toContain("#### User-Installed Skills")
+  })
+
+  it("should use bold header when specified", () => {
+    //#given: bold header level (used by Atlas)
+    const result = formatCustomSkillsBlock(customRows, customSkills, "**")
+
+    //#then: uses bold instead of h4
+    expect(result).toContain("**User-Installed Skills (HIGH PRIORITY):**")
+    expect(result).not.toContain("#### User-Installed Skills")
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #1490 — this commit was pushed after the merge and needs a separate PR.

- Extracts the custom skills formatting logic into a shared `formatCustomSkillsBlock()` helper in `dynamic-agent-prompt-builder.ts`
- `atlas/utils.ts` now imports and reuses this helper instead of duplicating the formatting
- Eliminates code duplication flagged by the review bot (P3) on #1490
- Updates tests to cover the extracted helper directly

No behavioral changes — pure refactor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared formatCustomSkillsBlock() for the “User-Installed Skills” section to remove duplicated prompt formatting across agents and Atlas. No behavior changes; output stays the same.

- **Refactors**
  - Added formatCustomSkillsBlock(customRows, customSkills, headerLevel?) with default "####" and optional "**" for Atlas.
  - Replaced duplicated blocks in buildCategorySkillsDelegationGuide() and atlas/utils.ts buildSkillsSection().
  - Added unit tests covering content and header variants.

<sup>Written for commit f08d4ecdda0b5ceb0f8f4faf92e99ec7ded9f296. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

