### PR TITLE
Expand isGptModel to detect GPT models behind proxy providers

### DIFF
--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "bun:test";
+import { isGptModel } from "./types";
+
+describe("isGptModel", () => {
+  test("standard openai provider models", () => {
+    expect(isGptModel("openai/gpt-5.2")).toBe(true);
+    expect(isGptModel("openai/gpt-4o")).toBe(true);
+    expect(isGptModel("openai/o1")).toBe(true);
+    expect(isGptModel("openai/o3-mini")).toBe(true);
+  });
+
+  test("github copilot gpt models", () => {
+    expect(isGptModel("github-copilot/gpt-5.2")).toBe(true);
+    expect(isGptModel("github-copilot/gpt-4o")).toBe(true);
+  });
+
+  test("litellm proxied gpt models", () => {
+    expect(isGptModel("litellm/gpt-5.2")).toBe(true);
+    expect(isGptModel("litellm/gpt-4o")).toBe(true);
+    expect(isGptModel("litellm/o1")).toBe(true);
+    expect(isGptModel("litellm/o3-mini")).toBe(true);
+    expect(isGptModel("litellm/o4-mini")).toBe(true);
+  });
+
+  test("other proxied gpt models", () => {
+    expect(isGptModel("ollama/gpt-4o")).toBe(true);
+    expect(isGptModel("custom-provider/gpt-5.2")).toBe(true);
+  });
+
+  test("gpt4 prefix without hyphen (legacy naming)", () => {
+    expect(isGptModel("litellm/gpt4o")).toBe(true);
+    expect(isGptModel("ollama/gpt4")).toBe(true);
+  });
+
+  test("claude models are not gpt", () => {
+    expect(isGptModel("anthropic/claude-opus-4-6")).toBe(false);
+    expect(isGptModel("anthropic/claude-sonnet-4-5")).toBe(false);
+    expect(isGptModel("litellm/anthropic.claude-opus-4-5")).toBe(false);
+  });
+
+  test("gemini models are not gpt", () => {
+    expect(isGptModel("google/gemini-3-pro")).toBe(false);
+    expect(isGptModel("litellm/gemini-3-pro")).toBe(false);
+  });
+
+  test("opencode provider is not gpt", () => {
+    expect(isGptModel("opencode/claude-opus-4-6")).toBe(false);
+  });
+});

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -66,8 +66,18 @@ export interface AgentPromptMetadata {
   keyTrigger?: string
 }
 
+function extractModelName(model: string): string {
+  return model.includes("/") ? model.split("/").pop() ?? model : model
+}
+
+const GPT_MODEL_PREFIXES = ["gpt-", "gpt4", "o1", "o3", "o4"]
+
 export function isGptModel(model: string): boolean {
-  return model.startsWith("openai/") || model.startsWith("github-copilot/gpt-")
+  if (model.startsWith("openai/") || model.startsWith("github-copilot/gpt-"))
+    return true
+
+  const modelName = extractModelName(model).toLowerCase()
+  return GPT_MODEL_PREFIXES.some((prefix) => modelName.startsWith(prefix))
 }
 
 export type BuiltinAgentName =

--- a/src/hooks/keyword-detector/ultrawork/source-detector.ts
+++ b/src/hooks/keyword-detector/ultrawork/source-detector.ts
@@ -7,6 +7,8 @@
  * 3. Everything else (Claude, etc.) → default.ts
  */
 
+import { isGptModel } from "../../../agents/types"
+
 /**
  * Checks if agent is a planner-type agent.
  * Planners don't need ultrawork injection (they ARE the planner).
@@ -20,15 +22,7 @@ export function isPlannerAgent(agentName?: string): boolean {
   return /\bplan\b/.test(normalized)
 }
 
-/**
- * Checks if model is GPT 5.2 series.
- * GPT models benefit from specific prompting patterns.
- */
-export function isGptModel(modelID?: string): boolean {
-  if (!modelID) return false
-  const lowerModel = modelID.toLowerCase()
-  return lowerModel.includes("gpt")
-}
+export { isGptModel }
 
 /** Ultrawork message source type */
 export type UltraworkSource = "planner" | "gpt" | "default"
@@ -45,8 +39,8 @@ export function getUltraworkSource(
     return "planner"
   }
 
-  // Priority 2: GPT 5.2 models
-  if (isGptModel(modelID)) {
+  // Priority 2: GPT models
+  if (modelID && isGptModel(modelID)) {
     return "gpt"
   }
 


### PR DESCRIPTION
## Summary

Closes #1788

`isGptModel()` only matched `openai/` and `github-copilot/gpt-` prefixes, so GPT models accessed through proxy providers (e.g. `litellm/gpt-5.2`, `ollama/gpt-4o`) were misidentified as non-GPT. This caused Claude-specific `thinking` config to be applied, which the runtime translates to the `reasoningSummary` parameter — rejected by the OpenAI API.

## Root Cause

All agent files (sisyphus, oracle, sisyphus-junior, momus, atlas) share this pattern:

```ts
if (isGptModel(model)) {
  // reasoningEffort config (OpenAI-compatible)
} else {
  // thinking config (Claude-specific)
}
```

When `isGptModel("litellm/gpt-5.2")` returned `false`, the else branch applied Claude's `thinking` config to a GPT model, resulting in the `reasoningSummary` API error reported in #1788.

## Fix

Instead of hardcoding every possible provider prefix, the fix extracts the model name after the provider prefix (e.g. `litellm/gpt-5.2` → `gpt-5.2`) and matches it against known GPT model prefixes (`gpt-`, `gpt4`, `o1`, `o3`, `o4`).

The original `openai/` and `github-copilot/gpt-` fast paths are preserved for backwards compatibility.

## Tests

Added `src/agents/types.test.ts` with 7 test cases covering:
- Standard `openai/` provider models
- `github-copilot/` models
- `litellm/` proxied GPT models (including o1, o3, o4 series)
- Other proxy providers (`ollama/`, `custom-provider/`)
- Negative cases: Claude, Gemini, and opencode provider models

All 120 existing agent tests continue to pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded isGptModel to detect GPT models behind proxy providers and wired it into the ultrawork source detector. This stops Claude-only settings from hitting GPT models and fixes OpenAI API errors with proxied models.

- **Bug Fixes**
  - Updated isGptModel to extract the model name after the provider prefix and match GPT prefixes (gpt-, gpt4, o1, o3, o4). Kept fast paths for openai/ and github-copilot/gpt-.
  - Replaced the ultrawork detector’s substring check with isGptModel for consistent GPT routing. Added tests for standard, proxied (litellm, ollama, custom), legacy gpt4*, and negative cases (Claude, Gemini, opencode).

<sup>Written for commit 58b7aff7bd79e9e855d4aa8c989e3a677468e977. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

