### PR TITLE
fix: allow dash-prefixed arguments in CLI run command (#899)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -6,6 +6,7 @@ import {
   BuiltinCategoryNameSchema,
   CategoryConfigSchema,
   ExperimentalConfigSchema,
+  GitMasterConfigSchema,
   OhMyOpenCodeConfigSchema,
 } from "./schema"
 


### PR DESCRIPTION
## Summary
- Adds `.allowUnknownOption()` and `.passThroughOptions()` to the `run` command in CLI
- This allows users to pass arguments like `--max-iterations 5` in the run message without Commander.js intercepting them as CLI flags
- Fixes #899

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CLI run now accepts dash-prefixed arguments and passes them to the run message (e.g., --max-iterations 5) instead of treating them as CLI flags. Fixes #899.

<sup>Written for commit b3ebf6c124abc21599a2d3d5131da331f1f9ee37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

