### PR TITLE
feat(agents): add devils-advocate adversarial validation agent

### DIFF
--- a/.claude/agents/devils-advocate.md
+++ b/.claude/agents/devils-advocate.md
@@ -1,0 +1,72 @@
+---
+description: "Adversarial validator that stress-tests ideas, plans, and proposals through structured critical analysis"
+tools: "read,grep,glob,lsp_diagnostics,lsp_find_references,lsp_goto_definition,webfetch"
+---
+
+<Role>
+You are "Devil's Advocate" — a relentlessly skeptical critic who stress-tests ideas, plans, and assumptions.
+You exist to find what will break, not to encourage.
+</Role>
+
+<Behavior_Instructions>
+
+## Phase 0 — Input Classification (EVERY request)
+
+Classify the input FIRST, then adjust your analysis focus:
+
+| Type | Signal | Analysis Focus |
+|------|--------|----------------|
+| Idea Pitch | "What if we...", "I want to build..." | Feasibility destruction |
+| Technical Plan | "Here's my approach..." | Implementation risk analysis |
+| Feature Proposal | "Let's add X..." | User friction + edge case analysis |
+| Architecture Decision | "Should we use X or Y?" | Trade-off stress testing |
+| Assumption Check | "Is this assumption valid?" | Logical consistency audit |
+
+## Phase 1 — Systematic Deconstruction (MANDATORY — ALL 5 lenses)
+
+Apply every lens. No shortcuts.
+
+| Lens | What to Find | Output |
+|------|-------------|--------|
+| Logical Inconsistency | Contradictions in reasoning | Contradictions with evidence |
+| Resource Realism | Underestimated time/effort | Reality check with estimates |
+| Market/Social Friction | Why people resist | Friction points ranked |
+| Edge Cases | "What if?" failures | Scenarios where plan fails |
+| Codebase Evidence | What code actually shows | File refs supporting/contradicting |
+
+## Phase 2 — Structured Output (MANDATORY format)
+
+### THE FATAL FLAW
+[Single biggest reason this fails. One paragraph.]
+
+### HIDDEN ASSUMPTIONS
+| # | Assumption | Why It's Unproven | What Breaks If Wrong |
+|---|-----------|-------------------|---------------------|
+[3-7 rows]
+
+### THE ADVERSARY VIEW
+[How a critic or hostile user would dismantle this.]
+
+### STRESS-TEST QUESTIONS
+1. [Uncomfortable question]
+2. [Uncomfortable question]
+3. [Uncomfortable question]
+
+### SEVERITY RATING
+CRITICAL / RISKY / VIABLE
+[One sentence justification]
+
+</Behavior_Instructions>
+
+<Constraints>
+
+## Hard Blocks (NEVER violate)
+
+| Constraint | No Exceptions |
+|-----------|---------------|
+| Praise or validate | Never |
+| Offer solutions/alternatives | Never |
+| Skip any lens/section | Never |
+| Write code or make edits | Never |
+
+</Constraints>

--- a/bun-test.d.ts
+++ b/bun-test.d.ts
@@ -1,0 +1,43 @@
+declare module "bun:test" {
+  export interface Expectation {
+    not: Expectation
+    rejects: {
+      toThrow(message?: string | RegExp): Promise<void>
+    }
+
+    toBe(expected: unknown): void
+    toEqual(expected: unknown): void
+    toContain(expected: string): void
+    toMatch(expected: RegExp): void
+    toBeInstanceOf(expected: unknown): void
+    toBeDefined(): void
+    toBeUndefined(): void
+    toBeGreaterThan(expected: number): void
+    toBeGreaterThanOrEqual(expected: number): void
+    toBeLessThan(expected: number): void
+    toBeLessThanOrEqual(expected: number): void
+  }
+
+  export function expect(value: unknown): Expectation
+
+  export function describe(name: string, fn: () => void): void
+  export function it(name: string, fn: () => void | Promise<void>): void
+  export function test(name: string, fn: () => void | Promise<void>): void
+  export function beforeEach(fn: () => void | Promise<void>): void
+  export function afterEach(fn: () => void | Promise<void>): void
+
+  export interface Spy {
+    mockResolvedValue(value: unknown): Spy
+    mockReturnValue(value: unknown): Spy
+    mockImplementation(fn: (...args: unknown[]) => unknown): Spy
+  }
+
+  export function spyOn<TObject extends object, TKey extends keyof TObject>(
+    object: TObject,
+    key: TKey
+  ): Spy
+
+  export const mock: {
+    module: (moduleName: string, factory: () => Record<string, unknown>) => void
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.3.0",
-        "oh-my-opencode-darwin-x64": "3.3.0",
-        "oh-my-opencode-linux-arm64": "3.3.0",
-        "oh-my-opencode-linux-arm64-musl": "3.3.0",
-        "oh-my-opencode-linux-x64": "3.3.0",
-        "oh-my-opencode-linux-x64-musl": "3.3.0",
-        "oh-my-opencode-windows-x64": "3.3.0",
+        "oh-my-opencode-darwin-arm64": "3.3.1",
+        "oh-my-opencode-darwin-x64": "3.3.1",
+        "oh-my-opencode-linux-arm64": "3.3.1",
+        "oh-my-opencode-linux-arm64-musl": "3.3.1",
+        "oh-my-opencode-linux-x64": "3.3.1",
+        "oh-my-opencode-linux-x64-musl": "3.3.1",
+        "oh-my-opencode-windows-x64": "3.3.1",
       },
     },
   },
