### PR TITLE
fix: execute all Stop hooks instead of returning after first non-blocking result

### DIFF
--- a/src/hooks/claude-code-hooks/stop.test.ts
+++ b/src/hooks/claude-code-hooks/stop.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import type { ClaudeHooksConfig } from "./types"
+import type { StopContext } from "./stop"
+
+const mockExecuteHookCommand = mock(() =>
+  Promise.resolve({ exitCode: 0, stdout: "", stderr: "" })
+)
+
+mock.module("../../shared/command-executor", () => ({
+  executeHookCommand: mockExecuteHookCommand,
+  executeCommand: mock(),
+  resolveCommandsInText: mock(),
+}))
+
+mock.module("../../shared/logger", () => ({
+  log: () => {},
+  getLogFilePath: () => "/tmp/test.log",
+}))
+
+const { executeStopHooks } = await import("./stop")
+
+function createStopContext(overrides?: Partial<StopContext>): StopContext {
+  return {
+    sessionId: "test-session",
+    cwd: "/tmp",
+    ...overrides,
+  }
+}
+
+function createConfig(stopHooks: ClaudeHooksConfig["Stop"]): ClaudeHooksConfig {
+  return { Stop: stopHooks }
+}
+
+describe("executeStopHooks", () => {
+  beforeEach(() => {
+    mockExecuteHookCommand.mockReset()
+    mockExecuteHookCommand.mockImplementation(() =>
+      Promise.resolve({ exitCode: 0, stdout: "", stderr: "" })
+    )
+  })
+
+  it("#given parent session #when stop hooks called #then skips execution", async () => {
+    const ctx = createStopContext({ parentSessionId: "parent-session" })
+    const config = createConfig([
+      { matcher: "*", hooks: [{ type: "command", command: "echo test" }] },
+    ])
+
+    const result = await executeStopHooks(ctx, config)
+
+    expect(result.block).toBe(false)
+    expect(mockExecuteHookCommand).not.toHaveBeenCalled()
+  })
+
+  it("#given null config #when stop hooks called #then returns non-blocking", async () => {
+    const ctx = createStopContext()
+
+    const result = await executeStopHooks(ctx, null)
+
+    expect(result.block).toBe(false)
+    expect(mockExecuteHookCommand).not.toHaveBeenCalled()
+  })
+
+  it("#given empty stop hooks #when stop hooks called #then returns non-blocking", async () => {
+    const ctx = createStopContext()
+    const config = createConfig([])
+
+    const result = await executeStopHooks(ctx, config)
+
+    expect(result.block).toBe(false)
+  })
+
+  it("#given hook with exit code 2 #when stop hooks called #then blocks", async () => {
+    const ctx = createStopContext()
+    const config = createConfig([
+      { matcher: "*", hooks: [{ type: "command", command: "exit 2" }] },
+    ])
+    mockExecuteHookCommand.mockResolvedValueOnce({
+      exitCode: 2,
+      stdout: "",
+      stderr: "blocked reason",
+    })
+
+    const result = await executeStopHooks(ctx, config)
+
+    expect(result.block).toBe(true)
+    expect(result.reason).toBe("blocked reason")
+  })
+
+  it("#given hook with decision=block #when stop hooks called #then blocks", async () => {
+    const ctx = createStopContext()
+    const config = createConfig([
+      { matcher: "*", hooks: [{ type: "command", command: "blocker" }] },
+    ])
+    mockExecuteHookCommand.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: JSON.stringify({ decision: "block", reason: "must fix" }),
+      stderr: "",
+    })
+
+    const result = await executeStopHooks(ctx, config)
+
+    expect(result.block).toBe(true)
+    expect(result.reason).toBe("must fix")
+  })
+
+  it("#given first hook returns non-blocking JSON #when multiple hooks #then executes all hooks", async () => {
+    const ctx = createStopContext()
+    const config = createConfig([
+      { matcher: "*", hooks: [{ type: "command", command: "hook-a" }] },
+      { matcher: "*", hooks: [{ type: "command", command: "hook-b" }] },
+    ])
+    mockExecuteHookCommand
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({ suppressOutput: true }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({ suppressOutput: true }),
+        stderr: "",
+      })
+
+    const result = await executeStopHooks(ctx, config)
+
+    expect(result.block).toBe(false)
+    expect(mockExecuteHookCommand).toHaveBeenCalledTimes(2)
+  })
+
+  it("#given first hook returns stdin passthrough JSON #when multiple hooks #then executes all hooks", async () => {
+    const ctx = createStopContext()
+    const stdinPassthrough = {
+      session_id: "test-session",
+      hook_event_name: "Stop",
+      hook_source: "opencode-plugin",
+    }
+    const config = createConfig([
+      { matcher: "*", hooks: [{ type: "command", command: "check-console-log" }] },
+      { matcher: "*", hooks: [{ type: "command", command: "task-complete-notify" }] },
+    ])
+    mockExecuteHookCommand
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify(stdinPassthrough),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({ suppressOutput: true }),
+        stderr: "",
+      })
+
+    const result = await executeStopHooks(ctx, config)
+
+    expect(result.block).toBe(false)
+    expect(mockExecuteHookCommand).toHaveBeenCalledTimes(2)
+  })
+
+  it("#given first hook blocks #when multiple hooks #then stops at blocking hook", async () => {
+    const ctx = createStopContext()
+    const config = createConfig([
+      { matcher: "*", hooks: [{ type: "command", command: "blocker" }] },
+      { matcher: "*", hooks: [{ type: "command", command: "notifier" }] },
+    ])
+    mockExecuteHookCommand.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: JSON.stringify({ decision: "block", reason: "fix first" }),
+      stderr: "",
+    })
+
+    const result = await executeStopHooks(ctx, config)
+
+    expect(result.block).toBe(true)
+    expect(mockExecuteHookCommand).toHaveBeenCalledTimes(1)
+  })
+
+  it("#given hook with non-JSON stdout #when stop hooks called #then continues to next hook", async () => {
+    const ctx = createStopContext()
+    const config = createConfig([
+      { matcher: "*", hooks: [{ type: "command", command: "hook-a" }] },
+      { matcher: "*", hooks: [{ type: "command", command: "hook-b" }] },
+    ])
+    mockExecuteHookCommand
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "not json",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+      })
+
+    const result = await executeStopHooks(ctx, config)
+
+    expect(result.block).toBe(false)
+    expect(mockExecuteHookCommand).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1707

