### PR TITLE
fix: normalize claude version separators across providers in fuzzyMatchModel

### DIFF
--- a/src/shared/model-availability.test.ts
+++ b/src/shared/model-availability.test.ts
@@ -363,6 +363,30 @@ describe("fuzzyMatchModel", () => {
 		const result = fuzzyMatchModel("gpt", available)
 		expect(result).toBeNull()
 	})
+
+	// given claude model with hyphen version separator (anthropic style)
+	// when matching against available models with dot separator (copilot style)
+	// then normalize and match across providers
+	it("should match claude models across providers despite version separator differences", () => {
+		const available = new Set([
+			"github-copilot/claude-opus-4.6",
+			"github-copilot/claude-sonnet-4.5",
+			"github-copilot/claude-haiku-4.5",
+		])
+		expect(fuzzyMatchModel("claude-opus-4-6", available, ["github-copilot"]))
+			.toBe("github-copilot/claude-opus-4.6")
+		expect(fuzzyMatchModel("claude-sonnet-4-5", available, ["github-copilot"]))
+			.toBe("github-copilot/claude-sonnet-4.5")
+	})
+
+	// given non-claude models with hyphens
+	// when matching
+	// then hyphens are not treated as version separators
+	it("should not normalize hyphens in non-claude model names", () => {
+		const available = new Set(["github-copilot/grok-code-fast-1"])
+		expect(fuzzyMatchModel("grok-code-fast-1", available, ["github-copilot"]))
+			.toBe("github-copilot/grok-code-fast-1")
+	})
 })
 
 describe("getConnectedProviders", () => {

--- a/src/shared/model-availability.ts
+++ b/src/shared/model-availability.ts
@@ -27,8 +27,7 @@ import * as connectedProvidersCache from "./connected-providers-cache"
 function normalizeModelName(name: string): string {
 	return name
 		.toLowerCase()
-		.replace(/claude-(opus|sonnet|haiku)-4-5/g, "claude-$1-4.5")
-		.replace(/claude-(opus|sonnet|haiku)-4\.5/g, "claude-$1-4.5")
+		.replace(/claude-(opus|sonnet|haiku)-(\d+)[.-](\d+)/g, "claude-$1-$2.$3")
 }
 
 export function fuzzyMatchModel(


### PR DESCRIPTION
## Summary

- Generalize `normalizeModelName` in `model-availability.ts` to handle all claude version numbers, not just 4.5
- Collapse two regex replacements into one using `[.-]` character class
- Add tests for cross-provider model matching and non-claude safety

## Problem

`models.dev` uses different version separators per provider for the same model:
- `anthropic` → `claude-opus-4-6` (hyphens)
- `github-copilot` → `claude-opus-4.6` (dots)

The fallback chains include `github-copilot` as a provider alongside `anthropic`, but `fuzzyMatchModel` only normalized `4-5`↔`4.5`. All other versions (4-6, 4-0, 4-1) silently failed to match, causing fallback chains to skip copilot entirely and land on lower-quality free models.

## Changes

**`src/shared/model-availability.ts`** — Replace two hardcoded `4-5` regexes with one generic pattern:

```typescript
// Before
.replace(/claude-(opus|sonnet|haiku)-4-5/g, "claude-$1-4.5")
.replace(/claude-(opus|sonnet|haiku)-4\.5/g, "claude-$1-4.5")

// After
.replace(/claude-(opus|sonnet|haiku)-(\d+)[.-](\d+)/g, "claude-$1-$2.$3")
```

**`src/shared/model-availability.test.ts`** — 2 new tests:
1. Cross-provider matching: `claude-opus-4-6` matches `github-copilot/claude-opus-4.6`
2. Safety: non-claude hyphens (`grok-code-fast-1`) are not affected

## Testing

All 50 tests pass locally (`bun test src/shared/model-availability.test.ts`).

Closes #1679