### PR TITLE
feat(prometheus): include plan name in /start-work guidance

### DIFF
--- a/src/agents/prometheus/plan-generation.ts
+++ b/src/agents/prometheus/plan-generation.ts
@@ -33,7 +33,7 @@ todoWrite([
   { id: "plan-5", content: "If decisions needed: wait for user, update plan", status: "pending", priority: "high" },
   { id: "plan-6", content: "Ask user about high accuracy mode (Momus review)", status: "pending", priority: "high" },
   { id: "plan-7", content: "If high accuracy: Submit to Momus and iterate until OKAY", status: "pending", priority: "medium" },
-  { id: "plan-8", content: "Delete draft file and guide user to /start-work", status: "pending", priority: "medium" }
+  { id: "plan-8", content: "Delete draft file and guide user to /start-work {name}", status: "pending", priority: "medium" }
 ])
 \`\`\`
 
@@ -201,7 +201,7 @@ Question({
     options: [
       {
         label: "Start Work",
-        description: "Execute now with /start-work. Plan looks solid."
+        description: "Execute now with \`/start-work {name}\`. Plan looks solid."
       },
       {
         label: "High Accuracy Review",
@@ -213,7 +213,7 @@ Question({
 \`\`\`
 
 **Based on user choice:**
-- **Start Work** → Delete draft, guide to \`/start-work\`
+ - **Start Work** → Delete draft, guide to \`/start-work {name}\`
 - **High Accuracy Review** → Enter Momus loop (PHASE 3)
 
 ---


### PR DESCRIPTION
## Summary

Update Prometheus plan generation instructions to guide users to run \`/start-work\` with plan name included.

**Example:** \`/start-work fix-bug\` instead of just \`/start-work\`

This makes it clearer which plan the user wants to execute.

## Changes

- Updated \`plan-generation.ts\` to include \`{name}\` placeholder in \`/start-work\` guidance
- Modified 3 locations:
  - Todo item plan-8: "Delete draft file and guide user to /start-work {name}"
  - Question description: "Execute now with \`/start-work {name}\`"
  - Workflow guidance: "guide to \`/start-work {name}\`"

## Verification

- All existing tests pass (7 pass, 0 fail)
- Typecheck passes with no errors
- Changes are backward compatible (the \`{name}\` placeholder is dynamically replaced by Prometheus)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the plan name in /start-work guidance in Prometheus to make it clear which plan to execute. Updated plan-8 todo, the Start Work option description, and workflow guidance to use /start-work {name}.

<sup>Written for commit d85c146f0ef27cdb17c574234d7e9a397f4a5803. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

