### PR TITLE
fix: interrupt no-output subagent zombies and abort stale sessions

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -2062,7 +2062,7 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
          promptAsync: async () => ({}),
          abort: async () => ({}),
        },
-    }
+     }
     const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
 
     const task: BackgroundTask = {
@@ -2087,6 +2087,46 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
 
     expect(task.status).toBe("running")
   })
+
+   test("should interrupt task with no output even when lastUpdate is fresh", async () => {
+     const abortedSessionIDs: string[] = []
+     const client = {
+       session: {
+         prompt: async () => ({}),
+         promptAsync: async () => ({}),
+         abort: async (args: { path: { id: string } }) => {
+           abortedSessionIDs.push(args.path.id)
+           return {}
+         },
+       },
+     }
+     const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
+     stubNotifyParentSession(manager)
+
+     const task: BackgroundTask = {
+       id: "task-no-output",
+       sessionID: "session-no-output",
+       parentSessionID: "parent-no-output",
+       parentMessageID: "msg-no-output",
+       description: "No output task",
+       prompt: "Test",
+       agent: "test-agent",
+       status: "running",
+       startedAt: new Date(Date.now() - 240_000),
+       progress: {
+         toolCalls: 0,
+         lastUpdate: new Date(Date.now() - 5_000),
+       },
+     }
+
+     getTaskMap(manager).set(task.id, task)
+
+     await manager["checkAndInterruptStaleTasks"]()
+
+     expect(task.status).toBe("cancelled")
+     expect(task.error).toContain("No output received")
+     expect(abortedSessionIDs).toContain("session-no-output")
+   })
 
    test("should interrupt task with stale lastUpdate (> 3min)", async () => {
      const client = {

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -2323,6 +2323,61 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
   })
 })
 
