### PR TITLE
fix(ultrawork): widen isPlannerAgent matching to prevent ULW infinite plan loop (#1501)

### DIFF
--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -598,6 +598,26 @@ describe("keyword-detector agent-specific ultrawork messages", () => {
     expect(textPart!.text).not.toContain("YOU ARE A PLANNER, NOT AN IMPLEMENTER")
   })
 
+  test("should skip ultrawork injection when agent name contains 'plan' token", async () => {
+    //#given - collector and agent name that includes a plan token
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "plan-agent-session"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "ultrawork draft a plan" }],
+    }
+
+    //#when - ultrawork keyword detected with plan-like agent name
+    await hook["chat.message"]({ sessionID, agent: "Plan Agent" }, output)
+
+    //#then - ultrawork should be skipped, text unchanged
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toBe("ultrawork draft a plan")
+    expect(textPart!.text).not.toContain("YOU ARE A PLANNER, NOT AN IMPLEMENTER")
+  })
+
   test("should use normal ultrawork message when agent is Sisyphus", async () => {
     // given - collector and Sisyphus agent
     const collector = new ContextCollector()

--- a/src/hooks/keyword-detector/ultrawork/utils.ts
+++ b/src/hooks/keyword-detector/ultrawork/utils.ts
@@ -14,7 +14,10 @@
 export function isPlannerAgent(agentName?: string): boolean {
   if (!agentName) return false
   const lowerName = agentName.toLowerCase()
-  return lowerName.includes("prometheus") || lowerName.includes("planner") || lowerName === "plan"
+  if (lowerName.includes("prometheus") || lowerName.includes("planner")) return true
+
+  const normalized = lowerName.replace(/[_-]+/g, " ")
+  return /\bplan\b/.test(normalized)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes #1501: ULW keyword triggers ultrawork injection even for plan-like agents (e.g. "Plan Agent"), causing an infinite planning loop
- The existing `isPlannerAgent()` only checked for `"prometheus"`, `"planner"`, or exact match `"plan"` — agents with compound names like `"Plan Agent"` or `"plan-reviewer"` slipped through

## Changes
- **`src/hooks/keyword-detector/ultrawork/utils.ts`**: Replace `=== "plan"` exact match with word-boundary regex `/\bplan\b/` after normalizing separators, so any agent name containing `plan` as a standalone token is recognized
- **`src/hooks/keyword-detector/index.test.ts`**: Add BDD test verifying ultrawork injection is skipped for agent names containing a `plan` token

## Test
```bash
bun test src/hooks/keyword-detector/index.test.ts
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened planner detection to skip ultrawork injection for plan-like agents, preventing the ULW infinite planning loop (fixes #1501). Agents like "Plan Agent" and "plan-reviewer" are now recognized as planners.

- **Bug Fixes**
  - Updated isPlannerAgent to normalize separators and match "plan" with a word-boundary regex.
  - Added a test to ensure ultrawork is skipped when the agent name contains a "plan" token.

<sup>Written for commit 0eddd28a955c1e84013cbd930f28eef9d40b45c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

