### PR TITLE
fix: guard against undefined output.output in tool.execute.after hooks

### DIFF
--- a/src/hooks/comment-checker/hook.ts
+++ b/src/hooks/comment-checker/hook.ts
@@ -91,6 +91,12 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
 
       const toolLower = input.tool.toLowerCase()
 
+      // Guard against undefined output (e.g., MCP tools may not return output.output)
+      if (!output.output || typeof output.output !== "string") {
+        debugLog("skipping due to non-string output:", typeof output.output)
+        return
+      }
+
       // Only skip if the output indicates a tool execution failure
       const outputLower = output.output.toLowerCase()
       const isToolFailure =

--- a/src/hooks/edit-error-recovery/hook.ts
+++ b/src/hooks/edit-error-recovery/hook.ts
@@ -44,6 +44,9 @@ export function createEditErrorRecoveryHook(_ctx: PluginInput) {
     ) => {
       if (input.tool.toLowerCase() !== "edit") return
 
+      // Guard against undefined output (e.g., MCP tools may not return output.output)
+      if (!output.output || typeof output.output !== "string") return
+
       const outputLower = output.output.toLowerCase()
       const hasEditError = EDIT_ERROR_PATTERNS.some((pattern) =>
         outputLower.includes(pattern.toLowerCase())


### PR DESCRIPTION
## Summary

MCP tools may not return `output.output` as a string, causing a `TypeError` when calling `.toLowerCase()` on it.

**Error:** `TypeError: undefined is not an object (evaluating 'output.output.toLowerCase')`

This happens when using MCP servers like `ida-pro-mcp` where the tool output format differs from standard OpenCode tools.

## Changes

- Added guard in `edit-error-recovery/hook.ts` to check if `output.output` exists and is a string before calling string methods
- Added guard in `comment-checker/hook.ts` with the same protection

## Files Changed

- `src/hooks/edit-error-recovery/hook.ts`
- `src/hooks/comment-checker/hook.ts`

## Testing

Tested with `ida-pro-mcp` MCP server - the error no longer occurs and MCP tools work correctly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes in tool.execute.after hooks by guarding against undefined or non-string output.output before calling .toLowerCase(). Fixes TypeErrors with MCP servers like ida-pro-mcp and keeps tool execution stable.

<sup>Written for commit b28269727b5d4e870651adbc1310745ea7770084. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

