### PR TITLE
fix(tool-execute-before): resolve subagent_type for TUI display

### DIFF
--- a/src/plugin/session-agent-resolver.test.ts
+++ b/src/plugin/session-agent-resolver.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test"
+import { resolveSessionAgent } from "./session-agent-resolver"
+
+describe("resolveSessionAgent", () => {
+  test("returns agent from first message with agent field", async () => {
+    //#given
+    const client = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { role: "user" } },
+            { info: { role: "assistant", agent: "explore" } },
+            { info: { role: "assistant", agent: "oracle" } },
+          ],
+        }),
+      },
+    }
+
+    //#when
+    const agent = await resolveSessionAgent(client, "ses_test")
+
+    //#then
+    expect(agent).toBe("explore")
+  })
+
+  test("skips messages without agent field", async () => {
+    //#given
+    const client = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { role: "user" } },
+            { info: { role: "system" } },
+            { info: { role: "assistant", agent: "plan" } },
+          ],
+        }),
+      },
+    }
+
+    //#when
+    const agent = await resolveSessionAgent(client, "ses_test")
+
+    //#then
+    expect(agent).toBe("plan")
+  })
+
+  test("returns undefined when no messages have agent", async () => {
+    //#given
+    const client = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { role: "user" } },
+            { info: { role: "assistant" } },
+          ],
+        }),
+      },
+    }
+
+    //#when
+    const agent = await resolveSessionAgent(client, "ses_test")
+
+    //#then
+    expect(agent).toBeUndefined()
+  })
+
+  test("returns undefined when session has no messages", async () => {
+    //#given
+    const client = {
+      session: {
+        messages: async () => ({ data: [] }),
+      },
+    }
+
+    //#when
+    const agent = await resolveSessionAgent(client, "ses_test")
+
+    //#then
+    expect(agent).toBeUndefined()
+  })
+
+  test("returns undefined when API call fails", async () => {
+    //#given
+    const client = {
+      session: {
+        messages: async () => { throw new Error("API error") },
+      },
+    }
+
+    //#when
+    const agent = await resolveSessionAgent(client, "ses_test")
+
+    //#then
+    expect(agent).toBeUndefined()
+  })
+})

--- a/src/plugin/session-agent-resolver.ts
+++ b/src/plugin/session-agent-resolver.ts
@@ -1,0 +1,36 @@
+import { log } from "../shared"
+
+interface SessionMessage {
+  info?: {
+    agent?: string
+    role?: string
+  }
+}
+
+type SessionClient = {
+  session: {
+    messages: (opts: { path: { id: string } }) => Promise<{ data?: SessionMessage[] }>
+  }
+}
+
+export async function resolveSessionAgent(
+  client: SessionClient,
+  sessionId: string,
+): Promise<string | undefined> {
+  try {
+    const messagesResp = await client.session.messages({ path: { id: sessionId } })
+    const messages = (messagesResp.data ?? []) as SessionMessage[]
+
+    for (const msg of messages) {
+      if (msg.info?.agent) {
+        return msg.info.agent
+      }
+    }
+  } catch (error) {
+    log("[session-agent-resolver] Failed to resolve agent from session", {
+      sessionId,
+      error: String(error),
+    })
+  }
+  return undefined
+}

