### PR TITLE
feat(comment-checker): support apply_patch

### DIFF
--- a/src/agents/sisyphus-junior/default.ts
+++ b/src/agents/sisyphus-junior/default.ts
@@ -12,6 +12,7 @@ export function buildDefaultSisyphusJuniorPrompt(
   promptAppend?: string
 ): string {
   const todoDiscipline = buildTodoDisciplineSection(useTaskSystem)
+  const constraintsSection = buildConstraintsSection(useTaskSystem)
   const verificationText = useTaskSystem
     ? "All tasks marked completed"
     : "All todos marked completed"
@@ -21,13 +22,7 @@ Sisyphus-Junior - Focused executor from OhMyOpenCode.
 Execute tasks directly. NEVER delegate or spawn other agents.
 </Role>
 
-<Critical_Constraints>
-BLOCKED ACTIONS (will fail if attempted):
-- task tool: BLOCKED
-
-ALLOWED: call_omo_agent - You CAN spawn explore/librarian agents for research.
-You work ALONE for implementation. No delegation of implementation tasks.
-</Critical_Constraints>
+${constraintsSection}
 
 ${todoDiscipline}
 
@@ -46,6 +41,29 @@ Task NOT complete without:
 
   if (!promptAppend) return prompt
   return prompt + "\n\n" + promptAppend
+}
+
+function buildConstraintsSection(useTaskSystem: boolean): string {
+  if (useTaskSystem) {
+    return `<Critical_Constraints>
+BLOCKED ACTIONS (will fail if attempted):
+- task (agent delegation tool): BLOCKED — you cannot delegate work to other agents
+
+ALLOWED tools:
+- call_omo_agent: You CAN spawn explore/librarian agents for research
+- task_create, task_update, task_list, task_get: ALLOWED — use these for tracking your work
+
+You work ALONE for implementation. No delegation of implementation tasks.
+</Critical_Constraints>`
+  }
+
+  return `<Critical_Constraints>
+BLOCKED ACTIONS (will fail if attempted):
+- task (agent delegation tool): BLOCKED — you cannot delegate work to other agents
+
+ALLOWED: call_omo_agent - You CAN spawn explore/librarian agents for research.
+You work ALONE for implementation. No delegation of implementation tasks.
+</Critical_Constraints>`
 }
 
 function buildTodoDisciplineSection(useTaskSystem: boolean): string {

--- a/src/agents/sisyphus-junior/gpt.ts
+++ b/src/agents/sisyphus-junior/gpt.ts
@@ -21,6 +21,7 @@ export function buildGptSisyphusJuniorPrompt(
   promptAppend?: string
 ): string {
   const taskDiscipline = buildGptTaskDisciplineSection(useTaskSystem)
+  const blockedActionsSection = buildGptBlockedActionsSection(useTaskSystem)
   const verificationText = useTaskSystem
     ? "All tasks marked completed"
     : "All todos marked completed"
@@ -45,19 +46,7 @@ Role: Execute tasks directly. You work ALONE.
 - Do NOT expand task boundaries beyond what's written.
 </scope_and_design_constraints>
 
-<blocked_actions>
-BLOCKED (will fail if attempted):
-| Tool | Status |
-|------|--------|
-| task | BLOCKED |
-
-ALLOWED:
-| Tool | Usage |
-|------|-------|
-| call_omo_agent | Spawn explore/librarian for research ONLY |
-
-You work ALONE for implementation. No delegation.
-</blocked_actions>
+${blockedActionsSection}
 
 <uncertainty_and_ambiguity>
 - If a task is ambiguous or underspecified:
@@ -97,6 +86,42 @@ Task NOT complete without evidence:
 
   if (!promptAppend) return prompt
   return prompt + "\n\n" + promptAppend
+}
+
+function buildGptBlockedActionsSection(useTaskSystem: boolean): string {
+  if (useTaskSystem) {
+    return `<blocked_actions>
+BLOCKED (will fail if attempted):
+| Tool | Status | Description |
+|------|--------|-------------|
+| task | BLOCKED | Agent delegation tool — you cannot spawn other agents |
+
+ALLOWED:
+| Tool | Usage |
+|------|-------|
+| call_omo_agent | Spawn explore/librarian for research ONLY |
+| task_create | Create tasks to track your work |
+| task_update | Update task status (in_progress, completed) |
+| task_list | List active tasks |
+| task_get | Get task details by ID |
+
+You work ALONE for implementation. No delegation.
+</blocked_actions>`
+  }
+
+  return `<blocked_actions>
+BLOCKED (will fail if attempted):
+| Tool | Status | Description |
+|------|--------|-------------|
+| task | BLOCKED | Agent delegation tool — you cannot spawn other agents |
+
+ALLOWED:
+| Tool | Usage |
+|------|-------|
+| call_omo_agent | Spawn explore/librarian for research ONLY |
+
+You work ALONE for implementation. No delegation.
+</blocked_actions>`
 }
 
 function buildGptTaskDisciplineSection(useTaskSystem: boolean): string {

--- a/src/agents/sisyphus-junior/index.test.ts
+++ b/src/agents/sisyphus-junior/index.test.ts
@@ -238,6 +238,48 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
       expect(result.prompt).toContain("todowrite")
       expect(result.prompt).not.toContain("TaskCreate")
     })
