### PR TITLE
fix(delegate-task): make plan agent categories/skills dynamic

### DIFF
--- a/src/agents/dynamic-agent-prompt-builder.ts
+++ b/src/agents/dynamic-agent-prompt-builder.ts
@@ -20,6 +20,7 @@ export interface AvailableSkill {
 export interface AvailableCategory {
   name: string
   description: string
+  model?: string
 }
 
 export function categorizeTools(toolNames: string[]): AvailableTool[] {

--- a/src/tools/delegate-task/prompt-builder.ts
+++ b/src/tools/delegate-task/prompt-builder.ts
@@ -1,14 +1,22 @@
-import { PLAN_AGENT_SYSTEM_PREPEND, isPlanAgent } from "./constants"
 import type { BuildSystemContentInput } from "./types"
+import { buildPlanAgentSystemPrepend, isPlanAgent } from "./constants"
 
 /**
  * Build the system content to inject into the agent prompt.
  * Combines skill content, category prompt append, and plan agent system prepend.
  */
 export function buildSystemContent(input: BuildSystemContentInput): string | undefined {
-  const { skillContent, categoryPromptAppend, agentName } = input
+  const {
+    skillContent,
+    categoryPromptAppend,
+    agentName,
+    availableCategories,
+    availableSkills,
+  } = input
 
-  const planAgentPrepend = isPlanAgent(agentName) ? PLAN_AGENT_SYSTEM_PREPEND : ""
+  const planAgentPrepend = isPlanAgent(agentName)
+    ? buildPlanAgentSystemPrepend(availableCategories, availableSkills)
+    : ""
 
   if (!skillContent && !categoryPromptAppend && !planAgentPrepend) {
     return undefined

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -1994,56 +1994,137 @@ describe("sisyphus-task", () => {
     test("prepends plan agent system prompt when agentName is 'plan'", () => {
       // given
       const { buildSystemContent } = require("./tools")
-      const { PLAN_AGENT_SYSTEM_PREPEND } = require("./constants")
+      const { buildPlanAgentSystemPrepend } = require("./constants")
+
+      const availableCategories = [
+        {
+          name: "deep",
+          description: "Goal-oriented autonomous problem-solving",
+          model: "openai/gpt-5.3-codex",
+        },
+      ]
+      const availableSkills = [
+        {
+          name: "typescript-programmer",
+          description: "Production TypeScript code.",
+          location: "plugin",
+        },
+      ]
 
       // when
-      const result = buildSystemContent({ agentName: "plan" })
+      const result = buildSystemContent({
+        agentName: "plan",
+        availableCategories,
+        availableSkills,
+      })
 
       // then
       expect(result).toContain("<system>")
       expect(result).toContain("MANDATORY CONTEXT GATHERING PROTOCOL")
-      expect(result).toBe(PLAN_AGENT_SYSTEM_PREPEND)
+      expect(result).toContain("### AVAILABLE CATEGORIES")
+      expect(result).toContain("`deep`")
+      expect(result).not.toContain("prompt-engineer")
+      expect(result).toBe(buildPlanAgentSystemPrepend(availableCategories, availableSkills))
     })
 
     test("prepends plan agent system prompt when agentName is 'prometheus'", () => {
       // given
       const { buildSystemContent } = require("./tools")
-      const { PLAN_AGENT_SYSTEM_PREPEND } = require("./constants")
+      const { buildPlanAgentSystemPrepend } = require("./constants")
+
+      const availableCategories = [
+        {
+          name: "ultrabrain",
+          description: "Complex architecture, deep logical reasoning",
+          model: "openai/gpt-5.3-codex",
+        },
+      ]
+      const availableSkills = [
+        {
+          name: "git-master",
+          description: "Atomic commits, git operations.",
+          location: "plugin",
+        },
+      ]
 
       // when
-      const result = buildSystemContent({ agentName: "prometheus" })
+      const result = buildSystemContent({
+        agentName: "prometheus",
+        availableCategories,
+        availableSkills,
+      })
 
       // then
       expect(result).toContain("<system>")
-      expect(result).toBe(PLAN_AGENT_SYSTEM_PREPEND)
+      expect(result).toBe(buildPlanAgentSystemPrepend(availableCategories, availableSkills))
     })
 
     test("prepends plan agent system prompt when agentName is 'Prometheus' (case insensitive)", () => {
       // given
       const { buildSystemContent } = require("./tools")
-      const { PLAN_AGENT_SYSTEM_PREPEND } = require("./constants")
+      const { buildPlanAgentSystemPrepend } = require("./constants")
+
+      const availableCategories = [
+        {
+          name: "quick",
+          description: "Trivial tasks",
+          model: "anthropic/claude-haiku-4-5",
+        },
+      ]
+      const availableSkills = [
+        {
+          name: "dev-browser",
+          description: "Persistent browser state automation.",
+          location: "plugin",
+        },
+      ]
 
       // when
-      const result = buildSystemContent({ agentName: "Prometheus" })
+      const result = buildSystemContent({
+        agentName: "Prometheus",
+        availableCategories,
+        availableSkills,
+      })
 
       // then
       expect(result).toContain("<system>")
-      expect(result).toBe(PLAN_AGENT_SYSTEM_PREPEND)
+      expect(result).toBe(buildPlanAgentSystemPrepend(availableCategories, availableSkills))
     })
 
     test("combines plan agent prepend with skill content", () => {
       // given
       const { buildSystemContent } = require("./tools")
-      const { PLAN_AGENT_SYSTEM_PREPEND } = require("./constants")
+      const { buildPlanAgentSystemPrepend } = require("./constants")
       const skillContent = "You are a planning expert"
 
+      const availableCategories = [
+        {
+          name: "writing",
+          description: "Documentation, prose, technical writing",
+          model: "google/gemini-3-flash",
+        },
+      ]
+      const availableSkills = [
+        {
+          name: "python-programmer",
+          description: "Production Python code.",
+          location: "plugin",
+        },
+      ]
+      const planPrepend = buildPlanAgentSystemPrepend(availableCategories, availableSkills)
+
       // when
-      const result = buildSystemContent({ skillContent, agentName: "plan" })
+      const result = buildSystemContent({
+        skillContent,
+        agentName: "plan",
+        availableCategories,
+        availableSkills,
+      })
 
       // then
-      expect(result).toContain(PLAN_AGENT_SYSTEM_PREPEND)
+      expect(result).toContain(planPrepend)
       expect(result).toContain(skillContent)
-      expect(result!.indexOf(PLAN_AGENT_SYSTEM_PREPEND)).toBeLessThan(result!.indexOf(skillContent))
+      expect(result!.indexOf(planPrepend)).toBeLessThan(result!.indexOf(skillContent))
     })
 
     test("does not prepend plan agent prompt for non-plan agents", () => {

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -1,6 +1,10 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
 import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider } from "../../config/schema"
+import type {
+  AvailableCategory,
+  AvailableSkill,
+} from "../../agents/dynamic-agent-prompt-builder"
 
 export type OpencodeClient = PluginInput["client"]
 
@@ -42,6 +46,8 @@ export interface DelegateTaskToolOptions {
   sisyphusJuniorModel?: string
   browserProvider?: BrowserAutomationProvider
   disabledSkills?: Set<string>
+  availableCategories?: AvailableCategory[]
+  availableSkills?: AvailableSkill[]
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>
 }
 
@@ -49,4 +55,6 @@ export interface BuildSystemContentInput {
   skillContent?: string
   categoryPromptAppend?: string
   agentName?: string
+  availableCategories?: AvailableCategory[]
+  availableSkills?: AvailableSkill[]
 }


### PR DESCRIPTION
## Background

The Plan agent prompt in `src/tools/delegate-task/constants.ts` hardcoded the available categories and skills.
That table was stale (`prompt-engineer` dead reference), incomplete (missing categories like `deep`), and could list user-installed skills that do not exist for every user.

## Changes

- Build the Plan agent category + skill tables dynamically from the actual available categories/skills.
- Split the Plan agent prepend into static sections + a dynamic table builder (`buildPlanAgentSkillsSection`).
- Thread `availableCategories` / `availableSkills` through `delegate_task` prompt building so Plan agent gets the same dynamic view as other orchestrator agents.
- Update `delegate-task` tests to assert dynamic content and remove the dead `prompt-engineer` reference.

## Testing

1. `bun test src/tools/delegate-task/`
2. `bun run typecheck`
3. `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Plan agent’s category and skill tables dynamic and sourced from actual, available categories/skills. This removes stale entries and ensures recommendations match each user’s setup.

- **New Features**
  - Build the Plan agent’s table at runtime using buildPlanAgentSystemPrepend/buildPlanAgentSkillsSection.
  - Compute availableCategories (with optional model) and availableSkills from merged config/discovered skills, and pass them into createDelegateTask → buildSystemContent.
  - Add model? to AvailableCategory to surface per-category model hints in the table.

- **Bug Fixes**
  - Remove the dead “prompt-engineer” reference and avoid listing skills a user doesn’t have.
  - Align the Plan agent’s view with other orchestrator agents; tests updated to assert dynamic content.

<sup>Written for commit 6b560ebf9ebeb7affeee524af11899eaf667e45e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

