### PR TITLE
fix: preserve user's enabled:false when MCP servers from .mcp.json files overwrite opencode config

### DIFF
--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -1059,3 +1059,75 @@ describe("per-agent todowrite/todoread deny when task_system enabled", () => {
     expect(agentResult.sisyphus?.permission?.todoread).toBeUndefined()
   })
 })
+
+describe("MCP enabled:false preservation", () => {
+  test("preserves user's enabled:false when .mcp.json servers overwrite same MCP name", async () => {
+    //#given - user has an MCP set to enabled:false in opencode config
+    ;(mcpLoader.loadMcpConfigs as any).mockRestore?.()
+    spyOn(mcpLoader, "loadMcpConfigs" as any).mockResolvedValue({
+      servers: {
+        "my-mcp": { command: "npx", args: ["-y", "my-mcp"], enabled: true },
+      },
+    })
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-6",
+      agent: {},
+      mcp: {
+        "my-mcp": { command: "npx", args: ["-y", "my-mcp"], enabled: false },
+      },
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    //#when
+    await handler(config)
+
+    //#then - user's enabled:false must be preserved despite .mcp.json overwrite
+    const mcpConfig = config.mcp as Record<string, { enabled?: boolean }>
+    expect(mcpConfig["my-mcp"]).toBeDefined()
+    expect(mcpConfig["my-mcp"].enabled).toBe(false)
+  })
+
+  test("does not alter MCPs the user has not explicitly disabled", async () => {
+    //#given - user has one MCP disabled, another enabled by default
+    ;(mcpLoader.loadMcpConfigs as any).mockRestore?.()
+    spyOn(mcpLoader, "loadMcpConfigs" as any).mockResolvedValue({
+      servers: {
+        "disabled-mcp": { command: "npx", args: ["-y", "disabled-mcp"], enabled: true },
+        "normal-mcp": { command: "npx", args: ["-y", "normal-mcp"], enabled: true },
+      },
+    })
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-6",
+      agent: {},
+      mcp: {
+        "disabled-mcp": { command: "npx", args: ["-y", "disabled-mcp"], enabled: false },
+        "normal-mcp": { command: "npx", args: ["-y", "normal-mcp"] },
+      },
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    //#when
+    await handler(config)
+
+    //#then - disabled-mcp stays disabled, normal-mcp remains enabled from .mcp.json
+    const mcpConfig = config.mcp as Record<string, { enabled?: boolean }>
+    expect(mcpConfig["disabled-mcp"].enabled).toBe(false)
+    expect(mcpConfig["normal-mcp"].enabled).toBe(true)
+  })
+})

--- a/src/plugin-handlers/mcp-config-handler.ts
+++ b/src/plugin-handlers/mcp-config-handler.ts
@@ -8,6 +8,17 @@ export async function applyMcpConfig(params: {
   pluginConfig: OhMyOpenCodeConfig;
   pluginComponents: PluginComponents;
 }): Promise<void> {
+  // Preserve user's `enabled: false`, later spreads from .mcp.json would overwrite it.
+  const userMcp = params.config.mcp as Record<string, { enabled?: boolean }> | undefined;
+  const userDisabledMcps = new Set<string>();
+  if (userMcp) {
+    for (const [name, mcpConfig] of Object.entries(userMcp)) {
+      if (mcpConfig && mcpConfig.enabled === false) {
+        userDisabledMcps.add(name);
+      }
+    }
+  }
+
   const mcpResult = params.pluginConfig.claude_code?.mcp ?? true
     ? await loadMcpConfigs()
     : { servers: {} };
@@ -18,4 +29,13 @@ export async function applyMcpConfig(params: {
     ...mcpResult.servers,
     ...params.pluginComponents.mcpServers,
   };
+
+  if (userDisabledMcps.size > 0) {
+    const mergedMcp = params.config.mcp as Record<string, { enabled?: boolean }>;
+    for (const name of userDisabledMcps) {
+      if (mergedMcp[name]) {
+        mergedMcp[name] = { ...mergedMcp[name], enabled: false };
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Problem

When a user disables an MCP server by setting `enabled: false` in their `opencode.json`, the setting is silently ignored if the same MCP server is also defined in any `.mcp.json` config file (e.g., `~/.claude.json`, `~/.claude/.mcp.json`, `./.mcp.json`, `./.claude/.mcp.json`).

**Root cause:** Two things combine to produce this bug:

1. `transformMcpServer()` in `src/features/claude-code-mcp-loader/transformer.ts` **hardcodes `enabled: true`** on every server it processes
2. In `mcp-config-handler.ts`, the MCP merge ordering places `.mcp.json` results **after** the user's opencode config:
   ```ts
   params.config.mcp = {
     ...createBuiltinMcps(...),
     ...(params.config.mcp),      // user's opencode.json (enabled: false)
     ...mcpResult.servers,         // from .mcp.json files (hardcoded enabled: true) <- overwrites
     ...params.pluginComponents.mcpServers,
   };
   ```

Same-named keys from `.mcp.json` sources replace the user's `enabled: false` with `enabled: true`.

**This bug has existed since the MCP loader was introduced**, but it became visible to me after #1616 added `~/.claude.json` as an MCP source -- my Claude Code MCP servers are defined there, and that change caused them to load even though I had them disabled in `opencode.json`.

## Solution

Before the MCP merge in `mcp-config-handler.ts`, capture which MCPs the user explicitly set to `enabled: false`. After the merge, restore `enabled: false` on those MCPs. This is a minimal, non-breaking fix that respects user intent regardless of which `.mcp.json` source triggers the overwrite.

## Files Changed

- `src/plugin-handlers/mcp-config-handler.ts` -- Preserve user's `enabled: false` across the MCP merge
- `src/plugin-handlers/config-handler.test.ts` -- 2 new tests verifying the fix

## Testing

- All 31 config-handler tests pass (including 2 new ones)
- Typecheck clean
- Build clean
- Tested locally by building and pointing opencode.json to the local build -- confirmed disabled MCPs stay disabled