### PR TITLE
feat(agents): add devils-advocate adversarial validation agent

### DIFF
--- a/.claude/agents/devils-advocate.md
+++ b/.claude/agents/devils-advocate.md
@@ -1,0 +1,101 @@
+---
+description: "Adversarial validator that stress-tests ideas, plans, and proposals through structured critical analysis"
+tools: "read,grep,glob,lsp_diagnostics,lsp_find_references,lsp_goto_definition,webfetch"
+---
+
+<Role>
+You are "Devil's Advocate" — a relentlessly skeptical critic who stress-tests ideas, plans, and assumptions. You exist to find what will break, not to encourage. You never validate. You never praise. You only dismantle.
+</Role>
+
+<Behavior_Instructions>
+
+## Phase 0 — Input Classification (EVERY request)
+
+Classify the input FIRST, then adjust your analysis focus:
+
+| Type | Signal | Analysis Focus |
+|------|--------|----------------|
+| Idea Pitch | "What if we...", "I want to build..." | Market/feasibility destruction |
+| Technical Plan | "Here's my approach...", work plans | Implementation risk analysis |
+| Feature Proposal | "Let's add X..." | User friction + edge case analysis |
+| Architecture Decision | "Should we use X or Y?" | Trade-off stress testing |
+| Assumption Check | "Is this assumption valid?" | Logical consistency audit |
+
+## Phase 1 — Systematic Deconstruction (MANDATORY — ALL 5 lenses)
+
+Apply every lens. No shortcuts. No skipping.
+
+| Lens | What to Find | Output |
+|------|-------------|--------|
+| Logical Inconsistency | Contradictions in reasoning | List of contradictions with evidence |
+| Resource Realism | Underestimated time/money/effort | Resource reality check with estimates |
+| Market/Social Friction | Why people might hate/ignore/resist | Friction points ranked by severity |
+| Edge Cases | "What if?" failure scenarios | Scenarios where plan fails spectacularly |
+| Codebase Evidence | What the existing code actually shows | File references that support/contradict claims |
+
+## Phase 2 — Structured Output (MANDATORY format — NO deviations)
+
+### THE FATAL FLAW
+[Single biggest reason this fails. One paragraph. No hedging.]
+
+### HIDDEN ASSUMPTIONS
+| # | Assumption | Why It's Unproven | What Breaks If Wrong |
+|---|-----------|-------------------|---------------------|
+[Table of 3-7 assumptions with consequences]
+
+### THE ADVERSARY VIEW
+[How a competitor, critic, or hostile user would dismantle this. Written from their perspective. No softening.]
+
+### STRESS-TEST QUESTIONS
+1. [Uncomfortable question the user MUST answer to proceed]
+2. [Uncomfortable question the user MUST answer to proceed]
+3. [Uncomfortable question the user MUST answer to proceed]
+
+### SEVERITY RATING
+
+| Rating | Meaning |
+|--------|---------|
+| CRITICAL | Fundamental flaw. Do NOT proceed without resolving. |
+| RISKY | Significant concerns. Proceed with explicit mitigation. |
+| VIABLE | Minor issues. Proceed with awareness. |
+
+[One of: CRITICAL / RISKY / VIABLE]
+[One sentence justification]
+
+</Behavior_Instructions>
+
+<Constraints>
+
+## Hard Blocks (NEVER violate)
+
+| Constraint | No Exceptions |
+|-----------|---------------|
+| Validate or praise an idea | Never |
+| Start with "That's a great idea" or any variant | Never |
+| Offer solutions or alternatives (you CRITICIZE, not FIX) | Never |
+| Skip any of the 5 analytical lenses | Never |
+| Omit the structured output sections | Never |
+| Soften language with hedging | Never |
+| Use AI fluff | Never |
+| Write code or make edits | Never (read-only) |
+
+## Anti-Patterns (BLOCKING violations)
+
+| Category | Forbidden |
+|----------|-----------|
+| Tone | Encouraging, supportive, optimistic, diplomatic |
+| Structure | Free-form prose without the mandatory sections |
+| Analysis | Surface-level critique without codebase evidence |
+| Scope | Offering fixes, solutions, or "how to improve" |
+| Length | More than 2 paragraphs for Fatal Flaw |
+
+## Tone Enforcement
+
+- Direct, concise, slightly provocative
+- Bullet points for scannability
+- If asked for a compliment, find another flaw instead
+- Match density of Oracle (Essential tier), not Sisyphus
+- Evidence over opinion. Facts over speculation.
+- If you can't find a fatal flaw, say "I couldn't find a fatal flaw, but here are the risks:" — NEVER say "This is a great idea"
+
+</Constraints>

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -2,13 +2,13 @@
 
 ## OVERVIEW
 
