### PR TITLE
fix: disable thinking params for Z.ai GLM models

### DIFF
--- a/src/hooks/think-mode/index.test.ts
+++ b/src/hooks/think-mode/index.test.ts
@@ -352,6 +352,25 @@ describe("createThinkModeHook integration", () => {
   })
 
   describe("Agent-level thinking configuration respect", () => {
+    it("should omit Z.ai GLM disabled thinking config", async () => {
+      //#given a Z.ai GLM model with think prompt
+      const hook = createThinkModeHook()
+      const input = createMockInput(
+        "zai-coding-plan",
+        "glm-4.7",
+        "ultrathink mode"
+      )
+
+      //#when think mode resolves Z.ai thinking configuration
+      await hook["chat.params"](input, sessionID)
+
+      //#then thinking config should be omitted from request
+      const message = input.message as MessageWithInjectedProps
+      expect(input.message.model?.modelID).toBe("glm-4.7")
+      expect(message.thinking).toBeUndefined()
+      expect(message.providerOptions).toBeUndefined()
+    })
+
     it("should NOT inject thinking config when agent has thinking disabled", async () => {
       // given agent with thinking explicitly disabled
       const hook = createThinkModeHook()

--- a/src/hooks/think-mode/switcher.test.ts
+++ b/src/hooks/think-mode/switcher.test.ts
@@ -470,10 +470,12 @@ describe("think-mode switcher", () => {
   describe("Z.AI GLM-4.7 provider support", () => {
     describe("getThinkingConfig for zai-coding-plan", () => {
       it("should return thinking config for glm-4.7", () => {
-        // given zai-coding-plan provider with glm-4.7 model
+        //#given a Z.ai GLM model
         const config = getThinkingConfig("zai-coding-plan", "glm-4.7")
 
-        // then should return zai-coding-plan thinking config
+        //#when thinking config is resolved
+
+        //#then thinking type is "disabled"
         expect(config).not.toBeNull()
         expect(config?.providerOptions).toBeDefined()
         const zaiOptions = (config?.providerOptions as Record<string, unknown>)?.[
@@ -482,8 +484,7 @@ describe("think-mode switcher", () => {
         expect(zaiOptions?.extra_body).toBeDefined()
         const extraBody = zaiOptions?.extra_body as Record<string, unknown>
         expect(extraBody?.thinking).toBeDefined()
-        expect((extraBody?.thinking as Record<string, unknown>)?.type).toBe("enabled")
-        expect((extraBody?.thinking as Record<string, unknown>)?.clear_thinking).toBe(false)
+        expect((extraBody?.thinking as Record<string, unknown>)?.type).toBe("disabled")
       })
 
       it("should return thinking config for glm-4.6v (multimodal)", () => {
@@ -505,7 +506,7 @@ describe("think-mode switcher", () => {
     })
 
     describe("HIGH_VARIANT_MAP for GLM", () => {
-      it("should NOT have high variant for glm-4.7 (thinking enabled by default)", () => {
+      it("should NOT have high variant for glm-4.7", () => {
         // given glm-4.7 model
         const variant = getHighVariant("glm-4.7")
 

--- a/src/hooks/think-mode/switcher.ts
+++ b/src/hooks/think-mode/switcher.ts
@@ -154,8 +154,7 @@ export const THINKING_CONFIGS = {
       "zai-coding-plan": {
         extra_body: {
           thinking: {
-            type: "enabled",
-            clear_thinking: false,
+            type: "disabled",
           },
         },
       },


### PR DESCRIPTION
## Summary
- Stop Z.ai GLM thinking payloads from being sent in think mode, because the provider does not support them and responds empty.
- Keep existing think-mode behavior for other providers unchanged.

## Changes
- Set `zai-coding-plan` thinking config to `{ extra_body: { thinking: { type: "disabled" }}}`.
- Update think-mode hook to skip injecting thinking configuration when resolved config is disabled, including disabled `extra_body.thinking.type`.
- Add/adjust tests to verify GLM configuration resolves to disabled thinking and is omitted from outgoing request payload.

## Verification
- `bun test src/hooks/think-mode/`
- `bun run typecheck`

## Related issue
Fixes #980

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable thinking for Z.ai GLM models to avoid empty responses. No changes to think-mode for other providers. Fixes #980.

- **Bug Fixes**
  - Mark zai-coding-plan thinking as disabled; remove clear_thinking; omit thinking/providerOptions from GLM request payloads.
  - Add disabled detection in the hook (top-level or providerOptions.extra_body.thinking.type), skip injection, and log.
  - Update switcher and tests to expect disabled and assert GLM messages contain no thinking/providerOptions.

<sup>Written for commit 9f52e48e8fe26c1fa3c60bb6427fda328172ab6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

