### PR TITLE
fix(cli): passThroughOptions cannot be used for 'run' without turning on enablePositionalOptions

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,7 @@ program
   .name("oh-my-opencode")
   .description("The ultimate OpenCode plugin - multi-model orchestration, LSP tools, and more")
   .version(VERSION, "-v, --version", "Show version number")
+  .enablePositionalOptions()
 
 program
   .command("install")


### PR DESCRIPTION
## Summary

Adds .enablePositionalOptions() to the parent command on line 21. Commander.js requires this on the parent when any subcommand uses .passThroughOptions(), so that positional arguments are correctly routed to the subcommand rather than being consumed by the parent.

This fixes the following error with the cli:
```
error: passThroughOptions cannot be used for 'run' without turning on enablePositionalOptions for parent command(s)
      at _checkForBrokenPassThrough (/$bunfs/root/oh-my-opencode:18:2326)
      at passThroughOptions (/$bunfs/root/oh-my-opencode:18:2198)
      at /$bunfs/root/oh-my-opencode:208:320
      at loadAndEvaluateModule (2:1)
```

## Testing

All type checks and tests pass (some are timing out, but it seems to do this upstream too).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable positional options on the root CLI command so subcommands using passThroughOptions (e.g., run) accept args without errors. This routes positional args to the subcommand as required by Commander.js and fixes the runtime error about needing enablePositionalOptions on the parent.

<sup>Written for commit 0cbbdd566e4c023f0deaf788ae2c4db565c6b8bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

