### PR TITLE
fix: handle session.error and prevent zombie task starts in background-agent

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -2530,18 +2530,16 @@ describe("BackgroundManager.handleEvent - session.error", () => {
     await concurrencyManager.acquire(concurrencyKey)
 
     const sessionID = "ses_error_1"
-    const task: BackgroundTask = {
+    const task = createMockTask({
       id: "task-session-error",
       sessionID,
       parentSessionID: "parent-session",
       parentMessageID: "msg-1",
       description: "task that errors",
-      prompt: "test",
       agent: "explore",
       status: "running",
-      startedAt: new Date(),
       concurrencyKey,
-    }
+    })
     getTaskMap(manager).set(task.id, task)
     getPendingByParent(manager).set(task.parentSessionID, new Set([task.id]))
 
@@ -2572,19 +2570,17 @@ describe("BackgroundManager.handleEvent - session.error", () => {
     //#given
     const manager = createBackgroundManager()
     const sessionID = "ses_error_ignored"
-    const task: BackgroundTask = {
+    const task = createMockTask({
       id: "task-non-running",
       sessionID,
       parentSessionID: "parent-session",
       parentMessageID: "msg-1",
       description: "task already done",
-      prompt: "test",
       agent: "explore",
       status: "completed",
-      startedAt: new Date(),
-      completedAt: new Date(),
-      error: "previous",
-    }
+    })
+    task.completedAt = new Date()
+    task.error = "previous"
     getTaskMap(manager).set(task.id, task)
 
     //#when

--- a/src/features/background-agent/session-idle-event-handler.ts
+++ b/src/features/background-agent/session-idle-event-handler.ts
@@ -1,0 +1,93 @@
+import { log } from "../../shared"
+import { MIN_IDLE_TIME_MS } from "./constants"
+import type { BackgroundTask } from "./types"
+
+function getString(obj: Record<string, unknown>, key: string): string | undefined {
+  const value = obj[key]
+  return typeof value === "string" ? value : undefined
+}
+
+export function handleSessionIdleBackgroundEvent(args: {
+  properties: Record<string, unknown>
+  findBySession: (sessionID: string) => BackgroundTask | undefined
+  idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>>
+  validateSessionHasOutput: (sessionID: string) => Promise<boolean>
+  checkSessionTodos: (sessionID: string) => Promise<boolean>
+  tryCompleteTask: (task: BackgroundTask, source: string) => Promise<boolean>
+  emitIdleEvent: (sessionID: string) => void
+}): void {
+  const {
+    properties,
+    findBySession,
+    idleDeferralTimers,
+    validateSessionHasOutput,
+    checkSessionTodos,
+    tryCompleteTask,
+    emitIdleEvent,
+  } = args
+
+  const sessionID = getString(properties, "sessionID")
+  if (!sessionID) return
+
+  const task = findBySession(sessionID)
+  if (!task || task.status !== "running") return
+
+  const startedAt = task.startedAt
+  if (!startedAt) return
+
+  const elapsedMs = Date.now() - startedAt.getTime()
+  if (elapsedMs < MIN_IDLE_TIME_MS) {
+    const remainingMs = MIN_IDLE_TIME_MS - elapsedMs
+    if (!idleDeferralTimers.has(task.id)) {
+      log("[background-agent] Deferring early session.idle:", {
+        elapsedMs,
+        remainingMs,
+        taskId: task.id,
+      })
+      const timer = setTimeout(() => {
+        idleDeferralTimers.delete(task.id)
+        emitIdleEvent(sessionID)
+      }, remainingMs)
+      idleDeferralTimers.set(task.id, timer)
+    } else {
+      log("[background-agent] session.idle already deferred:", { elapsedMs, taskId: task.id })
+    }
+    return
+  }
+
+  validateSessionHasOutput(sessionID)
+    .then(async (hasValidOutput) => {
+      if (task.status !== "running") {
+        log("[background-agent] Task status changed during validation, skipping:", {
+          taskId: task.id,
+          status: task.status,
+        })
+        return
+      }
+
+      if (!hasValidOutput) {
+        log("[background-agent] Session.idle but no valid output yet, waiting:", task.id)
+        return
+      }
+
+      const hasIncompleteTodos = await checkSessionTodos(sessionID)
+
+      if (task.status !== "running") {
+        log("[background-agent] Task status changed during todo check, skipping:", {
+          taskId: task.id,
+          status: task.status,
+        })
+        return
+      }
+
+      if (hasIncompleteTodos) {
+        log("[background-agent] Task has incomplete todos, waiting for todo-continuation:", task.id)
+        return
+      }
+
+      await tryCompleteTask(task, "session.idle event")
+    })
+    .catch((err) => {
+      log("[background-agent] Error in session.idle handler:", err)
+    })
+}

--- a/src/features/background-agent/session-task-cleanup.ts
+++ b/src/features/background-agent/session-task-cleanup.ts
@@ -1,0 +1,46 @@
+import { subagentSessions } from "../claude-code-session-state"
+import type { BackgroundTask } from "./types"
+
+export function cleanupTaskAfterSessionEnds(args: {
+  task: BackgroundTask
+  tasks: Map<string, BackgroundTask>
+  idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>>
+  completionTimers: Map<string, ReturnType<typeof setTimeout>>
+  cleanupPendingByParent: (task: BackgroundTask) => void
+  clearNotificationsForTask: (taskId: string) => void
+  releaseConcurrencyKey?: (key: string) => void
+}): void {
+  const {
+    task,
+    tasks,
+    idleDeferralTimers,
+    completionTimers,
+    cleanupPendingByParent,
+    clearNotificationsForTask,
+    releaseConcurrencyKey,
+  } = args
+
+  const completionTimer = completionTimers.get(task.id)
+  if (completionTimer) {
+    clearTimeout(completionTimer)
+    completionTimers.delete(task.id)
+  }
+
+  const idleTimer = idleDeferralTimers.get(task.id)
+  if (idleTimer) {
+    clearTimeout(idleTimer)
+    idleDeferralTimers.delete(task.id)
+  }
+
+  if (task.concurrencyKey && releaseConcurrencyKey) {
+    releaseConcurrencyKey(task.concurrencyKey)
+    task.concurrencyKey = undefined
+  }
+
+  cleanupPendingByParent(task)
+  clearNotificationsForTask(task.id)
+  tasks.delete(task.id)
+  if (task.sessionID) {
+    subagentSessions.delete(task.sessionID)
+  }
+}

--- a/src/features/background-agent/task-queue-processor.ts
+++ b/src/features/background-agent/task-queue-processor.ts
@@ -27,7 +27,7 @@ export async function processConcurrencyKeyQueue(args: {
 
       await concurrencyManager.acquire(key)
 
-      if (item.task.status === "cancelled") {
+      if (item.task.status === "cancelled" || item.task.status === "error") {
         concurrencyManager.release(key)
         queue.shift()
         continue


### PR DESCRIPTION
## Summary
- Fixes a production slot-leak where OpenCode emits `session.error` immediately after `promptAsync` (e.g. missing/invalid model), but background-agent never handled it, leaving tasks stuck `running` until TTL pruning.
- Prevents zombie task starts by skipping `error` tasks in queue processors and removing stale-pruned pending tasks from `queuesByKey`.

## Root cause (from production logs)
When `promptAsync` fired with an unavailable model (example: `Model not found: kimi-for-coding/k2p5.`), OpenCode emitted `session.error` within a few milliseconds. Background-agent only handled `session.idle` / `session.deleted`, so the task stayed `running` for ~30 minutes until TTL prune, wasting concurrency slots.

Separately, stale-pruned tasks were marked `error` and removed from `tasks`, but the queue item remained in `queuesByKey`. Queue processing only skipped `cancelled`, so the stale/pruned item could still be started later.

## Fix
- Handle `session.error`:
  - Find task by `properties.sessionID`.
  - If task is `running`, mark `status="error"`, extract message from `properties.error.data.message` (fallback `properties.error.message`), set `completedAt`, release concurrency, clear timers, clean pending/notifications, and remove from `tasks` + `subagentSessions`.
- Prevent zombie starts:
  - Skip `error` tasks in queue processing (`processKey` + `task-queue-processor`).
  - Remove stale-pruned pending tasks from `queuesByKey` during TTL pruning (and in the extracted stale pruner).

## Tests
Added coverage in `src/features/background-agent/manager.test.ts`:
- `session.error` marks task error + releases concurrency
- error-status tasks are skipped by queue processing
- stale-pruned pending tasks are removed from `queuesByKey`
- non-running task session.error is ignored
- unknown session session.error is ignored

## Verification
- `bun run typecheck`
- `bun test`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a concurrency slot leak by handling session.error events and stops “zombie” task starts. Running tasks now move to error immediately, release slots, and stale pending items are removed from queues.

- **Bug Fixes**
  - Handle session.error: mark running task as error with message, set completedAt, release concurrency, clear timers, clean pending/notifications, and remove task/session.
  - Skip tasks with status=error in queue processors to prevent late starts.
  - Remove stale-pruned pending tasks from queuesByKey during TTL pruning.

- **Refactors**
  - Extracted session.idle logic to session-idle-event-handler and shared cleanup to session-task-cleanup.
  - Centralized session.error message extraction.

<sup>Written for commit 3a019792e975fbd49e5b6b17e6c28afc24204276. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

