### PR TITLE
fix: add enablePositionalOptions() to parent command — fixes v3.3.x startup crash

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,7 @@ program
   .name("oh-my-opencode")
   .description("The ultimate OpenCode plugin - multi-model orchestration, LSP tools, and more")
   .version(VERSION, "-v, --version", "Show version number")
+  .enablePositionalOptions()
 
 program
   .command("install")


### PR DESCRIPTION
## Summary

Fixes #1640 — `oh-my-opencode` v3.3.0 and v3.3.1 crash immediately on startup with:

```
TypeError: passThroughOptions cannot be used for 'run' without turning on enablePositionalOptions for parent command(s)
```

## Root Cause

The `run` subcommand uses `.passThroughOptions()` (line 47), but Commander.js requires the **parent** command to have `.enablePositionalOptions()` enabled first. This was always required by Commander.js, but the check (`_checkForBrokenPassThrough`) was only enforced starting in recent versions.

## Fix

One-line change — add `.enablePositionalOptions()` to the parent `program` command:

```diff
 program
   .name("oh-my-opencode")
   .description("The ultimate OpenCode plugin - multi-model orchestration, LSP tools, and more")
   .version(VERSION, "-v, --version", "Show version number")
+  .enablePositionalOptions()
```

## Impact

- **Affected versions**: v3.3.0, v3.3.1
- **Workaround**: Downgrade to v3.2.4 (`bun add -g oh-my-opencode@3.2.4`)
- **Risk**: Minimal — `enablePositionalOptions()` is the documented prerequisite for `passThroughOptions()` per [Commander.js docs](https://github.com/tj/commander.js#parsing-configuration)

## Testing

- Verified the fix resolves the crash locally
- Confirmed `oh-my-opencode --version` and `oh-my-opencode run` work correctly after the change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix startup crash on all platforms in v3.3.0 and v3.3.1 (fixes #1640). Added enablePositionalOptions() to the parent CLI command so the run subcommand can use passThroughOptions without error.

<sup>Written for commit 830044d290c514fe059313ce8b507d692206c0b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

