### PR TITLE
fix(mcp): preserve user's enabled:false and apply disabled_mcps to all MCP sources

### DIFF
--- a/src/features/claude-code-mcp-loader/loader.ts
+++ b/src/features/claude-code-mcp-loader/loader.ts
@@ -68,16 +68,24 @@ export function getSystemMcpServerNames(): Set<string> {
   return names
 }
 
-export async function loadMcpConfigs(): Promise<McpLoadResult> {
+export async function loadMcpConfigs(
+  disabledMcps: string[] = []
+): Promise<McpLoadResult> {
   const servers: McpLoadResult["servers"] = {}
   const loadedServers: LoadedMcpServer[] = []
   const paths = getMcpConfigPaths()
+  const disabledSet = new Set(disabledMcps)
 
   for (const { path, scope } of paths) {
     const config = await loadMcpConfigFile(path)
     if (!config?.mcpServers) continue
 
     for (const [name, serverConfig] of Object.entries(config.mcpServers)) {
+      if (disabledSet.has(name)) {
+        log(`Skipping MCP "${name}" (in disabled_mcps)`, { path })
+        continue
+      }
+
       if (serverConfig.disabled) {
         log(`Disabling MCP server "${name}"`, { path })
         delete servers[name]

--- a/src/plugin-handlers/mcp-config-handler.test.ts
+++ b/src/plugin-handlers/mcp-config-handler.test.ts
@@ -1,0 +1,167 @@
+/// <reference types="bun-types" />
+
+import { describe, test, expect, spyOn, beforeEach, afterEach } from "bun:test"
+import type { OhMyOpenCodeConfig } from "../config"
+
+import * as mcpLoader from "../features/claude-code-mcp-loader"
+import * as mcpModule from "../mcp"
+import * as shared from "../shared"
+
+let loadMcpConfigsSpy: ReturnType<typeof spyOn>
+let createBuiltinMcpsSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  loadMcpConfigsSpy = spyOn(mcpLoader, "loadMcpConfigs" as any).mockResolvedValue({
+    servers: {},
+  })
+  createBuiltinMcpsSpy = spyOn(mcpModule, "createBuiltinMcps" as any).mockReturnValue({})
+  spyOn(shared, "log" as any).mockImplementation(() => {})
+})
+
+afterEach(() => {
+  loadMcpConfigsSpy.mockRestore()
+  createBuiltinMcpsSpy.mockRestore()
+  ;(shared.log as any)?.mockRestore?.()
+})
+
+function createPluginConfig(overrides: Partial<OhMyOpenCodeConfig> = {}): OhMyOpenCodeConfig {
+  return {
+    disabled_mcps: [],
+    ...overrides,
+  } as OhMyOpenCodeConfig
+}
+
+const EMPTY_PLUGIN_COMPONENTS = {
+  commands: {},
+  skills: {},
+  agents: {},
+  mcpServers: {},
+  hooksConfigs: [],
+  plugins: [],
+  errors: [],
+}
+
+describe("applyMcpConfig", () => {
+  test("preserves enabled:false from user config after merge with .mcp.json MCPs", async () => {
+    //#given
+    const userMcp = {
+      firecrawl: { type: "remote", url: "https://firecrawl.example.com", enabled: false },
+      exa: { type: "remote", url: "https://exa.example.com", enabled: true },
+    }
+
+    loadMcpConfigsSpy.mockResolvedValue({
+      servers: {
+        firecrawl: { type: "remote", url: "https://firecrawl.example.com", enabled: true },
+        exa: { type: "remote", url: "https://exa.example.com", enabled: true },
+      },
+    })
+
+    const config: Record<string, unknown> = { mcp: userMcp }
+    const pluginConfig = createPluginConfig()
+
+    //#when
+    const { applyMcpConfig } = await import("./mcp-config-handler")
+    await applyMcpConfig({ config, pluginConfig, pluginComponents: EMPTY_PLUGIN_COMPONENTS })
+
+    //#then
+    const mergedMcp = config.mcp as Record<string, Record<string, unknown>>
+    expect(mergedMcp.firecrawl.enabled).toBe(false)
+    expect(mergedMcp.exa.enabled).toBe(true)
+  })
+
+  test("applies disabled_mcps to MCPs from all sources", async () => {
+    //#given
+    createBuiltinMcpsSpy.mockReturnValue({
+      websearch: { type: "remote", url: "https://mcp.exa.ai/mcp", enabled: true },
+    })
+
+    loadMcpConfigsSpy.mockResolvedValue({
+      servers: {
+        playwright: { type: "local", command: ["npx", "@playwright/mcp"], enabled: true },
+      },
+    })
+
+    const config: Record<string, unknown> = { mcp: {} }
+    const pluginConfig = createPluginConfig({ disabled_mcps: ["playwright"] as any })
+
+    //#when
+    const { applyMcpConfig } = await import("./mcp-config-handler")
+    await applyMcpConfig({
+      config,
+      pluginConfig,
+      pluginComponents: {
+        ...EMPTY_PLUGIN_COMPONENTS,
+        mcpServers: {
+          "plugin:custom": { type: "local", command: ["npx", "custom"], enabled: true },
+        },
+      },
+    })
+
+    //#then
+    const mergedMcp = config.mcp as Record<string, Record<string, unknown>>
+    expect(mergedMcp).not.toHaveProperty("playwright")
+    expect(mergedMcp).toHaveProperty("websearch")
+    expect(mergedMcp).toHaveProperty("plugin:custom")
+  })
+
+  test("passes disabled_mcps to loadMcpConfigs", async () => {
+    //#given
+    const config: Record<string, unknown> = { mcp: {} }
+    const pluginConfig = createPluginConfig({ disabled_mcps: ["firecrawl", "exa"] as any })
+
+    //#when
+    const { applyMcpConfig } = await import("./mcp-config-handler")
+    await applyMcpConfig({ config, pluginConfig, pluginComponents: EMPTY_PLUGIN_COMPONENTS })
+
+    //#then
+    expect(loadMcpConfigsSpy).toHaveBeenCalledWith(["firecrawl", "exa"])
+  })
+
+  test("works when no user MCPs have enabled:false", async () => {
+    //#given
+    const userMcp = {
+      exa: { type: "remote", url: "https://exa.example.com", enabled: true },
+    }
+
+    loadMcpConfigsSpy.mockResolvedValue({
+      servers: {
+        firecrawl: { type: "remote", url: "https://firecrawl.example.com", enabled: true },
+      },
+    })
+
+    const config: Record<string, unknown> = { mcp: userMcp }
+    const pluginConfig = createPluginConfig()
+
+    //#when
+    const { applyMcpConfig } = await import("./mcp-config-handler")
+    await applyMcpConfig({ config, pluginConfig, pluginComponents: EMPTY_PLUGIN_COMPONENTS })
+
+    //#then
+    const mergedMcp = config.mcp as Record<string, Record<string, unknown>>
+    expect(mergedMcp.exa.enabled).toBe(true)
+    expect(mergedMcp.firecrawl.enabled).toBe(true)
+  })
+
+  test("deletes plugin MCPs that are in disabled_mcps", async () => {
+    //#given
+    const config: Record<string, unknown> = { mcp: {} }
+    const pluginConfig = createPluginConfig({ disabled_mcps: ["plugin:custom"] as any })
+
+    //#when
+    const { applyMcpConfig } = await import("./mcp-config-handler")
+    await applyMcpConfig({
+      config,
+      pluginConfig,
+      pluginComponents: {
+        ...EMPTY_PLUGIN_COMPONENTS,
+        mcpServers: {
+          "plugin:custom": { type: "local", command: ["npx", "custom"], enabled: true },
+        },
+      },
+    })
+
+    //#then
+    const mergedMcp = config.mcp as Record<string, Record<string, unknown>>
+    expect(mergedMcp).not.toHaveProperty("plugin:custom")
+  })
+})

--- a/src/plugin-handlers/mcp-config-handler.ts
+++ b/src/plugin-handlers/mcp-config-handler.ts
@@ -3,19 +3,58 @@ import { loadMcpConfigs } from "../features/claude-code-mcp-loader";
 import { createBuiltinMcps } from "../mcp";
 import type { PluginComponents } from "./plugin-components-loader";
 
+type McpEntry = Record<string, unknown>;
+
+function captureUserDisabledMcps(
+  userMcp: Record<string, unknown> | undefined
+): Set<string> {
+  const disabled = new Set<string>();
+  if (!userMcp) return disabled;
+
+  for (const [name, value] of Object.entries(userMcp)) {
+    if (
+      value &&
+      typeof value === "object" &&
+      "enabled" in value &&
+      (value as McpEntry).enabled === false
+    ) {
+      disabled.add(name);
+    }
+  }
+
+  return disabled;
+}
+
 export async function applyMcpConfig(params: {
   config: Record<string, unknown>;
   pluginConfig: OhMyOpenCodeConfig;
   pluginComponents: PluginComponents;
 }): Promise<void> {
+  const disabledMcps = params.pluginConfig.disabled_mcps ?? [];
+  const userMcp = params.config.mcp as Record<string, unknown> | undefined;
+  const userDisabledMcps = captureUserDisabledMcps(userMcp);
+
   const mcpResult = params.pluginConfig.claude_code?.mcp ?? true
-    ? await loadMcpConfigs()
+    ? await loadMcpConfigs(disabledMcps)
     : { servers: {} };
 
-  params.config.mcp = {
-    ...createBuiltinMcps(params.pluginConfig.disabled_mcps, params.pluginConfig),
-    ...(params.config.mcp as Record<string, unknown>),
+  const merged = {
+    ...createBuiltinMcps(disabledMcps, params.pluginConfig),
+    ...(userMcp ?? {}),
     ...mcpResult.servers,
     ...params.pluginComponents.mcpServers,
-  };
+  } as Record<string, McpEntry>;
+
+  for (const name of userDisabledMcps) {
+    if (merged[name]) {
+      merged[name] = { ...merged[name], enabled: false };
+    }
+  }
+
+  const disabledSet = new Set(disabledMcps);
+  for (const name of disabledSet) {
+    delete merged[name];
+  }
+
+  params.config.mcp = merged;
 }


### PR DESCRIPTION
## Summary

- Fixes regression from `598a4389` where OMO force-enabled all MCPs, ignoring user's `enabled: false` in `opencode.json`
- Re-adds `disabledMcps` parameter to `loadMcpConfigs()` that was dropped during refactor
- Preserves user's `enabled: false` settings after MCP config merge
- Applies `disabled_mcps` filtering to all MCP sources (built-in, `.mcp.json`, and plugins)

## Root Cause

Commit `598a4389` ("refactor(core): split index.ts and config-handler.ts into focused modules") extracted MCP config handling into `mcp-config-handler.ts` but:

1. Called `loadMcpConfigs()` **without** the `disabledMcps` parameter (originally added in `fab0f462`)
2. Did not handle the spread-order overwrite where `.mcp.json` MCPs (hardcoded `enabled: true` in `transformer.ts`) overwrote user's `enabled: false` from `opencode.json`

## Changes

| File | Change |
|------|--------|
| `loader.ts` | Re-added `disabledMcps: string[] = []` parameter; MCPs in the list are skipped during loading |
| `loader.test.ts` | 3 new test cases for `disabledMcps` filtering |
| `mcp-config-handler.ts` | Captures user's `enabled: false` before merge, passes `disabled_mcps` to loader, restores `enabled: false` after merge, deletes `disabled_mcps` entries from final result |
| `mcp-config-handler.test.ts` | New file with 5 test cases |

## Verification

- Typecheck: clean (0 errors)
- All 66 MCP-related tests pass (0 failures)
- Full test suite: 2472 pass (70 pre-existing failures unrelated to changes)
- Manually verified: user confirmed fix works in production
- Oracle review: approved as safe and ship-ready

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that force-enabled MCPs. We now respect enabled:false in user config and apply disabled_mcps across built-in, .mcp.json, and plugin MCPs.

- **Bug Fixes**
  - Preserve enabled:false from user config during merges with .mcp.json and plugins.
  - Re-add and pass disabled_mcps to loadMcpConfigs and built-ins; remove disabled MCPs from the final config.
  - Add 8 tests covering disabled list handling and enabled:false preservation.

<sup>Written for commit 3abc1d46baffad95211380be66ca416737957153. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

