### PR TITLE
fix: inherit parent session tool restrictions in background task notifications

### DIFF
--- a/src/features/background-agent/notify-parent-session.ts
+++ b/src/features/background-agent/notify-parent-session.ts
@@ -148,6 +148,7 @@ export async function notifyParentSession(args: {
         noReply: !allComplete,
         ...(agent !== undefined ? { agent } : {}),
         ...(model !== undefined ? { model } : {}),
+        ...(task.parentTools ? { tools: task.parentTools } : {}),
         parts: [{ type: "text", text: notification }],
       },
     })

--- a/src/features/background-agent/parent-session-notifier.ts
+++ b/src/features/background-agent/parent-session-notifier.ts
@@ -71,6 +71,7 @@ export async function notifyParentSession(
         noReply: !allComplete,
         ...(agent !== undefined ? { agent } : {}),
         ...(model !== undefined ? { model } : {}),
+        ...(task.parentTools ? { tools: task.parentTools } : {}),
         parts: [{ type: "text", text: notification }],
       },
     })

--- a/src/features/background-agent/spawner/task-factory.ts
+++ b/src/features/background-agent/spawner/task-factory.ts
@@ -13,6 +13,7 @@ export function createTask(input: LaunchInput): BackgroundTask {
     parentMessageID: input.parentMessageID,
     parentModel: input.parentModel,
     parentAgent: input.parentAgent,
+    parentTools: input.parentTools,
     model: input.model,
   }
 }

