### PR TITLE
docs: fix stale references in AGENTS.md files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ This is an **international open-source project**. To ensure accessibility and ma
 
 ## OVERVIEW
 
-OpenCode plugin: multi-model agent orchestration (Claude Opus 4.5, GPT-5.2, Gemini 3 Flash). 34 lifecycle hooks, 20+ tools (LSP, AST-Grep, delegation), 11 specialized agents, full Claude Code compatibility. "oh-my-zsh" for OpenCode.
+OpenCode plugin: multi-model agent orchestration (Claude Opus 4.5, GPT-5.2, Gemini 3 Flash). 41 lifecycle hooks, 20+ tools (LSP, AST-Grep, delegation), 11 specialized agents, full Claude Code compatibility. "oh-my-zsh" for OpenCode.
 
 ## STRUCTURE
 
@@ -128,7 +128,7 @@ OpenCode plugin: multi-model agent orchestration (Claude Opus 4.5, GPT-5.2, Gemi
 oh-my-opencode/
 ├── src/
 │   ├── agents/        # 11 AI agents - see src/agents/AGENTS.md
-│   ├── hooks/         # 34 lifecycle hooks - see src/hooks/AGENTS.md
+│   ├── hooks/         # 41 lifecycle hooks - see src/hooks/AGENTS.md
 │   ├── tools/         # 20+ tools - see src/tools/AGENTS.md
 │   ├── features/      # Background agents, Claude Code compat - see src/features/AGENTS.md
 │   ├── shared/        # 66 cross-cutting utilities - see src/shared/AGENTS.md
@@ -212,6 +212,9 @@ oh-my-opencode/
 | explore | xai/grok-code-fast-1 | Fast codebase grep (fallback: claude-haiku-4-5 → gpt-5-mini → gpt-5-nano) |
 | multimodal-looker | google/gemini-3-flash | PDF/image analysis |
 | Prometheus | anthropic/claude-opus-4-6 | Strategic planning (fallback: kimi-k2.5 → gpt-5.2) |
+| Metis | anthropic/claude-opus-4-6 | Pre-planning analysis (temp 0.3, fallback: kimi-k2.5 → gpt-5.2) |
+| Momus | openai/gpt-5.2 | Plan validation (temp 0.1, fallback: claude-opus-4-6) |
+| Sisyphus-Junior | anthropic/claude-sonnet-4-5 | Category-spawned executor (temp 0.1) |
 
 ## COMMANDS
 
@@ -233,9 +236,9 @@ bun test               # 100 test files
 
 | File | Lines | Description |
 |------|-------|-------------|
-| `src/features/builtin-skills/skills.ts` | 1729 | Skill definitions |
+| `src/features/builtin-skills/skills.ts` | 29 | Skill definitions |
 | `src/features/background-agent/manager.ts` | 1418 | Task lifecycle, concurrency |
-| `src/agents/prometheus-prompt.ts` | 1283 | Planning agent prompt |
+| `src/agents/prometheus/` | 1492 | Planning agent prompt |
 | `src/tools/delegate-task/tools.ts` | 1135 | Category-based delegation |
 | `src/hooks/atlas/index.ts` | 757 | Orchestrator hook |
 | `src/index.ts` | 788 | Main plugin entry |

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -13,15 +13,29 @@
 ## STRUCTURE
 ```
 agents/
-├── atlas.ts                    # Master Orchestrator (holds todo list)
+├── atlas/                      # Master Orchestrator (holds todo list)
+│   ├── index.ts
+│   ├── default.ts
+│   ├── gpt.ts
+│   └── utils.ts
 ├── sisyphus.ts                 # Main prompt (SF Bay Area engineer identity)
 ├── hephaestus.ts               # Autonomous Deep Worker (GPT 5.2 Codex, "The Legitimate Craftsman")
-├── sisyphus-junior.ts          # Delegated task executor (category-spawned)
+├── sisyphus-junior/            # Delegated task executor (category-spawned)
+│   ├── index.ts
+│   ├── default.ts
+│   └── gpt.ts
 ├── oracle.ts                   # Strategic advisor (GPT-5.2)
 ├── librarian.ts                # Multi-repo research (GitHub CLI, Context7)
 ├── explore.ts                  # Fast contextual grep (Grok Code Fast)
 ├── multimodal-looker.ts        # Media analyzer (Gemini 3 Flash)
-├── prometheus-prompt.ts        # Planning (Interview/Consultant mode, 1283 lines)
+├── prometheus/                 # Planning (Interview/Consultant mode)
+│   ├── index.ts
+│   ├── plan-template.ts
+│   ├── interview-mode.ts
+│   ├── plan-generation.ts
+│   ├── high-accuracy-mode.ts
+│   ├── identity-constraints.ts
+│   └── behavioral-summary.ts
 ├── metis.ts                    # Pre-planning analysis (Gap detection)
 ├── momus.ts                    # Plan reviewer (Ruthless fault-finding)
 ├── dynamic-agent-prompt-builder.ts  # Dynamic prompt generation

--- a/src/features/AGENTS.md
+++ b/src/features/AGENTS.md
@@ -14,7 +14,7 @@ features/
 │   ├── manager.ts              # Launch → poll → complete
 │   └── concurrency.ts          # Per-provider limits
 ├── builtin-skills/             # Core skills (1729 lines)
-│   └── skills.ts               # playwright, dev-browser, frontend-ui-ux, git-master, typescript-programmer
+│   └── skills.ts               # playwright, agent-browser, frontend-ui-ux, git-master, dev-browser
 ├── builtin-commands/           # ralph-loop, refactor, ulw-loop, init-deep, start-work, cancel-ralph, stop-continuation
 ├── claude-code-agent-loader/   # ~/.claude/agents/*.md
 ├── claude-code-command-loader/ # ~/.claude/commands/*.md

--- a/src/hooks/AGENTS.md
+++ b/src/hooks/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## OVERVIEW
 
-34 lifecycle hooks intercepting/modifying agent behavior across 5 events.
+41 lifecycle hooks intercepting/modifying agent behavior across 5 events.
 
 **Event Types**:
 - `UserPromptSubmit` (`chat.message`) - Can block


### PR DESCRIPTION
## What
Fix stale/incorrect references in AGENTS.md docs.

## Changes
- Update `src/agents/AGENTS.md` structure to match current directory layout (atlas/sisyphus-junior/prometheus)
- Update root `AGENTS.md`
  - Hook count references: 34 -> 41
  - Add missing agent model rows: Metis, Momus, Sisyphus-Junior
  - Fix complexity hotspots paths/counts using `wc -l`
- Update `src/features/AGENTS.md` builtin skills list (builtin vs user-installed)
- Update `src/hooks/AGENTS.md` hook count to 41

## Verification
- Verified referenced paths exist via `ls`
- Verified line counts via `wc -l`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated all AGENTS.md docs to reflect the current code layout and counts. Fixes stale paths, hook totals, and agent listings so the docs match the codebase.

- **Bug Fixes**
  - Synced src/agents/AGENTS.md with new directories: atlas/, sisyphus-junior/, prometheus/
  - Updated lifecycle hook totals from 34 to 41 (root and src/hooks/AGENTS.md)
  - Added missing agents to table: Metis, Momus, Sisyphus-Junior
  - Corrected complexity hotspots paths and line counts (e.g., prometheus/ dir, skills.ts)
  - Aligned builtin skills list with current names in src/features/AGENTS.md

<sup>Written for commit ca8ec494a36d750ee5e53a84597fd6ac2093e9e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

