### PR TITLE
fix(lsp): add Node.js proxy for Windows to avoid Bun spawn segfault

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -3030,6 +3030,30 @@
           }
         }
       }
+    },
+    "lsp_process": {
+      "type": "object",
+      "properties": {
+        "runtime": {
+          "default": "auto",
+          "type": "string",
+          "enum": [
+            "auto",
+            "bun",
+            "node"
+          ]
+        },
+        "node_command": {
+          "default": [
+            "node"
+          ],
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.2.1",
-        "oh-my-opencode-darwin-x64": "3.2.1",
-        "oh-my-opencode-linux-arm64": "3.2.1",
-        "oh-my-opencode-linux-arm64-musl": "3.2.1",
-        "oh-my-opencode-linux-x64": "3.2.1",
-        "oh-my-opencode-linux-x64-musl": "3.2.1",
-        "oh-my-opencode-windows-x64": "3.2.1",
+        "oh-my-opencode-darwin-arm64": "3.2.2",
+        "oh-my-opencode-darwin-x64": "3.2.2",
+        "oh-my-opencode-linux-arm64": "3.2.2",
+        "oh-my-opencode-linux-arm64-musl": "3.2.2",
+        "oh-my-opencode-linux-x64": "3.2.2",
+        "oh-my-opencode-linux-x64-musl": "3.2.2",
+        "oh-my-opencode-windows-x64": "3.2.2",
       },
     },
   },
@@ -226,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-IvhHRUXTr/g/hJlkKTU2oCdgRl2BDl/Qre31Rukhs4NumlvME6iDmdnm8mM7bTxugfCBkfUUr7QJLxxLhzjdLA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-KyfoWcANfcvpfanrrX+Wc8vH8vr9mvr7dJMHBe2bkvuhdtHnLHOG18hQwLg6jk4HhdoZAeBEmkolOsK2k4XajA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-V2JbAdThAVfhBOcb+wBPZrAI0vBxPPRBdvmAixAxBOFC49CIJUrEFIRBUYFKhSQGHYWrNy8z0zJYoNQm4oQPog=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.2", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ajZ1E36Ixwdz6rvSUKUI08M2xOaNIl1ZsdVjknZTrPRtct9xgS+BEFCoSCov9bnV/9DrZD3mlZtO/+FFDbseUg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-SeT8P7Icq5YH/AIaEF28J4q+ifUnOqO2UgMFtdFusr8JLadYFy+6dTdeAuD2uGGToDQ3ZNKuaG+lo84KzEhA5w=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ItJsYfigXcOa8/ejTjopC4qk5BCeYioMQ693kPTpeYHK3ByugTjJk8aamE7bHlVnmrdgWldz91QFzaP82yOAdg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-wJUEVVUn1gyVIFNV4mxWg9cYo1rQdTKUXdGLfiqPiyQhWhZLRfPJ+9qpghvIVv7Dne6rzkbhYWdwdk/tew5RtQ=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/TvjYe/Kb//ZSHnJzgRj0QPKpS5Y2nermVTSaMTGS2btObXQyQWzuphDhsVRu60SVrNLbflHzfuTdqb3avDjyA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-p/XValXi1RRTZV8mEsdStXwZBkyQpgZjB41HLf0VfizPMAKRr6/bhuFZ9BDZFIhcDnLYcGV54MAVEsWms5yC2A=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Ka5j+tjuQkNnpESVzcTzW5tZMlBhOfP9F12+UaR72cIcwFpSoLMBp84rV6R0vXM0zUcrrN7mPeW66DvQ6A0XQQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-G7aNMqAMO2P+wUUaaAV8sXymm59cX4G9aVNXKAd/PM6RgFWh2F4HkXkOhOdHKYZzCl1QRhjh672mNillYsvebg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ISl0sTNShKCgPFO+rsDqEDsvVHQAMfOSAxO0KuWbHFKaH+KaRV4d3N/ihgxZ2M94CZjJLzZEuln+6kLZ93cvzQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-pyqTGlNxirKxQgXx9YJBq2y8KN/1oIygVupClmws7dDPj9etI1l8fs/SBEnMsYzMqTlGbLVeJ5+kj9p+yg7YDA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.2", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-KeiJLQvJuZ+UYf/+eMsQXvCiHDRPk6tD15lL+qruLvU19va62JqMNvTuOv97732uF19iG0ZMiiVhqIMbSyVPqQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -1114,6 +1114,33 @@ Each server supports: `command`, `extensions`, `priority`, `env`, `initializatio
 }
 ```
 
