### PR TITLE
fix(cli-run): avoid hanging on event stream shutdown

### DIFF
--- a/src/cli/run/runner.test.ts
+++ b/src/cli/run/runner.test.ts
@@ -33,7 +33,9 @@ describe("waitForEventProcessorShutdown", () => {
     // then
     expect(elapsed).toBeGreaterThanOrEqual(20)
     expect(logSpy).toHaveBeenCalled()
-  })
+
+    // cleanup
+    logSpy.mockRestore()
 })
 
 describe("resolveRunAgent", () => {

--- a/src/cli/run/runner.test.ts
+++ b/src/cli/run/runner.test.ts
@@ -1,9 +1,39 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, spyOn } from "bun:test"
 import type { OhMyOpenCodeConfig } from "../../config"
-import { resolveRunAgent } from "./runner"
+import { resolveRunAgent, waitForEventProcessorShutdown } from "./runner"
 
 const createConfig = (overrides: Partial<OhMyOpenCodeConfig> = {}): OhMyOpenCodeConfig => ({
   ...overrides,
+})
+
+describe("waitForEventProcessorShutdown", () => {
+  it("returns quickly when event processor completes", async () => {
+    // given
+    const eventProcessor = Promise.resolve()
+
+    // when
+    const start = Date.now()
+    await waitForEventProcessorShutdown(eventProcessor, 50)
+    const elapsed = Date.now() - start
+
+    // then
+    expect(elapsed).toBeLessThan(50)
+  })
+
+  it("times out and continues when event processor does not complete", async () => {
+    // given
+    const never = new Promise<void>(() => {})
+    const logSpy = spyOn(console, "log").mockImplementation(() => {})
+
+    // when
+    const start = Date.now()
+    await waitForEventProcessorShutdown(never, 25)
+    const elapsed = Date.now() - start
+
+    // then
+    expect(elapsed).toBeGreaterThanOrEqual(20)
+    expect(logSpy).toHaveBeenCalled()
+  })
 })
 
 describe("resolveRunAgent", () => {

--- a/src/cli/run/runner.ts
+++ b/src/cli/run/runner.ts
@@ -12,6 +12,25 @@ import { pollForCompletion } from "./poll-for-completion"
 export { resolveRunAgent }
 
 const DEFAULT_TIMEOUT_MS = 600_000
+const EVENT_PROCESSOR_SHUTDOWN_TIMEOUT_MS = 2_000
+
+export async function waitForEventProcessorShutdown(
+  eventProcessor: Promise<void>,
+  timeoutMs = EVENT_PROCESSOR_SHUTDOWN_TIMEOUT_MS,
+): Promise<void> {
+  const completed = await Promise.race([
+    eventProcessor.then(() => true),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+  ])
+
+  if (!completed) {
+    console.log(
+      pc.dim(
+        `[run] Event stream did not close within ${timeoutMs}ms after abort; continuing shutdown.`
+      )
+    )
+  }
+}
 
 export async function run(options: RunOptions): Promise<number> {
   process.env.OPENCODE_CLI_RUN_MODE = "true"
@@ -84,11 +103,11 @@ export async function run(options: RunOptions): Promise<number> {
        console.log(pc.dim("Waiting for completion...\n"))
        const exitCode = await pollForCompletion(ctx, eventState, abortController)
 
-       // Abort the event stream to stop the processor
-       abortController.abort()
+      // Abort the event stream to stop the processor
+      abortController.abort()
 
-       await eventProcessor
-       cleanup()
+      await waitForEventProcessorShutdown(eventProcessor)
+      cleanup()
 
       const durationMs = Date.now() - startTime
 


### PR DESCRIPTION
## Summary
Fix `oh-my-opencode run` hanging during shutdown when the event stream doesn't close after abort.

## Root cause
`runner.ts` calls:
1. `abortController.abort()`
2. `await eventProcessor`

But `processEvents()` checks `abortController.signal.aborted` **inside** a `for await` loop. If no further stream event arrives after abort, the loop never advances to that check, so `eventProcessor` can remain pending forever.

## Changes
- Add `waitForEventProcessorShutdown()` helper in `runner.ts`
  - waits for event processor completion
  - but only up to a bounded timeout (default 2000ms)
  - logs a dim warning and continues shutdown if stream doesn't close
- Replace unbounded `await eventProcessor` with bounded shutdown wait
- Add tests in `runner.test.ts`:
  - returns quickly when processor resolves
  - times out and continues when processor never resolves

## Why this helps issue #1825
Even when the model work is done and comments are posted, the CLI no longer blocks forever waiting for event-stream teardown.

## Notes
Could not run tests in this environment because `bun` is unavailable in PATH.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a shutdown hang in `oh-my-opencode run` when the event stream doesn’t close after abort. The CLI now exits promptly by waiting briefly for the event processor and timing out if needed.

- **Bug Fixes**
  - Added waitForEventProcessorShutdown with a 2s timeout and dim warning; used instead of awaiting the event processor after abort.
  - Expanded tests to cover quick completion, timeout, and that the warning is logged.

<sup>Written for commit acd26c2d7c5ee20270350bef8ce29f40608fab1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

