### PR TITLE
fix(hooks): guard against non-string tool output in afterToolResult hooks

### DIFF
--- a/src/hooks/delegate-task-retry/hook.ts
+++ b/src/hooks/delegate-task-retry/hook.ts
@@ -10,6 +10,7 @@ export function createDelegateTaskRetryHook(_ctx: PluginInput) {
       output: { title: string; output: string; metadata: unknown }
     ) => {
       if (input.tool.toLowerCase() !== "task") return
+      if (typeof output.output !== "string") return
 
       const errorInfo = detectDelegateTaskError(output.output)
       if (errorInfo) {

--- a/src/hooks/edit-error-recovery/hook.ts
+++ b/src/hooks/edit-error-recovery/hook.ts
@@ -43,6 +43,7 @@ export function createEditErrorRecoveryHook(_ctx: PluginInput) {
       output: { title: string; output: string; metadata: unknown }
     ) => {
       if (input.tool.toLowerCase() !== "edit") return
+      if (typeof output.output !== "string") return
 
       const outputLower = output.output.toLowerCase()
       const hasEditError = EDIT_ERROR_PATTERNS.some((pattern) =>


### PR DESCRIPTION
## Summary

Fixes #1749

- Add `typeof output.output !== "string"` guard in `edit-error-recovery` and `delegate-task-retry` hooks to prevent `TypeError` crash when MCP tools return non-string results

## Problem

MCP tools (e.g., Linear MCP, Notion MCP) can return structured JSON objects instead of plain strings. When this happens, `output.output` is `undefined` in the `afterToolResult` callback, causing:

```
TypeError: undefined is not an object (evaluating 'output.output.toLowerCase')
```

Two hooks are affected:
- `src/hooks/edit-error-recovery/hook.ts` — calls `output.output.toLowerCase()`
- `src/hooks/delegate-task-retry/hook.ts` — passes `output.output` to `detectDelegateTaskError()`

## Fix

Added the same guard pattern already used in `tool-output-truncator.ts`:

```ts
if (typeof output.output !== "string") return
```

This ensures both hooks gracefully skip when the tool output is not a string, consistent with existing conventions in the codebase.

## Changes

| File | Change |
|------|--------|
| `src/hooks/edit-error-recovery/hook.ts` | Add string type guard before `.toLowerCase()` |
| `src/hooks/delegate-task-retry/hook.ts` | Add string type guard before `detectDelegateTaskError()` |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented TypeError crashes in afterToolResult hooks when MCP tools return non-string outputs. Added a string check for output.output in edit-error-recovery and delegate-task-retry, skipping processing if it isn’t a string.

<sup>Written for commit bb6a011964540cb6a328516f7306bc1526282373. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

