### PR TITLE
fix(skill-loader): discover skills from .agents/skills/ directory

### DIFF
--- a/src/features/opencode-skill-loader/loader.test.ts
+++ b/src/features/opencode-skill-loader/loader.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test"
 import { mkdirSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
+import { mock } from "bun:test"
 
 const TEST_DIR = join(tmpdir(), "skill-loader-test-" + Date.now())
 const SKILLS_DIR = join(TEST_DIR, ".opencode", "skills")
@@ -557,6 +558,120 @@ Skill body.
         } else {
           process.env.OPENCODE_CONFIG_DIR = originalOpenCodeConfigDir
         }
+      }
+     })
+   })
+
+  describe("agents skills discovery (.agents/skills/)", () => {
+    it("discoverProjectAgentsSkills discovers skills from .agents/skills/ directory", async () => {
+      // given
+      const skillContent = `---
+name: agent-project-skill
+description: A skill from project .agents/skills directory
+---
+Skill body.
+`
+      const agentsProjectSkillsDir = join(TEST_DIR, ".agents", "skills")
+      const skillDir = join(agentsProjectSkillsDir, "agent-project-skill")
+      mkdirSync(skillDir, { recursive: true })
+      writeFileSync(join(skillDir, "SKILL.md"), skillContent)
+
+      // when
+      const { discoverProjectAgentsSkills } = await import("./loader")
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+
+      try {
+        const skills = await discoverProjectAgentsSkills()
+        const skill = skills.find(s => s.name === "agent-project-skill")
+
+        // then
+        expect(skill).toBeDefined()
+        expect(skill?.scope).toBe("project")
+        expect(skill?.definition.description).toContain("A skill from project .agents/skills directory")
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
+    it("discoverGlobalAgentsSkills discovers skills from home ~/.agents/skills/ directory", async () => {
+      // given
+      const tempHome = join(TEST_DIR, "home")
+      const agentsGlobalSkillsDir = join(tempHome, ".agents", "skills")
+      const skillDir = join(agentsGlobalSkillsDir, "agent-global-skill")
+      mkdirSync(skillDir, { recursive: true })
+      const skillContent = `---
+name: agent-global-skill
+description: A skill from global .agents/skills directory
+---
+Skill body.
+`
+      writeFileSync(join(skillDir, "SKILL.md"), skillContent)
+
+      // given: mock homedir to return tempHome
+      mock.module("os", () => ({
+        homedir: () => tempHome,
+        tmpdir,
+      }))
+
+      // when
+      const { discoverGlobalAgentsSkills } = await import("./loader")
+
+      try {
+        const skills = await discoverGlobalAgentsSkills()
+        const skill = skills.find(s => s.name === "agent-global-skill")
+
+        // then
+        expect(skill).toBeDefined()
+        expect(skill?.scope).toBe("user")
+        expect(skill?.definition.description).toContain("A skill from global .agents/skills directory")
+      } finally {
+        mock.restore()
+      }
+    })
+
+    it("discoverSkills includes .agents/skills/ when includeClaudeCodePaths is true", async () => {
+      // given
+      const originalCwd = process.cwd()
+      const skillContentOpencode = `---
+name: mixed-skill
+description: From .opencode/skills
+---
+Opencode skill body.
+`
+      const skillContentAgents = `---
+name: agents-only-skill
+description: From .agents/skills
+---
+Agents skill body.
+`
+      const opencodeSkillsDir = join(TEST_DIR, ".opencode", "skills")
+      const agentsSkillsDir = join(TEST_DIR, ".agents", "skills")
+      
+      const opencodeSkillDir = join(opencodeSkillsDir, "mixed-skill")
+      mkdirSync(opencodeSkillDir, { recursive: true })
+      writeFileSync(join(opencodeSkillDir, "SKILL.md"), skillContentOpencode)
+
+      const agentsSkillDir = join(agentsSkillsDir, "agents-only-skill")
+      mkdirSync(agentsSkillDir, { recursive: true })
+      writeFileSync(join(agentsSkillDir, "SKILL.md"), skillContentAgents)
+
+      // when
+      const { discoverSkills } = await import("./loader")
+      process.chdir(TEST_DIR)
+
+      try {
+        const skills = await discoverSkills({ includeClaudeCodePaths: true })
+        const opencodeSkill = skills.find(s => s.name === "mixed-skill")
+        const agentsSkill = skills.find(s => s.name === "agents-only-skill")
+
+        // then
+        expect(opencodeSkill).toBeDefined()
+        expect(opencodeSkill?.scope).toBe("opencode-project")
+        expect(agentsSkill).toBeDefined()
+        expect(agentsSkill?.scope).toBe("project")
+      } finally {
+        process.chdir(originalCwd)
       }
     })
   })

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -1,4 +1,5 @@
 import { join } from "path"
+import { homedir } from "os"
 import { getClaudeConfigDir } from "../../shared/claude-config-dir"
 import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
@@ -37,15 +38,24 @@ export interface DiscoverSkillsOptions {
 }
 
 export async function discoverAllSkills(): Promise<LoadedSkill[]> {
-  const [opencodeProjectSkills, opencodeGlobalSkills, projectSkills, userSkills] = await Promise.all([
+  const [opencodeProjectSkills, opencodeGlobalSkills, projectSkills, userSkills, agentsProjectSkills, agentsGlobalSkills] = await Promise.all([
     discoverOpencodeProjectSkills(),
     discoverOpencodeGlobalSkills(),
     discoverProjectClaudeSkills(),
     discoverUserClaudeSkills(),
+    discoverProjectAgentsSkills(),
+    discoverGlobalAgentsSkills(),
   ])
 
-  // Priority: opencode-project > opencode > project > user
-  return deduplicateSkillsByName([...opencodeProjectSkills, ...opencodeGlobalSkills, ...projectSkills, ...userSkills])
+  // Priority: opencode-project > opencode > project (.claude + .agents) > user (.claude + .agents)
+  return deduplicateSkillsByName([
+    ...opencodeProjectSkills,
+    ...opencodeGlobalSkills,
+    ...projectSkills,
+    ...agentsProjectSkills,
+    ...userSkills,
+    ...agentsGlobalSkills,
+  ])
 }
 
 export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promise<LoadedSkill[]> {
@@ -61,13 +71,22 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
     return deduplicateSkillsByName([...opencodeProjectSkills, ...opencodeGlobalSkills])
   }
 
-  const [projectSkills, userSkills] = await Promise.all([
+  const [projectSkills, userSkills, agentsProjectSkills, agentsGlobalSkills] = await Promise.all([
     discoverProjectClaudeSkills(),
     discoverUserClaudeSkills(),
+    discoverProjectAgentsSkills(),
+    discoverGlobalAgentsSkills(),
   ])
 
-  // Priority: opencode-project > opencode > project > user
-  return deduplicateSkillsByName([...opencodeProjectSkills, ...opencodeGlobalSkills, ...projectSkills, ...userSkills])
+  // Priority: opencode-project > opencode > project (.claude + .agents) > user (.claude + .agents)
+  return deduplicateSkillsByName([
+    ...opencodeProjectSkills,
+    ...opencodeGlobalSkills,
+    ...projectSkills,
+    ...agentsProjectSkills,
+    ...userSkills,
+    ...agentsGlobalSkills,
+  ])
 }
 
 export async function getSkillByName(name: string, options: DiscoverSkillsOptions = {}): Promise<LoadedSkill | undefined> {
@@ -94,4 +113,14 @@ export async function discoverOpencodeGlobalSkills(): Promise<LoadedSkill[]> {
 export async function discoverOpencodeProjectSkills(): Promise<LoadedSkill[]> {
   const opencodeProjectDir = join(process.cwd(), ".opencode", "skills")
   return loadSkillsFromDir({ skillsDir: opencodeProjectDir, scope: "opencode-project" })
+}
+
+export async function discoverProjectAgentsSkills(): Promise<LoadedSkill[]> {
+  const agentsProjectDir = join(process.cwd(), ".agents", "skills")
+  return loadSkillsFromDir({ skillsDir: agentsProjectDir, scope: "project" })
+}
+
+export async function discoverGlobalAgentsSkills(): Promise<LoadedSkill[]> {
+  const agentsGlobalDir = join(homedir(), ".agents", "skills")
+  return loadSkillsFromDir({ skillsDir: agentsGlobalDir, scope: "user" })
 }

--- a/src/plugin/skill-context.ts
+++ b/src/plugin/skill-context.ts
@@ -55,15 +55,15 @@ export async function createSkillContext(args: {
     return true
   })
 
-  const includeExternalSkills = pluginConfig.claude_code?.skills !== false
+  const includeClaudeSkills = pluginConfig.claude_code?.skills !== false
   const [userSkills, globalSkills, projectSkills, opencodeProjectSkills, agentsProjectSkills, agentsGlobalSkills] =
     await Promise.all([
-      includeExternalSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
+      includeClaudeSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
       discoverOpencodeGlobalSkills(),
-      includeExternalSkills ? discoverProjectClaudeSkills() : Promise.resolve([]),
+      includeClaudeSkills ? discoverProjectClaudeSkills() : Promise.resolve([]),
       discoverOpencodeProjectSkills(),
-      includeExternalSkills ? discoverProjectAgentsSkills() : Promise.resolve([]),
-      includeExternalSkills ? discoverGlobalAgentsSkills() : Promise.resolve([]),
+      discoverProjectAgentsSkills(),
+      discoverGlobalAgentsSkills(),
     ])
 
   const mergedSkills = mergeSkills(

--- a/src/plugin/skill-context.ts
+++ b/src/plugin/skill-context.ts
@@ -11,6 +11,8 @@ import {
   discoverProjectClaudeSkills,
   discoverOpencodeGlobalSkills,
   discoverOpencodeProjectSkills,
+  discoverProjectAgentsSkills,
+  discoverGlobalAgentsSkills,
   mergeSkills,
 } from "../features/opencode-skill-loader"
 import { createBuiltinSkills } from "../features/builtin-skills"
@@ -53,21 +55,23 @@ export async function createSkillContext(args: {
     return true
   })
 
-  const includeClaudeSkills = pluginConfig.claude_code?.skills !== false
-  const [userSkills, globalSkills, projectSkills, opencodeProjectSkills] =
+  const includeExternalSkills = pluginConfig.claude_code?.skills !== false
+  const [userSkills, globalSkills, projectSkills, opencodeProjectSkills, agentsProjectSkills, agentsGlobalSkills] =
     await Promise.all([
-      includeClaudeSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
+      includeExternalSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
       discoverOpencodeGlobalSkills(),
-      includeClaudeSkills ? discoverProjectClaudeSkills() : Promise.resolve([]),
+      includeExternalSkills ? discoverProjectClaudeSkills() : Promise.resolve([]),
       discoverOpencodeProjectSkills(),
+      includeExternalSkills ? discoverProjectAgentsSkills() : Promise.resolve([]),
+      includeExternalSkills ? discoverGlobalAgentsSkills() : Promise.resolve([]),
     ])
 
   const mergedSkills = mergeSkills(
     builtinSkills,
     pluginConfig.skills,
-    userSkills,
+    [...userSkills, ...agentsGlobalSkills],
     globalSkills,
-    projectSkills,
+    [...projectSkills, ...agentsProjectSkills],
     opencodeProjectSkills,
     { configDir: directory },
   )


### PR DESCRIPTION
## Summary

- Plugin's `skill` tool overrides OpenCode's native `SkillTool`, but was missing `.agents/skills/` directory support
- Skills placed in `.agents/skills/` (project-level) and `~/.agents/skills/` (global) were silently dropped when the plugin was active
- OpenCode natively scans `EXTERNAL_DIRS = [".claude", ".agents"]`, but the plugin only covered `.claude/skills/`

## Root Cause

OpenCode's tool registry (`prompt.ts`) builds tools as `tools[item.id] = ...`. Since plugin custom tools come after built-in tools, the plugin's `skill` tool (id: `"skill"`) overwrites OpenCode's native `SkillTool`. The plugin's skill discovery only searched `.claude/skills/` and `.opencode/skills/`, missing `.agents/skills/` entirely.

## Changes

- **`loader.ts`**: Add `discoverProjectAgentsSkills()` (`.agents/skills/`, scope: `"project"`) and `discoverGlobalAgentsSkills()` (`~/.agents/skills/`, scope: `"user"`)
- **`skill-context.ts`**: Wire new discovery functions into the skill context pipeline
- **`loader.test.ts`**: Add 3 test cases covering project-level, global, and integration discovery

## Testing

All 17 loader tests pass. No regressions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes skill discovery so the plugin always loads skills from .agents/skills at project and user scopes, matching OpenCode’s behavior. Prevents .agents skills from being dropped or gated behind the claude_code.skills flag.

- **Bug Fixes**
  - Added discoverProjectAgentsSkills and discoverGlobalAgentsSkills; included in discoverSkills/discoverAllSkills with correct priority.
  - Updated skill-context to load .agents/skills unconditionally and merge into project/user scopes.
  - Aligns with OpenCode’s EXTERNAL_DIRS [".claude", ".agents"].

- **Tests**
  - Added tests for project-level, global, and integrated .agents discovery; mocked homedir for global tests.
  - All loader tests pass.

<sup>Written for commit e4ed668488841219ffc661bdfcda0489044f2b69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

