### PR TITLE
fix: use platform-aware binary detection on Windows (#1269)

### DIFF
--- a/src/cli/doctor/checks/gh.test.ts
+++ b/src/cli/doctor/checks/gh.test.ts
@@ -29,7 +29,7 @@ describe("gh cli check", () => {
 
     it("returns gh cli info structure", async () => {
       const spawnSpy = spyOn(Bun, "spawn").mockImplementation((cmd) => {
-        if (Array.isArray(cmd) && cmd[0] === "which" && cmd[1] === "gh") {
+        if (Array.isArray(cmd) && (cmd[0] === "which" || cmd[0] === "where") && cmd[1] === "gh") {
           return createProc({ stdout: "/usr/bin/gh\n" })
         }
 

--- a/src/cli/doctor/checks/gh.ts
+++ b/src/cli/doctor/checks/gh.ts
@@ -13,7 +13,8 @@ export interface GhCliInfo {
 
 async function checkBinaryExists(binary: string): Promise<{ exists: boolean; path: string | null }> {
   try {
-    const proc = Bun.spawn(["which", binary], { stdout: "pipe", stderr: "pipe" })
+    const whichCmd = process.platform === "win32" ? "where" : "which"
+    const proc = Bun.spawn([whichCmd, binary], { stdout: "pipe", stderr: "pipe" })
     const output = await new Response(proc.stdout).text()
     await proc.exited
     if (proc.exitCode === 0) {


### PR DESCRIPTION
## Summary

- Replaces `which` with `where` on Windows for binary detection (gh, ast-grep)
- `which` is a Unix command not available on Windows cmd/PowerShell
- Uses `process.platform === "win32"` to select the appropriate command
- Fixes #1269

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use platform-aware binary detection in the gh doctor check to fix Windows support. Uses "where" on Windows (via process.platform) instead of "which", and updates tests to accept both.

<sup>Written for commit b98697238b014bd237da2b2db5dd6053d4c777a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

