### PR TITLE
fix(config): set default_builder_enabled to true by default (#1639)

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -89,7 +89,7 @@ export async function applyAgentConfig(params: {
 
   const isSisyphusEnabled = params.pluginConfig.sisyphus_agent?.disabled !== true;
   const builderEnabled =
-    params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? false;
+    params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? true;
   const plannerEnabled = params.pluginConfig.sisyphus_agent?.planner_enabled ?? true;
   const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
   const shouldDemotePlan = plannerEnabled && replacePlan;

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -1053,9 +1053,113 @@ describe("per-agent todowrite/todoread deny when task_system enabled", () => {
     //#when
     await handler(config)
 
+     //#then
+     const agentResult = config.agent as Record<string, { permission?: Record<string, unknown> }>
+     expect(agentResult.sisyphus?.permission?.todowrite).toBeUndefined()
+     expect(agentResult.sisyphus?.permission?.todoread).toBeUndefined()
+   })
+})
+
+describe("OpenCode-Builder default registration", () => {
+  test("registers OpenCode-Builder by default when sisyphus is enabled", async () => {
+    //#given
+    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+      mockResolvedValue: (value: Record<string, unknown>) => void
+    }
+    createBuiltinAgentsMock.mockResolvedValue({
+      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+    })
+
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-6",
+      agent: {},
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    //#when
+    await handler(config)
+
     //#then
-    const agentResult = config.agent as Record<string, { permission?: Record<string, unknown> }>
-    expect(agentResult.sisyphus?.permission?.todowrite).toBeUndefined()
-    expect(agentResult.sisyphus?.permission?.todoread).toBeUndefined()
+    const agentConfig = config.agent as Record<string, unknown>
+    expect(agentConfig["OpenCode-Builder"]).toBeDefined()
+  })
+
+  test("does not register OpenCode-Builder when explicitly disabled", async () => {
+    //#given
+    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+      mockResolvedValue: (value: Record<string, unknown>) => void
+    }
+    createBuiltinAgentsMock.mockResolvedValue({
+      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+    })
+
+    const pluginConfig: OhMyOpenCodeConfig = {
+      sisyphus_agent: {
+        default_builder_enabled: false,
+      },
+    }
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-6",
+      agent: {},
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    //#when
+    await handler(config)
+
+    //#then
+    const agentConfig = config.agent as Record<string, unknown>
+    expect(agentConfig["OpenCode-Builder"]).toBeUndefined()
+  })
+
+  test("does not register OpenCode-Builder when sisyphus is disabled", async () => {
+    //#given
+    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+      mockResolvedValue: (value: Record<string, unknown>) => void
+    }
+    createBuiltinAgentsMock.mockResolvedValue({
+      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+    })
+
+    const pluginConfig: OhMyOpenCodeConfig = {
+      sisyphus_agent: {
+        disabled: true,
+        default_builder_enabled: true,
+      },
+    }
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-6",
+      agent: {},
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    //#when
+    await handler(config)
+
+    //#then
+    const agentConfig = config.agent as Record<string, unknown>
+    expect(agentConfig["OpenCode-Builder"]).toBeUndefined()
   })
 })


### PR DESCRIPTION
Closes #1639

`default_builder_enabled` defaults to `false`, so OpenCode-Builder never registers unless explicitly opted in. Should be `true`.

One-line fix (`?? false` → `?? true`) + tests.