### PR TITLE
fix: guard output.output in tool after-hooks for MCP tools

### DIFF
--- a/src/hooks/comment-checker/hook.ts
+++ b/src/hooks/comment-checker/hook.ts
@@ -92,7 +92,7 @@ export function createCommentCheckerHooks(config?: CommentCheckerConfig) {
       const toolLower = input.tool.toLowerCase()
 
       // Only skip if the output indicates a tool execution failure
-      const outputLower = output.output.toLowerCase()
+      const outputLower = (output.output ?? "").toLowerCase()
       const isToolFailure =
         outputLower.includes("error:") ||
         outputLower.includes("failed to") ||

--- a/src/hooks/edit-error-recovery/hook.ts
+++ b/src/hooks/edit-error-recovery/hook.ts
@@ -44,7 +44,7 @@ export function createEditErrorRecoveryHook(_ctx: PluginInput) {
     ) => {
       if (input.tool.toLowerCase() !== "edit") return
 
-      const outputLower = output.output.toLowerCase()
+      const outputLower = (output.output ?? "").toLowerCase()
       const hasEditError = EDIT_ERROR_PATTERNS.some((pattern) =>
         outputLower.includes(pattern.toLowerCase())
       )

--- a/src/hooks/edit-error-recovery/index.test.ts
+++ b/src/hooks/edit-error-recovery/index.test.ts
@@ -102,6 +102,23 @@ describe("createEditErrorRecoveryHook", () => {
       })
     })
 
+    describe("#given MCP tool with undefined output.output", () => {
+      describe("#when output.output is undefined", () => {
+        it("#then should not crash", async () => {
+          const input = createInput("Edit")
+          const output = {
+            title: "Edit",
+            output: undefined as unknown as string,
+            metadata: {},
+          }
+
+          await hook["tool.execute.after"](input, output)
+
+          expect(output.output).toBeUndefined()
+        })
+      })
+    })
+
     describe("#given case insensitive tool name", () => {
       describe("#when tool is 'edit' lowercase", () => {
         it("#then should still detect and append reminder", async () => {

--- a/src/hooks/task-resume-info/hook.ts
+++ b/src/hooks/task-resume-info/hook.ts
@@ -21,14 +21,15 @@ export function createTaskResumeInfoHook() {
     output: { title: string; output: string; metadata: unknown }
   ) => {
     if (!TARGET_TOOLS.includes(input.tool)) return
-    if (output.output.startsWith("Error:") || output.output.startsWith("Failed")) return
-    if (output.output.includes("\nto continue:")) return
+    const outputText = output.output ?? ""
+    if (outputText.startsWith("Error:") || outputText.startsWith("Failed")) return
+    if (outputText.includes("\nto continue:")) return
 
-    const sessionId = extractSessionId(output.output)
+    const sessionId = extractSessionId(outputText)
     if (!sessionId) return
 
     output.output =
-      output.output.trimEnd() +
+      outputText.trimEnd() +
       `\n\nto continue: task(session_id="${sessionId}", prompt="...")`
   }
 

--- a/src/hooks/task-resume-info/index.test.ts
+++ b/src/hooks/task-resume-info/index.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "bun:test"
+import { createTaskResumeInfoHook } from "./index"
+
+describe("createTaskResumeInfoHook", () => {
+  const hook = createTaskResumeInfoHook()
+  const afterHook = hook["tool.execute.after"]
+
+  const createInput = (tool: string) => ({
+    tool,
+    sessionID: "test-session",
+    callID: "test-call-id",
+  })
+
+  describe("#given MCP tool with undefined output.output", () => {
+    describe("#when tool.execute.after is called", () => {
+      it("#then should not crash", async () => {
+        const input = createInput("task")
+        const output = {
+          title: "delegate_task",
+          output: undefined as unknown as string,
+          metadata: {},
+        }
+
+        await afterHook(input, output)
+
+        expect(output.output).toBeUndefined()
+      })
+    })
+  })
+
+  describe("#given non-target tool", () => {
+    describe("#when tool is not in TARGET_TOOLS", () => {
+      it("#then should not modify output", async () => {
+        const input = createInput("Read")
+        const output = {
+          title: "Read",
+          output: "some output",
+          metadata: {},
+        }
+
+        await afterHook(input, output)
+
+        expect(output.output).toBe("some output")
+      })
+    })
+  })
+
+  describe("#given target tool with session ID in output", () => {
+    describe("#when output contains a session ID", () => {
+      it("#then should append resume info", async () => {
+        const input = createInput("call_omo_agent")
+        const output = {
+          title: "delegate_task",
+          output: "Task completed.\nSession ID: ses_abc123",
+          metadata: {},
+        }
+
+        await afterHook(input, output)
+
+        expect(output.output).toContain("to continue:")
+        expect(output.output).toContain("ses_abc123")
+      })
+    })
+  })
+
+  describe("#given target tool with error output", () => {
+    describe("#when output starts with Error:", () => {
+      it("#then should not modify output", async () => {
+        const input = createInput("task")
+        const output = {
+          title: "task",
+          output: "Error: something went wrong",
+          metadata: {},
+        }
+
+        await afterHook(input, output)
+
+        expect(output.output).toBe("Error: something went wrong")
+      })
+    })
+  })
+
+  describe("#given target tool with already-continued output", () => {
+    describe("#when output already contains continuation info", () => {
+      it("#then should not add duplicate", async () => {
+        const input = createInput("task")
+        const output = {
+          title: "task",
+          output:
+            'Done.\nSession ID: ses_abc123\nto continue: task(session_id="ses_abc123", prompt="...")',
+          metadata: {},
+        }
+
+        await afterHook(input, output)
+
+        const matches = output.output.match(/to continue:/g)
+        expect(matches?.length).toBe(1)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Fixes #1720

### Problem
MCP tool responses can have `output.output` as `undefined`, causing `TypeError: undefined is not an object (evaluating 'output.output.toLowerCase')` in `tool.execute.after` hooks.

Affected since v3.4.1 (yanked), still present in v3.5.0/v3.5.1.

### Changes
- **atlas/index.ts**: `output.output || ''` -> `output.output ?? ''` (falsy string `''` was being replaced)
- **edit-error-recovery/index.ts**: guard `output.output` with `?? ''` before `.toLowerCase()`
- **task-resume-info/index.ts**: extract `output.output ?? ''` into `outputText` variable, use it for all `.startsWith()`, `.includes()`, `.trimEnd()` calls
- **Tests**: added undefined `output.output` test cases for both edit-error-recovery and task-resume-info hooks

### Testing
```
bun test src/hooks/edit-error-recovery/index.test.ts src/hooks/task-resume-info/index.test.ts
# 14 pass, 0 fail
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard MCP tool after-hooks against undefined output.output to prevent TypeError crashes (#1720). Preserve empty string outputs when appending messages.

- **Bug Fixes**
  - comment-checker, edit-error-recovery: guard (output.output ?? '') before toLowerCase().
  - task-resume-info: use outputText = output.output ?? ''; append continuation only when a session ID exists.
  - atlas: use ?? when appending DIRECT_WORK_REMINDER.
  - tests: add undefined output.output cases for edit-error-recovery and task-resume-info.

<sup>Written for commit d5fd918bff9820302954874fd045e6b7db1df4a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

