### PR TITLE
fix: prevent run completion race condition with consecutive stability checks

### DIFF
--- a/src/cli/run/poll-for-completion.test.ts
+++ b/src/cli/run/poll-for-completion.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, mock, spyOn } from "bun:test"
+import type { RunContext, Todo, ChildSession, SessionStatus } from "./types"
+import { createEventState } from "./events"
+import { pollForCompletion } from "./poll-for-completion"
+
+const createMockContext = (overrides: {
+  todo?: Todo[]
+  childrenBySession?: Record<string, ChildSession[]>
+  statuses?: Record<string, SessionStatus>
+} = {}): RunContext => {
+  const {
+    todo = [],
+    childrenBySession = { "test-session": [] },
+    statuses = {},
+  } = overrides
+
+  return {
+    client: {
+      session: {
+        todo: mock(() => Promise.resolve({ data: todo })),
+        children: mock((opts: { path: { id: string } }) =>
+          Promise.resolve({ data: childrenBySession[opts.path.id] ?? [] })
+        ),
+        status: mock(() => Promise.resolve({ data: statuses })),
+      },
+    } as unknown as RunContext["client"],
+    sessionID: "test-session",
+    directory: "/test",
+    abortController: new AbortController(),
+  }
+}
+
+describe("pollForCompletion", () => {
+  it("requires consecutive stability checks before exiting - not immediate", async () => {
+    //#given - 0 todos, 0 children, session idle, meaningful work done
+    spyOn(console, "log").mockImplementation(() => {})
+    spyOn(console, "error").mockImplementation(() => {})
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.hasReceivedMeaningfulWork = true
+    const abortController = new AbortController()
+
+    //#when
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 10,
+      requiredConsecutive: 3,
+    })
+
+    //#then - exits with 0 but only after 3 consecutive checks
+    expect(result).toBe(0)
+    const todoCallCount = (ctx.client.session.todo as ReturnType<typeof mock>).mock.calls.length
+    expect(todoCallCount).toBeGreaterThanOrEqual(3)
+  })
+
+  it("does not exit when currentTool is set - resets consecutive counter", async () => {
+    //#given
+    spyOn(console, "log").mockImplementation(() => {})
+    spyOn(console, "error").mockImplementation(() => {})
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.hasReceivedMeaningfulWork = true
+    eventState.currentTool = "task"
+    const abortController = new AbortController()
+
+    //#when - abort after enough time to verify it didn't exit
+    setTimeout(() => abortController.abort(), 100)
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 10,
+      requiredConsecutive: 3,
+    })
+
+    //#then - should be aborted, not completed (tool blocked exit)
+    expect(result).toBe(130)
+    const todoCallCount = (ctx.client.session.todo as ReturnType<typeof mock>).mock.calls.length
+    expect(todoCallCount).toBe(0)
+  })
+
+  it("resets consecutive counter when session becomes busy between checks", async () => {
+    //#given
+    spyOn(console, "log").mockImplementation(() => {})
+    spyOn(console, "error").mockImplementation(() => {})
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.hasReceivedMeaningfulWork = true
+    const abortController = new AbortController()
+    let todoCallCount = 0
+    let busyInserted = false
+
+    ;(ctx.client.session as any).todo = mock(async () => {
+      todoCallCount++
+      if (todoCallCount === 1 && !busyInserted) {
+        busyInserted = true
+        eventState.mainSessionIdle = false
+        setTimeout(() => { eventState.mainSessionIdle = true }, 15)
+      }
+      return { data: [] }
+    })
+    ;(ctx.client.session as any).children = mock(() =>
+      Promise.resolve({ data: [] })
+    )
+    ;(ctx.client.session as any).status = mock(() =>
+      Promise.resolve({ data: {} })
+    )
+
+    //#when
+    const startMs = Date.now()
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 10,
+      requiredConsecutive: 3,
+    })
+    const elapsedMs = Date.now() - startMs
+
+    //#then - took longer than 3 polls because busy interrupted the streak
+    expect(result).toBe(0)
+    expect(elapsedMs).toBeGreaterThan(30)
+  })
+
+  it("returns 1 on session error", async () => {
+    //#given
+    spyOn(console, "log").mockImplementation(() => {})
+    spyOn(console, "error").mockImplementation(() => {})
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.mainSessionError = true
+    eventState.lastError = "Test error"
+    const abortController = new AbortController()
+
+    //#when
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 10,
+      requiredConsecutive: 3,
+    })
+
+    //#then
+    expect(result).toBe(1)
+  })
+
+  it("returns 130 when aborted", async () => {
+    //#given
+    spyOn(console, "log").mockImplementation(() => {})
+    spyOn(console, "error").mockImplementation(() => {})
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    const abortController = new AbortController()
+
+    //#when
+    setTimeout(() => abortController.abort(), 50)
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 10,
+      requiredConsecutive: 3,
+    })
+
+    //#then
+    expect(result).toBe(130)
+  })
+
+  it("does not check completion when hasReceivedMeaningfulWork is false", async () => {
+    //#given
+    spyOn(console, "log").mockImplementation(() => {})
+    spyOn(console, "error").mockImplementation(() => {})
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.hasReceivedMeaningfulWork = false
+    const abortController = new AbortController()
+
+    //#when
+    setTimeout(() => abortController.abort(), 100)
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 10,
+      requiredConsecutive: 3,
+    })
+
+    //#then
+    expect(result).toBe(130)
+    const todoCallCount = (ctx.client.session.todo as ReturnType<typeof mock>).mock.calls.length
+    expect(todoCallCount).toBe(0)
+  })
+
+  it("simulates race condition: brief idle with 0 todos does not cause immediate exit", async () => {
+    //#given - simulate Sisyphus outputting text, session goes idle briefly, then tool fires
+    spyOn(console, "log").mockImplementation(() => {})
+    spyOn(console, "error").mockImplementation(() => {})
+    const ctx = createMockContext()
+    const eventState = createEventState()
+    eventState.mainSessionIdle = true
+    eventState.hasReceivedMeaningfulWork = true
+    const abortController = new AbortController()
+    let pollTick = 0
+
+    ;(ctx.client.session as any).todo = mock(async () => {
+      pollTick++
+      if (pollTick === 2) {
+        eventState.currentTool = "task"
+      }
+      return { data: [] }
+    })
+    ;(ctx.client.session as any).children = mock(() =>
+      Promise.resolve({ data: [] })
+    )
+    ;(ctx.client.session as any).status = mock(() =>
+      Promise.resolve({ data: {} })
+    )
+
+    //#when - abort after tool stays in-flight
+    setTimeout(() => abortController.abort(), 200)
+    const result = await pollForCompletion(ctx, eventState, abortController, {
+      pollIntervalMs: 10,
+      requiredConsecutive: 3,
+    })
+
+    //#then - should NOT have exited with 0 (tool blocked it, then aborted)
+    expect(result).toBe(130)
+  })
+})


