### PR TITLE
fix(cli/run): abort event stream after poll completion to prevent deadlock

### DIFF
--- a/src/cli/run/runner.ts
+++ b/src/cli/run/runner.ts
@@ -82,6 +82,7 @@ export async function run(options: RunOptions): Promise<number> {
       console.log(pc.dim("Waiting for completion...\n"))
       const exitCode = await pollForCompletion(ctx, eventState, abortController)
 
+      abortController.abort()
       await eventProcessor.catch(() => {})
       cleanup()
 

--- a/src/cli/run/runner.ts
+++ b/src/cli/run/runner.ts
@@ -83,8 +83,8 @@ export async function run(options: RunOptions): Promise<number> {
       const exitCode = await pollForCompletion(ctx, eventState, abortController)
 
       abortController.abort()
-      await eventProcessor.catch(() => {})
       cleanup()
+      await eventProcessor.catch(() => {})
 
       const durationMs = Date.now() - startTime
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- Fix deadlock in `oh-my-opencode run` where the process hangs after "All tasks completed." and never exits

## Changes

<!-- What was changed and how. List specific modifications. -->

- Add `abortController.abort()` after `pollForCompletion()` returns in `src/cli/run/runner.ts`, allowing the event stream `for-await` loop to break and `cleanup()` to be reached

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run build
bun run dist/cli/index.js run "Say hello"
# Verify process exits after "All tasks completed."
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->

Closes #1712

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock in oh-my-opencode run where the process hung after "All tasks completed." by aborting the event stream after polling and moving cleanup before awaiting the event processor, so the loop exits and the process ends.

<sup>Written for commit 9fe4adf757a8b08ee189d528d6655e0af7e91050. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

