### PR TITLE
fix: include custom agents in orchestrator available agent list (#1623)

### DIFF
--- a/src/agents/dynamic-agent-prompt-builder.ts
+++ b/src/agents/dynamic-agent-prompt-builder.ts
@@ -1,8 +1,8 @@
-import type { AgentPromptMetadata, BuiltinAgentName } from "./types"
+import type { AgentPromptMetadata } from "./types"
 import { truncateDescription } from "../shared/truncate-description"
 
 export interface AvailableAgent {
-  name: BuiltinAgentName
+  name: string
   description: string
   metadata: AgentPromptMetadata
 }

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -225,6 +225,45 @@ function mapScopeToLocation(scope: SkillScope): AvailableSkill["location"] {
   return "plugin"
 }
 
+const CUSTOM_AGENT_PROMPT_METADATA: AgentPromptMetadata = {
+  category: "specialist",
+  cost: "CHEAP",
+  triggers: [],
+}
+
+function normalizeAgentName(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+function toCustomAvailableAgents(
+  customAgentConfigs: Record<string, AgentConfig>,
+  existingAgents: AvailableAgent[],
+  disabledAgents: string[]
+): AvailableAgent[] {
+  const disabled = new Set(disabledAgents.map(normalizeAgentName))
+  const seen = new Set(existingAgents.map((a) => normalizeAgentName(a.name)))
+  const result: AvailableAgent[] = []
+
+  for (const [name, config] of Object.entries(customAgentConfigs)) {
+    const normalizedName = normalizeAgentName(name)
+    if (!normalizedName) continue
+    if (disabled.has(normalizedName)) continue
+    if (seen.has(normalizedName)) continue
+
+    const configRecord = config as Record<string, unknown>
+    if (configRecord.hidden === true) continue
+
+    result.push({
+      name,
+      description: config.description ?? "",
+      metadata: CUSTOM_AGENT_PROMPT_METADATA,
+    })
+    seen.add(normalizedName)
+  }
+
+  return result
+}
+
 export async function createBuiltinAgents(
   disabledAgents: string[] = [],
   agentOverrides: AgentOverrides = {},
@@ -236,7 +275,8 @@ export async function createBuiltinAgents(
   client?: any,
   browserProvider?: BrowserAutomationProvider,
   uiSelectedModel?: string,
-  disabledSkills?: Set<string>
+  disabledSkills?: Set<string>,
+  customAgentConfigsForPrompt: Record<string, AgentConfig> = {}
 ): Promise<Record<string, AgentConfig>> {
   const connectedProviders = readConnectedProvidersCache()
   // IMPORTANT: Do NOT pass client to fetchAvailableModels during plugin initialization.
@@ -343,9 +383,14 @@ export async function createBuiltinAgents(
         metadata,
       })
     }
+   }
+
+  if (Object.keys(customAgentConfigsForPrompt).length > 0) {
+    const customAvailableAgents = toCustomAvailableAgents(customAgentConfigsForPrompt, availableAgents, disabledAgents)
+    availableAgents.push(...customAvailableAgents)
   }
 
-   const sisyphusOverride = agentOverrides["sisyphus"]
+    const sisyphusOverride = agentOverrides["sisyphus"]
    const sisyphusRequirement = AGENT_MODEL_REQUIREMENTS["sisyphus"]
    const hasSisyphusExplicitConfig = sisyphusOverride !== undefined
    const meetsSisyphusAnyModelRequirement =

--- a/src/features/claude-code-mcp-loader/loader.test.ts
+++ b/src/features/claude-code-mcp-loader/loader.test.ts
@@ -5,9 +5,24 @@ import { tmpdir } from "os"
 
 const TEST_DIR = join(tmpdir(), "mcp-loader-test-" + Date.now())
 
+async function importLoader() {
+  // Avoid cross-file module cache pollution (other tests may import ./loader first).
+  return import(`./loader?test=${Date.now()}-${Math.random()}`)
+}
+
 describe("getSystemMcpServerNames", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true })
