### PR TITLE
fix: remove redundant duplicate claude-opus-4-6 fallback entries

### DIFF
--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -23,28 +23,23 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(primary.variant).toBe("high")
   })
 
-  test("sisyphus has claude-opus-4-6 as primary before claude-opus-4-6 and requiresAnyModel", () => {
+  test("sisyphus has claude-opus-4-6 as primary and requiresAnyModel", () => {
     // #given - sisyphus agent requirement
     const sisyphus = AGENT_MODEL_REQUIREMENTS["sisyphus"]
 
     // #when - accessing Sisyphus requirement
-    // #then - fallbackChain has claude-opus-4-6 first, claude-opus-4-6 second, glm-4.7-free last
+    // #then - fallbackChain has claude-opus-4-6 first, glm-4.7-free last
     expect(sisyphus).toBeDefined()
     expect(sisyphus.fallbackChain).toBeArray()
-    expect(sisyphus.fallbackChain).toHaveLength(6)
+    expect(sisyphus.fallbackChain).toHaveLength(5)
     expect(sisyphus.requiresAnyModel).toBe(true)
 
     const primary = sisyphus.fallbackChain[0]
-    expect(primary.providers).toEqual(["anthropic"])
+    expect(primary.providers).toEqual(["anthropic", "github-copilot", "opencode"])
     expect(primary.model).toBe("claude-opus-4-6")
     expect(primary.variant).toBe("max")
 
-    const secondary = sisyphus.fallbackChain[1]
-    expect(secondary.providers[0]).toBe("anthropic")
-    expect(secondary.model).toBe("claude-opus-4-6")
-    expect(secondary.variant).toBe("max")
-
-    const last = sisyphus.fallbackChain[5]
+    const last = sisyphus.fallbackChain[4]
     expect(last.providers[0]).toBe("opencode")
     expect(last.model).toBe("glm-4.7-free")
   })
@@ -103,46 +98,36 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(primary.model).toBe("gemini-3-flash")
   })
 
