### PR TITLE
fix: resolve empty response when custom agents end with tool calls

### DIFF
--- a/src/tools/delegate-task/sync-result-fetcher.ts
+++ b/src/tools/delegate-task/sync-result-fetcher.ts
@@ -41,8 +41,17 @@ export async function fetchSyncResult(
     return { ok: false, error: `No assistant response found.\n\nSession ID: ${sessionID}` }
   }
 
-  const textParts = lastMessage?.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
-  const textContent = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+  // Search assistant messages (newest first) for one with text/reasoning content.
+  // The last assistant message may only contain tool calls with no text.
+  let textContent = ""
+  for (const msg of assistantMessages) {
+    const textParts = msg.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
+    const content = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+    if (content) {
+      textContent = content
+      break
+    }
+  }
 
   return { ok: true, textContent }
 }

--- a/src/tools/delegate-task/unstable-agent-task.ts
+++ b/src/tools/delegate-task/unstable-agent-task.ts
@@ -120,8 +120,15 @@ export async function executeUnstableAgentTask(
       return `No assistant response found (task ran in background mode).\n\nSession ID: ${sessionID}`
     }
 
-    const textParts = lastMessage?.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
-    const textContent = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+    let textContent = ""
+    for (const msg of assistantMessages) {
+      const textParts = msg.parts?.filter((p) => p.type === "text" || p.type === "reasoning") ?? []
+      const content = textParts.map((p) => p.text ?? "").filter(Boolean).join("\n")
+      if (content) {
+        textContent = content
+        break
+      }
+    }
     const duration = formatDuration(startTime)
 
     return `SUPERVISED TASK COMPLETED SUCCESSFULLY


### PR DESCRIPTION
## Summary

- When a custom agent's last assistant message contains only tool calls (no text/reasoning parts), the sync result fetcher returned empty content
- Walk assistant messages newest-first to find the first one with actual text content

## Changed Files

- `src/tools/delegate-task/sync-result-fetcher.ts`
- `src/tools/delegate-task/unstable-agent-task.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty responses from custom agents when the final assistant message only contains tool calls. We now return the latest available text/reasoning content instead of nothing.

- **Bug Fixes**
  - Update fetchSyncResult and executeUnstableAgentTask to scan assistant messages newest-first and pick the first with text/reasoning parts.
  - Prevents blank sync results and completion summaries when the last message has only tool calls.

<sup>Written for commit 0d1b6ebe2ccaaddd5864fabb4eae03fe389366f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