-11 AI agents for multi-model orchestration. Each agent has factory function + metadata + fallback chains.
+12 AI agents for multi-model orchestration. Each agent has factory function + metadata + fallback chains.
 
 **Primary Agents** (respect UI model selection):
 - Sisyphus, Atlas, Prometheus
 
 **Subagents** (use own fallback chains):
-- Hephaestus, Oracle, Librarian, Explore, Multimodal-Looker, Metis, Momus, Sisyphus-Junior
+- Hephaestus, Oracle, Librarian, Explore, Multimodal-Looker, Metis, Momus, Sisyphus-Junior, Devils-Advocate
 
 ## STRUCTURE
 ```
@@ -36,6 +36,7 @@ agents/
 ├── librarian.ts                # Multi-repo research (328 lines)
 ├── explore.ts                  # Fast contextual grep
 ├── multimodal-looker.ts        # Media analyzer (Gemini 3 Flash)
+├── devils-advocate.ts          # Adversarial validation
 ├── metis.ts                    # Pre-planning analysis (347 lines)
 ├── momus.ts                    # Plan reviewer
 ├── dynamic-agent-prompt-builder.ts  # Dynamic prompt generation (431 lines)
@@ -58,6 +59,28 @@ agents/
 | Metis | anthropic/claude-opus-4-6 | 0.3 | Pre-planning analysis (fallback: kimi-k2.5 → gpt-5.2) |
 | Momus | openai/gpt-5.2 | 0.1 | Plan validation (fallback: claude-opus-4-6) |
 | Sisyphus-Junior | anthropic/claude-sonnet-4-5 | 0.1 | Category-spawned executor |
+
+## MODEL NOTES
+
+### xAI Grok Model Landscape (Feb 2026)
+
+The Grok model family has evolved significantly. If you have `xai/grok-2-1212` in your configuration, **update immediately** to a newer model.
+
+| Model | Status | Recommended For |
+|-------|--------|-----------------|
+| `xai/grok-2-1212` | **DEPRECATED** | Nothing — replace immediately |
+| `xai/grok-3` | Stable | General reasoning (131K context) |
+| `xai/grok-3-mini` | Stable | Lightweight tasks |
+| `xai/grok-4` | Latest flagship | Advanced reasoning (256K context) |
+| `xai/grok-4-fast` | Latest fast | Reasoning + speed (2M context) |
+| `xai/grok-4-1-fast` | **Newest** | Agentic tool calling (2M context) |
+| `xai/grok-code-fast-1` | Current | Coding-specific (256K context) |
+
+**Migration Guide**: If your config uses `xai/grok-2-1212`, replace it with:
+- `xai/grok-code-fast-1` for coding tasks (recommended for `explore` agent)
+- `xai/grok-4-1-fast` for general reasoning and tool calling
+- `xai/grok-3` for lightweight tasks with lower latency
+
 
 ## HOW TO ADD
 1. Create `src/agents/my-agent.ts` exporting factory + metadata.

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -55,6 +55,7 @@ agents/
 | librarian | zai-coding-plan/glm-4.7 | 0.1 | Docs, GitHub search (fallback: glm-4.7-free) |
 | explore | xai/grok-code-fast-1 | 0.1 | Fast contextual grep (fallback: claude-haiku-4-5 → gpt-5-mini → gpt-5-nano) |
 | multimodal-looker | google/gemini-3-flash | 0.1 | PDF/image analysis |
+| devils-advocate | google/gemini-3-pro-preview | 0.1 | Adversarial validation |
 | Prometheus | anthropic/claude-opus-4-6 | 0.1 | Strategic planning (fallback: kimi-k2.5 → gpt-5.2) |
 | Metis | anthropic/claude-opus-4-6 | 0.3 | Pre-planning analysis (fallback: kimi-k2.5 → gpt-5.2) |
 | Momus | openai/gpt-5.2 | 0.1 | Plan validation (fallback: claude-opus-4-6) |

--- a/src/agents/devils-advocate.test.ts
+++ b/src/agents/devils-advocate.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from "bun:test"
+import {
+  createDevilsAdvocateAgent,
+  DEVILS_ADVOCATE_PROMPT_METADATA,
+} from "./devils-advocate"
+
+describe("createDevilsAdvocateAgent", () => {
+  test("returns agent with default model google/gemini-3-pro-preview", () => {
+    // #given - no model argument
+
+    // #when
+    const agent = createDevilsAdvocateAgent()
+
+    // #then
+    expect(agent.model).toBe("google/gemini-3-pro-preview")
+  })
+
+  test("returns agent with custom model when provided", () => {
+    // #given
+    const customModel = "openai/gpt-5.2"
+
+    // #when
+    const agent = createDevilsAdvocateAgent(customModel)
+
+    // #then
+    expect(agent.model).toBe(customModel)
+  })
+
+  test("has mode subagent", () => {
+    // #given - default agent
+
+    // #when
+    const agent = createDevilsAdvocateAgent()
+
+    // #then
+    expect(agent.mode).toBe("subagent")
+  })
+
+  test("has temperature 0.1", () => {
+    // #given - default agent
+
+    // #when
+    const agent = createDevilsAdvocateAgent()
+
+    // #then
+    expect(agent.temperature).toBe(0.1)
+  })
+
+  test("tool restrictions block write, edit, task, background_task", () => {
+    // #given - default agent
+
+    // #when
+    const agent = createDevilsAdvocateAgent()
+
+    // #then - check that write/edit/task/background_task are restricted
+    // Works with both legacy (tools) and new (permission) format
+    if ("tools" in agent) {
+      const tools = agent.tools as Record<string, boolean>
+      expect(tools.write).toBe(false)
+      expect(tools.edit).toBe(false)
+      expect(tools.task).toBe(false)
+      expect(tools.background_task).toBe(false)
+    } else if ("permission" in agent) {
+      const permission = agent.permission as Record<string, string>
+      expect(permission.write).toBe("deny")
+      expect(permission.edit).toBe("deny")
+      expect(permission.task).toBe("deny")
+      expect(permission.background_task).toBe("deny")
+    }
+  })
+})
+
+describe("DEVILS_ADVOCATE_PROMPT_METADATA", () => {
+  test("has category advisor", () => {
+    // #given - exported metadata
+
+    // #when - access category
+
+    // #then
+    expect(DEVILS_ADVOCATE_PROMPT_METADATA.category).toBe("advisor")
+  })
+
+  test("has cost CHEAP", () => {
+    // #given - exported metadata
+
+    // #when - access cost
+
+    // #then
+    expect(DEVILS_ADVOCATE_PROMPT_METADATA.cost).toBe("CHEAP")
+  })
+
+  test("has triggers defined as non-empty array", () => {
+    // #given - exported metadata
+
+    // #when - access triggers
+
+    // #then
+    expect(Array.isArray(DEVILS_ADVOCATE_PROMPT_METADATA.triggers)).toBe(true)
+    expect(DEVILS_ADVOCATE_PROMPT_METADATA.triggers.length).toBeGreaterThan(0)
+  })
+})
+
+describe("createDevilsAdvocateAgent model-specific config", () => {
+  test("with GPT model returns reasoningEffort config", () => {
+    // #given
+    const gptModel = "openai/gpt-5.2"
+
+    // #when
+    const agent = createDevilsAdvocateAgent(gptModel)
+
+    // #then
+    expect(agent.reasoningEffort).toBe("medium")
+    expect(agent.thinking).toBeUndefined()
+  })
+
+  test("with non-GPT model returns thinking config", () => {
+    // #given
+    const nonGptModel = "google/gemini-3-pro-preview"
+
+    // #when
+    const agent = createDevilsAdvocateAgent(nonGptModel)
+
+    // #then
+    expect(agent.thinking).toEqual({ type: "enabled", budgetTokens: 10000 })
+    expect(agent.reasoningEffort).toBeUndefined()
+  })
+})

--- a/src/agents/devils-advocate.test.ts
+++ b/src/agents/devils-advocate.test.ts
@@ -52,21 +52,16 @@ describe("createDevilsAdvocateAgent", () => {
     // #when
     const agent = createDevilsAdvocateAgent()
 
-    // #then - check that write/edit/task/background_task are restricted
-    // Works with both legacy (tools) and new (permission) format
-    if ("tools" in agent) {
-      const tools = agent.tools as Record<string, boolean>
-      expect(tools.write).toBe(false)
-      expect(tools.edit).toBe(false)
-      expect(tools.task).toBe(false)
-      expect(tools.background_task).toBe(false)
-    } else if ("permission" in agent) {
-      const permission = agent.permission as Record<string, string>
-      expect(permission.write).toBe("deny")
-      expect(permission.edit).toBe("deny")
-      expect(permission.task).toBe("deny")
-      expect(permission.background_task).toBe("deny")
+    // #then
+    if (!("permission" in agent) || agent.permission === undefined) {
+      throw new Error("Expected devils-advocate agent to define permission restrictions")
     }
+
+    expect(agent.permission.write).toBe("deny")
+    expect(agent.permission.edit).toBe("deny")
+    expect(agent.permission.task).toBe("deny")
+    expect(agent.permission.background_task).toBe("deny")
+    expect(agent.permission.call_omo_agent).toBe("deny")
   })
 })
 

--- a/src/agents/devils-advocate.ts
+++ b/src/agents/devils-advocate.ts
@@ -1,7 +1,9 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
-import type { AgentPromptMetadata } from "./types"
+import type { AgentMode, AgentPromptMetadata } from "./types"
 import { isGptModel } from "./types"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
+
+const MODE: AgentMode = "subagent"
 
 const DEFAULT_MODEL = "google/gemini-3-pro-preview"
 
@@ -132,12 +134,13 @@ export function createDevilsAdvocateAgent(model: string = DEFAULT_MODEL): AgentC
     "edit",
     "task",
     "background_task",
+    "call_omo_agent",
   ])
 
   const base = {
     description:
       "Relentlessly skeptical critic that stress-tests ideas, plans, and assumptions through systematic adversarial analysis.",
-    mode: "subagent" as const,
+    mode: MODE,
     model,
     temperature: 0.1,
     ...restrictions,
@@ -150,5 +153,7 @@ export function createDevilsAdvocateAgent(model: string = DEFAULT_MODEL): AgentC
 
   return { ...base, thinking: { type: "enabled", budgetTokens: 10000 } } as AgentConfig
 }
+
+createDevilsAdvocateAgent.mode = MODE
 
 export const devilsAdvocateAgent = createDevilsAdvocateAgent()

--- a/src/agents/devils-advocate.ts
+++ b/src/agents/devils-advocate.ts
@@ -1,0 +1,154 @@
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentPromptMetadata } from "./types"
+import { isGptModel } from "./types"
+import { createAgentToolRestrictions } from "../shared/permission-compat"
+
+const DEFAULT_MODEL = "google/gemini-3-pro-preview"
+
+export const DEVILS_ADVOCATE_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "advisor",
+  cost: "CHEAP",
+  promptAlias: "Devil's Advocate",
+  triggers: [
+    { domain: "Idea validation", trigger: "Before committing to a new approach or architecture" },
+    { domain: "Risk assessment", trigger: "Before major refactors or migrations" },
+    { domain: "Assumption check", trigger: "When plan relies on unverified assumptions" },
+  ],
+  useWhen: [
+    "Before committing to a major decision",
+    "After writing a work plan",
+    "When assumptions feel shaky",
+    "Before large refactors or migrations",
+    "When you need a reality check",
+  ],
+  avoidWhen: [
+    "Simple implementation tasks",
+    "When you need solutions, not critique",
+    "Trivial decisions with low stakes",
+    "After the decision is already shipped",
+  ],
+}
+
+const DEVILS_ADVOCATE_SYSTEM_PROMPT = `<Role>
+You are "Devil's Advocate" — a relentlessly skeptical critic who stress-tests ideas, plans, and assumptions. You exist to find what will break, not to encourage. You never validate. You never praise. You only dismantle.
+</Role>
+
+<Behavior_Instructions>
+
+## Phase 0 — Input Classification (EVERY request)
+
+Classify the input FIRST, then adjust your analysis focus:
+
+| Type | Signal | Analysis Focus |
+|------|--------|----------------|
+| Idea Pitch | "What if we...", "I want to build..." | Market/feasibility destruction |
+| Technical Plan | "Here's my approach...", work plans | Implementation risk analysis |
+| Feature Proposal | "Let's add X..." | User friction + edge case analysis |
+| Architecture Decision | "Should we use X or Y?" | Trade-off stress testing |
+| Assumption Check | "Is this assumption valid?" | Logical consistency audit |
+
+## Phase 1 — Systematic Deconstruction (MANDATORY — ALL 5 lenses)
+
+Apply every lens. No shortcuts. No skipping.
+
+| Lens | What to Find | Output |
+|------|-------------|--------|
+| Logical Inconsistency | Contradictions in reasoning | List of contradictions with evidence |
+| Resource Realism | Underestimated time/money/effort | Resource reality check with estimates |
+| Market/Social Friction | Why people might hate/ignore/resist | Friction points ranked by severity |
+| Edge Cases | "What if?" failure scenarios | Scenarios where plan fails spectacularly |
+| Codebase Evidence | What the existing code actually shows | File references that support/contradict claims |
+
+## Phase 2 — Structured Output (MANDATORY format — NO deviations)
+
+### THE FATAL FLAW
+[Single biggest reason this fails. One paragraph. No hedging.]
+
+### HIDDEN ASSUMPTIONS
+| # | Assumption | Why It's Unproven | What Breaks If Wrong |
+|---|-----------|-------------------|---------------------|
+[Table of 3-7 assumptions with consequences]
+
+### THE ADVERSARY VIEW
+[How a competitor, critic, or hostile user would dismantle this. Written from their perspective. No softening.]
+
+### STRESS-TEST QUESTIONS
+1. [Uncomfortable question the user MUST answer to proceed]
+2. [Uncomfortable question the user MUST answer to proceed]
+3. [Uncomfortable question the user MUST answer to proceed]
+
+### SEVERITY RATING
+
+| Rating | Meaning |
+|--------|---------|
+| CRITICAL | Fundamental flaw. Do NOT proceed without resolving. |
+| RISKY | Significant concerns. Proceed with explicit mitigation. |
+| VIABLE | Minor issues. Proceed with awareness. |
+
+[One of: CRITICAL / RISKY / VIABLE]
+[One sentence justification]
+
+</Behavior_Instructions>
+
+<Constraints>
+
+## Hard Blocks (NEVER violate)
+
+| Constraint | No Exceptions |
+|-----------|---------------|
+| Validate or praise an idea | Never |
+| Start with "That's a great idea" or any variant | Never |
+| Offer solutions or alternatives (you CRITICIZE, not FIX) | Never |
+| Skip any of the 5 analytical lenses | Never |
+| Omit the structured output sections | Never |
+| Soften language with hedging | Never |
+| Use AI fluff | Never |
+| Write code or make edits | Never (read-only) |
+
+## Anti-Patterns (BLOCKING violations)
+
+| Category | Forbidden |
+|----------|-----------|
+| Tone | Encouraging, supportive, optimistic, diplomatic |
+| Structure | Free-form prose without the mandatory sections |
+| Analysis | Surface-level critique without codebase evidence |
+| Scope | Offering fixes, solutions, or "how to improve" |
+| Length | More than 2 paragraphs for Fatal Flaw |
+
+## Tone Enforcement
+
+- Direct, concise, slightly provocative
+- Bullet points for scannability
+- If asked for a compliment, find another flaw instead
+- Match density of Oracle (Essential tier), not Sisyphus
+- Evidence over opinion. Facts over speculation.
+- If you can't find a fatal flaw, say "I couldn't find a fatal flaw, but here are the risks:" — NEVER say "This is a great idea"
+
+</Constraints>`
+
+export function createDevilsAdvocateAgent(model: string = DEFAULT_MODEL): AgentConfig {
+  const restrictions = createAgentToolRestrictions([
+    "write",
+    "edit",
+    "task",
+    "background_task",
+  ])
+
+  const base = {
+    description:
+      "Relentlessly skeptical critic that stress-tests ideas, plans, and assumptions through systematic adversarial analysis.",
+    mode: "subagent" as const,
+    model,
+    temperature: 0.1,
+    ...restrictions,
+    prompt: DEVILS_ADVOCATE_SYSTEM_PROMPT,
+  } as AgentConfig
+
+  if (isGptModel(model)) {
+    return { ...base, reasoningEffort: "medium" } as AgentConfig
+  }
+
+  return { ...base, thinking: { type: "enabled", budgetTokens: 10000 } } as AgentConfig
+}
+
+export const devilsAdvocateAgent = createDevilsAdvocateAgent()

--- a/src/agents/dynamic-agent-prompt-builder.ts
+++ b/src/agents/dynamic-agent-prompt-builder.ts
@@ -334,9 +334,42 @@ ${avoidWhen.map((w) => `- ${w}`).join("\n")}
 
 ### Usage Pattern:
 Briefly announce "Consulting Oracle for [reason]" before invocation.
-
-**Exception**: This is the ONLY case where you announce before acting. For all other work, start immediately without status updates.
 </Oracle_Usage>`