--- a/src/features/background-agent/types.ts
+++ b/src/features/background-agent/types.ts
@@ -37,6 +37,8 @@ export interface BackgroundTask {
   concurrencyGroup?: string
   /** Parent session's agent name for notification */
   parentAgent?: string
+  /** Parent session's tool restrictions for notification prompts */
+  parentTools?: Record<string, boolean>
   /** Marks if the task was launched from an unstable agent/category */
   isUnstableAgent?: boolean
   /** Category used for this task (e.g., 'quick', 'visual-engineering') */
@@ -56,6 +58,7 @@ export interface LaunchInput {
   parentMessageID: string
   parentModel?: { providerID: string; modelID: string }
   parentAgent?: string
+  parentTools?: Record<string, boolean>
   model?: { providerID: string; modelID: string; variant?: string }
   isUnstableAgent?: boolean
   skills?: string[]
@@ -70,4 +73,5 @@ export interface ResumeInput {
   parentMessageID: string
   parentModel?: { providerID: string; modelID: string }
   parentAgent?: string
+  parentTools?: Record<string, boolean>
 }

--- a/src/shared/session-tools-store.test.ts
+++ b/src/shared/session-tools-store.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, beforeEach } from "bun:test"
+import { setSessionTools, getSessionTools, clearSessionTools } from "./session-tools-store"
+
+describe("session-tools-store", () => {
+  beforeEach(() => {
+    clearSessionTools()
+  })
+
+  test("returns undefined for unknown session", () => {
+    //#given
+    const sessionID = "ses_unknown"
+
+    //#when
+    const result = getSessionTools(sessionID)
+
+    //#then
+    expect(result).toBeUndefined()
+  })
+
+  test("stores and retrieves tools for a session", () => {
+    //#given
+    const sessionID = "ses_abc123"
+    const tools = { question: false, task: true, call_omo_agent: true }
+
+    //#when
+    setSessionTools(sessionID, tools)
+    const result = getSessionTools(sessionID)
+
+    //#then
+    expect(result).toEqual({ question: false, task: true, call_omo_agent: true })
+  })
+
+  test("overwrites existing tools for same session", () => {
+    //#given
+    const sessionID = "ses_abc123"
+    setSessionTools(sessionID, { question: false })
+
+    //#when
+    setSessionTools(sessionID, { question: true, task: false })
+    const result = getSessionTools(sessionID)
+
+    //#then
+    expect(result).toEqual({ question: true, task: false })
+  })
+
+  test("clearSessionTools removes all entries", () => {
+    //#given
+    setSessionTools("ses_1", { question: false })
+    setSessionTools("ses_2", { task: true })
+
+    //#when
+    clearSessionTools()
+
+    //#then
+    expect(getSessionTools("ses_1")).toBeUndefined()
+    expect(getSessionTools("ses_2")).toBeUndefined()
+  })
+
+  test("returns a copy, not a reference", () => {
+    //#given
+    const sessionID = "ses_abc123"
+    const tools = { question: false }
+    setSessionTools(sessionID, tools)
+
+    //#when
+    const result = getSessionTools(sessionID)!
+    result.question = true
+
+    //#then
+    expect(getSessionTools(sessionID)).toEqual({ question: false })
+  })
+})

--- a/src/shared/session-tools-store.ts
+++ b/src/shared/session-tools-store.ts
@@ -1,0 +1,14 @@
+const store = new Map<string, Record<string, boolean>>()
+
+export function setSessionTools(sessionID: string, tools: Record<string, boolean>): void {
+  store.set(sessionID, { ...tools })
+}
+
+export function getSessionTools(sessionID: string): Record<string, boolean> | undefined {
+  const tools = store.get(sessionID)
+  return tools ? { ...tools } : undefined
+}
+
+export function clearSessionTools(): void {
+  store.clear()
+}

--- a/src/tools/call-omo-agent/background-agent-executor.ts
+++ b/src/tools/call-omo-agent/background-agent-executor.ts
@@ -5,6 +5,7 @@ import { log } from "../../shared"
 import type { CallOmoAgentArgs } from "./types"
 import type { ToolContextWithMetadata } from "./tool-context-with-metadata"
 import { getMessageDir } from "./message-storage-directory"
+import { getSessionTools } from "../../shared/session-tools-store"
 
 export async function executeBackgroundAgent(
 	args: CallOmoAgentArgs,
@@ -36,6 +37,7 @@ export async function executeBackgroundAgent(
 			parentSessionID: toolContext.sessionID,
 			parentMessageID: toolContext.messageID,
 			parentAgent,
+			parentTools: getSessionTools(toolContext.sessionID),
 		})
 
 		const waitStart = Date.now()

--- a/src/tools/call-omo-agent/background-executor.ts
+++ b/src/tools/call-omo-agent/background-executor.ts
@@ -5,6 +5,7 @@ import { consumeNewMessages } from "../../shared/session-cursor"
 import { findFirstMessageWithAgent, findNearestMessageWithFields } from "../../features/hook-message-injector"
 import { getSessionAgent } from "../../features/claude-code-session-state"
 import { getMessageDir } from "./message-dir"
+import { getSessionTools } from "../../shared/session-tools-store"
 
 export async function executeBackground(
   args: CallOmoAgentArgs,
@@ -41,6 +42,7 @@ export async function executeBackground(
       parentSessionID: toolContext.sessionID,
       parentMessageID: toolContext.messageID,
       parentAgent,
+      parentTools: getSessionTools(toolContext.sessionID),
     })
 
     const WAIT_FOR_SESSION_INTERVAL_MS = 50

--- a/src/tools/delegate-task/background-continuation.ts
+++ b/src/tools/delegate-task/background-continuation.ts
@@ -2,6 +2,7 @@ import type { DelegateTaskArgs, ToolContextWithMetadata } from "./types"
 import type { ExecutorContext, ParentContext } from "./executor-types"
 import { storeToolMetadata } from "../../features/tool-metadata-store"
 import { formatDetailedError } from "./error-formatting"
+import { getSessionTools } from "../../shared/session-tools-store"
 
 export async function executeBackgroundContinuation(
   args: DelegateTaskArgs,
@@ -19,6 +20,7 @@ export async function executeBackgroundContinuation(
       parentMessageID: parentContext.messageID,
       parentModel: parentContext.model,
       parentAgent: parentContext.agent,
+      parentTools: getSessionTools(parentContext.sessionID),
     })
 
     const bgContMeta = {

--- a/src/tools/delegate-task/background-task.ts
+++ b/src/tools/delegate-task/background-task.ts
@@ -3,6 +3,7 @@ import type { ExecutorContext, ParentContext } from "./executor-types"
 import { getTimingConfig } from "./timing"
 import { storeToolMetadata } from "../../features/tool-metadata-store"
 import { formatDetailedError } from "./error-formatting"
+import { getSessionTools } from "../../shared/session-tools-store"
 
 export async function executeBackgroundTask(
   args: DelegateTaskArgs,
@@ -24,6 +25,7 @@ export async function executeBackgroundTask(
       parentMessageID: parentContext.messageID,
       parentModel: parentContext.model,
       parentAgent: parentContext.agent,
+      parentTools: getSessionTools(parentContext.sessionID),
       model: categoryModel,
       skills: args.load_skills.length > 0 ? args.load_skills : undefined,
       skillContent: systemContent,

--- a/src/tools/delegate-task/unstable-agent-task.ts
+++ b/src/tools/delegate-task/unstable-agent-task.ts
@@ -4,6 +4,7 @@ import { getTimingConfig } from "./timing"
 import { storeToolMetadata } from "../../features/tool-metadata-store"
 import { formatDuration } from "./time-formatter"
 import { formatDetailedError } from "./error-formatting"
+import { getSessionTools } from "../../shared/session-tools-store"
 
 export async function executeUnstableAgentTask(
   args: DelegateTaskArgs,
@@ -26,6 +27,7 @@ export async function executeUnstableAgentTask(
       parentMessageID: parentContext.messageID,
       parentModel: parentContext.model,
       parentAgent: parentContext.agent,
+      parentTools: getSessionTools(parentContext.sessionID),
       model: categoryModel,
       skills: args.load_skills.length > 0 ? args.load_skills : undefined,
       skillContent: systemContent,


### PR DESCRIPTION
## Summary

1. **Fix**: background task completion notifications lose parent session tool restrictions (e.g., `question: false`), causing the Question tool to re-enable after `call_omo_agent` background tasks complete.
2. **Fix**: symlink resolution in skill config source discovery (macOS `/var` → `/private/var`).
3. **Fix**: test isolation — prevent `mock.module()` state from leaking across test files in bun's shared process.

## Problem

When a parent session sends a prompt with `tools: { question: false, ... }`, OpenCode stores this on the user message's `info.tools` field. The LLM tool filter at `llm.ts:265` checks `input.user.tools?.[tool] === false` to disable tools.

However, when a background task completes and `notifyParentSession` sends `promptAsync` to the parent, it did **not** include the original `tools` parameter. This created a new user message with `tools: undefined`, causing `undefined?.question === false → false` — the Question tool was no longer filtered out.

## Solution

### Parent Session Tools Inheritance

Introduced `session-tools-store` — an in-memory Map that captures tool restriction objects per sessionID at every prompt dispatch point:

1. **Store**: `setSessionTools(sessionID, tools)` called before every `prompt`/`promptAsync` call
2. **Retrieve**: `getSessionTools(parentSessionID)` called at background task launch sites
3. **Apply**: `parentTools` flows through `BackgroundTask → LaunchInput → task → notifyParentSession`

### Symlink Resolution

Use `fs.realpath()` in `config-source-discovery.ts` to resolve symlinks before loading skills, preventing duplicate/mismatched paths on systems where `tmpdir()` returns a symlink.

### Test Isolation

Added `afterAll` hooks that restore original module implementations after `mock.module()` overrides. This prevents mock state from leaking across test files when bun runs them in the same process.

## Commits

| Commit | Description |
|--------|-------------|
| `feat: add session-tools-store` | New `src/shared/session-tools-store.ts` with Map-based set/get/clear + 5 tests |
| `feat: add parentTools to types` | `parentTools?: Record<string, boolean>` on `BackgroundTask`, `LaunchInput`, `ResumeInput` |
| `feat: store tools at prompt sites` | `setSessionTools()` calls in sync-prompt-sender, sync-continuation, task-starter, task-resumer |
| `fix: inherit parent tools in bg tasks` | Pass `parentTools` through launch/resume lifecycle |
| `fix: apply parentTools at notification` | Include `parentTools` in `promptAsync` body in both notifier paths |
| `fix: resolve symlinks in config discovery` | `fs.realpath()` + `agents-config-dir` utility |
| `fix: test type casts and timeouts` | Type corrections, timeout additions, mock restructuring |
| `fix: directory injector test isolation` | Move `node:fs` mocks to `beforeEach`/`afterEach` with dynamic imports |
| `ci: mock.module afterAll restoration` | Restore original modules in 18 test files to prevent cross-file pollution |

## Verification

- ✅ `bun run typecheck` — no errors
- ✅ **2632 tests pass, 0 fail** across 205 test files (full suite, 275s)
