### PR TITLE
feat/fix: add system notification message format config and fix idle notification not firing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "oh-my-opencode",
@@ -27,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.3.2",
-        "oh-my-opencode-darwin-x64": "3.3.2",
-        "oh-my-opencode-linux-arm64": "3.3.2",
-        "oh-my-opencode-linux-arm64-musl": "3.3.2",
-        "oh-my-opencode-linux-x64": "3.3.2",
-        "oh-my-opencode-linux-x64-musl": "3.3.2",
-        "oh-my-opencode-windows-x64": "3.3.2",
+        "oh-my-opencode-darwin-arm64": "3.3.1",
+        "oh-my-opencode-darwin-x64": "3.3.1",
+        "oh-my-opencode-linux-arm64": "3.3.1",
+        "oh-my-opencode-linux-arm64-musl": "3.3.1",
+        "oh-my-opencode-linux-x64": "3.3.1",
+        "oh-my-opencode-linux-x64-musl": "3.3.1",
+        "oh-my-opencode-windows-x64": "3.3.1",
       },
     },
   },
@@ -225,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.3.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-3NIE2+G2hXEEJesINGdn2MMiHNR/QNZqqCFiyXKe51YD6nvpwTNWisT7Dyu92cIUZI/86+QwWQ4m7tG1rKrORA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.3.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-R+o42Km6bsIaW6D3I8uu2HCF3BjIWqa/fg38W5y4hJEOw4mL0Q7uV4R+0vtrXRHo9crXTK9ag0fqVQUm+Y6iAQ=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.3.2", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-6DQXbw2EccVF6j3wevLQKJPE6UIGIk2b/hBwX9puLV+LU0yEDExHyNDEJ3rIl+6FtTysXtp1cUFwIcCFLWzxYg=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7VTbpR1vH3OEkoJxBKtYuxFPX8M3IbJKoeHWME9iK6FpT11W1ASsjyuhvzB1jcxSeqF8ddMnjitlG5ub6h5EVw=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.3.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-glkg7Ofa2Z1DA+kFG5N17ZzLvVkrmzSS+GBs7MMSe+li1Ujdhx9QZt6hcqviQBIvq4YPYslSMGzbcv1AuSnVpQ=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-BZ/r/CFlvbOxkdZZrRoT16xFOjibRZHuwQnaE4f0JvOzgK6/HWp3zJI1+2/aX/oK5GA6lZxNWRrJC/SKUi8LEg=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.3.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MqSW76xZjeWE5LrFVaLlOVzt58aSX++++PR/nvPlaMjDM6YKKUrkDvLXUDbk/mhp/32IXXB0vH8ICvcIPSuiWg=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-U90Wruf21h+CJbtcrS7MeTAc/5VOF6RI+5jr7qj/cCxjXNJtjhyJdz/maehArjtgf304+lYCM/Mh1i+G2D3YFQ=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.3.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lf+GCflXNUwDQVdCtijQUj7WFQ4k6dedYDI6RdMatm5bV0fH3djy1MVaTiapL6UDYvllfUPIhxkPi3rCkMYUfQ=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-sYzohSNdwsAhivbXcbhPdF1qqQi2CCI7FSgbmvvfBOMyZ8HAgqOFqYW2r3GPdmtywzkjOTvCzTG56FZwEjx15w=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.3.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kTkbRPyU9T8202Mqi9hmZh8A4Cy0jhNw/JFdTg9myxQ4rQDHQTLt4gD3dO7dC/cvT+cAebPihUPZUER7wKA7Jw=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-aG5pZ4eWS0YSGUicOnjMkUPrIqQV4poYF+d9SIvrfvlaMcK6WlQn7jXzgNCwJsfGn5lyhSmjshZBEU+v79Ua3w=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.3.2", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-ubknqXlb8MEl4L3EOqhdQDph/d2axWuJTw5dPWsekDES90jT7QdAPYTQHdyDYp/frim6vlug9h+gcJFiN+UD3w=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-FGH7cnzBqNwjSkzCDglMsVttaq+MsykAxa7ehaFK+0dnBZArvllS3W13a3dGaANHMZzfK0vz8hNDUdVi7Z63cA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "oh-my-opencode",
@@ -28,13 +27,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.3.1",
-        "oh-my-opencode-darwin-x64": "3.3.1",
-        "oh-my-opencode-linux-arm64": "3.3.1",
-        "oh-my-opencode-linux-arm64-musl": "3.3.1",
-        "oh-my-opencode-linux-x64": "3.3.1",
-        "oh-my-opencode-linux-x64-musl": "3.3.1",
-        "oh-my-opencode-windows-x64": "3.3.1",
+        "oh-my-opencode-darwin-arm64": "3.3.2",
+        "oh-my-opencode-darwin-x64": "3.3.2",
+        "oh-my-opencode-linux-arm64": "3.3.2",
+        "oh-my-opencode-linux-arm64-musl": "3.3.2",
+        "oh-my-opencode-linux-x64": "3.3.2",
+        "oh-my-opencode-linux-x64-musl": "3.3.2",
+        "oh-my-opencode-windows-x64": "3.3.2",
       },
     },
   },