+
+    // Force user-level MCP paths into TEST_DIR so local machine state
+    // (~/.claude.json, ~/.claude/.mcp.json) can't affect these tests.
+    mock.module("os", () => ({
+      homedir: () => TEST_DIR,
+      tmpdir,
+    }))
+    mock.module("../../shared", () => ({
+      getClaudeConfigDir: () => join(TEST_DIR, ".claude"),
+    }))
   })
 
   afterEach(() => {
@@ -21,7 +36,7 @@ describe("getSystemMcpServerNames", () => {
 
     try {
       // when
-      const { getSystemMcpServerNames } = await import("./loader")
+      const { getSystemMcpServerNames } = await importLoader()
       const names = getSystemMcpServerNames()
 
       // then
@@ -53,7 +68,7 @@ describe("getSystemMcpServerNames", () => {
 
     try {
       // when
-      const { getSystemMcpServerNames } = await import("./loader")
+      const { getSystemMcpServerNames } = await importLoader()
       const names = getSystemMcpServerNames()
 
       // then
@@ -83,7 +98,7 @@ describe("getSystemMcpServerNames", () => {
 
     try {
       // when
-      const { getSystemMcpServerNames } = await import("./loader")
+      const { getSystemMcpServerNames } = await importLoader()
       const names = getSystemMcpServerNames()
 
       // then
@@ -115,7 +130,7 @@ describe("getSystemMcpServerNames", () => {
 
     try {
       // when
-      const { getSystemMcpServerNames } = await import("./loader")
+      const { getSystemMcpServerNames } = await importLoader()
       const names = getSystemMcpServerNames()
 
       // then
@@ -149,8 +164,8 @@ describe("getSystemMcpServerNames", () => {
 
      try {
        // when
-       const { getSystemMcpServerNames } = await import("./loader")
-       const names = getSystemMcpServerNames()
+        const { getSystemMcpServerNames } = await importLoader()
+        const names = getSystemMcpServerNames()
 
        // then
        expect(names.has("playwright")).toBe(true)
@@ -183,7 +198,7 @@ describe("getSystemMcpServerNames", () => {
 
         writeFileSync(userConfigPath, JSON.stringify(userMcpConfig))
 
-        const { getSystemMcpServerNames } = await import("./loader")
+        const { getSystemMcpServerNames } = await importLoader()
         const names = getSystemMcpServerNames()
 
         expect(names.has("user-server")).toBe(true)
@@ -235,7 +250,7 @@ describe("getSystemMcpServerNames", () => {
           getClaudeConfigDir: () => claudeDir,
         }))
 
-        const { getSystemMcpServerNames } = await import("./loader")
+        const { getSystemMcpServerNames } = await importLoader()
         const names = getSystemMcpServerNames()
 
         // Both sources should be merged

--- a/src/hooks/unstable-agent-babysitter/index.test.ts
+++ b/src/hooks/unstable-agent-babysitter/index.test.ts
@@ -21,6 +21,9 @@ function createMockPluginInput(options: {
         prompt: async (input: unknown) => {
           promptCalls.push({ input })
         },
+        promptAsync: async (input: unknown) => {
+          promptCalls.push({ input })
+        },
       },
     },
   }

--- a/src/plugin-handlers/config-handler.custom-agents.test.ts
+++ b/src/plugin-handlers/config-handler.custom-agents.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { createConfigHandler } from "./config-handler"
+import type { OhMyOpenCodeConfig } from "../config"
+
+import * as commandLoader from "../features/claude-code-command-loader"
+import * as builtinCommands from "../features/builtin-commands"
+import * as skillLoader from "../features/opencode-skill-loader"
+import * as agentLoader from "../features/claude-code-agent-loader"
+import * as mcpLoader from "../features/claude-code-mcp-loader"
+import * as pluginLoader from "../features/claude-code-plugin-loader"
+import * as mcpModule from "../mcp"
+import * as shared from "../shared"
+import * as configDir from "../shared/opencode-config-dir"
+import * as permissionCompat from "../shared/permission-compat"
+
+const TEST_DEFAULT_MODEL = "anthropic/claude-opus-4-6"
+
+describe("Issue #1623: custom agents visible to orchestrators", () => {
+  test("injects .opencode/agents into Sisyphus prompt available agent list", async () => {
+    // #given
+    spyOn(commandLoader, "loadUserCommands" as any).mockResolvedValue({})
+    spyOn(commandLoader, "loadProjectCommands" as any).mockResolvedValue({})
+    spyOn(commandLoader, "loadOpencodeGlobalCommands" as any).mockResolvedValue({})
+    spyOn(commandLoader, "loadOpencodeProjectCommands" as any).mockResolvedValue({})
+
+    spyOn(builtinCommands, "loadBuiltinCommands" as any).mockReturnValue({})
+
+    spyOn(skillLoader, "loadUserSkills" as any).mockResolvedValue({})
+    spyOn(skillLoader, "loadProjectSkills" as any).mockResolvedValue({})
+    spyOn(skillLoader, "loadOpencodeGlobalSkills" as any).mockResolvedValue({})
+    spyOn(skillLoader, "loadOpencodeProjectSkills" as any).mockResolvedValue({})
+    spyOn(skillLoader, "discoverUserClaudeSkills" as any).mockResolvedValue([])
+    spyOn(skillLoader, "discoverProjectClaudeSkills" as any).mockResolvedValue([])
+    spyOn(skillLoader, "discoverOpencodeGlobalSkills" as any).mockResolvedValue([])
+    spyOn(skillLoader, "discoverOpencodeProjectSkills" as any).mockResolvedValue([])
+
+    spyOn(agentLoader, "loadUserAgents" as any).mockReturnValue({})
+    spyOn(agentLoader, "loadProjectAgents" as any).mockReturnValue({})
+
+    spyOn(mcpLoader, "loadMcpConfigs" as any).mockResolvedValue({ servers: {} })
+    spyOn(mcpModule, "createBuiltinMcps" as any).mockReturnValue({})
+
+    spyOn(pluginLoader, "loadAllPluginComponents" as any).mockResolvedValue({
+      commands: {},
+      skills: {},
+      agents: {},
+      mcpServers: {},
+      hooksConfigs: [],
+      plugins: [],
+      errors: [],
+    })
+
+    spyOn(shared, "log" as any).mockImplementation(() => {})
+    spyOn(shared, "readConnectedProvidersCache" as any).mockReturnValue(null)
+    spyOn(shared, "fetchAvailableModels" as any).mockResolvedValue(
+      new Set([TEST_DEFAULT_MODEL, "openai/gpt-5.2", "anthropic/claude-sonnet-4-5"])
+    )
+
+    spyOn(configDir, "getOpenCodeConfigPaths" as any).mockReturnValue({
+      global: "/tmp/.config/opencode",
+      project: "/tmp/.opencode",
+    })
+
+    spyOn(permissionCompat, "migrateAgentConfig" as any).mockImplementation((config: Record<string, unknown>) => config)
+
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const config: Record<string, unknown> = {
+      model: TEST_DEFAULT_MODEL,
+      agent: {
+        researcher: {
+          name: "researcher",
+          mode: "subagent",
+          description: "Research agent for deep analysis",
+          prompt: "You are a research agent...",
+        },
+      },
+    }
+
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler(config)
+
+    // #then
+    const agents = config.agent as Record<string, { prompt?: string }>
+    expect(agents.sisyphus?.prompt).toBeDefined()
+    expect(agents.sisyphus?.prompt).toContain("`researcher`")
+  })
+})

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -25,6 +25,7 @@ import { loadMcpConfigs } from "../features/claude-code-mcp-loader";
 import { loadAllPluginComponents } from "../features/claude-code-plugin-loader";
 import { createBuiltinMcps } from "../mcp";
 import type { OhMyOpenCodeConfig } from "../config";
+import type { AgentConfig as OpenCodeAgentConfig } from "@opencode-ai/sdk";
 import { log, fetchAvailableModels, readConnectedProvidersCache, resolveModelPipeline, addConfigLoadError } from "../shared";
 import { getOpenCodeConfigPaths } from "../shared/opencode-config-dir";
 import { migrateAgentConfig } from "../shared/permission-compat";
@@ -49,6 +50,10 @@ export function resolveCategoryConfig(
 }
 
 const CORE_AGENT_ORDER = ["sisyphus", "hephaestus", "prometheus", "atlas"] as const;
+
+function isOpenCodeAgentConfig(value: unknown): value is OpenCodeAgentConfig {
+  return typeof value === "object" && value !== null
+}
 
 function reorderAgentsByPriority(agents: Record<string, unknown>): Record<string, unknown> {
   const ordered: Record<string, unknown> = {};
@@ -154,7 +159,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     }
 
     // Migrate disabled_agents from old names to new names
-    const migratedDisabledAgents = (pluginConfig.disabled_agents ?? []).map(agent => {
+    const migratedDisabledAgents = (pluginConfig.disabled_agents ?? []).map((agent: string) => {
       return AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent
     }) as typeof pluginConfig.disabled_agents
 
@@ -178,24 +183,8 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       ...discoveredUserSkills,
     ];
 
-    const browserProvider = pluginConfig.browser_automation_engine?.provider ?? "playwright";
-    // config.model represents the currently active model in OpenCode (including UI selection)
-    // Pass it as uiSelectedModel so it takes highest priority in model resolution
-    const currentModel = config.model as string | undefined;
-    const disabledSkills = new Set<string>(pluginConfig.disabled_skills ?? []);
-    const builtinAgents = await createBuiltinAgents(
-      migratedDisabledAgents,
-      pluginConfig.agents,
-      ctx.directory,
-      undefined, // systemDefaultModel - let fallback chain handle this
-      pluginConfig.categories,
-      pluginConfig.git_master,
-      allDiscoveredSkills,
-      ctx.client,
-      browserProvider,
-      currentModel, // uiSelectedModel - takes highest priority
-      disabledSkills
-    );
+    // Read OpenCode agent config BEFORE oh-my-opencode mutates config.agent
+    const existingAgentConfigs = (config.agent as Record<string, unknown> | undefined) ?? {}
 
     // Claude Code agents: Do NOT apply permission migration
     // Claude Code uses whitelist-based tools format which is semantically different
@@ -214,6 +203,48 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
         k,
         v ? migrateAgentConfig(v as Record<string, unknown>) : v,
       ])
+    );
+
+    const customAgentConfigsForPrompt: Record<string, OpenCodeAgentConfig> = {};
+    for (const [name, value] of Object.entries(existingAgentConfigs)) {
+      if (isOpenCodeAgentConfig(value)) {
+        customAgentConfigsForPrompt[name] = value
+      }
+    }
+    for (const [name, value] of Object.entries(userAgents)) {
+      if (isOpenCodeAgentConfig(value)) {
+        customAgentConfigsForPrompt[name] = value
+      }
+    }
+    for (const [name, value] of Object.entries(projectAgents)) {
+      if (isOpenCodeAgentConfig(value)) {
+        customAgentConfigsForPrompt[name] = value
+      }
+    }
+    for (const [name, value] of Object.entries(pluginAgents)) {
+      if (isOpenCodeAgentConfig(value)) {
+        customAgentConfigsForPrompt[name] = value
+      }
+    }
+
+    const browserProvider = pluginConfig.browser_automation_engine?.provider ?? "playwright";
+    // config.model represents the currently active model in OpenCode (including UI selection)
+    // Pass it as uiSelectedModel so it takes highest priority in model resolution
+    const currentModel = config.model as string | undefined;
+    const disabledSkills = new Set<string>(pluginConfig.disabled_skills ?? []);
+    const builtinAgents = await createBuiltinAgents(
+      migratedDisabledAgents,
+      pluginConfig.agents,
+      ctx.directory,
+      undefined, // systemDefaultModel - let fallback chain handle this
+      pluginConfig.categories,
+      pluginConfig.git_master,
+      allDiscoveredSkills,
+      ctx.client,
+      browserProvider,
+      currentModel, // uiSelectedModel - takes highest priority
+      disabledSkills,
+      customAgentConfigsForPrompt
     );
 
     const isSisyphusEnabled = pluginConfig.sisyphus_agent?.disabled !== true;


### PR DESCRIPTION
## Background
Custom agents loaded from `.opencode/agents/` (and other custom sources) were registered and callable via `@agent_name`, but orchestrator agents (Sisyphus/Atlas/Hephaestus) could not see them because their prompts were built from a hardcoded internal agent list only.

## Changes
- Extend the orchestrator prompt “available agents” list to include dynamically registered agents from OpenCode config + Claude Code agent loaders.
- Update `AvailableAgent` typing to allow custom agent names.
- Add regression test for issue #1623.

## Testing
1. `bun test`
2. `bun run build`

## Notes
Two test fixes were included to keep the suite deterministic on machines that have real user MCP config and to align mocks with `promptAsync` usage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes orchestrators not seeing custom agents by adding dynamically registered agents to their available list. Orchestrator prompts now include agents from .opencode/agents and plugin loaders. Addresses #1623.

- **Bug Fixes**
  - Include custom agents in orchestrator “available agents” by aggregating from OpenCode config and Claude Code loaders; respect disabled/hidden flags and dedupe.
  - Update AvailableAgent typing (name: string) to allow custom names.
  - Config handler collects custom agents and passes them into createBuiltinAgents for prompt building.
  - Tests: add regression for #1623; isolate MCP loader tests from local machine state; add promptAsync mock to babysitter tests.

<sup>Written for commit 5f68b3f5234f67fe373b6c415a24e44797b07c08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

