### PR TITLE
fix: prevent ULW infinite plan loop (#1501)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -6,6 +6,7 @@ import {
   BuiltinCategoryNameSchema,
   CategoryConfigSchema,
   ExperimentalConfigSchema,
+  GitMasterConfigSchema,
   OhMyOpenCodeConfigSchema,
 } from "./schema"
 


### PR DESCRIPTION
## Summary

- Removes the re-prepend of `ultrawork` prefix on continuation prompts in ralph-loop
- The ultrawork mode is already activated on the initial message; re-prepending it on every continuation triggers the keyword-detector hook to re-inject the ultrawork mandate, forcing the plan agent on each cycle and creating an infinite loop
- Fixes #1501

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop re-prepending the "ultrawork" prefix on continuation prompts in ralph-loop to prevent an infinite plan loop. ULW is enabled on the first message, and re-applying the prefix kept re-triggering the keyword detector and forcing the plan agent each cycle.

<sup>Written for commit b3ebf6c124abc21599a2d3d5131da331f1f9ee37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

