### PR TITLE
fix: trim whitespace from tool names before matching

### DIFF
--- a/src/hooks/claude-code-hooks/index.ts
+++ b/src/hooks/claude-code-hooks/index.ts
@@ -175,7 +175,7 @@ export function createClaudeCodeHooksHook(
       input: { tool: string; sessionID: string; callID: string },
       output: { args: Record<string, unknown> }
     ): Promise<void> => {
-      if (input.tool === "todowrite" && typeof output.args.todos === "string") {
+      if (input.tool.trim() === "todowrite" && typeof output.args.todos === "string") {
         let parsed: unknown
         try {
           parsed = JSON.parse(output.args.todos)

--- a/src/shared/tool-name.test.ts
+++ b/src/shared/tool-name.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "bun:test"
+import { transformToolName } from "./tool-name"
+
+describe("transformToolName", () => {
+  describe("whitespace trimming", () => {
+    it("trims leading whitespace from tool name", () => {
+      // given
+      const toolName = " delegate_task"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("DelegateTask")
+    })
+
+    it("trims trailing whitespace from tool name", () => {
+      // given
+      const toolName = "delegate_task "
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("DelegateTask")
+    })
+
+    it("trims both leading and trailing whitespace", () => {
+      // given
+      const toolName = " delegate_task "
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("DelegateTask")
+    })
+
+    it("applies special mapping after trimming whitespace", () => {
+      // given
+      const toolName = " webfetch"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("WebFetch")
+    })
+
+    it("handles simple case with leading and trailing spaces", () => {
+      // given
+      const toolName = " read "
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("Read")
+    })
+  })
+
+  describe("special tool mappings", () => {
+    it("maps webfetch to WebFetch", () => {
+      // given
+      const toolName = "webfetch"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("WebFetch")
+    })
+
+    it("maps websearch to WebSearch", () => {
+      // given
+      const toolName = "websearch"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("WebSearch")
+    })
+
+    it("maps todoread to TodoRead", () => {
+      // given
+      const toolName = "todoread"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("TodoRead")
+    })
+
+    it("maps todowrite to TodoWrite", () => {
+      // given
+      const toolName = "todowrite"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("TodoWrite")
+    })
+  })
+
+  describe("kebab-case and snake_case conversion", () => {
+    it("converts snake_case to PascalCase", () => {
+      // given
+      const toolName = "delegate_task"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("DelegateTask")
+    })
+
+    it("converts kebab-case to PascalCase", () => {
+      // given
+      const toolName = "call-omo-agent"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("CallOmoAgent")
+    })
+  })
+
+  describe("simple capitalization", () => {
+    it("capitalizes simple single-word tool names", () => {
+      // given
+      const toolName = "read"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("Read")
+    })
+
+    it("preserves capitalization of already capitalized names", () => {
+      // given
+      const toolName = "Write"
+
+      // when
+      const result = transformToolName(toolName)
+
+      // then
+      expect(result).toBe("Write")
+    })
+  })
+})

--- a/src/shared/tool-name.ts
+++ b/src/shared/tool-name.ts
@@ -13,14 +13,15 @@ function toPascalCase(str: string): string {
 }
 
 export function transformToolName(toolName: string): string {
-  const lower = toolName.toLowerCase()
+  const trimmed = toolName.trim()
+  const lower = trimmed.toLowerCase()
   if (lower in SPECIAL_TOOL_MAPPINGS) {
     return SPECIAL_TOOL_MAPPINGS[lower]
   }
 
-  if (toolName.includes("-") || toolName.includes("_")) {
-    return toPascalCase(toolName)
+  if (trimmed.includes("-") || trimmed.includes("_")) {
+    return toPascalCase(trimmed)
   }
 
-  return toolName.charAt(0).toUpperCase() + toolName.slice(1)
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1)
 }


### PR DESCRIPTION
## Summary
- Fixes #1568
- `transformToolName()` in `src/shared/tool-name.ts` does NOT `.trim()` input
- Some models (e.g., `openrouter/moonshotai/kimi-k2.5`) return tool names with leading whitespace like `" delegate_task"`, causing tool matching to fail

## Changes
- Added `.trim()` to `transformToolName()` before `.toLowerCase()`
- 155-line test suite covering whitespace edge cases

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim whitespace from tool names to prevent failed tool matching and invalid tool calls. Adds tests and a defensive hook check; fixes #1568.

- **Bug Fixes**
  - Trim input in transformToolName and in claude-code-hooks (todowrite check) to avoid mismatches from leading/trailing spaces.
  - Add tests for whitespace edge cases, special tool mappings, and snake/kebab to PascalCase conversions.

<sup>Written for commit eb5cc873eaba045a19bdb2589b8ea3b4d2c40765. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

