### PR TITLE
fix: allow dash-prefixed arguments in CLI run command (#899)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -64,8 +64,10 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
   })
 
 program
-  .command("run <message>")
-  .description("Run opencode with todo/background task completion enforcement")
+   .command("run <message>")
+   .allowUnknownOption()
+   .passThroughOptions()
+   .description("Run opencode with todo/background task completion enforcement")
   .option("-a, --agent <name>", "Agent to use (default: from CLI/env/config, fallback: Sisyphus)")
   .option("-d, --directory <path>", "Working directory")
   .option("-t, --timeout <ms>", "Timeout in milliseconds (default: 30 minutes)", parseInt)


### PR DESCRIPTION
## Summary
- Adds `.allowUnknownOption()` and `.passThroughOptions()` to the `run` command in CLI
- This allows users to pass arguments like `--max-iterations 5` in the run message without Commander.js intercepting them as CLI flags
- Fixes #899

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow dash‑prefixed arguments to pass through the CLI run command so user flags (e.g., --max-iterations 5) aren’t intercepted by Commander and reach the underlying process. Implemented via allowUnknownOption() and passThroughOptions() on the run command.

<sup>Written for commit d5b6a7c575ee699b8bc67b89e46450e116084be1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

