### PR TITLE
fix(lsp): add Node.js spawn fallback for Windows stability

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -1063,6 +1063,26 @@ OpenCode provides LSP tools for analysis.
 Oh My OpenCode adds refactoring tools (rename, code actions).
 All OpenCode LSP configs and custom settings (from opencode.json) are supported, plus additional Oh My OpenCode-specific settings.
 
+### Windows Users
+
+On Windows, LSP servers are spawned using Node.js's `child_process` by default instead of Bun's native spawn.
+This provides better stability and avoids segmentation faults that can occur with Bun's spawn on Windows.
+See [oven-sh/bun#25798](https://github.com/oven-sh/bun/issues/25798) for details.
+
+You can control the spawn mode via environment variable:
+
+```bash
+# Use Node spawn (default on Windows, recommended for stability)
+OMO_LSP_SPAWN_MODE=node
+
+# Use Bun spawn (default on non-Windows)
+OMO_LSP_SPAWN_MODE=bun
+```
+
+If you experience LSP crashes on Windows, ensure `OMO_LSP_SPAWN_MODE=node` is set (this is the default).
+
+### Configuration
+
 Add LSP servers via the `lsp` option in `~/.config/opencode/oh-my-opencode.json` or `.opencode/oh-my-opencode.json`:
 
 ```json
@@ -1228,3 +1248,4 @@ Tools that should never be pruned (default):
 | Variable              | Description                                                                                                                                     |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `OPENCODE_CONFIG_DIR` | Override the OpenCode configuration directory. Useful for profile isolation with tools like [OCX](https://github.com/kdcokenny/ocx) ghost mode. |
+| `OMO_LSP_SPAWN_MODE`  | LSP server spawn mode: `node` or `bun`. Defaults to `node` on Windows for stability, `bun` elsewhere. See [LSP](#lsp) section for details.      |

--- a/src/cli/doctor/checks/lsp.ts
+++ b/src/cli/doctor/checks/lsp.ts
@@ -1,5 +1,6 @@
 import type { CheckResult, CheckDefinition, LspServerInfo } from "../types"
 import { CHECK_IDS, CHECK_NAMES } from "../constants"
+import { getLspSpawnMode } from "../../../tools/lsp/spawn-mode"
 
 const DEFAULT_LSP_SERVERS: Array<{
   id: string
@@ -40,6 +41,9 @@ export async function checkLspServers(): Promise<CheckResult> {
   const stats = getLspServerStats(servers)
   const installedServers = servers.filter((s) => s.installed)
   const missingServers = servers.filter((s) => !s.installed)
+  const spawnMode = getLspSpawnMode()
+
+  const spawnModeInfo = `Spawn mode: ${spawnMode}${process.platform === "win32" ? " (Node recommended for Windows stability)" : ""}`
 
   if (stats.installed === 0) {
     return {
@@ -47,6 +51,7 @@ export async function checkLspServers(): Promise<CheckResult> {
       status: "warn",
       message: "No LSP servers detected",
       details: [
+        spawnModeInfo,
         "LSP tools will have limited functionality",
         ...missingServers.map((s) => `Missing: ${s.id}`),
       ],
@@ -54,6 +59,7 @@ export async function checkLspServers(): Promise<CheckResult> {
   }
 
   const details = [
+    spawnModeInfo,
     ...installedServers.map((s) => `Installed: ${s.id}`),
     ...missingServers.map((s) => `Not found: ${s.id} (optional)`),
   ]

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -1,4 +1,5 @@
-import { spawn, type Subprocess } from "bun"
+import { spawn as bunSpawn, type Subprocess } from "bun"
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process"
 import { Readable, Writable } from "node:stream"
 import { readFileSync } from "fs"
 import { extname, resolve } from "path"
@@ -12,36 +13,44 @@ import {
 import { getLanguageId } from "./config"
 import type { Diagnostic, ResolvedServer } from "./types"
 import { log } from "../../shared/logger"
+import { getLspSpawnMode, type LspSpawnMode } from "./spawn-mode"
+
+type BunProc = Subprocess<"pipe", "pipe", "pipe">
 
 /**
  * Check if the current Bun version is affected by Windows LSP crash bug.
  * Bun v1.3.5 and earlier have a known segmentation fault issue on Windows
- * when spawning LSP servers. This was fixed in Bun v1.3.6.
+ * when spawning LSP servers. This was addressed in Bun v1.3.6, but some
+ * users still report issues on later versions.
  * See: https://github.com/oven-sh/bun/issues/25798
+ *
+ * @returns Warning info if using Bun spawn on Windows, null otherwise
  */
-function checkWindowsBunVersion(): { isAffected: boolean; message: string } | null {
+function checkWindowsBunSpawnWarning(spawnMode: LspSpawnMode): { message: string } | null {
   if (process.platform !== "win32") return null
+  if (spawnMode !== "bun") return null
 
   const version = Bun.version
   const [major, minor, patch] = version.split(".").map((v) => parseInt(v.split("-")[0], 10))
 
-  // Bun v1.3.5 and earlier are affected
+  // Bun v1.3.5 and earlier have known segfault issues
   if (major < 1 || (major === 1 && minor < 3) || (major === 1 && minor === 3 && patch < 6)) {
     return {
-      isAffected: true,
       message:
-        `⚠️  Windows + Bun v${version} detected: Known segmentation fault bug with LSP.\n` +
-        `   This causes crashes when using LSP tools (lsp_diagnostics, lsp_goto_definition, etc.).\n` +
-        `   \n` +
-        `   SOLUTION: Upgrade to Bun v1.3.6 or later:\n` +
-        `   powershell -c "irm bun.sh/install.ps1|iex"\n` +
-        `   \n` +
-        `   WORKAROUND: Use WSL instead of native Windows.\n` +
+        `⚠️  Windows + Bun v${version} + bun spawn mode: Known segmentation fault risk.\n` +
+        `   Upgrade to Bun v1.3.6+ or use Node spawn mode (default on Windows).\n` +
+        `   Set OMO_LSP_SPAWN_MODE=node to force Node mode.\n` +
         `   See: https://github.com/oven-sh/bun/issues/25798`,
     }
   }
 
