### PR TITLE
fix(non-interactive-env): prevent environment variable duplication on repeated executions

### DIFF
--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -111,6 +111,34 @@ describe("non-interactive-env hook", () => {
 
       expect(output.args.command).toBeUndefined()
     })
+
+    test("#given git command already has prefix #when hook executes again #then does not duplicate prefix", async () => {
+      const hook = createNonInteractiveEnvHook(mockCtx)
+      
+      // First call: transforms the command
+      const output1: { args: Record<string, unknown>; message?: string } = {
+        args: { command: "git commit -m 'test'" },
+      }
+      await hook["tool.execute.before"](
+        { tool: "bash", sessionID: "test", callID: "1" },
+        output1
+      )
+      
+      const firstResult = output1.args.command as string
+      expect(firstResult).toStartWith("export ")
+      
+      // Second call: takes the already-prefixed command
+      const output2: { args: Record<string, unknown>; message?: string } = {
+        args: { command: firstResult },
+      }
+      await hook["tool.execute.before"](
+        { tool: "bash", sessionID: "test", callID: "2" },
+        output2
+      )
+      
+      // Should be exactly the same (no double prefix)
+      expect(output2.args.command).toBe(firstResult)
+    })
   })
 
   describe("shell escaping", () => {

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -55,6 +55,13 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
       // (via Git Bash, WSL, etc.), so always use unix export syntax.
       const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
+      
+      // Check if the command already starts with the prefix to avoid stacking.
+      // This maintain the non-interactive behaivor but make the operation idempotent.
+      if (command.trim().startsWith(envPrefix.trim())) {
+        return
+      }
+
       output.args.command = `${envPrefix} ${command}`
 
       log(`[${HOOK_NAME}] Prepended non-interactive env vars to git command`, {

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -57,7 +57,7 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
       
       // Check if the command already starts with the prefix to avoid stacking.
-      // This maintain the non-interactive behaivor but make the operation idempotent.
+      // This maintains the non-interactive behavior and makes the operation idempotent.
       if (command.trim().startsWith(envPrefix.trim())) {
         return
       }


### PR DESCRIPTION
## Summary

- Fixes environment variable duplication when multiple git commands are executed in sequence
- Adds idempotency check to prevent re-prepending env vars that are already present
- Maintains non-interactive behavior without reintroducing the removed isNonInteractive() check

## Changes

- Added idempotency guard in non-interactive-env-hook.ts (lines 59-63)
- Hook now checks if command already starts with the env prefix before prepending
- Early return if prefix is already present, avoiding duplication like export CI=true ... export CI=true ... git commit
- No changes to core behavior: env vars are still always injected for git commands (as per commit 8bf32025)

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
| <img width="1820" height="496" alt="Screenshot 2026-02-13 012039" src="https://github.com/user-attachments/assets/e73d4a05-9527-4356-a648-953b82408216" /> |  <img width="1768" height="61" alt="image" src="https://github.com/user-attachments/assets/c23ce918-5eb0-43cf-85ad-c64df2ffd320" /> |

> Screenshots after multiples calls

## Testing

```bash
bun run typecheck
bun test src/hooks/non-interactive-env/
```
**Verification:** All 15 tests pass. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate env vars in the non-interactive Git hook by making prefixing idempotent. Behavior is unchanged; env vars are injected once, avoiding stacked prefixes across sequential commands.

- **Bug Fixes**
  - Add idempotency guard and test to skip re-prefixing when the env prefix is already present.
  - Preserve existing behavior: inject env vars once for git commands.

<sup>Written for commit 8500abeb39aaec4cda544ae4417fe4fd8236bd6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