-  test("prometheus has claude-opus-4-6 as primary before claude-opus-4-6", () => {
+  test("prometheus has claude-opus-4-6 as primary", () => {
     // #given - prometheus agent requirement
     const prometheus = AGENT_MODEL_REQUIREMENTS["prometheus"]
 
     // #when - accessing Prometheus requirement
-    // #then - claude-opus-4-6 is first, claude-opus-4-6 is second
+    // #then - claude-opus-4-6 is first
     expect(prometheus).toBeDefined()
     expect(prometheus.fallbackChain).toBeArray()
     expect(prometheus.fallbackChain.length).toBeGreaterThan(1)
 
     const primary = prometheus.fallbackChain[0]
     expect(primary.model).toBe("claude-opus-4-6")
-    expect(primary.providers).toEqual(["anthropic"])
+    expect(primary.providers).toEqual(["anthropic", "github-copilot", "opencode"])
     expect(primary.variant).toBe("max")
-
-    const secondary = prometheus.fallbackChain[1]
-    expect(secondary.model).toBe("claude-opus-4-6")
-    expect(secondary.providers[0]).toBe("anthropic")
-    expect(secondary.variant).toBe("max")
   })
 
-  test("metis has claude-opus-4-6 as primary before claude-opus-4-6", () => {
+  test("metis has claude-opus-4-6 as primary", () => {
     // #given - metis agent requirement
     const metis = AGENT_MODEL_REQUIREMENTS["metis"]
 
     // #when - accessing Metis requirement
-    // #then - claude-opus-4-6 is first, claude-opus-4-6 is second
+    // #then - claude-opus-4-6 is first
     expect(metis).toBeDefined()
     expect(metis.fallbackChain).toBeArray()
     expect(metis.fallbackChain.length).toBeGreaterThan(1)
 
     const primary = metis.fallbackChain[0]
     expect(primary.model).toBe("claude-opus-4-6")
-    expect(primary.providers).toEqual(["anthropic"])
+    expect(primary.providers).toEqual(["anthropic", "github-copilot", "opencode"])
     expect(primary.variant).toBe("max")
-
-    const secondary = metis.fallbackChain[1]
-    expect(secondary.model).toBe("claude-opus-4-6")
-    expect(secondary.providers[0]).toBe("anthropic")
-    expect(secondary.variant).toBe("max")
   })
 
   test("momus has valid fallbackChain with gpt-5.2 as primary", () => {
@@ -301,12 +286,12 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     expect(primary.providers[0]).toBe("anthropic")
   })
 
-  test("unspecified-high has claude-opus-4-6 as primary before claude-opus-4-6", () => {
+  test("unspecified-high has claude-opus-4-6 as primary", () => {
     // #given - unspecified-high category requirement
     const unspecifiedHigh = CATEGORY_MODEL_REQUIREMENTS["unspecified-high"]
 
     // #when - accessing unspecified-high requirement
-    // #then - claude-opus-4-6 is first, claude-opus-4-6 is second
+    // #then - claude-opus-4-6 is first
     expect(unspecifiedHigh).toBeDefined()
     expect(unspecifiedHigh.fallbackChain).toBeArray()
     expect(unspecifiedHigh.fallbackChain.length).toBeGreaterThan(1)
@@ -314,12 +299,7 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     const primary = unspecifiedHigh.fallbackChain[0]
     expect(primary.model).toBe("claude-opus-4-6")
     expect(primary.variant).toBe("max")
-    expect(primary.providers).toEqual(["anthropic"])
-
-    const secondary = unspecifiedHigh.fallbackChain[1]
-    expect(secondary.model).toBe("claude-opus-4-6")
-    expect(secondary.variant).toBe("max")
-    expect(secondary.providers[0]).toBe("anthropic")
+    expect(primary.providers).toEqual(["anthropic", "github-copilot", "opencode"])
   })
 
   test("artistry has valid fallbackChain with gemini-3-pro as primary", () => {

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -15,7 +15,6 @@ export type ModelRequirement = {
 export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   sisyphus: {
     fallbackChain: [
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode"], model: "kimi-k2.5-free" },
@@ -34,7 +33,6 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
     ],
   },
@@ -65,7 +63,6 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   prometheus: {
     fallbackChain: [
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode"], model: "kimi-k2.5-free" },
@@ -75,7 +72,6 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   metis: {
     fallbackChain: [
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode"], model: "kimi-k2.5-free" },
@@ -86,7 +82,6 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   momus: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "medium" },
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
@@ -106,7 +101,6 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   "visual-engineering": {
     fallbackChain: [
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["zai-coding-plan"], model: "glm-4.7" },
     ],
@@ -115,14 +109,12 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "xhigh" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
     ],
   },
   deep: {
     fallbackChain: [
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
@@ -131,7 +123,6 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   artistry: {
     fallbackChain: [
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2" },
     ],
@@ -153,7 +144,6 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   "unspecified-high": {
     fallbackChain: [
-      { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },


### PR DESCRIPTION
## Summary

After the model version update (opus-4-5 → opus-4-6), several agents ended up with identical duplicate fallback entries:

```typescript
// BEFORE (dead code - first entry always matches, second never reached)
{ providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
{ providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },

// AFTER (consolidated)
{ providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
```

**Affected agents:** sisyphus, oracle, prometheus, metis, momus
**Affected categories:** visual-engineering, ultrabrain, deep, artistry, unspecified-high

- 10 redundant fallback entries removed
- Tests updated to match
- All 2162 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant duplicate claude-opus-4-6 fallback entries by consolidating them into a single multi-provider entry. This cleans up dead code and keeps fallback chains accurate without changing behavior.

- **Bug Fixes**
  - Consolidated to one entry: providers [anthropic, github-copilot, opencode] for claude-opus-4-6 (variant: max).
  - Removed 10 redundant entries across affected agents and categories; adjusted fallbackChain lengths.
  - Updated tests to match the consolidated entry and new expectations.

<sup>Written for commit 161a864ea3bb9679ea7ce6502913b55c3f02d5ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

