### PR TITLE
fix: preserve variant in sync continuation to maintain thinking budget

### DIFF
--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -1065,8 +1065,8 @@ describe("sisyphus-task", () => {
 
     const mockClient = {
       session: {
-        prompt: async () => ({ data: {} }),
-        promptAsync: promptMock,
+        prompt: promptMock,
+        promptAsync: async () => ({ data: {} }),
         messages: async () => ({
           data: [
             {
@@ -1116,7 +1116,7 @@ describe("sisyphus-task", () => {
       toolContext
     )
 
-    //#then promptAsync should include variant from previous message
+    //#then prompt should include variant from previous message
     expect(promptMock).toHaveBeenCalled()
     const callArgs = promptMock.mock.calls[0][0]
     expect(callArgs.body.variant).toBe("max")


### PR DESCRIPTION
## Summary
- Fix a bug where `executeSyncContinuation()` did not forward the `variant` field when continuing a session
- This caused the model variant (e.g., `"max"` for Anthropic thinking budget) to be silently lost on continuation turns
- Add regression test verifying variant preservation

## Problem
When using `session_id` to continue a previous task, the variant was not included in the sync continuation prompt body. Since OpenCode treats variant as per-message (not per-session), the continuation turn would run without thinking budget even if the original turn had `variant: "max"`.

## Changes
- `src/tools/delegate-task/executor.ts`: Extract `resumeVariant` from the previous session message and include it in the continuation prompt body
- `src/tools/delegate-task/tools.test.ts`: Add regression test for variant preservation in sync continuation


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sync continuation losing the model variant by forwarding it from the last session message, so thinking budget (e.g., Anthropic "max") is preserved. Adds a regression test to prevent future regressions.

- **Bug Fixes**
  - Include variant from previous session message in executeSyncContinuation prompt body.
  - Add test that verifies variant, agent, and model are forwarded on continuation.

<sup>Written for commit 6b4e149881c5ed964e73b7aed0a58d0487db2e5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

