### PR TITLE
fix: add default value for load_skills parameter in task tool (#1493)

### DIFF
--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -74,7 +74,7 @@ Prompts MUST be in English.`
   return tool({
     description,
     args: {
-      load_skills: tool.schema.array(tool.schema.string()).describe("Skill names to inject. REQUIRED - pass [] if no skills needed, but IT IS HIGHLY RECOMMENDED to pass proper skills like [\"playwright\"], [\"git-master\"] for best results."),
+      load_skills: tool.schema.array(tool.schema.string()).default([]).describe("Skill names to inject. Pass [] if no skills needed, but IT IS HIGHLY RECOMMENDED to pass proper skills like [\"playwright\"], [\"git-master\"] for best results."),
       description: tool.schema.string().describe("Short task description (3-5 words)"),
       prompt: tool.schema.string().describe("Full detailed prompt for the agent"),
       run_in_background: tool.schema.boolean().describe("true=async (returns task_id), false=sync (waits). Default: false"),
@@ -97,7 +97,7 @@ Prompts MUST be in English.`
         throw new Error(`Invalid arguments: 'run_in_background' parameter is REQUIRED. Use run_in_background=false for task delegation, run_in_background=true only for parallel exploration.`)
       }
       if (args.load_skills === undefined) {
-        throw new Error(`Invalid arguments: 'load_skills' parameter is REQUIRED. Pass [] if no skills needed, but IT IS HIGHLY RECOMMENDED to pass proper skills like ["playwright"], ["git-master"] for best results.`)
+        args.load_skills = []
       }
       if (args.load_skills === null) {
         throw new Error(`Invalid arguments: load_skills=null is not allowed. Pass [] if no skills needed, but IT IS HIGHLY RECOMMENDED to pass proper skills.`)


### PR DESCRIPTION
## Summary

Fixes #1493 — agents frequently omit the `load_skills` parameter when calling `task()` / `delegate_task()`, causing a runtime error and requiring a retry.

## Changes

- **Schema default**: Added `.default([])` to the `load_skills` parameter schema in `tools.ts`, so the tool schema itself declares the default
- **Runtime fallback**: Changed the `undefined` check from throwing an error to silently defaulting to `[]` — matching the schema default as a safety net
- **Test updated**: Replaced the "throws when undefined" test with a "defaults to empty array" test that verifies the tool proceeds without error when `load_skills` is omitted

## Why

The `load_skills` parameter was required but LLMs consistently forget to pass it (especially when no skills are needed). The existing retry hook catches the error and the second attempt succeeds, but this wastes tokens and time. Defaulting to `[]` eliminates this friction entirely.

The `null` check is preserved since explicitly passing `null` is likely a different mistake worth catching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted load_skills to an empty array in the delegate task tool to avoid errors when agents omit it. This removes retries and makes task() and delegate_task() calls more reliable.

- **Bug Fixes**
  - Tool schema: load_skills now default([]).
  - Runtime: undefined load_skills becomes []; null still throws.
  - Tests updated to verify default behavior.

<sup>Written for commit f6fc30ada51bf13aa5c98377e20a28b46b2089e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

