### PR TITLE
fix: respect user-configured agent models over system defaults

### DIFF
--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -79,6 +79,72 @@ describe("createBuiltinAgents with model overrides", () => {
     }
   })
 
+  test("user config model takes priority over uiSelectedModel for sisyphus", async () => {
+    // #given
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
+      new Set(["openai/gpt-5.2", "anthropic/claude-sonnet-4-5"])
+    )
+    const uiSelectedModel = "openai/gpt-5.2"
+    const overrides = {
+      sisyphus: { model: "google/antigravity-claude-opus-4-5-thinking" },
+    }
+
+    try {
+      // #when
+      const agents = await createBuiltinAgents(
+        [],
+        overrides,
+        undefined,
+        TEST_DEFAULT_MODEL,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        uiSelectedModel
+      )
+
+      // #then
+      expect(agents.sisyphus).toBeDefined()
+      expect(agents.sisyphus.model).toBe("google/antigravity-claude-opus-4-5-thinking")
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  test("user config model takes priority over uiSelectedModel for atlas", async () => {
+    // #given
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
+      new Set(["openai/gpt-5.2", "anthropic/claude-sonnet-4-5"])
+    )
+    const uiSelectedModel = "openai/gpt-5.2"
+    const overrides = {
+      atlas: { model: "google/antigravity-claude-opus-4-5-thinking" },
+    }
+
+    try {
+      // #when
+      const agents = await createBuiltinAgents(
+        [],
+        overrides,
+        undefined,
+        TEST_DEFAULT_MODEL,
+        undefined,
+        undefined,
+        [],
+        undefined,
+        undefined,
+        uiSelectedModel
+      )
+
+      // #then
+      expect(agents.atlas).toBeDefined()
+      expect(agents.atlas.model).toBe("google/antigravity-claude-opus-4-5-thinking")
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   test("Sisyphus is created on first run when no availableModels or cache exist", async () => {
     // #given
     const systemDefaultModel = "anthropic/claude-opus-4-5"
@@ -369,6 +435,58 @@ describe("createBuiltinAgents with requiresAnyModel gating (sisyphus)", () => {
       expect(agents.sisyphus).toBeUndefined()
     } finally {
       fetchSpy.mockRestore()
+    }
+  })
+
+  test("sisyphus uses user-configured plugin model even when not in cache or fallback chain", async () => {
+    // #given - user configures a model from a plugin provider (like antigravity)
+    // that is NOT in the availableModels cache and NOT in the fallback chain
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
+      new Set(["openai/gpt-5.2"])
+    )
+    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(
+      ["openai"]
+    )
+    const overrides = {
+      sisyphus: { model: "google/antigravity-claude-opus-4-5-thinking" },
+    }
+
+    try {
+      // #when
+      const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL, undefined, undefined, [], {})
+
+      // #then
+      expect(agents.sisyphus).toBeDefined()
+      expect(agents.sisyphus.model).toBe("google/antigravity-claude-opus-4-5-thinking")
+    } finally {
+      fetchSpy.mockRestore()
+      cacheSpy.mockRestore()
+    }
+  })
+
+  test("sisyphus uses user-configured plugin model when availableModels is empty but cache exists", async () => {
+    // #given - connected providers cache exists but models cache is empty
+    // This reproduces the exact scenario where provider-models.json has models: {}
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
+      new Set()
+    )
+    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(
+      ["google", "openai", "opencode"]
+    )
+    const overrides = {
+      sisyphus: { model: "google/antigravity-claude-opus-4-5-thinking" },
+    }
+
+    try {
+      // #when
+      const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL, undefined, undefined, [], {})
+
+      // #then
+      expect(agents.sisyphus).toBeDefined()
+      expect(agents.sisyphus.model).toBe("google/antigravity-claude-opus-4-5-thinking")
+    } finally {
+      fetchSpy.mockRestore()
+      cacheSpy.mockRestore()
     }
   })
 })

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -300,8 +300,8 @@ export async function createBuiltinAgents(
      
      const isPrimaryAgent = isFactory(source) && source.mode === "primary"
      
-    const resolution = applyModelResolution({
-      uiSelectedModel: isPrimaryAgent ? uiSelectedModel : undefined,
+     const resolution = applyModelResolution({
+      uiSelectedModel: (isPrimaryAgent && !override?.model) ? uiSelectedModel : undefined,
       userModel: override?.model,
       requirement,
       availableModels,
@@ -353,7 +353,7 @@ export async function createBuiltinAgents(
 
    if (!disabledAgents.includes("sisyphus") && meetsSisyphusAnyModelRequirement) {
     let sisyphusResolution = applyModelResolution({
-      uiSelectedModel,
+      uiSelectedModel: sisyphusOverride?.model ? undefined : uiSelectedModel,
       userModel: sisyphusOverride?.model,
       requirement: sisyphusRequirement,
       availableModels,
@@ -451,7 +451,7 @@ export async function createBuiltinAgents(
       const atlasRequirement = AGENT_MODEL_REQUIREMENTS["atlas"]
 
       const atlasResolution = applyModelResolution({
-        uiSelectedModel,
+        uiSelectedModel: orchestratorOverride?.model ? undefined : uiSelectedModel,
         userModel: orchestratorOverride?.model,
         requirement: atlasRequirement,
         availableModels,


### PR DESCRIPTION
fixes #1573

summary
when users configure a custom agent model in oh-my-opencode.json (e.g., `google/antigravity-*`), that model was being ignored because `config.model` from opencode was passed as `uiSelectedModel`, which takes highest priority in the resolution pipeline. this meant the user's explicit config was overridden by whatever opencode had as the active model (often a system default).

root cause
`uiSelectedModel` was being passed to `applyModelResolution()` unconditionally, even when the user had an explicit `userModel` configured. the resolution pipeline gives `uiSelectedModel` highest priority, so user config was bypassed.

changes
- only pass `uiSelectedModel` when there's no explicit `userModel` config
- applies to sisyphus, atlas, and general agent loop
- added test cases to verify user config takes priority over system defaults

testing
- `bun test src/agents/utils.test.ts` (44 pass)
- `bun test` (2054 pass, 9 pre-existing fail unrelated to this change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure user-configured agent models in oh-my-opencode.json take precedence over system defaults and the UI-selected model. Fixes #1573 and prevents custom plugin models from being overridden.

- **Bug Fixes**
  - Pass uiSelectedModel only when no user-configured model is set.
  - Applied to primary agents, Sisyphus, and Atlas resolution paths.
  - Added tests to verify precedence and support for plugin models even when absent from caches or fallback chains.

<sup>Written for commit 1be9ef489e3979ab1c4d75084e5c113368187fe3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