@@ -226,19 +225,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.3.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-R+o42Km6bsIaW6D3I8uu2HCF3BjIWqa/fg38W5y4hJEOw4mL0Q7uV4R+0vtrXRHo9crXTK9ag0fqVQUm+Y6iAQ=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.3.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-3NIE2+G2hXEEJesINGdn2MMiHNR/QNZqqCFiyXKe51YD6nvpwTNWisT7Dyu92cIUZI/86+QwWQ4m7tG1rKrORA=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.3.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-7VTbpR1vH3OEkoJxBKtYuxFPX8M3IbJKoeHWME9iK6FpT11W1ASsjyuhvzB1jcxSeqF8ddMnjitlG5ub6h5EVw=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.3.2", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-6DQXbw2EccVF6j3wevLQKJPE6UIGIk2b/hBwX9puLV+LU0yEDExHyNDEJ3rIl+6FtTysXtp1cUFwIcCFLWzxYg=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-BZ/r/CFlvbOxkdZZrRoT16xFOjibRZHuwQnaE4f0JvOzgK6/HWp3zJI1+2/aX/oK5GA6lZxNWRrJC/SKUi8LEg=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.3.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-glkg7Ofa2Z1DA+kFG5N17ZzLvVkrmzSS+GBs7MMSe+li1Ujdhx9QZt6hcqviQBIvq4YPYslSMGzbcv1AuSnVpQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.3.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-U90Wruf21h+CJbtcrS7MeTAc/5VOF6RI+5jr7qj/cCxjXNJtjhyJdz/maehArjtgf304+lYCM/Mh1i+G2D3YFQ=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.3.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-MqSW76xZjeWE5LrFVaLlOVzt58aSX++++PR/nvPlaMjDM6YKKUrkDvLXUDbk/mhp/32IXXB0vH8ICvcIPSuiWg=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-sYzohSNdwsAhivbXcbhPdF1qqQi2CCI7FSgbmvvfBOMyZ8HAgqOFqYW2r3GPdmtywzkjOTvCzTG56FZwEjx15w=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.3.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Lf+GCflXNUwDQVdCtijQUj7WFQ4k6dedYDI6RdMatm5bV0fH3djy1MVaTiapL6UDYvllfUPIhxkPi3rCkMYUfQ=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.3.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-aG5pZ4eWS0YSGUicOnjMkUPrIqQV4poYF+d9SIvrfvlaMcK6WlQn7jXzgNCwJsfGn5lyhSmjshZBEU+v79Ua3w=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.3.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-kTkbRPyU9T8202Mqi9hmZh8A4Cy0jhNw/JFdTg9myxQ4rQDHQTLt4gD3dO7dC/cvT+cAebPihUPZUER7wKA7Jw=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.3.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-FGH7cnzBqNwjSkzCDglMsVttaq+MsykAxa7ehaFK+0dnBZArvllS3W13a3dGaANHMZzfK0vz8hNDUdVi7Z63cA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.3.2", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-ubknqXlb8MEl4L3EOqhdQDph/d2axWuJTw5dPWsekDES90jT7QdAPYTQHdyDYp/frim6vlug9h+gcJFiN+UD3w=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -1008,14 +1008,16 @@ Configure notification behavior for background task completion.
 ```json
 {
   "notification": {
-    "force_enable": true
+    "force_enable": true,
+    "message_format": "{project} — Agent is ready for input"
   }
 }
 ```
 
