### PR TITLE
fix: guard output.output against undefined in tool.execute.after hooks

### DIFF
--- a/src/hooks/comment-checker/hook.ts
+++ b/src/hooks/comment-checker/hook.ts
@@ -89,6 +89,11 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
     ): Promise<void> => {
       debugLog("tool.execute.after:", { tool: input.tool, callID: input.callID })
 
+      if (!output.output || typeof output.output !== "string") {
+        debugLog("skipping: output.output is undefined or not a string")
+        return
+      }
+
       const toolLower = input.tool.toLowerCase()
 
       // Only skip if the output indicates a tool execution failure

--- a/src/hooks/edit-error-recovery/hook.ts
+++ b/src/hooks/edit-error-recovery/hook.ts
@@ -43,6 +43,7 @@ export function createEditErrorRecoveryHook(_ctx: PluginInput) {
       output: { title: string; output: string; metadata: unknown }
     ) => {
       if (input.tool.toLowerCase() !== "edit") return
+      if (!output.output || typeof output.output !== "string") return
 
       const outputLower = output.output.toLowerCase()
       const hasEditError = EDIT_ERROR_PATTERNS.some((pattern) =>

--- a/src/hooks/task-resume-info/hook.ts
+++ b/src/hooks/task-resume-info/hook.ts
@@ -21,6 +21,7 @@ export function createTaskResumeInfoHook() {
     output: { title: string; output: string; metadata: unknown }
   ) => {
     if (!TARGET_TOOLS.includes(input.tool)) return
+    if (!output.output || typeof output.output !== "string") return
     if (output.output.startsWith("Error:") || output.output.startsWith("Failed")) return
     if (output.output.includes("\nto continue:")) return
 


### PR DESCRIPTION
## Summary

- Add null/type guards for `output.output` in 3 hooks that crash when it's `undefined`
- Fixes `TypeError: undefined is not an object (evaluating 'output.output.toLowerCase')` for external MCP tools

## Problem

Three `tool.execute.after` hooks call string methods on `output.output` without checking if it's defined:

| Hook | Crash site |
|------|-----------|
| `comment-checker/hook.ts` | `output.output.toLowerCase()` (line 95) |
| `edit-error-recovery/hook.ts` | `output.output.toLowerCase()` (line 47) |
| `task-resume-info/hook.ts` | `output.output.startsWith()` (line 24) |

When OpenCode passes `undefined` for `output.output` (observed with external MCP tools), all three crash with `TypeError`.

## Fix

Added `if (!output.output || typeof output.output !== "string") return` guard before accessing `output.output` methods. This matches the existing pattern in `tool-output-truncator.ts` (line 42) which already had this guard.

## Context

- Related issue: #1720 (v3.4.1 broke all external MCP tools)
- All external MCP tools affected (user-configured and OMO-bundled)
- Built-in tools (bash, read, grep, write) were unaffected since OpenCode populates `output.output` for them

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard output.output against undefined in tool.execute.after hooks to prevent crashes with external MCP tools. Fixes #1720.

- **Bug Fixes**
  - Add null/type checks before calling string methods in comment-checker, edit-error-recovery, and task-resume-info hooks.
  - Early-return when output.output is missing or not a string (log skip in comment-checker), matching tool-output-truncator behavior.

<sup>Written for commit 290cf3db632f1fe34e49f7c43d385a104a2cd360. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

