### PR TITLE
fix(hooks): add defensive null check for matcher.hooks to prevent Windows crash (#441)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.2.3",
-        "oh-my-opencode-darwin-x64": "3.2.3",
-        "oh-my-opencode-linux-arm64": "3.2.3",
-        "oh-my-opencode-linux-arm64-musl": "3.2.3",
-        "oh-my-opencode-linux-x64": "3.2.3",
-        "oh-my-opencode-linux-x64-musl": "3.2.3",
-        "oh-my-opencode-windows-x64": "3.2.3",
+        "oh-my-opencode-darwin-arm64": "3.2.4",
+        "oh-my-opencode-darwin-x64": "3.2.4",
+        "oh-my-opencode-linux-arm64": "3.2.4",
+        "oh-my-opencode-linux-arm64-musl": "3.2.4",
+        "oh-my-opencode-linux-x64": "3.2.4",
+        "oh-my-opencode-linux-x64-musl": "3.2.4",
+        "oh-my-opencode-windows-x64": "3.2.4",
       },
     },
   },
@@ -226,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.3", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Doc9xQCj5Jmx3PzouBIfvDwmfWM94Y9Q9IngFqOjrVpfBef9V/WIH0PlhJU6ps4BKGey8Nf2afFq3UE06Z63Hg=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.2.4", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-6vG49R/nkbZYhAqN2oStA+8reZRo2KPPHSbhQd4htdEpzS4ipVz6pW/YTj/TDwunQO7hy66AhP9hOR4pJcoDeA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.3", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-w7lO0Hn/AlLCHe33KPbje83Js2h5weDWVMuopEs6d3pi/1zkRDBEhCi63S4J0d0EKod9kEPQA6ojtdVJ4J39zQ=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.2.4", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Utfpclg8xHj93+faX2L4dpkzhM6D58YEtjkVlHq4CxZ8MdpYCs2l4NtY/b9T1GWmtQWFxZQhmIdAcwe1qApgpQ=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-m1tS1jRLO2Svm5NuetK3BAgdAR8b2GkiIfMFoIYsLJTPmzIkXaigAYkFq+BXCs5JAbRmPmvjndz9cuCddnPADQ=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.2.4", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-z4Zlvt1a1PSQVprbgx6bLOeNuILX4d9p80GrTWuuYzqY+OEgbb74LVVUFCsvt8UgnhRTnHuhmphSpIL7UznzZg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Q/0AGtOuUFGNGIX8F6iD5W8c2spbjrqVBPt0B7laQSwnScKs/BI+TvM6HRE37vhoWg+fzhAX3QYJ2H9Un9FYrg=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.2.4", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-pCCPM8rsuwMR3a7XIDyYyr/D1HkMPffOYGXeOY8vBaLL8NKFl8d0H5twA3HIiEqcDINHV3kw9zteL2paW+mHSQ=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-RIAyoj2XbT8vH++5fPUkdO+D1tfqxh+iWto7CqWr1TgbABbBJljGk91HJgS9xjnxyCQJEpFhTmO7NMHKJcZOWQ=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.2.4", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-vU9l4rS1oRpCgyXalBiUOOFPddIwSmuWoGY1PgO4dr6Db+gtEpmaDpLcEi5j4jFUDRLH6btQvNAp/eAydVgOJQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-nnQK3y7R4DrBvqdqRGbujL2oAAQnVVb23JHUbJPQ6YxrRRGWpLOVGvK5c16ykSFEUPl8eZDmi1ON/R4opKLOUw=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.2.4", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OZ+yRl7tOXoWTHh7zQ8WsTasKqZaIaVO3QeUQhDIS5JXFjbgjMgFeC/XBegsCgfqglWTOlMatmCO1S3nx2vy2w=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.3", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-mt8E/TkpaCp04pvzwntT8x8TaqXDt3zCD5X2eA8ZZMrb5ofNr5HyG5G4SFXrUh+Ez3b/3YXpNWv6f6rnAlk1Dg=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.2.4", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-W6TX8OiPCOmu7UZgZESh5DSWat0zH/6WPC3tdvjzwYnik9ZvRiyJGHh9B4uAG3DdqTC+pZJrpuTq1NctqMJiDA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/claude-code-hooks/config.ts
+++ b/src/hooks/claude-code-hooks/config.ts
@@ -20,7 +20,7 @@ interface RawClaudeHooksConfig {
 function normalizeHookMatcher(raw: RawHookMatcher): HookMatcher {
   return {
     matcher: raw.matcher ?? raw.pattern ?? "*",
-    hooks: raw.hooks,
+    hooks: Array.isArray(raw.hooks) ? raw.hooks : [],
   }
 }
 

--- a/src/hooks/claude-code-hooks/post-tool-use.ts
+++ b/src/hooks/claude-code-hooks/post-tool-use.ts
@@ -91,11 +91,12 @@ export async function executePostToolUseHooks(
 
     const startTime = Date.now()
 
-    for (const matcher of matchers) {
-      for (const hook of matcher.hooks) {
-        if (hook.type !== "command") continue
+     for (const matcher of matchers) {
+       if (!matcher.hooks || matcher.hooks.length === 0) continue
+       for (const hook of matcher.hooks) {
+         if (hook.type !== "command") continue
 
-        if (isHookCommandDisabled("PostToolUse", hook.command, extendedConfig ?? null)) {
+         if (isHookCommandDisabled("PostToolUse", hook.command, extendedConfig ?? null)) {
           log("PostToolUse hook command skipped (disabled by config)", { command: hook.command, toolName: ctx.toolName })
           continue
         }

--- a/src/hooks/claude-code-hooks/pre-compact.ts
+++ b/src/hooks/claude-code-hooks/pre-compact.ts
@@ -47,11 +47,12 @@ export async function executePreCompactHooks(
   let firstHookName: string | undefined
   const collectedContext: string[] = []
 
-  for (const matcher of matchers) {
-    for (const hook of matcher.hooks) {
-      if (hook.type !== "command") continue
+   for (const matcher of matchers) {
+     if (!matcher.hooks || matcher.hooks.length === 0) continue
+     for (const hook of matcher.hooks) {
+       if (hook.type !== "command") continue
 
-      if (isHookCommandDisabled("PreCompact", hook.command, extendedConfig ?? null)) {
+       if (isHookCommandDisabled("PreCompact", hook.command, extendedConfig ?? null)) {
         log("PreCompact hook command skipped (disabled by config)", { command: hook.command })
         continue
       }

--- a/src/hooks/claude-code-hooks/pre-tool-use.ts
+++ b/src/hooks/claude-code-hooks/pre-tool-use.ts
@@ -74,11 +74,12 @@ export async function executePreToolUseHooks(
   let firstHookName: string | undefined
   const inputLines = buildInputLines(ctx.toolInput)
 
-  for (const matcher of matchers) {
-    for (const hook of matcher.hooks) {
-      if (hook.type !== "command") continue
+   for (const matcher of matchers) {
+     if (!matcher.hooks || matcher.hooks.length === 0) continue
+     for (const hook of matcher.hooks) {
+       if (hook.type !== "command") continue
 
-      if (isHookCommandDisabled("PreToolUse", hook.command, extendedConfig ?? null)) {
+       if (isHookCommandDisabled("PreToolUse", hook.command, extendedConfig ?? null)) {
         log("PreToolUse hook command skipped (disabled by config)", { command: hook.command, toolName: ctx.toolName })
         continue
       }

--- a/src/hooks/claude-code-hooks/stop.ts
+++ b/src/hooks/claude-code-hooks/stop.ts
@@ -65,11 +65,12 @@ export async function executeStopHooks(
     hook_source: "opencode-plugin",
   }
 
-  for (const matcher of matchers) {
-    for (const hook of matcher.hooks) {
-      if (hook.type !== "command") continue
+   for (const matcher of matchers) {
+     if (!matcher.hooks || matcher.hooks.length === 0) continue
+     for (const hook of matcher.hooks) {
+       if (hook.type !== "command") continue
 
-      if (isHookCommandDisabled("Stop", hook.command, extendedConfig ?? null)) {
+       if (isHookCommandDisabled("Stop", hook.command, extendedConfig ?? null)) {
         log("Stop hook command skipped (disabled by config)", { command: hook.command })
         continue
       }

--- a/src/hooks/claude-code-hooks/user-prompt-submit.ts
+++ b/src/hooks/claude-code-hooks/user-prompt-submit.ts
@@ -70,9 +70,10 @@ export async function executeUserPromptSubmitHooks(
     hook_source: "opencode-plugin",
   }
 
-  for (const matcher of matchers) {
-    for (const hook of matcher.hooks) {
-      if (hook.type !== "command") continue
+   for (const matcher of matchers) {
+     if (!matcher.hooks || matcher.hooks.length === 0) continue
+     for (const hook of matcher.hooks) {
+       if (hook.type !== "command") continue
 
       if (isHookCommandDisabled("UserPromptSubmit", hook.command, extendedConfig ?? null)) {
         log("UserPromptSubmit hook command skipped (disabled by config)", { command: hook.command })


### PR DESCRIPTION
## Summary

- `normalizeHookMatcher()` now defaults `hooks` to `[]` when undefined
- All 5 hook executor files have null checks before iterating `matcher.hooks`
- Prevents TypeError crash on Windows with malformed `.claude/settings.json`

## Changes

1. **config.ts**: Changed `hooks: raw.hooks` to `hooks: Array.isArray(raw.hooks) ? raw.hooks : []`
2. **All 5 executor files**: Added guard `if (!matcher.hooks || matcher.hooks.length === 0) continue` before inner loop:
   - user-prompt-submit.ts
   - pre-tool-use.ts
   - post-tool-use.ts
   - stop.ts
   - pre-compact.ts

## Testing

- ✅ `bun run typecheck` passes
- ✅ All 2246 tests pass
- ✅ No regressions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a Windows TypeError when matcher.hooks is undefined in malformed .claude/settings.json. Defaults hooks to [] and adds defensive checks across all hook executors.

- **Bug Fixes**
  - normalizeHookMatcher now sets hooks to [] when raw.hooks is not an array.
  - Added guards to skip iteration when matcher.hooks is empty/undefined in user-prompt-submit, pre-tool-use, post-tool-use, stop, and pre-compact.

<sup>Written for commit bbe08f0eef83f4fb2960c36b686f19a02c751683. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

