### PR TITLE
fix(delegate-task): parse load_skills when passed as JSON string

### DIFF
--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -103,6 +103,14 @@ Prompts MUST be in English.`
       if (args.run_in_background === undefined) {
         throw new Error(`Invalid arguments: 'run_in_background' parameter is REQUIRED. Use run_in_background=false for task delegation, run_in_background=true only for parallel exploration.`)
       }
+      if (typeof args.load_skills === "string") {
+        try {
+          const parsed = JSON.parse(args.load_skills)
+          args.load_skills = Array.isArray(parsed) ? parsed : []
+        } catch {
+          args.load_skills = []
+        }
+      }
       if (args.load_skills === undefined) {
         throw new Error(`Invalid arguments: 'load_skills' parameter is REQUIRED. Pass [] if no skills needed, but IT IS HIGHLY RECOMMENDED to pass proper skills like ["playwright"], ["git-master"] for best results.`)
       }


### PR DESCRIPTION
## Summary
- Adds defensive JSON.parse when `load_skills` is passed as a serialized JSON string instead of an array
- Handles malformed JSON strings gracefully by defaulting to empty array
- LLMs sometimes serialize array parameters as strings during tool calls

Fixes #1701

Community-reported-by: @omarmciver

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse load_skills when provided as a JSON string in delegate-task to prevent validation errors and ensure skills load correctly. Malformed JSON or non-array values now default to []. Fixes #1701.

- **Bug Fixes**
  - Parse string load_skills before validation; invalid JSON or non-array becomes [].
  - Added tests for valid strings and malformed input to confirm resolveSkillContent receives the correct array.

<sup>Written for commit 3fa543e851d304d627c06f52b0bc12958b3b43d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

