### PR TITLE
fix(skills): use directory param instead of process.cwd() for project skill discovery

### DIFF
--- a/src/features/claude-code-agent-loader/loader.ts
+++ b/src/features/claude-code-agent-loader/loader.ts
@@ -78,8 +78,8 @@ export function loadUserAgents(): Record<string, AgentConfig> {
   return result
 }
 
-export function loadProjectAgents(): Record<string, AgentConfig> {
-  const projectAgentsDir = join(process.cwd(), ".claude", "agents")
+export function loadProjectAgents(directory?: string): Record<string, AgentConfig> {
+  const projectAgentsDir = join(directory ?? process.cwd(), ".claude", "agents")
   const agents = loadAgentsFromDir(projectAgentsDir, "project")
 
   const result: Record<string, AgentConfig> = {}

--- a/src/features/claude-code-command-loader/loader.ts
+++ b/src/features/claude-code-command-loader/loader.ts
@@ -114,8 +114,8 @@ export async function loadUserCommands(): Promise<Record<string, CommandDefiniti
   return commandsToRecord(commands)
 }
 
-export async function loadProjectCommands(): Promise<Record<string, CommandDefinition>> {
-  const projectCommandsDir = join(process.cwd(), ".claude", "commands")
+export async function loadProjectCommands(directory?: string): Promise<Record<string, CommandDefinition>> {
+  const projectCommandsDir = join(directory ?? process.cwd(), ".claude", "commands")
   const commands = await loadCommandsFromDir(projectCommandsDir, "project")
   return commandsToRecord(commands)
 }
@@ -127,18 +127,18 @@ export async function loadOpencodeGlobalCommands(): Promise<Record<string, Comma
   return commandsToRecord(commands)
 }
 
-export async function loadOpencodeProjectCommands(): Promise<Record<string, CommandDefinition>> {
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "command")
+export async function loadOpencodeProjectCommands(directory?: string): Promise<Record<string, CommandDefinition>> {
+  const opencodeProjectDir = join(directory ?? process.cwd(), ".opencode", "command")
   const commands = await loadCommandsFromDir(opencodeProjectDir, "opencode-project")
   return commandsToRecord(commands)
 }
 
-export async function loadAllCommands(): Promise<Record<string, CommandDefinition>> {
+export async function loadAllCommands(directory?: string): Promise<Record<string, CommandDefinition>> {
   const [user, project, global, projectOpencode] = await Promise.all([
     loadUserCommands(),
-    loadProjectCommands(),
+    loadProjectCommands(directory),
     loadOpencodeGlobalCommands(),
-    loadOpencodeProjectCommands(),
+    loadOpencodeProjectCommands(directory),
   ])
   return { ...projectOpencode, ...global, ...project, ...user }
 }

--- a/src/features/opencode-skill-loader/loader.ts
+++ b/src/features/opencode-skill-loader/loader.ts
@@ -13,8 +13,8 @@ export async function loadUserSkills(): Promise<Record<string, CommandDefinition
   return skillsToCommandDefinitionRecord(skills)
 }
 
-export async function loadProjectSkills(): Promise<Record<string, CommandDefinition>> {
-  const projectSkillsDir = join(process.cwd(), ".claude", "skills")
+export async function loadProjectSkills(directory?: string): Promise<Record<string, CommandDefinition>> {
+  const projectSkillsDir = join(directory ?? process.cwd(), ".claude", "skills")
   const skills = await loadSkillsFromDir({ skillsDir: projectSkillsDir, scope: "project" })
   return skillsToCommandDefinitionRecord(skills)
 }
@@ -26,21 +26,22 @@ export async function loadOpencodeGlobalSkills(): Promise<Record<string, Command
   return skillsToCommandDefinitionRecord(skills)
 }
 
-export async function loadOpencodeProjectSkills(): Promise<Record<string, CommandDefinition>> {
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "skills")
+export async function loadOpencodeProjectSkills(directory?: string): Promise<Record<string, CommandDefinition>> {
+  const opencodeProjectDir = join(directory ?? process.cwd(), ".opencode", "skills")
   const skills = await loadSkillsFromDir({ skillsDir: opencodeProjectDir, scope: "opencode-project" })
   return skillsToCommandDefinitionRecord(skills)
 }
 
 export interface DiscoverSkillsOptions {
   includeClaudeCodePaths?: boolean
+  directory?: string
 }
 
-export async function discoverAllSkills(): Promise<LoadedSkill[]> {
+export async function discoverAllSkills(directory?: string): Promise<LoadedSkill[]> {
   const [opencodeProjectSkills, opencodeGlobalSkills, projectSkills, userSkills] = await Promise.all([
-    discoverOpencodeProjectSkills(),
+    discoverOpencodeProjectSkills(directory),
     discoverOpencodeGlobalSkills(),
-    discoverProjectClaudeSkills(),
+    discoverProjectClaudeSkills(directory),
     discoverUserClaudeSkills(),
   ])
 
@@ -49,10 +50,10 @@ export async function discoverAllSkills(): Promise<LoadedSkill[]> {
 }
 
 export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promise<LoadedSkill[]> {
-  const { includeClaudeCodePaths = true } = options
+  const { includeClaudeCodePaths = true, directory } = options
 
   const [opencodeProjectSkills, opencodeGlobalSkills] = await Promise.all([
-    discoverOpencodeProjectSkills(),
+    discoverOpencodeProjectSkills(directory),
     discoverOpencodeGlobalSkills(),
   ])
 
@@ -62,7 +63,7 @@ export async function discoverSkills(options: DiscoverSkillsOptions = {}): Promi
   }
 
   const [projectSkills, userSkills] = await Promise.all([
-    discoverProjectClaudeSkills(),
+    discoverProjectClaudeSkills(directory),
     discoverUserClaudeSkills(),
   ])
 
@@ -80,8 +81,8 @@ export async function discoverUserClaudeSkills(): Promise<LoadedSkill[]> {
   return loadSkillsFromDir({ skillsDir: userSkillsDir, scope: "user" })
 }
 
-export async function discoverProjectClaudeSkills(): Promise<LoadedSkill[]> {
-  const projectSkillsDir = join(process.cwd(), ".claude", "skills")
+export async function discoverProjectClaudeSkills(directory?: string): Promise<LoadedSkill[]> {
+  const projectSkillsDir = join(directory ?? process.cwd(), ".claude", "skills")
   return loadSkillsFromDir({ skillsDir: projectSkillsDir, scope: "project" })
 }
 
@@ -91,7 +92,7 @@ export async function discoverOpencodeGlobalSkills(): Promise<LoadedSkill[]> {
   return loadSkillsFromDir({ skillsDir: opencodeSkillsDir, scope: "opencode" })
 }
 
-export async function discoverOpencodeProjectSkills(): Promise<LoadedSkill[]> {
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "skills")
+export async function discoverOpencodeProjectSkills(directory?: string): Promise<LoadedSkill[]> {
+  const opencodeProjectDir = join(directory ?? process.cwd(), ".opencode", "skills")
   return loadSkillsFromDir({ skillsDir: opencodeProjectDir, scope: "opencode-project" })
 }

--- a/src/features/opencode-skill-loader/skill-discovery.ts
+++ b/src/features/opencode-skill-loader/skill-discovery.ts
@@ -20,7 +20,7 @@ export async function getAllSkills(options?: SkillResolutionOptions): Promise<Lo
 	}
 
 	const [discoveredSkills, builtinSkillDefinitions] = await Promise.all([
-		discoverSkills({ includeClaudeCodePaths: true }),
+		discoverSkills({ includeClaudeCodePaths: true, directory: options?.directory }),
 		Promise.resolve(
 			createBuiltinSkills({
 				browserProvider: options?.browserProvider,

--- a/src/features/opencode-skill-loader/skill-resolution-options.ts
+++ b/src/features/opencode-skill-loader/skill-resolution-options.ts
@@ -4,4 +4,6 @@ export interface SkillResolutionOptions {
 	gitMasterConfig?: GitMasterConfig
 	browserProvider?: BrowserAutomationProvider
 	disabledSkills?: Set<string>
+	/** Project directory to discover project-level skills from. Falls back to process.cwd() if not provided. */
+	directory?: string
 }

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -84,7 +84,7 @@ export async function applyAgentConfig(params: {
 
   const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
   const userAgents = includeClaudeAgents ? loadUserAgents() : {};
-  const projectAgents = includeClaudeAgents ? loadProjectAgents() : {};
+  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
 
   const rawPluginAgents = params.pluginComponents.agents;
   const pluginAgents = Object.fromEntries(

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -47,10 +47,10 @@ export async function applyAgentConfig(params: {
     }),
     includeClaudeSkillsForAwareness ? discoverUserClaudeSkills() : Promise.resolve([]),
     includeClaudeSkillsForAwareness
-      ? discoverProjectClaudeSkills()
-      : Promise.resolve([]),
+       ? discoverProjectClaudeSkills(params.ctx.directory)
+       : Promise.resolve([]),
     discoverOpencodeGlobalSkills(),
-    discoverOpencodeProjectSkills(),
+    discoverOpencodeProjectSkills(params.ctx.directory),
   ]);
 
   const allDiscoveredSkills = [

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -44,13 +44,13 @@ export async function applyCommandConfig(params: {
       configDir: params.ctx.directory,
     }),
     includeClaudeCommands ? loadUserCommands() : Promise.resolve({}),
-    includeClaudeCommands ? loadProjectCommands() : Promise.resolve({}),
+    includeClaudeCommands ? loadProjectCommands(params.ctx.directory) : Promise.resolve({}),
     loadOpencodeGlobalCommands(),
-    loadOpencodeProjectCommands(),
+    loadOpencodeProjectCommands(params.ctx.directory),
     includeClaudeSkills ? loadUserSkills() : Promise.resolve({}),
-    includeClaudeSkills ? loadProjectSkills() : Promise.resolve({}),
+    includeClaudeSkills ? loadProjectSkills(params.ctx.directory) : Promise.resolve({}),
     loadOpencodeGlobalSkills(),
-    loadOpencodeProjectSkills(),
+    loadOpencodeProjectSkills(params.ctx.directory),
   ]);
 
   params.config.command = {

--- a/src/plugin/skill-context.ts
+++ b/src/plugin/skill-context.ts
@@ -63,8 +63,8 @@ export async function createSkillContext(args: {
       }),
       includeClaudeSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
       discoverOpencodeGlobalSkills(),
-      includeClaudeSkills ? discoverProjectClaudeSkills() : Promise.resolve([]),
-      discoverOpencodeProjectSkills(),
+      includeClaudeSkills ? discoverProjectClaudeSkills(directory) : Promise.resolve([]),
+      discoverOpencodeProjectSkills(directory),
     ])
 
   const mergedSkills = mergeSkills(

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -101,7 +101,7 @@ export function createToolRegistry(args: {
     getSessionID: getSessionIDForMcp,
   })
 
-  const commands = discoverCommandsSync()
+  const commands = discoverCommandsSync(ctx.directory)
   const slashcommandTool = createSlashcommandTool({
     commands,
     skills: skillContext.mergedSkills,

--- a/src/tools/slashcommand/command-discovery.ts
+++ b/src/tools/slashcommand/command-discovery.ts
@@ -48,12 +48,12 @@ function discoverCommandsFromDir(commandsDir: string, scope: CommandScope): Comm
   return commands
 }
 
-export function discoverCommandsSync(): CommandInfo[] {
+export function discoverCommandsSync(directory?: string): CommandInfo[] {
   const configDir = getOpenCodeConfigDir({ binary: "opencode" })
   const userCommandsDir = join(getClaudeConfigDir(), "commands")
-  const projectCommandsDir = join(process.cwd(), ".claude", "commands")
+  const projectCommandsDir = join(directory ?? process.cwd(), ".claude", "commands")
   const opencodeGlobalDir = join(configDir, "command")
-  const opencodeProjectDir = join(process.cwd(), ".opencode", "command")
+  const opencodeProjectDir = join(directory ?? process.cwd(), ".opencode", "command")
 
   const userCommands = discoverCommandsFromDir(userCommandsDir, "user")
   const opencodeGlobalCommands = discoverCommandsFromDir(opencodeGlobalDir, "opencode")


### PR DESCRIPTION
## Summary

- Project-level skills (`.opencode/skills/` and `.claude/skills/`) were not discovered in the OpenCode desktop app because `discoverProjectClaudeSkills()` and `discoverOpencodeProjectSkills()` hardcoded `process.cwd()` to resolve project paths
- In desktop app environments, `process.cwd()` points to the app installation directory, not the user's project directory — while `ctx.directory` from the plugin context correctly points to the project

## Changes

- Added optional `directory` parameter to all project-level skill discovery functions in `loader.ts`
- Threaded `ctx.directory` from the plugin context through:
  - `skill-context.ts` (plugin init path)
  - `agent-config-handler.ts` (agent config path)  
  - `skill-discovery.ts` → `discoverSkills()` (runtime fallback path)
- Added `directory` field to `SkillResolutionOptions` interface
- Falls back to `process.cwd()` when `directory` is not provided, preserving CLI compatibility

## Testing

- `bun run typecheck` — clean
- `bun test src/features/opencode-skill-loader/` — 75 tests pass
- `bun test src/tools/skill/` — 11 tests pass
- `bun test src/plugin-handlers/config-handler.test.ts` — 29 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes project-level discovery in the desktop app by using the project directory from context instead of process.cwd(). Skills, agents, commands, and slash commands in .opencode/* and .claude/* now load correctly; CLI behavior is preserved with a cwd fallback.

- **Bug Fixes**
  - Added optional directory to all project-level loaders and discovery functions (skills, agents, commands, slash commands).
  - Threaded ctx.directory through skill-context, agent-config-handler, command-config-handler, tool-registry, and skill-discovery.
  - Extended SkillResolutionOptions and DiscoverSkillsOptions with a directory field.

<sup>Written for commit f9ea9a4ee9fd12b46dc44fa423642a3b7d185d8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

