### PR TITLE
fix(mcp): use query param for Exa API key auth

### DIFF
--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -5,13 +5,14 @@
 Tier 1 of three-tier MCP system: 3 built-in remote HTTP MCPs.
 
 **Three-Tier System**:
+
 1. **Built-in** (this directory): websearch, context7, grep_app
 2. **Claude Code compat**: `.mcp.json` with `${VAR}` expansion
 3. **Skill-embedded**: YAML frontmatter in skills
 
 ## STRUCTURE
 
-```
+```text
 mcp/
 ├── index.ts        # createBuiltinMcps() factory
 ├── websearch.ts    # Exa AI / Tavily web search
@@ -33,7 +34,7 @@ mcp/
 
 | Provider | URL | Auth | API Key Required |
 |----------|-----|------|------------------|
-| exa (default) | mcp.exa.ai | x-api-key header | No (optional) |
+| exa (default) | mcp.exa.ai | exaApiKey URL param | No (optional) |
 | tavily | mcp.tavily.com | Authorization Bearer | Yes |
 
 ```jsonc

--- a/src/mcp/websearch.test.ts
+++ b/src/mcp/websearch.test.ts
@@ -37,7 +37,7 @@ describe("websearch MCP provider configuration", () => {
     expect(result.type).toBe("remote")
   })
 
-  test("includes x-api-key header when EXA_API_KEY is set", () => {
+  test("includes exaApiKey in URL when EXA_API_KEY is set", () => {
     //#given
     const apiKey = "test-exa-key-12345"
     process.env.EXA_API_KEY = apiKey
@@ -46,7 +46,8 @@ describe("websearch MCP provider configuration", () => {
     const result = createWebsearchConfig()
 
     //#then
-    expect(result.headers).toEqual({ "x-api-key": apiKey })
+    expect(result.url).toContain(`exaApiKey=${apiKey}`)
+    expect(result.url).toContain("mcp.exa.ai")
   })
 
   test("returns Tavily config when provider is 'tavily' and TAVILY_API_KEY set", () => {
@@ -85,7 +86,7 @@ describe("websearch MCP provider configuration", () => {
 
     //#then
     expect(result.url).toContain("mcp.exa.ai")
-    expect(result.headers).toEqual({ "x-api-key": "test-exa-key" })
+    expect(result.url).toContain("exaApiKey=test-exa-key")
   })
 
   test("Tavily config uses Authorization Bearer header format", () => {
@@ -102,7 +103,7 @@ describe("websearch MCP provider configuration", () => {
     expect(result.headers?.Authorization).toBe(`Bearer ${tavilyKey}`)
   })
 
-  test("Exa config has no headers when EXA_API_KEY not set", () => {
+  test("Exa config has no exaApiKey param when EXA_API_KEY not set", () => {
     //#given
     delete process.env.EXA_API_KEY
 
@@ -111,6 +112,6 @@ describe("websearch MCP provider configuration", () => {
 
     //#then
     expect(result.url).toContain("mcp.exa.ai")
-    expect(result.headers).toBeUndefined()
+    expect(result.url).not.toContain("exaApiKey=")
   })
 })

--- a/src/mcp/websearch.ts
+++ b/src/mcp/websearch.ts
@@ -29,13 +29,17 @@ export function createWebsearchConfig(config?: WebsearchConfig): RemoteMcpConfig
   }
 
   // Default to Exa
+  // API key passed as query parameter per official docs:
+  // https://exa.ai/docs/reference/exa-mcp#opencode
+  // https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_KEY
+  const baseUrl = "https://mcp.exa.ai/mcp?tools=web_search_exa"
+  const exaApiKey = process.env.EXA_API_KEY
+  const url = exaApiKey ? `${baseUrl}&exaApiKey=${exaApiKey}` : baseUrl
+
   return {
     type: "remote" as const,
-    url: "https://mcp.exa.ai/mcp?tools=web_search_exa",
+    url,
     enabled: true,
-    headers: process.env.EXA_API_KEY
-      ? { "x-api-key": process.env.EXA_API_KEY }
-      : undefined,
     oauth: false as const,
   }
 }


### PR DESCRIPTION
## Summary

- Update Exa MCP configuration to pass API key via exaApiKey URL parameter
- Remove deprecated x-api-key header implementation
- Align with official Exa MCP documentation

ref: https://exa.ai/docs/reference/exa-mcp#opencode

## Changes

changed to the suggested official workflow


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Exa MCP auth to the exaApiKey URL parameter to match current docs and prevent auth failures. Removed the deprecated x-api-key header; updated config, tests, and docs; Tavily is unchanged.

- **Bug Fixes**
  - Pass EXA_API_KEY as exaApiKey in the URL; omit when unset.
  - Remove x-api-key header from Exa websearch config.
  - Update AGENTS.md and tests to reflect the new auth flow.

<sup>Written for commit f819f938257ae1f8f241bfa9ae5c12815d378ea7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

