### PR TITLE
fix(lsp): remove unreliable Windows binary availability check

### DIFF
--- a/src/tools/lsp/lsp-process.test.ts
+++ b/src/tools/lsp/lsp-process.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, spyOn } from "bun:test"
 
 describe("spawnProcess", () => {
   it("proceeds to node spawn on Windows when command is available", async () => {
-    // #given
+    //#given
     const originalPlatform = process.platform
     const rootDir = mkdtempSync(join(tmpdir(), "lsp-process-test-"))
     const childProcess = await import("node:child_process")
@@ -16,7 +16,7 @@ describe("spawnProcess", () => {
       Object.defineProperty(process, "platform", { value: "win32" })
       const { spawnProcess } = await import("./lsp-process")
 
-      // #when
+      //#when
       let result: ReturnType<typeof spawnProcess> | null = null
       expect(() => {
         result = spawnProcess(["node", "--version"], {
@@ -25,7 +25,7 @@ describe("spawnProcess", () => {
         })
       }).not.toThrow(/Binary 'node' not found/)
 
-      // #then
+      //#then
       expect(nodeSpawnSpy).toHaveBeenCalled()
       expect(result).not.toBeNull()
     } finally {

--- a/src/tools/lsp/lsp-process.test.ts
+++ b/src/tools/lsp/lsp-process.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { describe, expect, it, spyOn } from "bun:test"
+
+describe("spawnProcess", () => {
+  it("proceeds to node spawn on Windows when command is available", async () => {
+    // #given
+    const originalPlatform = process.platform
+    const rootDir = mkdtempSync(join(tmpdir(), "lsp-process-test-"))
+    const childProcess = await import("node:child_process")
+    const nodeSpawnSpy = spyOn(childProcess, "spawn")
+
+    try {
+      Object.defineProperty(process, "platform", { value: "win32" })
+      const { spawnProcess } = await import("./lsp-process")
+
+      // #when
+      let result: ReturnType<typeof spawnProcess> | null = null
+      expect(() => {
+        result = spawnProcess(["node", "--version"], {
+          cwd: rootDir,
+          env: process.env,
+        })
+      }).not.toThrow(/Binary 'node' not found/)
+
+      // #then
+      expect(nodeSpawnSpy).toHaveBeenCalled()
+      expect(result).not.toBeNull()
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform })
+      nodeSpawnSpy.mockRestore()
+      rmSync(rootDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- removed the Windows-only pre-check that called \`isBinaryAvailableOnWindows()\` in \`spawnProcess()\`
- removed the unused \`isBinaryAvailableOnWindows\` implementation from \`src/tools/lsp/lsp-process.ts\`
- kept \`nodeSpawn\` as the Windows path so OS-level spawn failures are surfaced directly
- added/updated LSP process test coverage to ensure Windows flow uses \`nodeSpawn\` and does not throw the misleading \"Binary ... not found\" error

## Testing
- \`bun test src/tools/lsp/\`
- \`bun run typecheck\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unreliable Windows-only binary pre-check in LSP spawn to stop false “Binary not found” errors when the binary is on PATH. Windows uses Node’s child_process spawn so OS-level errors surface correctly. Fixes #1805.

- **Bug Fixes**
  - Removed isBinaryAvailableOnWindows (spawnSync("where")) and its pre-check in spawnProcess; rely on nodeSpawn for resolution and errors.
  - Added a Windows spawn test with BDD markers to assert nodeSpawn is called and no false “Binary 'node' not found” error is thrown.

<sup>Written for commit 26ae666bc3a734a6c43e6d981c7ce6933956d165. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

