### PR TITLE
fix(hooks): guard against undefined output.output in tool.execute.after hooks

### DIFF
--- a/src/hooks/agent-usage-reminder/hook.ts
+++ b/src/hooks/agent-usage-reminder/hook.ts
@@ -77,6 +77,7 @@ export function createAgentUsageReminderHook(_ctx: PluginInput) {
       return;
     }
 
+    if (output.output == null) return;
     output.output += REMINDER_MESSAGE;
     state.reminderCount++;
     state.updatedAt = Date.now();

--- a/src/hooks/category-skill-reminder/hook.ts
+++ b/src/hooks/category-skill-reminder/hook.ts
@@ -105,7 +105,7 @@ export function createCategorySkillReminderHook(
 
     state.toolCallCount++
 
-    if (state.toolCallCount >= 3 && !state.delegationUsed && !state.reminderShown) {
+    if (state.toolCallCount >= 3 && !state.delegationUsed && !state.reminderShown && output.output != null) {
       output.output += reminderMessage
       state.reminderShown = true
       log("[category-skill-reminder] Reminder injected", {

--- a/src/hooks/claude-code-hooks/handlers/tool-execute-after-handler.ts
+++ b/src/hooks/claude-code-hooks/handlers/tool-execute-after-handler.ts
@@ -16,7 +16,7 @@ export function createToolExecuteAfterHandler(ctx: PluginInput, config: PluginCo
 		input: { tool: string; sessionID: string; callID: string },
 		output: { title: string; output: string; metadata: unknown } | undefined,
 	): Promise<void> => {
-		if (!output) {
+		if (!output || output.output == null) {
 			return
 		}
 

--- a/src/hooks/comment-checker/hook.null-output.test.ts
+++ b/src/hooks/comment-checker/hook.null-output.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, mock } from "bun:test"
+
+mock.module("./cli-runner", () => ({
+  initializeCommentCheckerCli: () => {},
+  getCommentCheckerCliPathPromise: () => Promise.resolve("/tmp/fake-comment-checker"),
+  isCliPathUsable: () => true,
+  processWithCli: async () => {},
+  processApplyPatchEditsWithCli: async () => {},
+}))
+
+const { createCommentCheckerHooks } = await import("./hook")
+
+describe("comment-checker null output guard", () => {
+  it("does not throw when output.output is undefined", async () => {
+    const hooks = createCommentCheckerHooks()
+    const input = { tool: "Edit", sessionID: "ses_test", callID: "call_test" }
+    const output = { title: "Edit", output: undefined as unknown as string, metadata: {} }
+
+    await hooks["tool.execute.after"](input, output)
+
+    expect(output.output).toBeUndefined()
+  })
+
+  it("does not throw when output.output is null", async () => {
+    const hooks = createCommentCheckerHooks()
+    const input = { tool: "Edit", sessionID: "ses_test", callID: "call_test" }
+    const output = { title: "Edit", output: null as unknown as string, metadata: {} }
+
+    await hooks["tool.execute.after"](input, output)
+
+    expect(output.output).toBeNull()
+  })
+
+  it("still processes valid string output", async () => {
+    const hooks = createCommentCheckerHooks()
+    const input = { tool: "Edit", sessionID: "ses_test", callID: "call_test" }
+    const output = { title: "Edit", output: "File edited successfully", metadata: {} }
+
+    await hooks["tool.execute.after"](input, output)
+
+    expect(typeof output.output).toBe("string")
+  })
+
+  it("skips tool failure output without crashing", async () => {
+    const hooks = createCommentCheckerHooks()
+    const input = { tool: "Edit", sessionID: "ses_test", callID: "call_test" }
+    const output = { title: "Edit", output: "Error: something went wrong", metadata: {} }
+
+    await hooks["tool.execute.after"](input, output)
+
+    expect(output.output).toBe("Error: something went wrong")
+  })
+})

--- a/src/hooks/comment-checker/hook.ts
+++ b/src/hooks/comment-checker/hook.ts
@@ -92,6 +92,7 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
       const toolLower = input.tool.toLowerCase()
 
       // Only skip if the output indicates a tool execution failure
+      if (output.output == null) return
       const outputLower = output.output.toLowerCase()
       const isToolFailure =
         outputLower.includes("error:") ||

--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -38,6 +38,7 @@ export function createContextWindowMonitorHook(ctx: PluginInput) {
     output: { title: string; output: string; metadata: unknown }
   ) => {
     const { sessionID } = input
+    if (output.output == null) return
 
     if (remindedSessions.has(sessionID)) return
 

--- a/src/hooks/delegate-task-retry/hook.ts
+++ b/src/hooks/delegate-task-retry/hook.ts
@@ -10,6 +10,7 @@ export function createDelegateTaskRetryHook(_ctx: PluginInput) {
       output: { title: string; output: string; metadata: unknown }
     ) => {
       if (input.tool.toLowerCase() !== "task") return
+      if (output.output == null) return
 
       const errorInfo = detectDelegateTaskError(output.output)
       if (errorInfo) {

--- a/src/hooks/directory-agents-injector/injector.ts
+++ b/src/hooks/directory-agents-injector/injector.ts
@@ -46,7 +46,9 @@ export async function processFilePathForAgentsInjection(input: {
       const truncationNotice = truncated
         ? `\n\n[Note: Content was truncated to save context window space. For full context, please read the file directly: ${agentsPath}]`
         : "";
-      input.output.output += `\n\n[Directory Context: ${agentsPath}]\n${result}${truncationNotice}`;
+      if (input.output.output != null) {
+        input.output.output += `\n\n[Directory Context: ${agentsPath}]\n${result}${truncationNotice}`;
+      }
       cache.add(agentsDir);
     } catch {}
   }

--- a/src/hooks/directory-readme-injector/injector.ts
+++ b/src/hooks/directory-readme-injector/injector.ts
@@ -46,7 +46,9 @@ export async function processFilePathForReadmeInjection(input: {
       const truncationNotice = truncated
         ? `\n\n[Note: Content was truncated to save context window space. For full context, please read the file directly: ${readmePath}]`
         : "";
-      input.output.output += `\n\n[Project README: ${readmePath}]\n${result}${truncationNotice}`;
+      if (input.output.output != null) {
+        input.output.output += `\n\n[Project README: ${readmePath}]\n${result}${truncationNotice}`;
+      }
       cache.add(readmeDir);
     } catch {}
   }

--- a/src/hooks/edit-error-recovery/hook.ts
+++ b/src/hooks/edit-error-recovery/hook.ts
@@ -44,6 +44,7 @@ export function createEditErrorRecoveryHook(_ctx: PluginInput) {
     ) => {
       if (input.tool.toLowerCase() !== "edit") return
 
+      if (output.output == null) return
       const outputLower = output.output.toLowerCase()
       const hasEditError = EDIT_ERROR_PATTERNS.some((pattern) =>
         outputLower.includes(pattern.toLowerCase())

--- a/src/hooks/edit-error-recovery/index.test.ts
+++ b/src/hooks/edit-error-recovery/index.test.ts
@@ -88,6 +88,26 @@ describe("createEditErrorRecoveryHook", () => {
       })
     })
 
+    describe("#given output.output is nullish", () => {
+      it("#then should not throw when output.output is undefined", async () => {
+        const input = createInput("Edit")
+        const output = { title: "Edit", output: undefined as unknown as string, metadata: {} }
+
+        await hook["tool.execute.after"](input, output)
+
+        expect(output.output).toBeUndefined()
+      })
+
+      it("#then should not throw when output.output is null", async () => {
+        const input = createInput("Edit")
+        const output = { title: "Edit", output: null as unknown as string, metadata: {} }
+
+        await hook["tool.execute.after"](input, output)
+
+        expect(output.output).toBeNull()
+      })
+    })
+
     describe("#given Edit tool with successful output", () => {
       describe("#when no error in output", () => {
         it("#then should not modify output", async () => {

--- a/src/hooks/interactive-bash-session/hook.ts
+++ b/src/hooks/interactive-bash-session/hook.ts
@@ -92,7 +92,7 @@ export function createInteractiveBashSessionHook(ctx: PluginInput) {
     }
 
     const isSessionOperation = isNewSession || isKillSession || isKillServer;
-    if (isSessionOperation) {
+    if (isSessionOperation && output.output != null) {
       const reminder = buildSessionReminderMessage(
         Array.from(state.tmuxSessions),
       );

--- a/src/hooks/rules-injector/injector.ts
+++ b/src/hooks/rules-injector/injector.ts
@@ -116,7 +116,9 @@ export function createRuleInjectionProcessor(deps: {
       const truncationNotice = truncated
         ? `\n\n[Note: Content was truncated to save context window space. For full context, please read the file directly: ${rule.relativePath}]`
         : "";
-      output.output += `\n\n[Rule: ${rule.relativePath}]\n[Match: ${rule.matchReason}]\n${result}${truncationNotice}`;
+      if (output.output != null) {
+        output.output += `\n\n[Rule: ${rule.relativePath}]\n[Match: ${rule.matchReason}]\n${result}${truncationNotice}`;
+      }
     }
 
     saveInjectedRules(sessionID, cache);

--- a/src/hooks/task-reminder/hook.ts
+++ b/src/hooks/task-reminder/hook.ts
@@ -38,7 +38,7 @@ export function createTaskReminderHook(_ctx: PluginInput) {
     const currentCount = sessionCounters.get(sessionID) ?? 0
     const newCount = currentCount + 1
 
-    if (newCount >= TURN_THRESHOLD) {
+    if (newCount >= TURN_THRESHOLD && output.output != null) {
       output.output += REMINDER_MESSAGE
       sessionCounters.set(sessionID, 0)
     } else {

--- a/src/hooks/task-reminder/index.test.ts
+++ b/src/hooks/task-reminder/index.test.ts
@@ -123,6 +123,40 @@ describe("TaskReminderHook", () => {
     expect(output2.output).not.toContain("task tools haven't been used")
   })
 
+  test("does not throw when output.output is nullish", async () => {
+    //#given
+    const sessionID = "test-session"
+    const output = { output: undefined as unknown as string }
+
+    //#when - run enough turns to trigger reminder
+    for (let i = 0; i < 10; i++) {
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID, callID: `call-${i}` },
+        output
+      )
+    }
+
+    //#then - should not throw, output remains undefined
+    expect(output.output).toBeUndefined()
+  })
+
+  test("does not throw when output.output is null", async () => {
+    //#given
+    const sessionID = "test-session-null"
+    const output = { output: null as unknown as string }
+
+    //#when
+    for (let i = 0; i < 10; i++) {
+      await hook["tool.execute.after"]?.(
+        { tool: "bash", sessionID, callID: `call-${i}` },
+        output
+      )
+    }
+
+    //#then
+    expect(output.output).toBeNull()
+  })
+
   test("cleans up counters on session.deleted", async () => {
     //#given
     const sessionID = "test-session"

--- a/src/hooks/task-resume-info/hook.ts
+++ b/src/hooks/task-resume-info/hook.ts
@@ -21,6 +21,7 @@ export function createTaskResumeInfoHook() {
     output: { title: string; output: string; metadata: unknown }
   ) => {
     if (!TARGET_TOOLS.includes(input.tool)) return
+    if (output.output == null) return
     if (output.output.startsWith("Error:") || output.output.startsWith("Failed")) return
     if (output.output.includes("\nto continue:")) return
 

--- a/src/hooks/tool-output-truncator.ts
+++ b/src/hooks/tool-output-truncator.ts
@@ -39,7 +39,7 @@ export function createToolOutputTruncatorHook(ctx: PluginInput, options?: ToolOu
     output: { title: string; output: string; metadata: unknown }
   ) => {
     if (!truncateAll && !TRUNCATABLE_TOOLS.includes(input.tool)) return
-    if (typeof output.output !== 'string') return
+    if (output.output == null) return
 
     try {
       const targetMaxTokens = TOOL_SPECIFIC_MAX_TOKENS[input.tool] ?? DEFAULT_MAX_TOKENS


### PR DESCRIPTION
## Summary

Guard against `undefined` `output.output` in **all 14** `tool.execute.after` hooks and injectors that access the field.

MCP tool results (e.g. Slack, Toggl) don't populate `output.output` as a string, causing:
- **TypeError crashes** in hooks that call `.toLowerCase()` or `.startsWith()` on `undefined`
- **Silent `"undefined"` string corruption** in hooks that use `+=` (producing `"undefined\n\nSome reminder"`)

## Root Cause

The `tool.execute.after` hook fires for **all** tool calls, including MCP tools. The hook type signature declares `output: { output: string }`, but MCP tool results don't always populate this field. Many hooks access `output.output` without null-checking first.

Two existing hooks already guarded against this:
- `empty-task-response-detector` uses `output.output?.trim() ?? ""`
- `tool-output-truncator` used `typeof output.output !== 'string'`

The rest did not, and the codebase was inconsistent.

## Fix

Add `output.output == null` early-return guard to every `tool.execute.after` handler that accesses `output.output`. This:
- Uses loose equality (`== null`) to catch both `null` and `undefined`
- Allows empty strings through (which are valid tool outputs)
- Is applied consistently across all hooks, including those behind tool filters (defense in depth)
- Normalizes the previous `typeof !== 'string'` check in `tool-output-truncator` to match

### Hooks fixed

| Hook | Failure mode | Had tool filter? |
|------|-------------|-----------------|
| `comment-checker` | **Crash**: `.toLowerCase()` on undefined | No — crashed before filter |
| `edit-error-recovery` | **Crash**: `.toLowerCase()` on undefined | Yes (`edit` only) |
| `task-resume-info` | **Crash**: `.startsWith()` on undefined | Yes (`task`/`call_omo_agent`) |
| `delegate-task-retry` | Passed undefined to function | Yes (`task` only) |
| `context-window-monitor` | **Corrupt**: `undefined +=` | No |
| `task-reminder` | **Corrupt**: `undefined +=` | No |
| `claude-code-hooks handler` | **Corrupt**: template literal | No |
| `category-skill-reminder` | **Corrupt**: `undefined +=` | Yes |
| `agent-usage-reminder` | **Corrupt**: `undefined +=` | Yes |
| `interactive-bash-session` | **Corrupt**: `undefined +=` | Yes (`interactive_bash`) |
| `directory-readme-injector` | **Corrupt**: `undefined +=` | Yes (`read`/`glob`/`grep`) |
| `directory-agents-injector` | **Corrupt**: `undefined +=` | Yes (`read`/`glob`/`grep`) |
| `rules-injector` | **Corrupt**: `undefined +=` | Yes (`read`/`glob`/`grep`) |
| `tool-output-truncator` | Already guarded (normalized) | Yes |

## Testing

- Built locally, loaded via `file://` plugin path in OpenCode config
- Verified Slack MCP `conversations_add_message` and `channels_list` calls succeed after fix (previously all Slack MCP calls returned TypeError)
- All existing tool functionality (edit, bash, read, grep, etc.) unaffected — the guard only skips when `output.output` is nullish