### PR TITLE
fix: use ctx.directory instead of process.cwd() for tool file discovery (#658)

### DIFF
--- a/src/cli/doctor/checks/lsp.ts
+++ b/src/cli/doctor/checks/lsp.ts
@@ -18,7 +18,7 @@ export async function getLspServersInfo(): Promise<LspServerInfo[]> {
   const servers: LspServerInfo[] = []
 
   for (const server of DEFAULT_LSP_SERVERS) {
-    const installed = isServerInstalled([server.binary])
+    const installed = isServerInstalled([server.binary], process.cwd())
     servers.push({
       id: server.id,
       installed,

--- a/src/features/claude-code-agent-loader/loader.ts
+++ b/src/features/claude-code-agent-loader/loader.ts
@@ -78,8 +78,8 @@ export function loadUserAgents(): Record<string, AgentConfig> {
   return result
 }
 
-export function loadProjectAgents(): Record<string, AgentConfig> {
-  const projectAgentsDir = join(process.cwd(), ".claude", "agents")
+export function loadProjectAgents(baseDir: string): Record<string, AgentConfig> {
+  const projectAgentsDir = join(baseDir, ".claude", "agents")
   const agents = loadAgentsFromDir(projectAgentsDir, "project")
 
   const result: Record<string, AgentConfig> = {}

--- a/src/features/claude-code-command-loader/loader.ts
+++ b/src/features/claude-code-command-loader/loader.ts
@@ -114,8 +114,8 @@ export async function loadUserCommands(): Promise<Record<string, CommandDefiniti
   return commandsToRecord(commands)
 }
 
-export async function loadProjectCommands(): Promise<Record<string, CommandDefinition>> {
-  const projectCommandsDir = join(process.cwd(), ".claude", "commands")
+export async function loadProjectCommands(baseDir: string): Promise<Record<string, CommandDefinition>> {
+  const projectCommandsDir = join(baseDir, ".claude", "commands")
   const commands = await loadCommandsFromDir(projectCommandsDir, "project")
   return commandsToRecord(commands)
 }
@@ -127,18 +127,18 @@ export async function loadOpencodeGlobalCommands(): Promise<Record<string, Comma
   return commandsToRecord(commands)
 }
 
-export async function loadOpencodeProjectCommands(): Promise<Record<string, CommandDefinition>> {
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "command")
+export async function loadOpencodeProjectCommands(baseDir: string): Promise<Record<string, CommandDefinition>> {
+  const opencodeProjectDir = join(baseDir, ".opencode", "command")
   const commands = await loadCommandsFromDir(opencodeProjectDir, "opencode-project")
   return commandsToRecord(commands)
 }
 
-export async function loadAllCommands(): Promise<Record<string, CommandDefinition>> {
+export async function loadAllCommands(baseDir: string): Promise<Record<string, CommandDefinition>> {
   const [user, project, global, projectOpencode] = await Promise.all([
     loadUserCommands(),
-    loadProjectCommands(),
+    loadProjectCommands(baseDir),
     loadOpencodeGlobalCommands(),
-    loadOpencodeProjectCommands(),
+    loadOpencodeProjectCommands(baseDir),
   ])
   return { ...projectOpencode, ...global, ...project, ...user }
 }

--- a/src/features/claude-code-mcp-loader/loader.test.ts
+++ b/src/features/claude-code-mcp-loader/loader.test.ts
@@ -16,20 +16,13 @@ describe("getSystemMcpServerNames", () => {
 
   it("returns empty set when no .mcp.json files exist", async () => {
     // given
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
+    // when
+    const { getSystemMcpServerNames } = await import("./loader")
+    const names = getSystemMcpServerNames(TEST_DIR)
 
-    try {
-      // when
-      const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
-
-      // then
-      expect(names).toBeInstanceOf(Set)
-      expect(names.size).toBe(0)
-    } finally {
-      process.chdir(originalCwd)
-    }
+    // then
+    expect(names).toBeInstanceOf(Set)
+    expect(names.size).toBe(0)
   })
 
   it("returns server names from project .mcp.json", async () => {
@@ -48,21 +41,14 @@ describe("getSystemMcpServerNames", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
+    // when
+    const { getSystemMcpServerNames } = await import("./loader")
+    const names = getSystemMcpServerNames(TEST_DIR)
 
-    try {
-      // when
-      const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
-
-      // then
-      expect(names.has("playwright")).toBe(true)
-      expect(names.has("sqlite")).toBe(true)
-      expect(names.size).toBe(2)
-    } finally {
-      process.chdir(originalCwd)
-    }
+    // then
+    expect(names.has("playwright")).toBe(true)
+    expect(names.has("sqlite")).toBe(true)
+    expect(names.size).toBe(2)
   })
 
   it("returns server names from .claude/.mcp.json", async () => {
@@ -78,19 +64,12 @@ describe("getSystemMcpServerNames", () => {
     }
     writeFileSync(join(TEST_DIR, ".claude", ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
+    // when
+    const { getSystemMcpServerNames } = await import("./loader")
+    const names = getSystemMcpServerNames(TEST_DIR)
 
-    try {
-      // when
-      const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
-
-      // then
-      expect(names.has("memory")).toBe(true)
-    } finally {
-      process.chdir(originalCwd)
-    }
+    // then
+    expect(names.has("memory")).toBe(true)
   })
 
   it("excludes disabled MCP servers", async () => {
@@ -110,20 +89,13 @@ describe("getSystemMcpServerNames", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
+    // when
+    const { getSystemMcpServerNames } = await import("./loader")
+    const names = getSystemMcpServerNames(TEST_DIR)
 
-    try {
-      // when
-      const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
-
-      // then
-      expect(names.has("playwright")).toBe(false)
-      expect(names.has("active")).toBe(true)
-    } finally {
-      process.chdir(originalCwd)
-    }
+    // then
+    expect(names.has("playwright")).toBe(false)
+    expect(names.has("active")).toBe(true)
   })
 
   it("merges server names from multiple .mcp.json files", async () => {
@@ -144,19 +116,12 @@ describe("getSystemMcpServerNames", () => {
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(projectMcp))
     writeFileSync(join(TEST_DIR, ".claude", ".mcp.json"), JSON.stringify(localMcp))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
+    // when
+    const { getSystemMcpServerNames } = await import("./loader")
+    const names = getSystemMcpServerNames(TEST_DIR)
 
-    try {
-      // when
-      const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
-
-      // then
-      expect(names.has("playwright")).toBe(true)
-      expect(names.has("memory")).toBe(true)
-    } finally {
-      process.chdir(originalCwd)
-    }
+    // then
+    expect(names.has("playwright")).toBe(true)
+    expect(names.has("memory")).toBe(true)
   })
 })

--- a/src/features/claude-code-mcp-loader/loader.ts
+++ b/src/features/claude-code-mcp-loader/loader.ts
@@ -15,14 +15,13 @@ interface McpConfigPath {
   scope: McpScope
 }
 
-function getMcpConfigPaths(): McpConfigPath[] {
+function getMcpConfigPaths(baseDir: string): McpConfigPath[] {
   const claudeConfigDir = getClaudeConfigDir()
-  const cwd = process.cwd()
 
   return [
     { path: join(claudeConfigDir, ".mcp.json"), scope: "user" },
-    { path: join(cwd, ".mcp.json"), scope: "project" },
-    { path: join(cwd, ".claude", ".mcp.json"), scope: "local" },
+    { path: join(baseDir, ".mcp.json"), scope: "project" },
+    { path: join(baseDir, ".claude", ".mcp.json"), scope: "local" },
   ]
 }
 
@@ -42,9 +41,9 @@ async function loadMcpConfigFile(
   }
 }
 
-export function getSystemMcpServerNames(): Set<string> {
+export function getSystemMcpServerNames(baseDir: string): Set<string> {
   const names = new Set<string>()
-  const paths = getMcpConfigPaths()
+  const paths = getMcpConfigPaths(baseDir)
 
   for (const { path } of paths) {
     if (!existsSync(path)) continue
@@ -66,10 +65,10 @@ export function getSystemMcpServerNames(): Set<string> {
   return names
 }
 
-export async function loadMcpConfigs(): Promise<McpLoadResult> {
+export async function loadMcpConfigs(baseDir: string): Promise<McpLoadResult> {
   const servers: McpLoadResult["servers"] = {}
   const loadedServers: LoadedMcpServer[] = []
-  const paths = getMcpConfigPaths()
+  const paths = getMcpConfigPaths(baseDir)
 
   for (const { path, scope } of paths) {
     const config = await loadMcpConfigFile(path)

--- a/src/features/claude-tasks/storage.test.ts
+++ b/src/features/claude-tasks/storage.test.ts
@@ -44,7 +44,7 @@ describe("getTaskDir", () => {
     const expectedListId = sanitizePathSegment(basename(process.cwd()))
 
     //#when
-    const result = getTaskDir(config)
+    const result = getTaskDir(config, process.cwd())
 
     //#then
     expect(result).toBe(join(configDir, "tasks", expectedListId))
@@ -56,7 +56,7 @@ describe("getTaskDir", () => {
     const configDir = getOpenCodeConfigDir({ binary: "opencode" })
 
     //#when
-    const result = getTaskDir()
+    const result = getTaskDir({}, process.cwd())
 
     //#then
     expect(result).toBe(join(configDir, "tasks", "custom-list-id"))
@@ -69,7 +69,7 @@ describe("getTaskDir", () => {
     const expectedListId = sanitizePathSegment(basename(process.cwd()))
 
     //#when
-    const result = getTaskDir()
+    const result = getTaskDir({}, process.cwd())
 
     //#then
     expect(result).toBe(join(configDir, "tasks", expectedListId))
@@ -87,7 +87,7 @@ describe("getTaskDir", () => {
     }
 
     //#when
-    const result = getTaskDir(config)
+    const result = getTaskDir(config, process.cwd())
 
     //#then
     expect(result).toBe("/tmp/custom-task-path")
@@ -105,7 +105,7 @@ describe("getTaskDir", () => {
     }
 
     //#when
-    const result = getTaskDir(config)
+    const result = getTaskDir(config, process.cwd())
 
     //#then
     expect(result).toBe(join(process.cwd(), ".custom/tasks"))
@@ -136,7 +136,7 @@ describe("resolveTaskListId", () => {
     process.env.ULTRAWORK_TASK_LIST_ID = "custom-list"
 
     //#when
-    const result = resolveTaskListId()
+    const result = resolveTaskListId({}, process.cwd())
 
     //#then
     expect(result).toBe("custom-list")
@@ -147,7 +147,7 @@ describe("resolveTaskListId", () => {
     process.env.ULTRAWORK_TASK_LIST_ID = "custom list/id"
 
     //#when
-    const result = resolveTaskListId()
+    const result = resolveTaskListId({}, process.cwd())
 
     //#then
     expect(result).toBe("custom-list-id")
@@ -159,7 +159,7 @@ describe("resolveTaskListId", () => {
     const expected = sanitizePathSegment(basename(process.cwd()))
 
     //#when
-    const result = resolveTaskListId()
+    const result = resolveTaskListId({}, process.cwd())
 
     //#then
     expect(result).toBe(expected)
@@ -206,7 +206,7 @@ describe("listTaskFiles", () => {
     }
 
     //#when
-    const result = listTaskFiles(config)
+    const result = listTaskFiles(config, process.cwd())
 
     //#then
     expect(result).toEqual([])
@@ -222,7 +222,7 @@ describe("listTaskFiles", () => {
     writeFileSync(join(TEST_DIR_ABS, "other.json"), "{}", "utf-8")
 
     //#when
-    const result = listTaskFiles(config)
+    const result = listTaskFiles(config, process.cwd())
 
     //#then
     expect(result).toEqual([])
@@ -241,7 +241,7 @@ describe("listTaskFiles", () => {
     writeFileSync(join(TEST_DIR_ABS, "notes.md"), "# notes", "utf-8")
 
     //#when
-    const result = listTaskFiles(config)
+    const result = listTaskFiles(config, process.cwd())
 
     //#then
     expect(result).toHaveLength(2)
@@ -259,7 +259,7 @@ describe("listTaskFiles", () => {
     writeFileSync(join(TEST_DIR_ABS, "T-test-id.json"), "{}", "utf-8")
 
     //#when
-    const result = listTaskFiles(config)
+    const result = listTaskFiles(config, process.cwd())
 
     //#then
     expect(result[0]).toBe("T-test-id")

--- a/src/features/claude-tasks/storage.ts
+++ b/src/features/claude-tasks/storage.ts
@@ -5,16 +5,20 @@ import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 import type { z } from "zod"
 import type { OhMyOpenCodeConfig } from "../../config/schema"
 
-export function getTaskDir(config: Partial<OhMyOpenCodeConfig> = {}): string {
+export function getTaskDir(
+  config: Partial<OhMyOpenCodeConfig> = {},
+  baseDir?: string
+): string {
+  const resolvedBaseDir = baseDir ?? getOpenCodeConfigDir({ binary: "opencode" })
   const tasksConfig = config.sisyphus?.tasks
   const storagePath = tasksConfig?.storage_path
 
   if (storagePath) {
-    return isAbsolute(storagePath) ? storagePath : join(process.cwd(), storagePath)
+    return isAbsolute(storagePath) ? storagePath : join(resolvedBaseDir, storagePath)
   }
 
   const configDir = getOpenCodeConfigDir({ binary: "opencode" })
-  const listId = resolveTaskListId(config)
+  const listId = resolveTaskListId(config, resolvedBaseDir)
   return join(configDir, "tasks", listId)
 }
 
@@ -22,14 +26,17 @@ export function sanitizePathSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]/g, "-") || "default"
 }
 
-export function resolveTaskListId(config: Partial<OhMyOpenCodeConfig> = {}): string {
+export function resolveTaskListId(
+  config: Partial<OhMyOpenCodeConfig> = {},
+  baseDir: string
+): string {
   const envId = process.env.ULTRAWORK_TASK_LIST_ID?.trim()
   if (envId) return sanitizePathSegment(envId)
 
   const configId = config.sisyphus?.tasks?.task_list_id?.trim()
   if (configId) return sanitizePathSegment(configId)
 
-  return sanitizePathSegment(basename(process.cwd()))
+  return sanitizePathSegment(basename(baseDir))
 }
 
 export function ensureDir(dirPath: string): void {
@@ -85,8 +92,11 @@ export function generateTaskId(): string {
   return `T-${randomUUID()}`
 }
 
-export function listTaskFiles(config: Partial<OhMyOpenCodeConfig> = {}): string[] {
-  const dir = getTaskDir(config)
+export function listTaskFiles(
+  config: Partial<OhMyOpenCodeConfig> = {},
+  baseDir?: string
+): string[] {
+  const dir = getTaskDir(config, baseDir)
   if (!existsSync(dir)) return []
   return readdirSync(dir)
     .filter((f) => f.endsWith('.json') && f.startsWith('T-'))

--- a/src/features/opencode-skill-loader/loader.test.ts
+++ b/src/features/opencode-skill-loader/loader.test.ts
@@ -53,7 +53,7 @@ This is the skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "test-skill")
 
         // then
@@ -89,7 +89,7 @@ This is a simple skill.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "simple-skill")
 
         // then
@@ -122,7 +122,7 @@ Skill with env vars.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "env-skill")
 
         // then
@@ -149,7 +149,7 @@ Skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         // then - when YAML fails, skill uses directory name as fallback
         const skill = skills.find(s => s.name === "bad-yaml-skill")
 
@@ -186,7 +186,7 @@ Skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "ampcode-skill")
 
         // then
@@ -227,7 +227,7 @@ Skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "priority-skill")
 
         // then - mcp.json should take priority
@@ -259,7 +259,7 @@ Skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "direct-format")
 
         // then
@@ -289,7 +289,7 @@ Skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "space-separated-tools")
 
         // then
@@ -317,7 +317,7 @@ Skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "yaml-inline-array")
 
         // then
@@ -349,7 +349,7 @@ Skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "yaml-multiline-array")
 
         // then
@@ -376,7 +376,7 @@ Skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
         const skill = skills.find(s => s.name === "no-allowed-tools")
 
         // then
@@ -442,7 +442,7 @@ claude project body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills()
+        const skills = await discoverSkills({ directory: TEST_DIR })
         const duplicates = skills.filter(s => s.name === "duplicate-skill")
 
         // then
@@ -503,7 +503,7 @@ claude project body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills()
+        const skills = await discoverSkills({ directory: TEST_DIR })
         const matches = skills.filter(s => s.name === "global-over-project")
 
         expect(matches).toHaveLength(1)
@@ -544,7 +544,7 @@ Skill body.
       process.chdir(TEST_DIR)
 
       try {
-        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skills = await discoverSkills({ includeClaudeCodePaths: false, directory: TEST_DIR })
 
         // then
         const names = skills.map(s => s.name)

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -210,8 +210,8 @@ export async function loadUserSkills(): Promise<Record<string, CommandDefinition
   return skillsToRecord(skills)
 }
 
-export async function loadProjectSkills(): Promise<Record<string, CommandDefinition>> {
-  const projectSkillsDir = join(process.cwd(), ".claude", "skills")
+export async function loadProjectSkills(baseDir: string): Promise<Record<string, CommandDefinition>> {
+  const projectSkillsDir = join(baseDir, ".claude", "skills")
   const skills = await loadSkillsFromDir(projectSkillsDir, "project")
   return skillsToRecord(skills)
 }
@@ -223,14 +223,15 @@ export async function loadOpencodeGlobalSkills(): Promise<Record<string, Command
   return skillsToRecord(skills)
 }
 
-export async function loadOpencodeProjectSkills(): Promise<Record<string, CommandDefinition>> {
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "skills")
+export async function loadOpencodeProjectSkills(baseDir: string): Promise<Record<string, CommandDefinition>> {
+  const opencodeProjectDir = join(baseDir, ".opencode", "skills")
   const skills = await loadSkillsFromDir(opencodeProjectDir, "opencode-project")
   return skillsToRecord(skills)
 }
 
 export interface DiscoverSkillsOptions {
   includeClaudeCodePaths?: boolean
+  directory?: string
 }
 
 /**
@@ -250,11 +251,12 @@ function deduplicateSkills(skills: LoadedSkill[]): LoadedSkill[] {
   return result
 }
 
-export async function discoverAllSkills(): Promise<LoadedSkill[]> {
+export async function discoverAllSkills(options: DiscoverSkillsOptions = {}): Promise<LoadedSkill[]> {
+  const baseDir = options.directory
   const [opencodeProjectSkills, opencodeGlobalSkills, projectSkills, userSkills] = await Promise.all([
-    discoverOpencodeProjectSkills(),
+    baseDir ? discoverOpencodeProjectSkills(baseDir) : Promise.resolve([]),
     discoverOpencodeGlobalSkills(),
-    discoverProjectClaudeSkills(),
+    baseDir ? discoverProjectClaudeSkills(baseDir) : Promise.resolve([]),
     discoverUserClaudeSkills(),
   ])
 
@@ -263,10 +265,10 @@ export async function discoverAllSkills(): Promise<LoadedSkill[]> {
 }
 
 export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promise<LoadedSkill[]> {
-  const { includeClaudeCodePaths = true } = options
+  const { includeClaudeCodePaths = true, directory } = options
 
   const [opencodeProjectSkills, opencodeGlobalSkills] = await Promise.all([
-    discoverOpencodeProjectSkills(),
+    directory ? discoverOpencodeProjectSkills(directory) : Promise.resolve([]),
     discoverOpencodeGlobalSkills(),
   ])
 
@@ -276,7 +278,7 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
   }
 
   const [projectSkills, userSkills] = await Promise.all([
-    discoverProjectClaudeSkills(),
+    directory ? discoverProjectClaudeSkills(directory) : Promise.resolve([]),
     discoverUserClaudeSkills(),
   ])
 
@@ -294,8 +296,8 @@ export async function discoverUserClaudeSkills(): Promise<LoadedSkill[]> {
   return loadSkillsFromDir(userSkillsDir, "user")
 }
 
-export async function discoverProjectClaudeSkills(): Promise<LoadedSkill[]> {
-  const projectSkillsDir = join(process.cwd(), ".claude", "skills")
+export async function discoverProjectClaudeSkills(baseDir: string): Promise<LoadedSkill[]> {
+  const projectSkillsDir = join(baseDir, ".claude", "skills")
   return loadSkillsFromDir(projectSkillsDir, "project")
 }
 
@@ -305,7 +307,7 @@ export async function discoverOpencodeGlobalSkills(): Promise<LoadedSkill[]> {
   return loadSkillsFromDir(opencodeSkillsDir, "opencode")
 }
 
-export async function discoverOpencodeProjectSkills(): Promise<LoadedSkill[]> {
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "skills")
+export async function discoverOpencodeProjectSkills(baseDir: string): Promise<LoadedSkill[]> {
+  const opencodeProjectDir = join(baseDir, ".opencode", "skills")
   return loadSkillsFromDir(opencodeProjectDir, "opencode-project")
 }

--- a/src/features/opencode-skill-loader/merger.ts
+++ b/src/features/opencode-skill-loader/merger.ts
@@ -64,7 +64,7 @@ function resolveFilePath(from: string, configDir?: string): string {
     return filePath
   }
 
-  const baseDir = configDir || process.cwd()
+  const baseDir = configDir ?? homedir()
   return resolve(baseDir, filePath)
 }
 
@@ -103,7 +103,7 @@ function configEntryToLoaded(
   }
 
   const description = entry.description || fileMetadata.description || ""
-  const resolvedPath = entry.from ? dirname(resolveFilePath(entry.from, configDir)) : configDir || process.cwd()
+  const resolvedPath = entry.from ? dirname(resolveFilePath(entry.from, configDir)) : (configDir ?? homedir())
 
   const wrappedTemplate = `<skill-instruction>
 Base directory for this skill: ${resolvedPath}/

--- a/src/features/opencode-skill-loader/skill-content.ts
+++ b/src/features/opencode-skill-loader/skill-content.ts
@@ -9,6 +9,7 @@ export interface SkillResolutionOptions {
 	gitMasterConfig?: GitMasterConfig
 	browserProvider?: BrowserAutomationProvider
 	disabledSkills?: Set<string>
+	directory?: string
 }
 
 const cachedSkillsByProvider = new Map<string, LoadedSkill[]>()
@@ -18,7 +19,9 @@ function clearSkillCache(): void {
 }
 
 async function getAllSkills(options?: SkillResolutionOptions): Promise<LoadedSkill[]> {
-	const cacheKey = options?.browserProvider ?? "playwright"
+	const providerKey = options?.browserProvider ?? "playwright"
+	const directoryKey = options?.directory ?? "default"
+	const cacheKey = `${providerKey}:${directoryKey}`
 	const hasDisabledSkills = options?.disabledSkills && options.disabledSkills.size > 0
 
 	// Skip cache if disabledSkills is provided (varies between calls)
@@ -28,7 +31,7 @@ async function getAllSkills(options?: SkillResolutionOptions): Promise<LoadedSki
 	}
 
 	const [discoveredSkills, builtinSkillDefs] = await Promise.all([
-		discoverSkills({ includeClaudeCodePaths: true }),
+		discoverSkills({ includeClaudeCodePaths: true, directory: options?.directory }),
 		Promise.resolve(
 			createBuiltinSkills({
 				browserProvider: options?.browserProvider,

--- a/src/hooks/auto-slash-command/executor.ts
+++ b/src/hooks/auto-slash-command/executor.ts
@@ -99,14 +99,15 @@ function skillToCommandInfo(skill: LoadedSkill): CommandInfo {
 
 export interface ExecutorOptions {
   skills?: LoadedSkill[]
+  directory: string
 }
 
-async function discoverAllCommands(options?: ExecutorOptions): Promise<CommandInfo[]> {
+async function discoverAllCommands(options: ExecutorOptions): Promise<CommandInfo[]> {
   const configDir = getOpenCodeConfigDir({ binary: "opencode" })
   const userCommandsDir = join(getClaudeConfigDir(), "commands")
-  const projectCommandsDir = join(process.cwd(), ".claude", "commands")
+  const projectCommandsDir = join(options.directory, ".claude", "commands")
   const opencodeGlobalDir = join(configDir, "command")
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "command")
+  const opencodeProjectDir = join(options.directory, ".opencode", "command")
 
   const userCommands = discoverCommandsFromDir(userCommandsDir, "user")
   const opencodeGlobalCommands = discoverCommandsFromDir(opencodeGlobalDir, "opencode")
@@ -126,7 +127,7 @@ async function discoverAllCommands(options?: ExecutorOptions): Promise<CommandIn
     scope: "builtin",
   }))
 
-  const skills = options?.skills ?? await discoverAllSkills()
+  const skills = options.skills ?? await discoverAllSkills({ directory: options.directory })
   const skillCommands = skills.map(skillToCommandInfo)
 
   return [
@@ -139,14 +140,18 @@ async function discoverAllCommands(options?: ExecutorOptions): Promise<CommandIn
   ]
 }
 
-async function findCommand(commandName: string, options?: ExecutorOptions): Promise<CommandInfo | null> {
+async function findCommand(commandName: string, options: ExecutorOptions): Promise<CommandInfo | null> {
   const allCommands = await discoverAllCommands(options)
   return allCommands.find(
     (cmd) => cmd.name.toLowerCase() === commandName.toLowerCase()
   ) ?? null
 }
 
-async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<string> {
+async function formatCommandTemplate(
+  cmd: CommandInfo,
+  args: string,
+  options: ExecutorOptions
+): Promise<string> {
   const sections: string[] = []
 
   sections.push(`# /${cmd.name} Command\n`)
@@ -176,7 +181,7 @@ async function formatCommandTemplate(cmd: CommandInfo, args: string): Promise<st
     content = await cmd.lazyContentLoader.load()
   }
 
-  const commandDir = cmd.path ? dirname(cmd.path) : process.cwd()
+  const commandDir = cmd.path ? dirname(cmd.path) : options.directory
   const withFileRefs = await resolveFileReferencesInText(content, commandDir)
   const resolvedContent = await resolveCommandsInText(withFileRefs)
   sections.push(resolvedContent.trim())
@@ -196,7 +201,7 @@ export interface ExecuteResult {
   error?: string
 }
 
-export async function executeSlashCommand(parsed: ParsedSlashCommand, options?: ExecutorOptions): Promise<ExecuteResult> {
+export async function executeSlashCommand(parsed: ParsedSlashCommand, options: ExecutorOptions): Promise<ExecuteResult> {
   const command = await findCommand(parsed.command, options)
 
   if (!command) {
@@ -207,7 +212,7 @@ export async function executeSlashCommand(parsed: ParsedSlashCommand, options?: 
   }
 
   try {
-    const template = await formatCommandTemplate(command, parsed.args)
+    const template = await formatCommandTemplate(command, parsed.args, options)
     return {
       success: true,
       replacementText: template,

--- a/src/hooks/auto-slash-command/index.test.ts
+++ b/src/hooks/auto-slash-command/index.test.ts
@@ -5,6 +5,7 @@ import type {
   CommandExecuteBeforeInput,
   CommandExecuteBeforeOutput,
 } from "./types"
+import type { PluginInput } from "@opencode-ai/plugin"
 
 // Import real shared module to avoid mock leaking to other test files
 import * as shared from "../../shared"
@@ -15,6 +16,8 @@ const logMock = spyOn(shared, "log").mockImplementation(() => {})
 
 
 const { createAutoSlashCommandHook } = await import("./index")
+
+const mockCtx = { directory: "/test" } as PluginInput
 
 function createMockInput(sessionID: string, messageID?: string): AutoSlashCommandHookInput {
   return {
@@ -45,7 +48,7 @@ describe("createAutoSlashCommandHook", () => {
   describe("slash command replacement", () => {
     it("should not modify message when command not found", async () => {
       // given a slash command that doesn't exist
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-notfound-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("/nonexistent-command args")
@@ -60,7 +63,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should not modify message for unknown command (feature inactive)", async () => {
       // given unknown slash command
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-tags-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("/some-command")
@@ -75,7 +78,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should not modify for unknown command (no prepending)", async () => {
       // given unknown slash command
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-replace-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("/test-cmd some args")
@@ -92,7 +95,7 @@ describe("createAutoSlashCommandHook", () => {
   describe("no slash command", () => {
     it("should do nothing for regular text", async () => {
       // given regular text without slash
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-regular-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("Just regular text")
@@ -107,7 +110,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should do nothing for slash in middle of text", async () => {
       // given slash in middle
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-middle-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("Please run /commit later")
@@ -124,7 +127,7 @@ describe("createAutoSlashCommandHook", () => {
   describe("excluded commands", () => {
     it("should NOT trigger for ralph-loop command", async () => {
       // given ralph-loop command
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-ralph-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("/ralph-loop do something")
@@ -139,7 +142,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should NOT trigger for cancel-ralph command", async () => {
       // given cancel-ralph command
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-cancel-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("/cancel-ralph")
@@ -156,7 +159,7 @@ describe("createAutoSlashCommandHook", () => {
   describe("already processed", () => {
     it("should skip if auto-slash-command tags already present", async () => {
       // given text with existing tags
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-existing-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput(
@@ -175,7 +178,7 @@ describe("createAutoSlashCommandHook", () => {
   describe("code blocks", () => {
     it("should NOT detect command inside code block", async () => {
       // given command inside code block
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-codeblock-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("```\n/commit\n```")
@@ -192,7 +195,7 @@ describe("createAutoSlashCommandHook", () => {
   describe("edge cases", () => {
     it("should handle empty text", async () => {
       // given empty text
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-empty-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("")
@@ -204,7 +207,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should handle just slash", async () => {
       // given just slash
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-slash-only-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput("/")
@@ -219,7 +222,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should handle command with special characters in args (not found = no modification)", async () => {
       // given command with special characters that doesn't exist
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-special-${Date.now()}`
       const input = createMockInput(sessionID)
       const output = createMockOutput('/execute "test & stuff <tag>"')
@@ -234,7 +237,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should handle multiple text parts (unknown command = no modification)", async () => {
       // given multiple text parts with unknown command
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const sessionID = `test-session-multi-${Date.now()}`
       const input = createMockInput(sessionID)
       const output: AutoSlashCommandHookOutput = {
@@ -271,7 +274,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should not modify output for unknown command", async () => {
       //#given
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const input = createCommandInput("nonexistent-command-xyz")
       const output = createCommandOutput("original text")
       const originalText = output.parts[0].text
@@ -285,7 +288,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should add text part when parts array is empty and command is unknown", async () => {
       //#given
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const input = createCommandInput("nonexistent-command-abc")
       const output = createCommandOutput()
 
@@ -298,7 +301,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should inject template for known builtin commands like ralph-loop", async () => {
       //#given
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const input = createCommandInput("ralph-loop")
       const output = createCommandOutput("original")
 
@@ -312,7 +315,7 @@ describe("createAutoSlashCommandHook", () => {
 
     it("should pass command arguments correctly", async () => {
       //#given
-      const hook = createAutoSlashCommandHook()
+    const hook = createAutoSlashCommandHook(mockCtx)
       const input = createCommandInput("some-command", "arg1 arg2 arg3")
       const output = createCommandOutput("original")
 

--- a/src/hooks/auto-slash-command/index.ts
+++ b/src/hooks/auto-slash-command/index.ts
@@ -4,6 +4,7 @@ import {
   findSlashCommandPartIndex,
 } from "./detector"
 import { executeSlashCommand, type ExecutorOptions } from "./executor"
+import type { PluginInput } from "@opencode-ai/plugin"
 import { log } from "../../shared"
 import {
   AUTO_SLASH_COMMAND_TAG_OPEN,
@@ -29,9 +30,10 @@ export interface AutoSlashCommandHookOptions {
   skills?: LoadedSkill[]
 }
 
-export function createAutoSlashCommandHook(options?: AutoSlashCommandHookOptions) {
+export function createAutoSlashCommandHook(ctx: PluginInput, options?: AutoSlashCommandHookOptions) {
   const executorOptions: ExecutorOptions = {
     skills: options?.skills,
+    directory: ctx.directory,
   }
 
   return {

--- a/src/hooks/claude-code-hooks/config-loader.ts
+++ b/src/hooks/claude-code-hooks/config-loader.ts
@@ -18,8 +18,8 @@ export interface PluginExtendedConfig {
 
 const USER_CONFIG_PATH = join(getOpenCodeConfigDir({ binary: "opencode" }), "opencode-cc-plugin.json")
 
-function getProjectConfigPath(): string {
-  return join(process.cwd(), ".opencode", "opencode-cc-plugin.json")
+function getProjectConfigPath(baseDir: string): string {
+  return join(baseDir, ".opencode", "opencode-cc-plugin.json")
 }
 
 async function loadConfigFromPath(path: string): Promise<PluginExtendedConfig | null> {
@@ -52,9 +52,9 @@ function mergeDisabledHooks(
   }
 }
 
-export async function loadPluginExtendedConfig(): Promise<PluginExtendedConfig> {
+export async function loadPluginExtendedConfig(baseDir: string): Promise<PluginExtendedConfig> {
   const userConfig = await loadConfigFromPath(USER_CONFIG_PATH)
-  const projectConfig = await loadConfigFromPath(getProjectConfigPath())
+  const projectConfig = await loadConfigFromPath(getProjectConfigPath(baseDir))
 
   const merged: PluginExtendedConfig = {
     disabledHooks: mergeDisabledHooks(

--- a/src/hooks/claude-code-hooks/config.ts
+++ b/src/hooks/claude-code-hooks/config.ts
@@ -43,12 +43,12 @@ function normalizeHooksConfig(raw: RawClaudeHooksConfig): ClaudeHooksConfig {
   return result
 }
 
-export function getClaudeSettingsPaths(customPath?: string): string[] {
+export function getClaudeSettingsPaths(baseDir: string, customPath?: string): string[] {
   const claudeConfigDir = getClaudeConfigDir()
   const paths = [
     join(claudeConfigDir, "settings.json"),
-    join(process.cwd(), ".claude", "settings.json"),
-    join(process.cwd(), ".claude", "settings.local.json"),
+    join(baseDir, ".claude", "settings.json"),
+    join(baseDir, ".claude", "settings.local.json"),
   ]
 
   if (customPath && existsSync(customPath)) {
@@ -81,9 +81,10 @@ function mergeHooksConfig(
 }
 
 export async function loadClaudeHooksConfig(
+  baseDir: string,
   customSettingsPath?: string
 ): Promise<ClaudeHooksConfig | null> {
-  const paths = getClaudeSettingsPaths(customSettingsPath)
+  const paths = getClaudeSettingsPaths(baseDir, customSettingsPath)
   let mergedConfig: ClaudeHooksConfig = {}
 
   for (const settingsPath of paths) {

--- a/src/hooks/claude-code-hooks/index.ts
+++ b/src/hooks/claude-code-hooks/index.ts
@@ -47,8 +47,8 @@ export function createClaudeCodeHooksHook(
         return
       }
 
-      const claudeConfig = await loadClaudeHooksConfig()
-      const extendedConfig = await loadPluginExtendedConfig()
+      const claudeConfig = await loadClaudeHooksConfig(ctx.directory)
+      const extendedConfig = await loadPluginExtendedConfig(ctx.directory)
 
       const preCompactCtx: PreCompactContext = {
         sessionId: input.sessionID,
@@ -86,8 +86,8 @@ export function createClaudeCodeHooksHook(
         return
       }
 
-      const claudeConfig = await loadClaudeHooksConfig()
-      const extendedConfig = await loadPluginExtendedConfig()
+      const claudeConfig = await loadClaudeHooksConfig(ctx.directory)
+      const extendedConfig = await loadPluginExtendedConfig(ctx.directory)
 
       const textParts = output.parts.filter((p) => p.type === "text" && p.text)
       const prompt = textParts.map((p) => p.text ?? "").join("\n")
@@ -199,8 +199,8 @@ export function createClaudeCodeHooksHook(
         log("todowrite: parsed todos string to array", { sessionID: input.sessionID })
       }
 
-      const claudeConfig = await loadClaudeHooksConfig()
-      const extendedConfig = await loadPluginExtendedConfig()
+      const claudeConfig = await loadClaudeHooksConfig(ctx.directory)
+      const extendedConfig = await loadPluginExtendedConfig(ctx.directory)
 
       appendTranscriptEntry(input.sessionID, {
         type: "tool_use",
@@ -251,8 +251,8 @@ export function createClaudeCodeHooksHook(
         return
       }
 
-      const claudeConfig = await loadClaudeHooksConfig()
-      const extendedConfig = await loadPluginExtendedConfig()
+      const claudeConfig = await loadClaudeHooksConfig(ctx.directory)
+      const extendedConfig = await loadPluginExtendedConfig(ctx.directory)
 
       const cachedInput = getToolInput(input.sessionID, input.tool, input.callID) || {}
 
@@ -363,8 +363,8 @@ export function createClaudeCodeHooksHook(
 
         if (!sessionID) return
 
-        const claudeConfig = await loadClaudeHooksConfig()
-        const extendedConfig = await loadPluginExtendedConfig()
+        const claudeConfig = await loadClaudeHooksConfig(ctx.directory)
+        const extendedConfig = await loadPluginExtendedConfig(ctx.directory)
 
         const errorStateBefore = sessionErrorState.get(sessionID)
         const endedWithErrorBefore = errorStateBefore?.hasError === true

--- a/src/hooks/comment-checker/index.ts
+++ b/src/hooks/comment-checker/index.ts
@@ -1,3 +1,4 @@
+import type { PluginInput } from "@opencode-ai/plugin"
 import type { PendingCall } from "./types"
 import { runCommentChecker, getCommentCheckerPath, startBackgroundInit, type HookInput } from "./cli"
 import type { CommentCheckerConfig } from "../../config/schema"
@@ -32,7 +33,8 @@ function cleanupOldPendingCalls(): void {
   }
 }
 
-export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
+export function createCommentCheckerHooks(ctx: PluginInput, config?: CommentCheckerConfig) {
+  const baseDir = ctx.directory
   debugLog("createCommentCheckerHooks called", { config })
 
   if (!cleanupIntervalStarted) {
@@ -128,7 +130,7 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
         
         // CLI mode only
         debugLog("using CLI:", cliPath)
-        await processWithCli(input, pendingCall, output, cliPath, config?.custom_prompt)
+        await processWithCli(input, pendingCall, output, cliPath, baseDir, config?.custom_prompt)
       } catch (err) {
         debugLog("tool.execute.after failed:", err)
       }
@@ -141,6 +143,7 @@ async function processWithCli(
   pendingCall: PendingCall,
   output: { output: string },
   cliPath: string,
+  baseDir: string,
   customPrompt?: string
 ): Promise<void> {
   debugLog("using CLI mode with path:", cliPath)
@@ -149,7 +152,7 @@ async function processWithCli(
     session_id: pendingCall.sessionID,
     tool_name: pendingCall.tool.charAt(0).toUpperCase() + pendingCall.tool.slice(1),
     transcript_path: "",
-    cwd: process.cwd(),
+    cwd: baseDir,
     hook_event_name: "PostToolUse",
     tool_input: {
       file_path: pendingCall.filePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   }
 
   const commentChecker = isHookEnabled("comment-checker")
-    ? safeCreateHook("comment-checker", () => createCommentCheckerHooks(pluginConfig.comment_checker), { enabled: safeHookEnabled })
+    ? safeCreateHook("comment-checker", () => createCommentCheckerHooks(ctx, pluginConfig.comment_checker), { enabled: safeHookEnabled })
     : null;
   const toolOutputTruncator = isHookEnabled("tool-output-truncator")
     ? safeCreateHook("tool-output-truncator", () => createToolOutputTruncatorHook(ctx, {
@@ -407,7 +407,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   const browserProvider =
     pluginConfig.browser_automation_engine?.provider ?? "playwright";
   const disabledSkills = new Set<string>(pluginConfig.disabled_skills ?? []);
-  const systemMcpNames = getSystemMcpServerNames();
+  const systemMcpNames = getSystemMcpServerNames(ctx.directory);
   const builtinSkills = createBuiltinSkills({ browserProvider, disabledSkills }).filter((skill) => {
       if (skill.mcpConfig) {
         for (const mcpName of Object.keys(skill.mcpConfig)) {
@@ -422,8 +422,8 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     await Promise.all([
       includeClaudeSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
       discoverOpencodeGlobalSkills(),
-      includeClaudeSkills ? discoverProjectClaudeSkills() : Promise.resolve([]),
-      discoverOpencodeProjectSkills(),
+      includeClaudeSkills ? discoverProjectClaudeSkills(ctx.directory) : Promise.resolve([]),
+      discoverOpencodeProjectSkills(ctx.directory),
     ]);
   const mergedSkills = mergeSkills(
     builtinSkills,
@@ -432,6 +432,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     globalSkills,
     projectSkills,
     opencodeProjectSkills,
+    { configDir: ctx.directory },
   );
 
   function mapScopeToLocation(scope: SkillScope): AvailableSkill["location"] {
@@ -502,7 +503,8 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     mcpManager: skillMcpManager,
     getSessionID: getSessionIDForMcp,
     gitMasterConfig: pluginConfig.git_master,
-    disabledSkills
+    disabledSkills,
+    directory: ctx.directory,
   });
   const skillMcpTool = createSkillMcpTool({
     manager: skillMcpManager,
@@ -510,14 +512,15 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     getSessionID: getSessionIDForMcp,
   });
 
-  const commands = discoverCommandsSync();
+  const commands = discoverCommandsSync(ctx.directory);
   const slashcommandTool = createSlashcommandTool({
     commands,
     skills: mergedSkills,
+    directory: ctx.directory,
   });
 
   const autoSlashCommand = isHookEnabled("auto-slash-command")
-    ? safeCreateHook("auto-slash-command", () => createAutoSlashCommandHook({ skills: mergedSkills }), { enabled: safeHookEnabled })
+    ? safeCreateHook("auto-slash-command", () => createAutoSlashCommandHook(ctx, { skills: mergedSkills }), { enabled: safeHookEnabled })
     : null;
 
   const configHandler = createConfigHandler({

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -166,9 +166,9 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       discoveredOpencodeProjectSkills,
     ] = await Promise.all([
       includeClaudeSkillsForAwareness ? discoverUserClaudeSkills() : Promise.resolve([]),
-      includeClaudeSkillsForAwareness ? discoverProjectClaudeSkills() : Promise.resolve([]),
+      includeClaudeSkillsForAwareness ? discoverProjectClaudeSkills(ctx.directory) : Promise.resolve([]),
       discoverOpencodeGlobalSkills(),
-      discoverOpencodeProjectSkills(),
+      discoverOpencodeProjectSkills(ctx.directory),
     ]);
 
     const allDiscoveredSkills = [
@@ -204,7 +204,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       ? loadUserAgents()
       : {};
     const projectAgents = (pluginConfig.claude_code?.agents ?? true)
-      ? loadProjectAgents()
+      ? loadProjectAgents(ctx.directory)
       : {};
 
     // Plugin agents: Apply permission migration for compatibility
@@ -471,7 +471,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     };
 
     const mcpResult = (pluginConfig.claude_code?.mcp ?? true)
-      ? await loadMcpConfigs()
+      ? await loadMcpConfigs(ctx.directory)
       : { servers: {} };
 
     config.mcp = {
@@ -499,13 +499,13 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       opencodeProjectSkills,
     ] = await Promise.all([
       includeClaudeCommands ? loadUserCommands() : Promise.resolve({}),
-      includeClaudeCommands ? loadProjectCommands() : Promise.resolve({}),
+      includeClaudeCommands ? loadProjectCommands(ctx.directory) : Promise.resolve({}),
       loadOpencodeGlobalCommands(),
-      loadOpencodeProjectCommands(),
+      loadOpencodeProjectCommands(ctx.directory),
       includeClaudeSkills ? loadUserSkills() : Promise.resolve({}),
-      includeClaudeSkills ? loadProjectSkills() : Promise.resolve({}),
+      includeClaudeSkills ? loadProjectSkills(ctx.directory) : Promise.resolve({}),
       loadOpencodeGlobalSkills(),
-      loadOpencodeProjectSkills(),
+      loadOpencodeProjectSkills(ctx.directory),
     ]);
 
     config.command = {

--- a/src/shared/file-reference-resolver.ts
+++ b/src/shared/file-reference-resolver.ts
@@ -51,7 +51,7 @@ function readFileContent(resolvedPath: string): string {
 
 export async function resolveFileReferencesInText(
   text: string,
-  cwd: string = process.cwd(),
+  cwd: string,
   depth: number = 0,
   maxDepth: number = 3
 ): Promise<string> {

--- a/src/tools/glob/tools.ts
+++ b/src/tools/glob/tools.ts
@@ -1,4 +1,4 @@
-import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import { tool, type ToolDefinition, type ToolContext } from "@opencode-ai/plugin/tool"
 import { runRgFiles } from "./cli"
 import { resolveGrepCliWithAutoInstall } from "./constants"
 import { formatGlobResult } from "./utils"
@@ -20,11 +20,10 @@ export const glob: ToolDefinition = tool({
           "simply omit it for the default behavior. Must be a valid directory path if provided."
       ),
   },
-  execute: async (args) => {
+  execute: async (args, context: ToolContext & { directory: string }) => {
     try {
       const cli = await resolveGrepCliWithAutoInstall()
-      // Use process.cwd() as the default search path when no path is provided
-      const searchPath = args.path ?? process.cwd()
+      const searchPath = args.path ?? context.directory
       const paths = [searchPath]
 
       const result = await runRgFiles(

--- a/src/tools/grep/tools.ts
+++ b/src/tools/grep/tools.ts
@@ -1,4 +1,4 @@
-import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import { tool, type ToolDefinition, type ToolContext } from "@opencode-ai/plugin/tool"
 import { runRg } from "./cli"
 import { formatGrepResult } from "./utils"
 
@@ -20,11 +20,10 @@ export const grep: ToolDefinition = tool({
       .optional()
       .describe("The directory to search in. Defaults to the current working directory."),
   },
-  execute: async (args) => {
+  execute: async (args, context: ToolContext & { directory: string }) => {
     try {
       const globs = args.include ? [args.include] : undefined
-      // Use process.cwd() as the default search path when no path is provided
-      const searchPath = args.path ?? process.cwd()
+      const searchPath = args.path ?? context.directory
       const paths = [searchPath]
 
       const result = await runRg({

--- a/src/tools/lsp/config.test.ts
+++ b/src/tools/lsp/config.test.ts
@@ -65,11 +65,11 @@ describe("isServerInstalled", () => {
     const pathSep = process.platform === "win32" ? ";" : ":"
     process.env.PATH = `${tempDir}${pathSep}${process.env.PATH || ""}`
 
-    expect(isServerInstalled([binName])).toBe(true)
+    expect(isServerInstalled([binName], tempDir)).toBe(true)
   })
 
   test("returns false for missing executable", () => {
-    expect(isServerInstalled(["non-existent-server"])).toBe(false)
+    expect(isServerInstalled(["non-existent-server"], tempDir)).toBe(false)
   })
 
   if (process.platform === "win32") {
@@ -81,7 +81,7 @@ describe("isServerInstalled", () => {
        delete process.env.PATH
        process.env.Path = tempDir
 
-       expect(isServerInstalled([binName])).toBe(true)
+       expect(isServerInstalled([binName], tempDir)).toBe(true)
     })
 
     test("Windows: respects PATHEXT", () => {
@@ -92,7 +92,7 @@ describe("isServerInstalled", () => {
        process.env.PATH = tempDir
        process.env.PATHEXT = ".COM;.EXE"
 
-       expect(isServerInstalled([binName])).toBe(true)
+       expect(isServerInstalled([binName], tempDir)).toBe(true)
     })
     
     test("Windows: ensures default extensions are checked even if PATHEXT is missing", () => {
@@ -103,7 +103,7 @@ describe("isServerInstalled", () => {
        process.env.PATH = tempDir
        delete process.env.PATHEXT
 
-       expect(isServerInstalled([binName])).toBe(true)
+       expect(isServerInstalled([binName], tempDir)).toBe(true)
     })
 
     test("Windows: ensures default extensions are checked even if PATHEXT does not include them", () => {
@@ -114,7 +114,7 @@ describe("isServerInstalled", () => {
         process.env.PATH = tempDir
         process.env.PATHEXT = ".COM"
  
-        expect(isServerInstalled([binName])).toBe(true)
+        expect(isServerInstalled([binName], tempDir)).toBe(true)
      })
   } else {
       test("Non-Windows: does not use windows extensions", () => {
@@ -124,7 +124,7 @@ describe("isServerInstalled", () => {
           
           process.env.PATH = tempDir
           
-          expect(isServerInstalled([binName])).toBe(false)
+          expect(isServerInstalled([binName], tempDir)).toBe(false)
       })
   }
 })

--- a/src/tools/lsp/config.ts
+++ b/src/tools/lsp/config.ts
@@ -32,18 +32,17 @@ function loadJsonFile<T>(path: string): T | null {
   }
 }
 
-function getConfigPaths(): { project: string; user: string; opencode: string } {
-  const cwd = process.cwd()
+function getConfigPaths(baseDir: string): { project: string; user: string; opencode: string } {
   const configDir = getOpenCodeConfigDir({ binary: "opencode" })
   return {
-    project: join(cwd, ".opencode", "oh-my-opencode.json"),
+    project: join(baseDir, ".opencode", "oh-my-opencode.json"),
     user: join(configDir, "oh-my-opencode.json"),
     opencode: join(configDir, "opencode.json"),
   }
 }
 
-function loadAllConfigs(): Map<ConfigSource, ConfigJson> {
-  const paths = getConfigPaths()
+function loadAllConfigs(baseDir: string): Map<ConfigSource, ConfigJson> {
+  const paths = getConfigPaths(baseDir)
   const configs = new Map<ConfigSource, ConfigJson>()
 
   const project = loadJsonFile<ConfigJson>(paths.project)
@@ -58,8 +57,8 @@ function loadAllConfigs(): Map<ConfigSource, ConfigJson> {
   return configs
 }
 
-function getMergedServers(): ServerWithSource[] {
-  const configs = loadAllConfigs()
+function getMergedServers(baseDir: string): ServerWithSource[] {
+  const configs = loadAllConfigs(baseDir)
   const servers: ServerWithSource[] = []
   const disabled = new Set<string>()
   const seen = new Set<string>()
@@ -113,11 +112,11 @@ function getMergedServers(): ServerWithSource[] {
   })
 }
 
-export function findServerForExtension(ext: string): ServerLookupResult {
-  const servers = getMergedServers()
+export function findServerForExtension(ext: string, baseDir: string): ServerLookupResult {
+  const servers = getMergedServers(baseDir)
 
   for (const server of servers) {
-    if (server.extensions.includes(ext) && isServerInstalled(server.command)) {
+    if (server.extensions.includes(ext) && isServerInstalled(server.command, baseDir)) {
       return {
         status: "found",
         server: {
@@ -160,7 +159,7 @@ export function getLanguageId(ext: string): string {
   return EXT_TO_LANG[ext] || "plaintext"
 }
 
-export function isServerInstalled(command: string[]): boolean {
+export function isServerInstalled(command: string[], baseDir: string): boolean {
   if (command.length === 0) return false
 
   const cmd = command[0]
@@ -199,11 +198,10 @@ export function isServerInstalled(command: string[]): boolean {
     }
   }
 
-  const cwd = process.cwd()
   const configDir = getOpenCodeConfigDir({ binary: "opencode" })
   const dataDir = join(getDataDir(), "opencode")
   const additionalBases = [
-    join(cwd, "node_modules", ".bin"),
+    join(baseDir, "node_modules", ".bin"),
     join(configDir, "bin"),
     join(configDir, "node_modules", ".bin"),
     join(dataDir, "bin"),
@@ -225,7 +223,7 @@ export function isServerInstalled(command: string[]): boolean {
   return false
 }
 
-export function getAllServers(): Array<{
+export function getAllServers(baseDir: string): Array<{
   id: string
   installed: boolean
   extensions: string[]
@@ -233,8 +231,8 @@ export function getAllServers(): Array<{
   source: string
   priority: number
 }> {
-  const configs = loadAllConfigs()
-  const servers = getMergedServers()
+  const configs = loadAllConfigs(baseDir)
+  const servers = getMergedServers(baseDir)
   const disabled = new Set<string>()
 
   for (const config of configs.values()) {
@@ -259,7 +257,7 @@ export function getAllServers(): Array<{
     if (seen.has(server.id)) continue
     result.push({
       id: server.id,
-      installed: isServerInstalled(server.command),
+      installed: isServerInstalled(server.command, baseDir),
       extensions: server.extensions,
       disabled: false,
       source: server.source,
@@ -273,7 +271,7 @@ export function getAllServers(): Array<{
     const builtin = BUILTIN_SERVERS[id]
     result.push({
       id,
-      installed: builtin ? isServerInstalled(builtin.command) : false,
+      installed: builtin ? isServerInstalled(builtin.command, baseDir) : false,
       extensions: builtin?.extensions || [],
       disabled: true,
       source: "disabled",
@@ -284,6 +282,6 @@ export function getAllServers(): Array<{
   return result
 }
 
-export function getConfigPaths_(): { project: string; user: string; opencode: string } {
-  return getConfigPaths()
+export function getConfigPaths_(baseDir: string): { project: string; user: string; opencode: string } {
+  return getConfigPaths(baseDir)
 }

--- a/src/tools/lsp/tools.ts
+++ b/src/tools/lsp/tools.ts
@@ -1,4 +1,4 @@
-import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import { tool, type ToolDefinition, type ToolContext } from "@opencode-ai/plugin/tool"
 import {
   DEFAULT_MAX_REFERENCES,
   DEFAULT_MAX_SYMBOLS,
@@ -26,6 +26,8 @@ import type {
   WorkspaceEdit,
 } from "./types"
 
+type ToolContextWithDirectory = ToolContext & { directory: string }
+
 export const lsp_goto_definition: ToolDefinition = tool({
   description: "Jump to symbol definition. Find WHERE something is defined.",
   args: {
@@ -33,9 +35,9 @@ export const lsp_goto_definition: ToolDefinition = tool({
     line: tool.schema.number().min(1).describe("1-based"),
     character: tool.schema.number().min(0).describe("0-based"),
   },
-  execute: async (args, context) => {
+  execute: async (args, context: ToolContextWithDirectory) => {
     try {
-      const result = await withLspClient(args.filePath, async (client) => {
+      const result = await withLspClient(args.filePath, context.directory, async (client) => {
         return (await client.definition(args.filePath, args.line, args.character)) as
           | Location
           | Location[]
@@ -71,9 +73,9 @@ export const lsp_find_references: ToolDefinition = tool({
     character: tool.schema.number().min(0).describe("0-based"),
     includeDeclaration: tool.schema.boolean().optional().describe("Include the declaration itself"),
   },
-  execute: async (args, context) => {
+  execute: async (args, context: ToolContextWithDirectory) => {
     try {
-      const result = await withLspClient(args.filePath, async (client) => {
+      const result = await withLspClient(args.filePath, context.directory, async (client) => {
         return (await client.references(args.filePath, args.line, args.character, args.includeDeclaration ?? true)) as
           | Location[]
           | null
@@ -108,7 +110,7 @@ export const lsp_symbols: ToolDefinition = tool({
     query: tool.schema.string().optional().describe("Symbol name to search (required for workspace scope)"),
     limit: tool.schema.number().optional().describe("Max results (default 50)"),
   },
-  execute: async (args, context) => {
+  execute: async (args, context: ToolContextWithDirectory) => {
     try {
       const scope = args.scope ?? "document"
       
@@ -117,7 +119,7 @@ export const lsp_symbols: ToolDefinition = tool({
           return "Error: 'query' is required for workspace scope"
         }
         
-        const result = await withLspClient(args.filePath, async (client) => {
+        const result = await withLspClient(args.filePath, context.directory, async (client) => {
           return (await client.workspaceSymbols(args.query!)) as SymbolInfo[] | null
         })
 
@@ -135,7 +137,7 @@ export const lsp_symbols: ToolDefinition = tool({
         }
         return lines.join("\n")
       } else {
-        const result = await withLspClient(args.filePath, async (client) => {
+        const result = await withLspClient(args.filePath, context.directory, async (client) => {
           return (await client.documentSymbols(args.filePath)) as DocumentSymbol[] | SymbolInfo[] | null
         })
 
@@ -175,9 +177,9 @@ export const lsp_diagnostics: ToolDefinition = tool({
       .optional()
       .describe("Filter by severity level"),
   },
-  execute: async (args, context) => {
+  execute: async (args, context: ToolContextWithDirectory) => {
     try {
-      const result = await withLspClient(args.filePath, async (client) => {
+      const result = await withLspClient(args.filePath, context.directory, async (client) => {
         return (await client.diagnostics(args.filePath)) as { items?: Diagnostic[] } | Diagnostic[] | null
       })
 
@@ -220,9 +222,9 @@ export const lsp_prepare_rename: ToolDefinition = tool({
     line: tool.schema.number().min(1).describe("1-based"),
     character: tool.schema.number().min(0).describe("0-based"),
   },
-  execute: async (args, context) => {
+  execute: async (args, context: ToolContextWithDirectory) => {
     try {
-      const result = await withLspClient(args.filePath, async (client) => {
+      const result = await withLspClient(args.filePath, context.directory, async (client) => {
         return (await client.prepareRename(args.filePath, args.line, args.character)) as
           | PrepareRenameResult
           | PrepareRenameDefaultBehavior
@@ -245,9 +247,9 @@ export const lsp_rename: ToolDefinition = tool({
     character: tool.schema.number().min(0).describe("0-based"),
     newName: tool.schema.string().describe("New symbol name"),
   },
-  execute: async (args, context) => {
+  execute: async (args, context: ToolContextWithDirectory) => {
     try {
-      const edit = await withLspClient(args.filePath, async (client) => {
+      const edit = await withLspClient(args.filePath, context.directory, async (client) => {
         return (await client.rename(args.filePath, args.line, args.character, args.newName)) as WorkspaceEdit | null
       })
       const result = applyWorkspaceEdit(edit)

--- a/src/tools/lsp/utils.ts
+++ b/src/tools/lsp/utils.ts
@@ -79,10 +79,14 @@ export function formatServerLookupError(result: Exclude<ServerLookupResult, { st
   ].join("\n")
 }
 
-export async function withLspClient<T>(filePath: string, fn: (client: LSPClient) => Promise<T>): Promise<T> {
+export async function withLspClient<T>(
+  filePath: string,
+  baseDir: string,
+  fn: (client: LSPClient) => Promise<T>
+): Promise<T> {
   const absPath = resolve(filePath)
   const ext = extname(absPath)
-  const result = findServerForExtension(ext)
+  const result = findServerForExtension(ext, baseDir)
 
   if (result.status !== "found") {
     throw new Error(formatServerLookupError(result))

--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -26,7 +26,7 @@ mock.module("./constants", () => ({
   TOOL_NAME_PREFIX: "session_",
 }))
 
-const { getAllSessions, getMessageDir, sessionExists, readSessionMessages, readSessionTodos, getSessionInfo } =
+const { getAllSessions, getMainSessions, getMessageDir, sessionExists, readSessionMessages, readSessionTodos, getSessionInfo } =
   await import("./storage")
 
 const storage = await import("./storage")
@@ -42,6 +42,38 @@ describe("session-manager storage", () => {
     mkdirSync(TEST_SESSION_STORAGE, { recursive: true })
     mkdirSync(TEST_TODO_DIR, { recursive: true })
     mkdirSync(TEST_TRANSCRIPT_DIR, { recursive: true })
+  })
+
+  test("filters main sessions by directory", async () => {
+    // given
+    const projectDirOne = join(TEST_SESSION_STORAGE, "project-one")
+    const projectDirTwo = join(TEST_SESSION_STORAGE, "project-two")
+    mkdirSync(projectDirOne, { recursive: true })
+    mkdirSync(projectDirTwo, { recursive: true })
+
+    writeFileSync(
+      join(projectDirOne, "ses_one.json"),
+      JSON.stringify({
+        id: "ses_one",
+        directory: "/project-one",
+        time: { created: Date.now(), updated: Date.now() },
+      })
+    )
+    writeFileSync(
+      join(projectDirTwo, "ses_two.json"),
+      JSON.stringify({
+        id: "ses_two",
+        directory: "/project-two",
+        time: { created: Date.now(), updated: Date.now() },
+      })
+    )
+
+    // when
+    const sessions = await getMainSessions({ directory: "/project-one" })
+
+    // then
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]?.directory).toBe("/project-one")
   })
 
   afterEach(() => {

--- a/src/tools/session-manager/tools.test.ts
+++ b/src/tools/session-manager/tools.test.ts
@@ -48,13 +48,13 @@ describe("session-manager tools", () => {
     expect(typeof result).toBe("string")
   })
 
-  test("session_list uses process.cwd() as default project_path", async () => {
+  test("session_list uses context directory as default project_path", async () => {
     // given - no project_path provided
 
     // when
     const result = await session_list.execute({}, mockContext)
 
-    // then - should not throw and return string (uses process.cwd() internally)
+    // then - should not throw and return string (uses context.directory internally)
     expect(typeof result).toBe("string")
   })
 

--- a/src/tools/session-manager/tools.ts
+++ b/src/tools/session-manager/tools.ts
@@ -1,4 +1,4 @@
-import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
+import { tool, type ToolDefinition, type ToolContext } from "@opencode-ai/plugin/tool"
 import {
   SESSION_LIST_DESCRIPTION,
   SESSION_READ_DESCRIPTION,
@@ -32,11 +32,11 @@ export const session_list: ToolDefinition = tool({
     limit: tool.schema.number().optional().describe("Maximum number of sessions to return"),
     from_date: tool.schema.string().optional().describe("Filter sessions from this date (ISO 8601 format)"),
     to_date: tool.schema.string().optional().describe("Filter sessions until this date (ISO 8601 format)"),
-    project_path: tool.schema.string().optional().describe("Filter sessions by project path (default: current working directory)"),
+    project_path: tool.schema.string().optional().describe("Filter sessions by project path (default: current session directory)"),
   },
-  execute: async (args: SessionListArgs, _context) => {
+  execute: async (args: SessionListArgs, context: ToolContext & { directory: string }) => {
     try {
-      const directory = args.project_path ?? process.cwd()
+      const directory = args.project_path ?? context.directory
       let sessions = await getMainSessions({ directory })
       let sessionIDs = sessions.map((s) => s.id)
 

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -133,7 +133,10 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
   const getSkills = async (): Promise<LoadedSkill[]> => {
     if (options.skills) return options.skills
     if (cachedSkills) return cachedSkills
-    cachedSkills = await getAllSkills({disabledSkills: options?.disabledSkills})
+    cachedSkills = await getAllSkills({
+      disabledSkills: options?.disabledSkills,
+      directory: options?.directory,
+    })
     return cachedSkills
   }
 
@@ -163,7 +166,7 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
     args: {
       name: tool.schema.string().describe("The skill identifier from available_skills (e.g., 'code-review')"),
     },
-    async execute(args: SkillArgs, ctx?: { agent?: string }) {
+    async execute(args: SkillArgs, ctx?: { agent?: string; directory?: string }) {
       const skills = await getSkills()
       const skill = skills.find(s => s.name === args.name)
 
@@ -182,7 +185,11 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
         body = injectGitMasterConfig(body, options.gitMasterConfig)
       }
 
-      const dir = skill.path ? dirname(skill.path) : skill.resolvedPath || process.cwd()
+      const baseDir = ctx?.directory ?? options?.directory
+      const dir = skill.path ? dirname(skill.path) : (skill.resolvedPath || baseDir)
+      if (!dir) {
+        throw new Error(`Skill "${skill.name}" requires a base directory to resolve file references.`)
+      }
 
       const output = [
         `## Skill: ${skill.name}`,

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -22,6 +22,8 @@ export interface SkillLoadOptions {
   opencodeOnly?: boolean
   /** Pre-merged skills to use instead of discovering */
   skills?: LoadedSkill[]
+  /** Base directory for project-scoped skill resolution */
+  directory?: string
   /** MCP manager for querying skill-embedded MCP servers */
   mcpManager?: SkillMcpManager
   /** Session ID getter for MCP client identification */

--- a/src/tools/slashcommand/tools.ts
+++ b/src/tools/slashcommand/tools.ts
@@ -1,4 +1,4 @@
-import { tool, type ToolDefinition } from "@opencode-ai/plugin"
+import { tool, type ToolDefinition, type ToolContext } from "@opencode-ai/plugin"
 import { existsSync, readdirSync, readFileSync } from "fs"
 import { join, basename, dirname } from "path"
 import { parseFrontmatter, resolveCommandsInText, resolveFileReferencesInText, sanitizeModelField, getOpenCodeConfigDir } from "../../shared"
@@ -8,6 +8,8 @@ import { getClaudeConfigDir } from "../../shared"
 import { discoverAllSkills, type LoadedSkill } from "../../features/opencode-skill-loader"
 import { loadBuiltinCommands } from "../../features/builtin-commands"
 import type { CommandScope, CommandMetadata, CommandInfo, SlashcommandToolOptions } from "./types"
+
+type ToolContextWithDirectory = ToolContext & { directory?: string }
 
 function discoverCommandsFromDir(commandsDir: string, scope: CommandScope): CommandInfo[] {
   if (!existsSync(commandsDir)) {
@@ -52,17 +54,21 @@ function discoverCommandsFromDir(commandsDir: string, scope: CommandScope): Comm
   return commands
 }
 
-export function discoverCommandsSync(): CommandInfo[] {
+export function discoverCommandsSync(baseDir?: string): CommandInfo[] {
   const configDir = getOpenCodeConfigDir({ binary: "opencode" })
   const userCommandsDir = join(getClaudeConfigDir(), "commands")
-  const projectCommandsDir = join(process.cwd(), ".claude", "commands")
+  const projectCommandsDir = baseDir ? join(baseDir, ".claude", "commands") : null
   const opencodeGlobalDir = join(configDir, "command")
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "command")
+  const opencodeProjectDir = baseDir ? join(baseDir, ".opencode", "command") : null
 
   const userCommands = discoverCommandsFromDir(userCommandsDir, "user")
   const opencodeGlobalCommands = discoverCommandsFromDir(opencodeGlobalDir, "opencode")
-  const projectCommands = discoverCommandsFromDir(projectCommandsDir, "project")
-  const opencodeProjectCommands = discoverCommandsFromDir(opencodeProjectDir, "opencode-project")
+  const projectCommands = projectCommandsDir
+    ? discoverCommandsFromDir(projectCommandsDir, "project")
+    : []
+  const opencodeProjectCommands = opencodeProjectDir
+    ? discoverCommandsFromDir(opencodeProjectDir, "opencode-project")
+    : []
 
   const builtinCommandsMap = loadBuiltinCommands()
   const builtinCommands: CommandInfo[] = Object.values(builtinCommandsMap).map(cmd => ({
@@ -100,7 +106,11 @@ function skillToCommandInfo(skill: LoadedSkill): CommandInfo {
   }
 }
 
-async function formatLoadedCommand(cmd: CommandInfo, userMessage?: string): Promise<string> {
+async function formatLoadedCommand(
+  cmd: CommandInfo,
+  baseDir: string | undefined,
+  userMessage?: string
+): Promise<string> {
   const sections: string[] = []
 
   sections.push(`# /${cmd.name} Command\n`)
@@ -138,7 +148,10 @@ async function formatLoadedCommand(cmd: CommandInfo, userMessage?: string): Prom
     content = await cmd.lazyContentLoader.load()
   }
 
-  const commandDir = cmd.path ? dirname(cmd.path) : process.cwd()
+  const commandDir = cmd.path ? dirname(cmd.path) : baseDir
+  if (!commandDir) {
+    throw new Error(`Command "${cmd.name}" requires a base directory to resolve file references.`)
+  }
   const withFileRefs = await resolveFileReferencesInText(content, commandDir)
   const resolvedContent = await resolveCommandsInText(withFileRefs)
   
@@ -200,21 +213,23 @@ export function createSlashcommandTool(options: SlashcommandToolOptions = {}): T
   let cachedCommands: CommandInfo[] | null = options.commands ?? null
   let cachedSkills: LoadedSkill[] | null = options.skills ?? null
   let cachedDescription: string | null = null
+  const baseDir = options.directory
 
-  const getCommands = (): CommandInfo[] => {
+  const getCommands = (context?: { directory?: string }): CommandInfo[] => {
     if (cachedCommands) return cachedCommands
-    cachedCommands = discoverCommandsSync()
+    const resolvedBaseDir = baseDir ?? context?.directory
+    cachedCommands = discoverCommandsSync(resolvedBaseDir)
     return cachedCommands
   }
 
   const getSkills = async (): Promise<LoadedSkill[]> => {
     if (cachedSkills) return cachedSkills
-    cachedSkills = await discoverAllSkills()
+    cachedSkills = await discoverAllSkills(baseDir ? { directory: baseDir } : undefined)
     return cachedSkills
   }
 
-  const getAllItems = async (): Promise<CommandInfo[]> => {
-    const commands = getCommands()
+  const getAllItems = async (context?: { directory?: string }): Promise<CommandInfo[]> => {
+    const commands = getCommands(context)
     const skills = await getSkills()
     return [...commands, ...skills.map(skillToCommandInfo)]
   }
@@ -252,8 +267,9 @@ export function createSlashcommandTool(options: SlashcommandToolOptions = {}): T
         ),
     },
 
-    async execute(args) {
-      const allItems = await getAllItems()
+    async execute(args, context?: ToolContextWithDirectory) {
+      const resolvedBaseDir = baseDir ?? context?.directory
+      const allItems = await getAllItems(context)
 
       if (!args.command) {
         return formatCommandList(allItems) + "\n\nProvide a command or skill name to execute."
@@ -266,7 +282,7 @@ export function createSlashcommandTool(options: SlashcommandToolOptions = {}): T
       )
 
       if (exactMatch) {
-        return await formatLoadedCommand(exactMatch, args.user_message)
+        return await formatLoadedCommand(exactMatch, resolvedBaseDir, args.user_message)
       }
 
       const partialMatches = allItems.filter((cmd) =>

--- a/src/tools/slashcommand/types.ts
+++ b/src/tools/slashcommand/types.ts
@@ -25,4 +25,6 @@ export interface SlashcommandToolOptions {
   commands?: CommandInfo[]
   /** Pre-loaded skills (skip discovery if provided) */
   skills?: LoadedSkill[]
+  /** Base directory for project-scoped command discovery */
+  directory?: string
 }

--- a/src/tools/task/task-create.test.ts
+++ b/src/tools/task/task-create.test.ts
@@ -19,6 +19,7 @@ const TEST_CONTEXT = {
   sessionID: TEST_SESSION_ID,
   messageID: "test-message-123",
   agent: "test-agent",
+  directory: process.cwd(),
   abort: TEST_ABORT_CONTROLLER.signal,
 }
 

--- a/src/tools/task/task-create.ts
+++ b/src/tools/task/task-create.ts
@@ -60,11 +60,12 @@ async function handleCreate(
   args: Record<string, unknown>,
   config: Partial<OhMyOpenCodeConfig>,
   ctx: PluginInput | undefined,
-  context: { sessionID: string },
+  context: { sessionID: string; directory?: string },
 ): Promise<string> {
   try {
     const validatedArgs = TaskCreateInputSchema.parse(args);
-    const taskDir = getTaskDir(config);
+    const baseDir = ctx?.directory ?? context.directory;
+    const taskDir = getTaskDir(config, baseDir);
     const lock = acquireLock(taskDir);
 
     if (!lock.acquired) {

--- a/src/tools/task/task-get.test.ts
+++ b/src/tools/task/task-get.test.ts
@@ -19,6 +19,7 @@ const TEST_CONTEXT = {
   sessionID: TEST_SESSION_ID,
   messageID: "test-message-123",
   agent: "test-agent",
+  directory: process.cwd(),
   abort: TEST_ABORT_CONTROLLER.signal,
 }
 

--- a/src/tools/task/task-get.ts
+++ b/src/tools/task/task-get.ts
@@ -1,5 +1,6 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { join } from "path"
+import type { ToolContext } from "@opencode-ai/plugin/tool"
 import type { OhMyOpenCodeConfig } from "../../config/schema"
 import type { TaskGetInput } from "./types"
 import { TaskGetInputSchema, TaskObjectSchema } from "./types"
@@ -22,7 +23,10 @@ Returns null if the task does not exist or the file is invalid.`,
     args: {
       id: tool.schema.string().describe("Task ID to retrieve (format: T-{uuid})"),
     },
-    execute: async (args: Record<string, unknown>): Promise<string> => {
+    execute: async (
+      args: Record<string, unknown>,
+      context: ToolContext & { directory: string }
+    ): Promise<string> => {
       try {
         const validatedArgs = TaskGetInputSchema.parse(args)
         const taskId = parseTaskId(validatedArgs.id)
@@ -31,7 +35,7 @@ Returns null if the task does not exist or the file is invalid.`,
           return JSON.stringify({ error: "invalid_task_id" })
         }
 
-        const taskDir = getTaskDir(config)
+        const taskDir = getTaskDir(config, context.directory)
         const taskPath = join(taskDir, `${taskId}.json`)
 
          const task = readJsonSafe(taskPath, TaskObjectSchema)

--- a/src/tools/task/task-list.test.ts
+++ b/src/tools/task/task-list.test.ts
@@ -36,7 +36,7 @@ describe("createTaskList", () => {
     const tool = createTaskList(config)
 
     //#when
-    const result = await tool.execute({}, { sessionID: "test-session" })
+    const result = await tool.execute({}, { sessionID: "test-session", directory: testProjectDir })
 
     //#then
     const parsed = JSON.parse(result)
@@ -78,7 +78,7 @@ describe("createTaskList", () => {
     const tool = createTaskList(config)
 
     //#when
-    const result = await tool.execute({}, { sessionID: "test-session" })
+    const result = await tool.execute({}, { sessionID: "test-session", directory: testProjectDir })
 
     //#then
     const parsed = JSON.parse(result)
@@ -121,7 +121,7 @@ describe("createTaskList", () => {
      const tool = createTaskList(config)
 
      //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+    const result = await tool.execute({}, { sessionID: "test-session", directory: testProjectDir })
 
      //#then
      const parsed = JSON.parse(result)
@@ -155,7 +155,7 @@ describe("createTaskList", () => {
      const tool = createTaskList(config)
 
      //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+    const result = await tool.execute({}, { sessionID: "test-session", directory: testProjectDir })
 
      //#then
      const parsed = JSON.parse(result)
@@ -219,7 +219,7 @@ describe("createTaskList", () => {
      const tool = createTaskList(config)
 
      //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+    const result = await tool.execute({}, { sessionID: "test-session", directory: testProjectDir })
 
      //#then
      const parsed = JSON.parse(result)
@@ -262,7 +262,7 @@ describe("createTaskList", () => {
      const tool = createTaskList(config)
 
      //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+    const result = await tool.execute({}, { sessionID: "test-session", directory: testProjectDir })
 
      //#then
      const parsed = JSON.parse(result)
@@ -294,7 +294,7 @@ describe("createTaskList", () => {
      const tool = createTaskList(config)
 
      //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+    const result = await tool.execute({}, { sessionID: "test-session", directory: testProjectDir })
 
      //#then
      const parsed = JSON.parse(result)
@@ -326,7 +326,7 @@ describe("createTaskList", () => {
      const tool = createTaskList(config)
 
      //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+    const result = await tool.execute({}, { sessionID: "test-session", directory: testProjectDir })
 
      //#then
      const parsed = JSON.parse(result)

--- a/src/tools/task/task-list.ts
+++ b/src/tools/task/task-list.ts
@@ -1,5 +1,6 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { join } from "path"
+import type { ToolContext } from "@opencode-ai/plugin/tool"
 import { existsSync, readdirSync } from "fs"
 import type { OhMyOpenCodeConfig } from "../../config/schema"
 import type { TaskObject, TaskStatus } from "./types"
@@ -22,8 +23,8 @@ Returns tasks excluding completed and deleted statuses by default.
 For each task's blockedBy field, filters to only include unresolved (non-completed) blockers.
 Returns summary format: id, subject, status, owner, blockedBy (not full description).`,
     args: {},
-    execute: async (): Promise<string> => {
-      const taskDir = getTaskDir(config)
+    execute: async (_args, context: ToolContext & { directory: string }): Promise<string> => {
+      const taskDir = getTaskDir(config, context.directory)
 
       if (!existsSync(taskDir)) {
         return JSON.stringify({ tasks: [] })

--- a/src/tools/task/task-update.test.ts
+++ b/src/tools/task/task-update.test.ts
@@ -19,6 +19,7 @@ const TEST_CONTEXT = {
   sessionID: TEST_SESSION_ID,
   messageID: "test-message-123",
   agent: "test-agent",
+  directory: process.cwd(),
   abort: TEST_ABORT_CONTROLLER.signal,
 }
 

--- a/src/tools/task/task-update.ts
+++ b/src/tools/task/task-update.ts
@@ -73,7 +73,7 @@ async function handleUpdate(
   args: Record<string, unknown>,
   config: Partial<OhMyOpenCodeConfig>,
   ctx: PluginInput | undefined,
-  context: { sessionID: string },
+  context: { sessionID: string; directory?: string },
 ): Promise<string> {
   try {
     const validatedArgs = TaskUpdateInputSchema.parse(args);
@@ -82,7 +82,8 @@ async function handleUpdate(
       return JSON.stringify({ error: "invalid_task_id" });
     }
 
-    const taskDir = getTaskDir(config);
+    const baseDir = ctx?.directory ?? context.directory;
+    const taskDir = getTaskDir(config, baseDir);
     const lock = acquireLock(taskDir);
 
     if (!lock.acquired) {

--- a/src/tools/task/task.test.ts
+++ b/src/tools/task/task.test.ts
@@ -21,6 +21,7 @@ const TEST_CONTEXT = {
   sessionID: TEST_SESSION_ID,
   messageID: "test-message-123",
   agent: "test-agent",
+  directory: process.cwd(),
   abort: TEST_ABORT_CONTROLLER.signal,
 }
 

--- a/src/tools/task/task.ts
+++ b/src/tools/task/task.ts
@@ -72,13 +72,13 @@ All actions return JSON strings.`,
         case "create":
           return handleCreate(args, config, context)
         case "list":
-          return handleList(args, config)
+          return handleList(args, config, context)
         case "get":
-          return handleGet(args, config)
+          return handleGet(args, config, context)
         case "update":
-          return handleUpdate(args, config)
+          return handleUpdate(args, config, context)
         case "delete":
-          return handleDelete(args, config)
+          return handleDelete(args, config, context)
         default:
           return JSON.stringify({ error: "invalid_action" })
       }
@@ -89,10 +89,10 @@ All actions return JSON strings.`,
 async function handleCreate(
   args: Record<string, unknown>,
   config: Partial<OhMyOpenCodeConfig>,
-  context: { sessionID: string }
+  context: { sessionID: string; directory?: string }
 ): Promise<string> {
   const validatedArgs = TaskCreateInputSchema.parse(args)
-  const taskDir = getTaskDir(config)
+  const taskDir = getTaskDir(config, context.directory)
   const lock = acquireLock(taskDir)
 
   if (!lock.acquired) {
@@ -124,16 +124,17 @@ async function handleCreate(
 
 async function handleList(
   args: Record<string, unknown>,
-  config: Partial<OhMyOpenCodeConfig>
+  config: Partial<OhMyOpenCodeConfig>,
+  context: { sessionID: string; directory?: string }
 ): Promise<string> {
   const validatedArgs = TaskListInputSchema.parse(args)
-  const taskDir = getTaskDir(config)
+  const taskDir = getTaskDir(config, context.directory)
 
   if (!existsSync(taskDir)) {
     return JSON.stringify({ tasks: [] })
   }
 
-  const files = listTaskFiles(config)
+  const files = listTaskFiles(config, context.directory)
   if (files.length === 0) {
     return JSON.stringify({ tasks: [] })
   }
@@ -185,14 +186,15 @@ async function handleList(
 
 async function handleGet(
   args: Record<string, unknown>,
-  config: Partial<OhMyOpenCodeConfig>
+  config: Partial<OhMyOpenCodeConfig>,
+  context: { sessionID: string; directory?: string }
 ): Promise<string> {
   const validatedArgs = TaskGetInputSchema.parse(args)
   const taskId = parseTaskId(validatedArgs.id)
   if (!taskId) {
     return JSON.stringify({ error: "invalid_task_id" })
   }
-  const taskDir = getTaskDir(config)
+  const taskDir = getTaskDir(config, context.directory)
   const taskPath = join(taskDir, `${taskId}.json`)
 
   const task = readJsonSafe(taskPath, TaskObjectSchema)
@@ -202,14 +204,15 @@ async function handleGet(
 
 async function handleUpdate(
   args: Record<string, unknown>,
-  config: Partial<OhMyOpenCodeConfig>
+  config: Partial<OhMyOpenCodeConfig>,
+  context: { sessionID: string; directory?: string }
 ): Promise<string> {
   const validatedArgs = TaskUpdateInputSchema.parse(args)
   const taskId = parseTaskId(validatedArgs.id)
   if (!taskId) {
     return JSON.stringify({ error: "invalid_task_id" })
   }
-  const taskDir = getTaskDir(config)
+  const taskDir = getTaskDir(config, context.directory)
   const lock = acquireLock(taskDir)
 
   if (!lock.acquired) {
@@ -255,14 +258,15 @@ async function handleUpdate(
 
 async function handleDelete(
   args: Record<string, unknown>,
-  config: Partial<OhMyOpenCodeConfig>
+  config: Partial<OhMyOpenCodeConfig>,
+  context: { sessionID: string; directory?: string }
 ): Promise<string> {
   const validatedArgs = TaskDeleteInputSchema.parse(args)
   const taskId = parseTaskId(validatedArgs.id)
   if (!taskId) {
     return JSON.stringify({ error: "invalid_task_id" })
   }
-  const taskDir = getTaskDir(config)
+  const taskDir = getTaskDir(config, context.directory)
   const lock = acquireLock(taskDir)
 
   if (!lock.acquired) {


### PR DESCRIPTION
## Summary
- replace tool and hook project path resolution with `ctx.directory` for project-scoped discovery
- thread directory context through loaders/config handlers for commands, skills, MCP, and LSP
- update task storage and session-manager tests for directory-aware behavior

## Testing
- bun test src/tools/session-manager/tools.test.ts src/tools/session-manager/storage.test.ts src/tools/slashcommand/tools.test.ts src/hooks/auto-slash-command/index.test.ts src/features/opencode-skill-loader/loader.test.ts src/features/claude-code-mcp-loader/loader.test.ts src/tools/lsp/config.test.ts src/features/claude-tasks/storage.test.ts src/tools/task/task-create.test.ts src/tools/task/task-update.test.ts src/tools/task/task-get.test.ts src/tools/task/task-list.test.ts src/tools/task/task.test.ts src/tools/skill/tools.test.ts
- bun run typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch project-scoped discovery to use ctx.directory instead of process.cwd() across tools, loaders, and hooks. This fixes wrong lookups in hosted or multi-project setups and makes file resolution consistent.

- **Refactors**
  - Threaded directory through command/skill discovery, MCP and LSP config, slashcommand executor, session-manager, tasks, grep/glob, and file reference resolver.
  - Updated APIs to accept a baseDir/directory (e.g., loadProjectCommands/Skills, discoverProjectClaudeSkills, loadMcpConfigs, findServerForExtension/isServerInstalled, discoverCommandsSync, getTaskDir/listTaskFiles).
  - Plugin now passes ctx.directory to loaders, tools, and hooks; tests updated to be directory-aware.

- **Migration**
  - Update hook calls: createAutoSlashCommandHook(ctx, options) and createCommentCheckerHooks(ctx, config).
  - Ensure ToolContext includes directory; tools default to context.directory when no path is provided.
  - If calling discovery/load helpers directly, pass the project base directory.

<sup>Written for commit 7f4db8e46f1f096bd37d34126c72d385cd3ff164. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

