### PR TITLE
fix(compaction): remove hardcoded Claude model from compaction hooks

### DIFF
--- a/src/hooks/compaction-context-injector/index.test.ts
+++ b/src/hooks/compaction-context-injector/index.test.ts
@@ -1,14 +1,4 @@
-import { describe, expect, it, mock, beforeEach } from "bun:test"
-
-// Mock dependencies before importing
-const mockInjectHookMessage = mock(() => true)
-mock.module("../../features/hook-message-injector", () => ({
-  injectHookMessage: mockInjectHookMessage,
-}))
-
-mock.module("../../shared/logger", () => ({
-  log: () => {},
-}))
+import { describe, expect, it, mock } from "bun:test"
 
 mock.module("../../shared/system-directive", () => ({
   createSystemDirective: (type: string) => `[DIRECTIVE:${type}]`,
@@ -25,78 +15,45 @@ mock.module("../../shared/system-directive", () => ({
 }))
 
 import { createCompactionContextInjector } from "./index"
-import type { SummarizeContext } from "./index"
 
 describe("createCompactionContextInjector", () => {
-  beforeEach(() => {
-    mockInjectHookMessage.mockClear()
-  })
-
   describe("Agent Verification State preservation", () => {
     it("includes Agent Verification State section in compaction prompt", async () => {
-      // given
+      //#given
       const injector = createCompactionContextInjector()
-      const context: SummarizeContext = {
-        sessionID: "test-session",
-        providerID: "anthropic",
-        modelID: "claude-sonnet-4-5",
-        usageRatio: 0.85,
-        directory: "/test/dir",
-      }
 
-      // when
-      await injector(context)
+      //#when
+      const prompt = injector()
 
-      // then
-      expect(mockInjectHookMessage).toHaveBeenCalledTimes(1)
-      const calls = mockInjectHookMessage.mock.calls as unknown as [string, string, unknown][]
-      const injectedPrompt = calls[0]?.[1] ?? ""
-      expect(injectedPrompt).toContain("Agent Verification State")
-      expect(injectedPrompt).toContain("Current Agent")
-      expect(injectedPrompt).toContain("Verification Progress")
+      //#then
+      expect(prompt).toContain("Agent Verification State")
+      expect(prompt).toContain("Current Agent")
+      expect(prompt).toContain("Verification Progress")
     })
 
-    it("includes Momus-specific context for reviewer agents", async () => {
-      // given
+    it("includes reviewer-agent continuity fields", async () => {
+      //#given
       const injector = createCompactionContextInjector()
-      const context: SummarizeContext = {
-        sessionID: "test-session",
-        providerID: "anthropic",
-        modelID: "claude-sonnet-4-5",
-        usageRatio: 0.9,
-        directory: "/test/dir",
-      }
 
-      // when
-      await injector(context)
+      //#when
+      const prompt = injector()
 
-      // then
-      const calls = mockInjectHookMessage.mock.calls as unknown as [string, string, unknown][]
-      const injectedPrompt = calls[0]?.[1] ?? ""
-      expect(injectedPrompt).toContain("Previous Rejections")
-      expect(injectedPrompt).toContain("Acceptance Status")
-      expect(injectedPrompt).toContain("reviewer agents")
+      //#then
+      expect(prompt).toContain("Previous Rejections")
+      expect(prompt).toContain("Acceptance Status")
+      expect(prompt).toContain("reviewer agents")
     })
 
-    it("preserves file verification progress in compaction prompt", async () => {
-      // given
+    it("preserves file verification progress fields", async () => {
+      //#given
       const injector = createCompactionContextInjector()
-      const context: SummarizeContext = {
-        sessionID: "test-session",
-        providerID: "anthropic",
-        modelID: "claude-sonnet-4-5",
-        usageRatio: 0.95,
-        directory: "/test/dir",
-      }
 
-      // when
-      await injector(context)
+      //#when
+      const prompt = injector()
 
-      // then
-      const calls = mockInjectHookMessage.mock.calls as unknown as [string, string, unknown][]
-      const injectedPrompt = calls[0]?.[1] ?? ""
-      expect(injectedPrompt).toContain("Pending Verifications")
-      expect(injectedPrompt).toContain("Files already verified")
+      //#then
+      expect(prompt).toContain("Pending Verifications")
+      expect(prompt).toContain("Files already verified")
     })
   })
 })

--- a/src/hooks/compaction-context-injector/index.ts
+++ b/src/hooks/compaction-context-injector/index.ts
@@ -1,16 +1,6 @@
-import { injectHookMessage } from "../../features/hook-message-injector"
-import { log } from "../../shared/logger"
 import { createSystemDirective, SystemDirectiveTypes } from "../../shared/system-directive"
 
-export interface SummarizeContext {
-  sessionID: string
-  providerID: string
-  modelID: string
-  usageRatio: number
-  directory: string
-}
-
-const SUMMARIZE_CONTEXT_PROMPT = `${createSystemDirective(SystemDirectiveTypes.COMPACTION_CONTEXT)}
+const COMPACTION_CONTEXT_PROMPT = `${createSystemDirective(SystemDirectiveTypes.COMPACTION_CONTEXT)}
 
 When summarizing this session, you MUST include the following sections in your summary:
 
@@ -58,19 +48,5 @@ This context is critical for maintaining continuity after compaction.
 `
 
 export function createCompactionContextInjector() {
-  return async (ctx: SummarizeContext): Promise<void> => {
-    log("[compaction-context-injector] injecting context", { sessionID: ctx.sessionID })
-
-    const success = injectHookMessage(ctx.sessionID, SUMMARIZE_CONTEXT_PROMPT, {
-      agent: "general",
-      model: { providerID: ctx.providerID, modelID: ctx.modelID },
-      path: { cwd: ctx.directory },
-    })
-
-    if (success) {
-      log("[compaction-context-injector] context injected", { sessionID: ctx.sessionID })
-    } else {
-      log("[compaction-context-injector] injection failed", { sessionID: ctx.sessionID })
-    }
-  }
+  return (): string => COMPACTION_CONTEXT_PROMPT
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -34,7 +34,7 @@ export { createDelegateTaskRetryHook } from "./delegate-task-retry";
 export { createQuestionLabelTruncatorHook } from "./question-label-truncator";
 export { createSubagentQuestionBlockerHook } from "./subagent-question-blocker";
 export { createStopContinuationGuardHook, type StopContinuationGuard } from "./stop-continuation-guard";
-export { createCompactionContextInjector, type SummarizeContext } from "./compaction-context-injector";
+export { createCompactionContextInjector } from "./compaction-context-injector";
 export { createUnstableAgentBabysitterHook } from "./unstable-agent-babysitter";
 export { createPreemptiveCompactionHook } from "./preemptive-compaction";
 export { createTasksTodowriteDisablerHook } from "./tasks-todowrite-disabler";

--- a/src/index.compaction-model-agnostic.static.test.ts
+++ b/src/index.compaction-model-agnostic.static.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+describe("experimental.session.compacting", () => {
+  test("does not hardcode a model and uses output.context", () => {
+    //#given
+    const indexUrl = new URL("./index.ts", import.meta.url)
+    const content = readFileSync(indexUrl, "utf-8")
+    const hookIndex = content.indexOf('"experimental.session.compacting"')
+
+    //#when
+    const hookSlice = hookIndex >= 0 ? content.slice(hookIndex, hookIndex + 1200) : ""
+
+    //#then
+    expect(hookIndex).toBeGreaterThanOrEqual(0)
+    expect(content.includes('modelID: "claude-opus-4-6"')).toBe(false)
+    expect(hookSlice.includes("output.context.push")).toBe(true)
+    expect(hookSlice.includes("providerID:")).toBe(false)
+    expect(hookSlice.includes("modelID:")).toBe(false)
+  })
+})

--- a/src/shared/disabled-tools.ts
+++ b/src/shared/disabled-tools.ts
@@ -1,0 +1,19 @@
+import type { ToolDefinition } from "@opencode-ai/plugin"
+
+export function filterDisabledTools(
+  tools: Record<string, ToolDefinition>,
+  disabledTools: readonly string[] | undefined
+): Record<string, ToolDefinition> {
+  if (!disabledTools || disabledTools.length === 0) {
+    return tools
+  }
+
+  const disabledToolSet = new Set(disabledTools)
+  const filtered: Record<string, ToolDefinition> = {}
+  for (const [toolName, toolDefinition] of Object.entries(tools)) {
+    if (!disabledToolSet.has(toolName)) {
+      filtered[toolName] = toolDefinition
+    }
+  }
+  return filtered
+}


### PR DESCRIPTION
Closes #796

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make compaction model-agnostic by removing hardcoded Claude/Anthropic references and shifting to a prompt-based injector that works across providers. Addresses Linear #796.

- **Bug Fixes**
  - Removed provider/model fields from compaction context injector; it now returns a prompt string.
  - experimental.session.compacting appends the prompt via output.context.push with no provider/model IDs.
  - Preemptive compaction now works for any provider with a 200k default limit (Anthropic still supports 1M via env); added test for non-Anthropic.

- **Refactors**
  - Extracted filterDisabledTools utility and updated index to use it.

<sup>Written for commit 60bbeb730405e6aa4d25b4ea110e0aa8d7db776f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

