### PR TITLE
fix: escape regex special chars in pattern matcher

### DIFF
--- a/src/shared/pattern-matcher.test.ts
+++ b/src/shared/pattern-matcher.test.ts
@@ -1,0 +1,177 @@
+import { describe, test, expect } from "bun:test"
+import { matchesToolMatcher, findMatchingHooks } from "./pattern-matcher"
+import type { ClaudeHooksConfig } from "../hooks/claude-code-hooks/types"
+
+describe("matchesToolMatcher", () => {
+  describe("exact matching", () => {
+    //#given a pattern without wildcards
+    //#when matching against a tool name
+    //#then it should match case-insensitively
+
+    test("matches exact tool name", () => {
+      expect(matchesToolMatcher("bash", "bash")).toBe(true)
+    })
+
+    test("matches case-insensitively", () => {
+      expect(matchesToolMatcher("Bash", "bash")).toBe(true)
+      expect(matchesToolMatcher("bash", "BASH")).toBe(true)
+    })
+
+    test("does not match different tool names", () => {
+      expect(matchesToolMatcher("bash", "edit")).toBe(false)
+    })
+  })
+
+  describe("wildcard matching", () => {
+    //#given a pattern with asterisk wildcard
+    //#when matching against tool names
+    //#then it should treat * as glob-style wildcard
+
+    test("matches prefix wildcard", () => {
+      expect(matchesToolMatcher("lsp_goto_definition", "lsp_*")).toBe(true)
+      expect(matchesToolMatcher("lsp_find_references", "lsp_*")).toBe(true)
+    })
+
+    test("matches suffix wildcard", () => {
+      expect(matchesToolMatcher("file_read", "*_read")).toBe(true)
+    })
+
+    test("matches middle wildcard", () => {
+      expect(matchesToolMatcher("get_user_info", "get_*_info")).toBe(true)
+    })
+
+    test("matches multiple wildcards", () => {
+      expect(matchesToolMatcher("get_user_data", "*_user_*")).toBe(true)
+    })
+
+    test("single asterisk matches any tool", () => {
+      expect(matchesToolMatcher("anything", "*")).toBe(true)
+    })
+  })
+
+  describe("pipe-separated patterns", () => {
+    //#given multiple patterns separated by pipes
+    //#when matching against tool names
+    //#then it should match if any pattern matches
+
+    test("matches first pattern", () => {
+      expect(matchesToolMatcher("bash", "bash | edit | write")).toBe(true)
+    })
+
+    test("matches middle pattern", () => {
+      expect(matchesToolMatcher("edit", "bash | edit | write")).toBe(true)
+    })
+
+    test("matches last pattern", () => {
+      expect(matchesToolMatcher("write", "bash | edit | write")).toBe(true)
+    })
+
+    test("does not match if none match", () => {
+      expect(matchesToolMatcher("read", "bash | edit | write")).toBe(false)
+    })
+  })
+
+  describe("regex special character escaping (issue #1521)", () => {
+    //#given a pattern containing regex special characters
+    //#when matching against tool names
+    //#then it should NOT throw SyntaxError and should handle them as literals
+
+    test("handles parentheses in pattern without throwing", () => {
+      expect(() => matchesToolMatcher("bash", "bash(*)")).not.toThrow()
+      expect(matchesToolMatcher("bash(test)", "bash(*)")).toBe(true)
+    })
+
+    test("handles unmatched opening parenthesis", () => {
+      expect(() => matchesToolMatcher("test", "test(*")).not.toThrow()
+    })
+
+    test("handles unmatched closing parenthesis", () => {
+      expect(() => matchesToolMatcher("test", "test*)")).not.toThrow()
+    })
+
+    test("handles square brackets", () => {
+      expect(() => matchesToolMatcher("test", "test[*]")).not.toThrow()
+      expect(matchesToolMatcher("test[1]", "test[*]")).toBe(true)
+    })
+
+    test("handles plus sign", () => {
+      expect(() => matchesToolMatcher("test", "test+*")).not.toThrow()
+    })
+
+    test("handles question mark", () => {
+      expect(() => matchesToolMatcher("test", "test?*")).not.toThrow()
+    })
+
+    test("handles caret", () => {
+      expect(() => matchesToolMatcher("test", "^test*")).not.toThrow()
+    })
+
+    test("handles dollar sign", () => {
+      expect(() => matchesToolMatcher("test", "test$*")).not.toThrow()
+    })
+
+    test("handles curly braces", () => {
+      expect(() => matchesToolMatcher("test", "test{*}")).not.toThrow()
+    })
+
+    test("handles pipe as pattern separator", () => {
+      expect(() => matchesToolMatcher("test", "test|value")).not.toThrow()
+      expect(matchesToolMatcher("test", "test|value")).toBe(true)
+      expect(matchesToolMatcher("value", "test|value")).toBe(true)
+    })
+
+    test("handles backslash", () => {
+      expect(() => matchesToolMatcher("test\\path", "test\\*")).not.toThrow()
+    })
+
+    test("handles dot", () => {
+      expect(() => matchesToolMatcher("test.ts", "test.*")).not.toThrow()
+      expect(matchesToolMatcher("test.ts", "test.*")).toBe(true)
+    })
+
+    test("complex pattern with multiple special chars", () => {
+      expect(() => matchesToolMatcher("func(arg)", "func(*)")).not.toThrow()
+      expect(matchesToolMatcher("func(arg)", "func(*)")).toBe(true)
+    })
+  })
+
+  describe("empty matcher", () => {
+    //#given an empty or undefined matcher
+    //#when matching
+    //#then it should match everything
+
+    test("empty string matches everything", () => {
+      expect(matchesToolMatcher("anything", "")).toBe(true)
+    })
+  })
+})
+
+describe("findMatchingHooks", () => {
+  const mockHooks: ClaudeHooksConfig = {
+    PreToolUse: [
+      { matcher: "bash", hooks: [{ type: "command", command: "/test/hook1" }] },
+      { matcher: "edit*", hooks: [{ type: "command", command: "/test/hook2" }] },
+      { matcher: "*", hooks: [{ type: "command", command: "/test/hook3" }] },
+    ],
+  }
+
+  test("finds hooks matching exact tool name", () => {
+    const result = findMatchingHooks(mockHooks, "PreToolUse", "bash")
+    expect(result.length).toBe(2) // "bash" and "*"
+  })
+
+  test("finds hooks matching wildcard pattern", () => {
+    const result = findMatchingHooks(mockHooks, "PreToolUse", "edit_file")
+    expect(result.length).toBe(2) // "edit*" and "*"
+  })
+
+  test("returns all hooks when no toolName provided", () => {
+    const result = findMatchingHooks(mockHooks, "PreToolUse")
+    expect(result.length).toBe(3)
+  })
+
+  test("returns empty array for non-existent event", () => {
+    const result = findMatchingHooks(mockHooks, "PostToolUse", "bash")
+    expect(result.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1521. When hook matcher patterns in `.claude/settings.json` contained regex special characters like parentheses, the `matchesToolMatcher` function threw `SyntaxError: Invalid regular expression: unmatched parentheses`. This happened because these characters were passed directly to `new RegExp()` without escaping.

## Root Cause

In `src/shared/pattern-matcher.ts`, the `matchesToolMatcher` function converts glob-style patterns (using `*` as wildcard) to regex patterns. However, only the asterisk (`*`) was being converted to `.*` while other regex special characters (`.`, `+`, `?`, `^`, `$`, `{`, `}`, `(`, `)`, `|`, `[`, `]`, `\`) were passed through unescaped, causing `SyntaxError` when the regex was constructed.

**Before (broken):**
```typescript
const regex = new RegExp(`^${p.replace(/\*/g, ".*")}$`, "i")
// Pattern "bash(*)" becomes regex /^bash(.*)$/ - OK
// Pattern "bash(" becomes regex /^bash($/ - THROWS SyntaxError!
```

**After (fixed):**
```typescript
const escaped = escapeRegexExceptAsterisk(p) // Escapes all special chars except *
const regex = new RegExp(`^${escaped.replace(/\*/g, ".*")}$`, "i")
// Pattern "bash(*)" becomes regex /^bash\(.*\)$/ - matches literal parentheses with glob
// Pattern "bash(" becomes regex /^bash\($/ - no longer throws
```

## Changes

1. **`src/shared/pattern-matcher.ts`**: Added `escapeRegexExceptAsterisk()` helper that escapes all regex special characters except `*`, which is intentionally preserved for glob-to-regex conversion.

2. **`src/shared/pattern-matcher.test.ts`**: Added comprehensive test suite with 30 tests covering:
   - Exact matching (case-insensitive)
   - Wildcard matching (glob-style `*`)
   - Pipe-separated patterns (`bash | edit | write`)
   - All regex special characters: `(`, `)`, `[`, `]`, `+`, `?`, `^`, `$`, `{`, `}`, `\`, `.`
   - Edge cases (empty matcher, complex patterns)

## Testing

```bash
bun test src/shared/pattern-matcher.test.ts
# 30 pass, 0 fail

bun run typecheck
# No errors

bun test  
# 2194 pass, 10 fail (all failures are pre-existing flaky tests unrelated to this change)
```

## Why This Happened

Users with hooks configured in `.claude/settings.json` that used matchers containing special characters (even innocuous patterns like `bash` that happen to follow file read operations with parentheses in filenames) would trigger this error. The error persisted even with all hooks disabled via `disabled_hooks` because the pattern matching happens during hook configuration loading, not execution.

## Verification

After this fix, any matcher pattern containing regex special characters will be treated as literal characters (except `*` which remains a glob wildcard), preventing the `SyntaxError` and allowing the pattern to match as intended.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes regex special characters in hook matcher patterns so patterns with parentheses, brackets, etc., no longer crash and are matched literally, while * still works as a glob. Fixes #1521 and prevents SyntaxError during hook loading from .claude/settings.json.

- **Bug Fixes**
  - Escape . + ? ^ $ { } ( ) | [ ] \ before converting * to .* in matchesToolMatcher.
  - Added tests for exact, wildcard, pipe-separated, and special-char patterns, including edge cases.

<sup>Written for commit bc782ca4d4f408953e6704da17e59cbcae3b22e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

