### PR TITLE
fix: expand ALLOWED_AGENTS to include all subagent-capable agents (#957)

### DIFF
--- a/src/tools/call-omo-agent/constants.ts
+++ b/src/tools/call-omo-agent/constants.ts
@@ -1,4 +1,12 @@
-export const ALLOWED_AGENTS = ["explore", "librarian"] as const
+export const ALLOWED_AGENTS = [
+  "explore",
+  "librarian",
+  "oracle",
+  "hephaestus",
+  "metis",
+  "momus",
+  "multimodal-looker",
+] as const
 
 export const CALL_OMO_AGENT_DESCRIPTION = `Spawn explore/librarian agent. run_in_background REQUIRED (true=async with task_id, false=sync).
 


### PR DESCRIPTION
## Summary
- Expands the hardcoded ALLOWED_AGENTS whitelist from just [explore, librarian] to include all subagent-capable agents: oracle, hephaestus, metis, momus, multimodal-looker
- The previous restriction prevented agents from delegating to specialized subagents like oracle for debugging or hephaestus for deep work
- Primary/orchestrator agents (sisyphus, atlas) are intentionally excluded as they should not be called as subagents
- Fixes #957

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded ALLOWED_AGENTS to include all subagent-capable agents (oracle, hephaestus, metis, momus, multimodal-looker) so delegation to specialized subagents works. Orchestrators (sisyphus, atlas) remain excluded; resolves #957.

<sup>Written for commit 2bb82c250c8a34f2b742e33de51351cf11b66139. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

