### PR TITLE
fix: use fs.realpath for symlink resolution (fixes #1738)

### DIFF
--- a/src/shared/file-utils.test.ts
+++ b/src/shared/file-utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test"
+import { mkdirSync, writeFileSync, symlinkSync, rmSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+import { resolveSymlink, resolveSymlinkAsync, isSymbolicLink } from "./file-utils"
+
+const testDir = join(tmpdir(), "file-utils-test-" + Date.now())
+
+// Create a directory structure that mimics the real-world scenario:
+//
+//   testDir/
+//   ├── repo/
+//   │   ├── skills/
+//   │   │   └── category/
+//   │   │       └── my-skill/
+//   │   │           └── SKILL.md
+//   │   └── .opencode/
+//   │       └── skills/
+//   │           └── my-skill -> ../../skills/category/my-skill  (relative symlink)
+//   └── config/
+//       └── skills -> ../repo/.opencode/skills                  (absolute symlink)
+
+const realSkillDir = join(testDir, "repo", "skills", "category", "my-skill")
+const repoOpencodeSkills = join(testDir, "repo", ".opencode", "skills")
+const configSkills = join(testDir, "config", "skills")
+
+beforeAll(() => {
+	// Create real skill directory with a file
+	mkdirSync(realSkillDir, { recursive: true })
+	writeFileSync(join(realSkillDir, "SKILL.md"), "# My Skill")
+
+	// Create .opencode/skills/ with a relative symlink to the real skill
+	mkdirSync(repoOpencodeSkills, { recursive: true })
+	symlinkSync("../../skills/category/my-skill", join(repoOpencodeSkills, "my-skill"))
+
+	// Create config/skills as an absolute symlink to .opencode/skills
+	mkdirSync(join(testDir, "config"), { recursive: true })
+	symlinkSync(repoOpencodeSkills, configSkills)
+})
+
+afterAll(() => {
+	rmSync(testDir, { recursive: true, force: true })
+})
+
+describe("resolveSymlink", () => {
+	it("resolves a regular file path to itself", () => {
+		const filePath = join(realSkillDir, "SKILL.md")
+		expect(resolveSymlink(filePath)).toBe(filePath)
+	})
+
+	it("resolves a relative symlink to its real path", () => {
+		const symlinkPath = join(repoOpencodeSkills, "my-skill")
+		expect(resolveSymlink(symlinkPath)).toBe(realSkillDir)
+	})
+
+	it("resolves a chained symlink (symlink-to-dir-containing-symlinks) to the real path", () => {
+		// This is the real-world scenario:
+		// config/skills/my-skill -> (follows config/skills) -> repo/.opencode/skills/my-skill -> repo/skills/category/my-skill
+		const chainedPath = join(configSkills, "my-skill")
+		expect(resolveSymlink(chainedPath)).toBe(realSkillDir)
+	})
+
+	it("returns the original path for non-existent paths", () => {
+		const fakePath = join(testDir, "does-not-exist")
+		expect(resolveSymlink(fakePath)).toBe(fakePath)
+	})
+})
+
+describe("resolveSymlinkAsync", () => {
+	it("resolves a regular file path to itself", async () => {
+		const filePath = join(realSkillDir, "SKILL.md")
+		expect(await resolveSymlinkAsync(filePath)).toBe(filePath)
+	})
+
+	it("resolves a relative symlink to its real path", async () => {
+		const symlinkPath = join(repoOpencodeSkills, "my-skill")
+		expect(await resolveSymlinkAsync(symlinkPath)).toBe(realSkillDir)
+	})
+
+	it("resolves a chained symlink (symlink-to-dir-containing-symlinks) to the real path", async () => {
+		const chainedPath = join(configSkills, "my-skill")
+		expect(await resolveSymlinkAsync(chainedPath)).toBe(realSkillDir)
+	})
+
+	it("returns the original path for non-existent paths", async () => {
+		const fakePath = join(testDir, "does-not-exist")
+		expect(await resolveSymlinkAsync(fakePath)).toBe(fakePath)
+	})
+})
+
+describe("isSymbolicLink", () => {
+	it("returns true for a symlink", () => {
+		expect(isSymbolicLink(join(repoOpencodeSkills, "my-skill"))).toBe(true)
+	})
+
+	it("returns false for a regular directory", () => {
+		expect(isSymbolicLink(realSkillDir)).toBe(false)
+	})
+
+	it("returns false for a non-existent path", () => {
+		expect(isSymbolicLink(join(testDir, "does-not-exist"))).toBe(false)
+	})
+})

--- a/src/shared/file-utils.ts
+++ b/src/shared/file-utils.ts
@@ -1,6 +1,5 @@
-import { lstatSync, readlinkSync } from "fs"
+import { lstatSync, realpathSync } from "fs"
 import { promises as fs } from "fs"
-import { resolve } from "path"
 
 export function isMarkdownFile(entry: { name: string; isFile: () => boolean }): boolean {
   return !entry.name.startsWith(".") && entry.name.endsWith(".md") && entry.isFile()
@@ -16,11 +15,7 @@ export function isSymbolicLink(filePath: string): boolean {
 
 export function resolveSymlink(filePath: string): string {
   try {
-    const stats = lstatSync(filePath, { throwIfNoEntry: false })
-    if (stats?.isSymbolicLink()) {
-      return resolve(filePath, "..", readlinkSync(filePath))
-    }
-    return filePath
+    return realpathSync(filePath)
   } catch {
     return filePath
   }
@@ -28,12 +23,7 @@ export function resolveSymlink(filePath: string): string {
 
 export async function resolveSymlinkAsync(filePath: string): Promise<string> {
   try {
-    const stats = await fs.lstat(filePath)
-    if (stats.isSymbolicLink()) {
-      const linkTarget = await fs.readlink(filePath)
-      return resolve(filePath, "..", linkTarget)
-    }
-    return filePath
+    return await fs.realpath(filePath)
   } catch {
     return filePath
   }


### PR DESCRIPTION
## Summary

- **Fixes** `resolveSymlink()` and `resolveSymlinkAsync()` in `src/shared/file-utils.ts` which incorrectly resolved relative symlinks, breaking skill discovery for all symlinked skills
- **Replaces** manual `path.resolve(filePath, '..', readlink())` with `fs.realpathSync()` / `fs.realpath()` which delegates to the OS for correct resolution
- **Adds** test suite (`file-utils.test.ts`) covering relative symlinks, chained symlinks, regular paths, and non-existent paths

## Problem

When skills are installed as relative symlinks (e.g. via a git-tracked knowledgebase repo), `resolveSymlinkAsync` resolves the `../../` components from the wrong base directory:

```
filePath:   /home/user/.config/opencode/skills/api-integration
readlink:   ../../skills/frontend-development/api-integration/

resolve(filePath, "..", linkTarget):
  → /home/user/.config/skills/frontend-development/api-integration/  ← WRONG (doesn't exist)

fs.realpath(filePath):
  → /home/user/git/repo/skills/frontend-development/api-integration/  ← CORRECT
```

This causes **all user-installed skills** to silently disappear — the `skill` tool, `task()` load_skills, and slash commands all fail to find them.

## Changes

| File | Change |
|---|---|
| `src/shared/file-utils.ts` | Replace `resolve(filePath, "..", readlinkSync())` with `realpathSync()`, replace `resolve(filePath, "..", readlink())` with `fs.realpath()` |
| `src/shared/file-utils.test.ts` | New test suite: 11 tests covering all symlink resolution scenarios |

## Testing

```bash
bun test src/shared/file-utils.test.ts
# 11 pass, 0 fail
```

Closes #1738

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes symlink resolution for skills by switching resolveSymlink/resolveSymlinkAsync to fs.realpathSync/fs.realpath so relative and chained links resolve correctly. Restores discovery of symlinked skills; adds tests for key scenarios (fixes #1738).

<sup>Written for commit 1511886c0cedbdcad64ab815fe242543ec855ee0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

![Symlinks finally resolving to the right path](https://media.giphy.com/media/xT1R9KDFNSKB7BOFy0/giphy.gif)

*path.resolve() confidently walking symlinks into the void vs fs.realpath() calmly finding the actual destination* 🔗