### PR TITLE
feat: auto-recover from Anthropic assistant message prefill errors

### DIFF
--- a/src/hooks/session-recovery/index.test.ts
+++ b/src/hooks/session-recovery/index.test.ts
@@ -129,6 +129,63 @@ describe("detectErrorType", () => {
     })
   })
 
+  describe("assistant_prefill_unsupported errors", () => {
+    it("should detect assistant message prefill error from direct message", () => {
+      //#given an error about assistant message prefill not being supported
+      const error = {
+        message: "This model does not support assistant message prefill. The conversation must end with a user message.",
+      }
+
+      //#when detectErrorType is called
+      const result = detectErrorType(error)
+
+      //#then should return assistant_prefill_unsupported
+      expect(result).toBe("assistant_prefill_unsupported")
+    })
+
+    it("should detect assistant message prefill error from nested error object", () => {
+      //#given an Anthropic API error with nested structure matching the real error format
+      const error = {
+        error: {
+          type: "invalid_request_error",
+          message: "This model does not support assistant message prefill. The conversation must end with a user message.",
+        },
+      }
+
+      //#when detectErrorType is called
+      const result = detectErrorType(error)
+
+      //#then should return assistant_prefill_unsupported
+      expect(result).toBe("assistant_prefill_unsupported")
+    })
+
+    it("should detect error with only 'conversation must end with a user message' fragment", () => {
+      //#given an error containing only the user message requirement
+      const error = {
+        message: "The conversation must end with a user message.",
+      }
+
+      //#when detectErrorType is called
+      const result = detectErrorType(error)
+
+      //#then should return assistant_prefill_unsupported
+      expect(result).toBe("assistant_prefill_unsupported")
+    })
+
+    it("should detect error with only 'assistant message prefill' fragment", () => {
+      //#given an error containing only the prefill mention
+      const error = {
+        message: "This model does not support assistant message prefill.",
+      }
+
+      //#when detectErrorType is called
+      const result = detectErrorType(error)
+
+      //#then should return assistant_prefill_unsupported
+      expect(result).toBe("assistant_prefill_unsupported")
+    })
+  })
+
   describe("unrecognized errors", () => {
     it("should return null for unrecognized error patterns", () => {
       // given an unrelated error


### PR DESCRIPTION
## Summary

- Add auto-recovery for Anthropic `assistant message prefill` errors — when the model rejects a request with "This model does not support assistant message prefill. The conversation must end with a user message.", the plugin now detects this as a recoverable error and automatically sends "Continue" once to resume the conversation
- Extends the existing `session-recovery` hook with a new `assistant_prefill_unsupported` error type, leveraging the existing `session.error` → recovery → auto-continue flow in `index.ts`

## How It Works

1. **Error Detection**: `detectErrorType()` now matches `"assistant message prefill"` or `"conversation must end with a user message"` patterns
2. **Recovery**: On detection, the session is aborted and `handleSessionRecovery()` returns `success = true` (no message structure repair needed — just needs a user message)
3. **Auto-Continue**: The existing `session.error` handler in `index.ts` already sends `"continue"` after successful recovery — no duplicate logic added

## Changes

| File | Change |
|------|--------|
| `src/hooks/session-recovery/index.ts` | Add `assistant_prefill_unsupported` error type, detection logic, toast messages, and recovery branch |
| `src/hooks/session-recovery/index.test.ts` | 4 new test cases covering direct message, nested error object, and partial pattern matching |

## Test Plan

- ✅ 4 new tests for `detectErrorType()` — all pass
- ✅ 15 existing tests — all pass (no regressions)
- ✅ TypeScript compilation — clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-recovers when Anthropic rejects assistant message prefill by detecting the error and sending a single “Continue” to resume the chat. Adds a new assistant_prefill_unsupported type to the session-recovery hook to plug into the existing auto-continue flow.

- **New Features**
  - Detects errors with “assistant message prefill” or “conversation must end with a user message”.
  - Marks recovery as successful (no message repair) and lets the existing session.error handler auto-send “Continue”.
  - Adds “Prefill Error Recovery” toast and “Sending ‘Continue’ to recover...” status.
  - Adds 4 tests for detectErrorType (direct, nested, fragment matches); all existing tests still pass.

<sup>Written for commit 7abefcca1fa6ed23c899462d538328345b2c4a5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

