### PR TITLE
fix: make model migration run only once by storing history

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -426,6 +426,8 @@ export const OhMyOpenCodeConfigSchema = z.object({
   websearch: WebsearchConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),
   sisyphus: SisyphusConfigSchema.optional(),
+  /** Migration history to prevent re-applying migrations (e.g., model version upgrades) */
+  _migrations: z.array(z.string()).optional(),
 })
 
 export type OhMyOpenCodeConfig = z.infer<typeof OhMyOpenCodeConfigSchema>


### PR DESCRIPTION
## Problem
Issue #1570 - `migrateModelVersions()` runs unconditionally every time config is loaded. If a user explicitly sets `"model": "openai/gpt-5.2-codex"` in their config, it gets auto-upgraded to `gpt-5.3-codex` on every startup, even if the user intentionally reverted it.

## Solution
Store migration history in a `_migrations` field in the config. When a migration is applied, record its key (e.g., `"model-version:openai/gpt-5.2-codex->openai/gpt-5.3-codex"`). On subsequent runs, skip already-applied migrations.

## Changes
1. **`src/config/schema.ts`** - Added `_migrations: z.array(z.string()).optional()` to config schema
2. **`src/shared/migration.ts`**:
   - Added `migrationKey()` helper to generate consistent migration keys
   - Updated `migrateModelVersions()` signature: accepts `appliedMigrations: Set<string>`, returns `newMigrations: string[]`
   - Skip migrations that are already in `appliedMigrations` (preserves user reverts)
   - Updated `migrateConfigFile()` to read `_migrations` from config, pass it to `migrateModelVersions()`, and append new migrations
3. **`src/shared/migration.test.ts`** - Added 8 new test cases covering migration history tracking

## How it works
1. **First time**: User has `gpt-5.2-codex` → migrated to `gpt-5.3-codex`, key recorded in `_migrations`
2. **User reverts**: Manually changes back to `gpt-5.2-codex` → next startup sees the key in `_migrations`, skips the migration
3. **New migrations**: Future migrations that aren't in `_migrations` still get applied normally

## Testing
- ✅ All existing tests pass (2307/2307)
- ✅ 8 new tests added for migration history tracking
- ✅ Type check clean (`bun run typecheck`)

Fixes #1570

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make model version migrations run only once by tracking applied migrations in the config. Prevents repeated auto-upgrades on startup and respects user reverts. Fixes #1570.

- **Bug Fixes**
  - Added _migrations array to the config schema to store applied migration keys.
  - Updated migrateModelVersions to accept an appliedMigrations Set, skip recorded migrations, and return newMigrations.
  - Updated migrateConfigFile to read/write _migrations, pass history to migrations, and apply to agents and categories.
  - Added 8 tests for migration tracking; all existing tests pass.

<sup>Written for commit 66419918f91d829e5d8bfb32b0395b19e0449a01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

