### PR TITLE
fix(session-recovery): two-layer fix for Vertex AI assistant prefill error (#1528)

### DIFF
--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -26,6 +26,7 @@ export const HookNameSchema = z.enum([
   "interactive-bash-session",
 
   "thinking-block-validator",
+  "trailing-assistant-guard",
   "ralph-loop",
   "category-skill-reminder",
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -25,6 +25,7 @@ export { createNonInteractiveEnvHook } from "./non-interactive-env";
 export { createInteractiveBashSessionHook } from "./interactive-bash-session";
 
 export { createThinkingBlockValidatorHook } from "./thinking-block-validator";
+export { createTrailingAssistantGuardHook } from "./trailing-assistant-guard";
 export { createCategorySkillReminderHook } from "./category-skill-reminder";
 export { createRalphLoopHook, type RalphLoopHook } from "./ralph-loop";
 export { createAutoSlashCommandHook } from "./auto-slash-command";

--- a/src/hooks/session-recovery/hook.ts
+++ b/src/hooks/session-recovery/hook.ts
@@ -7,6 +7,7 @@ import type { MessageData } from "./types"
 import { recoverToolResultMissing } from "./recover-tool-result-missing"
 import { recoverThinkingBlockOrder } from "./recover-thinking-block-order"
 import { recoverThinkingDisabledViolation } from "./recover-thinking-disabled-violation"
+import { canAttemptPrefillRecovery, markPrefillRecoveryAttempted } from "./recover-assistant-prefill"
 import { extractResumeConfig, findLastUserMessage, resumeSession } from "./resume"
 
 interface MessageInfo {
@@ -81,13 +82,13 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
         tool_result_missing: "Tool Crash Recovery",
         thinking_block_order: "Thinking Block Recovery",
         thinking_disabled_violation: "Thinking Strip Recovery",
-        "assistant_prefill_unsupported": "Prefill Unsupported",
+        "assistant_prefill_unsupported": "Prefill Recovery",
       }
       const toastMessages: Record<RecoveryErrorType & string, string> = {
         tool_result_missing: "Injecting cancelled tool results...",
         thinking_block_order: "Fixing message structure...",
         thinking_disabled_violation: "Stripping thinking blocks...",
-        "assistant_prefill_unsupported": "Prefill not supported; continuing without recovery.",
+        "assistant_prefill_unsupported": "Retrying — conversation ended with assistant message.",
       }
 
       await ctx.client.tui
@@ -120,7 +121,13 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
           await resumeSession(ctx.client, resumeConfig)
         }
       } else if (errorType === "assistant_prefill_unsupported") {
-        success = false
+        if (canAttemptPrefillRecovery(sessionID)) {
+          markPrefillRecoveryAttempted(sessionID)
+          success = true
+        } else {
+          log("[session-recovery] Prefill recovery already attempted within cooldown, skipping")
+          success = false
+        }
       }
 
       return success

--- a/src/hooks/session-recovery/recover-assistant-prefill.test.ts
+++ b/src/hooks/session-recovery/recover-assistant-prefill.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import {
+  canAttemptPrefillRecovery,
+  markPrefillRecoveryAttempted,
+  clearPrefillRecoveryState,
+} from "./recover-assistant-prefill"
+
+describe("prefill recovery cooldown", () => {
+  beforeEach(() => {
+    clearPrefillRecoveryState("test-session-1")
+    clearPrefillRecoveryState("test-session-2")
+  })
+
+  test("should allow first recovery attempt", () => {
+    //#given - no previous recovery attempt
+    //#when - checking if recovery can be attempted
+    const result = canAttemptPrefillRecovery("test-session-1")
+
+    //#then - should allow recovery
+    expect(result).toBe(true)
+  })
+
+  test("should block second recovery attempt within cooldown", () => {
+    //#given - first recovery was already attempted
+    markPrefillRecoveryAttempted("test-session-1")
+
+    //#when - checking if recovery can be attempted again
+    const result = canAttemptPrefillRecovery("test-session-1")
+
+    //#then - should block recovery (within 60s cooldown)
+    expect(result).toBe(false)
+  })
+
+  test("should track sessions independently", () => {
+    //#given - recovery attempted on session-1 only
+    markPrefillRecoveryAttempted("test-session-1")
+
+    //#when - checking session-2
+    const result = canAttemptPrefillRecovery("test-session-2")
+
+    //#then - session-2 should still allow recovery
+    expect(result).toBe(true)
+  })
+
+  test("should allow recovery after clearing state", () => {
+    //#given - recovery was attempted then cleared
+    markPrefillRecoveryAttempted("test-session-1")
+    clearPrefillRecoveryState("test-session-1")
+
+    //#when - checking if recovery can be attempted
+    const result = canAttemptPrefillRecovery("test-session-1")
+
+    //#then - should allow recovery again
+    expect(result).toBe(true)
+  })
+})

--- a/src/hooks/session-recovery/recover-assistant-prefill.ts
+++ b/src/hooks/session-recovery/recover-assistant-prefill.ts
@@ -1,0 +1,16 @@
+const RECOVERY_COOLDOWN_MS = 60_000
+const recoveryTimestamps = new Map<string, number>()
+
+export function canAttemptPrefillRecovery(sessionID: string): boolean {
+  const lastAttempt = recoveryTimestamps.get(sessionID)
+  if (!lastAttempt) return true
+  return Date.now() - lastAttempt > RECOVERY_COOLDOWN_MS
+}
+
+export function markPrefillRecoveryAttempted(sessionID: string): void {
+  recoveryTimestamps.set(sessionID, Date.now())
+}
+
+export function clearPrefillRecoveryState(sessionID: string): void {
+  recoveryTimestamps.delete(sessionID)
+}

--- a/src/hooks/trailing-assistant-guard/hook.test.ts
+++ b/src/hooks/trailing-assistant-guard/hook.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test"
+import { createTrailingAssistantGuardHook } from "./hook"
+
+function makeMessage(role: "user" | "assistant", text = "hello") {
+  return {
+    info: { id: `msg_${Math.random()}`, role } as any,
+    parts: [{ type: "text" as const, text }] as any[],
+  }
+}
+
+describe("createTrailingAssistantGuardHook", () => {
+  test("should remove trailing assistant message", async () => {
+    //#given - messages ending with assistant
+    const hook = createTrailingAssistantGuardHook()
+    const messages = [
+      makeMessage("user", "hi"),
+      makeMessage("assistant", "hello"),
+      makeMessage("user", "do stuff"),
+      makeMessage("assistant", "orphaned response"),
+    ]
+    const output = { messages }
+
+    //#when - transform runs
+    await hook["experimental.chat.messages.transform"]!({} as any, output)
+
+    //#then - trailing assistant removed, last message is user
+    expect(output.messages).toHaveLength(3)
+    expect(output.messages[output.messages.length - 1].info.role).toBe("user")
+  })
+
+  test("should remove multiple trailing assistant messages", async () => {
+    //#given - messages ending with two assistant messages
+    const hook = createTrailingAssistantGuardHook()
+    const messages = [
+      makeMessage("user", "hi"),
+      makeMessage("assistant", "first"),
+      makeMessage("assistant", "second"),
+    ]
+    const output = { messages }
+
+    //#when - transform runs
+    await hook["experimental.chat.messages.transform"]!({} as any, output)
+
+    //#then - both trailing assistants removed
+    expect(output.messages).toHaveLength(1)
+    expect(output.messages[0].info.role).toBe("user")
+  })
+
+  test("should not remove anything when last message is user", async () => {
+    //#given - messages ending with user (normal case)
+    const hook = createTrailingAssistantGuardHook()
+    const messages = [
+      makeMessage("user", "hi"),
+      makeMessage("assistant", "hello"),
+      makeMessage("user", "continue"),
+    ]
+    const output = { messages }
+
+    //#when - transform runs
+    await hook["experimental.chat.messages.transform"]!({} as any, output)
+
+    //#then - no changes
+    expect(output.messages).toHaveLength(3)
+  })
+
+  test("should not remove the only message even if assistant", async () => {
+    //#given - single assistant message (edge case)
+    const hook = createTrailingAssistantGuardHook()
+    const messages = [makeMessage("assistant", "solo")]
+    const output = { messages }
+
+    //#when - transform runs
+    await hook["experimental.chat.messages.transform"]!({} as any, output)
+
+    //#then - message preserved (never empty the array)
+    expect(output.messages).toHaveLength(1)
+  })
+
+  test("should handle empty messages array", async () => {
+    //#given - empty messages
+    const hook = createTrailingAssistantGuardHook()
+    const output = { messages: [] as any[] }
+
+    //#when - transform runs
+    await hook["experimental.chat.messages.transform"]!({} as any, output)
+
+    //#then - no error, still empty
+    expect(output.messages).toHaveLength(0)
+  })
+
+  test("should preserve middle assistant messages", async () => {
+    //#given - assistant in middle, user at end
+    const hook = createTrailingAssistantGuardHook()
+    const messages = [
+      makeMessage("user", "q1"),
+      makeMessage("assistant", "a1"),
+      makeMessage("user", "q2"),
+      makeMessage("assistant", "a2"),
+      makeMessage("user", "q3"),
+    ]
+    const output = { messages }
+
+    //#when - transform runs
+    await hook["experimental.chat.messages.transform"]!({} as any, output)
+
+    //#then - all messages preserved
+    expect(output.messages).toHaveLength(5)
+  })
+})

--- a/src/hooks/trailing-assistant-guard/hook.ts
+++ b/src/hooks/trailing-assistant-guard/hook.ts
@@ -1,0 +1,39 @@
+import type { Message, Part } from "@opencode-ai/sdk"
+
+import { log } from "../../shared/logger"
+
+interface MessageWithParts {
+  info: Message
+  parts: Part[]
+}
+
+type MessagesTransformHook = {
+  "experimental.chat.messages.transform"?: (
+    input: Record<string, never>,
+    output: { messages: MessageWithParts[] }
+  ) => Promise<void>
+}
+
+export function createTrailingAssistantGuardHook(): MessagesTransformHook {
+  return {
+    "experimental.chat.messages.transform": async (_input, output) => {
+      const { messages } = output
+      if (!messages || messages.length < 2) return
+
+      let removed = 0
+      while (
+        messages.length > 1 &&
+        messages[messages.length - 1].info.role === "assistant"
+      ) {
+        messages.pop()
+        removed++
+      }
+
+      if (removed > 0) {
+        log(
+          `[trailing-assistant-guard] Removed ${removed} trailing assistant message(s) to prevent prefill error`,
+        )
+      }
+    },
+  }
+}

--- a/src/hooks/trailing-assistant-guard/index.ts
+++ b/src/hooks/trailing-assistant-guard/index.ts
@@ -1,0 +1,1 @@
+export { createTrailingAssistantGuardHook } from "./hook"

--- a/src/plugin/hooks/create-transform-hooks.ts
+++ b/src/plugin/hooks/create-transform-hooks.ts
@@ -5,6 +5,7 @@ import {
   createClaudeCodeHooksHook,
   createKeywordDetectorHook,
   createThinkingBlockValidatorHook,
+  createTrailingAssistantGuardHook,
 } from "../../hooks"
 import {
   contextCollector,
@@ -17,6 +18,7 @@ export type TransformHooks = {
   keywordDetector: ReturnType<typeof createKeywordDetectorHook> | null
   contextInjectorMessagesTransform: ReturnType<typeof createContextInjectorMessagesTransformHook>
   thinkingBlockValidator: ReturnType<typeof createThinkingBlockValidatorHook> | null
+  trailingAssistantGuard: ReturnType<typeof createTrailingAssistantGuardHook> | null
 }
 
 export function createTransformHooks(args: {
@@ -56,10 +58,19 @@ export function createTransformHooks(args: {
       )
     : null
 
+  const trailingAssistantGuard = isHookEnabled("trailing-assistant-guard")
+    ? safeCreateHook(
+        "trailing-assistant-guard",
+        () => createTrailingAssistantGuardHook(),
+        { enabled: safeHookEnabled },
+      )
+    : null
+
   return {
     claudeCodeHooks,
     keywordDetector,
     contextInjectorMessagesTransform,
     thinkingBlockValidator,
+    trailingAssistantGuard,
   }
 }

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -20,5 +20,9 @@ export function createMessagesTransformHandler(args: {
     await args.hooks.thinkingBlockValidator?.[
       "experimental.chat.messages.transform"
     ]?.(input, output)
+
+    await args.hooks.trailingAssistantGuard?.[
+      "experimental.chat.messages.transform"
+    ]?.(input, output)
   }
 }


### PR DESCRIPTION
## Summary

Fixes the regression where Vertex AI Claude Opus 4.6 fails with "assistant message prefill" error (#1528). The previous fix (7abefcca) caused an infinite retry loop and was reverted to a noop (a8681a9f). This PR implements a proper two-layer fix.

## Root Cause

1. **Original fix** (`7abefcca`): Detected `assistant_prefill_unsupported` and returned `success=true` to trigger auto-continue
2. **Why it broke** (`a8681a9f`): Orphaned `function_call_output` items (from `opencode-openai-codex-auth`) persist across retries, so each auto-continue hit the same error → infinite loop
3. **The revert** set `success=false`, which stopped the loop but disabled recovery entirely — users now see the raw error

## Fix: Two Layers

### Layer 1 — Proactive: `trailing-assistant-guard` hook (new)
- Runs as the **last step** in the `messages.transform` pipeline (after context-injector and thinking-block-validator)
- Strips trailing assistant messages from the messages array **before** the API call
- Prevents the error entirely for cases where the plugin's own message history has trailing assistant messages (e.g., after abort, crash, or thinking-block-validator reinforcing a problematic message)

### Layer 2 — Reactive: Cooldown-gated retry in `session-recovery`
- Replaces the `success=false` noop with a **60-second per-session cooldown**
- First occurrence: returns `success=true` → event handler sends "continue" as user message
- Second occurrence within 60s: returns `success=false` → prevents infinite loop
- Handles cases that slip past the proactive guard (e.g., transformations by external plugins after our hooks)

## Changes

| File | Change |
|------|--------|
| `src/hooks/trailing-assistant-guard/hook.ts` | **NEW** — proactive guard in messages.transform |
| `src/hooks/trailing-assistant-guard/index.ts` | **NEW** — barrel export |
| `src/hooks/trailing-assistant-guard/hook.test.ts` | **NEW** — 6 tests |
| `src/hooks/session-recovery/recover-assistant-prefill.ts` | **NEW** — cooldown state management |
| `src/hooks/session-recovery/recover-assistant-prefill.test.ts` | **NEW** — 4 tests |
| `src/hooks/session-recovery/hook.ts` | Wired cooldown-gated recovery, updated toasts |
| `src/hooks/index.ts` | Added export |
| `src/config/schema/hooks.ts` | Added `trailing-assistant-guard` to HookNameSchema |
| `src/plugin/hooks/create-transform-hooks.ts` | Registered new hook |
| `src/plugin/messages-transform.ts` | Added guard as 3rd pipeline step |

## Verification

- `bun run typecheck` — clean
- 10 new tests pass (6 guard + 4 recovery)
- 23 session-recovery tests pass (19 existing + 4 new)
- 46 config schema tests pass
- Zero LSP errors on all changed files

Closes #1528

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1528 by preventing Vertex Claude “assistant prefill” errors. We remove trailing assistant messages before the API call and add a cooldown‑gated recovery to stop retry loops.

- **Bug Fixes**
  - Added trailing-assistant-guard hook to strip trailing assistant messages; runs last in messages.transform.
  - Implemented 60s per‑session cooldown in session recovery: first error auto‑continues, subsequent errors within cooldown stop to prevent loops.
  - Registered the new hook and updated schema/exports; adjusted recovery toast copy.

<sup>Written for commit 3f58147a5d5b47188bf5f23ef5635a5e3e159739. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

