### PR TITLE
fix: handle both string[] and object[] formats in provider-models cache

### DIFF
--- a/src/shared/connected-providers-cache.ts
+++ b/src/shared/connected-providers-cache.ts
@@ -11,8 +11,16 @@ interface ConnectedProvidersCache {
 	updatedAt: string
 }
 
+interface ModelMetadata {
+	id: string
+	provider?: string
+	context?: number
+	output?: number
+	name?: string
+}
+
 interface ProviderModelsCache {
-	models: Record<string, string[]>
+	models: Record<string, string[] | ModelMetadata[]>
 	connected: string[]
 	updatedAt: string
 }

--- a/src/shared/model-availability.ts
+++ b/src/shared/model-availability.ts
@@ -187,16 +187,23 @@ export async function fetchAvailableModels(
 		if (providerCount === 0) {
 			log("[fetchAvailableModels] provider-models cache empty, falling back to models.json")
 		} else {
-			log("[fetchAvailableModels] using provider-models cache (whitelist-filtered)")
-			
-			for (const [providerId, modelIds] of Object.entries(providerModelsCache.models)) {
-				if (!connectedSet.has(providerId)) {
-					continue
-				}
-				for (const modelId of modelIds) {
+		log("[fetchAvailableModels] using provider-models cache (whitelist-filtered)")
+		
+		for (const [providerId, modelIds] of Object.entries(providerModelsCache.models)) {
+			if (!connectedSet.has(providerId)) {
+				continue
+			}
+			for (const modelItem of modelIds) {
+				// Handle both string[] (legacy) and object[] (with metadata) formats
+				const modelId = typeof modelItem === 'string' 
+					? modelItem 
+					: (modelItem as any)?.id
+				
+				if (modelId) {
 					modelSet.add(`${providerId}/${modelId}`)
 				}
 			}
+		}
 
 			log("[fetchAvailableModels] parsed from provider-models cache", {
 				count: modelSet.size,


### PR DESCRIPTION
## Summary

Fixes category delegation failing when `provider-models.json` contains model objects with metadata instead of plain strings.

**Root Cause**: Line 196 in `model-availability.ts` assumes `string[]` format when iterating over cached models, but manually-populated caches (like Ollama) use `object[]` format with metadata (`{id, provider, context, output}`).

**Impact**:
- `delegate_task(category='quick')` → ❌ "Model not configured for category"
- `delegate_task(subagent_type='explore')` → ✅ Works (bypasses cache)

## Changes

### Core Fix (`model-availability.ts`)
```typescript
// Before (line 196)
for (const modelId of modelIds) {
  modelSet.add(`${providerId}/${modelId}`)  // ❌ Breaks with objects
}

// After
for (const modelItem of modelIds) {
  const modelId = typeof modelItem === 'string' 
    ? modelItem 
    : (modelItem as any)?.id  // ✅ Handles both formats
  
  if (modelId) {
    modelSet.add(`${providerId}/${modelId}`)
  }
}
```

### Type Safety (`connected-providers-cache.ts`)
```typescript
interface ProviderModelsCache {
  models: Record<string, string[] | ModelMetadata[]>  // Now accepts both
  connected: string[]
  updatedAt: string
}
```

### Test Coverage (`model-availability.test.ts`)
Added 4 test cases:
- ✅ Handle `object[]` format with metadata (Ollama-style)
- ✅ Handle mixed `string[]` and `object[]` across providers
- ✅ Skip invalid entries gracefully
- ✅ Backward compatibility with legacy `string[]` format

## Testing

```bash
npm test -- src/shared/model-availability.test.ts
# ✅ 48 pass (including 4 new tests)

npm run typecheck
# ✅ No errors
```

## Context

This fix enables category-based delegation to work with manually-populated Ollama model caches, which is the intended approach per Vercel AI SDK (no `model.list()` for local providers).

**Related**:
- Fixes #1508
- Complements PR #1197 (NDJSON streaming fix)

## Backward Compatibility

✅ Fully backward compatible - handles both legacy `string[]` and new `object[]` formats without breaking existing deployments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes category delegation by supporting both string[] and object[] formats in provider-models.json. Prevents “Model not configured for category” errors with Ollama and other manually populated caches.

- **Bug Fixes**
  - Parse both string[] and object[] when building available models; skip invalid entries.
  - Updated ProviderModelsCache types and added tests for object[], mixed formats, and legacy compatibility.

<sup>Written for commit bd3a3bcfb989fdb1fb73400bdd3f29797914d7d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

