### PR TITLE
fix: don't fallback to system sg command for ast-grep (#1365)

### DIFF
--- a/src/agents/dynamic-agent-prompt-builder.ts
+++ b/src/agents/dynamic-agent-prompt-builder.ts
@@ -421,7 +421,7 @@ export function buildUltraworkSection(
 
     lines.push("**Agents** (for specialized consultation/exploration):")
     for (const agent of sortedAgents) {
-      const shortDesc = agent.description.split(".")[0] || agent.description
+      const shortDesc = agent.description.length > 120 ? agent.description.slice(0, 120) + "..." : agent.description
       const suffix = agent.name === "explore" || agent.name === "librarian" ? " (multiple)" : ""
       lines.push(`- \`${agent.name}${suffix}\`: ${shortDesc}`)
     }

--- a/src/tools/ast-grep/cli.ts
+++ b/src/tools/ast-grep/cli.ts
@@ -86,10 +86,22 @@ export async function runSg(options: RunOptions): Promise<SgResult> {
 
   let cliPath = getSgCliPath()
 
-  if (!existsSync(cliPath) && cliPath !== "sg") {
+  if (!cliPath || !existsSync(cliPath)) {
     const downloadedPath = await getAstGrepPath()
     if (downloadedPath) {
       cliPath = downloadedPath
+    } else {
+      return {
+        matches: [],
+        totalMatches: 0,
+        truncated: false,
+        error:
+          `ast-grep (sg) binary not found.\n\n` +
+          `Install options:\n` +
+          `  bun add -D @ast-grep/cli\n` +
+          `  cargo install ast-grep --locked\n` +
+          `  brew install ast-grep`,
+      }
     }
   }
 

--- a/src/tools/ast-grep/constants.ts
+++ b/src/tools/ast-grep/constants.ts
@@ -82,7 +82,7 @@ export function findSgCliPathSync(): string | null {
 
 let resolvedCliPath: string | null = null
 
-export function getSgCliPath(): string {
+export function getSgCliPath(): string | null {
   if (resolvedCliPath !== null) {
     return resolvedCliPath
   }
@@ -93,7 +93,7 @@ export function getSgCliPath(): string {
     return syncPath
   }
 
-  return "sg"
+  return null
 }
 
 export function setSgCliPath(path: string): void {
@@ -186,29 +186,17 @@ export function checkEnvironment(): EnvironmentCheckResult {
   const result: EnvironmentCheckResult = {
     cli: {
       available: false,
-      path: cliPath,
+      path: cliPath ?? "not found",
     },
     napi: {
       available: false,
     },
   }
 
-  if (existsSync(cliPath)) {
+  if (cliPath && existsSync(cliPath)) {
     result.cli.available = true
-  } else if (cliPath === "sg") {
-    try {
-      const { spawnSync } = require("child_process")
-      const whichResult = spawnSync(process.platform === "win32" ? "where" : "which", ["sg"], {
-        encoding: "utf-8",
-        timeout: 5000,
-      })
-      result.cli.available = whichResult.status === 0 && !!whichResult.stdout?.trim()
-      if (!result.cli.available) {
-        result.cli.error = "sg binary not found in PATH"
-      }
-    } catch {
-      result.cli.error = "Failed to check sg availability"
-    }
+  } else if (!cliPath) {
+    result.cli.error = "ast-grep binary not found. Install with: bun add -D @ast-grep/cli"
   } else {
     result.cli.error = `Binary not found: ${cliPath}`
   }


### PR DESCRIPTION
## Summary

- Changes `getSgCliPath()` to return `null` instead of `"sg"` when ast-grep binary is not found
- On Linux systems, `sg` is a mailutils command, not ast-grep. The previous fallback would silently run the wrong binary
- Call sites now check for null and return a user-facing error with installation instructions
- Fixes #1365

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop falling back to the system ‘sg’ when ast-grep isn’t installed, and show a clear install error instead. Fixes #1365 and prevents running the mailutils ‘sg’ on Linux.

- **Bug Fixes**
  - getSgCliPath now returns null instead of 'sg' when ast-grep isn’t found.
  - runSg returns a user-facing error with install options (bun, cargo, brew) if no binary is available.
  - checkEnvironment handles a null path and reports missing ast-grep cleanly.

- **Refactors**
  - Truncate long agent descriptions to 120 characters in the prompt builder.

<sup>Written for commit 7fdbabb2644c94f98d21362e4ee819c138647f75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

