### PR TITLE
Block remote URLs in look_at file_path

### DIFF
--- a/src/tools/look-at/look-at-arguments.ts
+++ b/src/tools/look-at/look-at-arguments.ts
@@ -16,6 +16,9 @@ export function validateArgs(args: LookAtArgs): string | null {
   const hasFilePath = Boolean(args.file_path && args.file_path.length > 0)
   const hasImageData = Boolean(args.image_data && args.image_data.length > 0)
 
+  if (hasFilePath && /^https?:\/\//i.test(args.file_path!)) {
+    return "Error: Remote URLs are not supported for file_path. Download the file first or use a local path."
+  }
   if (!hasFilePath && !hasImageData) {
     return `Error: Must provide either 'file_path' or 'image_data'. Usage:
 - look_at(file_path="/path/to/file", goal="what to extract")

--- a/src/tools/look-at/tools.test.ts
+++ b/src/tools/look-at/tools.test.ts
@@ -108,6 +108,33 @@ describe("look-at tool", () => {
       expect(error).toContain("file_path")
       expect(error).toContain("image_data")
     })
+
+    // given file_path is a remote HTTP URL
+    // when validated
+    // then return error about remote URLs not supported
+    test("returns error when file_path is an http:// URL", () => {
+      const args = { file_path: "http://example.com/image.png", goal: "analyze" }
+      const error = validateArgs(args)
+      expect(error).toContain("Remote URLs are not supported")
+    })
+
+    // given file_path is a remote HTTPS URL
+    // when validated
+    // then return error about remote URLs not supported
+    test("returns error when file_path is an https:// URL", () => {
+      const args = { file_path: "https://example.com/document.pdf", goal: "extract text" }
+      const error = validateArgs(args)
+      expect(error).toContain("Remote URLs are not supported")
+    })
+
+    // given file_path is a remote URL with mixed case scheme
+    // when validated
+    // then return error (case-insensitive check)
+    test("returns error when file_path is a remote URL with mixed case", () => {
+      const args = { file_path: "HTTPS://Example.com/file.png", goal: "analyze" }
+      const error = validateArgs(args)
+      expect(error).toContain("Remote URLs are not supported")
+    })
   })
 
   describe("createLookAt error handling", () => {


### PR DESCRIPTION
## Summary

- Block `http://` and `https://` URLs in `look_at` tool's `file_path` parameter.
- The tool only supports local files and base64 image data — remote URLs were silently mangled by `pathToFileURL()` instead of returning a clear error.

## Changes

- Add remote URL check to `validateArgs()` in `look-at-arguments.ts` — rejects `file_path` starting with `http://` or `https://` (case-insensitive).
- Add 3 tests covering `http://`, `https://`, and mixed-case `HTTPS://` URLs.

## Testing

```bash
bun test src/tools/look-at/tools.test.ts
# 23 pass, 0 fail
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks remote HTTP/HTTPS URLs in look_at’s file_path to prevent silent mangling. Users now get a clear error and must use a local path or image_data.

- **Bug Fixes**
  - Added case-insensitive check in validateArgs to reject file_path starting with http:// or https://.
  - Added tests for http, https, and mixed-case schemes.

<sup>Written for commit 3eb7dc73b788d158a00a888d3f4c4a30b18c88db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

