### PR TITLE
docs: Fix link in Google Auth section of configurations.md

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -83,7 +83,7 @@ When both `oh-my-opencode.jsonc` and `oh-my-opencode.json` files exist, `.jsonc`
 
 ## Google Auth
 
-**Recommended**: For Google Gemini authentication, install the [`opencode-antigravity-auth`](https://github.com/NoeFabris/opencode-antigravity-auth) plugin (`@latest`). It provides multi-account load balancing, variant-based thinking levels, dual quota system (Antigravity + Gemini CLI), and active maintenance. See [Installation > Google Gemini](docs/guide/installation.md#google-gemini-antigravity-oauth).
+**Recommended**: For Google Gemini authentication, install the [`opencode-antigravity-auth`](https://github.com/NoeFabris/opencode-antigravity-auth) plugin (`@latest`). It provides multi-account load balancing, variant-based thinking levels, dual quota system (Antigravity + Gemini CLI), and active maintenance. See [Installation > Google Gemini](guide/installation.md#google-gemini-antigravity-oauth).
 
 ## Ollama Provider
 


### PR DESCRIPTION
## Description

Fixes a broken relative link in `docs/configurations.md`.

The previous link pointed to `docs/guide/installation.md` relative to the current file location (`docs/`), which likely resolved incorrectly (e.g., to `docs/docs/guide/...`). This change updates the path to `guide/installation.md` to correctly target the installation guide.

## Changes

- Corrected the relative link to the "Google Gemini" installation guide.

## Related Issue

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the broken link in the Google Auth section of configurations.md. Update the relative path to point to guide/installation.md#google-gemini-antigravity-oauth so readers reach the correct installation guide.

<sup>Written for commit 6c7b6115ddc053b89fe2098a3f5bbe84f99d668e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

