### PR TITLE
fix(skill-loader): discover skills from .agents/skills/ directory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.5.2",
-        "oh-my-opencode-darwin-x64": "3.5.2",
-        "oh-my-opencode-linux-arm64": "3.5.2",
-        "oh-my-opencode-linux-arm64-musl": "3.5.2",
-        "oh-my-opencode-linux-x64": "3.5.2",
-        "oh-my-opencode-linux-x64-musl": "3.5.2",
-        "oh-my-opencode-windows-x64": "3.5.2",
+        "oh-my-opencode-darwin-arm64": "3.5.3",
+        "oh-my-opencode-darwin-x64": "3.5.3",
+        "oh-my-opencode-linux-arm64": "3.5.3",
+        "oh-my-opencode-linux-arm64-musl": "3.5.3",
+        "oh-my-opencode-linux-x64": "3.5.3",
+        "oh-my-opencode-linux-x64-musl": "3.5.3",
+        "oh-my-opencode-windows-x64": "3.5.3",
       },
     },
   },
@@ -226,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.5.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-oIS3lB2F9/N+3mF5wCKk6/EPVSz516XWN+mNdquSSeddw+xqMxGdhKY6K/XeYbHJzeN2Z8IOikNEJ6psR2/a8g=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.5.3", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Dq0+PC2dyAqG7c3DUnQmdOkKbKmOsRHwoqgLCQNKN1lTRllF8zbWqp5B+LGKxSPxPqJIPS3mKt+wIR2KvkYJVw=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.5.2", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OAdXo4ZCCYO4kRWtnyz3tdmaGYPUB3WcXimXAxp+/sEZxAnh7n1RQkpLn6UxWX4AIAdRT9dfrOfRic6VoCYv2g=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.5.3", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Ke45Bv/ygZm3YUSUumIyk647KZ2PFzw30tH597cOpG8MDPGbNVBCM6EKFezcukUPT+gPFVpE1IiGzEkn4JmgZA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.5.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5XXNMFhp1VsyrGNRBoXcOyoaUeVkbrWkBRPDGZfpiq+kRXH3aaSWdR5G7Pl/TadOQv9Bl8/8YaxsuHRTFT1aXw=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.5.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-aP5S3DngUhFkNeqYM33Ge6zccCWLzB/O3FLXLFXy/Iws03N8xugw72pnMK6lUbIia9QQBKK7IZBoYm9C79pZ3g=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.5.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/woIpqvEI85MgJvEVnz4g5FBLeiQNK7srRsueIFPBmtTahh42HFleCDaIltOl/ndjsE5nCHacQVJHkC9W9/F3Q=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.5.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UiD/hVKYZQyX4D5N5SnZT4M5Z/B2SDtJWBW4MibpYSAcPKNCEBKi/5E4hOPxAtTfFGR8tIXFmYZdQJDkVfvluw=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.5.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-vTL2A+6zzGhi+m7sC8peLDq5OAp2dRR0UEb4RbZAOHtlEruF7qFEmcK3ccWxwc3+Z3G/ITfwn5VNa72ZS4pNTg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.5.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-L9kqwzElGkaQ8pgtv1ZjcHARw9LPaU4UEVjzauByTMi+/5Js/PTsNXBggxSRzZfQ8/MNBPSCiA4K10Kc0YjjvA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.5.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-bOAA55snLsK2QB00IkQy8le0Oqh/GJ7pxEHtm1oUezlQrW/nX5SS/hJ7dPHMmOd9FoiqnqyqWZxNkLmFoG463A=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.5.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Z0fVVih/b2dbNeb9DK9oca5dNYCZyPySBRtxRhDXod5d7fJNgIPrvUoEd3SNfkRGORyFB3hGBZ6nqQ6N8+8DEA=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.5.2", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-fnHiAPYglw3unPckmQBoCT6+VqjSWCE3S3J551mRo0ZFrxuEP2ZKyHZeFMMOtKwDepCvmKgd1W040+KmuVUXOA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.5.3", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-ocWPjRs2sJgN02PJnEIYtqdMVDex1YhEj1FzAU5XIicfzQbgxLh9nz1yhHZzfqGJq69QStU6ofpc5kQpfX1LMg=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/features/opencode-skill-loader/agents-skills-global.test.ts
+++ b/src/features/opencode-skill-loader/agents-skills-global.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test"
+import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+
+const TEST_DIR = join(tmpdir(), "agents-global-skills-test-" + Date.now())
+const TEMP_HOME = join(TEST_DIR, "home")
+
+describe("discoverGlobalAgentsSkills", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true })
+    mkdirSync(TEMP_HOME, { recursive: true })
+  })
+
+  afterEach(() => {
+    mock.restore()
+    rmSync(TEST_DIR, { recursive: true, force: true })
+  })
+
+  it("#given a skill in ~/.agents/skills/ #when discoverGlobalAgentsSkills is called #then it discovers the skill", async () => {
+    //#given
+    const skillContent = `---
+name: agent-global-skill
+description: A skill from global .agents/skills directory
+---
+Skill body.
+`
+    const agentsGlobalSkillsDir = join(TEMP_HOME, ".agents", "skills")
+    const skillDir = join(agentsGlobalSkillsDir, "agent-global-skill")
+    mkdirSync(skillDir, { recursive: true })
+    writeFileSync(join(skillDir, "SKILL.md"), skillContent)
+
+    mock.module("os", () => ({
+      homedir: () => TEMP_HOME,
+      tmpdir,
+    }))
+
+    //#when
+    const { discoverGlobalAgentsSkills } = await import("./loader")
+    const skills = await discoverGlobalAgentsSkills()
+    const skill = skills.find(s => s.name === "agent-global-skill")
+
+    //#then
+    expect(skill).toBeDefined()
+    expect(skill?.scope).toBe("user")
+    expect(skill?.definition.description).toContain("A skill from global .agents/skills directory")
+  })
+})