@@ -226,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.3.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-P2kZKJqZaA4j0qtGM3I8+ZeH204ai27ni/OXLjtFdOewRjJgrahxaC1XslgK7q/KU9fXz6BQfEqAjbvyPf/rgQ=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.3.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-R+o42Km6bsIaW6D3I8uu2HCF3BjIWqa/fg38W5y4hJEOw4mL0Q7uV4R+0vtrXRHo9crXTK9ag0fqVQUm+Y6iAQ=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.3.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-RopOorbW1WyhMQJ+ipuqiOA1GICS+3IkOwNyEe0KZlCLpoEDTyFopIL87HSns+gEQPMxnknroDp8lzxn1AKgjw=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7VTbpR1vH3OEkoJxBKtYuxFPX8M3IbJKoeHWME9iK6FpT11W1ASsjyuhvzB1jcxSeqF8ddMnjitlG5ub6h5EVw=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.3.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-297iEfuK+05g+q64crPW78Zbgm/j5PGjDDweSPkZ6rI6SEfHMvOIkGxMvN8gugM3zcH8FOCQXoY2nC8b6x3pwQ=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-BZ/r/CFlvbOxkdZZrRoT16xFOjibRZHuwQnaE4f0JvOzgK6/HWp3zJI1+2/aX/oK5GA6lZxNWRrJC/SKUi8LEg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.3.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-oVxP0+yn66HQYfrl9QT6I7TumRzciuPB4z24+PwKEVcDjPbWXQqLY1gwOGHZAQBPLf0vwewv9ybEDVD42RRH4g=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-U90Wruf21h+CJbtcrS7MeTAc/5VOF6RI+5jr7qj/cCxjXNJtjhyJdz/maehArjtgf304+lYCM/Mh1i+G2D3YFQ=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.3.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-k9LoLkisLJwJNR1J0Bh1bjGtGBkl5D9WzFPSdZCAlyiT6TgG9w5erPTlXqtl2Lt0We5tYUVYlkEIHRMK/ugNsQ=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-sYzohSNdwsAhivbXcbhPdF1qqQi2CCI7FSgbmvvfBOMyZ8HAgqOFqYW2r3GPdmtywzkjOTvCzTG56FZwEjx15w=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.3.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7asXCeae7wBxJrzoZ7J6Yo1oaOxwUN3bTO7jWurCTMs5TDHO+pEHysgv/nuF1jvj1T+r1vg1H5ZmopuKy1qvXg=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-aG5pZ4eWS0YSGUicOnjMkUPrIqQV4poYF+d9SIvrfvlaMcK6WlQn7jXzgNCwJsfGn5lyhSmjshZBEU+v79Ua3w=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.3.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-ABvwfaXb2xdrpbivzlPPJzIm5vXp+QlVakkaHEQf3TU6Mi/+fehH6Qhq/KMh66FDO2gq3xmxbH7nktHRQp9kNA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-FGH7cnzBqNwjSkzCDglMsVttaq+MsykAxa7ehaFK+0dnBZArvllS3W13a3dGaANHMZzfK0vz8hNDUdVi7Z63cA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -2,13 +2,13 @@
 
 ## OVERVIEW
 
-11 AI agents for multi-model orchestration. Each agent has factory function + metadata + fallback chains.
+12 AI agents for multi-model orchestration. Each agent has factory function + metadata + fallback chains.
 
 **Primary Agents** (respect UI model selection):
 - Sisyphus, Atlas, Prometheus
 
 **Subagents** (use own fallback chains):
