### PR TITLE
fix(delegate-task): default load_skills to empty array when omitted (#1493)

### DIFF
--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -849,78 +849,151 @@ describe("sisyphus-task", () => {
   })
 
   describe("skills parameter", () => {
-    test("skills parameter is required - throws error when not provided", async () => {
+    test("omitting load_skills defaults to empty array and proceeds without error", async () => {
       // given
       const { createDelegateTask } = require("./tools")
-      
-       const mockManager = { launch: async () => ({}) }
-       const mockClient = {
-         app: { agents: async () => ({ data: [] }) },
-         config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
-         session: {
-           create: async () => ({ data: { id: "test-session" } }),
-           prompt: async () => ({ data: {} }),
-           promptAsync: async () => ({ data: {} }),
-           messages: async () => ({ data: [] }),
-         },
-       }
-       
-       const tool = createDelegateTask({
-         manager: mockManager,
-         client: mockClient,
-       })
-       
-       const toolContext = {
-         sessionID: "parent-session",
-         messageID: "parent-message",
-         agent: "sisyphus",
-         abort: new AbortController().signal,
-       }
-       
-       // when - skills not provided (undefined)
-       // then - should throw error about missing skills
-       await expect(tool.execute(
-         {
-           description: "Test task",
-           prompt: "Do something",
-           category: "ultrabrain",
-           run_in_background: false,
-         },
-         toolContext
-       )).rejects.toThrow("IT IS HIGHLY RECOMMENDED")
-    })
+      let promptBody: any
 
-     test("null skills throws error", async () => {
+      const mockManager = { launch: async () => ({}) }
+
+      const promptMock = async (input: any) => {
+        promptBody = input.body
+        return { data: {} }
+      }
+
+      const mockClient = {
+        app: { agents: async () => ({ data: [] }) },
+        config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
+        session: {
+          get: async () => ({ data: { directory: "/project" } }),
+          create: async () => ({ data: { id: "ses_default_skills" } }),
+          prompt: promptMock,
+          promptAsync: promptMock,
+          messages: async () => ({
+            data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Done without skills" }] }]
+          }),
+          status: async () => ({ data: { "ses_default_skills": { type: "idle" } } }),
+        },
+      }
+
+      const tool = createDelegateTask({
+        manager: mockManager,
+        client: mockClient,
+      })
+
+      const toolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "sisyphus",
+        abort: new AbortController().signal,
+      }
+
+      // when - load_skills omitted entirely (simulating LLM forgetting the parameter)
+      const result = await tool.execute(
+        {
+          description: "Test task",
+          prompt: "Do something",
+          category: "ultrabrain",
+          run_in_background: false,
+        },
+        toolContext
+      )
+
+      // then - should proceed normally with default empty skills
+      expect(result).toContain("Done without skills")
+      expect(result).not.toContain("REQUIRED")
+    }, { timeout: 20000 })
+
+    test("providing load_skills explicitly still works", async () => {
+      // given
+      const { createDelegateTask } = require("./tools")
+
+      const mockManager = {
+        launch: async () => ({
+          id: "task-with-skills",
+          sessionID: "ses_with_skills",
+          description: "Task with skills",
+          agent: "sisyphus-junior",
+          status: "running",
+        }),
+      }
+
+      const mockClient = {
+        app: { agents: async () => ({ data: [] }) },
+        config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
+        session: {
+          create: async () => ({ data: { id: "test-session" } }),
+          prompt: async () => ({ data: {} }),
+          promptAsync: async () => ({ data: {} }),
+          messages: async () => ({ data: [] }),
+        },
+      }
+
+      const tool = createDelegateTask({
+        manager: mockManager,
+        client: mockClient,
+      })
+
+      const toolContext = {
+        sessionID: "parent-session",
+        messageID: "parent-message",
+        agent: "sisyphus",
+        abort: new AbortController().signal,
+      }
+
+      // when - load_skills explicitly provided
+      const result = await tool.execute(
+        {
+          description: "Task with explicit skills",
+          prompt: "Do something",
+          category: "quick",
+          run_in_background: true,
+          load_skills: ["git-master"],
+        },
+        toolContext
+      )
+
+      // then - should proceed without error
+      expect(result).not.toContain("REQUIRED")
+      expect(result).not.toContain("Invalid arguments")
+    }, { timeout: 10000 })
+
+     test("null load_skills defaults to empty array instead of throwing", async () => {
        // given
        const { createDelegateTask } = require("./tools")
-       
+
+       const promptMock = async (input: any) => ({ data: {} })
+
        const mockManager = { launch: async () => ({}) }
        const mockClient = {
          app: { agents: async () => ({ data: [] }) },
          config: { get: async () => ({ data: { model: SYSTEM_DEFAULT_MODEL } }) },
          session: {
-           create: async () => ({ data: { id: "test-session" } }),
-           prompt: async () => ({ data: {} }),
-           promptAsync: async () => ({ data: {} }),
-           messages: async () => ({ data: [] }),
+           get: async () => ({ data: { directory: "/project" } }),
+           create: async () => ({ data: { id: "ses_null_skills" } }),
+           prompt: promptMock,
+           promptAsync: promptMock,
+           messages: async () => ({
+             data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Done with null skills" }] }]
+           }),
+           status: async () => ({ data: { "ses_null_skills": { type: "idle" } } }),
          },
        }
-       
+
        const tool = createDelegateTask({
          manager: mockManager,
          client: mockClient,
        })
-       
+
        const toolContext = {
          sessionID: "parent-session",
          messageID: "parent-message",
          agent: "sisyphus",
          abort: new AbortController().signal,
        }
-       
-       // when - null passed
-       // then - should throw error about null
-       await expect(tool.execute(
+
+       // when - null passed (LLM sometimes sends null instead of [])
+       const result = await tool.execute(
          {
            description: "Test task",
            prompt: "Do something",
@@ -929,8 +1002,12 @@ describe("sisyphus-task", () => {
            load_skills: null,
          },
          toolContext
-       )).rejects.toThrow("IT IS HIGHLY RECOMMENDED")
-    })
+       )
+
+       // then - should default to [] and proceed
+       expect(result).toContain("Done with null skills")
+       expect(result).not.toContain("REQUIRED")
+    }, { timeout: 20000 })
 
      test("empty array [] is allowed and proceeds without skill content", async () => {
        // given

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -74,7 +74,7 @@ Prompts MUST be in English.`
   return tool({
     description,
     args: {
-      load_skills: tool.schema.array(tool.schema.string()).describe("Skill names to inject. REQUIRED - pass [] if no skills needed, but IT IS HIGHLY RECOMMENDED to pass proper skills like [\"playwright\"], [\"git-master\"] for best results."),
+      load_skills: tool.schema.array(tool.schema.string()).default([]).describe("Skill names to inject. Pass [] if no skills needed, but IT IS HIGHLY RECOMMENDED to pass proper skills like [\"playwright\"], [\"git-master\"] for best results."),
       description: tool.schema.string().describe("Short task description (3-5 words)"),
       prompt: tool.schema.string().describe("Full detailed prompt for the agent"),
       run_in_background: tool.schema.boolean().describe("true=async (returns task_id), false=sync (waits). Default: false"),
@@ -97,10 +97,10 @@ Prompts MUST be in English.`
         throw new Error(`Invalid arguments: 'run_in_background' parameter is REQUIRED. Use run_in_background=false for task delegation, run_in_background=true only for parallel exploration.`)
       }
       if (args.load_skills === undefined) {
-        throw new Error(`Invalid arguments: 'load_skills' parameter is REQUIRED. Pass [] if no skills needed, but IT IS HIGHLY RECOMMENDED to pass proper skills like ["playwright"], ["git-master"] for best results.`)
+        args.load_skills = []
       }
       if (args.load_skills === null) {
-        throw new Error(`Invalid arguments: load_skills=null is not allowed. Pass [] if no skills needed, but IT IS HIGHLY RECOMMENDED to pass proper skills.`)
+        args.load_skills = []
       }
 
       const runInBackground = args.run_in_background === true


### PR DESCRIPTION
## Summary

Closes #1493

- **Default `load_skills` to `[]`** when agents omit the parameter, eliminating the retry loop that wasted tokens and time
- Both `undefined` and `null` values now silently default to `[]` instead of throwing errors
- Added `.default([])` to the Zod schema so the parameter is optional at the schema level

## Changes

### `src/tools/delegate-task/tools.ts`
- Added `.default([])` to the `load_skills` Zod schema definition
- Removed "REQUIRED" from the parameter description
- Changed `undefined` check from throwing an error to defaulting to `[]`
- Changed `null` check from throwing an error to defaulting to `[]`

### `src/tools/delegate-task/tools.test.ts`
- Updated existing test: `"omitting load_skills defaults to empty array"` — verifies delegation succeeds when `load_skills` is omitted
- Updated existing test: `"null load_skills defaults to empty array"` — verifies `null` is handled gracefully
- Added test: `"providing load_skills explicitly still works"` — verifies explicit skills still pass through correctly

## Testing

```
bun test src/tools/delegate-task/tools.test.ts
# 94 pass, 0 fail
bun run typecheck  # clean
bun run build      # clean
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default load_skills to [] when omitted or null to prevent delegate-task errors and retry loops. The parameter is now optional in the schema; explicit skills continue to work.

- **Bug Fixes**
  - Zod schema: load_skills now default([]); description no longer marks it required.
  - Runtime: undefined/null load_skills coerced to [] instead of throwing.
  - Tests updated: omit/null defaults pass; explicit skills still pass through.

<sup>Written for commit 44c47d5123be13361a87507c13b3cac03797ea1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

