### PR TITLE
fix: include custom skills in delegate_task load_skills resolution

### DIFF
--- a/src/features/opencode-skill-loader/loader.test.ts
+++ b/src/features/opencode-skill-loader/loader.test.ts
@@ -451,8 +451,16 @@ claude project body.
         expect(duplicates[0]?.definition.description).toContain("opencode-project")
       } finally {
         process.chdir(originalCwd)
-        process.env.OPENCODE_CONFIG_DIR = originalOpenCodeConfigDir
-        process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
+        if (originalOpenCodeConfigDir === undefined) {
+          delete process.env.OPENCODE_CONFIG_DIR
+        } else {
+          process.env.OPENCODE_CONFIG_DIR = originalOpenCodeConfigDir
+        }
+        if (originalClaudeConfigDir === undefined) {
+          delete process.env.CLAUDE_CONFIG_DIR
+        } else {
+          process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
+        }
       }
     })
 
@@ -503,8 +511,16 @@ claude project body.
         expect(matches[0]?.definition.description).toContain("opencode-global")
       } finally {
         process.chdir(originalCwd)
-        process.env.OPENCODE_CONFIG_DIR = originalOpenCodeConfigDir
-        process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
+        if (originalOpenCodeConfigDir === undefined) {
+          delete process.env.OPENCODE_CONFIG_DIR
+        } else {
+          process.env.OPENCODE_CONFIG_DIR = originalOpenCodeConfigDir
+        }
+        if (originalClaudeConfigDir === undefined) {
+          delete process.env.CLAUDE_CONFIG_DIR
+        } else {
+          process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
+        }
       }
     })
 
@@ -536,7 +552,11 @@ Skill body.
         expect(names.length).toBe(uniqueNames.length)
       } finally {
         process.chdir(originalCwd)
-        process.env.OPENCODE_CONFIG_DIR = originalOpenCodeConfigDir
+        if (originalOpenCodeConfigDir === undefined) {
+          delete process.env.OPENCODE_CONFIG_DIR
+        } else {
+          process.env.OPENCODE_CONFIG_DIR = originalOpenCodeConfigDir
+        }
       }
     })
   })

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -251,10 +251,10 @@ function deduplicateSkills(skills: LoadedSkill[]): LoadedSkill[] {
 }
 
 export async function discoverAllSkills(): Promise<LoadedSkill[]> {
-  const [opencodeProjectSkills, projectSkills, opencodeGlobalSkills, userSkills] = await Promise.all([
+  const [opencodeProjectSkills, opencodeGlobalSkills, projectSkills, userSkills] = await Promise.all([
     discoverOpencodeProjectSkills(),
-    discoverProjectClaudeSkills(),
     discoverOpencodeGlobalSkills(),
+    discoverProjectClaudeSkills(),
     discoverUserClaudeSkills(),
   ])
 

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -233,6 +233,22 @@ export interface DiscoverSkillsOptions {
   includeClaudeCodePaths?: boolean
 }
 
+/**
+ * Deduplicates skills by name, keeping the first occurrence (higher priority).
+ * Priority order: opencode-project > project > opencode > user
+ */
+function deduplicateSkills(skills: LoadedSkill[]): LoadedSkill[] {
+  const seen = new Set<string>()
+  const result: LoadedSkill[] = []
+  for (const skill of skills) {
+    if (!seen.has(skill.name)) {
+      seen.add(skill.name)
+      result.push(skill)
+    }
+  }
+  return result
+}
+
 export async function discoverAllSkills(): Promise<LoadedSkill[]> {
   const [opencodeProjectSkills, projectSkills, opencodeGlobalSkills, userSkills] = await Promise.all([
     discoverOpencodeProjectSkills(),
@@ -241,7 +257,8 @@ export async function discoverAllSkills(): Promise<LoadedSkill[]> {
     discoverUserClaudeSkills(),
   ])
 
-  return [...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills]
+  // Priority: opencode-project > project > opencode > user
+  return deduplicateSkills([...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills])
 }
 
 export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promise<LoadedSkill[]> {
@@ -253,7 +270,8 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
   ])
 
   if (!includeClaudeCodePaths) {
-    return [...opencodeProjectSkills, ...opencodeGlobalSkills]
+    // Priority: opencode-project > opencode
+    return deduplicateSkills([...opencodeProjectSkills, ...opencodeGlobalSkills])
   }
 
   const [projectSkills, userSkills] = await Promise.all([
@@ -261,7 +279,8 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
     discoverUserClaudeSkills(),
   ])
 
-  return [...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills]
+  // Priority: opencode-project > project > opencode > user
+  return deduplicateSkills([...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills])
 }
 
 export async function getSkillByName(name: string, options: DiscoverSkillsOptions = {}): Promise<LoadedSkill | undefined> {

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -235,7 +235,8 @@ export interface DiscoverSkillsOptions {
 
 /**
  * Deduplicates skills by name, keeping the first occurrence (higher priority).
- * Priority order: opencode-project > project > opencode > user
+ * Priority order: opencode-project > opencode > project > user
+ * (OpenCode Global skills take precedence over legacy Claude project skills)
  */
 function deduplicateSkills(skills: LoadedSkill[]): LoadedSkill[] {
   const seen = new Set<string>()
@@ -257,8 +258,8 @@ export async function discoverAllSkills(): Promise<LoadedSkill[]> {
     discoverUserClaudeSkills(),
   ])
 
-  // Priority: opencode-project > project > opencode > user
-  return deduplicateSkills([...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills])
+  // Priority: opencode-project > opencode > project > user
+  return deduplicateSkills([...opencodeProjectSkills, ...opencodeGlobalSkills, ...projectSkills, ...userSkills])
 }
 
 export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promise<LoadedSkill[]> {
@@ -279,8 +280,8 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
     discoverUserClaudeSkills(),
   ])
 
-  // Priority: opencode-project > project > opencode > user
-  return deduplicateSkills([...opencodeProjectSkills, ...projectSkills, ...opencodeGlobalSkills, ...userSkills])
+  // Priority: opencode-project > opencode > project > user
+  return deduplicateSkills([...opencodeProjectSkills, ...opencodeGlobalSkills, ...projectSkills, ...userSkills])
 }
 
 export async function getSkillByName(name: string, options: DiscoverSkillsOptions = {}): Promise<LoadedSkill | undefined> {


### PR DESCRIPTION
Rebased and conflict-resolved version of #1494.

## Changes
- Add deduplicateSkills() to prevent duplicate skill entries from multiple sources
- Priority order: opencode-project > opencode > project > user
- Add tests for deduplication behavior

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom skill resolution in delegate_task load_skills by deduplicating skills and enforcing priority: opencode-project > opencode > project > user. OpenCode global skills now properly override legacy Claude project skills.

- **Bug Fixes**
  - Added deduplicateSkills to return unique skills by name.
  - Applied priority in discoverAllSkills and discoverSkills.
  - Updated tests to verify precedence and no duplicates; corrected field to scope.
  - Safely restore env vars in tests when originally undefined.

<sup>Written for commit a644d38623fabed2dde56f631cba09a0df6bb8f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

