### PR TITLE
fix(lsp): use Node.js child_process on Windows to avoid Bun spawn segfault

### DIFF
--- a/src/tools/lsp/client.test.ts
+++ b/src/tools/lsp/client.test.ts
@@ -12,7 +12,7 @@ mock.module("vscode-jsonrpc/node", () => ({
   StreamMessageWriter: function StreamMessageWriter() {},
 }))
 
-import { LSPClient } from "./client"
+import { LSPClient, validateCwd } from "./client"
 import type { ResolvedServer } from "./types"
 
 describe("LSPClient", () => {
@@ -56,6 +56,93 @@ describe("LSPClient", () => {
         expect(methods).toContain("textDocument/didChange")
       } finally {
         globalThis.setTimeout = originalSetTimeout
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe("validateCwd", () => {
+    it("returns valid for existing directory", () => {
+      // #given
+      const dir = mkdtempSync(join(tmpdir(), "lsp-cwd-test-"))
+
+      try {
+        // #when
+        const result = validateCwd(dir)
+
+        // #then
+        expect(result.valid).toBe(true)
+        expect(result.error).toBeUndefined()
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it("returns invalid for non-existent directory", () => {
+      // #given
+      const nonExistentDir = join(tmpdir(), "lsp-cwd-nonexistent-" + Date.now())
+
+      // #when
+      const result = validateCwd(nonExistentDir)
+
+      // #then
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain("Working directory does not exist")
+    })
+
+    it("returns invalid when path is a file", () => {
+      // #given
+      const dir = mkdtempSync(join(tmpdir(), "lsp-cwd-file-test-"))
+      const filePath = join(dir, "not-a-dir.txt")
+      writeFileSync(filePath, "test content")
+
+      try {
+        // #when
+        const result = validateCwd(filePath)
+
+        // #then
+        expect(result.valid).toBe(false)
+        expect(result.error).toContain("Path is not a directory")
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  })
+
+  describe("start", () => {
+    it("throws error when working directory does not exist", async () => {
+      // #given
+      const nonExistentDir = join(tmpdir(), "lsp-test-nonexistent-" + Date.now())
+      const server: ResolvedServer = {
+        id: "typescript",
+        command: ["typescript-language-server", "--stdio"],
+        extensions: [".ts"],
+        priority: 0,
+      }
+      const client = new LSPClient(nonExistentDir, server)
+
+      // #when / #then
+      await expect(client.start()).rejects.toThrow("Working directory does not exist")
+    })
+
+    it("throws error when path is a file instead of directory", async () => {
+      // #given
+      const dir = mkdtempSync(join(tmpdir(), "lsp-client-test-"))
+      const filePath = join(dir, "not-a-dir.txt")
+      writeFileSync(filePath, "test content")
+
+      const server: ResolvedServer = {
+        id: "typescript",
+        command: ["typescript-language-server", "--stdio"],
+        extensions: [".ts"],
+        priority: 0,
+      }
+      const client = new LSPClient(filePath, server)
+
+      try {
+        // #when / #then
+        await expect(client.start()).rejects.toThrow("Path is not a directory")
+      } finally {
         rmSync(dir, { recursive: true, force: true })
       }
     })


### PR DESCRIPTION
## Summary

- **Use Node.js `child_process.spawn` on Windows** instead of `Bun.spawn()` to avoid segfaults caused by unfixed Bun bugs (oven-sh/bun#25798, #26026, #23043)
- **Remove ineffective Bun version blocking** — the v1.3.5 check was insufficient since v1.3.6+ still crashes
- **Add robust CWD validation** before spawn to prevent libuv null pointer dereference (root cause of the segfault)

## Problem

On Windows, `Bun.spawn()` triggers a segmentation fault (null pointer dereference at address 0x0) in libuv's `uv_spawn`. This has been reported across Bun v1.3.5 through v1.3.8+ and remains unfixed upstream.

The current code blocks LSP entirely on Windows with Bun < v1.3.6, but:
1. The issue persists on v1.3.6+
2. OpenCode embeds Bun v1.3.5 in standalone executables, making system upgrades irrelevant
3. Windows users have **zero LSP functionality**

## Solution

Instead of blocking, use Node.js `child_process.spawn` as the spawn backend on Windows:

| Platform | Spawn Backend | Why |
|----------|--------------|-----|
| Windows | `node:child_process` | Avoids Bun's buggy `uv_spawn` codepath |
| macOS/Linux | `Bun.spawn()` | Better performance, no segfault issues |

### Additional safeguards:
- **CWD validation** before spawn — prevents the specific null dereference in libuv
- **Binary existence check** on Windows via `where` command — helpful error messages instead of crashes
- **`shell: true`** on Windows — required for `.cmd`/`.bat` resolution (npm global packages)
- **`windowsHide: true`** — prevents console window flash

### Architecture:
```
UnifiedProcess (interface)
├── Bun Subprocess (macOS/Linux) — used as-is
└── Node ChildProcess (Windows) — wrapped via wrapNodeProcess()
```

## Testing

- ✅ `bun run typecheck` — zero errors
- ✅ `bun test` — 2145 tests pass, 0 failures
- New tests for CWD validation (valid dir, non-existent dir, file-as-dir)
- New tests for `start()` error handling with invalid working directories

## References

- oven-sh/bun#25798 — Original segfault report (OPEN)
- oven-sh/bun#26026, #23043, #22344 — Related Windows spawn issues
- #1047 — oh-my-opencode LSP crash on Windows
- #1325 — Related segfault report

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Node.js child_process to spawn LSP servers on Windows to avoid Bun spawn segfaults and restore LSP functionality. Adds cwd validation and binary checks for safer startup and clearer errors.

- **Bug Fixes**
  - Windows: spawn with Node.js child_process (shell: true, windowsHide: true) to bypass Bun segfaults; macOS/Linux still use Bun.spawn.
  - Validate working directory before spawn; fail with clear errors if missing or not a directory.
  - Pre-check server binary on Windows via where; show helpful guidance instead of crashing.
  - Remove Bun version gate that blocked LSP on Windows.

- **Refactors**
  - Introduce a UnifiedProcess wrapper to unify Bun and Node spawn APIs.
  - Add tests for cwd validation and start() error cases.

<sup>Written for commit 8ff9c246235096a26560a8346d294f20b67fede0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

