### PR TITLE
fix: reduce session.messages() calls with event-based caching to prevent memory leaks

### DIFF
--- a/src/hooks/claude-code-hooks/tool-input-cache.ts
+++ b/src/hooks/claude-code-hooks/tool-input-cache.ts
@@ -37,7 +37,7 @@ export function getToolInput(
 }
 
 // Periodic cleanup (every minute)
-setInterval(() => {
+const cleanupInterval = setInterval(() => {
   const now = Date.now()
   for (const [key, entry] of cache.entries()) {
     if (now - entry.timestamp > CACHE_TTL) {
@@ -45,3 +45,7 @@ setInterval(() => {
     }
   }
 }, CACHE_TTL)
+// Allow process to exit naturally even if interval is running
+if (typeof cleanupInterval === "object" && "unref" in cleanupInterval) {
+  cleanupInterval.unref()
+}

--- a/src/hooks/claude-code-hooks/transcript.test.ts
+++ b/src/hooks/claude-code-hooks/transcript.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { existsSync, unlinkSync, readFileSync } from "fs"
+import {
+  buildTranscriptFromSession,
+  deleteTempTranscript,
+  clearTranscriptCache,
+} from "./transcript"
+
+function createMockClient(messages: unknown[] = []) {
+  return {
+    session: {
+      messages: mock(() =>
+        Promise.resolve({
+          data: messages,
+        })
+      ),
+    },
+  }
+}
+
+describe("transcript caching", () => {
+  afterEach(() => {
+    clearTranscriptCache()
+  })
+
+  // #given same session called twice
+  // #when buildTranscriptFromSession is invoked
+  // #then session.messages() should be called only once (cached)
+  it("should cache transcript and not re-fetch for same session", async () => {
+    const client = createMockClient([
+      {
+        info: { role: "assistant" },
+        parts: [
+          {
+            type: "tool",
+            tool: "bash",
+            state: { status: "completed", input: { command: "ls" } },
+          },
+        ],
+      },
+    ])
+
+    const path1 = await buildTranscriptFromSession(
+      client,
+      "ses_cache1",
+      "/tmp",
+      "bash",
+      { command: "echo hi" }
+    )
+
+    const path2 = await buildTranscriptFromSession(
+      client,
+      "ses_cache1",
+      "/tmp",
+      "read",
+      { path: "/tmp/file" }
+    )
+
+    // session.messages() called only once
+    expect(client.session.messages).toHaveBeenCalledTimes(1)
+
+    // Both return valid paths
+    expect(path1).not.toBeNull()
+    expect(path2).not.toBeNull()
+
+    // Second call should append the new tool entry
+    if (path2) {
+      const content = readFileSync(path2, "utf-8")
+      expect(content).toContain("Read")
+    }
+
+    deleteTempTranscript(path1)
+    deleteTempTranscript(path2)
+  })
+
+  // #given different sessions
+  // #when buildTranscriptFromSession called for each
+  // #then session.messages() should be called for each
+  it("should not share cache between different sessions", async () => {
+    const client = createMockClient([])
+
+    await buildTranscriptFromSession(client, "ses_a", "/tmp", "bash", {})
+    await buildTranscriptFromSession(client, "ses_b", "/tmp", "bash", {})
+
+    expect(client.session.messages).toHaveBeenCalledTimes(2)
+
+    clearTranscriptCache()
+  })
+
+  // #given clearTranscriptCache is called
+  // #when buildTranscriptFromSession called again
+  // #then should re-fetch
+  it("should re-fetch after cache is cleared", async () => {
+    const client = createMockClient([])
+
+    await buildTranscriptFromSession(client, "ses_clear", "/tmp", "bash", {})
+    clearTranscriptCache()
+    await buildTranscriptFromSession(client, "ses_clear", "/tmp", "bash", {})
+
+    expect(client.session.messages).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/hooks/claude-code-hooks/transcript.ts
+++ b/src/hooks/claude-code-hooks/transcript.ts
@@ -29,12 +29,9 @@ export function appendTranscriptEntry(
 }
 
 // ============================================================================
-// Claude Code Compatible Transcript Builder (PORT FROM DISABLED)
+// Claude Code Compatible Transcript Builder
 // ============================================================================
 
-/**
- * OpenCode API response type (loosely typed)
- */
 interface OpenCodeMessagePart {
   type: string
   tool?: string
@@ -51,9 +48,6 @@ interface OpenCodeMessage {
   parts?: OpenCodeMessagePart[]
 }
 
-/**
- * Claude Code compatible transcript entry (from disabled file)
- */
 interface DisabledTranscriptEntry {
   type: "assistant"
   message: {
@@ -66,18 +60,93 @@ interface DisabledTranscriptEntry {
   }
 }
 
+// ============================================================================
+// Session-scoped transcript cache to avoid full session.messages() rebuild
+// on every tool call. Cache stores base entries from initial fetch;
+// subsequent calls append new tool entries without re-fetching.
+// ============================================================================
+
+interface TranscriptCacheEntry {
+  baseEntries: string[]
+  tempPath: string | null
+  createdAt: number
+}
+
+const TRANSCRIPT_CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+
+const transcriptCache = new Map<string, TranscriptCacheEntry>()
+
 /**
- * Build Claude Code compatible transcript from session messages
- * 
- * PORT FROM DISABLED: This calls client.session.messages() API to fetch
- * the full session history and builds a JSONL file in Claude Code format.
- * 
- * @param client OpenCode client instance
- * @param sessionId Session ID
- * @param directory Working directory
- * @param currentToolName Current tool being executed (added as last entry)
- * @param currentToolInput Current tool input
- * @returns Temp file path (caller must call deleteTempTranscript!)
+ * Clear transcript cache for a specific session or all sessions.
+ * Call on session.deleted to prevent memory accumulation.
+ */
+export function clearTranscriptCache(sessionId?: string): void {
+  if (sessionId) {
+    const entry = transcriptCache.get(sessionId)
+    if (entry?.tempPath) {
+      try { unlinkSync(entry.tempPath) } catch { /* ignore */ }
+    }
+    transcriptCache.delete(sessionId)
+  } else {
+    for (const [, entry] of transcriptCache) {
+      if (entry.tempPath) {
+        try { unlinkSync(entry.tempPath) } catch { /* ignore */ }
+      }
+    }
+    transcriptCache.clear()
+  }
+}
+
+function isCacheValid(entry: TranscriptCacheEntry): boolean {
+  return Date.now() - entry.createdAt < TRANSCRIPT_CACHE_TTL_MS
+}
+
+function buildCurrentEntry(toolName: string, toolInput: Record<string, unknown>): string {
+  const entry: DisabledTranscriptEntry = {
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          name: transformToolName(toolName),
+          input: toolInput,
+        },
+      ],
+    },
+  }
+  return JSON.stringify(entry)
+}
+
+function parseMessagesToEntries(messages: OpenCodeMessage[]): string[] {
+  const entries: string[] = []
+  for (const msg of messages) {
+    if (msg.info?.role !== "assistant") continue
+    for (const part of msg.parts || []) {
+      if (part.type !== "tool") continue
+      if (part.state?.status !== "completed") continue
+      if (!part.state?.input) continue
+
+      const rawToolName = part.tool as string
+      const toolName = transformToolName(rawToolName)
+
+      const entry: DisabledTranscriptEntry = {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", name: toolName, input: part.state.input }],
+        },
+      }
+      entries.push(JSON.stringify(entry))
+    }
+  }
+  return entries
+}
+
+/**
+ * Build Claude Code compatible transcript from session messages.
+ * Uses per-session cache to avoid redundant session.messages() API calls.
+ * First call fetches and caches; subsequent calls reuse cached base entries.
  */
 export async function buildTranscriptFromSession(
   client: {
@@ -91,97 +160,63 @@ export async function buildTranscriptFromSession(
   currentToolInput: Record<string, unknown>
 ): Promise<string | null> {
   try {
-    const response = await client.session.messages({
-      path: { id: sessionId },
-      query: { directory },
-    })
+    let baseEntries: string[]
 
-    // Handle various response formats
-    const messages = (response as { "200"?: unknown[]; data?: unknown[] })["200"]
-      ?? (response as { data?: unknown[] }).data
-      ?? (Array.isArray(response) ? response : [])
+    const cached = transcriptCache.get(sessionId)
+    if (cached && isCacheValid(cached)) {
+      baseEntries = cached.baseEntries
+    } else {
+      // Fetch full session messages (only on first call or cache expiry)
+      const response = await client.session.messages({
+        path: { id: sessionId },
+        query: { directory },
+      })
 
-    const entries: string[] = []
+      const messages = (response as { "200"?: unknown[]; data?: unknown[] })["200"]
+        ?? (response as { data?: unknown[] }).data
+        ?? (Array.isArray(response) ? response : [])
 
-    if (Array.isArray(messages)) {
-      for (const msg of messages as OpenCodeMessage[]) {
-        if (msg.info?.role !== "assistant") continue
+      baseEntries = Array.isArray(messages)
+        ? parseMessagesToEntries(messages as OpenCodeMessage[])
+        : []
 
-        for (const part of msg.parts || []) {
-          if (part.type !== "tool") continue
-          if (part.state?.status !== "completed") continue
-          if (!part.state?.input) continue
-
-          const rawToolName = part.tool as string
-          const toolName = transformToolName(rawToolName)
-
-          const entry: DisabledTranscriptEntry = {
-            type: "assistant",
-            message: {
-              role: "assistant",
-              content: [
-                {
-                  type: "tool_use",
-                  name: toolName,
-                  input: part.state.input,
-                },
-              ],
-            },
-          }
-          entries.push(JSON.stringify(entry))
-        }
+      // Clean up old temp file if exists
+      if (cached?.tempPath) {
+        try { unlinkSync(cached.tempPath) } catch { /* ignore */ }
       }
+
+      transcriptCache.set(sessionId, {
+        baseEntries,
+        tempPath: null,
+        createdAt: Date.now(),
+      })
     }
 
-    // Always add current tool call as the last entry
-    const currentEntry: DisabledTranscriptEntry = {
-      type: "assistant",
-      message: {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            name: transformToolName(currentToolName),
-            input: currentToolInput,
-          },
-        ],
-      },
-    }
-    entries.push(JSON.stringify(currentEntry))
+    // Append current tool call
+    const allEntries = [...baseEntries, buildCurrentEntry(currentToolName, currentToolInput)]
 
-    // Write to temp file
     const tempPath = join(
       tmpdir(),
       `opencode-transcript-${sessionId}-${randomUUID()}.jsonl`
     )
-    writeFileSync(tempPath, entries.join("\n") + "\n")
+    writeFileSync(tempPath, allEntries.join("\n") + "\n")
+
+    // Update cache temp path for cleanup tracking
+    const cacheEntry = transcriptCache.get(sessionId)
+    if (cacheEntry) {
+      cacheEntry.tempPath = tempPath
+    }
 
     return tempPath
   } catch {
-    // CRITICAL FIX: Even on API failure, create file with current tool entry only
-    // (matching original disabled behavior - never return null with incompatible format)
     try {
-      const currentEntry: DisabledTranscriptEntry = {
-        type: "assistant",
-        message: {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_use",
-              name: transformToolName(currentToolName),
-              input: currentToolInput,
-            },
-          ],
-        },
-      }
       const tempPath = join(
         tmpdir(),
         `opencode-transcript-${sessionId}-${randomUUID()}.jsonl`
       )
-      writeFileSync(tempPath, JSON.stringify(currentEntry) + "\n")
+      writeFileSync(tempPath, buildCurrentEntry(currentToolName, currentToolInput) + "\n")
       return tempPath
     } catch {
-      // If even this fails, return null (truly catastrophic failure)
       return null
     }
   }
@@ -189,8 +224,6 @@ export async function buildTranscriptFromSession(
 
 /**
  * Delete temp transcript file (call in finally block)
- * 
- * PORT FROM DISABLED: Cleanup mechanism to avoid disk accumulation
  */
 export function deleteTempTranscript(path: string | null): void {
   if (!path) return

--- a/src/hooks/context-window-monitor.test.ts
+++ b/src/hooks/context-window-monitor.test.ts
@@ -1,22 +1,18 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test"
-import { createPreemptiveCompactionHook } from "./preemptive-compaction"
+import { createContextWindowMonitorHook } from "./context-window-monitor"
 
 function createMockCtx() {
   return {
     client: {
       session: {
         messages: mock(() => Promise.resolve({ data: [] })),
-        summarize: mock(() => Promise.resolve({})),
-      },
-      tui: {
-        showToast: mock(() => Promise.resolve()),
       },
     },
     directory: "/tmp/test",
   }
 }
 
-describe("preemptive-compaction", () => {
+describe("context-window-monitor", () => {
   let ctx: ReturnType<typeof createMockCtx>
 
   beforeEach(() => {
@@ -27,10 +23,10 @@ describe("preemptive-compaction", () => {
   // #when tool.execute.after is called
   // #then session.messages() should NOT be called
   it("should use cached token info instead of fetching session.messages()", async () => {
-    const hook = createPreemptiveCompactionHook(ctx as never)
+    const hook = createContextWindowMonitorHook(ctx as never)
     const sessionID = "ses_test1"
 
-    // Simulate message.updated with token info below threshold
+    // Simulate message.updated event with token info
     await hook.event({
       event: {
         type: "message.updated",
@@ -39,63 +35,9 @@ describe("preemptive-compaction", () => {
             role: "assistant",
             sessionID,
             providerID: "anthropic",
-            modelID: "claude-sonnet-4-5",
             finish: true,
             tokens: {
               input: 50000,
-              output: 1000,
-              reasoning: 0,
-              cache: { read: 5000, write: 0 },
-            },
-          },
-        },
-      },
-    })
-
-    const output = { title: "", output: "test", metadata: null }
-    await hook["tool.execute.after"](
-      { tool: "bash", sessionID, callID: "call_1" },
-      output
-    )
-
-    expect(ctx.client.session.messages).not.toHaveBeenCalled()
-  })
-
-  // #given no cached token info
-  // #when tool.execute.after is called
-  // #then should skip without fetching
-  it("should skip gracefully when no cached token info exists", async () => {
-    const hook = createPreemptiveCompactionHook(ctx as never)
-
-    const output = { title: "", output: "test", metadata: null }
-    await hook["tool.execute.after"](
-      { tool: "bash", sessionID: "ses_none", callID: "call_1" },
-      output
-    )
-
-    expect(ctx.client.session.messages).not.toHaveBeenCalled()
-  })
-
-  // #given usage above 78% threshold
-  // #when tool.execute.after runs
-  // #then should trigger summarize
-  it("should trigger compaction when usage exceeds threshold", async () => {
-    const hook = createPreemptiveCompactionHook(ctx as never)
-    const sessionID = "ses_high"
-
-    // 170K input + 10K cache = 180K → 90% of 200K
-    await hook.event({
-      event: {
-        type: "message.updated",
-        properties: {
-          info: {
-            role: "assistant",
-            sessionID,
-            providerID: "anthropic",
-            modelID: "claude-sonnet-4-5",
-            finish: true,
-            tokens: {
-              input: 170000,
               output: 1000,
               reasoning: 0,
               cache: { read: 10000, write: 0 },
@@ -105,22 +47,42 @@ describe("preemptive-compaction", () => {
       },
     })
 
-    const output = { title: "", output: "test", metadata: null }
+    const output = { title: "", output: "test output", metadata: null }
     await hook["tool.execute.after"](
       { tool: "bash", sessionID, callID: "call_1" },
       output
     )
 
+    // session.messages() should NOT have been called
     expect(ctx.client.session.messages).not.toHaveBeenCalled()
-    expect(ctx.client.session.summarize).toHaveBeenCalled()
   })
 
-  // #given session deleted
-  // #then cache should be cleaned up
-  it("should clean up cache on session.deleted", async () => {
-    const hook = createPreemptiveCompactionHook(ctx as never)
-    const sessionID = "ses_del"
+  // #given no cached token info exists
+  // #when tool.execute.after is called
+  // #then should skip gracefully without fetching
+  it("should skip gracefully when no cached token info exists", async () => {
+    const hook = createContextWindowMonitorHook(ctx as never)
+    const sessionID = "ses_no_cache"
 
+    const output = { title: "", output: "test output", metadata: null }
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      output
+    )
+
+    // No fetch, no crash
+    expect(ctx.client.session.messages).not.toHaveBeenCalled()
+    expect(output.output).toBe("test output")
+  })
+
+  // #given token usage exceeds 70% threshold
+  // #when tool.execute.after is called
+  // #then context reminder should be appended to output
+  it("should append context reminder when usage exceeds threshold", async () => {
+    const hook = createContextWindowMonitorHook(ctx as never)
+    const sessionID = "ses_high_usage"
+
+    // 150K input + 10K cache read = 160K, which is 80% of 200K limit
     await hook.event({
       event: {
         type: "message.updated",
@@ -129,18 +91,87 @@ describe("preemptive-compaction", () => {
             role: "assistant",
             sessionID,
             providerID: "anthropic",
-            modelID: "claude-sonnet-4-5",
             finish: true,
-            tokens: { input: 180000, output: 0, reasoning: 0, cache: { read: 10000, write: 0 } },
+            tokens: {
+              input: 150000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
           },
         },
       },
     })
 
+    const output = { title: "", output: "original", metadata: null }
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      output
+    )
+
+    expect(output.output).toContain("context remaining")
+    expect(ctx.client.session.messages).not.toHaveBeenCalled()
+  })
+
+  // #given session is deleted
+  // #when session.deleted event fires
+  // #then cached data should be cleaned up
+  it("should clean up cache on session.deleted", async () => {
+    const hook = createContextWindowMonitorHook(ctx as never)
+    const sessionID = "ses_deleted"
+
+    // Cache some data
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            finish: true,
+            tokens: { input: 150000, output: 0, reasoning: 0, cache: { read: 10000, write: 0 } },
+          },
+        },
+      },
+    })
+
+    // Delete session
     await hook.event({
       event: {
         type: "session.deleted",
         properties: { info: { id: sessionID } },
+      },
+    })
+
+    // After deletion, no reminder should fire (cache gone, reminded set gone)
+    const output = { title: "", output: "test", metadata: null }
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      output
+    )
+    expect(output.output).toBe("test")
+  })
+
+  // #given non-anthropic provider
+  // #when message.updated fires
+  // #then should not trigger reminder
+  it("should ignore non-anthropic providers", async () => {
+    const hook = createContextWindowMonitorHook(ctx as never)
+    const sessionID = "ses_openai"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "openai",
+            finish: true,
+            tokens: { input: 200000, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          },
+        },
       },
     })
 
@@ -149,7 +180,6 @@ describe("preemptive-compaction", () => {
       { tool: "bash", sessionID, callID: "call_1" },
       output
     )
-
-    expect(ctx.client.session.summarize).not.toHaveBeenCalled()
+    expect(output.output).toBe("test")
   })
 })

--- a/src/hooks/todo-continuation-enforcer/session-state.ts
+++ b/src/hooks/todo-continuation-enforcer/session-state.ts
@@ -1,33 +1,69 @@
 import type { SessionState } from "./types"
 
+// TTL for idle session state entries (10 minutes)
+const SESSION_STATE_TTL_MS = 10 * 60 * 1000
+// Prune interval (every 2 minutes)
+const SESSION_STATE_PRUNE_INTERVAL_MS = 2 * 60 * 1000
+
+interface TrackedSessionState {
+  state: SessionState
+  lastAccessedAt: number
+}
+
 export interface SessionStateStore {
   getState: (sessionID: string) => SessionState
   getExistingState: (sessionID: string) => SessionState | undefined
   cancelCountdown: (sessionID: string) => void
   cleanup: (sessionID: string) => void
   cancelAllCountdowns: () => void
+  shutdown: () => void
 }
 
 export function createSessionStateStore(): SessionStateStore {
-  const sessions = new Map<string, SessionState>()
+  const sessions = new Map<string, TrackedSessionState>()
+
+  // Periodic pruning of stale session states to prevent unbounded Map growth
+  let pruneInterval: ReturnType<typeof setInterval> | undefined
+  pruneInterval = setInterval(() => {
+    const now = Date.now()
+    for (const [sessionID, tracked] of sessions.entries()) {
+      if (now - tracked.lastAccessedAt > SESSION_STATE_TTL_MS) {
+        cancelCountdown(sessionID)
+        sessions.delete(sessionID)
+      }
+    }
+  }, SESSION_STATE_PRUNE_INTERVAL_MS)
+  // Allow process to exit naturally even if interval is running
+  if (typeof pruneInterval === "object" && "unref" in pruneInterval) {
+    pruneInterval.unref()
+  }
 
   function getState(sessionID: string): SessionState {
-    const existingState = sessions.get(sessionID)
-    if (existingState) return existingState
+    const existing = sessions.get(sessionID)
+    if (existing) {
+      existing.lastAccessedAt = Date.now()
+      return existing.state
+    }
 
     const state: SessionState = {}
-    sessions.set(sessionID, state)
+    sessions.set(sessionID, { state, lastAccessedAt: Date.now() })
     return state
   }
 
   function getExistingState(sessionID: string): SessionState | undefined {
-    return sessions.get(sessionID)
+    const existing = sessions.get(sessionID)
+    if (existing) {
+      existing.lastAccessedAt = Date.now()
+      return existing.state
+    }
+    return undefined
   }
 
   function cancelCountdown(sessionID: string): void {
-    const state = sessions.get(sessionID)
-    if (!state) return
+    const tracked = sessions.get(sessionID)
+    if (!tracked) return
 
+    const state = tracked.state
     if (state.countdownTimer) {
       clearTimeout(state.countdownTimer)
       state.countdownTimer = undefined
@@ -52,11 +88,18 @@ export function createSessionStateStore(): SessionStateStore {
     }
   }
 
+  function shutdown(): void {
+    clearInterval(pruneInterval)
+    cancelAllCountdowns()
+    sessions.clear()
+  }
+
   return {
     getState,
     getExistingState,
     cancelCountdown,
     cleanup,
     cancelAllCountdowns,
+    shutdown,
   }
 }


### PR DESCRIPTION
## Summary

Eliminate redundant `session.messages()` API calls in hot paths to fix memory leaks during extended sessions.

### Root Cause
Multiple hooks call `session.messages()` (full session history fetch) on **every tool execution**, causing memory to grow proportionally with session length. In a 200+ message session, each tool call triggered 3-4 full fetches of the entire message history.

### Changes
| File | Change | Effect |
|---|---|---|
| `context-window-monitor.ts` | Replace `session.messages()` with `message.updated` event cache | **0 API calls per tool** (was 1) |
| `preemptive-compaction.ts` | Same event-based caching | **0 API calls per tool** (was 1) |
| `transcript.ts` | Per-session transcript cache (5min TTL) | **1 call per session** (was 1 per tool) |
| `background-agent/manager.ts` | Remove `session.messages()` from polling loop | **0 calls per poll** (was 1 per task × every 3s) |
| `todo-continuation-enforcer/session-state.ts` | TTL-based pruning for session state Map | Prevents unbounded Map growth |
| `tool-input-cache.ts` | `setInterval.unref()` | Prevents blocking process exit |

### Impact
- **Before**: ~3-4 `session.messages()` calls per tool execution + continuous polling fetches
- **After**: 0 calls per tool execution (event-cached), 1 per session for transcript

### Testing
- 12 new tests (TDD RED→GREEN→REFACTOR)
- All 2595 existing tests pass, 0 new failures
- `bun run typecheck` ✅
- `bun run build` ✅

### Verification
```bash
bun run typecheck
bun test src/hooks/context-window-monitor.test.ts
bun test src/hooks/preemptive-compaction.test.ts
bun test src/hooks/claude-code-hooks/transcript.test.ts
bun test src/features/background-agent/manager.test.ts
bun test src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
bun run build
```

### Related Issues
Fixes #1222
Related: #1769, #1752, #1486, #361

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced repeated session.messages() fetches with event-based caching to stop memory leaks in long sessions and cut API calls to near-zero during tool runs. Addresses #1222 by moving hot paths to use message.updated data and adding TTL-based cleanup.

- **Bug Fixes**
  - Context-window-monitor and preemptive-compaction now use message.updated token cache; no history fetches on tool.execute.after; cache cleared on session.deleted.
  - Background-agent manager removes session.messages() from the polling loop; progress tracked via event handlers.
  - Transcript builder adds a per-session cache (5 min TTL) to avoid rebuilding from full history on each tool call; includes cleanup helpers.
  - Todo-continuation-enforcer store gains TTL pruning and a shutdown method to prevent unbounded Map growth.
  - Tool-input-cache cleanup timer now uses setInterval.unref() so it won’t block process exit.
  - Impact: 0 session.messages() calls per tool execution (was ~3–4) and no polling fetches; transcript now 1 fetch per session.

<sup>Written for commit eb56701996b9e7ff1edd2e9333eb79048c875b2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

