### PR TITLE
fix: accept string values for commit_footer config (#919)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -6,6 +6,7 @@ import {
   BuiltinCategoryNameSchema,
   CategoryConfigSchema,
   ExperimentalConfigSchema,
+  GitMasterConfigSchema,
   OhMyOpenCodeConfigSchema,
 } from "./schema"
 


### PR DESCRIPTION
## Summary
- Changes `commit_footer` Zod schema from `z.boolean()` to `z.union([z.boolean(), z.string()])`
- Users can now set `commit_footer` to a custom string (e.g. their name or tag) instead of only true/false
- Previously, setting a string value caused Zod validation to silently discard the entire config section
- Fixes #919

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts string values for the commit_footer config and fixes validation that previously dropped the section when a string was used. The schema now allows boolean or string, so you can set a custom footer (e.g., your name) instead of only true/false.

<sup>Written for commit b3ebf6c124abc21599a2d3d5131da331f1f9ee37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

