### PR TITLE
feat: include subagent in task_metadata when resuming sessions

### DIFF
--- a/src/tools/delegate-task/background-continuation.test.ts
+++ b/src/tools/delegate-task/background-continuation.test.ts
@@ -1,0 +1,95 @@
+const { describe, test, expect, mock } = require("bun:test")
+
+describe("executeBackgroundContinuation - subagent metadata", () => {
+  test("includes subagent in task_metadata when task has agent", async () => {
+    //#given - mock manager.resume returning task with agent info
+    const mockManager = {
+      resume: async () => ({
+        id: "bg_task_001",
+        description: "oracle consultation",
+        agent: "oracle",
+        status: "running",
+        sessionID: "ses_resumed_123",
+      }),
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-456",
+      metadata: mock(() => Promise.resolve()),
+    }
+
+    const mockExecutorCtx = {
+      manager: mockManager,
+    }
+
+    const parentContext = {
+      sessionID: "parent-session",
+      messageID: "msg-parent",
+      agent: "sisyphus",
+    }
+
+    const args = {
+      session_id: "ses_resumed_123",
+      prompt: "continue working",
+      description: "resume oracle",
+      load_skills: [],
+      run_in_background: true,
+    }
+
+    //#when - executeBackgroundContinuation completes
+    const { executeBackgroundContinuation } = require("./background-continuation")
+    const result = await executeBackgroundContinuation(args, mockCtx, mockExecutorCtx, parentContext)
+
+    //#then - task_metadata should contain subagent field
+    expect(result).toContain("<task_metadata>")
+    expect(result).toContain("subagent: oracle")
+    expect(result).toContain("session_id: ses_resumed_123")
+  })
+
+  test("omits subagent from task_metadata when task agent is undefined", async () => {
+    //#given - mock manager.resume returning task without agent
+    const mockManager = {
+      resume: async () => ({
+        id: "bg_task_002",
+        description: "unknown task",
+        agent: undefined,
+        status: "running",
+        sessionID: "ses_resumed_456",
+      }),
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-789",
+      metadata: mock(() => Promise.resolve()),
+    }
+
+    const mockExecutorCtx = {
+      manager: mockManager,
+    }
+
+    const parentContext = {
+      sessionID: "parent-session",
+      messageID: "msg-parent",
+      agent: "sisyphus",
+    }
+
+    const args = {
+      session_id: "ses_resumed_456",
+      prompt: "continue",
+      description: "resume task",
+      load_skills: [],
+      run_in_background: true,
+    }
+
+    //#when - executeBackgroundContinuation completes without agent
+    const { executeBackgroundContinuation } = require("./background-continuation")
+    const result = await executeBackgroundContinuation(args, mockCtx, mockExecutorCtx, parentContext)
+
+    //#then - task_metadata should NOT contain subagent field
+    expect(result).toContain("<task_metadata>")
+    expect(result).toContain("session_id: ses_resumed_456")
+    expect(result).not.toContain("subagent:")
+  })
+})

--- a/src/tools/delegate-task/background-continuation.ts
+++ b/src/tools/delegate-task/background-continuation.ts
@@ -50,7 +50,7 @@ Use \`background_output\` with task_id="${task.id}" to check progress.
 
 <task_metadata>
 session_id: ${task.sessionID}
-</task_metadata>`
+${task.agent ? `subagent: ${task.agent}\n` : ""}</task_metadata>`
   } catch (error) {
     return formatDetailedError(error, {
       operation: "Continue background task",

--- a/src/tools/delegate-task/sync-continuation.ts
+++ b/src/tools/delegate-task/sync-continuation.ts
@@ -128,7 +128,7 @@ ${result.textContent || "(No text output)"}
 
 <task_metadata>
 session_id: ${args.session_id}
-</task_metadata>`
+${resumeAgent ? `subagent: ${resumeAgent}\n` : ""}</task_metadata>`
    } finally {
      if (toastManager) {
        toastManager.removeTask(taskId)


### PR DESCRIPTION
## Summary

- Include `subagent` field in `<task_metadata>` when resuming sessions via `session_id` in the delegate-task tool
- Enables the parent agent to identify which subagent was running in the resumed session without parsing human-readable output

## Problem

When `delegate-task` resumes a session using `session_id`, the returned `<task_metadata>` block only contained `session_id`. The parent orchestrator (Sisyphus) had no structured way to know which agent type (oracle, explore, librarian, etc.) was being continued.

## Changes

| File | Change |
|------|--------|
| `sync-continuation.ts` | Add `subagent: {resumeAgent}` to `task_metadata` (uses agent extracted from session message history) |
| `background-continuation.ts` | Add `subagent: {task.agent}` to `task_metadata` (uses agent from BackgroundTask object) |
| `sync-continuation.test.ts` | 2 new tests: subagent present when agent info exists, omitted when absent |
| `background-continuation.test.ts` | New test file: 2 tests for subagent presence/absence in task_metadata |

## Example Output (Before → After)

**Before:**
```
<task_metadata>
session_id: ses_abc123
</task_metadata>
```

**After:**
```
<task_metadata>
session_id: ses_abc123
subagent: oracle
</task_metadata>
```

## Testing

- 143 tests pass across all delegate-task test files, 0 failures
- TDD approach: RED → GREEN → verified


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the subagent to <task_metadata> when resuming a session via session_id so the parent orchestrator can see which subagent is being continued without parsing text.

- **New Features**
  - task_metadata now includes subagent when resuming with session_id.
  - sync-continuation: reads agent from the session message history; background-continuation: uses task.agent.
  - Omits subagent if unknown. Tests added for presence/absence cases.

<sup>Written for commit 95aa7595f8e7529727ad800cc5a613175641af24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

