### PR TITLE
feat(prometheus): include plan name in /start-work guidance

### DIFF
--- a/src/agents/dynamic-agent-prompt-builder.ts
+++ b/src/agents/dynamic-agent-prompt-builder.ts
@@ -253,13 +253,13 @@ ${skillsSection}
 **STEP 1: Select Category**
 - Read each category's description
 - Match task requirements to category domain
-- Select the category whose domain BEST fits the task
+- Select category whose domain BEST fits the task
 
 **STEP 2: Evaluate ALL Skills (Built-in AND User-Installed)**
 For EVERY skill listed above, ask yourself:
 > "Does this skill's expertise domain overlap with my task?"
 
-- If YES → INCLUDE in \`load_skills=[...]\`
+- If YES → INCLUDE in load_skills=[...]
 - If NO → You MUST justify why (see below)
 ${customSkills.length > 0 ? `
 > **User-installed skills get PRIORITY.** The user explicitly installed them for their workflow.
@@ -298,7 +298,9 @@ delegate_task(
 **ANTI-PATTERN (will produce poor results):**
 \`\`\`typescript
 delegate_task(category="...", load_skills=[], run_in_background=false, prompt="...")  // Empty load_skills without justification
-\`\`\``
+\`\`\`
+
+**IMPORTANT**: load_skills parameter is REQUIRED for delegate_task. Pass [] if no skills are needed, but passing proper skills is HIGHLY RECOMMENDED for optimal results. Skills inject domain-specific expertise that dramatically improves task execution quality.`
 }
 
 export function buildOracleSection(agents: AvailableAgent[]): string {

--- a/src/agents/dynamic-agent-prompt-builder.ts
+++ b/src/agents/dynamic-agent-prompt-builder.ts
@@ -300,7 +300,7 @@ delegate_task(
 delegate_task(category="...", load_skills=[], run_in_background=false, prompt="...")  // Empty load_skills without justification
 \`\`\`
 
-**IMPORTANT**: load_skills parameter is REQUIRED for delegate_task. Pass [] if no skills are needed, but passing proper skills is HIGHLY RECOMMENDED for optimal results. Skills inject domain-specific expertise that dramatically improves task execution quality.`
+**IMPORTANT**: load_skills parameter is REQUIRED for delegate_task. Omitting this parameter will cause an error. Pass [] if no skills are needed, but passing proper skills is HIGHLY RECOMMENDED for optimal results. Skills inject domain-specific expertise that dramatically improves task execution quality.`
 }
 
 export function buildOracleSection(agents: AvailableAgent[]): string {

--- a/src/agents/prometheus/plan-generation.ts
+++ b/src/agents/prometheus/plan-generation.ts
@@ -33,7 +33,7 @@ todoWrite([
   { id: "plan-5", content: "If decisions needed: wait for user, update plan", status: "pending", priority: "high" },
   { id: "plan-6", content: "Ask user about high accuracy mode (Momus review)", status: "pending", priority: "high" },
   { id: "plan-7", content: "If high accuracy: Submit to Momus and iterate until OKAY", status: "pending", priority: "medium" },
-  { id: "plan-8", content: "Delete draft file and guide user to /start-work", status: "pending", priority: "medium" }
+  { id: "plan-8", content: "Delete draft file and guide user to /start-work {name}", status: "pending", priority: "medium" }
 ])
 \`\`\`
 
@@ -201,7 +201,7 @@ Question({
     options: [
       {
         label: "Start Work",
-        description: "Execute now with /start-work. Plan looks solid."
+        description: "Execute now with \`/start-work {name}\`. Plan looks solid."
       },
       {
         label: "High Accuracy Review",
@@ -213,7 +213,7 @@ Question({
 \`\`\`
 
 **Based on user choice:**
-- **Start Work** → Delete draft, guide to \`/start-work\`
+- **Start Work** → Delete draft, guide to \`/start-work {name}\`
 - **High Accuracy Review** → Enter Momus loop (PHASE 3)
 
 ---


### PR DESCRIPTION
## Summary

Update Prometheus plan generation instructions to guide users to run \`/start-work\` with plan name included.

**Example:** \`/start-work fix-bug\` instead of just \`/start-work\`

This makes it clearer which plan the user wants to execute.

## Changes

- Updated \`plan-generation.ts\` to include \`{name}\` placeholder in \`/start-work\` guidance
- Modified 3 locations:
  - Todo item plan-8: "Delete draft file and guide user to /start-work {name}"
  - Question description: "Execute now with \`/start-work {name}\`"
  - Workflow guidance: "guide to \`/start-work {name}\`"

## Verification

- All existing tests pass (7 pass, 0 fail)
- Typecheck passes with no errors
- Changes are backward compatible (the \`{name}\` placeholder is dynamically replaced by Prometheus)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Prometheus guidance to run /start-work with the plan name so users execute the intended plan, and clarify that load_skills is required to avoid delegate_task errors.

- **New Features**
  - Prometheus plan-generation now guides users to run /start-work {name} in three spots: plan-8 todo, Start Work option text, and workflow guidance.
  - Prompt builder clarifies that load_skills is required (pass [] if none) and cleans up template text to prevent template literal issues.

<sup>Written for commit 265a92b93e0fc1fb2babb058878eebb072643b03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