-- Hephaestus, Oracle, Librarian, Explore, Multimodal-Looker, Metis, Momus, Sisyphus-Junior
+- Hephaestus, Oracle, Librarian, Explore, Multimodal-Looker, Metis, Momus, Devil's Advocate, Sisyphus-Junior
 
 ## STRUCTURE
 ```
@@ -36,9 +36,10 @@ agents/
 ├── librarian.ts                # Multi-repo research (328 lines)
 ├── explore.ts                  # Fast contextual grep
 ├── multimodal-looker.ts        # Media analyzer (Gemini 3 Flash)
-├── metis.ts                    # Pre-planning analysis (347 lines)
-├── momus.ts                    # Plan reviewer
-├── dynamic-agent-prompt-builder.ts  # Dynamic prompt generation (431 lines)
+ ├── metis.ts                    # Pre-planning analysis (347 lines)
+ ├── momus.ts                    # Plan reviewer
+ ├── devils-advocate.ts           # Adversarial validator
+ ├── dynamic-agent-prompt-builder.ts  # Dynamic prompt generation (431 lines)
 ├── types.ts                    # AgentModelConfig, AgentPromptMetadata
 ├── utils.ts                    # createBuiltinAgents(), resolveModelWithFallback() (485 lines)
 └── index.ts                    # builtinAgents export
@@ -57,6 +58,7 @@ agents/
 | Prometheus | anthropic/claude-opus-4-6 | 0.1 | Strategic planning (fallback: kimi-k2.5 → gpt-5.2) |
 | Metis | anthropic/claude-opus-4-6 | 0.3 | Pre-planning analysis (fallback: kimi-k2.5 → gpt-5.2) |
 | Momus | openai/gpt-5.2 | 0.1 | Plan validation (fallback: claude-opus-4-6) |
+| Devil's Advocate | google/gemini-3-pro | 0.1 | Adversarial validation (fallback: gpt-5.2, claude-sonnet-4-5) |
 | Sisyphus-Junior | anthropic/claude-sonnet-4-5 | 0.1 | Category-spawned executor |
 
 ## HOW TO ADD
@@ -72,6 +74,7 @@ agents/
 | librarian | write, edit, task, task, call_omo_agent |
 | explore | write, edit, task, task, call_omo_agent |
 | multimodal-looker | Allowlist: read only |
+| Devil's Advocate | write, edit, task, background_task, call_omo_agent |
 | Sisyphus-Junior | task, task |
 | Atlas | task, call_omo_agent |
 

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -68,13 +68,13 @@ agents/
 4. Register in `src/index.ts` initialization.
 
 ## TOOL RESTRICTIONS
-| Agent | Denied Tools |
-|-------|-------------|
+| Agent | Tool Restrictions |
+|-------|-------------------|
 | oracle | write, edit, task, task |
 | librarian | write, edit, task, task, call_omo_agent |
 | explore | write, edit, task, task, call_omo_agent |
 | multimodal-looker | Allowlist: read only |
-| Devil's Advocate | write, edit, task, background_task, call_omo_agent |
+| Devil's Advocate | Allowlist: read, grep, glob, lsp_diagnostics, lsp_symbols, lsp_find_references, lsp_goto_definition, webfetch, ast_grep_search |
 | Sisyphus-Junior | task, task |
 | Atlas | task, call_omo_agent |
 

--- a/src/agents/devils-advocate.test.ts
+++ b/src/agents/devils-advocate.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "bun:test"
+import { createDevilsAdvocateAgent, devilsAdvocatePromptMetadata } from "./devils-advocate"
+
+describe("createDevilsAdvocateAgent", () => {
+  test("returns a subagent with denied write/edit/task/background_task/call_omo_agent permissions", () => {
+    // given
+    const model = "google/gemini-3-pro"
+
+    // when
+    const agent = createDevilsAdvocateAgent(model)
+
+    // then
+    expect(agent.mode).toBe("subagent")
+    expect(agent.model).toBe(model)
+    expect(agent.temperature).toBe(0.1)
+
+    expect(agent.permission).toBeDefined()
+    expect(agent.permission?.write).toBe("deny")
+    expect(agent.permission?.edit).toBe("deny")
+    expect(agent.permission?.task).toBe("deny")
+    expect(agent.permission?.background_task).toBe("deny")
+    expect(agent.permission?.call_omo_agent).toBe("deny")
+  })
+
+  test("uses reasoningEffort for GPT-family models", () => {
+    // given
+    const model = "openai/gpt-5.2"
+
+    // when
+    const agent = createDevilsAdvocateAgent(model)
+
+    // then
+    expect(agent.reasoningEffort).toBe("medium")
+    expect(agent.thinking).toBeUndefined()
+  })
+
+  test("uses thinking for non-GPT models", () => {
+    // given
+    const model = "google/gemini-3-pro"
+
+    // when
+    const agent = createDevilsAdvocateAgent(model)
+
+    // then
+    expect(agent.thinking).toEqual({ type: "enabled", budgetTokens: 10000 })
+    expect(agent.reasoningEffort).toBeUndefined()
+  })
+})
+
+describe("devilsAdvocatePromptMetadata", () => {
+  test("declares advisor category and CHEAP cost", () => {
+    // given
+
+    // when
+    const metadata = devilsAdvocatePromptMetadata
+
+    // then
+    expect(metadata.category).toBe("advisor")
+    expect(metadata.cost).toBe("CHEAP")
+  })
+
+  test("defines triggers and keyTrigger", () => {
+    // given
+
+    // when
+    const metadata = devilsAdvocatePromptMetadata
+
+    // then
+    expect(metadata.triggers.length).toBeGreaterThan(0)
+    expect(typeof metadata.keyTrigger).toBe("string")
+    expect((metadata.keyTrigger ?? "").length).toBeGreaterThan(0)
+  })
+})

--- a/src/agents/devils-advocate.test.ts
+++ b/src/agents/devils-advocate.test.ts
@@ -1,8 +1,10 @@
+/// <reference types="bun-types" />
+
 import { describe, test, expect } from "bun:test"
 import { createDevilsAdvocateAgent, devilsAdvocatePromptMetadata } from "./devils-advocate"
 
 describe("createDevilsAdvocateAgent", () => {
-  test("returns a subagent with denied write/edit/task/background_task/call_omo_agent permissions", () => {
+  test("returns a subagent with allowlist-based read-only tool permissions", () => {
     // given
     const model = "google/gemini-3-pro"
 
@@ -15,11 +17,17 @@ describe("createDevilsAdvocateAgent", () => {
     expect(agent.temperature).toBe(0.1)
 
     expect(agent.permission).toBeDefined()
-    expect(agent.permission?.write).toBe("deny")
-    expect(agent.permission?.edit).toBe("deny")
-    expect(agent.permission?.task).toBe("deny")
-    expect(agent.permission?.background_task).toBe("deny")
-    expect(agent.permission?.call_omo_agent).toBe("deny")
+
+    expect(agent.permission?.["*"]).toBe("deny")
+    expect(agent.permission?.["read"]).toBe("allow")
+    expect(agent.permission?.["grep"]).toBe("allow")
+    expect(agent.permission?.["glob"]).toBe("allow")
+    expect(agent.permission?.["lsp_diagnostics"]).toBe("allow")
+    expect(agent.permission?.["lsp_symbols"]).toBe("allow")
+    expect(agent.permission?.["lsp_find_references"]).toBe("allow")
+    expect(agent.permission?.["lsp_goto_definition"]).toBe("allow")
+    expect(agent.permission?.["webfetch"]).toBe("allow")
+    expect(agent.permission?.["ast_grep_search"]).toBe("allow")
   })
 
   test("uses reasoningEffort for GPT-family models", () => {

--- a/src/agents/devils-advocate.ts
+++ b/src/agents/devils-advocate.ts
@@ -1,7 +1,7 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode, AgentPromptMetadata } from "./types"
 import { isGptModel } from "./types"
-import { createAgentToolRestrictions } from "../shared/permission-compat"
+import { createAgentToolAllowlist } from "../shared/permission-compat"
 
 const MODE: AgentMode = "subagent"
 
@@ -69,12 +69,16 @@ CRITICAL / RISKY / VIABLE
 </Constraints>`
 
 export function createDevilsAdvocateAgent(model: string): AgentConfig {
-  const restrictions = createAgentToolRestrictions([
-    "write",
-    "edit",
-    "task",
-    "background_task",
-    "call_omo_agent",
+  const restrictions = createAgentToolAllowlist([
+    "read",
+    "grep",
+    "glob",
+    "lsp_diagnostics",
+    "lsp_symbols",
+    "lsp_find_references",
+    "lsp_goto_definition",
+    "webfetch",
+    "ast_grep_search",
   ])
 
   const base: AgentConfig = {

--- a/src/agents/devils-advocate.ts
+++ b/src/agents/devils-advocate.ts
@@ -1,0 +1,116 @@
+import type { AgentConfig } from "@opencode-ai/sdk"
+import type { AgentMode, AgentPromptMetadata } from "./types"
+import { isGptModel } from "./types"
+import { createAgentToolRestrictions } from "../shared/permission-compat"
+
+const MODE: AgentMode = "subagent"
+
+const DEVILS_ADVOCATE_SYSTEM_PROMPT = `<Role>
+You are "Devil's Advocate" — a relentlessly skeptical critic who stress-tests ideas, plans, and assumptions. You exist to find what will break, not to encourage.
+</Role>
+
+<Behavior_Instructions>
+
+## Phase 0 — Input Classification (EVERY request)
+
+Classify the input FIRST, then adjust your analysis focus:
+
+| Type | Signal | Analysis Focus |
+|------|--------|----------------|
+| Idea Pitch | "What if we...", "I want to build..." | Feasibility destruction |
+| Technical Plan | "Here's my approach..." | Implementation risk analysis |
+| Feature Proposal | "Let's add X..." | User friction + edge case analysis |
+| Architecture Decision | "Should we use X or Y?" | Trade-off stress testing |
+| Assumption Check | "Is this assumption valid?" | Logical consistency audit |
+
+## Phase 1 — Systematic Deconstruction (MANDATORY — ALL 5 lenses)
+
+Apply every lens. No shortcuts.
+
+| Lens | What to Find | Output |
+|------|-------------|--------|
+| Logical Inconsistency | Contradictions in reasoning | List contradictions with evidence |
+| Resource Realism | Underestimated time/effort | Reality check with rough estimates |
+| Market/Social Friction | Why people resist | Friction points ranked by severity |
+| Edge Cases | "What if?" failures | Failure scenarios |
+| Codebase Evidence | What code actually shows | File references supporting/contradicting |
+
+## Phase 2 — Structured Output (MANDATORY format)
+
+### THE FATAL FLAW
+[Single biggest reason this fails. One paragraph.]
+
+### HIDDEN ASSUMPTIONS
+| # | Assumption | Why It's Unproven | What Breaks If Wrong |
+|---|-----------|-------------------|---------------------|
+[3-7 rows]
+
+### THE ADVERSARY VIEW
+[How a critic/hostile user would dismantle this. No softening.]
+
+### STRESS-TEST QUESTIONS
+1. [Uncomfortable question]
+2. [Uncomfortable question]
+3. [Uncomfortable question]
+
+### SEVERITY RATING
+CRITICAL / RISKY / VIABLE
+[One sentence justification]
+
+</Behavior_Instructions>
+
+<Constraints>
+
+- Never praise or validate.
+- Never offer solutions; only critique.
+- Always include codebase evidence when relevant.
+- Do not write code or modify files.
+
+</Constraints>`
+
+export function createDevilsAdvocateAgent(model: string): AgentConfig {
+  const restrictions = createAgentToolRestrictions([
+    "write",
+    "edit",
+    "task",
+    "background_task",
+    "call_omo_agent",
+  ])
+
+  const base: AgentConfig = {
+    description:
+      "Adversarial validator that stress-tests ideas, plans, and assumptions through structured critical analysis. (Devil's Advocate - OhMyOpenCode)",
+    mode: MODE,
+    model,
+    temperature: 0.1,
+    ...restrictions,
+    prompt: DEVILS_ADVOCATE_SYSTEM_PROMPT,
+  }
+
+  if (isGptModel(model)) {
+    return { ...base, reasoningEffort: "medium" }
+  }
+
+  return { ...base, thinking: { type: "enabled", budgetTokens: 10000 } }
+}
+createDevilsAdvocateAgent.mode = MODE
+
+export const devilsAdvocatePromptMetadata: AgentPromptMetadata = {
+  category: "advisor",
+  cost: "CHEAP",
+  promptAlias: "Devil's Advocate",
+  keyTrigger: "User-facing behavior/design proposal → consult `devils-advocate` before implementation",
+  triggers: [
+    { domain: "Adversarial validation", trigger: "Stress-test ideas/plans for fatal flaws and hidden assumptions" },
+  ],
+  useWhen: [
+    "Before committing to a major decision",
+    "Before user-facing feature work",
+    "When a plan relies on unverified assumptions",
+  ],
+  avoidWhen: [
+    "Trivial edits",
+    "Pure bugfixes restoring expected behavior",
+    "When you explicitly need solutions (use oracle)",
+  ],
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -10,6 +10,7 @@ export { createExploreAgent, EXPLORE_PROMPT_METADATA } from "./explore"
 export { createMultimodalLookerAgent, MULTIMODAL_LOOKER_PROMPT_METADATA } from "./multimodal-looker"
 export { createMetisAgent, METIS_SYSTEM_PROMPT, metisPromptMetadata } from "./metis"
 export { createMomusAgent, MOMUS_SYSTEM_PROMPT, momusPromptMetadata } from "./momus"
+export { createDevilsAdvocateAgent, devilsAdvocatePromptMetadata } from "./devils-advocate"
 export { createAtlasAgent, atlasPromptMetadata } from "./atlas"
 export {
   PROMETHEUS_SYSTEM_PROMPT,

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -79,6 +79,7 @@ export type BuiltinAgentName =
   | "multimodal-looker"
   | "metis"
   | "momus"
+  | "devils-advocate"
   | "atlas"
 
 export type OverridableAgentName =

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -9,6 +9,7 @@ import { createMultimodalLookerAgent, MULTIMODAL_LOOKER_PROMPT_METADATA } from "
 import { createMetisAgent, metisPromptMetadata } from "./metis"
 import { createAtlasAgent, atlasPromptMetadata } from "./atlas"
 import { createMomusAgent, momusPromptMetadata } from "./momus"
+import { createDevilsAdvocateAgent, devilsAdvocatePromptMetadata } from "./devils-advocate"
 import { createHephaestusAgent } from "./hephaestus"
 import type { AvailableAgent, AvailableCategory, AvailableSkill } from "./dynamic-agent-prompt-builder"
 import { deepMerge, fetchAvailableModels, resolveModelPipeline, AGENT_MODEL_REQUIREMENTS, readConnectedProvidersCache, isModelAvailable, isAnyFallbackModelAvailable, isAnyProviderConnected, migrateAgentConfig } from "../shared"
@@ -29,6 +30,7 @@ const agentSources: Record<BuiltinAgentName, AgentSource> = {
   "multimodal-looker": createMultimodalLookerAgent,
   metis: createMetisAgent,
   momus: createMomusAgent,
+  "devils-advocate": createDevilsAdvocateAgent,
   // Note: Atlas is handled specially in createBuiltinAgents()
   // because it needs OrchestratorContext, not just a model string
   atlas: createAtlasAgent as unknown as AgentFactory,
@@ -45,6 +47,7 @@ const agentMetadata: Partial<Record<BuiltinAgentName, AgentPromptMetadata>> = {
   "multimodal-looker": MULTIMODAL_LOOKER_PROMPT_METADATA,
   metis: metisPromptMetadata,
   momus: momusPromptMetadata,
+  "devils-advocate": devilsAdvocatePromptMetadata,
   atlas: atlasPromptMetadata,
 }
 

--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -7,6 +7,9 @@ exports[`generateModelConfig no providers available returns ULTIMATE_FALLBACK fo
     "atlas": {
       "model": "opencode/glm-4.7-free",
     },
+    "devils-advocate": {
+      "model": "opencode/glm-4.7-free",
+    },
     "explore": {
       "model": "opencode/glm-4.7-free",
     },
@@ -66,6 +69,9 @@ exports[`generateModelConfig single native provider uses Claude models when only
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
   "agents": {
     "atlas": {
+      "model": "anthropic/claude-sonnet-4-5",
+    },
+    "devils-advocate": {
       "model": "anthropic/claude-sonnet-4-5",
     },
     "explore": {
@@ -130,6 +136,9 @@ exports[`generateModelConfig single native provider uses Claude models with isMa
     "atlas": {
       "model": "anthropic/claude-sonnet-4-5",
     },
+    "devils-advocate": {
+      "model": "anthropic/claude-sonnet-4-5",
+    },
     "explore": {
       "model": "anthropic/claude-haiku-4-5",
     },
@@ -192,6 +201,10 @@ exports[`generateModelConfig single native provider uses OpenAI models when only
   "agents": {
     "atlas": {
       "model": "openai/gpt-5.2",
+    },
+    "devils-advocate": {
+      "model": "openai/gpt-5.2",
+      "variant": "medium",
     },
     "explore": {
       "model": "opencode/gpt-5-nano",
@@ -260,6 +273,10 @@ exports[`generateModelConfig single native provider uses OpenAI models with isMa
     "atlas": {
       "model": "openai/gpt-5.2",
     },
+    "devils-advocate": {
+      "model": "openai/gpt-5.2",
+      "variant": "medium",
+    },
     "explore": {
       "model": "opencode/gpt-5-nano",
     },
@@ -327,6 +344,9 @@ exports[`generateModelConfig single native provider uses Gemini models when only
     "atlas": {
       "model": "google/gemini-3-pro",
     },
+    "devils-advocate": {
+      "model": "google/gemini-3-pro",
+    },
     "explore": {
       "model": "opencode/gpt-5-nano",
     },
@@ -385,6 +405,9 @@ exports[`generateModelConfig single native provider uses Gemini models with isMa
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
   "agents": {
     "atlas": {
+      "model": "google/gemini-3-pro",
+    },
+    "devils-advocate": {
       "model": "google/gemini-3-pro",
     },
     "explore": {
@@ -446,6 +469,9 @@ exports[`generateModelConfig all native providers uses preferred models from fal
   "agents": {
     "atlas": {
       "model": "anthropic/claude-sonnet-4-5",
+    },
+    "devils-advocate": {
+      "model": "google/gemini-3-pro",
     },
     "explore": {
       "model": "anthropic/claude-haiku-4-5",
@@ -519,6 +545,9 @@ exports[`generateModelConfig all native providers uses preferred models with isM
   "agents": {
     "atlas": {
       "model": "anthropic/claude-sonnet-4-5",
+    },
+    "devils-advocate": {
+      "model": "google/gemini-3-pro",
     },
     "explore": {
       "model": "anthropic/claude-haiku-4-5",
@@ -594,6 +623,9 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models when on
     "atlas": {
       "model": "opencode/kimi-k2.5-free",
     },
+    "devils-advocate": {
+      "model": "opencode/gemini-3-pro",
+    },
     "explore": {
       "model": "opencode/claude-haiku-4-5",
     },
@@ -666,6 +698,9 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models with is
   "agents": {
     "atlas": {
       "model": "opencode/kimi-k2.5-free",
+    },
+    "devils-advocate": {
+      "model": "opencode/gemini-3-pro",
     },
     "explore": {
       "model": "opencode/claude-haiku-4-5",
@@ -741,6 +776,9 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
     "atlas": {
       "model": "github-copilot/claude-sonnet-4.5",
     },
+    "devils-advocate": {
+      "model": "github-copilot/gemini-3-pro-preview",
+    },
     "explore": {
       "model": "github-copilot/gpt-5-mini",
     },
@@ -813,6 +851,9 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
   "agents": {
     "atlas": {
       "model": "github-copilot/claude-sonnet-4.5",
+    },
+    "devils-advocate": {
+      "model": "github-copilot/gemini-3-pro-preview",
     },
     "explore": {
       "model": "github-copilot/gpt-5-mini",
@@ -888,6 +929,9 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian whe
     "atlas": {
       "model": "opencode/glm-4.7-free",
     },
+    "devils-advocate": {
+      "model": "opencode/glm-4.7-free",
+    },
     "explore": {
       "model": "opencode/gpt-5-nano",
     },
@@ -941,6 +985,9 @@ exports[`generateModelConfig fallback providers uses ZAI model for librarian wit
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
   "agents": {
     "atlas": {
+      "model": "opencode/glm-4.7-free",
+    },
+    "devils-advocate": {
       "model": "opencode/glm-4.7-free",
     },
     "explore": {
@@ -997,6 +1044,9 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + OpenCode Zen
   "agents": {
     "atlas": {
       "model": "opencode/kimi-k2.5-free",
+    },
+    "devils-advocate": {
+      "model": "opencode/gemini-3-pro",
     },
     "explore": {
       "model": "anthropic/claude-haiku-4-5",
@@ -1071,6 +1121,9 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
     "atlas": {
       "model": "github-copilot/claude-sonnet-4.5",
     },
+    "devils-advocate": {
+      "model": "github-copilot/gemini-3-pro-preview",
+    },
     "explore": {
       "model": "github-copilot/gpt-5-mini",
     },
@@ -1144,6 +1197,9 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + ZAI combinat
     "atlas": {
       "model": "anthropic/claude-sonnet-4-5",
     },
+    "devils-advocate": {
+      "model": "anthropic/claude-sonnet-4-5",
+    },
     "explore": {
       "model": "anthropic/claude-haiku-4-5",
     },
@@ -1205,6 +1261,9 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
   "agents": {
     "atlas": {
       "model": "anthropic/claude-sonnet-4-5",
+    },
+    "devils-advocate": {
+      "model": "google/gemini-3-pro",
     },
     "explore": {
       "model": "anthropic/claude-haiku-4-5",
@@ -1270,6 +1329,9 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
   "agents": {
     "atlas": {
       "model": "opencode/kimi-k2.5-free",
+    },
+    "devils-advocate": {
+      "model": "github-copilot/gemini-3-pro-preview",
     },
     "explore": {
       "model": "opencode/claude-haiku-4-5",
@@ -1344,6 +1406,9 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
     "atlas": {
       "model": "opencode/kimi-k2.5-free",
     },
+    "devils-advocate": {
+      "model": "google/gemini-3-pro",
+    },
     "explore": {
       "model": "anthropic/claude-haiku-4-5",
     },
@@ -1416,6 +1481,9 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
   "agents": {
     "atlas": {
       "model": "opencode/kimi-k2.5-free",
+    },
+    "devils-advocate": {
+      "model": "google/gemini-3-pro",
     },
     "explore": {
       "model": "anthropic/claude-haiku-4-5",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -27,6 +27,7 @@ export const BuiltinAgentNameSchema = z.enum([
   "multimodal-looker",
   "metis",
   "momus",
+  "devils-advocate",
   "atlas",
 ])
 
@@ -48,6 +49,7 @@ export const OverridableAgentNameSchema = z.enum([
   "prometheus",
   "metis",
   "momus",
+  "devils-advocate",
   "oracle",
   "librarian",
   "explore",
@@ -161,6 +163,7 @@ export const AgentOverridesSchema = z.object({
   prometheus: AgentOverrideConfigSchema.optional(),
   metis: AgentOverrideConfigSchema.optional(),
   momus: AgentOverrideConfigSchema.optional(),
+  "devils-advocate": AgentOverrideConfigSchema.optional(),
   oracle: AgentOverrideConfigSchema.optional(),
   librarian: AgentOverrideConfigSchema.optional(),
   explore: AgentOverrideConfigSchema.optional(),

--- a/src/features/claude-code-mcp-loader/loader.test.ts
+++ b/src/features/claude-code-mcp-loader/loader.test.ts
@@ -1,9 +1,20 @@
+/// <reference types="bun-types" />
+
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
 import { mkdirSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
 const TEST_DIR = join(tmpdir(), "mcp-loader-test-" + Date.now())
+
+mock.module("os", () => ({
+  homedir: () => TEST_DIR,
+  tmpdir,
+}))
+
+mock.module("../../shared", () => ({
+  getClaudeConfigDir: () => join(TEST_DIR, ".claude"),
+}))
 
 describe("getSystemMcpServerNames", () => {
   beforeEach(() => {
@@ -176,11 +187,6 @@ describe("getSystemMcpServerNames", () => {
       process.chdir(TEST_DIR)
 
       try {
-        mock.module("os", () => ({
-          homedir: () => TEST_DIR,
-          tmpdir,
-        }))
-
         writeFileSync(userConfigPath, JSON.stringify(userMcpConfig))
 
         const { getSystemMcpServerNames } = await import("./loader")
@@ -225,16 +231,6 @@ describe("getSystemMcpServerNames", () => {
       process.chdir(TEST_DIR)
 
       try {
-        mock.module("os", () => ({
-          homedir: () => TEST_DIR,
-          tmpdir,
-        }))
-
-        // Also mock getClaudeConfigDir to point to our test .claude dir
-        mock.module("../../shared", () => ({
-          getClaudeConfigDir: () => claudeDir,
-        }))
-
         const { getSystemMcpServerNames } = await import("./loader")
         const names = getSystemMcpServerNames()
 

--- a/src/hooks/unstable-agent-babysitter/index.test.ts
+++ b/src/hooks/unstable-agent-babysitter/index.test.ts
@@ -1,3 +1,6 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, test } from "bun:test"
 import { _resetForTesting, setMainSession } from "../../features/claude-code-session-state"
 import type { BackgroundTask } from "../../features/background-agent"
 import { createUnstableAgentBabysitterHook } from "./index"
@@ -19,6 +22,9 @@ function createMockPluginInput(options: {
           data: messagesBySession[path.id] ?? [],
         }),
         prompt: async (input: unknown) => {
+          promptCalls.push({ input })
+        },
+        promptAsync: async (input: unknown) => {
           promptCalls.push({ input })
         },
       },

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -172,8 +172,8 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(hephaestus.requiresModel).toBeUndefined()
   })
 
-  test("all 10 builtin agents have valid fallbackChain arrays", () => {
-    // #given - list of 10 agent names
+  test("all 11 builtin agents have valid fallbackChain arrays", () => {
+    // given - list of 11 agent names
     const expectedAgents = [
       "sisyphus",
       "hephaestus",
@@ -184,14 +184,15 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
       "prometheus",
       "metis",
       "momus",
+      "devils-advocate",
       "atlas",
     ]
 
     // when - checking AGENT_MODEL_REQUIREMENTS
     const definedAgents = Object.keys(AGENT_MODEL_REQUIREMENTS)
 
-    // #then - all agents present with valid fallbackChain
-    expect(definedAgents).toHaveLength(10)
+    // then - all agents present with valid fallbackChain
+    expect(definedAgents).toHaveLength(11)
     for (const agent of expectedAgents) {
       const requirement = AGENT_MODEL_REQUIREMENTS[agent]
       expect(requirement).toBeDefined()

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -86,6 +86,13 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
   },
+  "devils-advocate": {
+    fallbackChain: [
+      { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "medium" },
+      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-5" },
+    ],
+  },
   atlas: {
     fallbackChain: [
       { providers: ["kimi-for-coding"], model: "k2p5" },


### PR DESCRIPTION
## Why
Supersedes #1572 with a clean re-implementation on current `dev`.

## What
- Adds new `devils-advocate` agent (adversarial validation) as a read-only subagent.
- Registers the agent across agent registry + config schema overrides.
- Adds model fallback chain entry for the new agent.
- Updates CLI model-fallback snapshots for the new agent.
- Adds Claude Code agent loader at `.claude/agents/devils-advocate.md`.

## Notes
- This PR intentionally avoids wiring new auto-invocation logic into other agents; instead it exposes `devils-advocate` via metadata (`keyTrigger`, `triggers`) so it shows up in dynamic prompt sections.

## Test
- `HOME=$(mktemp -d) bun test src/agents/devils-advocate.test.ts src/shared/model-requirements.test.ts src/cli/model-fallback.test.ts`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only “devils-advocate” subagent for adversarial validation to stress-test ideas and plans. Discoverable via dynamic prompt triggers and backed by provider-aware model fallbacks.

- **New Features**
  - Enforced read-only via default-deny tool allowlist; allows read, grep, glob, lsp_diagnostics, lsp_symbols, lsp_find_references, lsp_goto_definition, webfetch, ast_grep_search.
  - Registered across agents, types, and config (override-able), with docs at .claude/agents/devils-advocate.md.
  - Fallback chain: gemini-3-pro → gpt-5.2 (medium) → claude-sonnet-4-5; CLI snapshots updated.
  - Reasoning config: GPT uses reasoningEffort=medium; others enable thinking (10k tokens).
  - Metadata includes keyTrigger and triggers for dynamic prompts; no auto-invocation.
  - Tests added for permissions, reasoning mode, model requirements, and fallback generation.

<sup>Written for commit 55968d2d87ed787a07a8bc2817747f70108c0a30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

