### PR TITLE
fix: parse config sections independently so one invalid field doesn't discard entire config

### DIFF
--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -11,6 +11,42 @@ import {
   migrateConfigFile,
 } from "./shared";
 
+export function parseConfigPartially(
+  rawConfig: Record<string, unknown>
+): OhMyOpenCodeConfig | null {
+  const fullResult = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
+  if (fullResult.success) {
+    return fullResult.data;
+  }
+
+  const partialConfig: Record<string, unknown> = {};
+  const invalidSections: string[] = [];
+
+  for (const key of Object.keys(rawConfig)) {
+    const sectionResult = OhMyOpenCodeConfigSchema.safeParse({ [key]: rawConfig[key] });
+    if (sectionResult.success) {
+      const parsed = sectionResult.data as Record<string, unknown>;
+      if (parsed[key] !== undefined) {
+        partialConfig[key] = parsed[key];
+      }
+    } else {
+      const sectionErrors = sectionResult.error.issues
+        .filter((i) => i.path[0] === key)
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join(", ");
+      if (sectionErrors) {
+        invalidSections.push(`${key}: ${sectionErrors}`);
+      }
+    }
+  }
+
+  if (invalidSections.length > 0) {
+    log("Partial config loaded — invalid sections skipped:", invalidSections);
+  }
+
+  return partialConfig as OhMyOpenCodeConfig;
+}
+
 export function loadConfigFromPath(
   configPath: string,
   ctx: unknown
@@ -24,20 +60,27 @@ export function loadConfigFromPath(
 
       const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
 
-      if (!result.success) {
-        const errorMsg = result.error.issues
-          .map((i) => `${i.path.join(".")}: ${i.message}`)
-          .join(", ");
-        log(`Config validation error in ${configPath}:`, result.error.issues);
-        addConfigLoadError({
-          path: configPath,
-          error: `Validation error: ${errorMsg}`,
-        });
-        return null;
+      if (result.success) {
+        log(`Config loaded from ${configPath}`, { agents: result.data.agents });
+        return result.data;
       }
 
-      log(`Config loaded from ${configPath}`, { agents: result.data.agents });
-      return result.data;
+      const errorMsg = result.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join(", ");
+      log(`Config validation error in ${configPath}:`, result.error.issues);
+      addConfigLoadError({
+        path: configPath,
+        error: `Partial config loaded — invalid sections skipped: ${errorMsg}`,
+      });
+
+      const partialResult = parseConfigPartially(rawConfig);
+      if (partialResult) {
+        log(`Partial config loaded from ${configPath}`, { agents: partialResult.agents });
+        return partialResult;
+      }
+
+      return null;
     }
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
fixes #1767

summary
a single invalid field in oh-my-opencode.json (e.g. wrong type for `prometheus.permission.edit`) caused `safeParse` to fail on the whole object, silently replacing the entire config with `{}`. all agent model overrides, categories, and disabled hooks were lost with no useful indication.

root cause
`loadConfigFromPath` used `OhMyOpenCodeConfigSchema.safeParse()` on the full raw config. if any field failed validation the function returned `null`, and the caller fell back to `{}`.

changes
- added `parseConfigPartially()` that tries the full parse first (fast path), then falls back to validating each top-level key independently — keeping sections that pass, dropping ones that fail
- `loadConfigFromPath` now falls back to partial parsing instead of returning null on validation failure
- invalid sections are logged with details so users can fix them
- added tests covering: fully valid, partially invalid, completely invalid, empty, and unknown-key configs

testing
- `bun test src/plugin-config.test.ts` — 11 pass
- `bun run typecheck` — clean
- `bun test` — 2200 pass, 10 pre-existing fail (mcp-oauth network tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented full config loss when one field is invalid by validating config sections independently and keeping the valid parts. Invalid sections are logged so users can fix them.

- **Bug Fixes**
  - Added parseConfigPartially() to validate each top-level key and build a partial config.
  - loadConfigFromPath now falls back to partial parsing on validation errors instead of returning null.
  - Logs detailed errors for skipped sections; unknown keys are ignored.
  - Added tests for fully valid, partially invalid, completely invalid, empty, and unknown-key configs.

<sup>Written for commit d3978ab49173abbc4ba1cb77684a6288d7eb851c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