-  return null
+  // Even on newer versions, warn that Node mode is safer
+  return {
+    message:
+      `⚠️  Windows + Bun spawn mode: Some users report stability issues.\n` +
+      `   If LSP crashes, set OMO_LSP_SPAWN_MODE=node (default on Windows).\n` +
+      `   See: https://github.com/oven-sh/bun/issues/25798`,
+  }
 }
 
 interface ManagedClient {
@@ -252,7 +261,10 @@ class LSPServerManager {
 export const lspManager = LSPServerManager.getInstance()
 
 export class LSPClient {
-  private proc: Subprocess<"pipe", "pipe", "pipe"> | null = null
+  private bunProc: BunProc | null = null
+  private nodeProc: ChildProcess | null = null
+  private spawnMode: LspSpawnMode = "bun"
+  private nodeExitedPromise: Promise<number | null> | null = null
   private connection: MessageConnection | null = null
   private openedFiles = new Set<string>()
   private documentVersions = new Map<string, number>()
@@ -268,40 +280,51 @@ export class LSPClient {
   ) {}
 
   async start(): Promise<void> {
-    const windowsCheck = checkWindowsBunVersion()
-    if (windowsCheck?.isAffected) {
-      throw new Error(
-        `LSP server cannot be started safely.\n\n${windowsCheck.message}`
-      )
+    this.spawnMode = getLspSpawnMode()
+    
+    // Log warning if using Bun spawn on Windows
+    const warning = checkWindowsBunSpawnWarning(this.spawnMode)
+    if (warning) {
+      log(warning.message)
     }
 
-    this.proc = spawn(this.server.command, {
+    const env = {
+      ...process.env,
+      ...this.server.env,
+    }
+
+    if (this.spawnMode === "node") {
+      await this.startWithNode(env)
+    } else {
+      await this.startWithBun(env)
+    }
+  }
+
+  private async startWithBun(env: NodeJS.ProcessEnv): Promise<void> {
+    this.bunProc = bunSpawn(this.server.command, {
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",
       cwd: this.root,
-      env: {
-        ...process.env,
-        ...this.server.env,
-      },
+      env,
     })
 
-    if (!this.proc) {
+    if (!this.bunProc) {
       throw new Error(`Failed to spawn LSP server: ${this.server.command.join(" ")}`)
     }
 
-    this.startStderrReading()
+    this.startStderrReadingBun()
 
     await new Promise((resolve) => setTimeout(resolve, 100))
 
-    if (this.proc.exitCode !== null) {
+    if (this.bunProc.exitCode !== null) {
       const stderr = this.stderrBuffer.join("\n")
       throw new Error(
-        `LSP server exited immediately with code ${this.proc.exitCode}` + (stderr ? `\nstderr: ${stderr}` : "")
+        `LSP server exited immediately with code ${this.bunProc.exitCode}` + (stderr ? `\nstderr: ${stderr}` : "")
       )
     }
 
-    const stdoutReader = this.proc.stdout.getReader()
+    const stdoutReader = this.bunProc.stdout.getReader()
     const nodeReadable = new Readable({
       async read() {
         try {
@@ -317,7 +340,7 @@ export class LSPClient {
       },
     })
 
-    const stdin = this.proc.stdin
+    const stdin = this.bunProc.stdin
     const nodeWritable = new Writable({
       write(chunk, _encoding, callback) {
         try {
@@ -329,9 +352,55 @@ export class LSPClient {
       },
     })
 
+    this.setupConnection(nodeReadable, nodeWritable)
+  }
+
+  private async startWithNode(env: NodeJS.ProcessEnv): Promise<void> {
+    const [cmd, ...args] = this.server.command
+    
+    this.nodeProc = nodeSpawn(cmd, args, {
+      cwd: this.root,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+      // On Windows, use shell for .cmd/.bat/.ps1 files
+      shell: process.platform === "win32",
+      windowsHide: true,
+    })
+
+    if (!this.nodeProc || !this.nodeProc.stdin || !this.nodeProc.stdout || !this.nodeProc.stderr) {
+      throw new Error(`Failed to spawn LSP server: ${this.server.command.join(" ")}`)
+    }
+
+    // Create a promise that resolves when the process exits
+    this.nodeExitedPromise = new Promise((resolve) => {
+      this.nodeProc!.on("exit", (code) => {
+        this.processExited = true
+        resolve(code)
+      })
+      this.nodeProc!.on("error", () => {
+        this.processExited = true
+        resolve(null)
+      })
+    })
+
+    this.startStderrReadingNode()
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    if (this.nodeProc.exitCode !== null) {
+      const stderr = this.stderrBuffer.join("\n")
+      throw new Error(
+        `LSP server exited immediately with code ${this.nodeProc.exitCode}` + (stderr ? `\nstderr: ${stderr}` : "")
+      )
+    }
+
+    this.setupConnection(this.nodeProc.stdout, this.nodeProc.stdin)
+  }
+
+  private setupConnection(readable: Readable, writable: Writable): void {
     this.connection = createMessageConnection(
-      new StreamMessageReader(nodeReadable),
-      new StreamMessageWriter(nodeWritable)
+      new StreamMessageReader(readable),
+      new StreamMessageWriter(writable)
     )
 
     this.connection.onNotification("textDocument/publishDiagnostics", (params: { uri?: string; diagnostics?: Diagnostic[] }) => {
@@ -362,10 +431,10 @@ export class LSPClient {
     this.connection.listen()
   }
 
-  private startStderrReading(): void {
-    if (!this.proc) return
+  private startStderrReadingBun(): void {
+    if (!this.bunProc) return
 
-    const reader = this.proc.stderr.getReader()
+    const reader = this.bunProc.stderr.getReader()
     const read = async () => {
       const decoder = new TextDecoder()
       try {
@@ -383,12 +452,32 @@ export class LSPClient {
     read()
   }
 
+  private startStderrReadingNode(): void {
+    if (!this.nodeProc?.stderr) return
+
+    this.nodeProc.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString()
+      this.stderrBuffer.push(text)
+      if (this.stderrBuffer.length > 100) {
+        this.stderrBuffer.shift()
+      }
+    })
+  }
+
+  private getExitCode(): number | null {
+    if (this.spawnMode === "node") {
+      return this.nodeProc?.exitCode ?? null
+    }
+    return this.bunProc?.exitCode ?? null
+  }
+
   private async sendRequest<T>(method: string, params?: unknown): Promise<T> {
     if (!this.connection) throw new Error("LSP client not started")
 
-    if (this.processExited || (this.proc && this.proc.exitCode !== null)) {
+    const exitCode = this.getExitCode()
+    if (this.processExited || exitCode !== null) {
       const stderr = this.stderrBuffer.slice(-10).join("\n")
-      throw new Error(`LSP server already exited (code: ${this.proc?.exitCode})` + (stderr ? `\nstderr: ${stderr}` : ""))
+      throw new Error(`LSP server already exited (code: ${exitCode})` + (stderr ? `\nstderr: ${stderr}` : ""))
     }
 
     let timeoutId: ReturnType<typeof setTimeout>
@@ -413,7 +502,8 @@ export class LSPClient {
 
   private sendNotification(method: string, params?: unknown): void {
     if (!this.connection) return
-    if (this.processExited || (this.proc && this.proc.exitCode !== null)) return
+    const exitCode = this.getExitCode()
+    if (this.processExited || exitCode !== null) return
 
     this.connection.sendNotification(method, params)
   }
@@ -596,7 +686,12 @@ export class LSPClient {
   }
 
   isAlive(): boolean {
-    return this.proc !== null && !this.processExited && this.proc.exitCode === null
+    if (this.processExited) return false
+    
+    if (this.spawnMode === "node") {
+      return this.nodeProc !== null && this.nodeProc.exitCode === null
+    }
+    return this.bunProc !== null && this.bunProc.exitCode === null
   }
 
   async stop(): Promise<void> {
@@ -608,35 +703,72 @@ export class LSPClient {
       this.connection.dispose()
       this.connection = null
     }
-    const proc = this.proc
-    if (proc) {
-      this.proc = null
-      let exitedBeforeTimeout = false
-      try {
-        proc.kill()
-        // Wait for exit with timeout to prevent indefinite hang
-        let timeoutId: ReturnType<typeof setTimeout> | undefined
-        const timeoutPromise = new Promise<void>((resolve) => {
-          timeoutId = setTimeout(resolve, 5000)
-        })
-        await Promise.race([
-          proc.exited.then(() => { exitedBeforeTimeout = true }).finally(() => timeoutId && clearTimeout(timeoutId)),
-          timeoutPromise,
-        ])
-        if (!exitedBeforeTimeout) {
-          log("[LSPClient] Process did not exit within timeout, escalating to SIGKILL")
-          try {
-            proc.kill("SIGKILL")
-            // Wait briefly for SIGKILL to take effect
-            await Promise.race([
-              proc.exited,
-              new Promise<void>((resolve) => setTimeout(resolve, 1000)),
-            ])
-          } catch {}
-        }
-      } catch {}
+
+    if (this.spawnMode === "node") {
+      await this.stopNodeProc()
+    } else {
+      await this.stopBunProc()
     }
+
     this.processExited = true
     this.diagnosticsStore.clear()
+  }
+
+  private async stopBunProc(): Promise<void> {
+    const proc = this.bunProc
+    if (!proc) return
+    
+    this.bunProc = null
+    let exitedBeforeTimeout = false
+    try {
+      proc.kill()
+      // Wait for exit with timeout to prevent indefinite hang
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
+      const timeoutPromise = new Promise<void>((resolve) => {
+        timeoutId = setTimeout(resolve, 5000)
+      })
+      await Promise.race([
+        proc.exited.then(() => { exitedBeforeTimeout = true }).finally(() => timeoutId && clearTimeout(timeoutId)),
+        timeoutPromise,
+      ])
+      if (!exitedBeforeTimeout) {
+        log("[LSPClient] Process did not exit within timeout, escalating to SIGKILL")
+        try {
+          proc.kill("SIGKILL")
+          // Wait briefly for SIGKILL to take effect
+          await Promise.race([
+            proc.exited,
+            new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+          ])
+        } catch {}
+      }
+    } catch {}
+  }
+
+  private async stopNodeProc(): Promise<void> {
+    const proc = this.nodeProc
+    if (!proc) return
+
+    this.nodeProc = null
+    let exitedBeforeTimeout = false
+    try {
+      proc.kill()
+      // Wait for exit with timeout
+      const timeoutPromise = new Promise<void>((resolve) => setTimeout(resolve, 5000))
+      await Promise.race([
+        this.nodeExitedPromise?.then(() => { exitedBeforeTimeout = true }) ?? Promise.resolve(),
+        timeoutPromise,
+      ])
+      if (!exitedBeforeTimeout) {
+        log("[LSPClient] Process did not exit within timeout, escalating to SIGKILL")
+        try {
+          proc.kill("SIGKILL")
+          await Promise.race([
+            this.nodeExitedPromise ?? Promise.resolve(),
+            new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+          ])
+        } catch {}
+      }
+    } catch {}
   }
 }

--- a/src/tools/lsp/index.ts
+++ b/src/tools/lsp/index.ts
@@ -3,5 +3,6 @@ export * from "./constants"
 export * from "./config"
 export * from "./client"
 export * from "./utils"
+export * from "./spawn-mode"
 // NOTE: lsp_servers removed - duplicates OpenCode's built-in LspServers
 export { lsp_goto_definition, lsp_find_references, lsp_symbols, lsp_diagnostics, lsp_prepare_rename, lsp_rename } from "./tools"

--- a/src/tools/lsp/spawn-mode.test.ts
+++ b/src/tools/lsp/spawn-mode.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "bun:test"
+import { getLspSpawnMode } from "./spawn-mode"
+
+describe("getLspSpawnMode", () => {
+  test("defaults to node on Windows", () => {
+    expect(getLspSpawnMode("win32", {} as any)).toBe("node")
+  })
+
+  test("defaults to bun on non-Windows", () => {
+    expect(getLspSpawnMode("darwin", {} as any)).toBe("bun")
+    expect(getLspSpawnMode("linux", {} as any)).toBe("bun")
+  })
+
+  test("respects OMO_LSP_SPAWN_MODE env", () => {
+    expect(getLspSpawnMode("win32", { OMO_LSP_SPAWN_MODE: "bun" } as any)).toBe("bun")
+    expect(getLspSpawnMode("darwin", { OMO_LSP_SPAWN_MODE: "node" } as any)).toBe("node")
+  })
+
+  test("respects OH_MY_OPENCODE_LSP_SPAWN_MODE env", () => {
+    expect(getLspSpawnMode("win32", { OH_MY_OPENCODE_LSP_SPAWN_MODE: "bun" } as any)).toBe("bun")
+  })
+})

--- a/src/tools/lsp/spawn-mode.ts
+++ b/src/tools/lsp/spawn-mode.ts
@@ -1,0 +1,20 @@
+export type LspSpawnMode = "bun" | "node"
+
+/**
+ * Select how LSP servers are spawned.
+ *
+ * Background:
+ * - Native Windows + Bun has had intermittent segfaults around process spawning/stdio pipes.
+ * - Using the Node-compatible child_process implementation tends to be more stable.
+ */
+export function getLspSpawnMode(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env
+): LspSpawnMode {
+  const raw = (env.OMO_LSP_SPAWN_MODE ?? env.OH_MY_OPENCODE_LSP_SPAWN_MODE ?? "").toLowerCase()
+  if (raw === "bun" || raw === "node") return raw
+
+  // Default: prefer Node mode on Windows for stability.
+  if (platform === "win32") return "node"
+  return "bun"
+}


### PR DESCRIPTION
## Summary

Windows + Bun has intermittent segmentation faults when spawning LSP servers due to [oven-sh/bun#25798](https://github.com/oven-sh/bun/issues/25798). Even after upgrading to Bun v1.3.6+, some users continue to experience crashes.

## Changes

1. **Dual spawn mode support** - LSPClient now supports both Bun native spawn and Node.js child_process
2. **Node spawn default on Windows** - For stability, Windows defaults to Node spawn mode
3. **Environment variable override** - `OMO_LSP_SPAWN_MODE=bun|node` allows manual control
4. **Doctor check update** - Shows current spawn mode in `oh-my-opencode doctor`
5. **Documentation update** - Windows-specific guidance in LSP section

## Implementation Details

- `src/tools/lsp/spawn-mode.ts` - New module for spawn mode selection
- `src/tools/lsp/client.ts` - Updated LSPClient with dual backend support:
  - `startWithBun()` - Uses Bun.spawn with Web Streams
  - `startWithNode()` - Uses child_process.spawn with native Node streams
- Process management (stop, isAlive) works with both backends

## Testing

- Added unit tests for spawn mode selection
- Existing LSP tests pass
- Typecheck passes

## Related Issues

- Addresses stability issues from [oven-sh/bun#25798](https://github.com/oven-sh/bun/issues/25798)
- Helps users who experience LSP crashes on Windows even after Bun upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Node.js child_process spawn path and makes it the default on Windows to avoid Bun-related LSP crashes. This stabilizes LSP startup on Windows affected by bun#25798.

- **Bug Fixes**
  - Default LSP spawn mode to Node on Windows; override via OMO_LSP_SPAWN_MODE=node|bun.
  - LSPClient supports both Bun.spawn and Node child_process backends.
  - Doctor now shows the active spawn mode; docs include Windows guidance.
  - Added tests for spawn mode selection and unified process management across backends.

<sup>Written for commit f2921a1e1452468356505813db6d9d6d165f3ad8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

