### PR TITLE
fix: sync Zod schemas with actual implementations

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,6 +32,7 @@ export const BuiltinAgentNameSchema = z.enum([
 export const BuiltinSkillNameSchema = z.enum([
   "playwright",
   "agent-browser",
+  "dev-browser",
   "frontend-ui-ux",
   "git-master",
 ])
@@ -63,10 +64,12 @@ export const HookNameSchema = z.enum([
   "comment-checker",
   "grep-output-truncator",
   "tool-output-truncator",
+  "question-label-truncator",
   "directory-agents-injector",
   "directory-readme-injector",
   "empty-task-response-detector",
   "think-mode",
+  "subagent-question-blocker",
   "anthropic-context-window-limit-recovery",
   "preemptive-compaction",
   "rules-injector",
@@ -92,6 +95,8 @@ export const HookNameSchema = z.enum([
   "start-work",
   "atlas",
   "unstable-agent-babysitter",
+  "task-reminder",
+  "task-resume-info",
   "stop-continuation-guard",
   "tasks-todowrite-disabler",
   "write-existing-file-guard",
@@ -99,7 +104,12 @@ export const HookNameSchema = z.enum([
 
 export const BuiltinCommandNameSchema = z.enum([
   "init-deep",
+  "ralph-loop",
+  "ulw-loop",
+  "cancel-ralph",
+  "refactor",
   "start-work",
+  "stop-continuation",
 ])
 
 export const AgentOverrideConfigSchema = z.object({


### PR DESCRIPTION
## Background
`src/config/schema.ts` Zod enums for builtin skills/commands/hooks were missing values that are already implemented/registered.

## Changes
- Add `dev-browser` to `BuiltinSkillNameSchema`
- Add missing builtin commands to `BuiltinCommandNameSchema`: `ralph-loop`, `ulw-loop`, `cancel-ralph`, `refactor`, `stop-continuation`
- Add missing hooks to `HookNameSchema`: `question-label-truncator`, `subagent-question-blocker`, `task-reminder`, `task-resume-info`

## Testing
- `bun run build:schema`
- `bun test` (see note)
- `bun run typecheck`
- `bun run build`

Note: `src/index.disabled-tools.test.ts` uses `mock.module()` and leaks mocks across files under Bun. To avoid cross-file mock pollution, tests were executed in 3 isolated invocations:
1. `bun test src/agents src/cli src/features src/hooks src/shared src/tools script`
2. `bun test src/index.test.ts src/plugin-config.test.ts`
3. `bun test src/index.disabled-tools.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Zod enums with registered skills, commands, and hooks so schema validation matches the implementation and avoids false validation/type errors.

- **Bug Fixes**
  - Add dev-browser to BuiltinSkillNameSchema.
  - Add commands: ralph-loop, ulw-loop, cancel-ralph, refactor, stop-continuation.
  - Add hooks: question-label-truncator, subagent-question-blocker, task-reminder, task-resume-info.

<sup>Written for commit 53537a9a90f9cb667090cd478bec1269b07d3a88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

