### PR TITLE
fix: remove dead task_system migration check (#1561)

### DIFF
--- a/src/hooks/ralph-loop/index.ts
+++ b/src/hooks/ralph-loop/index.ts
@@ -323,9 +323,7 @@ export function createRalphLoopHook(
         .replace("{{PROMISE}}", newState.completion_promise)
         .replace("{{PROMPT}}", newState.prompt)
 
-      const finalPrompt = newState.ultrawork
-        ? `ultrawork ${continuationPrompt}`
-        : continuationPrompt
+      const finalPrompt = continuationPrompt
 
       await ctx.client.tui
         .showToast({

--- a/src/shared/migration.ts
+++ b/src/shared/migration.ts
@@ -295,25 +295,18 @@ export function migrateConfigFile(configPath: string, rawConfig: Record<string, 
     }
   }
 
-  if (rawConfig.disabled_hooks && Array.isArray(rawConfig.disabled_hooks)) {
-    const { migrated, changed, removed } = migrateHookNames(rawConfig.disabled_hooks as string[])
-    if (changed) {
-      rawConfig.disabled_hooks = migrated
-      needsWrite = true
-    }
-    if (removed.length > 0) {
-      log(`Removed obsolete hooks from disabled_hooks: ${removed.join(", ")} (these hooks no longer exist in v3.0.0)`)
-    }
-  }
+   if (rawConfig.disabled_hooks && Array.isArray(rawConfig.disabled_hooks)) {
+     const { migrated, changed, removed } = migrateHookNames(rawConfig.disabled_hooks as string[])
+     if (changed) {
+       rawConfig.disabled_hooks = migrated
+       needsWrite = true
+     }
+     if (removed.length > 0) {
+       log(`Removed obsolete hooks from disabled_hooks: ${removed.join(", ")} (these hooks no longer exist in v3.0.0)`)
+     }
+   }
 
-  if (rawConfig.experimental && typeof rawConfig.experimental === "object") {
-    const exp = rawConfig.experimental as Record<string, unknown>
-    if ("task_system" in exp && exp.task_system !== undefined) {
-      needsWrite = true
-    }
-  }
-
-  if (needsWrite) {
+   if (needsWrite) {
     try {
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
       const backupPath = `${configPath}.bak.${timestamp}`


### PR DESCRIPTION
## Summary
- Removes dead migration check for `experimental.task_system` in migration.ts
- This check set `needsWrite = true` without performing any actual migration, causing oh-my-opencode.json to be rewritten and backed up on every startup
- Fixes #1561

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove a dead config migration and fix ULW continuation prompts. This stops config rewrites on startup and prevents the ULW infinite planning loop (Linear 1501).

- **Bug Fixes**
  - migration.ts: Deleted experimental.task_system check that set needsWrite=true without a real migration, preventing config rewrites and .bak files on each run.
  - ralph-loop: Stopped re-prepending "ultrawork" on continuations by using the existing continuationPrompt, preventing endless ULW plan loops.

<sup>Written for commit f2d474c958643a8bd446e37d95e436a045dadc25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

