### PR TITLE
    fix(config): add dev-browser to BuiltinSkillNameSchema enum

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -34,6 +34,7 @@ export const BuiltinSkillNameSchema = z.enum([
   "agent-browser",
   "frontend-ui-ux",
   "git-master",
+  "dev-browser",
 ])
 
 export const OverridableAgentNameSchema = z.enum([


### PR DESCRIPTION
fix(config): add dev-browser to BuiltinSkillNameSchema enum
## Summary
- Allows users to disable dev-browser skill via `disabled_skills` configuration
- Fixes Zod validation rejection when disabling built-in dev-browser skill
- Enables proper config validation for mixed built-in/external skill disabling
## Changes
- Added `"dev-browser"` to `BuiltinSkillNameSchema` enum in `src/config/schema.ts`
- This allows `disabled_skills: ["dev-browser"]` to be validated and applied
## Screenshots
<!-- Delete this section - no screenshots needed for schema change -->
## Testing
```bash
# Type check (verify schema compiles)
bun run typecheck
# Build (verify no build errors)
bun run build
# Manual verification:
# 1. Add to oh-my-opencode.jsonc: "disabled_skills": ["dev-browser"]
# 2. Run: opencode run "list your available skills"
# 3. Verify: dev-browser should NOT appear in skill list
# 4. Remove disabled_skills config
# 5. Run again and verify: dev-browser SHOULD appear in skill list
Related Issues
Fixes #1202 (partial)
Closes #1202

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add "dev-browser" to BuiltinSkillNameSchema so configs with disabled_skills: ["dev-browser"] validate and the skill is actually disabled. Fixes Zod rejection when disabling the built-in dev-browser and supports mixed built-in/external skill disabling.

<sup>Written for commit 45bd7d1c0c3794629882c331cbc6ff91315ad061. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