`executeStopHooks` previously returned immediately after the first hook that produced valid JSON stdout, even when the result was non-blocking. This prevented subsequent Stop hooks from executing.

## Root Cause

When a user defines multiple Stop hooks in `~/.claude/settings.json`:

```json
"Stop": [
  { "matcher": "*", "hooks": [{ "type": "command", "command": "check-console-log.js" }] },
  { "matcher": "*", "hooks": [{ "type": "command", "command": "task-complete-notify.sh" }] }
]
```

The first hook (`check-console-log.js`) echoes its stdin data back to stdout via `console.log(data)`. Since the stdin data is valid JSON (the `StopInput` object), `executeStopHooks` parsed it successfully and returned immediately — preventing `task-complete-notify.sh` (and any subsequent hooks) from ever executing.

This differs from Claude Code's native behavior, which executes **all** Stop hooks sequentially regardless of individual non-blocking results.

## Fix

Changed `executeStopHooks` to only return early when a hook **explicitly blocks** (exit code 2 or `decision: "block"` in JSON output). Non-blocking hook results are now processed (e.g., `stop_hook_active` state updates) but execution continues to the next hook.

## Changes

- `src/hooks/claude-code-hooks/stop.ts` — Remove early return for non-blocking JSON results
- `src/hooks/claude-code-hooks/stop.test.ts` — Add comprehensive test coverage for `executeStopHooks` (9 test cases)

## Testing

All 9 new tests pass:
- Parent session skip
- Null/empty config handling
- Exit code 2 blocking
- `decision=block` JSON blocking  
- **Multiple hooks with non-blocking first hook → all hooks execute** (the key regression test)
- Stdin passthrough JSON (simulates check-console-log.js behavior)
- Blocking first hook stops execution
- Non-JSON stdout continues to next hook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure all Stop hooks run in order and only stop when a hook explicitly blocks. Fixes #1707 and prevents non-blocking JSON output from skipping later hooks.

- **Bug Fixes**
  - executeStopHooks now continues after non-blocking results; only exits early on exit code 2 or decision: "block".
  - Added tests for multiple hooks, JSON passthrough, and blocking behavior to prevent regressions.

<sup>Written for commit 5c8d69449185693deca23b00ef83ff9093464a7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

