### PR TITLE
fix: preserve tools config for MCP tool restriction

### DIFF
--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -788,7 +788,7 @@ describe("agent override tools migration", () => {
     expect(permission["jetbrains_get_*"]).toBe("allow")
   })
 
-  test("tools config is removed after migration", async () => {
+  test("tools config is preserved for OpenCode native tool restriction", async () => {
     // #given
     const overrides = {
       explore: { tools: { "some_tool": false } } as any,
@@ -797,9 +797,9 @@ describe("agent override tools migration", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then
+    // #then - tools should be preserved (not deleted) for OpenCode to use
     expect(agents.explore).toBeDefined()
-    expect((agents.explore as any).tools).toBeUndefined()
+    expect((agents.explore as any).tools).toEqual({ "some_tool": false })
   })
 })
 

--- a/src/shared/permission-compat.test.ts
+++ b/src/shared/permission-compat.test.ts
@@ -71,7 +71,7 @@ describe("permission-compat", () => {
   })
 
   describe("migrateAgentConfig", () => {
-    test("migrates tools to permission", () => {
+    test("migrates tools to permission and preserves tools", () => {
       // given config with tools
       const config = {
         model: "test",
@@ -81,8 +81,8 @@ describe("permission-compat", () => {
       // when migrating
       const result = migrateAgentConfig(config)
 
-      // then converts to permission
-      expect(result.tools).toBeUndefined()
+      // then converts to permission AND preserves tools for OpenCode
+      expect(result.tools).toEqual({ write: false, edit: false })
       expect(result.permission).toEqual({ write: "deny", edit: "deny" })
       expect(result.model).toBe("test")
     })
@@ -105,7 +105,7 @@ describe("permission-compat", () => {
       expect(result.prompt).toBe("hello")
     })
 
-    test("merges existing permission with migrated tools", () => {
+    test("merges existing permission with migrated tools and preserves tools", () => {
       // given config with both tools and permission
       const config = {
         tools: { write: false },
@@ -115,8 +115,8 @@ describe("permission-compat", () => {
       // when migrating
       const result = migrateAgentConfig(config)
 
-      // then merges permission (existing takes precedence)
-      expect(result.tools).toBeUndefined()
+      // then merges permission AND preserves tools for OpenCode native restriction
+      expect(result.tools).toEqual({ write: false })
       expect(result.permission).toEqual({ write: "deny", bash: "deny" })
     })
 

--- a/src/shared/permission-compat.ts
+++ b/src/shared/permission-compat.ts
@@ -56,7 +56,12 @@ export function migrateToolsToPermission(
 
 /**
  * Migrates agent config from legacy tools format to permission format.
- * If config has `tools`, converts to `permission`.
+ * If config has `tools`, converts to `permission` BUT ALSO PRESERVES `tools`.
+ * 
+ * IMPORTANT: We preserve `tools` because:
+ * - `permission` only works for edit/bash/webfetch in OpenCode
+ * - `tools` (boolean format) is needed for native tool restriction of MCP tools
+ * - OpenCode uses `agent.tools` to enable/disable arbitrary tools like slack_*
  */
 export function migrateAgentConfig(
   config: Record<string, unknown>
@@ -70,7 +75,8 @@ export function migrateAgentConfig(
       result.tools as Record<string, boolean>
     )
     result.permission = { ...migratedPermission, ...existingPermission }
-    delete result.tools
+    // DO NOT delete result.tools - OpenCode needs it for native tool restriction
+    // The permission system only works for edit/bash/webfetch, not MCP tools
   }
 
   return result


### PR DESCRIPTION
## Summary

- Preserve `tools` field in `migrateAgentConfig()` instead of deleting it after conversion to `permission`
- This enables user-configured tool restrictions for MCP tools (e.g., `slack_*`)

## Problem

When users configure tool restrictions in `oh-my-opencode.json`:

```json
{
  "agents": {
    "sisyphus": {
      "tools": { "slack_*": false }
    }
  }
}
```

The `migrateAgentConfig()` function was:
1. Converting `tools: { "slack_*": false }` to `permission: { "slack_*": "deny" }`
2. **Deleting** the original `tools` field

However, OpenCode's `permission` system only works for `edit`, `bash`, and `webfetch` tools. For MCP tools like `slack_*`, OpenCode requires the native `tools` boolean format in the agent config.

## Solution

Keep `tools` in the agent config so OpenCode can use it for native tool restriction, while also generating `permission` for tools that support ask/allow/deny semantics.

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds  
- [x] Updated tests in `permission-compat.test.ts` and `utils.test.ts`
- [x] Tested locally with slack MCP - sisyphus no longer has access to slack tools when configured

## Checklist

- [x] Code follows project conventions
- [x] No version changes in `package.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves agent.tools during migrateAgentConfig so MCP tool restrictions (e.g., slack_*) continue to work, while still generating permission for supported tools. Restores user-configured blocks that were lost after migration.

- **Bug Fixes**
  - Do not delete config.tools after migration; OpenCode uses it for MCP tool restriction.
  - Merge migrated permission with existing entries; permission still applies to edit/bash/webfetch.
  - Updated tests to assert tools are preserved and permissions are correctly merged.

<sup>Written for commit 122d35550164a29ae4291bd11de9cc4ffafd4560. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