-| Option         | Default | Description                                                                                   |
-| -------------- | ------- | ---------------------------------------------------------------------------------------------- |
-| `force_enable` | `false` | Force enable session-notification even if external notification plugins are detected. Default: `false`. |
+| Option           | Default                                    | Description                                                                                   |
+| ---------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `force_enable`   | `false`                                    | Force enable session-notification even if external notification plugins are detected. Default: `false`. |
+| `message_format` | `"{project} — Agent is ready for input"` | Custom message format for OS notifications. Supports template variables: `{project}` (folder name) and `{cwd}` (full working directory path). Unrecognized variables are left as-is. |
 
 ## Sisyphus Tasks
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -333,6 +333,8 @@ export const BackgroundTaskConfigSchema = z.object({
 export const NotificationConfigSchema = z.object({
   /** Force enable session-notification even if external notification plugins are detected (default: false) */
   force_enable: z.boolean().optional(),
+  /** Custom message format with template variables: {project} (folder name), {cwd} (full path). Default: "{project} — Agent is ready for input" */
+  message_format: z.string().optional(),
 })
 
 export const BabysittingConfigSchema = z.object({

--- a/src/hooks/session-notification-format.test.ts
+++ b/src/hooks/session-notification-format.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test"
+
+import { extractProjectName, resolveMessageFormat } from "./session-notification-format"
+
+describe("session-notification-format", () => {
+  describe("resolveMessageFormat", () => {
+    test("should replace {project} variable", () => {
+      // given - a format string with {project} placeholder
+      const format = "{project} — Agent is ready"
+      const vars = { project: "my-app", cwd: "/home/user/my-app" }
+
+      // when - resolving the format
+      const result = resolveMessageFormat(format, vars)
+
+      // then - {project} should be replaced with the project value
+      expect(result).toBe("my-app — Agent is ready")
+    })
+
+    test("should replace {cwd} variable", () => {
+      // given - a format string with {cwd} placeholder
+      const format = "{cwd} is idle"
+      const vars = { project: "app", cwd: "/full/path/app" }
+
+      // when - resolving the format
+      const result = resolveMessageFormat(format, vars)
+
+      // then - {cwd} should be replaced with the cwd value
+      expect(result).toBe("/full/path/app is idle")
+    })
+
+    test("should replace both {project} and {cwd} variables", () => {
+      // given - a format string with both placeholders
+      const format = "Both {project} and {cwd}"
+      const vars = { project: "p", cwd: "/c" }
+
+      // when - resolving the format
+      const result = resolveMessageFormat(format, vars)
+
+      // then - both variables should be replaced
+      expect(result).toBe("Both p and /c")
+    })
+
+    test("should leave strings without variables unchanged", () => {
+      // given - a format string with no placeholders
+      const format = "No variables here"
+      const vars = { project: "p", cwd: "/c" }
+
+      // when - resolving the format
+      const result = resolveMessageFormat(format, vars)
+
+      // then - the string should remain unchanged
+      expect(result).toBe("No variables here")
+    })
+
+    test("should leave unrecognized variables as-is", () => {
+      // given - a format string with an unrecognized variable
+      const format = "{unknown} stays"
+      const vars = { project: "p", cwd: "/c" }
+
+      // when - resolving the format
+      const result = resolveMessageFormat(format, vars)
+
+      // then - unrecognized variables should pass through unchanged
+      expect(result).toBe("{unknown} stays")
+    })
+
+    test("should handle empty format string", () => {
+      // given - an empty format string
+      const format = ""
+      const vars = { project: "p", cwd: "/c" }
+
+      // when - resolving the format
+      const result = resolveMessageFormat(format, vars)
+
+      // then - should return empty string
+      expect(result).toBe("")
+    })
+  })
+
+  describe("extractProjectName", () => {
+    test("should extract project name from directory path", () => {
+      // given - a directory path
+      const directory = "/home/user/my-project"
+
+      // when - extracting the project name
+      const result = extractProjectName(directory)
+
+      // then - should return the last path component
+      expect(result).toBe("my-project")
+    })
+
+    test("should return empty string for root path", () => {
+      // given - the root path
+      const directory = "/"
+
+      // when - extracting the project name
+      const result = extractProjectName(directory)
+
+      // then - should return empty string
+      expect(result).toBe("")
+    })
+
+    test("should return empty string for empty input", () => {
+      // given - an empty string
+      const directory = ""
+
+      // when - extracting the project name
+      const result = extractProjectName(directory)
+
+      // then - should return empty string
+      expect(result).toBe("")
+    })
+
+    test("should handle trailing slash in path", () => {
+      // given - a directory path with trailing slash
+      const directory = "/home/user/project/"
+
+      // when - extracting the project name
+      const result = extractProjectName(directory)
+
+      // then - should return the project name without the slash
+      expect(result).toBe("project")
+    })
+  })
+})

--- a/src/hooks/session-notification-format.test.ts
+++ b/src/hooks/session-notification-format.test.ts
@@ -64,6 +64,18 @@ describe("session-notification-format", () => {
       expect(result).toBe("{unknown} stays")
     })
 
+    test("should replace all occurrences of repeated variables", () => {
+      // given - a format string with repeated {project} placeholders
+      const format = "{project} — {project} is ready"
+      const vars = { project: "my-app", cwd: "/home/user/my-app" }
+
+      // when - resolving the format
+      const result = resolveMessageFormat(format, vars)
+
+      // then - all occurrences should be replaced
+      expect(result).toBe("my-app — my-app is ready")
+    })
+
     test("should handle empty format string", () => {
       // given - an empty format string
       const format = ""

--- a/src/hooks/session-notification-format.ts
+++ b/src/hooks/session-notification-format.ts
@@ -20,6 +20,6 @@ export function resolveMessageFormat(
   vars: { project: string; cwd: string }
 ): string {
   return format
-    .replace("{project}", vars.project)
-    .replace("{cwd}", vars.cwd)
+    .replaceAll("{project}", vars.project)
+    .replaceAll("{cwd}", vars.cwd)
 }

--- a/src/hooks/session-notification-format.ts
+++ b/src/hooks/session-notification-format.ts
@@ -1,0 +1,25 @@
+import { basename, resolve } from "path"
+
+/**
+ * Extracts the project folder name from a directory path.
+ * Returns empty string for root path "/" or empty input.
+ */
+export function extractProjectName(directory: string): string {
+  if (!directory) return ""
+  const resolved = resolve(directory)
+  const name = basename(resolved)
+  return name === "/" ? "" : name
+}
+
+/**
+ * Resolves template variables {project} and {cwd} in a format string.
+ * Unrecognized variables (e.g., {unknown}) are left as-is.
+ */
+export function resolveMessageFormat(
+  format: string,
+  vars: { project: string; cwd: string }
+): string {
+  return format
+    .replace("{project}", vars.project)
+    .replace("{cwd}", vars.cwd)
+}

--- a/src/hooks/session-notification-platform.ts
+++ b/src/hooks/session-notification-platform.ts
@@ -1,0 +1,125 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { platform } from "os"
+import {
+  getOsascriptPath,
+  getNotifySendPath,
+  getPowershellPath,
+  getAfplayPath,
+  getPaplayPath,
+  getAplayPath,
+} from "./session-notification-utils"
+
+interface Todo {
+  content: string
+  status: string
+  priority: string
+  id: string
+}
+
+export type Platform = "darwin" | "linux" | "win32" | "unsupported"
+
+export function detectPlatform(): Platform {
+  const p = platform()
+  if (p === "darwin" || p === "linux" || p === "win32") return p
+  return "unsupported"
+}
+
+export function getDefaultSoundPath(p: Platform): string {
+  switch (p) {
+    case "darwin":
+      return "/System/Library/Sounds/Glass.aiff"
+    case "linux":
+      return "/usr/share/sounds/freedesktop/stereo/complete.oga"
+    case "win32":
+      return "C:\\Windows\\Media\\notify.wav"
+    default:
+      return ""
+  }
+}
+
+export async function sendNotification(
+  ctx: PluginInput,
+  p: Platform,
+  title: string,
+  message: string
+): Promise<void> {
+  switch (p) {
+    case "darwin": {
+      const osascriptPath = await getOsascriptPath()
+      if (!osascriptPath) return
+
+      const esTitle = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+      const esMessage = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+      await ctx.$`${osascriptPath} -e ${"display notification \"" + esMessage + "\" with title \"" + esTitle + "\""}`.catch(() => {})
+      break
+    }
+    case "linux": {
+      const notifySendPath = await getNotifySendPath()
+      if (!notifySendPath) return
+
+      await ctx.$`${notifySendPath} ${title} ${message} 2>/dev/null`.catch(() => {})
+      break
+    }
+    case "win32": {
+      const powershellPath = await getPowershellPath()
+      if (!powershellPath) return
+
+      const psTitle = title.replace(/'/g, "''")
+      const psMessage = message.replace(/'/g, "''")
+      const toastScript = `
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+$Template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+$RawXml = [xml] $Template.GetXml()
+($RawXml.toast.visual.binding.text | Where-Object {$_.id -eq '1'}).AppendChild($RawXml.CreateTextNode('${psTitle}')) | Out-Null
+($RawXml.toast.visual.binding.text | Where-Object {$_.id -eq '2'}).AppendChild($RawXml.CreateTextNode('${psMessage}')) | Out-Null
+$SerializedXml = New-Object Windows.Data.Xml.Dom.XmlDocument
+$SerializedXml.LoadXml($RawXml.OuterXml)
+$Toast = [Windows.UI.Notifications.ToastNotification]::new($SerializedXml)
+$Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('OpenCode')
+$Notifier.Show($Toast)
+`.trim().replace(/\n/g, "; ")
+      await ctx.$`${powershellPath} -Command ${toastScript}`.catch(() => {})
+      break
+    }
+  }
+}
+
+export async function playSound(ctx: PluginInput, p: Platform, soundPath: string): Promise<void> {
+  switch (p) {
+    case "darwin": {
+      const afplayPath = await getAfplayPath()
+      if (!afplayPath) return
+      ctx.$`${afplayPath} ${soundPath}`.catch(() => {})
+      break
+    }
+    case "linux": {
+      const paplayPath = await getPaplayPath()
+      if (paplayPath) {
+        ctx.$`${paplayPath} ${soundPath} 2>/dev/null`.catch(() => {})
+      } else {
+        const aplayPath = await getAplayPath()
+        if (aplayPath) {
+          ctx.$`${aplayPath} ${soundPath} 2>/dev/null`.catch(() => {})
+        }
+      }
+      break
+    }
+    case "win32": {
+      const powershellPath = await getPowershellPath()
+      if (!powershellPath) return
+      ctx.$`${powershellPath} -Command ${"(New-Object Media.SoundPlayer '" + soundPath.replace(/'/g, "''") + "').PlaySync()"}`.catch(() => {})
+      break
+    }
+  }
+}
+
+export async function hasIncompleteTodos(ctx: PluginInput, sessionID: string): Promise<boolean> {
+  try {
+    const response = await ctx.client.session.todo({ path: { id: sessionID } })
+    const todos = (response.data ?? response) as Todo[]
+    if (!todos || todos.length === 0) return false
+    return todos.some((t) => t.status !== "completed" && t.status !== "cancelled")
+  } catch {
+    return false
+  }
+}

--- a/src/hooks/session-notification-platform.ts
+++ b/src/hooks/session-notification-platform.ts
@@ -124,20 +124,4 @@ export async function hasIncompleteTodos(ctx: PluginInput, sessionID: string): P
   }
 }
 
-/**
- * Cleans up old sessions from tracking sets when they exceed maxSessions limit.
- */
-export function cleanupOldSessions(
-  maxSessions: number,
-  ...sets: (Set<string> | Map<string, unknown>)[]
-) {
-  for (const collection of sets) {
-    if (collection.size > maxSessions) {
-      const keys = collection instanceof Map
-        ? Array.from(collection.keys())
-        : Array.from(collection)
-      const toRemove = keys.slice(0, collection.size - maxSessions)
-      toRemove.forEach(id => collection.delete(id))
-    }
-  }
-}
+

--- a/src/hooks/session-notification-platform.ts
+++ b/src/hooks/session-notification-platform.ts
@@ -123,3 +123,21 @@ export async function hasIncompleteTodos(ctx: PluginInput, sessionID: string): P
     return false
   }
 }
+
+/**
+ * Cleans up old sessions from tracking sets when they exceed maxSessions limit.
+ */
+export function cleanupOldSessions(
+  maxSessions: number,
+  ...sets: (Set<string> | Map<string, unknown>)[]
+) {
+  for (const collection of sets) {
+    if (collection.size > maxSessions) {
+      const keys = collection instanceof Map
+        ? Array.from(collection.keys())
+        : Array.from(collection)
+      const toRemove = keys.slice(0, collection.size - maxSessions)
+      toRemove.forEach(id => collection.delete(id))
+    }
+  }
+}

--- a/src/hooks/session-notification-platform.ts
+++ b/src/hooks/session-notification-platform.ts
@@ -1,5 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { platform } from "os"
+import type { Platform } from "./session-notification-utils"
 import {
   getOsascriptPath,
   getNotifySendPath,
@@ -15,8 +16,6 @@ interface Todo {
   priority: string
   id: string
 }
-
-export type Platform = "darwin" | "linux" | "win32" | "unsupported"
 
 export function detectPlatform(): Platform {
   const p = platform()
@@ -123,5 +122,3 @@ export async function hasIncompleteTodos(ctx: PluginInput, sessionID: string): P
     return false
   }
 }
-
-

--- a/src/hooks/session-notification-utils.ts
+++ b/src/hooks/session-notification-utils.ts
@@ -1,6 +1,5 @@
 import { spawn } from "bun"
-
-type Platform = "darwin" | "linux" | "win32" | "unsupported"
+import type { Platform } from "./session-notification-platform"
 
 async function findCommand(commandName: string): Promise<string | null> {
   try {
@@ -34,6 +33,21 @@ export const getPowershellPath = createCommandFinder("powershell")
 export const getAfplayPath = createCommandFinder("afplay")
 export const getPaplayPath = createCommandFinder("paplay")
 export const getAplayPath = createCommandFinder("aplay")
+
+export function cleanupOldSessions(
+  maxSessions: number,
+  ...sets: (Set<string> | Map<string, unknown>)[]
+) {
+  for (const collection of sets) {
+    if (collection.size > maxSessions) {
+      const keys = collection instanceof Map
+        ? Array.from(collection.keys())
+        : Array.from(collection)
+      const toRemove = keys.slice(0, collection.size - maxSessions)
+      toRemove.forEach(id => collection.delete(id))
+    }
+  }
+}
 
 export function startBackgroundCheck(platform: Platform): void {
   if (platform === "darwin") {

--- a/src/hooks/session-notification-utils.ts
+++ b/src/hooks/session-notification-utils.ts
@@ -1,5 +1,6 @@
 import { spawn } from "bun"
-import type { Platform } from "./session-notification-platform"
+
+export type Platform = "darwin" | "linux" | "win32" | "unsupported"
 
 async function findCommand(commandName: string): Promise<string | null> {
   try {

--- a/src/hooks/session-notification.test.ts
+++ b/src/hooks/session-notification.test.ts
@@ -358,4 +358,55 @@ describe("session-notification", () => {
     // then - only one notification should be sent
     expect(notificationCalls).toHaveLength(1)
   })
+
+  test("should use default message format with project name", async () => {
+    //#given - a session notification with default config and a project directory
+    const mockInput = createMockPluginInput()
+    mockInput.directory = "/home/user/my-awesome-project"
+    const handler = createSessionNotification(mockInput)
+    setMainSession("session-format-default")
+
+    //#when - session goes idle and notification fires
+    await handler({ event: { type: "session.idle", properties: { sessionID: "session-format-default" } } })
+    await new Promise(resolve => setTimeout(resolve, 2000))
+
+    //#then - notification message should contain the project name
+    expect(notificationCalls.length).toBeGreaterThan(0)
+    expect(notificationCalls[0]).toContain("my-awesome-project")
+  })
+
+  test("should resolve custom message_format with {project} and {cwd}", async () => {
+    //#given - a session notification with custom message_format
+    const mockInput = createMockPluginInput()
+    mockInput.directory = "/workspace/cool-app"
+    const handler = createSessionNotification(mockInput, {
+      message_format: "Done in {project} at {cwd}",
+    })
+    setMainSession("session-format-custom")
+
+    //#when - session goes idle and notification fires
+    await handler({ event: { type: "session.idle", properties: { sessionID: "session-format-custom" } } })
+    await new Promise(resolve => setTimeout(resolve, 2000))
+
+    //#then - notification should use the resolved custom format
+    expect(notificationCalls.length).toBeGreaterThan(0)
+    expect(notificationCalls[0]).toContain("Done in cool-app at /workspace/cool-app")
+  })
+
+  test("should use literal string when message_format has no variables", async () => {
+    //#given - a session notification with a literal message_format (no template variables)
+    const mockInput = createMockPluginInput()
+    const handler = createSessionNotification(mockInput, {
+      message_format: "Custom static message",
+    })
+    setMainSession("session-format-literal")
+
+    //#when - session goes idle and notification fires
+    await handler({ event: { type: "session.idle", properties: { sessionID: "session-format-literal" } } })
+    await new Promise(resolve => setTimeout(resolve, 2000))
+
+    //#then - notification should use the literal string as-is
+    expect(notificationCalls.length).toBeGreaterThan(0)
+    expect(notificationCalls[0]).toContain("Custom static message")
+  })
 })

--- a/src/hooks/session-notification.test.ts
+++ b/src/hooks/session-notification.test.ts
@@ -394,23 +394,23 @@ describe("session-notification", () => {
   })
 
   test("should use default message format with project name", async () => {
-    //#given - a session notification with default config and a project directory
+    // given - a session notification with default config and a project directory
     const mockInput = createMockPluginInput()
     mockInput.directory = "/home/user/my-awesome-project"
     const handler = createSessionNotification(mockInput)
     setMainSession("session-format-default")
 
-    //#when - session goes idle and notification fires
+    // when - session goes idle and notification fires
     await handler({ event: { type: "session.idle", properties: { sessionID: "session-format-default" } } })
     await new Promise(resolve => setTimeout(resolve, 2000))
 
-    //#then - notification message should use the default format with project name
+    // then - notification message should use the default format with project name
     expect(notificationCalls).toHaveLength(1)
-    expect(notificationCalls[0]).toBe('/usr/bin/osascript -e display notification "my-awesome-project \u2014 Agent is ready for input" with title "OpenCode"')
+    expect(notificationCalls[0]).toContain("my-awesome-project \u2014 Agent is ready for input")
   })
 
   test("should resolve custom message_format with {project} and {cwd}", async () => {
-    //#given - a session notification with custom message_format
+    // given - a session notification with custom message_format
     const mockInput = createMockPluginInput()
     mockInput.directory = "/workspace/cool-app"
     const handler = createSessionNotification(mockInput, {
@@ -418,29 +418,29 @@ describe("session-notification", () => {
     })
     setMainSession("session-format-custom")
 
-    //#when - session goes idle and notification fires
+    // when - session goes idle and notification fires
     await handler({ event: { type: "session.idle", properties: { sessionID: "session-format-custom" } } })
     await new Promise(resolve => setTimeout(resolve, 2000))
 
-    //#then - notification should use the resolved custom format
+    // then - notification should use the resolved custom format
     expect(notificationCalls).toHaveLength(1)
-    expect(notificationCalls[0]).toBe('/usr/bin/osascript -e display notification "Done in cool-app at /workspace/cool-app" with title "OpenCode"')
+    expect(notificationCalls[0]).toContain("Done in cool-app at /workspace/cool-app")
   })
 
   test("should use literal string when message_format has no variables", async () => {
-    //#given - a session notification with a literal message_format (no template variables)
+    // given - a session notification with a literal message_format (no template variables)
     const mockInput = createMockPluginInput()
     const handler = createSessionNotification(mockInput, {
       message_format: "Custom static message",
     })
     setMainSession("session-format-literal")
 
-    //#when - session goes idle and notification fires
+    // when - session goes idle and notification fires
     await handler({ event: { type: "session.idle", properties: { sessionID: "session-format-literal" } } })
     await new Promise(resolve => setTimeout(resolve, 2000))
 
-    //#then - notification should use the literal string as-is
+    // then - notification should use the literal string as-is
     expect(notificationCalls).toHaveLength(1)
-    expect(notificationCalls[0]).toBe('/usr/bin/osascript -e display notification "Custom static message" with title "OpenCode"')
+    expect(notificationCalls[0]).toContain("Custom static message")
   })
 })

--- a/src/hooks/session-notification.test.ts
+++ b/src/hooks/session-notification.test.ts
@@ -258,7 +258,7 @@ describe("session-notification", () => {
     expect(notificationCalls).toHaveLength(0)
   })
 
-  test("should mark session activity on message.updated event", async () => {
+  test("should mark session activity on message.updated with assistant role", async () => {
     // given - main session is set
     const mainSessionID = "main-message"
     setMainSession(mainSessionID)
@@ -268,7 +268,41 @@ describe("session-notification", () => {
       skipIfIncompleteTodos: false,
     })
 
-    // when - session goes idle, then message.updated fires
+    // when - session goes idle, then assistant message.updated fires
+    await hook({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: mainSessionID },
+      },
+    })
+
+    await hook({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: { sessionID: mainSessionID, role: "assistant", finish: false },
+        },
+      },
+    })
+
+    // Wait for idle delay to pass
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // then - notification should NOT be sent (assistant activity cancelled it)
+    expect(notificationCalls).toHaveLength(0)
+  })
+
+  test("should NOT mark session activity on message.updated with user role", async () => {
+    // given - main session is set
+    const mainSessionID = "main-message-user"
+    setMainSession(mainSessionID)
+
+    const hook = createSessionNotification(createMockPluginInput(), {
+      idleConfirmationDelay: 50,
+      skipIfIncompleteTodos: false,
+    })
+
+    // when - session goes idle, then user message.updated fires
     await hook({
       event: {
         type: "session.idle",
@@ -288,8 +322,8 @@ describe("session-notification", () => {
     // Wait for idle delay to pass
     await new Promise((resolve) => setTimeout(resolve, 100))
 
-    // then - notification should NOT be sent (activity cancelled it)
-    expect(notificationCalls).toHaveLength(0)
+    // then - notification SHOULD be sent (user message.updated does not cancel timer)
+    expect(notificationCalls).toHaveLength(1)
   })
 
   test("should mark session activity on tool.execute.before event", async () => {
@@ -370,9 +404,9 @@ describe("session-notification", () => {
     await handler({ event: { type: "session.idle", properties: { sessionID: "session-format-default" } } })
     await new Promise(resolve => setTimeout(resolve, 2000))
 
-    //#then - notification message should contain the project name
-    expect(notificationCalls.length).toBeGreaterThan(0)
-    expect(notificationCalls[0]).toContain("my-awesome-project")
+    //#then - notification message should use the default format with project name
+    expect(notificationCalls).toHaveLength(1)
+    expect(notificationCalls[0]).toBe('/usr/bin/osascript -e display notification "my-awesome-project \u2014 Agent is ready for input" with title "OpenCode"')
   })
 
   test("should resolve custom message_format with {project} and {cwd}", async () => {
@@ -389,8 +423,8 @@ describe("session-notification", () => {
     await new Promise(resolve => setTimeout(resolve, 2000))
 
     //#then - notification should use the resolved custom format
-    expect(notificationCalls.length).toBeGreaterThan(0)
-    expect(notificationCalls[0]).toContain("Done in cool-app at /workspace/cool-app")
+    expect(notificationCalls).toHaveLength(1)
+    expect(notificationCalls[0]).toBe('/usr/bin/osascript -e display notification "Done in cool-app at /workspace/cool-app" with title "OpenCode"')
   })
 
   test("should use literal string when message_format has no variables", async () => {
@@ -406,7 +440,7 @@ describe("session-notification", () => {
     await new Promise(resolve => setTimeout(resolve, 2000))
 
     //#then - notification should use the literal string as-is
-    expect(notificationCalls.length).toBeGreaterThan(0)
-    expect(notificationCalls[0]).toContain("Custom static message")
+    expect(notificationCalls).toHaveLength(1)
+    expect(notificationCalls[0]).toBe('/usr/bin/osascript -e display notification "Custom static message" with title "OpenCode"')
   })
 })

--- a/src/hooks/session-notification.ts
+++ b/src/hooks/session-notification.ts
@@ -8,11 +8,15 @@ import {
   sendNotification,
   playSound,
   hasIncompleteTodos,
+  cleanupOldSessions,
 } from "./session-notification-platform"
+import { extractProjectName, resolveMessageFormat } from "./session-notification-format"
 
 interface SessionNotificationConfig {
   title?: string
   message?: string
+  /** Custom message format with {project} and {cwd} template variables */
+  message_format?: string
   playSound?: boolean
   soundPath?: string
   /** Delay in ms before sending notification to confirm session is still idle (default: 1500) */
@@ -35,6 +39,7 @@ export function createSessionNotification(
   const mergedConfig = {
     title: "OpenCode",
     message: "Agent is ready for input",
+    message_format: "{project} \u2014 Agent is ready for input",
     playSound: false,
     soundPath: defaultSoundPath,
     idleConfirmationDelay: 1500,
@@ -51,24 +56,14 @@ export function createSessionNotification(
   // Track sessions currently executing notification (prevents duplicate execution)
   const executingNotifications = new Set<string>()
 
-  function cleanupOldSessions() {
-    const maxSessions = mergedConfig.maxTrackedSessions
-    if (notifiedSessions.size > maxSessions) {
-      const sessionsToRemove = Array.from(notifiedSessions).slice(0, notifiedSessions.size - maxSessions)
-      sessionsToRemove.forEach(id => notifiedSessions.delete(id))
-    }
-    if (sessionActivitySinceIdle.size > maxSessions) {
-      const sessionsToRemove = Array.from(sessionActivitySinceIdle).slice(0, sessionActivitySinceIdle.size - maxSessions)
-      sessionsToRemove.forEach(id => sessionActivitySinceIdle.delete(id))
-    }
-    if (notificationVersions.size > maxSessions) {
-      const sessionsToRemove = Array.from(notificationVersions.keys()).slice(0, notificationVersions.size - maxSessions)
-      sessionsToRemove.forEach(id => notificationVersions.delete(id))
-    }
-    if (executingNotifications.size > maxSessions) {
-      const sessionsToRemove = Array.from(executingNotifications).slice(0, executingNotifications.size - maxSessions)
-      sessionsToRemove.forEach(id => executingNotifications.delete(id))
-    }
+  function cleanupTrackedSessions() {
+    cleanupOldSessions(
+      mergedConfig.maxTrackedSessions,
+      notifiedSessions,
+      sessionActivitySinceIdle,
+      notificationVersions,
+      executingNotifications,
+    )
   }
 
   function cancelPendingNotification(sessionID: string) {
@@ -132,7 +127,12 @@ export function createSessionNotification(
 
       notifiedSessions.add(sessionID)
 
-      await sendNotification(ctx, currentPlatform, mergedConfig.title, mergedConfig.message)
+      const project = extractProjectName(ctx.directory)
+      const resolvedMessage = resolveMessageFormat(
+        mergedConfig.message_format,
+        { project, cwd: ctx.directory }
+      )
+      await sendNotification(ctx, currentPlatform, mergedConfig.title, resolvedMessage)
 
       if (mergedConfig.playSound && mergedConfig.soundPath) {
         await playSound(ctx, currentPlatform, mergedConfig.soundPath)
@@ -185,9 +185,9 @@ export function createSessionNotification(
         executeNotification(sessionID, currentVersion)
       }, mergedConfig.idleConfirmationDelay)
 
-      pendingTimers.set(sessionID, timer)
-      cleanupOldSessions()
-      return
+       pendingTimers.set(sessionID, timer)
+       cleanupTrackedSessions()
+       return
     }
 
     if (event.type === "message.updated") {

--- a/src/hooks/session-notification.ts
+++ b/src/hooks/session-notification.ts
@@ -1,22 +1,14 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { platform } from "os"
 import { subagentSessions, getMainSessionID } from "../features/claude-code-session-state"
+import { startBackgroundCheck } from "./session-notification-utils"
 import {
-  getOsascriptPath,
-  getNotifySendPath,
-  getPowershellPath,
-  getAfplayPath,
-  getPaplayPath,
-  getAplayPath,
-  startBackgroundCheck,
-} from "./session-notification-utils"
-
-interface Todo {
-  content: string
-  status: string
-  priority: string
-  id: string
-}
+  Platform,
+  detectPlatform,
+  getDefaultSoundPath,
+  sendNotification,
+  playSound,
+  hasIncompleteTodos,
+} from "./session-notification-platform"
 
 interface SessionNotificationConfig {
   title?: string
@@ -29,114 +21,6 @@ interface SessionNotificationConfig {
   skipIfIncompleteTodos?: boolean
   /** Maximum number of sessions to track before cleanup (default: 100) */
   maxTrackedSessions?: number
-}
-
-type Platform = "darwin" | "linux" | "win32" | "unsupported"
-
-function detectPlatform(): Platform {
-  const p = platform()
-  if (p === "darwin" || p === "linux" || p === "win32") return p
-  return "unsupported"
-}
-
-function getDefaultSoundPath(p: Platform): string {
-  switch (p) {
-    case "darwin":
-      return "/System/Library/Sounds/Glass.aiff"
-    case "linux":
-      return "/usr/share/sounds/freedesktop/stereo/complete.oga"
-    case "win32":
-      return "C:\\Windows\\Media\\notify.wav"
-    default:
-      return ""
-  }
-}
-
-async function sendNotification(
-  ctx: PluginInput,
-  p: Platform,
-  title: string,
-  message: string
-): Promise<void> {
-  switch (p) {
-    case "darwin": {
-      const osascriptPath = await getOsascriptPath()
-      if (!osascriptPath) return
-
-      const esTitle = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
-      const esMessage = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
-      await ctx.$`${osascriptPath} -e ${"display notification \"" + esMessage + "\" with title \"" + esTitle + "\""}`.catch(() => {})
-      break
-    }
-    case "linux": {
-      const notifySendPath = await getNotifySendPath()
-      if (!notifySendPath) return
-
-      await ctx.$`${notifySendPath} ${title} ${message} 2>/dev/null`.catch(() => {})
-      break
-    }
-    case "win32": {
-      const powershellPath = await getPowershellPath()
-      if (!powershellPath) return
-
-      const psTitle = title.replace(/'/g, "''")
-      const psMessage = message.replace(/'/g, "''")
-      const toastScript = `
-[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
-$Template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
-$RawXml = [xml] $Template.GetXml()
-($RawXml.toast.visual.binding.text | Where-Object {$_.id -eq '1'}).AppendChild($RawXml.CreateTextNode('${psTitle}')) | Out-Null
-($RawXml.toast.visual.binding.text | Where-Object {$_.id -eq '2'}).AppendChild($RawXml.CreateTextNode('${psMessage}')) | Out-Null
-$SerializedXml = New-Object Windows.Data.Xml.Dom.XmlDocument
-$SerializedXml.LoadXml($RawXml.OuterXml)
-$Toast = [Windows.UI.Notifications.ToastNotification]::new($SerializedXml)
-$Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('OpenCode')
-$Notifier.Show($Toast)
-`.trim().replace(/\n/g, "; ")
-      await ctx.$`${powershellPath} -Command ${toastScript}`.catch(() => {})
-      break
-    }
-  }
-}
-
-async function playSound(ctx: PluginInput, p: Platform, soundPath: string): Promise<void> {
-  switch (p) {
-    case "darwin": {
-      const afplayPath = await getAfplayPath()
-      if (!afplayPath) return
-      ctx.$`${afplayPath} ${soundPath}`.catch(() => {})
-      break
-    }
-    case "linux": {
-      const paplayPath = await getPaplayPath()
-      if (paplayPath) {
-        ctx.$`${paplayPath} ${soundPath} 2>/dev/null`.catch(() => {})
-      } else {
-        const aplayPath = await getAplayPath()
-        if (aplayPath) {
-          ctx.$`${aplayPath} ${soundPath} 2>/dev/null`.catch(() => {})
-        }
-      }
-      break
-    }
-    case "win32": {
-      const powershellPath = await getPowershellPath()
-      if (!powershellPath) return
-      ctx.$`${powershellPath} -Command ${"(New-Object Media.SoundPlayer '" + soundPath.replace(/'/g, "''") + "').PlaySync()"}`.catch(() => {})
-      break
-    }
-  }
-}
-
-async function hasIncompleteTodos(ctx: PluginInput, sessionID: string): Promise<boolean> {
-  try {
-    const response = await ctx.client.session.todo({ path: { id: sessionID } })
-    const todos = (response.data ?? response) as Todo[]
-    if (!todos || todos.length === 0) return false
-    return todos.some((t) => t.status !== "completed" && t.status !== "cancelled")
-  } catch {
-    return false
-  }
 }
 
 export function createSessionNotification(

--- a/src/hooks/session-notification.ts
+++ b/src/hooks/session-notification.ts
@@ -81,24 +81,41 @@ export function createSessionNotification(
   }
 
   async function executeNotification(sessionID: string, version: number) {
-    if (executingNotifications.has(sessionID)) { pendingTimers.delete(sessionID); return }
-    if (notificationVersions.get(sessionID) !== version) { pendingTimers.delete(sessionID); return }
-    if (sessionActivitySinceIdle.has(sessionID)) {
-      sessionActivitySinceIdle.delete(sessionID); pendingTimers.delete(sessionID); return
+    if (executingNotifications.has(sessionID)) {
+      pendingTimers.delete(sessionID)
+
+      return
     }
-    if (notifiedSessions.has(sessionID)) { pendingTimers.delete(sessionID); return }
+    if (notificationVersions.get(sessionID) !== version) {
+      pendingTimers.delete(sessionID)
+      return
+    }
+    if (sessionActivitySinceIdle.has(sessionID)) {
+      sessionActivitySinceIdle.delete(sessionID)
+      pendingTimers.delete(sessionID)
+      return
+    }
+    if (notifiedSessions.has(sessionID)) {
+      pendingTimers.delete(sessionID)
+      return
+    }
 
     executingNotifications.add(sessionID)
     try {
       if (mergedConfig.skipIfIncompleteTodos) {
         const hasPendingWork = await hasIncompleteTodos(ctx, sessionID)
-        if (notificationVersions.get(sessionID) !== version) return
+        if (notificationVersions.get(sessionID) !== version) {
+          return
+        }
         if (hasPendingWork) return
       }
 
-      if (notificationVersions.get(sessionID) !== version) return
+      if (notificationVersions.get(sessionID) !== version) {
+        return
+      }
       if (sessionActivitySinceIdle.has(sessionID)) {
-        sessionActivitySinceIdle.delete(sessionID); return
+        sessionActivitySinceIdle.delete(sessionID)
+        return
       }
 
       notifiedSessions.add(sessionID)

--- a/src/hooks/session-notification.ts
+++ b/src/hooks/session-notification.ts
@@ -83,18 +83,20 @@ export function createSessionNotification(
   async function executeNotification(sessionID: string, version: number) {
     if (executingNotifications.has(sessionID)) {
       pendingTimers.delete(sessionID)
-
       return
     }
+
     if (notificationVersions.get(sessionID) !== version) {
       pendingTimers.delete(sessionID)
       return
     }
+
     if (sessionActivitySinceIdle.has(sessionID)) {
       sessionActivitySinceIdle.delete(sessionID)
       pendingTimers.delete(sessionID)
       return
     }
+
     if (notifiedSessions.has(sessionID)) {
       pendingTimers.delete(sessionID)
       return
@@ -113,6 +115,7 @@ export function createSessionNotification(
       if (notificationVersions.get(sessionID) !== version) {
         return
       }
+      
       if (sessionActivitySinceIdle.has(sessionID)) {
         sessionActivitySinceIdle.delete(sessionID)
         return

--- a/src/hooks/session-notification.ts
+++ b/src/hooks/session-notification.ts
@@ -1,20 +1,17 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { subagentSessions, getMainSessionID } from "../features/claude-code-session-state"
-import { startBackgroundCheck } from "./session-notification-utils"
+import { startBackgroundCheck, cleanupOldSessions } from "./session-notification-utils"
 import {
-  Platform,
   detectPlatform,
   getDefaultSoundPath,
   sendNotification,
   playSound,
   hasIncompleteTodos,
-  cleanupOldSessions,
 } from "./session-notification-platform"
 import { extractProjectName, resolveMessageFormat } from "./session-notification-format"
 
 interface SessionNotificationConfig {
   title?: string
-  message?: string
   /** Custom message format with {project} and {cwd} template variables */
   message_format?: string
   playSound?: boolean
@@ -38,7 +35,6 @@ export function createSessionNotification(
 
   const mergedConfig = {
     title: "OpenCode",
-    message: "Agent is ready for input",
     message_format: "{project} \u2014 Agent is ready for input",
     playSound: false,
     soundPath: defaultSoundPath,
@@ -85,44 +81,24 @@ export function createSessionNotification(
   }
 
   async function executeNotification(sessionID: string, version: number) {
-    if (executingNotifications.has(sessionID)) {
-      pendingTimers.delete(sessionID)
-      return
-    }
-
-    if (notificationVersions.get(sessionID) !== version) {
-      pendingTimers.delete(sessionID)
-      return
-    }
-
+    if (executingNotifications.has(sessionID)) { pendingTimers.delete(sessionID); return }
+    if (notificationVersions.get(sessionID) !== version) { pendingTimers.delete(sessionID); return }
     if (sessionActivitySinceIdle.has(sessionID)) {
-      sessionActivitySinceIdle.delete(sessionID)
-      pendingTimers.delete(sessionID)
-      return
+      sessionActivitySinceIdle.delete(sessionID); pendingTimers.delete(sessionID); return
     }
-
-    if (notifiedSessions.has(sessionID)) {
-      pendingTimers.delete(sessionID)
-      return
-    }
+    if (notifiedSessions.has(sessionID)) { pendingTimers.delete(sessionID); return }
 
     executingNotifications.add(sessionID)
     try {
       if (mergedConfig.skipIfIncompleteTodos) {
         const hasPendingWork = await hasIncompleteTodos(ctx, sessionID)
-        if (notificationVersions.get(sessionID) !== version) {
-          return
-        }
+        if (notificationVersions.get(sessionID) !== version) return
         if (hasPendingWork) return
       }
 
-      if (notificationVersions.get(sessionID) !== version) {
-        return
-      }
-
+      if (notificationVersions.get(sessionID) !== version) return
       if (sessionActivitySinceIdle.has(sessionID)) {
-        sessionActivitySinceIdle.delete(sessionID)
-        return
+        sessionActivitySinceIdle.delete(sessionID); return
       }
 
       notifiedSessions.add(sessionID)
@@ -168,7 +144,6 @@ export function createSessionNotification(
 
       if (subagentSessions.has(sessionID)) return
 
-      // Only trigger notifications for the main session (not subagent sessions)
       const mainSessionID = getMainSessionID()
       if (mainSessionID && sessionID !== mainSessionID) return
 
@@ -185,15 +160,16 @@ export function createSessionNotification(
         executeNotification(sessionID, currentVersion)
       }, mergedConfig.idleConfirmationDelay)
 
-       pendingTimers.set(sessionID, timer)
-       cleanupTrackedSessions()
-       return
+      pendingTimers.set(sessionID, timer)
+      cleanupTrackedSessions()
+      return
     }
 
     if (event.type === "message.updated") {
       const info = props?.info as Record<string, unknown> | undefined
+      const role = info?.role as string | undefined
       const sessionID = info?.sessionID as string | undefined
-      if (sessionID) {
+      if (sessionID && role === "assistant") {
         markSessionActivity(sessionID)
       }
       return

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,9 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
         allPlugins: externalNotifier.allPlugins,
       });
     } else {
-      sessionNotification = safeCreateHook("session-notification", () => createSessionNotification(ctx), { enabled: safeHookEnabled });
+      sessionNotification = safeCreateHook("session-notification", () => createSessionNotification(ctx, {
+        message_format: pluginConfig.notification?.message_format,
+      }), { enabled: safeHookEnabled });
     }
   }
 


### PR DESCRIPTION
**Problem**
The system notification message shown when an agent completes execution is hardcoded, making it difficult to identify which project's work has completed when working across multiple projects in parallel.

**Solution**
Expose the project name and working directory in the notification message, and allow users to freely customize the format through configuration. Additionally, fixed a bug discovered during development where notifications were never actually being sent.

## Summary

- Add `message_format` config option to customize OS notification messages with `{project}` (folder name) and `{cwd}` (full path) template variables
- Refactor `session-notification.ts` to comply with 200 LOC rule by extracting platform functions and cleanup logic into separate modules
- Fix config passthrough bug in `index.ts` where `message_format` was not forwarded to the notification hook
- **Fix `message.updated` bug**: notifications were never firing because `message.updated` with `role: "user"` (metadata updates) was incorrectly cancelling the idle notification timer ~21ms after `session.idle`

## Changes

### New Files
- **`src/hooks/session-notification-format.ts`** — Format resolver with `extractProjectName()` and `resolveMessageFormat()` using `String.replace()`
- **`src/hooks/session-notification-format.test.ts`** — 10 TDD tests covering project name extraction, template variable resolution, edge cases
- **`src/hooks/session-notification-platform.ts`** — Extracted platform detection, notification sending, sound playback, session cleanup
- **`src/hooks/session-notification-utils.ts`** — Moved `cleanupOldSessions` for better separation of concerns

### Modified Files
- **`src/config/schema.ts`** — Added `message_format: z.string().optional()` to `NotificationConfigSchema`
- **`src/hooks/session-notification.ts`** — Imports extracted modules, resolves format before sending notification; filters `message.updated` by `role === "assistant"` to fix notification bug
- **`src/hooks/session-notification.test.ts`** — Tests for default/custom format, literal strings, assistant vs user role filtering
- **`src/index.ts`** — Passes `message_format` from plugin config to notification hook

## Bug Fix: Notifications Never Firing

### Root Cause

After `session.idle` fires, OpenCode emits a `message.updated` event (~21ms later) to update the user message's `summary` metadata. The old code treated **all** `message.updated` events as "new agent activity", calling `cancelPendingNotification()` which cleared the idle notification timer before it could fire.

```
session.idle  → start 1500ms timer
message.updated (role: "user", summary update) → cancel timer (21ms later!)
→ notification never sent
```

### Fix

Filter `message.updated` by role — only `role === "assistant"` marks session activity. This matches the existing pattern in `cli/run/events.ts` (line 269) and `todo-continuation-enforcer.ts` (line 450).

```typescript
// Before: all message.updated cancelled the timer
if (sessionID) { markSessionActivity(sessionID) }

// After: only assistant messages cancel the timer
if (sessionID && role === "assistant") { markSessionActivity(sessionID) }
```

## Usage

```jsonc
// .opencode/oh-my-opencode.json
{
  "notification": {
    "message_format": "{project} — Agent is ready for input"  // default
    // or: "{cwd} — Done!"
    // or: "Build complete"  (literal, no variables)
  }
}
```

### Template Variables

| Variable | Description | Example |
|----------|-------------|---------|
| `{project}` | Folder name (`path.basename`) | `my-app` |
| `{cwd}` | Full working directory path | `/Users/me/projects/my-app` |

Unrecognized variables (e.g., `{unknown}`) pass through as-is — no errors.

## Backward Compatibility

- Default format is `"{project} — Agent is ready for input"` (em dash U+2014)
- Without config, behavior is identical to before (project name replaces the old hardcoded message)
- `notification.force_enable` continues to work as before

## Verification

- `bun run typecheck` — zero errors
- `bun run build` — succeeds
- `bun test` — 15 session-notification tests pass, all project tests pass
- Manually tested: notification now fires correctly after agent completes work