### PR TITLE
fix(model-requirements): use supported variant for gemini-3-pro

### DIFF
--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -111,22 +111,22 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
     ],
   },
-   deep: {
-     fallbackChain: [
-       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "medium" },
-       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
-     ],
-     requiresModel: "gpt-5.2-codex",
-   },
-    artistry: {
-      fallbackChain: [
-        { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
-        { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
-        { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
-      ],
-      requiresModel: "gemini-3-pro",
-    },
+  deep: {
+    fallbackChain: [
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2-codex", variant: "medium" },
+      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
+    ],
+    requiresModel: "gpt-5.2-codex",
+  },
+  artistry: {
+    fallbackChain: [
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
+      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-5", variant: "max" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
+    ],
+    requiresModel: "gemini-3-pro",
+  },
   quick: {
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-haiku-4-5" },


### PR DESCRIPTION
## Summary
- Change `variant: "max"` to `variant: "high"` for all gemini-3-pro entries
- Google API only supports "low" and "high" thinking levels for Gemini 3 Pro

## Changes
- oracle agent
- metis agent
- momus agent
- ultrabrain category
- deep category
- artistry category

## Original PR
Rebased from #1434 by @sk0x0y (closed due to fork push permission constraints)

Closes #1433

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched gemini-3-pro thinking variant from "max" to "high" across model requirements to match Google’s supported modes and prevent API errors.

- **Bug Fixes**
  - Set variant "high" for gemini-3-pro in oracle, metis, and momus agents.
  - Updated ultrabrain, deep, and artistry categories to use "high" in fallback chains/requirements.

<sup>Written for commit b7f7cb4341ff64a9a9affcc03a17a3d3da3e4818. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