--- a/src/plugin/skill-context.ts
+++ b/src/plugin/skill-context.ts
@@ -12,6 +12,8 @@ import {
   discoverProjectClaudeSkills,
   discoverOpencodeGlobalSkills,
   discoverOpencodeProjectSkills,
+  discoverProjectAgentsSkills,
+  discoverGlobalAgentsSkills,
   mergeSkills,
 } from "../features/opencode-skill-loader"
 import { createBuiltinSkills } from "../features/builtin-skills"
@@ -55,7 +57,7 @@ export async function createSkillContext(args: {
   })
 
   const includeClaudeSkills = pluginConfig.claude_code?.skills !== false
-  const [configSourceSkills, userSkills, globalSkills, projectSkills, opencodeProjectSkills] =
+  const [configSourceSkills, userSkills, globalSkills, projectSkills, opencodeProjectSkills, agentsProjectSkills, agentsGlobalSkills] =
     await Promise.all([
       discoverConfigSourceSkills({
         config: pluginConfig.skills,
@@ -65,15 +67,17 @@ export async function createSkillContext(args: {
       discoverOpencodeGlobalSkills(),
       includeClaudeSkills ? discoverProjectClaudeSkills(directory) : Promise.resolve([]),
       discoverOpencodeProjectSkills(directory),
+      discoverProjectAgentsSkills(directory),
+      discoverGlobalAgentsSkills(),
     ])
 
   const mergedSkills = mergeSkills(
     builtinSkills,
     pluginConfig.skills,
     configSourceSkills,
-    userSkills,
+    [...userSkills, ...agentsGlobalSkills],
     globalSkills,
-    projectSkills,
+    [...projectSkills, ...agentsProjectSkills],
     opencodeProjectSkills,
     { configDir: directory },
   )


### PR DESCRIPTION
## Summary

- Add `discoverProjectAgentsSkills()` for project-level `.agents/skills/` discovery
- Add `discoverGlobalAgentsSkills()` for global `~/.agents/skills/` discovery
- Update `discoverAllSkills()`, `discoverSkills()`, and `createSkillContext()` to include these new sources with correct priority ordering

## Context

Skills placed in `.agents/skills/` (both project and global) were not being discovered by oh-my-opencode, even though OpenCode natively supports this path (https://opencode.ai/docs/skills/). This caused skills to be visible in `/skills` but inaccessible to agents.

## Priority Order

```
opencode-project (.opencode/skills/) > opencode (~/.config/opencode/skills/) > project (.claude + .agents) > user (.claude + .agents)
```

## Testing

- Added tests for `discoverProjectAgentsSkills()` (with and without directory param)
- Added isolated test for `discoverGlobalAgentsSkills()` (uses `mock.module("os")`)
- All existing tests pass

## Credit

Based on community PR #1710 by @dtateks (CLA check prevented merge).

Co-authored-by: dtateks <dtateks@users.noreply.github.com>

Closes #1818

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add skill discovery for .agents/skills at project and global (~/.agents/skills) so agents can use these skills. Updates discovery priority to: opencode-project > opencode-global > project (.claude + .agents) > user (.claude + .agents).

- **Bug Fixes**
  - Add discoverProjectAgentsSkills() and discoverGlobalAgentsSkills(), and include them in discoverAllSkills(), discoverSkills(), and createSkillContext with correct priority.
  - Add tests for both paths (including explicit directory param).

- **Dependencies**
  - Bump oh-my-opencode optional binaries to 3.5.3.

<sup>Written for commit 7186c368b9cd1d18a1b0e078e96b1a4692b04216. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