+### Windows: Bun LSP crash workaround (Node proxy)
+
+Some Bun builds on Windows can crash (segfault) when spawning LSP servers over stdio.
+See: <https://github.com/oven-sh/bun/issues/25798>
+
+Oh My OpenCode works around this by spawning LSP servers via a **Node.js proxy process** on Windows by default.
+
+You can configure it via `lsp_process`:
+
+```json
+{
+  "lsp_process": {
+    "runtime": "auto",
+    "node_command": ["node"]
+  }
+}
+```
+
+- `runtime`:
+  - `"auto"` (default): Windows → `"node"`, others → `"bun"`
+  - `"node"`: always use Node proxy (recommended on Windows)
+  - `"bun"`: always spawn LSP server directly (may crash on Windows)
+
+You can also override at runtime with an env var:
+
+- `OH_MY_OPENCODE_LSP_RUNTIME=auto|node|bun`
+
 ## Experimental
 
 Opt-in experimental features that may change or be removed in future versions. Use with caution.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "./schema.json": "./dist/oh-my-opencode.schema.json"
   },
   "scripts": {
-    "build": "bun build src/index.ts --outdir dist --target bun --format esm --external @ast-grep/napi && tsc --emitDeclarationOnly && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external @ast-grep/napi && bun run build:schema",
+    "build": "bun build src/index.ts --outdir dist --target bun --format esm --external @ast-grep/napi && tsc --emitDeclarationOnly && bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external @ast-grep/napi && bun build src/tools/lsp/node-proxy.ts --outdir dist/lsp --target node --format esm && bun run build:schema",
     "build:all": "bun run build && bun run build:binaries",
     "build:binaries": "bun run script/build-binaries.ts",
     "build:schema": "bun run script/build-schema.ts",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -366,6 +366,24 @@ export const SisyphusTasksConfigSchema = z.object({
 export const SisyphusConfigSchema = z.object({
   tasks: SisyphusTasksConfigSchema.optional(),
 })
+
+export const LspProcessRuntimeSchema = z.enum(["auto", "bun", "node"])
+
+export const LspProcessConfigSchema = z.object({
+  /**
+   * LSP process runtime strategy.
+   * - "auto": on Windows use Node proxy; otherwise spawn directly (Bun)
+   * - "bun": always spawn LSP servers directly (may crash on Windows in some Bun builds)
+   * - "node": spawn a Node.js proxy process which then spawns the real LSP server (recommended on Windows)
+   */
+  runtime: LspProcessRuntimeSchema.default("auto"),
+  /**
+   * Command to invoke Node.js for the proxy process.
+   * Example: ["node"] or ["C:/Program Files/nodejs/node.exe", "--no-warnings"]
+   */
+  node_command: z.array(z.string()).min(1).default(["node"]),
+})
+
 export const OhMyOpenCodeConfigSchema = z.object({
   $schema: z.string().optional(),
   /** Enable new task system (default: false) */
@@ -395,6 +413,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
   browser_automation_engine: BrowserAutomationConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),
   sisyphus: SisyphusConfigSchema.optional(),
+  lsp_process: LspProcessConfigSchema.optional(),
 })
 
 export type OhMyOpenCodeConfig = z.infer<typeof OhMyOpenCodeConfigSchema>
@@ -424,5 +443,7 @@ export type TmuxConfig = z.infer<typeof TmuxConfigSchema>
 export type TmuxLayout = z.infer<typeof TmuxLayoutSchema>
 export type SisyphusTasksConfig = z.infer<typeof SisyphusTasksConfigSchema>
 export type SisyphusConfig = z.infer<typeof SisyphusConfigSchema>
+export type LspProcessRuntime = z.infer<typeof LspProcessRuntimeSchema>
+export type LspProcessConfig = z.infer<typeof LspProcessConfigSchema>
 
 export { AnyMcpNameSchema, type AnyMcpName, McpNameSchema, type McpName } from "../mcp/types"

--- a/src/tools/lsp/node-proxy.ts
+++ b/src/tools/lsp/node-proxy.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Node-side LSP proxy.
+ *
+ * Why?
+ * Bun on Windows has had intermittent crashes when spawning + piping LSP servers.
+ * By spawning a single Node.js process from Bun and letting Node spawn the actual
+ * LSP server, we avoid the problematic Bun spawn path on Windows.
+ */
+
+import { spawn } from "node:child_process"
+
+function fatal(message: string, err?: unknown): never {
+  const suffix = err instanceof Error ? `\n${err.stack ?? err.message}` : err ? `\n${String(err)}` : ""
+  process.stderr.write(`${message}${suffix}\n`)
+  process.exit(1)
+}
+
+const commandJson = process.env.OH_MY_OPENCODE_LSP_PROXY_COMMAND
+if (!commandJson) {
+  fatal(
+    "Missing env OH_MY_OPENCODE_LSP_PROXY_COMMAND. This script is not meant to be run directly."
+  )
+}
+
+let command: unknown
+try {
+  command = JSON.parse(commandJson)
+} catch (e) {
+  fatal("Failed to parse OH_MY_OPENCODE_LSP_PROXY_COMMAND as JSON", e)
+}
+
+if (!Array.isArray(command) || command.length === 0 || !command.every((x) => typeof x === "string")) {
+  fatal("OH_MY_OPENCODE_LSP_PROXY_COMMAND must be a JSON array of strings")
+}
+
+const [cmd, ...args] = command as string[]
+const cwd = process.env.OH_MY_OPENCODE_LSP_PROXY_CWD || process.cwd()
+
+const child = spawn(cmd, args, {
+  cwd,
+  env: process.env,
+  stdio: ["pipe", "pipe", "pipe"],
+  windowsHide: true,
+  shell: false,
+})
+
+child.on("error", (e) => {
+  fatal(`Failed to spawn LSP server: ${[cmd, ...args].join(" ")}`, e)
+})
+
+// Proxy stdio to behave exactly like the real LSP server.
+process.stdin.pipe(child.stdin)
+child.stdout.pipe(process.stdout)
+child.stderr.pipe(process.stderr)
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.stderr.write(`LSP server exited with signal ${signal}\n`)
+    process.exit(1)
+  }
+  process.exit(code ?? 1)
+})