+
+    test("useTaskSystem=true explicitly lists task management tools as ALLOWED for Claude", () => {
+      //#given
+      const override = { model: "anthropic/claude-sonnet-4-5" }
+
+      //#when
+      const result = createSisyphusJuniorAgentWithOverrides(override, undefined, true)
+
+      //#then - prompt must disambiguate: delegation tool blocked, management tools allowed
+      expect(result.prompt).toContain("task_create")
+      expect(result.prompt).toContain("task_update")
+      expect(result.prompt).toContain("task_list")
+      expect(result.prompt).toContain("task_get")
+      expect(result.prompt).toContain("agent delegation tool")
+    })
+
+    test("useTaskSystem=true explicitly lists task management tools as ALLOWED for GPT", () => {
+      //#given
+      const override = { model: "openai/gpt-5.2" }
+
+      //#when
+      const result = createSisyphusJuniorAgentWithOverrides(override, undefined, true)
+
+      //#then - prompt must disambiguate: delegation tool blocked, management tools allowed
+      expect(result.prompt).toContain("task_create")
+      expect(result.prompt).toContain("task_update")
+      expect(result.prompt).toContain("task_list")
+      expect(result.prompt).toContain("task_get")
+      expect(result.prompt).toContain("Agent delegation tool")
+    })
+
+    test("useTaskSystem=false does NOT list task management tools in constraints", () => {
+      //#given - Claude model without task system
+      const override = { model: "anthropic/claude-sonnet-4-5" }
+
+      //#when
+      const result = createSisyphusJuniorAgentWithOverrides(override, undefined, false)
+
+      //#then - no task management tool references in constraints section
+      expect(result.prompt).not.toContain("task_create")
+      expect(result.prompt).not.toContain("task_update")
+    })
   })
 
   describe("prompt composition", () => {

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -1,5 +1,5 @@
 import { join } from "path"
-import { getClaudeConfigDir } from "../../shared"
+import { getClaudeConfigDir } from "../../shared/claude-config-dir"
 import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { LoadedSkill } from "./types"

--- a/src/hooks/atlas/event-handler.ts
+++ b/src/hooks/atlas/event-handler.ts
@@ -89,13 +89,20 @@ export function createAtlasEventHandler(input: {
         return
       }
 
-      const requiredAgent = (boulderState.agent ?? "atlas").toLowerCase()
       const lastAgent = getLastAgentFromSession(sessionID)
-      if (!lastAgent || lastAgent !== requiredAgent) {
+      const requiredAgent = (boulderState.agent ?? "atlas").toLowerCase()
+      const lastAgentMatchesRequired = lastAgent === requiredAgent
+      const boulderAgentWasNotExplicitlySet = boulderState.agent === undefined
+      const boulderAgentDefaultsToAtlas = requiredAgent === "atlas"
+      const lastAgentIsSisyphus = lastAgent === "sisyphus"
+      const allowSisyphusWhenDefaultAtlas = boulderAgentWasNotExplicitlySet && boulderAgentDefaultsToAtlas && lastAgentIsSisyphus
+      const agentMatches = lastAgentMatchesRequired || allowSisyphusWhenDefaultAtlas
+      if (!agentMatches) {
         log(`[${HOOK_NAME}] Skipped: last agent does not match boulder agent`, {
           sessionID,
           lastAgent: lastAgent ?? "unknown",
           requiredAgent,
+          boulderAgentExplicitlySet: boulderState.agent !== undefined,
         })
         return
       }

--- a/src/hooks/comment-checker/hook.apply-patch.test.ts
+++ b/src/hooks/comment-checker/hook.apply-patch.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+
+const processApplyPatchEditsWithCli = mock(async () => {})
+
+mock.module("./cli-runner", () => ({
+  initializeCommentCheckerCli: () => {},
+  getCommentCheckerCliPathPromise: () => Promise.resolve("/tmp/fake-comment-checker"),
+  isCliPathUsable: () => true,
+  processWithCli: async () => {},
+  processApplyPatchEditsWithCli,
+}))
+
+const { createCommentCheckerHooks } = await import("./hook")
+
+describe("comment-checker apply_patch integration", () => {
+  beforeEach(() => {
+    processApplyPatchEditsWithCli.mockClear()
+  })
+
+  it("runs comment checker using apply_patch metadata.files", async () => {
+    // given
+    const hooks = createCommentCheckerHooks()
+
+    const input = { tool: "apply_patch", sessionID: "ses_test", callID: "call_test" }
+    const output = {
+      title: "ok",
+      output: "Success. Updated the following files:\nM src/a.ts",
+      metadata: {
+        files: [
+          {
+            filePath: "/repo/src/a.ts",
+            before: "const a = 1\n",
+            after: "// comment\nconst a = 1\n",
+            type: "update",
+          },
+          {
+            filePath: "/repo/src/old.ts",
+            movePath: "/repo/src/new.ts",
+            before: "const b = 1\n",
+            after: "// moved comment\nconst b = 1\n",
+            type: "move",
+          },
+          {
+            filePath: "/repo/src/delete.ts",
+            before: "// deleted\n",
+            after: "",
+            type: "delete",
+          },
+        ],
+      },
+    }
+
+    // when
+    await hooks["tool.execute.after"](input, output)
+
+    // then
+    expect(processApplyPatchEditsWithCli).toHaveBeenCalledTimes(1)
+    expect(processApplyPatchEditsWithCli).toHaveBeenCalledWith(
+      "ses_test",
+      [
+        { filePath: "/repo/src/a.ts", before: "const a = 1\n", after: "// comment\nconst a = 1\n" },
+        { filePath: "/repo/src/new.ts", before: "const b = 1\n", after: "// moved comment\nconst b = 1\n" },
+      ],
+      expect.any(Object),
+      "/tmp/fake-comment-checker",
+      undefined,
+      expect.any(Function),
+    )
+  })
+
+  it("skips when apply_patch metadata.files is missing", async () => {
+    // given
+    const hooks = createCommentCheckerHooks()
+    const input = { tool: "apply_patch", sessionID: "ses_test", callID: "call_test" }
+    const output = { title: "ok", output: "ok", metadata: {} }
+
+    // when
+    await hooks["tool.execute.after"](input, output)
+
+    // then
+    expect(processApplyPatchEditsWithCli).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -13,6 +13,7 @@ import { lspManager } from "../tools"
 import type { CreatedHooks } from "../create-hooks"
 import type { Managers } from "../create-managers"
 import { normalizeSessionStatusToIdle } from "./session-status-normalizer"
+import { pruneRecentSyntheticIdles } from "./recent-synthetic-idles"
 
 type FirstMessageVariantGate = {
   markSessionCreated: (sessionInfo: { id?: string; title?: string; parentID?: string } | undefined) => void
@@ -54,6 +55,12 @@ export function createEventHandler(args: {
   const DEDUP_WINDOW_MS = 500
 
   return async (input): Promise<void> => {
+    pruneRecentSyntheticIdles({
+      recentSyntheticIdles,
+      now: Date.now(),
+      dedupWindowMs: DEDUP_WINDOW_MS,
+    })
+
     if (input.event.type === "session.idle") {
       const sessionID = (input.event.properties as Record<string, unknown> | undefined)?.sessionID as string | undefined
       if (sessionID) {

--- a/src/plugin/recent-synthetic-idles.test.ts
+++ b/src/plugin/recent-synthetic-idles.test.ts
@@ -4,20 +4,20 @@ import { pruneRecentSyntheticIdles } from "./recent-synthetic-idles"
 
 describe("pruneRecentSyntheticIdles", () => {
   it("removes entries older than dedup window", () => {
-    // given
+    //#given
     const recentSyntheticIdles = new Map<string, number>([
       ["ses_old", 1000],
       ["ses_new", 1600],
     ])
 
-    // when
+    //#when
     pruneRecentSyntheticIdles({
       recentSyntheticIdles,
       now: 2000,
       dedupWindowMs: 500,
     })
 
-    // then
+    //#then
     expect(recentSyntheticIdles.has("ses_old")).toBe(false)
     expect(recentSyntheticIdles.has("ses_new")).toBe(true)
   })

--- a/src/plugin/recent-synthetic-idles.test.ts
+++ b/src/plugin/recent-synthetic-idles.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "bun:test"
+
+import { pruneRecentSyntheticIdles } from "./recent-synthetic-idles"
+
+describe("pruneRecentSyntheticIdles", () => {
+  it("removes entries older than dedup window", () => {
+    // given
+    const recentSyntheticIdles = new Map<string, number>([
+      ["ses_old", 1000],
+      ["ses_new", 1600],
+    ])
+
+    // when
+    pruneRecentSyntheticIdles({
+      recentSyntheticIdles,
+      now: 2000,
+      dedupWindowMs: 500,
+    })
+
+    // then
+    expect(recentSyntheticIdles.has("ses_old")).toBe(false)
+    expect(recentSyntheticIdles.has("ses_new")).toBe(true)
+  })
+})

--- a/src/plugin/recent-synthetic-idles.ts
+++ b/src/plugin/recent-synthetic-idles.ts
@@ -1,0 +1,13 @@
+export function pruneRecentSyntheticIdles(args: {
+  recentSyntheticIdles: Map<string, number>
+  now: number
+  dedupWindowMs: number
+}): void {
+  const { recentSyntheticIdles, now, dedupWindowMs } = args
+
+  for (const [sessionID, emittedAt] of recentSyntheticIdles) {
+    if (now - emittedAt >= dedupWindowMs) {
+      recentSyntheticIdles.delete(sessionID)
+    }
+  }
+}

--- a/src/plugin/session-status-normalizer.test.ts
+++ b/src/plugin/session-status-normalizer.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "bun:test"
+import { normalizeSessionStatusToIdle } from "./session-status-normalizer"
+
+type EventInput = { event: { type: string; properties?: Record<string, unknown> } }
+
+describe("normalizeSessionStatusToIdle", () => {
+	it("converts session.status with idle type to synthetic session.idle event", () => {
+		//#given - a session.status event with type=idle
+		const input: EventInput = {
+			event: {
+				type: "session.status",
+				properties: {
+					sessionID: "ses_abc123",
+					status: { type: "idle" },
+				},
+			},
+		}
+
+		//#when - normalizeSessionStatusToIdle is called
+		const result = normalizeSessionStatusToIdle(input)
+
+		//#then - returns a synthetic session.idle event
+		expect(result).toEqual({
+			event: {
+				type: "session.idle",
+				properties: {
+					sessionID: "ses_abc123",
+				},
+			},
+		})
+	})
+
+	it("returns null for session.status with busy type", () => {
+		//#given - a session.status event with type=busy
+		const input: EventInput = {
+			event: {
+				type: "session.status",
+				properties: {
+					sessionID: "ses_abc123",
+					status: { type: "busy" },
+				},
+			},
+		}
+
+		//#when - normalizeSessionStatusToIdle is called
+		const result = normalizeSessionStatusToIdle(input)
+
+		//#then - returns null (no synthetic idle event)
+		expect(result).toBeNull()
+	})
+
+	it("returns null for session.status with retry type", () => {
+		//#given - a session.status event with type=retry
+		const input: EventInput = {
+			event: {
+				type: "session.status",
+				properties: {
+					sessionID: "ses_abc123",
+					status: { type: "retry", attempt: 1, message: "retrying", next: 5000 },
+				},
+			},
+		}
+
+		//#when - normalizeSessionStatusToIdle is called
+		const result = normalizeSessionStatusToIdle(input)
+
+		//#then - returns null
+		expect(result).toBeNull()
+	})
+
+	it("returns null for non-session.status events", () => {
+		//#given - a message.updated event
+		const input: EventInput = {
+			event: {
+				type: "message.updated",
+				properties: { info: { sessionID: "ses_abc123" } },
+			},
+		}
+
+		//#when - normalizeSessionStatusToIdle is called
+		const result = normalizeSessionStatusToIdle(input)
+
+		//#then - returns null
+		expect(result).toBeNull()
+	})
+
+	it("returns null when session.status has no properties", () => {
+		//#given - a session.status event with no properties
+		const input: EventInput = {
+			event: {
+				type: "session.status",
+			},
+		}
+
+		//#when - normalizeSessionStatusToIdle is called
+		const result = normalizeSessionStatusToIdle(input)
+
+		//#then - returns null
+		expect(result).toBeNull()
+	})
+
+	it("returns null when session.status has no status object", () => {
+		//#given - a session.status event with sessionID but no status
+		const input: EventInput = {
+			event: {
+				type: "session.status",
+				properties: {
+					sessionID: "ses_abc123",
+				},
+			},
+		}
+
+		//#when - normalizeSessionStatusToIdle is called
+		const result = normalizeSessionStatusToIdle(input)
+
+		//#then - returns null
+		expect(result).toBeNull()
+	})
+})

--- a/src/plugin/session-status-normalizer.ts
+++ b/src/plugin/session-status-normalizer.ts
@@ -1,0 +1,22 @@
+type EventInput = { event: { type: string; properties?: Record<string, unknown> } }
+type SessionStatus = { type: string }
+
+export function normalizeSessionStatusToIdle(input: EventInput): EventInput | null {
+	if (input.event.type !== "session.status") return null
+
+	const props = input.event.properties
+	if (!props) return null
+
+	const status = props.status as SessionStatus | undefined
+	if (!status || status.type !== "idle") return null
+
+	const sessionID = props.sessionID as string | undefined
+	if (!sessionID) return null
+
+	return {
+		event: {
+			type: "session.idle",
+			properties: { sessionID },
+		},
+	}
+}

--- a/src/shared/connected-providers-cache.test.ts
+++ b/src/shared/connected-providers-cache.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test"
+import { existsSync, mkdirSync, rmSync } from "fs"
+import { join } from "path"
+import * as dataPath from "./data-path"
+import { updateConnectedProvidersCache, readProviderModelsCache } from "./connected-providers-cache"
+
+const TEST_CACHE_DIR = join(import.meta.dir, "__test-cache__")
+
+describe("updateConnectedProvidersCache", () => {
+	let cacheDirSpy: ReturnType<typeof spyOn>
+
+	beforeEach(() => {
+		cacheDirSpy = spyOn(dataPath, "getOmoOpenCodeCacheDir").mockReturnValue(TEST_CACHE_DIR)
+		if (existsSync(TEST_CACHE_DIR)) {
+			rmSync(TEST_CACHE_DIR, { recursive: true })
+		}
+		mkdirSync(TEST_CACHE_DIR, { recursive: true })
+	})
+
+	afterEach(() => {
+		cacheDirSpy.mockRestore()
+		if (existsSync(TEST_CACHE_DIR)) {
+			rmSync(TEST_CACHE_DIR, { recursive: true })
+		}
+	})
+
+	test("extracts models from provider.list().all response", async () => {
+		//#given
+		const mockClient = {
+			provider: {
+				list: async () => ({
+					data: {
+						connected: ["openai", "anthropic"],
+						all: [
+							{
+								id: "openai",
+								name: "OpenAI",
+								env: [],
+								models: {
+									"gpt-5.3-codex": { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+									"gpt-5.2": { id: "gpt-5.2", name: "GPT-5.2" },
+								},
+							},
+							{
+								id: "anthropic",
+								name: "Anthropic",
+								env: [],
+								models: {
+									"claude-opus-4-6": { id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+									"claude-sonnet-4-5": { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+								},
+							},
+						],
+					},
+				}),
+			},
+		}
+
+		//#when
+		await updateConnectedProvidersCache(mockClient)
+
+		//#then
+		const cache = readProviderModelsCache()
+		expect(cache).not.toBeNull()
+		expect(cache!.connected).toEqual(["openai", "anthropic"])
+		expect(cache!.models).toEqual({
+			openai: ["gpt-5.3-codex", "gpt-5.2"],
+			anthropic: ["claude-opus-4-6", "claude-sonnet-4-5"],
+		})
+	})
+
+	test("writes empty models when provider has no models", async () => {
+		//#given
+		const mockClient = {
+			provider: {
+				list: async () => ({
+					data: {
+						connected: ["empty-provider"],
+						all: [
+							{
+								id: "empty-provider",
+								name: "Empty",
+								env: [],
+								models: {},
+							},
+						],
+					},
+				}),
+			},
+		}
+
+		//#when
+		await updateConnectedProvidersCache(mockClient)
+
+		//#then
+		const cache = readProviderModelsCache()
+		expect(cache).not.toBeNull()
+		expect(cache!.models).toEqual({})
+	})
+
+	test("writes empty models when all field is missing", async () => {
+		//#given
+		const mockClient = {
+			provider: {
+				list: async () => ({
+					data: {
+						connected: ["openai"],
+					},
+				}),
+			},
+		}
+
+		//#when
+		await updateConnectedProvidersCache(mockClient)
+
+		//#then
+		const cache = readProviderModelsCache()
+		expect(cache).not.toBeNull()
+		expect(cache!.models).toEqual({})
+	})
+
+	test("does nothing when client.provider.list is not available", async () => {
+		//#given
+		const mockClient = {}
+
+		//#when
+		await updateConnectedProvidersCache(mockClient)
+
+		//#then
+		const cache = readProviderModelsCache()
+		expect(cache).toBeNull()
+	})
+})

--- a/src/shared/git-worktree/collect-git-diff-stats.test.ts
+++ b/src/shared/git-worktree/collect-git-diff-stats.test.ts
@@ -1,79 +1,79 @@
 /// <reference types="bun-types" />
 
-import { describe, expect, mock, test } from "bun:test"
-
-const execSyncMock = mock(() => {
-  throw new Error("execSync should not be called")
-})
-
-const execFileSyncMock = mock((file: string, args: string[], _opts: { cwd?: string }) => {
-  if (file !== "git") throw new Error(`unexpected file: ${file}`)
-  const subcommand = args[0]
-
-  if (subcommand === "diff") {
-    return "1\t2\tfile.ts\n"
-  }
-
-  if (subcommand === "status") {
-    return " M file.ts\n?? new-file.ts\n"
-  }
-
-  if (subcommand === "ls-files") {
-    return "new-file.ts\n"
-  }
-
-  throw new Error(`unexpected args: ${args.join(" ")}`)
-})
-
-const readFileSyncMock = mock((_path: string, _encoding: string) => {
-  return "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n"
-})
-
-mock.module("node:child_process", () => ({
-  execSync: execSyncMock,
-  execFileSync: execFileSyncMock,
-}))
-
-mock.module("node:fs", () => ({
-  readFileSync: readFileSyncMock,
-}))
-
-const { collectGitDiffStats } = await import("./collect-git-diff-stats")
+import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test"
+import * as childProcess from "node:child_process"
+import * as fs from "node:fs"
 
 describe("collectGitDiffStats", () => {
-  test("uses execFileSync with arg arrays (no shell injection)", () => {
+  let execFileSyncSpy: ReturnType<typeof spyOn>
+  let execSyncSpy: ReturnType<typeof spyOn>
+  let readFileSyncSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    execSyncSpy = spyOn(childProcess, "execSync").mockImplementation(() => {
+      throw new Error("execSync should not be called")
+    })
+
+    execFileSyncSpy = spyOn(childProcess, "execFileSync").mockImplementation(
+      ((file: string, args: string[], _opts: { cwd?: string }) => {
+        if (file !== "git") throw new Error(`unexpected file: ${file}`)
+        const subcommand = args[0]
+
+        if (subcommand === "diff") return "1\t2\tfile.ts\n"
+        if (subcommand === "status") return " M file.ts\n?? new-file.ts\n"
+        if (subcommand === "ls-files") return "new-file.ts\n"
+
+        throw new Error(`unexpected args: ${args.join(" ")}`)
+      }) as typeof childProcess.execFileSync
+    )
+
+    readFileSyncSpy = spyOn(fs, "readFileSync").mockImplementation(
+      ((_path: unknown, _encoding: unknown) => {
+        return "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n"
+      }) as typeof fs.readFileSync
+    )
+  })
+
+  afterEach(() => {
+    execSyncSpy.mockRestore()
+    execFileSyncSpy.mockRestore()
+    readFileSyncSpy.mockRestore()
+  })
+
+  test("uses execFileSync with arg arrays (no shell injection)", async () => {
     //#given
+    const { collectGitDiffStats } = await import("./collect-git-diff-stats")
     const directory = "/tmp/safe-repo;touch /tmp/pwn"
 
     //#when
     const result = collectGitDiffStats(directory)
 
     //#then
-    expect(execSyncMock).not.toHaveBeenCalled()
-    expect(execFileSyncMock).toHaveBeenCalledTimes(3)
+    expect(execSyncSpy).not.toHaveBeenCalled()
+    expect(execFileSyncSpy).toHaveBeenCalledTimes(3)
 
-    const [firstCallFile, firstCallArgs, firstCallOpts] = execFileSyncMock.mock
+    const [firstCallFile, firstCallArgs, firstCallOpts] = execFileSyncSpy.mock
       .calls[0]! as unknown as [string, string[], { cwd?: string }]
     expect(firstCallFile).toBe("git")
     expect(firstCallArgs).toEqual(["diff", "--numstat", "HEAD"])
     expect(firstCallOpts.cwd).toBe(directory)
     expect(firstCallArgs.join(" ")).not.toContain(directory)
 
-    const [secondCallFile, secondCallArgs, secondCallOpts] = execFileSyncMock.mock
+    const [secondCallFile, secondCallArgs, secondCallOpts] = execFileSyncSpy.mock
       .calls[1]! as unknown as [string, string[], { cwd?: string }]
     expect(secondCallFile).toBe("git")
     expect(secondCallArgs).toEqual(["status", "--porcelain"])
     expect(secondCallOpts.cwd).toBe(directory)
     expect(secondCallArgs.join(" ")).not.toContain(directory)
 
-    const [thirdCallFile, thirdCallArgs, thirdCallOpts] = execFileSyncMock.mock
+    const [thirdCallFile, thirdCallArgs, thirdCallOpts] = execFileSyncSpy.mock
       .calls[2]! as unknown as [string, string[], { cwd?: string }]
     expect(thirdCallFile).toBe("git")
     expect(thirdCallArgs).toEqual(["ls-files", "--others", "--exclude-standard"])
     expect(thirdCallOpts.cwd).toBe(directory)
     expect(thirdCallArgs.join(" ")).not.toContain(directory)
 
-    expect(readFileSyncMock).toHaveBeenCalled()
+    expect(readFileSyncSpy).toHaveBeenCalled()
 
     expect(result).toEqual([
       {

--- a/src/tools/delegate-task/category-resolver.test.ts
+++ b/src/tools/delegate-task/category-resolver.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect } from "bun:test"
+import { resolveCategoryExecution } from "./category-resolver"
+import type { ExecutorContext } from "./executor-types"
+
+describe("resolveCategoryExecution", () => {
+	const createMockExecutorContext = (): ExecutorContext => ({
+		client: {} as any,
+		manager: {} as any,
+		directory: "/tmp/test",
+		userCategories: {},
+		sisyphusJuniorModel: undefined,
+	})
+
+	test("returns clear error when category exists but required model is not available", async () => {
+		//#given
+		const args = {
+			category: "deep",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+			blockedBy: undefined,
+			enableSkillTools: false,
+		}
+		const executorCtx = createMockExecutorContext()
+		const inheritedModel = undefined
+		const systemDefaultModel = "anthropic/claude-sonnet-4-5"
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+		//#then
+		expect(result.error).toBeDefined()
+		expect(result.error).toContain("deep")
+		expect(result.error).toMatch(/model.*not.*available|requires.*model/i)
+		expect(result.error).not.toContain("Unknown category")
+	})
+
+	test("returns 'unknown category' error for truly unknown categories", async () => {
+		//#given
+		const args = {
+			category: "definitely-not-a-real-category-xyz123",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+			blockedBy: undefined,
+			enableSkillTools: false,
+		}
+		const executorCtx = createMockExecutorContext()
+		const inheritedModel = undefined
+		const systemDefaultModel = "anthropic/claude-sonnet-4-5"
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+		//#then
+		expect(result.error).toBeDefined()
+		expect(result.error).toContain("Unknown category")
+		expect(result.error).toContain("definitely-not-a-real-category-xyz123")
+	})
+})


### PR DESCRIPTION
## What
- Run comment-checker for `apply_patch` by consuming OpenCode `apply_patch` tool result `metadata.files`.
- Use `Edit` mode (before/after) so only newly added comments are flagged.

## Where
- `src/hooks/comment-checker/hook.ts`
- `src/hooks/comment-checker/cli-runner.ts`

## Test
- `bun test src/hooks/comment-checker`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds comment-checker support for apply_patch edits, flagging only newly added comments from before/after diffs via the CLI. Also fixes prompt constraints, event normalization with dedup, and model caching to unblock related flows.

- **New Features**
  - Comment-checker: consume apply_patch metadata.files, run in Edit mode (before/after), skip deletes, handle moves, and append findings to tool output.
  - Session status: normalize session.status with type=idle into synthetic session.idle events with 500ms dedup so hooks run reliably.

- **Bug Fixes**
  - Sisyphus-Junior prompts: block the delegation “task” tool while allowing task_create, task_update, task_list, task_get when task_system=true.
  - Atlas continuation: allow Sisyphus sessions to continue boulder flows when agent defaults to atlas and wasn’t explicitly set.
  - Event dedup: prune the synthetic idle dedup map to avoid stale entries and prevent duplicate idle dispatches.
  - Provider cache: extract models from provider.list().all, fixing empty model caches and enabling clearer category errors (“model not available” vs “unknown category”).
  - Tests: replace fs mock.module with spyOn to prevent cross-test pollution.

<sup>Written for commit f3f5b98c687e7c53f85f8e8c7a8a63b9d06806ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