### PR DESCRIPTION
## Summary

- Fix race condition in `oh-my-opencode run` where `pollForCompletion` exits immediately when session goes idle before agent creates TODOs or registers child sessions (0 todos + 0 children = vacuously complete)
- Add consecutive stability checks (3×500ms debounce) requiring completion conditions to be met 3 consecutive polls before exiting
- Add `currentTool` guard to prevent exit while main-session tool is in-flight

## Problem

When Sisyphus receives a prompt and outputs text (e.g., "ULTRAWORK MODE ENABLED!"), then fires background `task()` agents:

1. `hasReceivedMeaningfulWork = true` (text was output)
2. Session goes idle briefly between turns
3. `areAllTodosComplete()`: 0 TODOs → `filter().length === 0` → `true` (vacuously true)
4. `areAllChildrenIdle()`: 0 children registered yet → `true`
5. **Result: premature "All tasks completed" exit**

Reported by Jobdori running parallel Sisyphus instances via `oh-my-opencode run`.

## Solution

**Option A from Oracle consultation**: Consecutive stability (debounce) in `pollForCompletion()`:
- Require `REQUIRED_CONSECUTIVE = 3` consecutive positive `checkCompletionConditions()` checks before exiting (3×500ms = 1.5s stability window)
- Reset counter when session becomes busy, tool is in-flight, or completion check fails
- No changes to `completion.ts` semantics (0 TODOs can still be valid "done" state)

**Extracted** `pollForCompletion` to dedicated `poll-for-completion.ts` module for testability.

## Changes

| File | Change |
|------|--------|
| `src/cli/run/poll-for-completion.ts` | **New** — extracted poll logic with debounce + currentTool guard |
| `src/cli/run/poll-for-completion.test.ts` | **New** — 7 test cases covering race condition, debounce, guards |
| `src/cli/run/runner.ts` | Import from new module, remove old inline `pollForCompletion` |

## Test Plan

| Test Case | Verifies |
|-----------|----------|
| Requires consecutive stability checks before exiting | Debounce prevents instant exit |
| Does not exit when currentTool is set | Tool in-flight guard works |
| Resets counter when session becomes busy | Busy interruption resets streak |
| Returns 1 on session error | Error handling preserved |
| Returns 130 when aborted | Abort handling preserved |
| Does not check completion without meaningful work | Pre-condition preserved |
| Race condition: brief idle with 0 todos doesn't exit | **The actual bug scenario** |

## Verification

- ✅ 7/7 new tests pass
- ✅ 68/68 run/ directory tests pass
- ✅ 2449/2449 full test suite passes
- ✅ Typecheck clean
- ✅ Build clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents premature run completion by debouncing completion checks and guarding against in-flight tools. Fixes a race where an idle session with 0 TODOs and no children exited early.

- **Bug Fixes**
  - Require 3 consecutive positive checks (default 500ms interval) before exiting.
  - Block exit while the main-session tool is running (currentTool guard).

- **Refactors**
  - Extracted pollForCompletion to src/cli/run/poll-for-completion.ts.
  - Added tests covering debounce, tool guard, and abort/error paths.

<sup>Written for commit e55fc1f14c6dacf593851756726447630507d6b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

