### PR TITLE
fix(cli-run): bounded shutdown wait for event stream processor

### DIFF
--- a/src/cli/run/runner.test.ts
+++ b/src/cli/run/runner.test.ts
@@ -117,7 +117,8 @@ describe("waitForEventProcessorShutdown", () => {
       //#then
       const elapsed = performance.now() - start
       expect(elapsed).toBeGreaterThanOrEqual(timeoutMs)
-      expect(spy).toHaveBeenCalledWith(
+      const callArgs = spy.mock.calls.flat().join("")
+      expect(callArgs).toContain(
         `[run] Event stream did not close within ${timeoutMs}ms after abort; continuing shutdown.`,
       )
     } finally {


### PR DESCRIPTION
## Summary
- Adds waitForEventProcessorShutdown() with configurable timeout (default 2s)
- Uses Promise.race to prevent indefinite hanging when event stream fails to close
- Replaces bare await eventProcessor with bounded wait

Fixes #1825

Community credit: Based on PR #1827 by @cloudwaddie-agent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Run CLI from hanging on shutdown when the event stream doesn’t close by adding a bounded wait (2s default). Fixes #1825.

- **Bug Fixes**
  - Added waitForEventProcessorShutdown(eventProcessor, timeoutMs) using Promise.race (2s default).
  - After abort in run(), replaced await eventProcessor with the bounded wait, then cleanup.
  - Logs a dim timeout notice and continues shutdown.
  - Tests cover fast completion and timeout; switched to substring check to avoid ANSI-wrapped output issues on CI.

<sup>Written for commit b7c32e8f50771cd82c7ba2bc2f90a79c0ebab82a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

