### PR TITLE
fix: /stop-continuation now cancels boulder continuation

### DIFF
--- a/src/hooks/atlas/index.ts
+++ b/src/hooks/atlas/index.ts
@@ -399,6 +399,7 @@ const CONTINUATION_COOLDOWN_MS = 5000
 export interface AtlasHookOptions {
   directory: string
   backgroundManager?: BackgroundManager
+  isContinuationStopped?: (sessionID: string) => boolean
 }
 
 function isAbortError(error: unknown): boolean {
@@ -570,6 +571,11 @@ export function createAtlasHook(
 
         if (!boulderState) {
           log(`[${HOOK_NAME}] No active boulder`, { sessionID })
+          return
+        }
+
+        if (options?.isContinuationStopped?.(sessionID)) {
+          log(`[${HOOK_NAME}] Skipped: continuation stopped for session`, { sessionID })
           return
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,11 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   );
 
   const atlasHook = isHookEnabled("atlas")
-    ? safeCreateHook("atlas", () => createAtlasHook(ctx, { directory: ctx.directory, backgroundManager }), { enabled: safeHookEnabled })
+    ? safeCreateHook("atlas", () => createAtlasHook(ctx, { 
+        directory: ctx.directory, 
+        backgroundManager,
+        isContinuationStopped: (sessionID: string) => stopContinuationGuard?.isStopped(sessionID) ?? false,
+      }), { enabled: safeHookEnabled })
     : null;
 
   initTaskToastManager(ctx.client);


### PR DESCRIPTION
## Summary
- Fixes #1575
- Atlas hook's `session.idle` boulder continuation handler does NOT check `stopContinuationGuard.isStopped()`
- This PR adds `isContinuationStopped` to `AtlasHookOptions` and wires it through to the boulder continuation handler

## Changes
- Added `isContinuationStopped` callback to Atlas hook options
- Boulder continuation now checks stop guard before injecting prompts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops boulder continuation when a user runs /stop-continuation, preventing prompts after a stop. Aligns boulder behavior with todo continuation and session recovery.

- **Bug Fixes**
  - Added isContinuationStopped to AtlasHookOptions and checked in session.idle before continuing.
  - Wired isContinuationStopped to stopContinuationGuard during plugin init.
  - Added a test to verify continuation is skipped when stopped.

<sup>Written for commit f980e256dd2ec4720262d41fe2f1c84cbc56df01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