### PR DESCRIPTION
## Summary
Windows + Bun has intermittent segfaults when spawning LSP servers over stdio (see oven-sh/bun#25798). This PR adds a Node.js proxy approach as a workaround.

## Problem
- Bun on Windows crashes with segfault when spawning LSP servers
- The issue affects various Bun versions including 1.3.6+
- Users on Windows cannot use LSP features reliably

## Solution
On Windows, spawn a Node.js process which then spawns the real LSP server. Node's `child_process.spawn` is stable on Windows.

### Configuration
```json
{
  "lsp_process": {
    "runtime": "auto",
    "node_command": ["node"]
  }
}
```

- `runtime`:
  - `"auto"` (default): Windows → `"node"`, others → `"bun"`
  - `"node"`: always use Node proxy
  - `"bun"`: always spawn LSP server directly

- Environment override: `OH_MY_OPENCODE_LSP_RUNTIME=auto|node|bun`

## Files Changed
- `src/tools/lsp/node-proxy.ts`: Node-side proxy script (pipes stdio to child LSP server)
- `src/tools/lsp/client.ts`: Runtime selection logic
- `src/tools/lsp/config.ts`: `getLspProcessConfig()` to read config
- `src/config/schema.ts`: `LspProcessConfigSchema` for validation
- `docs/configurations.md`: Documentation for new options

## Testing
- All 2059 tests pass
- Build succeeds with new `dist/lsp/node-proxy.js` output

Closes #TBD (if there's a related issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent Windows LSP crashes under Bun by spawning servers through a Node.js proxy. Adds a runtime selector with sane defaults so Windows uses Node automatically.

- **Bug Fixes**
  - Prevents Bun spawn segfaults on Windows by proxying LSP startup via Node.
  - Preserves stdio behavior by piping through the proxy.

- **New Features**
  - lsp_process.runtime: auto | node | bun (default: auto; Windows → node).
  - lsp_process.node_command to set the Node binary and args.
  - Env override: OH_MY_OPENCODE_LSP_RUNTIME.
  - Updates schema, build to produce dist/lsp/node-proxy.js, and docs.

<sup>Written for commit caf10bd74bdacf025c728a84a48e66523abc8a0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