+}
+
+export function buildDevilsAdvocateSection(agents: AvailableAgent[]): string {
+  const devilsAdvocateAgent = agents.find((a) => a.name === "devils-advocate")
+  if (!devilsAdvocateAgent) return ""
+
+  return `<Devils_Advocate_Usage>
+## Devil's Advocate — Adversarial Validation
+
+Use Devil's Advocate to stress-test user-facing changes before implementation.
+
+### WHEN to Invoke (AUTO — user-facing changes):
+
+| Trigger | Action |
+|---------|--------|
+| New user-facing feature | DA FIRST, then implement |
+| New API endpoint exposed to consumers | DA FIRST, then implement |
+| Behavior change to existing feature | DA FIRST, then implement |
+| Work plans / architecture proposals | DA FIRST, then implement |
+
+### WHEN NOT to Invoke:
+
+- Internal refactoring (no user impact)
+- Bug fixes (restoring expected behavior)
+- Tests-only changes
+- Documentation-only changes
+
+### Manual Trigger:
+- Mention: \`@devils-advocate\` (or delegate to \`devils-advocate\` agent)
+
+### Handling Output:
+- CRITICAL: Present findings to user; do not proceed without acknowledgment.
+- RISKY: Proceed only with explicit mitigation.
+- VIABLE: Proceed normally.
+</Devils_Advocate_Usage>`
 }
 
 export function buildHardBlocksSection(): string {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -8,6 +8,7 @@ export { createExploreAgent, EXPLORE_PROMPT_METADATA } from "./explore"
 
 
 export { createMultimodalLookerAgent, MULTIMODAL_LOOKER_PROMPT_METADATA } from "./multimodal-looker"
+export { createDevilsAdvocateAgent, DEVILS_ADVOCATE_PROMPT_METADATA } from "./devils-advocate"
 export { createMetisAgent, METIS_SYSTEM_PROMPT, metisPromptMetadata } from "./metis"
 export { createMomusAgent, MOMUS_SYSTEM_PROMPT, momusPromptMetadata } from "./momus"
 export { createAtlasAgent, atlasPromptMetadata } from "./atlas"

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -18,6 +18,7 @@ import {
   buildDelegationTable,
   buildCategorySkillsDelegationGuide,
   buildOracleSection,
+  buildDevilsAdvocateSection,
   buildHardBlocksSection,
   buildAntiPatternsSection,
   categorizeTools,
@@ -155,6 +156,7 @@ function buildDynamicSisyphusPrompt(
   const categorySkillsGuide = buildCategorySkillsDelegationGuide(availableCategories, availableSkills)
   const delegationTable = buildDelegationTable(availableAgents)
   const oracleSection = buildOracleSection(availableAgents)
+  const devilsAdvocateSection = buildDevilsAdvocateSection(availableAgents)
   const hardBlocks = buildHardBlocksSection()
   const antiPatterns = buildAntiPatternsSection()
   const taskManagementSection = buildTaskManagementSection(useTaskSystem)
@@ -435,6 +437,8 @@ If verification fails:
 </Behavior_Instructions>
 
 ${oracleSection}
+
+${devilsAdvocateSection}
 
 ${taskManagementSection}
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -80,6 +80,7 @@ export type BuiltinAgentName =
   | "metis"
   | "momus"
   | "atlas"
+  | "devils-advocate"
 
 export type OverridableAgentName =
   | "build"

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -6,6 +6,7 @@ import { createOracleAgent, ORACLE_PROMPT_METADATA } from "./oracle"
 import { createLibrarianAgent, LIBRARIAN_PROMPT_METADATA } from "./librarian"
 import { createExploreAgent, EXPLORE_PROMPT_METADATA } from "./explore"
 import { createMultimodalLookerAgent, MULTIMODAL_LOOKER_PROMPT_METADATA } from "./multimodal-looker"
+import { createDevilsAdvocateAgent, DEVILS_ADVOCATE_PROMPT_METADATA } from "./devils-advocate"
 import { createMetisAgent, metisPromptMetadata } from "./metis"
 import { createAtlasAgent, atlasPromptMetadata } from "./atlas"
 import { createMomusAgent, momusPromptMetadata } from "./momus"
@@ -27,6 +28,7 @@ const agentSources: Record<BuiltinAgentName, AgentSource> = {
   librarian: createLibrarianAgent,
   explore: createExploreAgent,
   "multimodal-looker": createMultimodalLookerAgent,
+  "devils-advocate": createDevilsAdvocateAgent,
   metis: createMetisAgent,
   momus: createMomusAgent,
   // Note: Atlas is handled specially in createBuiltinAgents()
@@ -43,6 +45,7 @@ const agentMetadata: Partial<Record<BuiltinAgentName, AgentPromptMetadata>> = {
   librarian: LIBRARIAN_PROMPT_METADATA,
   explore: EXPLORE_PROMPT_METADATA,
   "multimodal-looker": MULTIMODAL_LOOKER_PROMPT_METADATA,
+  "devils-advocate": DEVILS_ADVOCATE_PROMPT_METADATA,
   metis: metisPromptMetadata,
   momus: momusPromptMetadata,
   atlas: atlasPromptMetadata,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -54,7 +54,6 @@ export const OverridableAgentNameSchema = z.enum([
   "explore",
   "multimodal-looker",
   "devils-advocate",
-  "devils-advocate",
   "atlas",
 ])
 
@@ -168,6 +167,7 @@ export const AgentOverridesSchema = z.object({
   librarian: AgentOverrideConfigSchema.optional(),
   explore: AgentOverrideConfigSchema.optional(),
   "multimodal-looker": AgentOverrideConfigSchema.optional(),
+  "devils-advocate": AgentOverrideConfigSchema.optional(),
   atlas: AgentOverrideConfigSchema.optional(),
 })
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -25,6 +25,7 @@ export const BuiltinAgentNameSchema = z.enum([
   "librarian",
   "explore",
   "multimodal-looker",
+  "devils-advocate",
   "metis",
   "momus",
   "atlas",
@@ -52,6 +53,8 @@ export const OverridableAgentNameSchema = z.enum([
   "librarian",
   "explore",
   "multimodal-looker",
+  "devils-advocate",
+  "devils-advocate",
   "atlas",
 ])
 

--- a/src/hooks/unstable-agent-babysitter/index.test.ts
+++ b/src/hooks/unstable-agent-babysitter/index.test.ts
@@ -21,6 +21,9 @@ function createMockPluginInput(options: {
         prompt: async (input: unknown) => {
           promptCalls.push({ input })
         },
+        promptAsync: async (input: unknown) => {
+          promptCalls.push({ input })
+        },
       },
     },
   }


### PR DESCRIPTION
## Summary
- Add new \devils-advocate\ agent — an adversarial validator that stress-tests ideas/plans through structured critical analysis
- Sisyphus auto-invokes on user-facing changes (new features, API changes, behavior changes)
- Includes Claude Code agent loader markdown for upgrade persistence
- Documents Grok model deprecation (\grok-2-1212\ → \grok-3\/\grok-4-fast\)

## Details
- **Model**: \google/gemini-3-pro-preview\ (Gemini 3 Pro)
- **Structured output**: Fatal Flaw → Hidden Assumptions → Adversary View → Stress-Test Questions → Severity Rating
- **Invocation**: Auto (user-facing changes) + Manual (@devils-advocate)
- **Tool access**: Read-only (blocked from write/edit/task/background_task)

## Files Changed
- NEW: \src/agents/devils-advocate.ts\ — Agent with structured prompt
- NEW: \src/agents/devils-advocate.test.ts\ — TDD test suite (10 tests)
- NEW: \.claude/agents/devils-advocate.md\ — CC agent loader version
- UPDATED: \src/agents/types.ts\, \index.ts\, \utils.ts\ — Registration
- UPDATED: \src/config/schema.ts\ — Zod enum updates
- UPDATED: \src/agents/sisyphus-prompt-builder.ts\ — DA section builder
- UPDATED: \src/agents/sisyphus.ts\ — Prompt assembly wiring
- UPDATED: \src/agents/AGENTS.md\ — Documentation + Grok notes

Closes #1571

## Note on Grok Model Deprecation
\xai/grok-2-1212\ is deprecated. Users should update their oh-my-opencode.json oracle model to \xai/grok-3\ or \xai/grok-4-fast\.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Devil’s Advocate agent that adversarially validates ideas and plans, auto-invoked by Sisyphus for user‑facing changes. Updates Grok model notes with clear migration paths.

- New Features
  - New devils-advocate agent (default: google/gemini-3-pro-preview) with structured output: Fatal Flaw, Hidden Assumptions, Adversary View, Stress-Test Questions, Severity.
  - Sisyphus auto-invokes on user-facing feature/API/behavior changes; manual trigger via @devils-advocate; prompt now includes when/when-not and severity handling.
  - Read-only tool access; deny write/edit/task/background_task/call_omo_agent; registered in agents index/utils/types/schema; wired into Sisyphus prompt assembly.
  - Tests cover model-specific config (reasoningEffort vs thinking), permissions, metadata; unstable-agent-babysitter tests now mock promptAsync.
  - Claude Code agent loader markdown included for upgrade persistence.

- Migration
  - xai/grok-2-1212 is deprecated. Migrate to xai/grok-4-1-fast or xai/grok-4-fast for reasoning, xai/grok-code-fast-1 for coding, or xai/grok-3 for lightweight tasks.

<sup>Written for commit c48fe185f2202c520296c62c6e6a5f68356c0313. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