--- a/src/plugin/tool-execute-before.test.ts
+++ b/src/plugin/tool-execute-before.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test"
+import { createToolExecuteBeforeHandler } from "./tool-execute-before"
+import type { CreatedHooks } from "../create-hooks"
+
+describe("createToolExecuteBeforeHandler", () => {
+  describe("task tool subagent_type normalization", () => {
+    const emptyHooks = {} as CreatedHooks
+
+    function createCtxWithSessionMessages(messages: Array<{ info?: { agent?: string; role?: string } }> = []) {
+      return {
+        client: {
+          session: {
+            messages: async () => ({ data: messages }),
+          },
+        },
+      } as unknown as Parameters<typeof createToolExecuteBeforeHandler>[0]["ctx"]
+    }
+
+    test("sets subagent_type to sisyphus-junior when category is provided without subagent_type", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages()
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "task", sessionID: "ses_123", callID: "call_1" }
+      const output = { args: { category: "quick", description: "Test" } as Record<string, unknown> }
+
+      //#when
+      await handler(input, output)
+
+      //#then
+      expect(output.args.subagent_type).toBe("sisyphus-junior")
+    })
+
+    test("preserves existing subagent_type when explicitly provided", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages()
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "task", sessionID: "ses_123", callID: "call_1" }
+      const output = { args: { subagent_type: "plan", description: "Plan test" } as Record<string, unknown> }
+
+      //#when
+      await handler(input, output)
+
+      //#then
+      expect(output.args.subagent_type).toBe("plan")
+    })
+
+    test("sets subagent_type to sisyphus-junior when category provided with different subagent_type", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages()
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "task", sessionID: "ses_123", callID: "call_1" }
+      const output = { args: { category: "quick", subagent_type: "oracle", description: "Test" } as Record<string, unknown> }
+
+      //#when
+      await handler(input, output)
+
+      //#then
+      expect(output.args.subagent_type).toBe("sisyphus-junior")
+    })
+
+    test("resolves subagent_type from session first message when session_id provided without subagent_type", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages([
+        { info: { role: "user" } },
+        { info: { role: "assistant", agent: "explore" } },
+        { info: { role: "assistant", agent: "oracle" } },
+      ])
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "task", sessionID: "ses_123", callID: "call_1" }
+      const output = { args: { session_id: "ses_abc123", description: "Continue task", prompt: "fix it" } as Record<string, unknown> }
+
+      //#when
+      await handler(input, output)
+
+      //#then
+      expect(output.args.subagent_type).toBe("explore")
+    })
+
+    test("falls back to 'continue' when session has no agent info", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages([
+        { info: { role: "user" } },
+        { info: { role: "assistant" } },
+      ])
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "task", sessionID: "ses_123", callID: "call_1" }
+      const output = { args: { session_id: "ses_abc123", description: "Continue task", prompt: "fix it" } as Record<string, unknown> }
+
+      //#when
+      await handler(input, output)
+
+      //#then
+      expect(output.args.subagent_type).toBe("continue")
+    })
+
+    test("preserves subagent_type when session_id is provided with explicit subagent_type", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages()
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "task", sessionID: "ses_123", callID: "call_1" }
+      const output = { args: { session_id: "ses_abc123", subagent_type: "explore", description: "Continue explore" } as Record<string, unknown> }
+
+      //#when
+      await handler(input, output)
+
+      //#then
+      expect(output.args.subagent_type).toBe("explore")
+    })
+
+    test("does not modify args for non-task tools", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages()
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "bash", sessionID: "ses_123", callID: "call_1" }
+      const output = { args: { command: "ls" } as Record<string, unknown> }
+
+      //#when
+      await handler(input, output)
+
+      //#then
+      expect(output.args.subagent_type).toBeUndefined()
+    })
+
+    test("does not set subagent_type when neither category nor session_id is provided and subagent_type is present", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages()
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "task", sessionID: "ses_123", callID: "call_1" }
+      const output = { args: { subagent_type: "oracle", description: "Oracle task" } as Record<string, unknown> }
+
+      //#when
+      await handler(input, output)
+
+      //#then
+      expect(output.args.subagent_type).toBe("oracle")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fix "Unknown Task" display in OpenCode TUI when `subagent_type` is missing from task tool args.

## Problem

OpenCode TUI reads `input.subagent_type` from the `task` tool's args to display the task type header:

```tsx
// opencode TUI: packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:1869
title={"# " + Locale.titlecase(props.input.subagent_type ?? "unknown") + " Task"}
```

When `subagent_type` was missing (e.g., category-only delegation or session continuation), the TUI displayed **"Unknown Task"** instead of a meaningful agent name.

## Root Cause

Two scenarios caused missing `subagent_type`:

1. **Category delegation**: `tool-execute-before` only set `subagent_type = "sisyphus-junior"` when `subagent_type` was absent. If LLM sent both `category` AND `subagent_type`, the original value persisted instead of being overridden.

2. **Session continuation**: When resuming via `session_id`, LLM could omit `subagent_type` entirely, leaving TUI with no agent info.

## Fix

In `tool-execute-before.ts`:

- **Category**: Always override `subagent_type` to `"sisyphus-junior"` when `category` is present (regardless of existing `subagent_type` value)
- **Session continuation**: Resolve agent from the target session's first message via new `session-agent-resolver.ts`, falling back to `"continue"` if no agent info found

## Changes

| File | Change |
|------|--------|
| `src/plugin/session-agent-resolver.ts` | New: resolves agent from session's first message |
| `src/plugin/session-agent-resolver.test.ts` | 5 test cases covering success, no-agent, empty, and error paths |
| `src/plugin/tool-execute-before.ts` | Updated: resolve `subagent_type` for category and session_id cases |
| `src/plugin/tool-execute-before.test.ts` | 8 test cases covering all normalization scenarios |

## Testing

- 13 new tests, all passing
- Existing 107 delegate-task tests pass
- Full plugin test suite (30 tests) passes
- TypeScript typecheck clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Unknown Task” label in the OpenCode TUI by always setting subagent_type for task tool calls, covering category delegation and session continuation cases.

- **Bug Fixes**
  - When category is provided, always set subagent_type to "sisyphus-junior".
  - When session_id is provided without subagent_type, resolve it from the session’s first assistant message (via session-agent-resolver), falling back to "continue".

<sup>Written for commit 1a5c9f228d5d8efedadd978a613cc7b1f36ee701. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

