### PR TITLE
test(session-manager): add positive-path tests for todos and transcript

### DIFF
--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -26,7 +26,7 @@ mock.module("./constants", () => ({
   TOOL_NAME_PREFIX: "session_",
 }))
 
-const { getAllSessions, getMessageDir, sessionExists, readSessionMessages, readSessionTodos, getSessionInfo } =
+const { getAllSessions, getMessageDir, sessionExists, readSessionMessages, readSessionTodos, getSessionInfo, readSessionTranscript } =
   await import("./storage")
 
 const storage = await import("./storage")
@@ -133,6 +133,50 @@ describe("session-manager storage", () => {
 
     // then
     expect(todos).toEqual([])
+  })
+
+  test("readSessionTodos returns mapped todo items from matching JSON file", async () => {
+    // given
+    const sessionID = "ses_test123"
+    const todoData = [
+      { id: "msg_001", content: "implement feature", status: "pending", priority: "high" },
+      { id: "msg_002", content: "write tests", status: "completed", priority: "medium" },
+      { id: "msg_003", content: "update docs", status: "in_progress", priority: "low" },
+    ]
+
+    writeFileSync(join(TEST_TODO_DIR, `${sessionID}_todos.json`), JSON.stringify(todoData))
+
+    // when
+    const todos = await readSessionTodos(sessionID)
+
+    // then
+    expect(todos.length).toBe(3)
+    expect(todos[0]).toEqual({ id: "msg_001", content: "implement feature", status: "pending", priority: "high" })
+    expect(todos[1]).toEqual({ id: "msg_002", content: "write tests", status: "completed", priority: "medium" })
+    expect(todos[2]).toEqual({ id: "msg_003", content: "update docs", status: "in_progress", priority: "low" })
+  })
+
+  test("readSessionTranscript returns count of non-empty lines", async () => {
+    // given
+    const sessionID = "ses_test123"
+
+    const transcriptContent = [
+      '{"role":"user","content":"implement feature"}',
+      "",
+      '{"role":"assistant","content":"feature implemented"}',
+      "",
+      "",
+      '{"role":"user","content":"write tests"}',
+      '{"role":"assistant","content":"tests added"}',
+      "",
+    ].join("\n")
+    writeFileSync(join(TEST_TRANSCRIPT_DIR, `${sessionID}.jsonl`), transcriptContent)
+
+    // when
+    const lineCount = await readSessionTranscript(sessionID)
+
+    // then
+    expect(lineCount).toBe(4)
   })
 
   test("getSessionInfo returns null for non-existent session", async () => {


### PR DESCRIPTION
## Summary

- Add positive-path tests for session-manager todo and transcript readers.

## Changes

- Add `readSessionTodos` happy-path test using a session-matching todo JSON file
- Add `readSessionTranscript` happy-path test counting non-empty lines in `.jsonl`

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add happy-path tests for session-manager storage to verify todo parsing and transcript line counting.
Covers readSessionTodos mapping from a matching JSON file and readSessionTranscript returning the count of non-empty lines in .jsonl.

<sup>Written for commit 6a050a3c9b288295aa37c7d3e1b92dd226e6fce7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

