### PR TITLE
fix(lsp): use Node.js child_process on Windows to avoid Bun spawn segfault

### DIFF
--- a/src/tools/lsp/client.test.ts
+++ b/src/tools/lsp/client.test.ts
@@ -60,4 +60,43 @@ describe("LSPClient", () => {
       }
     })
   })
+
+  describe("start", () => {
+    it("throws error when working directory does not exist", async () => {
+      // #given
+      const nonExistentDir = join(tmpdir(), "lsp-test-nonexistent-" + Date.now())
+      const server: ResolvedServer = {
+        id: "typescript",
+        command: ["typescript-language-server", "--stdio"],
+        extensions: [".ts"],
+        priority: 0,
+      }
+      const client = new LSPClient(nonExistentDir, server)
+
+      // #when / #then
+      await expect(client.start()).rejects.toThrow("Working directory does not exist")
+    })
+
+    it("throws error when path is a file instead of directory", async () => {
+      // #given
+      const dir = mkdtempSync(join(tmpdir(), "lsp-client-test-"))
+      const filePath = join(dir, "not-a-dir.txt")
+      writeFileSync(filePath, "test content")
+
+      const server: ResolvedServer = {
+        id: "typescript",
+        command: ["typescript-language-server", "--stdio"],
+        extensions: [".ts"],
+        priority: 0,
+      }
+      const client = new LSPClient(filePath, server)
+
+      try {
+        // #when / #then
+        await expect(client.start()).rejects.toThrow("Path is not a directory")
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  })
 })

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -1,4 +1,5 @@
-import { spawn, type Subprocess } from "bun"
+import { spawn as bunSpawn, type Subprocess } from "bun"
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process"
 import { Readable, Writable } from "node:stream"
 import { readFileSync } from "fs"
 import { extname, resolve } from "path"
@@ -14,34 +15,175 @@ import type { Diagnostic, ResolvedServer } from "./types"
 import { log } from "../../shared/logger"
 
 /**
- * Check if the current Bun version is affected by Windows LSP crash bug.
- * Bun v1.3.5 and earlier have a known segmentation fault issue on Windows
- * when spawning LSP servers. This was fixed in Bun v1.3.6.
+ * Check if we should use Node.js child_process instead of Bun spawn on Windows.
+ * Bun has known segmentation fault issues on Windows when spawning subprocesses.
  * See: https://github.com/oven-sh/bun/issues/25798
+ *
+ * This function returns true if we should use Node.js fallback.
  */
-function checkWindowsBunVersion(): { isAffected: boolean; message: string } | null {
-  if (process.platform !== "win32") return null
+function shouldUseNodeSpawnOnWindows(): boolean {
+  return process.platform === "win32"
+}
 
-  const version = Bun.version
-  const [major, minor, patch] = version.split(".").map((v) => parseInt(v.split("-")[0], 10))
+interface StreamReader {
+  read(): Promise<{ done: boolean; value: Uint8Array | undefined }>
+}
 
-  // Bun v1.3.5 and earlier are affected
-  if (major < 1 || (major === 1 && minor < 3) || (major === 1 && minor === 3 && patch < 6)) {
+/**
+ * Unified process interface for both Bun Subprocess and Node.js ChildProcess.
+ */
+interface UnifiedProcess {
+  stdin: {
+    write(chunk: Uint8Array | string): void
+  }
+  stdout: {
+    getReader(): StreamReader
+  }
+  stderr: {
+    getReader(): StreamReader
+  }
+  exitCode: number | null
+  exited: Promise<number>
+  kill(signal?: string): void
+}
+
+/**
+ * Wrap Node.js ChildProcess to match Bun Subprocess interface.
+ */
+function wrapNodeProcess(proc: ChildProcess): UnifiedProcess {
+  let resolveExited: (code: number) => void
+  let exitCode: number | null = null
+
+  const exitedPromise = new Promise<number>((resolve) => {
+    resolveExited = resolve
+  })
+
+  proc.on("exit", (code) => {
+    exitCode = code ?? 1
+    resolveExited(exitCode)
+  })
+
+  proc.on("error", () => {
+    if (exitCode === null) {
+      exitCode = 1
+      resolveExited(1)
+    }
+  })
+
+  const createStreamReader = (nodeStream: NodeJS.ReadableStream | null): StreamReader => {
+    const chunks: Uint8Array[] = []
+    let streamEnded = false
+    type ReadResult = { done: boolean; value: Uint8Array | undefined }
+    let waitingResolve: ((result: ReadResult) => void) | null = null
+
+    if (nodeStream) {
+      nodeStream.on("data", (chunk: Buffer) => {
+        const uint8 = new Uint8Array(chunk)
+        if (waitingResolve) {
+          const resolve = waitingResolve
+          waitingResolve = null
+          resolve({ done: false, value: uint8 })
+        } else {
+          chunks.push(uint8)
+        }
+      })
+
+      nodeStream.on("end", () => {
+        streamEnded = true
+        if (waitingResolve) {
+          const resolve = waitingResolve
+          waitingResolve = null
+          resolve({ done: true, value: undefined })
+        }
+      })
+
+      nodeStream.on("error", () => {
+        streamEnded = true
+        if (waitingResolve) {
+          const resolve = waitingResolve
+          waitingResolve = null
+          resolve({ done: true, value: undefined })
+        }
+      })
+    } else {
+      streamEnded = true
+    }
+
     return {
-      isAffected: true,
-      message:
-        `⚠️  Windows + Bun v${version} detected: Known segmentation fault bug with LSP.\n` +
-        `   This causes crashes when using LSP tools (lsp_diagnostics, lsp_goto_definition, etc.).\n` +
-        `   \n` +
-        `   SOLUTION: Upgrade to Bun v1.3.6 or later:\n` +
-        `   powershell -c "irm bun.sh/install.ps1|iex"\n` +
-        `   \n` +
-        `   WORKAROUND: Use WSL instead of native Windows.\n` +
-        `   See: https://github.com/oven-sh/bun/issues/25798`,
+      read(): Promise<ReadResult> {
+        return new Promise((resolve) => {
+          if (chunks.length > 0) {
+            resolve({ done: false, value: chunks.shift()! })
+          } else if (streamEnded) {
+            resolve({ done: true, value: undefined })
+          } else {
+            waitingResolve = resolve
+          }
+        })
+      },
     }
   }
 
-  return null
+  return {
+    stdin: {
+      write(chunk: Uint8Array | string) {
+        if (proc.stdin) {
+          proc.stdin.write(chunk)
+        }
+      },
+    },
+    stdout: {
+      getReader: () => createStreamReader(proc.stdout),
+    },
+    stderr: {
+      getReader: () => createStreamReader(proc.stderr),
+    },
+    get exitCode() {
+      return exitCode
+    },
+    exited: exitedPromise,
+    kill(signal?: string) {
+      try {
+        if (signal === "SIGKILL") {
+          proc.kill("SIGKILL")
+        } else {
+          proc.kill()
+        }
+      } catch {}
+    },
+  }
+}
+
+/**
+ * Spawn a process using the appropriate method for the platform.
+ * On Windows, uses Node.js child_process to avoid Bun segfault issues.
+ * On other platforms, uses Bun spawn for better performance.
+ */
+function spawnProcess(
+  command: string[],
+  options: { cwd: string; env: Record<string, string | undefined> }
+): UnifiedProcess {
+  if (shouldUseNodeSpawnOnWindows()) {
+    log("[LSP] Using Node.js child_process on Windows to avoid Bun spawn segfault")
+    const [cmd, ...args] = command
+    const proc = nodeSpawn(cmd, args, {
+      cwd: options.cwd,
+      env: options.env as NodeJS.ProcessEnv,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    })
+    return wrapNodeProcess(proc)
+  }
+
+  const proc = bunSpawn(command, {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: options.cwd,
+    env: options.env,
+  })
+
+  return proc as unknown as UnifiedProcess
 }
 
 interface ManagedClient {
@@ -252,7 +394,7 @@ class LSPServerManager {
 export const lspManager = LSPServerManager.getInstance()
 
 export class LSPClient {
-  private proc: Subprocess<"pipe", "pipe", "pipe"> | null = null
+  private proc: UnifiedProcess | null = null
   private connection: MessageConnection | null = null
   private openedFiles = new Set<string>()
   private documentVersions = new Map<string, number>()
@@ -268,17 +410,7 @@ export class LSPClient {
   ) {}
 
   async start(): Promise<void> {
-    const windowsCheck = checkWindowsBunVersion()
-    if (windowsCheck?.isAffected) {
-      throw new Error(
-        `LSP server cannot be started safely.\n\n${windowsCheck.message}`
-      )
-    }
-
-    this.proc = spawn(this.server.command, {
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
+    this.proc = spawnProcess(this.server.command, {
       cwd: this.root,
       env: {
         ...process.env,
@@ -306,7 +438,7 @@ export class LSPClient {
       async read() {
         try {
           const { done, value } = await stdoutReader.read()
-          if (done) {
+          if (done || !value) {
             this.push(null)
           } else {
             this.push(Buffer.from(value))


### PR DESCRIPTION
## Summary

- Use Node.js `child_process.spawn` on Windows instead of Bun's `spawn` to avoid segmentation faults
- Bun has known, unfixed segfault issues on Windows when spawning subprocesses (oven-sh/bun#25798, #26026, #23043, #22344)
- Remove version-based blocking that was ineffective (upgrading Bun didn't fix the issue)

## Problem

Bun's subprocess spawning on Windows causes segmentation faults, making LSP tools completely unusable. The previous approach of blocking older Bun versions and recommending upgrades didn't work because the bug exists across multiple Bun versions and remains unfixed.

**Related Bun Issues:**
- https://github.com/oven-sh/bun/issues/25798 - Main issue (OPEN, needs triage)
- https://github.com/oven-sh/bun/issues/26026 - Similar report (OPEN)
- https://github.com/oven-sh/bun/issues/23043 - Windows global shim crash (OPEN)
- https://github.com/oven-sh/bun/issues/22344 - Windows segfault (OPEN)

## Solution

On Windows, use Node.js `child_process.spawn` which is stable and works correctly. A unified process interface (`UnifiedProcess`) wraps both Bun's `Subprocess` and Node.js `ChildProcess` to maintain consistent behavior.

**Changes:**
1. Add `StreamReader` and `UnifiedProcess` interfaces for cross-runtime compatibility
2. Add `wrapNodeProcess()` to adapt Node.js ChildProcess to the unified interface
3. Add `spawnProcess()` that selects the appropriate spawning method by platform
4. Remove `checkWindowsBunVersion()` blocking logic (no longer needed)

## Testing

- [x] TypeScript compilation passes
- [x] All 2059 tests pass
- [ ] Manual testing on Windows (needed from Windows user)

## Notes

This is a workaround for Bun's Windows subprocess bug. Once Bun fixes the underlying issue, we could optionally revert to using Bun spawn on Windows, but the Node.js fallback provides a stable solution that works today.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On Windows, LSP now uses Node.js child_process to spawn servers to avoid Bun segfaults. Startup is hardened with CWD validation, binary checks, and shell:true; ineffective Bun version checks are removed.

- **Bug Fixes**
  - Use Node.js child_process.spawn on Windows to prevent Bun subprocess segfaults.
  - Validate working directory and pre-check binary availability on Windows; enable shell:true for proper .cmd/.bat resolution.

- **Refactors**
  - Added UnifiedProcess and StreamReader to unify Bun/Node process I/O.
  - Introduced spawnProcess() with wrapNodeProcess to select the spawner per platform; Bun spawn remains on non-Windows.

<sup>Written for commit ec7d2957cfc0dfbd4caf21caa241bd4d75c33961. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

