### PR TITLE
fix(hooks): use 1M context limit for Claude Opus 4.6

### DIFF
--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -2,12 +2,18 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import { createSystemDirective, SystemDirectiveTypes } from "../shared/system-directive"
 
 const ANTHROPIC_DISPLAY_LIMIT = 1_000_000
+const OPUS_4_6_LIMIT = 1_000_000
 const ANTHROPIC_ACTUAL_LIMIT =
   process.env.ANTHROPIC_1M_CONTEXT === "true" ||
   process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
     ? 1_000_000
     : 200_000
 const CONTEXT_WARNING_THRESHOLD = 0.70
+
+function isOpus46(modelID: string | undefined): boolean {
+  if (!modelID) return false
+  return modelID.includes("opus-4-6") || modelID.includes("opus-4.6")
+}
 
 const CONTEXT_REMINDER = `${createSystemDirective(SystemDirectiveTypes.CONTEXT_WINDOW_MONITOR)}
 
@@ -18,6 +24,7 @@ Complete your work thoroughly and methodically.`
 interface AssistantMessageInfo {
   role: "assistant"
   providerID: string
+  modelID?: string
   tokens: {
     input: number
     output: number
@@ -57,12 +64,11 @@ export function createContextWindowMonitorHook(ctx: PluginInput) {
       const lastAssistant = assistantMessages[assistantMessages.length - 1]
       if (lastAssistant.providerID !== "anthropic") return
 
-      // Use only the last assistant message's input tokens
-      // This reflects the ACTUAL current context window usage (post-compaction)
       const lastTokens = lastAssistant.tokens
       const totalInputTokens = (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0)
 
-      const actualUsagePercentage = totalInputTokens / ANTHROPIC_ACTUAL_LIMIT
+      const actualLimit = isOpus46(lastAssistant.modelID) ? OPUS_4_6_LIMIT : ANTHROPIC_ACTUAL_LIMIT
+      const actualUsagePercentage = totalInputTokens / actualLimit
 
       if (actualUsagePercentage < CONTEXT_WARNING_THRESHOLD) return
 

--- a/src/hooks/preemptive-compaction.test.ts
+++ b/src/hooks/preemptive-compaction.test.ts
@@ -25,8 +25,43 @@ describe("preemptive-compaction", () => {
     } as never
   }
 
-  test("triggers summarize when usage exceeds threshold", async () => {
-    // #given
+  test("triggers summarize for anthropic non-opus-4.6 when usage exceeds 200K threshold", async () => {
+    //#given - sonnet 4.5 at 180K (90% of 200K limit)
+    const messages = mock(() =>
+      Promise.resolve({
+        data: [
+          {
+            info: {
+              role: "assistant",
+              providerID: "anthropic",
+              modelID: "claude-sonnet-4-5",
+              tokens: {
+                input: 180000,
+                output: 0,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+              },
+            },
+          },
+        ],
+      })
+    )
+    const summarize = mock(() => Promise.resolve())
+    const hook = createPreemptiveCompactionHook(createMockCtx({ messages, summarize }))
+    const output = { title: "", output: "", metadata: {} }
+
+    //#when
+    await hook["tool.execute.after"](
+      { tool: "Read", sessionID, callID: "call-1" },
+      output
+    )
+
+    //#then
+    expect(summarize).toHaveBeenCalled()
+  })
+
+  test("does not trigger summarize for opus 4.6 at 180K (well under 1M limit)", async () => {
+    //#given - opus 4.6 at 180K (18% of 1M limit)
     const messages = mock(() =>
       Promise.resolve({
         data: [
@@ -50,13 +85,48 @@ describe("preemptive-compaction", () => {
     const hook = createPreemptiveCompactionHook(createMockCtx({ messages, summarize }))
     const output = { title: "", output: "", metadata: {} }
 
-    // #when
+    //#when
     await hook["tool.execute.after"](
-      { tool: "Read", sessionID, callID: "call-1" },
+      { tool: "Read", sessionID, callID: "call-opus" },
       output
     )
 
-    // #then
+    //#then
+    expect(summarize).not.toHaveBeenCalled()
+  })
+
+  test("triggers summarize for opus 4.6 when usage exceeds 78% of 1M", async () => {
+    //#given - opus 4.6 at 800K (80% of 1M limit)
+    const messages = mock(() =>
+      Promise.resolve({
+        data: [
+          {
+            info: {
+              role: "assistant",
+              providerID: "anthropic",
+              modelID: "claude-opus-4-6",
+              tokens: {
+                input: 800000,
+                output: 0,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+              },
+            },
+          },
+        ],
+      })
+    )
+    const summarize = mock(() => Promise.resolve())
+    const hook = createPreemptiveCompactionHook(createMockCtx({ messages, summarize }))
+    const output = { title: "", output: "", metadata: {} }
+
+    //#when
+    await hook["tool.execute.after"](
+      { tool: "Read", sessionID, callID: "call-opus-high" },
+      output
+    )
+
+    //#then
     expect(summarize).toHaveBeenCalled()
   })
 

--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -1,10 +1,17 @@
 const DEFAULT_ACTUAL_LIMIT = 200_000
+const OPUS_4_6_LIMIT = 1_000_000
 
 const ANTHROPIC_ACTUAL_LIMIT =
   process.env.ANTHROPIC_1M_CONTEXT === "true" ||
   process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
     ? 1_000_000
     : DEFAULT_ACTUAL_LIMIT
+
+/** Claude Opus 4.6 supports 1M context regardless of what models.dev reports for the direct Anthropic provider */
+function isOpus46(modelID: string | undefined): boolean {
+  if (!modelID) return false
+  return modelID.includes("opus-4-6") || modelID.includes("opus-4.6")
+}
 
 const PREEMPTIVE_COMPACTION_THRESHOLD = 0.78
 
@@ -61,8 +68,9 @@ export function createPreemptiveCompactionHook(ctx: PluginInput) {
       if (assistantMessages.length === 0) return
 
       const lastAssistant = assistantMessages[assistantMessages.length - 1]
-      const actualLimit =
-        lastAssistant.providerID === "anthropic"
+      const actualLimit = isOpus46(lastAssistant.modelID)
+        ? OPUS_4_6_LIMIT
+        : lastAssistant.providerID === "anthropic"
           ? ANTHROPIC_ACTUAL_LIMIT
           : DEFAULT_ACTUAL_LIMIT
 


### PR DESCRIPTION
## Summary

- Add `isOpus46()` check to `context-window-monitor` and `preemptive-compaction` hooks so Claude Opus 4.6 uses its actual 1M context limit instead of the hardcoded 200K default
- The `ANTHROPIC_1M_CONTEXT` env var is preserved as a fallback for other Anthropic models

## Problem

Both hooks hardcode `200_000` as the Anthropic context limit, gated behind the `ANTHROPIC_1M_CONTEXT` env var. This causes premature compaction at 200K for Opus 4.6 sessions, which actually support 1M context. The env var workaround applies a blanket 1M to *all* Anthropic models, which is incorrect for 200K models like Sonnet 4.5.

## Solution

Check the `modelID` for Opus 4.6 patterns (`opus-4-6`, `opus-4.6`) and use 1M for that model specifically. All other Anthropic models continue using the existing 200K default (or env var override).

## Changes

- `src/hooks/context-window-monitor.ts` — added `modelID` to interface, `isOpus46()` check
- `src/hooks/preemptive-compaction.ts` — added `isOpus46()` check before provider-based fallback
- `src/hooks/preemptive-compaction.test.ts` — updated tests for Opus 4.6 vs non-Opus behavior

## Testing

- `bun run typecheck` ✅
- `bun test src/hooks/preemptive-compaction.test.ts` — 5/5 pass ✅