### PR TITLE
[Bug]: Fix TypeError crash in tool.execute.after hooks when output.output is undefined

### DIFF
--- a/src/hooks/comment-checker/hook.ts
+++ b/src/hooks/comment-checker/hook.ts
@@ -91,6 +91,8 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
 
       const toolLower = input.tool.toLowerCase()
 
+      if (typeof output.output !== 'string') return
+
       // Only skip if the output indicates a tool execution failure
       const outputLower = output.output.toLowerCase()
       const isToolFailure =

--- a/src/hooks/edit-error-recovery/hook.ts
+++ b/src/hooks/edit-error-recovery/hook.ts
@@ -43,6 +43,7 @@ export function createEditErrorRecoveryHook(_ctx: PluginInput) {
       output: { title: string; output: string; metadata: unknown }
     ) => {
       if (input.tool.toLowerCase() !== "edit") return
+      if (typeof output.output !== 'string') return
 
       const outputLower = output.output.toLowerCase()
       const hasEditError = EDIT_ERROR_PATTERNS.some((pattern) =>

--- a/src/hooks/task-resume-info/hook.ts
+++ b/src/hooks/task-resume-info/hook.ts
@@ -21,6 +21,7 @@ export function createTaskResumeInfoHook() {
     output: { title: string; output: string; metadata: unknown }
   ) => {
     if (!TARGET_TOOLS.includes(input.tool)) return
+    if (typeof output.output !== 'string') return
     if (output.output.startsWith("Error:") || output.output.startsWith("Failed")) return
     if (output.output.includes("\nto continue:")) return
 


### PR DESCRIPTION
## Problem

Multiple `tool.execute.after` hooks crash with `TypeError: undefined is not an object (evaluating 'output.output.toLowerCase')` when MCP tools return responses where `output.output` is `undefined` or not a string.

This affects **v3.4.0** and was also present in **v3.4.1** (which was yanked via #1720).

### Error

```
TypeError: undefined is not an object (evaluating 'output.output.toLowerCase')
```

### Reproduction

Any MCP tool that returns a response where `output.output` is `undefined` instead of a string will trigger this crash. This commonly happens with:
- MCP servers that return structured responses without a string `output` field
- Tools that return metadata-only responses
- Error conditions where the output field is not populated

## Root Cause

Three `tool.execute.after` hooks access `output.output` without checking if it's a string first:

1. **`src/hooks/comment-checker/hook.ts`** (line 95):
   ```typescript
   const outputLower = output.output.toLowerCase()  // CRASHES if undefined
   ```

2. **`src/hooks/edit-error-recovery/hook.ts`** (line 47):
   ```typescript
   const outputLower = output.output.toLowerCase()  // CRASHES if undefined
   ```

3. **`src/hooks/task-resume-info/hook.ts`** (lines 24-25, 31):
   ```typescript
   if (output.output.startsWith("Error:") || output.output.startsWith("Failed")) return  // CRASHES
   if (output.output.includes("\nto continue:")) return  // CRASHES
   output.output.trimEnd()  // CRASHES
   ```

## Fix

Added `if (typeof output.output !== 'string') return` as an early guard in all three affected hooks, **matching the existing pattern** already used in `src/hooks/tool-output-truncator.ts` (line 42):

```typescript
// tool-output-truncator.ts already does this correctly:
if (typeof output.output !== 'string') return
```

This is the minimal, consistent fix — it follows the established convention in the codebase and gracefully handles the case where `output.output` is `undefined`, `null`, or any non-string type.

### Files Changed

| File | Change |
|------|--------|
| `src/hooks/comment-checker/hook.ts` | Added guard before `output.output.toLowerCase()` |
| `src/hooks/edit-error-recovery/hook.ts` | Added guard before `output.output.toLowerCase()` |
| `src/hooks/task-resume-info/hook.ts` | Added guard before `output.output.startsWith()` |

## Verification

- ✅ `bun run typecheck` — passes clean (0 errors)
- ✅ `bun run build` — passes clean
- ✅ All pre-existing tests unaffected

## Related Issues

- #1720 — v3.4.1 yanked due to this same `TypeError` class
- #1035 — Same category of `output.output` crash (closed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TypeError crash in tool.execute.after hooks when MCP tools return non-string or undefined output.output. Adds a simple guard so structured or metadata-only responses no longer break execution.

- **Bug Fixes**
  - Add if (typeof output.output !== "string") return to:
    - src/hooks/comment-checker/hook.ts
    - src/hooks/edit-error-recovery/hook.ts
    - src/hooks/task-resume-info/hook.ts
  - Matches the existing pattern in tool-output-truncator and prevents crashes seen in v3.4.0/v3.4.1.

<sup>Written for commit 5a2075a4861237eb6c6ed54c14f78540f3750910. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

