### PR TITLE
fix: deny todowrite/todoread per-agent when task_system is enabled

### DIFF
--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -436,6 +436,11 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     // In CLI run mode, deny Question tool for all agents (no TUI to answer questions)
     const isCliRunMode = process.env.OPENCODE_CLI_RUN_MODE === "true";
     const questionPermission = isCliRunMode ? "deny" : "allow";
+
+    // When task system is enabled, deny todowrite/todoread per-agent so models never see them
+    const todoPermission = pluginConfig.experimental?.task_system
+      ? { todowrite: "deny" as const, todoread: "deny" as const }
+      : {};
     
     if (agentResult.librarian) {
       const agent = agentResult.librarian as AgentWithPermission;
@@ -447,23 +452,23 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     }
     if (agentResult["atlas"]) {
       const agent = agentResult["atlas"] as AgentWithPermission;
-      agent.permission = { ...agent.permission, task: "allow", call_omo_agent: "deny", "task_*": "allow", teammate: "allow" };
+      agent.permission = { ...agent.permission, ...todoPermission, task: "allow", call_omo_agent: "deny", "task_*": "allow", teammate: "allow" };
     }
     if (agentResult.sisyphus) {
       const agent = agentResult.sisyphus as AgentWithPermission;
-      agent.permission = { ...agent.permission, call_omo_agent: "deny", task: "allow", question: questionPermission, "task_*": "allow", teammate: "allow" };
+      agent.permission = { ...agent.permission, ...todoPermission, call_omo_agent: "deny", task: "allow", question: questionPermission, "task_*": "allow", teammate: "allow" };
     }
     if (agentResult.hephaestus) {
       const agent = agentResult.hephaestus as AgentWithPermission;
-      agent.permission = { ...agent.permission, call_omo_agent: "deny", task: "allow", question: questionPermission };
+      agent.permission = { ...agent.permission, ...todoPermission, call_omo_agent: "deny", task: "allow", question: questionPermission };
     }
     if (agentResult["prometheus"]) {
       const agent = agentResult["prometheus"] as AgentWithPermission;
-      agent.permission = { ...agent.permission, call_omo_agent: "deny", task: "allow", question: questionPermission, "task_*": "allow", teammate: "allow" };
+      agent.permission = { ...agent.permission, ...todoPermission, call_omo_agent: "deny", task: "allow", question: questionPermission, "task_*": "allow", teammate: "allow" };
     }
     if (agentResult["sisyphus-junior"]) {
       const agent = agentResult["sisyphus-junior"] as AgentWithPermission;
-      agent.permission = { ...agent.permission, task: "allow", "task_*": "allow", teammate: "allow" };
+      agent.permission = { ...agent.permission, ...todoPermission, task: "allow", "task_*": "allow", teammate: "allow" };
     }
 
     config.permission = {


### PR DESCRIPTION
## Summary

- When `experimental.task_system` is enabled, adds `todowrite: "deny"` and `todoread: "deny"` to per-agent permissions for all primary agents (sisyphus, hephaestus, atlas, prometheus, sisyphus-junior)
- This ensures models never see these tools in their tool list, complementing the existing global `tools` config and the `tasks-todowrite-disabler` runtime hook

## Changes

- `src/plugin-handlers/config-handler.ts`: Added conditional `todoPermission` spread to all primary agent permission blocks
- `src/plugin-handlers/config-handler.test.ts`: Added 3 test cases covering enabled, disabled, and undefined task_system states

## Context

Previously, when the task system was enabled:
1. Global `tools: { todowrite: false, todoread: false }` was set (line 431)
2. `tasks-todowrite-disabler` hook threw errors at runtime

But per-agent permissions didn't include todowrite/todoread deny, meaning models could still see these tools in their tool list and waste tokens attempting to call them before getting blocked. This fix adds the deny at the per-agent permission level so models never receive these tools.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deny todowrite and todoread per-agent when experimental.task_system is enabled so models never see or call these tools. This avoids wasted tokens and aligns with the global tools config and runtime hook.

- **Bug Fixes**
  - Add per-agent permission denies for sisyphus, hephaestus, atlas, prometheus, and sisyphus-junior when task_system is true.
  - Add tests for enabled, disabled, and undefined task_system states.

<sup>Written for commit e7f4f6dd137bf0541e89bca20f2392df32e2aa03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