+describe("BackgroundManager.pollRunningTasks lastMessageAt updates", () => {
+  test("should not refresh lastMessageAt when there is no new output", async () => {
+    const sessionID = "session-no-new-output"
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+        status: async () => ({ data: { [sessionID]: { type: "running" } } }),
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "assistant" },
+              parts: [{ type: "text", text: "same output" }],
+            },
+          ],
+        }),
+      },
+    }
+
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, {
+      staleTimeoutMs: 180_000,
+    })
+
+    const originalLastMessageAt = new Date(Date.now() - 60_000)
+    const task: BackgroundTask = {
+      id: "task-no-new-output",
+      sessionID,
+      parentSessionID: "parent-no-new-output",
+      parentMessageID: "msg-no-new-output",
+      description: "No new output task",
+      prompt: "Test",
+      agent: "test-agent",
+      status: "running",
+      startedAt: new Date(Date.now() - 60_000),
+      lastMsgCount: 1,
+      progress: {
+        toolCalls: 0,
+        lastUpdate: new Date(),
+        lastMessage: "same output",
+        lastMessageAt: originalLastMessageAt,
+      },
+    }
+
+    getTaskMap(manager).set(task.id, task)
+
+    await manager["pollRunningTasks"]()
+
+    expect(task.status).toBe("running")
+    expect(task.progress?.lastMessageAt?.getTime()).toBe(originalLastMessageAt.getTime())
+
+    manager.shutdown()
+  })
+})
+
 describe("BackgroundManager.shutdown session abort", () => {
    test("should call session.abort for all running tasks during shutdown", () => {
      // given

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1309,6 +1309,7 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
       
       const age = now - timestamp
       if (age > TASK_TTL_MS) {
+        const wasRunning = task.status === "running"
         const errorMessage = task.status === "pending"
           ? "Task timed out while queued (30 minutes)"
           : "Task timed out after 30 minutes"
@@ -1320,6 +1321,11 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
         if (task.concurrencyKey) {
           this.concurrencyManager.release(task.concurrencyKey)
           task.concurrencyKey = undefined
+        }
+        if (wasRunning && task.sessionID) {
+          this.client.session.abort({
+            path: { id: task.sessionID },
+          }).catch(() => {})
         }
         // Clean up pendingByParent to prevent stale entries
         this.cleanupPendingByParent(task)
@@ -1363,6 +1369,39 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
 
       const runtime = now - startedAt.getTime()
       if (runtime < MIN_RUNTIME_BEFORE_STALE_MS) continue
+
+      const hasReceivedOutput = !!task.progress.lastMessageAt || (task.progress.toolCalls ?? 0) > 0
+      if (!hasReceivedOutput && runtime > staleTimeoutMs) {
+        if (task.status !== "running") continue
+
+        const noOutputMinutes = Math.max(1, Math.round(runtime / 60000))
+        const selectedModel = task.model
+          ? `${task.model.providerID}/${task.model.modelID}`
+          : undefined
+        task.status = "cancelled"
+        task.error = selectedModel
+          ? `No output received for ${noOutputMinutes}min (model: ${selectedModel}). Possible model/provider issue (unavailable, blocked, or incompatible model).`
+          : `No output received for ${noOutputMinutes}min. Possible model/provider issue (unavailable, blocked, or incompatible model).`
+        task.completedAt = new Date()
+
+        if (task.concurrencyKey) {
+          this.concurrencyManager.release(task.concurrencyKey)
+          task.concurrencyKey = undefined
+        }
+
+        this.client.session.abort({
+          path: { id: sessionID },
+        }).catch(() => {})
+
+        log(`[background-agent] Task ${task.id} interrupted: no output timeout`)
+
+        try {
+          await this.enqueueNotificationForParent(task.parentSessionID, () => this.notifyParentSession(task))
+        } catch (err) {
+          log("[background-agent] Error in notifyParentSession for no-output task:", { taskId: task.id, error: err })
+        }
+        continue
+      }
 
       const timeSinceLastUpdate = now - task.progress.lastUpdate.getTime()
       if (timeSinceLastUpdate <= staleTimeoutMs) continue
@@ -1461,19 +1500,37 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
             }
           }
 
+          const currentMsgCount = messages.length
+          const previousMsgCount = task.lastMsgCount ?? -1
+          const previousToolCalls = task.progress?.toolCalls ?? 0
+          const previousLastMessage = task.progress?.lastMessage
+          const hasAssistantOrToolOutput = messages.some(
+            (m) => m.info?.role === "assistant" || m.info?.role === "tool"
+          )
+          const hasNewMessageText = Boolean(lastMessage && lastMessage !== previousLastMessage)
+          const hasProgressDelta =
+            currentMsgCount !== previousMsgCount ||
+            toolCalls !== previousToolCalls ||
+            hasNewMessageText
+          const now = new Date()
+
           if (!task.progress) {
             task.progress = { toolCalls: 0, lastUpdate: new Date() }
           }
           task.progress.toolCalls = toolCalls
           task.progress.lastTool = lastTool
-          task.progress.lastUpdate = new Date()
+          if (hasProgressDelta) {
+            task.progress.lastUpdate = now
+          }
+          if (hasAssistantOrToolOutput && !task.progress.lastMessageAt) {
+            task.progress.lastMessageAt = now
+          }
           if (lastMessage) {
             task.progress.lastMessage = lastMessage
-            task.progress.lastMessageAt = new Date()
+            task.progress.lastMessageAt = now
           }
 
           // Stability detection: complete when message count unchanged for 3 polls
-          const currentMsgCount = messages.length
           const startedAt = task.startedAt
           if (!startedAt) continue
           

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1527,7 +1527,9 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
           }
           if (lastMessage) {
             task.progress.lastMessage = lastMessage
-            task.progress.lastMessageAt = now
+            if (hasProgressDelta) {
+              task.progress.lastMessageAt = now
+            }
           }
 
           // Stability detection: complete when message count unchanged for 3 polls

--- a/src/features/background-agent/poll-running-tasks.ts
+++ b/src/features/background-agent/poll-running-tasks.ts
@@ -117,18 +117,36 @@ export async function pollRunningTasks(args: {
         }
       }
 
+      const currentMsgCount = messages.length
+      const previousMsgCount = task.lastMsgCount ?? -1
+      const previousToolCalls = task.progress?.toolCalls ?? 0
+      const previousLastMessage = task.progress?.lastMessage
+      const hasAssistantOrToolOutput = messages.some(
+        (m) => m.info?.role === "assistant" || m.info?.role === "tool"
+      )
+      const hasNewMessageText = Boolean(lastMessage && lastMessage !== previousLastMessage)
+      const hasProgressDelta =
+        currentMsgCount !== previousMsgCount ||
+        toolCalls !== previousToolCalls ||
+        hasNewMessageText
+      const now = new Date()
+
       if (!task.progress) {
         task.progress = { toolCalls: 0, lastUpdate: new Date() }
       }
       task.progress.toolCalls = toolCalls
       task.progress.lastTool = lastTool
-      task.progress.lastUpdate = new Date()
+      if (hasProgressDelta) {
+        task.progress.lastUpdate = now
+      }
+      if (hasAssistantOrToolOutput && !task.progress.lastMessageAt) {
+        task.progress.lastMessageAt = now
+      }
       if (lastMessage) {
         task.progress.lastMessage = lastMessage
-        task.progress.lastMessageAt = new Date()
+        task.progress.lastMessageAt = now
       }
 
-      const currentMsgCount = messages.length
       const startedAt = task.startedAt
       if (!startedAt) continue
 

--- a/src/features/background-agent/poll-running-tasks.ts
+++ b/src/features/background-agent/poll-running-tasks.ts
@@ -144,7 +144,9 @@ export async function pollRunningTasks(args: {
       }
       if (lastMessage) {
         task.progress.lastMessage = lastMessage
-        task.progress.lastMessageAt = now
+        if (hasProgressDelta) {
+          task.progress.lastMessageAt = now
+        }
       }
 
       const startedAt = task.startedAt

--- a/src/features/background-agent/stale-task-pruner.ts
+++ b/src/features/background-agent/stale-task-pruner.ts
@@ -11,6 +11,7 @@ export function pruneStaleState(args: {
   tasks: Map<string, BackgroundTask>
   notifications: Map<string, BackgroundTask[]>
   concurrencyManager: ConcurrencyManager
+  abortSession: (sessionID: string) => void
   cleanupPendingByParent: (task: BackgroundTask) => void
   clearNotificationsForTask: (taskId: string) => void
 }): void {
@@ -18,6 +19,7 @@ export function pruneStaleState(args: {
     tasks,
     notifications,
     concurrencyManager,
+    abortSession,
     cleanupPendingByParent,
     clearNotificationsForTask,
   } = args
@@ -26,6 +28,7 @@ export function pruneStaleState(args: {
     tasks,
     notifications,
     onTaskPruned: (taskId, task, errorMessage) => {
+      const wasRunning = task.status === "running"
       const now = Date.now()
       const timestamp = task.status === "pending"
         ? task.queuedAt?.getTime()
@@ -44,6 +47,9 @@ export function pruneStaleState(args: {
       if (task.concurrencyKey) {
         concurrencyManager.release(task.concurrencyKey)
         task.concurrencyKey = undefined
+      }
+      if (wasRunning && task.sessionID) {
+        abortSession(task.sessionID)
       }
 
       cleanupPendingByParent(task)

--- a/src/features/background-agent/task-poller.ts
+++ b/src/features/background-agent/task-poller.ts
@@ -78,6 +78,39 @@ export async function checkAndInterruptStaleTasks(args: {
     const runtime = now - startedAt.getTime()
     if (runtime < MIN_RUNTIME_BEFORE_STALE_MS) continue
 
+    const hasReceivedOutput = !!task.progress.lastMessageAt || (task.progress.toolCalls ?? 0) > 0
+    if (!hasReceivedOutput && runtime > staleTimeoutMs) {
+      if (task.status !== "running") continue
+
+      const noOutputMinutes = Math.max(1, Math.round(runtime / 60000))
+      const selectedModel = task.model
+        ? `${task.model.providerID}/${task.model.modelID}`
+        : undefined
+      task.status = "cancelled"
+      task.error = selectedModel
+        ? `No output received for ${noOutputMinutes}min (model: ${selectedModel}). Possible model/provider issue (unavailable, blocked, or incompatible model).`
+        : `No output received for ${noOutputMinutes}min. Possible model/provider issue (unavailable, blocked, or incompatible model).`
+      task.completedAt = new Date()
+
+      if (task.concurrencyKey) {
+        concurrencyManager.release(task.concurrencyKey)
+        task.concurrencyKey = undefined
+      }
+
+      client.session.abort({
+        path: { id: sessionID },
+      }).catch(() => {})
+
+      log(`[background-agent] Task ${task.id} interrupted: no output timeout`)
+
+      try {
+        await notifyParentSession(task)
+      } catch (err) {
+        log("[background-agent] Error in notifyParentSession for no-output task:", { taskId: task.id, error: err })
+      }
+      continue
+    }
+
     const timeSinceLastUpdate = now - task.progress.lastUpdate.getTime()
     if (timeSinceLastUpdate <= staleTimeoutMs) continue
     if (task.status !== "running") continue


### PR DESCRIPTION
## Summary
- add no-output timeout handling for running background tasks so delegated subagent sessions with zero messages are cancelled instead of hanging indefinitely
- stop refreshing task activity timestamps when polling sees no progress, allowing stale detection to trigger correctly
- abort stale running sessions during TTL pruning and add regression tests for no-output timeout behavior

## Verification
- `bun run typecheck`
- `bun test src/features/background-agent/manager.test.ts`
- `bun test src/features/background-agent`

## Related Issues
- closes #1694
- closes #1711

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops background subagent runs that produce no output and aborts stale sessions so they don’t hang or block concurrency. Tightens stale detection by only marking progress when real, new output appears; addresses #1694 and #1711.

- **Bug Fixes**
  - Cancel “no-output” tasks after staleTimeoutMs using lastMessageAt/toolCalls; abort the session and notify the parent.
  - Don’t refresh lastUpdate/lastMessageAt on no-op polls or repeated identical messages; set lastMessageAt only on assistant/tool output.
  - Abort running zombies during TTL pruning and release concurrency; clear pending-state and notifications.

<sup>Written for commit 9fdf08a09ceb63d145e9cc2cc303ccea67b88974. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

