### PR TITLE
fix(delegate-task): resolve user agent model config in subagent_type path (#1357)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -488,6 +488,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     disabledSkills,
     availableCategories,
     availableSkills,
+    agentOverrides: pluginConfig.agents,
     onSyncSessionCreated: async (event) => {
       log("[index] onSyncSessionCreated callback", {
         sessionID: event.sessionID,

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
-import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider } from "../../config/schema"
+import type { CategoriesConfig, GitMasterConfig, BrowserAutomationProvider, AgentOverrides } from "../../config/schema"
 import type {
   AvailableCategory,
   AvailableSkill,
@@ -53,6 +53,7 @@ export interface DelegateTaskToolOptions {
   disabledSkills?: Set<string>
   availableCategories?: AvailableCategory[]
   availableSkills?: AvailableSkill[]
+  agentOverrides?: AgentOverrides
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>
 }
 


### PR DESCRIPTION
## Summary
- When using `delegate_task(subagent_type="oracle")`, the user's configured model for that agent was ignored
- Now resolves agent model overrides from user config (e.g., `agents.oracle.model`) before falling back to hardcoded defaults
- Uses `resolveModelPipeline` with proper fallback chain support
- Fixes #1357

## Changes
- `src/tools/delegate-task/executor.ts`: Added agent override resolution in `resolveSubagentExecution()`
- `src/tools/delegate-task/types.ts`: Added `agentOverrides` to `ExecutorContext`
- `src/index.ts`: Pass `agentOverrides` to executor context
- `src/tools/delegate-task/tools.test.ts`: Added tests for model override behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes delegate_task(subagent_type=...) to respect user-configured agent models and variants, with proper fallback when none is set. Delegated sessions now run on the intended model. Fixes #1357.

- **Bug Fixes**
  - Resolve model from user config (agents.<name>.model) and apply variant; this takes priority over matchedAgent.model.
  - Use resolveModelPipeline with AGENT_MODEL_REQUIREMENTS to select a model via fallback chain when no override exists.
  - Pass agentOverrides through ExecutorContext from plugin config.
  - Add tests for override precedence, variant application, and fallback-chain resolution.

<sup>Written for commit a06364081b33417621538265359e8038bb3ab047. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

