### PR TITLE
feat(audit-loop): enforce continuous looping and strict ui guardrails

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -110,6 +110,7 @@
           "init-deep",
           "ralph-loop",
           "ulw-loop",
+          "audit-loop",
           "cancel-ralph",
           "refactor",
           "start-work",
@@ -162,9 +163,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -210,9 +208,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -300,9 +295,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -344,9 +336,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -392,9 +381,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -482,9 +468,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -526,9 +509,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -574,9 +554,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -664,9 +641,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -708,9 +682,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -756,9 +727,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -846,9 +814,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -890,9 +855,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -938,9 +900,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1028,9 +987,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1072,9 +1028,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1120,9 +1073,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1210,9 +1160,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1254,9 +1201,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1302,9 +1246,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1392,9 +1333,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1436,9 +1374,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1484,9 +1419,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1574,9 +1506,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1618,9 +1547,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1666,9 +1592,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1756,9 +1679,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1800,9 +1720,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1848,9 +1765,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1938,9 +1852,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1982,9 +1893,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2030,9 +1938,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2120,9 +2025,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2164,9 +2066,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2212,9 +2111,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2302,9 +2198,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2346,9 +2239,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2394,9 +2284,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2484,9 +2371,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2528,9 +2412,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2576,9 +2457,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2666,9 +2544,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2679,9 +2554,6 @@
     },
     "categories": {
       "type": "object",
-      "propertyNames": {
-        "type": "string"
-      },
       "additionalProperties": {
         "type": "object",
         "properties": {
@@ -2745,9 +2617,6 @@
           },
           "tools": {
             "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
             "additionalProperties": {
               "type": "boolean"
             }
@@ -2788,9 +2657,6 @@
         },
         "plugins_override": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "boolean"
           }
@@ -3061,9 +2927,6 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
                     "additionalProperties": {}
                   },
                   "allowed-tools": {
@@ -3115,9 +2978,6 @@
         },
         "providerConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0
@@ -3125,9 +2985,6 @@
         },
         "modelConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0

--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.5.2",
-        "oh-my-opencode-darwin-x64": "3.5.2",
-        "oh-my-opencode-linux-arm64": "3.5.2",
-        "oh-my-opencode-linux-arm64-musl": "3.5.2",
-        "oh-my-opencode-linux-x64": "3.5.2",
-        "oh-my-opencode-linux-x64-musl": "3.5.2",
-        "oh-my-opencode-windows-x64": "3.5.2",
+        "oh-my-opencode-darwin-arm64": "3.5.3",
+        "oh-my-opencode-darwin-x64": "3.5.3",
+        "oh-my-opencode-linux-arm64": "3.5.3",
+        "oh-my-opencode-linux-arm64-musl": "3.5.3",
+        "oh-my-opencode-linux-x64": "3.5.3",
+        "oh-my-opencode-linux-x64-musl": "3.5.3",
+        "oh-my-opencode-windows-x64": "3.5.3",
       },
     },
   },
@@ -226,19 +226,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.5.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-oIS3lB2F9/N+3mF5wCKk6/EPVSz516XWN+mNdquSSeddw+xqMxGdhKY6K/XeYbHJzeN2Z8IOikNEJ6psR2/a8g=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.5.3", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Dq0+PC2dyAqG7c3DUnQmdOkKbKmOsRHwoqgLCQNKN1lTRllF8zbWqp5B+LGKxSPxPqJIPS3mKt+wIR2KvkYJVw=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.5.2", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-OAdXo4ZCCYO4kRWtnyz3tdmaGYPUB3WcXimXAxp+/sEZxAnh7n1RQkpLn6UxWX4AIAdRT9dfrOfRic6VoCYv2g=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.5.3", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Ke45Bv/ygZm3YUSUumIyk647KZ2PFzw30tH597cOpG8MDPGbNVBCM6EKFezcukUPT+gPFVpE1IiGzEkn4JmgZA=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.5.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-5XXNMFhp1VsyrGNRBoXcOyoaUeVkbrWkBRPDGZfpiq+kRXH3aaSWdR5G7Pl/TadOQv9Bl8/8YaxsuHRTFT1aXw=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.5.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-aP5S3DngUhFkNeqYM33Ge6zccCWLzB/O3FLXLFXy/Iws03N8xugw72pnMK6lUbIia9QQBKK7IZBoYm9C79pZ3g=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.5.2", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/woIpqvEI85MgJvEVnz4g5FBLeiQNK7srRsueIFPBmtTahh42HFleCDaIltOl/ndjsE5nCHacQVJHkC9W9/F3Q=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.5.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-UiD/hVKYZQyX4D5N5SnZT4M5Z/B2SDtJWBW4MibpYSAcPKNCEBKi/5E4hOPxAtTfFGR8tIXFmYZdQJDkVfvluw=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.5.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-vTL2A+6zzGhi+m7sC8peLDq5OAp2dRR0UEb4RbZAOHtlEruF7qFEmcK3ccWxwc3+Z3G/ITfwn5VNa72ZS4pNTg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.5.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-L9kqwzElGkaQ8pgtv1ZjcHARw9LPaU4UEVjzauByTMi+/5Js/PTsNXBggxSRzZfQ8/MNBPSCiA4K10Kc0YjjvA=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.5.2", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-bOAA55snLsK2QB00IkQy8le0Oqh/GJ7pxEHtm1oUezlQrW/nX5SS/hJ7dPHMmOd9FoiqnqyqWZxNkLmFoG463A=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.5.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Z0fVVih/b2dbNeb9DK9oca5dNYCZyPySBRtxRhDXod5d7fJNgIPrvUoEd3SNfkRGORyFB3hGBZ6nqQ6N8+8DEA=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.5.2", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-fnHiAPYglw3unPckmQBoCT6+VqjSWCE3S3J551mRo0ZFrxuEP2ZKyHZeFMMOtKwDepCvmKgd1W040+KmuVUXOA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.5.3", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-ocWPjRs2sJgN02PJnEIYtqdMVDex1YhEj1FzAU5XIicfzQbgxLh9nz1yhHZzfqGJq69QStU6ofpc5kQpfX1LMg=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -10,7 +10,14 @@ export function resolvePromptAppend(promptAppend: string, configDir?: string): s
   let filePath: string
   try {
     const decoded = decodeURIComponent(encoded)
-    const expanded = decoded.startsWith("~/") ? decoded.replace(/^~\//, `${homedir()}/`) : decoded
+    const expanded = decoded.startsWith("~/")
+      ? (() => {
+          const home = homedir().replace(/\\/g, "/")
+          const tail = decoded.slice(2).replace(/\\/g, "/")
+          if (tail.startsWith(`${home}/`)) return tail
+          return `${home}/${tail}`
+        })()
+      : decoded
     filePath = isAbsolute(expanded)
       ? expanded
       : resolve(configDir ?? process.cwd(), expanded)

--- a/src/config/schema/commands.ts
+++ b/src/config/schema/commands.ts
@@ -4,6 +4,7 @@ export const BuiltinCommandNameSchema = z.enum([
   "init-deep",
   "ralph-loop",
   "ulw-loop",
+  "audit-loop",
   "cancel-ralph",
   "refactor",
   "start-work",

--- a/src/features/builtin-commands/commands.test.ts
+++ b/src/features/builtin-commands/commands.test.ts
@@ -4,6 +4,51 @@ import { HANDOFF_TEMPLATE } from "./templates/handoff"
 import type { BuiltinCommandName } from "./types"
 
 describe("loadBuiltinCommands", () => {
+  test("should include audit-loop command in loaded commands", () => {
+    //#given
+    const disabledCommands: BuiltinCommandName[] = []
+
+    //#when
+    const commands = loadBuiltinCommands(disabledCommands)
+
+    //#then
+    expect(commands["audit-loop"]).toBeDefined()
+    expect(commands["audit-loop"].name).toBe("audit-loop")
+    expect(commands["audit-loop"].template).toContain("You are starting an Audit Loop")
+    expect(commands["audit-loop"].template).toContain("PHASE 10 COMPREHENSIVE PLAN")
+    expect(commands["audit-loop"].template).toContain("Focus Lock")
+    expect(commands["audit-loop"].template).toContain("AGENTS.md")
+    expect(commands["audit-loop"].template).toContain("AGENTS.md wins")
+    expect(commands["audit-loop"].template).toContain("Hardcoded component styling is prohibited")
+    expect(commands["audit-loop"].template).toContain("Component-token gate")
+    expect(commands["audit-loop"].template).toContain("Focus-Screen Completion Lock")
+    expect(commands["audit-loop"].template).toContain("Gate Status table")
+    expect(commands["audit-loop"].template).toContain("Deterministic validator pipeline")
+    expect(commands["audit-loop"].template).toContain("Adaptive agent policy")
+    expect(commands["audit-loop"].template).toContain("Required test delta")
+    expect(commands["audit-loop"].template).toContain("objective cap")
+    expect(commands["audit-loop"].template).toContain("Risk budget")
+    expect(commands["audit-loop"].template).toContain("Saturation / Freeze")
+    expect(commands["audit-loop"].template).toContain("Required-skills rule")
+    expect(commands["audit-loop"].template).toContain("Skill Coverage")
+    expect(commands["audit-loop"].template).toContain("at least 85% of edited files/changes")
+    expect(commands["audit-loop"].template).toContain("BLOCKER REPORT")
+    expect(commands["audit-loop"].template).toContain("Auto-progression rule")
+    expect(commands["audit-loop"].template).toContain("SCREEN COMPLETE")
+    expect(commands["audit-loop"].template).toContain("Required Cycle Evidence Format")
+  })
+
+  test("should exclude audit-loop when disabled", () => {
+    //#given
+    const disabledCommands: BuiltinCommandName[] = ["audit-loop"]
+
+    //#when
+    const commands = loadBuiltinCommands(disabledCommands)
+
+    //#then
+    expect(commands["audit-loop"]).toBeUndefined()
+  })
+
   test("should include handoff command in loaded commands", () => {
     //#given
     const disabledCommands: BuiltinCommandName[] = []

--- a/src/features/builtin-commands/commands.ts
+++ b/src/features/builtin-commands/commands.ts
@@ -2,6 +2,7 @@ import type { CommandDefinition } from "../claude-code-command-loader"
 import type { BuiltinCommandName, BuiltinCommands } from "./types"
 import { INIT_DEEP_TEMPLATE } from "./templates/init-deep"
 import { RALPH_LOOP_TEMPLATE, CANCEL_RALPH_TEMPLATE } from "./templates/ralph-loop"
+import { AUDIT_LOOP_TEMPLATE } from "./templates/audit-loop"
 import { STOP_CONTINUATION_TEMPLATE } from "./templates/stop-continuation"
 import { REFACTOR_TEMPLATE } from "./templates/refactor"
 import { START_WORK_TEMPLATE } from "./templates/start-work"
@@ -28,7 +29,7 @@ ${RALPH_LOOP_TEMPLATE}
 <user-task>
 $ARGUMENTS
 </user-task>`,
-     argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N]',
+     argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N] [--max-duration=3h]',
    },
    "ulw-loop": {
      description: "(builtin) Start ultrawork loop - continues until completion with ultrawork mode",
@@ -39,7 +40,18 @@ ${RALPH_LOOP_TEMPLATE}
 <user-task>
 $ARGUMENTS
 </user-task>`,
-     argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N]',
+     argumentHint: '"task description" [--completion-promise=TEXT] [--max-iterations=N] [--max-duration=3h]',
+   },
+   "audit-loop": {
+     description: "(builtin) Start 3-hour style audit loop with strict UI-first quality and hard timebox",
+     template: `<command-instruction>
+${AUDIT_LOOP_TEMPLATE}
+</command-instruction>
+
+<user-task>
+$ARGUMENTS
+</user-task>`,
+     argumentHint: '"task description" [--max-duration=3h] [--completion-promise=TEXT] [--max-iterations=N]',
    },
   "cancel-ralph": {
     description: "(builtin) Cancel active Ralph Loop",

--- a/src/features/builtin-commands/templates/audit-loop.ts
+++ b/src/features/builtin-commands/templates/audit-loop.ts
@@ -11,7 +11,7 @@ Run a repeated cycle until completion promise OR time limit:
 
 ## Non-Negotiable Constraints
 
-- DO NOT modify Supabase database-related logic, migrations, SQL schema, or DB commands
+- DO NOT modify database-layer logic, migrations, SQL schema, or DB commands
 - UI quality must be top-tier and intentional (Apple HIG-inspired interaction quality)
 - No AI-slop outputs: avoid generic layouts, weak hierarchy, and superficial restyling
 - Keep accessibility, clarity, and visual/system consistency high

--- a/src/features/builtin-commands/templates/audit-loop.ts
+++ b/src/features/builtin-commands/templates/audit-loop.ts
@@ -1,0 +1,125 @@
+export const AUDIT_LOOP_TEMPLATE = `You are starting an Audit Loop - a timeboxed, high-rigor improvement loop focused on top-tier UI quality.
+
+## Mission
+
+Run a repeated cycle until completion promise OR time limit:
+1. Audit the codebase deeply (focus UI/UX quality and frontend architecture first)
+2. Build and execute a PHASE 10 COMPREHENSIVE PLAN
+3. Implement substantial improvements (not a single tiny patch)
+4. Verify with tests/build/checks
+5. Re-audit and continue
+
+## Non-Negotiable Constraints
+
+- DO NOT modify Supabase database-related logic, migrations, SQL schema, or DB commands
+- UI quality must be top-tier and intentional (Apple HIG-inspired interaction quality)
+- No AI-slop outputs: avoid generic layouts, weak hierarchy, and superficial restyling
+- Keep accessibility, clarity, and visual/system consistency high
+- Follow AGENTS.md instructions strictly (root + nearest directory AGENTS.md files for touched code paths); if AGENTS rules conflict, AGENTS.md wins
+- Hardcoded component styling is prohibited: use global design tokens/theme primitives/shared UI components only (color/spacing/typography/radius/shadow/motion)
+- Required-skills rule: identify task-matched skills from AGENTS.md/skill catalog and use all required skills before implementation
+
+## Focus Lock (Required)
+
+- In cycle 1, choose ONE primary screen/surface as the focus target.
+- Keep improving that SAME screen repeatedly each loop (audit -> plan -> implement -> validate -> re-audit).
+- For timeboxed runs (default 3h), remain on the same screen for the full timebox unless blocked.
+- Do not switch screens unless truly blocked; if switching is unavoidable, explain why and continue with one new screen only.
+- Auto-progression rule: when the previous cycle includes SCREEN COMPLETE + Validation PASS + Regression Scan PASS, automatically move to the next highest-impact focus screen in the next cycle (no user instruction required).
+- Focus lock hard rule: at least 85% of edited files/changes per cycle must remain in the chosen screen path.
+- Switch blocker protocol: if you must switch screens for blocker reasons (not SCREEN COMPLETE progression), first write a BLOCKER REPORT with reason, attempted fixes, and why blocked.
+
+## Execution Hard Rules (Required Every Cycle)
+
+- Parallel research floor: before coding each cycle, launch at least 2 parallel explore/librarian tasks and use findings.
+- Adaptive agent policy: start with 2 parallel research agents; escalate to 4-6 when blocked, failing validation, or stagnant cycles.
+- Validation hard gate: do not start next loop until analyze/test/build checks were run and results were reported.
+- Deterministic validator pipeline: run analyze -> focused tests -> build in this exact order every cycle and report each exit status.
+- No-repeat guard: do not repeat the same plan items in consecutive cycles unless retry is required and approach changed.
+- Design-system enforcement: prefer tokens/reusable components; avoid one-off inline styles and hardcoded visual values.
+- Component-token gate: new/refactored UI components must consume global tokens; reject literal style values unless they are already defined token aliases.
+- A11y exit criteria: explicitly verify keyboard navigation, focus visibility/order, semantics/labels, and contrast.
+- Anti-micro-patch rule: if changes are too small, continue iterating in the same cycle until substantial improvements are delivered.
+- Stagnation protocol: if two consecutive cycles are near-identical, force strategy change (different refactor route + more research agents).
+- Time-budget policy per cycle: target ~20% audit/planning, ~50% implementation, ~30% validation + re-audit.
+- Max churn guard: avoid re-editing the same saturated file across repeated cycles once quality gates keep passing.
+- Required test delta: structural refactors must add or update at least one related test.
+- Cycle objective cap: keep Next-Cycle Targets to maximum 3.
+- Risk budget: at most one high-risk refactor per cycle.
+
+## Required Cycle Evidence Format
+
+End every cycle with:
+- Focus Screen: primary screen path and reason
+- Files Changed: list plus primary-screen ratio (%)
+- Commands Run: analyze/test/build commands with pass/fail
+- Screen Completion Signal: write SCREEN COMPLETE only when the current focus screen is truly complete and validated
+- Skill Coverage: Required Skills + Skills Used + why each was applied
+- Payload Checklist: structural refactor + removal/simplification + UX/a11y polish
+- Remaining UI Debt: unresolved issues and risk notes
+- Next-Cycle Targets: prioritized follow-ups on the same screen
+
+## Focus-Screen Completion Lock (Strict)
+
+If \`--completion-promise\` is used, completion is valid ONLY when every gate below is PASS:
+
+- Scope Coverage Gate: enumerate and review all files in the focus-screen path (include reviewed file list in report)
+- Issue Closure Gate: close all High/Medium issues for the focus screen, or explicitly waive each with rationale
+- Validation Gate: run analyze + related tests + build for touched scope; all required checks must pass
+- Accessibility Gate: verify keyboard traversal, focus order/visibility, semantics/labels, and contrast on the focus screen
+- Re-Audit Gate: perform a second audit pass after fixes and report no newly introduced High issues
+- Evidence Gate: publish a Gate Status table with PASS/FAIL for every gate
+- Regression Gate: include Regression Scan PASS each cycle
+- A11y Evidence Gate: include keyboard/focus/semantics/contrast checklist with PASS/FAIL
+- Test Delta Gate: include Test Delta PASS evidence for structural refactors
+- Risk Budget Gate: include High-Risk Refactors count (must be <= 1)
+- Objective Cap Gate: Next-Cycle Targets must be <= 3
+- Skill Coverage Gate: include Skill Coverage PASS and list Required Skills/Skills Used evidence
+
+If any gate is FAIL or missing evidence, DO NOT output completion promise and continue looping on the same focus screen.
+
+Saturation / Freeze:
+- When a focus file is saturated and repeatedly validated, freeze it.
+- Do not edit frozen files again unless BUG EVIDENCE or REGRESSION EVIDENCE is provided first.
+
+## PHASE 10 COMPREHENSIVE PLAN (Required Every Cycle)
+
+Before coding, write a concrete 10-phase plan for the current cycle and then execute all phases:
+
+1. Baseline: map current UI architecture and quality gaps
+2. Issue Ranking: prioritize highest-impact UI/UX and frontend engineering issues
+3. Additions: identify what should be added for quality/completeness
+4. Removals: identify what should be removed/simplified/de-duplicated
+5. Structural Refactor: improve component boundaries, composition, and maintainability
+6. Visual System: typography/spacing/color/hierarchy refinements to production quality
+7. Interaction Quality: states, transitions, feedback, and error UX polishing
+8. Accessibility: WCAG-aligned semantics, keyboard/focus, contrast, and labels
+9. Validation: run tests/build/checks and fix regressions
+10. Final Polish + Re-Prioritization: summarize outcomes and queue next cycle targets
+
+Minimum cycle workload:
+- Complete all 10 phases before ending a cycle
+- Include both "add" and "remove/simplify" changes
+- Deliver multiple meaningful improvements, not one minor change
+- Keep the same-screen focus lock active while iterating
+- Include at least: 1 structural refactor + 1 removal/simplification + 1 UX/a11y polish
+
+## Loop Control
+
+- If \`--completion-promise\` is provided, when fully complete output: \`<promise>{{COMPLETION_PROMISE}}</promise>\`
+- If \`--completion-promise\` is omitted, loop will continue until timebox/max-iterations/cancel
+- If promise is not output, continuation is injected automatically
+- Max iterations: configurable (default 100)
+- Max duration: configurable via \`--max-duration\` (default 3h)
+
+## Exit Conditions
+
+1. **Completion**: output completion promise tag
+2. **Timebox**: hard stop when max duration is reached
+3. **Max Iterations**: stop at iteration cap
+4. **Cancel**: user runs \`/cancel-ralph\` or \`/stop-continuation\`
+
+## Arguments
+
+Parse arguments in this format and begin immediately:
+\`"task description" [--max-duration=3h] [--completion-promise=TEXT] [--max-iterations=N]\``

--- a/src/features/builtin-commands/templates/ralph-loop.ts
+++ b/src/features/builtin-commands/templates/ralph-loop.ts
@@ -24,7 +24,7 @@ export const RALPH_LOOP_TEMPLATE = `You are starting a Ralph Loop - a self-refer
 ## Your Task
 
 Parse the arguments below and begin working on the task. The format is:
-\`"task description" [--completion-promise=TEXT] [--max-iterations=N]\`
+\`"task description" [--completion-promise=TEXT] [--max-iterations=N] [--max-duration=3h]\`
 
 Default completion promise is "DONE" and default max iterations is 100.`
 

--- a/src/features/builtin-commands/types.ts
+++ b/src/features/builtin-commands/types.ts
@@ -1,6 +1,6 @@
 import type { CommandDefinition } from "../claude-code-command-loader"
 
-export type BuiltinCommandName = "init-deep" | "ralph-loop" | "cancel-ralph" | "ulw-loop" | "refactor" | "start-work" | "stop-continuation" | "handoff"
+export type BuiltinCommandName = "init-deep" | "ralph-loop" | "cancel-ralph" | "ulw-loop" | "audit-loop" | "refactor" | "start-work" | "stop-continuation" | "handoff"
 
 export interface BuiltinCommandConfig {
   disabled_commands?: BuiltinCommandName[]

--- a/src/hooks/auto-slash-command/constants.ts
+++ b/src/hooks/auto-slash-command/constants.ts
@@ -9,4 +9,5 @@ export const EXCLUDED_COMMANDS = new Set([
   "ralph-loop",
   "cancel-ralph",
   "ulw-loop",
+  "audit-loop",
 ])

--- a/src/hooks/auto-slash-command/detector.test.ts
+++ b/src/hooks/auto-slash-command/detector.test.ts
@@ -174,12 +174,20 @@ After`
       expect(isExcludedCommand("cancel-ralph")).toBe(true)
     })
 
+    it("should exclude audit-loop", () => {
+      // given audit-loop command
+      // when checking exclusion
+      // then should be excluded
+      expect(isExcludedCommand("audit-loop")).toBe(true)
+    })
+
     it("should be case-insensitive for exclusion", () => {
       // given uppercase variants
       // when checking exclusion
       // then should still be excluded
       expect(isExcludedCommand("RALPH-LOOP")).toBe(true)
       expect(isExcludedCommand("Cancel-Ralph")).toBe(true)
+      expect(isExcludedCommand("Audit-Loop")).toBe(true)
     })
 
     it("should not exclude regular commands", () => {

--- a/src/hooks/auto-slash-command/index.test.ts
+++ b/src/hooks/auto-slash-command/index.test.ts
@@ -151,6 +151,21 @@ describe("createAutoSlashCommandHook", () => {
       // then should not modify
       expect(output.parts[0].text).toBe(originalText)
     })
+
+    it("should NOT trigger for audit-loop command", async () => {
+      // given audit-loop command
+      const hook = createAutoSlashCommandHook()
+      const sessionID = `test-session-audit-loop-${Date.now()}`
+      const input = createMockInput(sessionID)
+      const output = createMockOutput("/audit-loop \"run ui audit\" --max-duration=3h")
+      const originalText = output.parts[0].text
+
+      // when hook is called
+      await hook["chat.message"](input, output)
+
+      // then should not modify (excluded command)
+      expect(output.parts[0].text).toBe(originalText)
+    })
   })
 
   describe("already processed", () => {

--- a/src/hooks/ralph-loop/audit-ledger.ts
+++ b/src/hooks/ralph-loop/audit-ledger.ts
@@ -1,0 +1,224 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+
+export const DEFAULT_AUDIT_LEDGER_FILE = ".sisyphus/audit-loop-ledger.jsonl"
+export const DEFAULT_AUDIT_CHECKPOINT_FILE = ".sisyphus/audit-loop-checkpoint.json"
+
+export interface AuditLedgerEntry {
+  timestamp: string
+  session_id: string
+  iteration: number
+  mode?: string
+  event:
+    | "cycle_observed"
+    | "completion_blocked"
+    | "completed"
+    | "timeout"
+    | "max_iterations"
+    | "aborted"
+  focus_screen?: string
+  files_changed?: string
+  stagnation_detected?: boolean
+  missing_gates?: string[]
+}
+
+export interface AuditCyclePolicySummary {
+  focus_screen?: string
+  files_changed?: string
+  files: string[]
+  files_key: string
+  validation_pass: boolean
+  regression_scan_pass: boolean
+  objective_count: number
+  screen_complete: boolean
+}
+
+export interface AuditCheckpointState {
+  version: 1
+  updated_at: string
+  locked_files: string[]
+  recent_cycles: AuditCyclePolicySummary[]
+  consecutive_validation_failures: number
+  allow_focus_progression_once: boolean
+}
+
+export function appendAuditLedgerEntry(
+  directory: string,
+  entry: AuditLedgerEntry,
+): void {
+  const ledgerPath = join(directory, DEFAULT_AUDIT_LEDGER_FILE)
+  const ledgerDir = dirname(ledgerPath)
+  if (!existsSync(ledgerDir)) mkdirSync(ledgerDir, { recursive: true })
+  appendFileSync(ledgerPath, `${JSON.stringify(entry)}\n`, "utf-8")
+}
+
+export function writeAuditCheckpoint(
+  directory: string,
+  checkpoint: AuditCheckpointState | Record<string, unknown>,
+): void {
+  const checkpointPath = join(directory, DEFAULT_AUDIT_CHECKPOINT_FILE)
+  const checkpointDir = dirname(checkpointPath)
+  if (!existsSync(checkpointDir)) mkdirSync(checkpointDir, { recursive: true })
+  writeFileSync(checkpointPath, JSON.stringify(checkpoint, null, 2), "utf-8")
+}
+
+export function extractCycleEvidenceSummary(text: string | null): {
+  focus_screen?: string
+  files_changed?: string
+} {
+  if (!text) return {}
+  const lines = text.split(/\r?\n/).map((line) => line.trim())
+  const focusLine = lines.find((line) => /focus screen/i.test(line))
+  const filesLine = lines.find((line) => /files changed/i.test(line))
+
+  return {
+    focus_screen: focusLine,
+    files_changed: filesLine,
+  }
+}
+
+function lineHasPass(lines: string[], pattern: RegExp): boolean {
+  return lines.some(
+    (line) => pattern.test(line) && /(pass|passed|success|succeeded|ok|✅)/i.test(line),
+  )
+}
+
+function extractFiles(text: string): string[] {
+  const matches = text.match(/[A-Za-z0-9_./-]+\.(dart|ts|tsx|js|jsx|vue|css|scss)\b/gi) ?? []
+  const unique = [...new Set(matches.map((m) => m.replace(/\\/g, "/")))]
+  return unique
+}
+
+function countNextCycleTargets(lines: string[]): number {
+  const sectionStart = lines.findIndex((line) => /next-cycle targets/i.test(line))
+  if (sectionStart < 0) return 0
+  let count = 0
+  for (let i = sectionStart + 1; i < lines.length; i += 1) {
+    const line = lines[i].trim()
+    if (!line) continue
+    if (/^[A-Z][A-Za-z ]+:/.test(line)) break
+    if (/^[-*]\s+/.test(line) || /^\d+\.\s+/.test(line)) count += 1
+  }
+  return count
+}
+
+export function summarizeAuditCycleEvidence(text: string | null): AuditCyclePolicySummary {
+  const summary = extractCycleEvidenceSummary(text)
+  if (!text) {
+    return {
+      ...summary,
+      files: [],
+      files_key: "",
+      validation_pass: false,
+      regression_scan_pass: false,
+      objective_count: 0,
+      screen_complete: false,
+    }
+  }
+
+  const lines = text.split(/\r?\n/).map((line) => line.trim())
+  const files = extractFiles(summary.files_changed ?? text)
+  const sortedFiles = [...files].sort()
+
+  const analyzePassed = lineHasPass(lines, /(analyze|lint)/i)
+  const testPassed = lineHasPass(lines, /\btest(s)?\b/i)
+  const buildPassed = lineHasPass(lines, /\bbuild\b/i)
+  const regressionScanPassed = lineHasPass(lines, /regression scan/i)
+
+  return {
+    ...summary,
+    files: sortedFiles,
+    files_key: sortedFiles.join("|"),
+    validation_pass: analyzePassed && testPassed && buildPassed,
+    regression_scan_pass: regressionScanPassed,
+    objective_count: countNextCycleTargets(lines),
+    screen_complete: /screen complete/i.test(text),
+  }
+}
+
+function defaultCheckpoint(): AuditCheckpointState {
+  return {
+    version: 1,
+    updated_at: new Date().toISOString(),
+    locked_files: [],
+    recent_cycles: [],
+    consecutive_validation_failures: 0,
+    allow_focus_progression_once: false,
+  }
+}
+
+export function readAuditCheckpoint(directory: string): AuditCheckpointState {
+  const checkpointPath = join(directory, DEFAULT_AUDIT_CHECKPOINT_FILE)
+  if (!existsSync(checkpointPath)) return defaultCheckpoint()
+
+  try {
+    const parsed = JSON.parse(readFileSync(checkpointPath, "utf-8")) as Partial<AuditCheckpointState>
+    return {
+      version: 1,
+      updated_at: typeof parsed.updated_at === "string" ? parsed.updated_at : new Date().toISOString(),
+      locked_files: Array.isArray(parsed.locked_files)
+        ? parsed.locked_files.filter((v): v is string => typeof v === "string")
+        : [],
+      recent_cycles: Array.isArray(parsed.recent_cycles)
+        ? parsed.recent_cycles.filter((v): v is AuditCyclePolicySummary => typeof v === "object" && v !== null)
+        : [],
+      consecutive_validation_failures:
+        typeof parsed.consecutive_validation_failures === "number"
+          ? parsed.consecutive_validation_failures
+          : 0,
+      allow_focus_progression_once: parsed.allow_focus_progression_once === true,
+    }
+  } catch {
+    return defaultCheckpoint()
+  }
+}
+
+export function updateAuditCheckpointWithCycle(
+  directory: string,
+  cycle: AuditCyclePolicySummary,
+): {
+  checkpoint: AuditCheckpointState
+  lockedFilesAdded: string[]
+  forceStrategySwitch: boolean
+  objectiveCapViolation: boolean
+  regressionGateMissing: boolean
+  allowAutoFocusProgression: boolean
+} {
+  const checkpoint = readAuditCheckpoint(directory)
+  checkpoint.updated_at = new Date().toISOString()
+  checkpoint.recent_cycles = [...checkpoint.recent_cycles, cycle].slice(-6)
+  checkpoint.consecutive_validation_failures = cycle.validation_pass
+    ? 0
+    : checkpoint.consecutive_validation_failures + 1
+
+  const lockedFilesAdded: string[] = []
+  const lastThree = checkpoint.recent_cycles.slice(-3)
+  const sameFileSet =
+    lastThree.length === 3 &&
+    lastThree.every((c) => c.validation_pass) &&
+    lastThree.every((c) => c.files_key && c.files_key === lastThree[0].files_key)
+
+  if (sameFileSet) {
+    for (const file of lastThree[2].files) {
+      if (!checkpoint.locked_files.includes(file)) {
+        checkpoint.locked_files.push(file)
+        lockedFilesAdded.push(file)
+      }
+    }
+  }
+
+  checkpoint.locked_files = [...new Set(checkpoint.locked_files)].sort()
+  const allowAutoFocusProgression =
+    cycle.screen_complete && cycle.validation_pass && cycle.regression_scan_pass
+  checkpoint.allow_focus_progression_once = allowAutoFocusProgression
+  writeAuditCheckpoint(directory, checkpoint)
+
+  return {
+    checkpoint,
+    lockedFilesAdded,
+    forceStrategySwitch: checkpoint.consecutive_validation_failures >= 2,
+    objectiveCapViolation: cycle.objective_count > 3,
+    regressionGateMissing: !cycle.regression_scan_pass,
+    allowAutoFocusProgression,
+  }
+}

--- a/src/hooks/ralph-loop/command-args.test.ts
+++ b/src/hooks/ralph-loop/command-args.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import {
+  DEFAULT_AUDIT_LOOP_DURATION_MS,
+  DEFAULT_AUDIT_LOOP_MAX_ITERATIONS,
+  extractRawLoopArgs,
+  parseLoopCommandArgs,
+} from "./command-args"
+
+describe("ralph-loop command args parser", () => {
+  test("extractRawLoopArgs strips command prefix", () => {
+    expect(extractRawLoopArgs('/audit-loop "task" --max-duration=3h', "audit-loop")).toBe(
+      '"task" --max-duration=3h'
+    )
+  })
+
+  test("parseLoopCommandArgs parses duration and standard flags", () => {
+    const parsed = parseLoopCommandArgs(
+      '"Improve UI" --max-iterations=50 --completion-promise=DONE --max-duration=3h'
+    )
+
+    expect(parsed.prompt).toBe("Improve UI")
+    expect(parsed.maxIterations).toBe(50)
+    expect(parsed.completionPromise).toBe("DONE")
+    expect(parsed.hasExplicitCompletionPromise).toBe(true)
+    expect(parsed.maxDurationMs).toBe(3 * 60 * 60 * 1000)
+  })
+
+  test("parseLoopCommandArgs applies default audit duration", () => {
+    const parsed = parseLoopCommandArgs('"Improve UI"', { mode: "audit-loop" })
+    expect(parsed.maxDurationMs).toBe(DEFAULT_AUDIT_LOOP_DURATION_MS)
+    expect(parsed.maxIterations).toBe(DEFAULT_AUDIT_LOOP_MAX_ITERATIONS)
+    expect(parsed.hasExplicitCompletionPromise).toBe(false)
+  })
+
+  test("parseLoopCommandArgs throws on invalid duration format", () => {
+    expect(() => parseLoopCommandArgs('"Task" --max-duration=3hours')).toThrow(
+      "Invalid --max-duration value"
+    )
+  })
+})

--- a/src/hooks/ralph-loop/command-args.ts
+++ b/src/hooks/ralph-loop/command-args.ts
@@ -1,0 +1,90 @@
+import type { RalphLoopMode } from "./types"
+
+export interface ParsedLoopCommandArgs {
+  prompt: string
+  maxIterations?: number
+  completionPromise?: string
+  hasExplicitCompletionPromise: boolean
+  maxDurationMs?: number
+}
+
+export const DEFAULT_AUDIT_LOOP_DURATION_MS = 3 * 60 * 60 * 1000
+export const DEFAULT_AUDIT_LOOP_MAX_ITERATIONS = 100
+export const MAX_LOOP_DURATION_MS = 24 * 60 * 60 * 1000
+
+const MAX_ITERATIONS_PATTERN = /--max-iterations=(\d+)/i
+const COMPLETION_PROMISE_PATTERN = /--completion-promise=(?:"([^"]+)"|'([^']+)'|([^\s]+))/i
+const MAX_DURATION_PATTERN = /--max-duration=([^\s]+)/i
+const DURATION_PATTERN = /^(\d+)([smh])$/i
+
+function parseDurationToMs(raw: string): number {
+  const match = raw.trim().match(DURATION_PATTERN)
+  if (!match) {
+    throw new Error(
+      `Invalid --max-duration value "${raw}". Use formats like 30m, 2h, or 3600s.`
+    )
+  }
+
+  const value = Number(match[1])
+  const unit = match[2].toLowerCase()
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid --max-duration value "${raw}". Duration must be greater than 0.`)
+  }
+
+  const multiplier =
+    unit === "h" ? 60 * 60 * 1000 : unit === "m" ? 60 * 1000 : 1000
+  const ms = value * multiplier
+  if (ms > MAX_LOOP_DURATION_MS) {
+    throw new Error(
+      `Invalid --max-duration value "${raw}". Maximum allowed duration is 24h.`
+    )
+  }
+
+  return ms
+}
+
+export function extractRawLoopArgs(rawCommand: string | undefined, commandName: string): string {
+  if (!rawCommand) return ""
+  const pattern = new RegExp(`^/?(${commandName})\\s*`, "i")
+  return rawCommand.replace(pattern, "")
+}
+
+export function parseLoopCommandArgs(
+  rawArgs: string,
+  options?: { defaultPrompt?: string; mode?: RalphLoopMode }
+): ParsedLoopCommandArgs {
+  const defaultPrompt = options?.defaultPrompt ?? "Complete the task as instructed"
+  const trimmed = rawArgs.trim()
+  const taskMatch = trimmed.match(/^["']([\s\S]*?)["']/)
+  const prompt =
+    taskMatch?.[1] ??
+    trimmed.split(/\s+--/)[0]?.trim() ??
+    defaultPrompt
+
+  const parsed: ParsedLoopCommandArgs = {
+    prompt: prompt || defaultPrompt,
+    hasExplicitCompletionPromise: false,
+  }
+
+  const maxIterMatch = rawArgs.match(MAX_ITERATIONS_PATTERN)
+  if (maxIterMatch) {
+    parsed.maxIterations = Number.parseInt(maxIterMatch[1], 10)
+  } else if (options?.mode === "audit-loop") {
+    parsed.maxIterations = DEFAULT_AUDIT_LOOP_MAX_ITERATIONS
+  }
+
+  const promiseMatch = rawArgs.match(COMPLETION_PROMISE_PATTERN)
+  if (promiseMatch) {
+    parsed.completionPromise = promiseMatch[1] ?? promiseMatch[2] ?? promiseMatch[3]
+    parsed.hasExplicitCompletionPromise = true
+  }
+
+  const durationMatch = rawArgs.match(MAX_DURATION_PATTERN)
+  if (durationMatch) {
+    parsed.maxDurationMs = parseDurationToMs(durationMatch[1])
+  } else if (options?.mode === "audit-loop") {
+    parsed.maxDurationMs = DEFAULT_AUDIT_LOOP_DURATION_MS
+  }
+
+  return parsed
+}

--- a/src/hooks/ralph-loop/completion-promise-detector.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.ts
@@ -5,103 +5,297 @@ import { HOOK_NAME } from "./constants"
 import { withTimeout } from "./with-timeout"
 
 interface OpenCodeSessionMessage {
-	info?: { role?: string }
-	parts?: Array<{ type: string; text?: string }>
+  info?: { role?: string }
+  parts?: Array<{ type: string; text?: string }>
 }
 
+type TranscriptEntry = Record<string, unknown> & { type?: string }
+
 function escapeRegex(str: string): string {
-	return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
 function buildPromisePattern(promise: string): RegExp {
-	return new RegExp(`<promise>\\s*${escapeRegex(promise)}\\s*</promise>`, "is")
+  return new RegExp(`<promise>\\s*${escapeRegex(promise)}\\s*</promise>`, "is")
+}
+
+function readTranscriptEntries(transcriptPath: string | undefined): TranscriptEntry[] {
+  if (!transcriptPath || !existsSync(transcriptPath)) return []
+  try {
+    const content = readFileSync(transcriptPath, "utf-8")
+    const lines = content.split("\n").filter((line) => line.trim())
+    const entries: TranscriptEntry[] = []
+    for (const line of lines) {
+      try {
+        entries.push(JSON.parse(line) as TranscriptEntry)
+      } catch {
+        continue
+      }
+    }
+    return entries
+  } catch {
+    return []
+  }
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value
+  if (value === null || value === undefined) return ""
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function extractTextFromTranscriptEntry(entry: TranscriptEntry): string {
+  const chunks: string[] = []
+  if (typeof entry.content === "string") chunks.push(entry.content)
+  if (typeof entry.text === "string") chunks.push(entry.text)
+  if (typeof entry.output === "string") chunks.push(entry.output)
+
+  const info = entry.info as Record<string, unknown> | undefined
+  if (info && typeof info.text === "string") chunks.push(info.text)
+
+  if (Array.isArray(entry.parts)) {
+    for (const part of entry.parts) {
+      if (typeof part !== "object" || part === null) continue
+      const rec = part as Record<string, unknown>
+      if (typeof rec.text === "string") chunks.push(rec.text)
+    }
+  }
+
+  if ("tool_output" in entry) {
+    const toolOutput = entry.tool_output as Record<string, unknown> | string | undefined
+    if (
+      typeof toolOutput === "object" &&
+      toolOutput !== null &&
+      typeof toolOutput.output === "string"
+    ) {
+      chunks.push(toolOutput.output)
+    } else {
+      chunks.push(stringifyUnknown(entry.tool_output))
+    }
+  }
+  return chunks.filter(Boolean).join("\n")
+}
+
+function lineHasPass(lines: string[], pattern: RegExp): boolean {
+  return lines.some(
+    (line) => pattern.test(line) && /(pass|passed|success|succeeded|ok)/i.test(line),
+  )
+}
+
+function countNextCycleTargets(lines: string[]): number {
+  const start = lines.findIndex((line) => /next-cycle targets/i.test(line))
+  if (start < 0) return 0
+  let count = 0
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i]
+    if (!line) continue
+    if (/^[A-Z][A-Za-z ]+:/.test(line)) break
+    if (/^[-*]\s+/.test(line) || /^\d+\.\s+/.test(line)) count += 1
+  }
+  return count
+}
+
+export function getLatestNonUserTranscriptText(transcriptPath: string | undefined): string | null {
+  const entries = readTranscriptEntries(transcriptPath)
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const entry = entries[i]
+    if (entry.type === "user") continue
+    const text = extractTextFromTranscriptEntry(entry)
+    if (text.trim()) return text
+  }
+  return null
+}
+
+export function evaluateAuditCompletionLock(transcriptPath: string | undefined): {
+  passed: boolean
+  missing: string[]
+} {
+  const latestText = getLatestNonUserTranscriptText(transcriptPath)
+  if (!latestText) {
+    return { passed: false, missing: ["evidence text missing"] }
+  }
+
+  const lines = latestText.split(/\r?\n/).map((line) => line.trim())
+  const missing: string[] = []
+
+  if (!/gate status/i.test(latestText)) missing.push("Gate Status table")
+
+  const gates = [
+    { name: "Scope Coverage", pattern: /scope coverage/i },
+    { name: "Issue Closure", pattern: /issue closure/i },
+    { name: "Validation", pattern: /validation/i },
+    { name: "Accessibility", pattern: /(accessibility|a11y)/i },
+    { name: "Re-Audit", pattern: /re[- ]?audit/i },
+    { name: "Skill Coverage", pattern: /skill coverage/i },
+    { name: "Evidence", pattern: /evidence/i },
+  ]
+  for (const gate of gates) {
+    if (!lineHasPass(lines, gate.pattern)) missing.push(`${gate.name} PASS`)
+  }
+
+  const analyzePassed = lineHasPass(lines, /(analyze|lint)/i)
+  const testPassed = lineHasPass(lines, /\btest(s)?\b/i)
+  const buildPassed = lineHasPass(lines, /\bbuild\b/i)
+  if (!analyzePassed || !testPassed || !buildPassed) {
+    missing.push("deterministic validator pipeline (analyze/test/build PASS)")
+  }
+
+  if (!lineHasPass(lines, /regression scan/i)) missing.push("Regression Scan PASS")
+
+  const keyboardPassed = lineHasPass(lines, /keyboard/i)
+  const focusPassed = lineHasPass(lines, /\bfocus\b/i)
+  const semanticsPassed = lineHasPass(lines, /(semantics|labels)/i)
+  const contrastPassed = lineHasPass(lines, /contrast/i)
+  if (!keyboardPassed || !focusPassed || !semanticsPassed || !contrastPassed) {
+    missing.push("A11y checklist PASS (keyboard/focus/semantics/contrast)")
+  }
+
+  const testDeltaPassed =
+    lineHasPass(lines, /test delta/i) ||
+    lines.some((line) => /(added|updated).*(test|tests)/i.test(line)) ||
+    lines.some((line) => /(\.test\.|_test\.)/.test(line))
+  if (!testDeltaPassed) missing.push("Test Delta PASS")
+
+  const highRiskLine = lines.find((line) => /high[- ]?risk refactors?/i.test(line))
+  if (highRiskLine) {
+    const match = highRiskLine.match(/(\d+)/)
+    const count = match ? Number(match[1]) : 0
+    if (Number.isFinite(count) && count > 1) {
+      missing.push("Risk budget (high-risk refactors <= 1)")
+    }
+  } else {
+    missing.push("Risk budget evidence")
+  }
+
+  if (countNextCycleTargets(lines) > 3) {
+    missing.push("Objective cap (<= 3 next-cycle targets)")
+  }
+
+  if (!/focus screen/i.test(latestText)) missing.push("Focus Screen evidence")
+  if (!/files changed/i.test(latestText)) missing.push("Files Changed evidence")
+  if (!/required skills/i.test(latestText) || !/skills used/i.test(latestText)) {
+    missing.push("Required Skills evidence (Required Skills + Skills Used)")
+  }
+
+  const structural = lines.some((line) => /(structural refactor|refactor)/i.test(line))
+  const a11yOrUx = lines.some((line) => /(a11y|accessibility|ux)/i.test(line))
+  const cosmeticOnlySignals = lines.some((line) => /(visual|cosmetic|styling)/i.test(line))
+  if (cosmeticOnlySignals && !structural && !a11yOrUx) {
+    missing.push("No cosmetic-only cycle")
+  }
+
+  return { passed: missing.length === 0, missing }
+}
+
+function extractStagnationFingerprint(text: string): string | null {
+  const lines = text.split(/\r?\n/)
+  const focus = lines.find((line) => /focus screen/i.test(line)) ?? ""
+  const files = lines.find((line) => /files changed/i.test(line)) ?? ""
+  const nextTargets = lines.find((line) => /next-cycle targets/i.test(line)) ?? ""
+  const fingerprint = [focus, files, nextTargets]
+    .map((line) => line.toLowerCase().replace(/\s+/g, " ").trim())
+    .filter(Boolean)
+    .join(" | ")
+  return fingerprint || null
+}
+
+export function detectAuditCycleStagnation(transcriptPath: string | undefined): boolean {
+  const entries = readTranscriptEntries(transcriptPath)
+  const fingerprints: string[] = []
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const entry = entries[i]
+    if (entry.type === "user") continue
+    const text = extractTextFromTranscriptEntry(entry)
+    if (!/files changed/i.test(text) || !/next-cycle targets/i.test(text)) continue
+    const fingerprint = extractStagnationFingerprint(text)
+    if (fingerprint) fingerprints.push(fingerprint)
+    if (fingerprints.length >= 2) break
+  }
+  if (fingerprints.length < 2) return false
+  return fingerprints[0] === fingerprints[1]
 }
 
 export function detectCompletionInTranscript(
-	transcriptPath: string | undefined,
-	promise: string,
+  transcriptPath: string | undefined,
+  promise: string,
 ): boolean {
-	if (!transcriptPath) return false
-
-	try {
-		if (!existsSync(transcriptPath)) return false
-
-		const content = readFileSync(transcriptPath, "utf-8")
-		const pattern = buildPromisePattern(promise)
-		const lines = content.split("\n").filter((line) => line.trim())
-
-		for (const line of lines) {
-			try {
-				const entry = JSON.parse(line) as { type?: string }
-				if (entry.type === "user") continue
-				if (pattern.test(line)) return true
-			} catch {
-				continue
-			}
-		}
-		return false
-	} catch {
-		return false
-	}
+  if (!transcriptPath || !existsSync(transcriptPath)) return false
+  try {
+    const pattern = buildPromisePattern(promise)
+    const lines = readFileSync(transcriptPath, "utf-8").split("\n").filter((line) => line.trim())
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as { type?: string }
+        if (entry.type === "user") continue
+        if (pattern.test(line)) return true
+      } catch {
+        continue
+      }
+    }
+    return false
+  } catch {
+    return false
+  }
 }
 
 export async function detectCompletionInSessionMessages(
-	ctx: PluginInput,
-	options: {
-		sessionID: string
-		promise: string
-		apiTimeoutMs: number
-		directory: string
-	},
+  ctx: PluginInput,
+  options: {
+    sessionID: string
+    promise: string
+    apiTimeoutMs: number
+    directory: string
+  },
 ): Promise<boolean> {
-	try {
-		const response = await withTimeout(
-			ctx.client.session.messages({
-				path: { id: options.sessionID },
-				query: { directory: options.directory },
-			}),
-			options.apiTimeoutMs,
-		)
+  try {
+    const response = await withTimeout(
+      ctx.client.session.messages({
+        path: { id: options.sessionID },
+        query: { directory: options.directory },
+      }),
+      options.apiTimeoutMs,
+    )
 
-		const messagesResponse: unknown = response
-		const responseData =
-			typeof messagesResponse === "object" && messagesResponse !== null && "data" in messagesResponse
-				? (messagesResponse as { data?: unknown }).data
-				: undefined
+    const responseData =
+      typeof response === "object" && response !== null && "data" in response
+        ? (response as { data?: unknown }).data
+        : undefined
 
-		const messageArray: unknown[] = Array.isArray(messagesResponse)
-			? messagesResponse
-			: Array.isArray(responseData)
-				? responseData
-				: []
+    const messageArray: unknown[] = Array.isArray(response)
+      ? response
+      : Array.isArray(responseData)
+        ? responseData
+        : []
 
-		const assistantMessages = (messageArray as OpenCodeSessionMessage[]).filter((msg) => msg.info?.role === "assistant")
-		if (assistantMessages.length === 0) return false
+    const assistantMessages = (messageArray as OpenCodeSessionMessage[]).filter(
+      (msg) => msg.info?.role === "assistant",
+    )
+    if (assistantMessages.length === 0) return false
 
-		const pattern = buildPromisePattern(options.promise)
-		const recentAssistants = assistantMessages.slice(-3)
-		for (const assistant of recentAssistants) {
-			if (!assistant.parts) continue
+    const pattern = buildPromisePattern(options.promise)
+    const recentAssistants = assistantMessages.slice(-3)
+    for (const assistant of recentAssistants) {
+      if (!assistant.parts) continue
+      let responseText = ""
+      for (const part of assistant.parts) {
+        if (part.type !== "text") continue
+        responseText += `${responseText ? "\n" : ""}${part.text ?? ""}`
+      }
+      if (pattern.test(responseText)) return true
+    }
 
-			let responseText = ""
-			for (const part of assistant.parts) {
-				if (part.type !== "text") continue
-				responseText += `${responseText ? "\n" : ""}${part.text ?? ""}`
-			}
-
-			if (pattern.test(responseText)) {
-				return true
-			}
-		}
-
-		return false
-	} catch (err) {
-		setTimeout(() => {
-			log(`[${HOOK_NAME}] Session messages check failed`, {
-				sessionID: options.sessionID,
-				error: String(err),
-			})
-		}, 0)
-		return false
-	}
+    return false
+  } catch (err) {
+    setTimeout(() => {
+      log(`[${HOOK_NAME}] Session messages check failed`, {
+        sessionID: options.sessionID,
+        error: String(err),
+      })
+    }, 0)
+    return false
+  }
 }

--- a/src/hooks/ralph-loop/continuation-prompt-builder.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-builder.ts
@@ -14,8 +14,137 @@ IMPORTANT:
 Original task:
 {{PROMPT}}`
 
+const AUDIT_LOOP_CONTINUATION_PROMPT = `${SYSTEM_DIRECTIVE_PREFIX} - AUDIT LOOP {{ITERATION}}/{{MAX}}]
+
+Continue the audit-improve cycle with UI-first focus.
+
+MANDATORY RULES:
+- DO NOT modify Supabase database-related logic, migrations, SQL schema, or DB commands
+- Follow AGENTS.md instructions strictly (root + nearest AGENTS.md files in edited directories); if AGENTS rules conflict, AGENTS.md wins
+- Required-skills rule: identify task-matched skills and use all required skills for the cycle
+- Prioritize top-tier UI quality inspired by production standards (Apple HIG-level rigor)
+- No AI-slop patterns: avoid generic layouts and superficial cosmetic edits
+- Maintain strong visual hierarchy, accessibility, interaction quality, and design consistency
+- Hardcoded component styling is prohibited: use global design tokens/theme primitives/shared UI components only
+- Validate each iteration (tests/build/checks when applicable)
+- Start by writing a PHASE 10 COMPREHENSIVE PLAN (add/remove/refactor/polish)
+- Execute all 10 phases before considering this cycle complete
+- Do not stop after one small patch; perform a substantial multi-change cycle
+- Keep improving the SAME primary screen selected in iteration 1; do not switch screens unless blocked
+- At least 85% of file edits must stay in the primary screen path
+- Auto-progression rule: if previous cycle shows SCREEN COMPLETE + Validation PASS + Regression Scan PASS, switch once to the next highest-impact screen automatically (no user instruction and no blocker report needed)
+- If switching screens for blocker reasons (not SCREEN COMPLETE progression), first write BLOCKER REPORT: reason, attempted fixes, why blocked
+- Before coding each cycle, run at least 2 parallel explore/librarian research tasks
+- Adaptive agent policy: increase research agents to 4-6 when blocked, validation fails, or stagnation is detected
+- Do not start next loop until analyze/test/build checks are run and reported
+- Deterministic validator pipeline: run analyze -> focused tests -> build in that order with explicit pass/fail
+- Regression gate: include Regression Scan PASS in cycle evidence before new implementation
+- Do not repeat identical plan items across consecutive loops unless retry strategy changed
+- Use design tokens/reusable components, avoid one-off inline hardcoded visual styles
+- Component-token gate: new/refactored UI components must consume global tokens; reject literal style values unless they are token aliases
+- Explicitly verify keyboard navigation, focus order/visibility, semantics/labels, and contrast
+- Payload minimum per cycle: structural refactor + removal/simplification + UX/a11y polish
+- Required test delta: structural refactors must add/update at least one related test
+- Risk budget: maximum one high-risk refactor per cycle
+- Objective cap: keep Next-Cycle Targets to at most 3 items
+- If changes are too small, continue same cycle (anti-micro-patch)
+- Focus-Screen Completion Lock: if using completion promise, only complete when all gates pass (Scope Coverage, Issue Closure, Validation, Accessibility, Re-Audit, Evidence)
+- Time-budget policy per cycle: spend ~20% on audit/planning, ~50% on implementation, ~30% on validation/re-audit
+- File freeze rule: saturated files stay locked unless BUG EVIDENCE or REGRESSION EVIDENCE is supplied
+
+Required end-of-cycle evidence:
+- Focus Screen
+- Files Changed + primary-screen ratio (%)
+- Commands Run + pass/fail
+- Screen Completion Signal (SCREEN COMPLETE only when current focus screen is complete + validated)
+- Payload Checklist
+- Remaining UI Debt
+- Next-Cycle Targets on same screen
+- Gate Status table (PASS/FAIL for Scope Coverage, Issue Closure, Validation, Accessibility, Re-Audit, Evidence)
+- Skill Coverage (Required Skills + Skills Used + PASS/FAIL)
+
+Only when all 10 phases are genuinely completed and validated AND every completion-lock gate is PASS, output: <promise>{{PROMISE}}</promise>
+
+Original task:
+{{PROMPT}}`
+
+const AUDIT_LOOP_CONTINUATION_NO_PROMISE_PROMPT = `${SYSTEM_DIRECTIVE_PREFIX} - AUDIT LOOP {{ITERATION}}/{{MAX}}]
+
+Continue the audit-improve cycle with UI-first focus.
+
+MANDATORY RULES:
+- DO NOT modify Supabase database-related logic, migrations, SQL schema, or DB commands
+- Follow AGENTS.md instructions strictly (root + nearest AGENTS.md files in edited directories); if AGENTS rules conflict, AGENTS.md wins
+- Required-skills rule: identify task-matched skills and use all required skills for the cycle
+- Prioritize top-tier UI quality inspired by production standards (Apple HIG-level rigor)
+- No AI-slop patterns: avoid generic layouts and superficial cosmetic edits
+- Maintain strong visual hierarchy, accessibility, interaction quality, and design consistency
+- Hardcoded component styling is prohibited: use global design tokens/theme primitives/shared UI components only
+- Validate each iteration (tests/build/checks when applicable)
+- Start by writing a PHASE 10 COMPREHENSIVE PLAN (add/remove/refactor/polish)
+- Execute all 10 phases before ending the cycle
+- Include both additive improvements and simplification/removal improvements
+- Keep improving the SAME primary screen selected in iteration 1; do not switch screens unless blocked
+- At least 85% of file edits must stay in the primary screen path
+- Auto-progression rule: if previous cycle shows SCREEN COMPLETE + Validation PASS + Regression Scan PASS, switch once to the next highest-impact screen automatically (no user instruction and no blocker report needed)
+- If switching screens for blocker reasons (not SCREEN COMPLETE progression), first write BLOCKER REPORT: reason, attempted fixes, why blocked
+- Before coding each cycle, run at least 2 parallel explore/librarian research tasks
+- Adaptive agent policy: increase research agents to 4-6 when blocked, validation fails, or stagnation is detected
+- Do not start next loop until analyze/test/build checks are run and reported
+- Deterministic validator pipeline: run analyze -> focused tests -> build in that order with explicit pass/fail
+- Regression gate: include Regression Scan PASS in cycle evidence before new implementation
+- Do not repeat identical plan items across consecutive loops unless retry strategy changed
+- Use design tokens/reusable components, avoid one-off inline hardcoded visual styles
+- Component-token gate: new/refactored UI components must consume global tokens; reject literal style values unless they are token aliases
+- Explicitly verify keyboard navigation, focus order/visibility, semantics/labels, and contrast
+- Payload minimum per cycle: structural refactor + removal/simplification + UX/a11y polish
+- Required test delta: structural refactors must add/update at least one related test
+- Risk budget: maximum one high-risk refactor per cycle
+- Objective cap: keep Next-Cycle Targets to at most 3 items
+- If changes are too small, continue same cycle (anti-micro-patch)
+- Apply Focus-Screen Completion Lock discipline every cycle (Scope Coverage, Issue Closure, Validation, Accessibility, Re-Audit, Evidence)
+- Time-budget policy per cycle: spend ~20% on audit/planning, ~50% on implementation, ~30% on validation/re-audit
+- File freeze rule: saturated files stay locked unless BUG EVIDENCE or REGRESSION EVIDENCE is supplied
+
+Required end-of-cycle evidence:
+- Focus Screen
+- Files Changed + primary-screen ratio (%)
+- Commands Run + pass/fail
+- Screen Completion Signal (SCREEN COMPLETE only when current focus screen is complete + validated)
+- Payload Checklist
+- Remaining UI Debt
+- Next-Cycle Targets on same screen
+- Gate Status table (PASS/FAIL for Scope Coverage, Issue Closure, Validation, Accessibility, Re-Audit, Evidence)
+- Skill Coverage (Required Skills + Skills Used + PASS/FAIL)
+
+Do NOT stop early. Keep iterating until timebox, max iterations, or explicit user stop command.
+
+Original task:
+{{PROMPT}}`
+
+const TIMEOUT_SUMMARY_PROMPT = `${SYSTEM_DIRECTIVE_PREFIX} - RALPH LOOP TIMEBOX ENDED]
+
+Hard time limit reached. STOP implementation now.
+
+Provide a final report only:
+1. Highest-impact issues found
+2. Improvements completed
+3. Validation results (tests/build/checks)
+4. Remaining risks / unfinished items
+5. Suggested next wave priorities
+`
+
 export function buildContinuationPrompt(state: RalphLoopState): string {
-	const continuationPrompt = CONTINUATION_PROMPT.replace(
+  const useAuditTemplateWithoutPromise =
+    state.mode === "audit-loop" && state.completion_detection_enabled === false
+	const baseTemplate =
+		state.mode === "audit-loop"
+      ? useAuditTemplateWithoutPromise
+        ? AUDIT_LOOP_CONTINUATION_NO_PROMISE_PROMPT
+        : AUDIT_LOOP_CONTINUATION_PROMPT
+      : CONTINUATION_PROMPT
+
+	const continuationPrompt = baseTemplate.replace(
 		"{{ITERATION}}",
 		String(state.iteration),
 	)
@@ -24,4 +153,21 @@ export function buildContinuationPrompt(state: RalphLoopState): string {
 		.replace("{{PROMPT}}", state.prompt)
 
 	return state.ultrawork ? `ultrawork ${continuationPrompt}` : continuationPrompt
+}
+
+export function buildTimeoutSummaryPrompt(state: RalphLoopState): string {
+  if (state.mode === "audit-loop") {
+    return `${TIMEOUT_SUMMARY_PROMPT}
+
+Audit-loop specific constraints reminder:
+- Confirm that no Supabase DB mutation was performed.
+- Keep recommendations UI-first and production-grade.
+- Confirm AGENTS.md instructions were followed for touched paths.
+- Confirm UI styling changes use global tokens/shared components (no hardcoded literal visual values).
+- Include final Gate Status table for the focus-screen completion lock.
+- Include final Skill Coverage evidence (Required Skills + Skills Used + PASS/FAIL).
+`
+  }
+
+  return TIMEOUT_SUMMARY_PROMPT
 }

--- a/src/hooks/ralph-loop/continuation-prompt-builder.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-builder.ts
@@ -19,7 +19,7 @@ const AUDIT_LOOP_CONTINUATION_PROMPT = `${SYSTEM_DIRECTIVE_PREFIX} - AUDIT LOOP 
 Continue the audit-improve cycle with UI-first focus.
 
 MANDATORY RULES:
-- DO NOT modify Supabase database-related logic, migrations, SQL schema, or DB commands
+- DO NOT modify database-layer logic, migrations, SQL schema, or DB commands
 - Follow AGENTS.md instructions strictly (root + nearest AGENTS.md files in edited directories); if AGENTS rules conflict, AGENTS.md wins
 - Required-skills rule: identify task-matched skills and use all required skills for the cycle
 - Prioritize top-tier UI quality inspired by production standards (Apple HIG-level rigor)
@@ -73,7 +73,7 @@ const AUDIT_LOOP_CONTINUATION_NO_PROMISE_PROMPT = `${SYSTEM_DIRECTIVE_PREFIX} - 
 Continue the audit-improve cycle with UI-first focus.
 
 MANDATORY RULES:
-- DO NOT modify Supabase database-related logic, migrations, SQL schema, or DB commands
+- DO NOT modify database-layer logic, migrations, SQL schema, or DB commands
 - Follow AGENTS.md instructions strictly (root + nearest AGENTS.md files in edited directories); if AGENTS rules conflict, AGENTS.md wins
 - Required-skills rule: identify task-matched skills and use all required skills for the cycle
 - Prioritize top-tier UI quality inspired by production standards (Apple HIG-level rigor)
@@ -160,7 +160,7 @@ export function buildTimeoutSummaryPrompt(state: RalphLoopState): string {
     return `${TIMEOUT_SUMMARY_PROMPT}
 
 Audit-loop specific constraints reminder:
-- Confirm that no Supabase DB mutation was performed.
+- Confirm that no database-layer mutation was performed.
 - Keep recommendations UI-first and production-grade.
 - Confirm AGENTS.md instructions were followed for touched paths.
 - Confirm UI styling changes use global tokens/shared components (no hardcoded literal visual values).

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -322,7 +322,7 @@ describe("ralph-loop", () => {
       // then - continuation prompt should use audit template
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].text).toContain("AUDIT LOOP")
-      expect(promptCalls[0].text).toContain("DO NOT modify Supabase")
+      expect(promptCalls[0].text).toContain("DO NOT modify database-layer logic")
       expect(promptCalls[0].text).toContain("AGENTS.md")
       expect(promptCalls[0].text).toContain("AGENTS.md wins")
       expect(promptCalls[0].text).toContain("Hardcoded component styling is prohibited")

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -171,6 +171,33 @@ describe("ralph-loop", () => {
       // then - multiline prompt preserved
       expect(readResult?.prompt).toBe("Build a feature\nwith multiple lines\nand requirements")
     })
+
+    test("should persist mode and timebox metadata fields", () => {
+      // given - state with audit-loop metadata
+      const state: RalphLoopState = {
+        active: true,
+        iteration: 2,
+        max_iterations: 20,
+        completion_promise: "DONE",
+        started_at: "2025-12-30T02:00:00Z",
+        prompt: "Audit UI",
+        session_id: "session-timebox",
+        mode: "audit-loop",
+        max_duration_ms: 10_800_000,
+        deadline_at: "2025-12-30T05:00:00Z",
+        stop_reason: "timeout",
+      }
+
+      // when - write and read state
+      writeState(TEST_DIR, state)
+      const readResult = readState(TEST_DIR)
+
+      // then - metadata fields should be preserved
+      expect(readResult?.mode).toBe("audit-loop")
+      expect(readResult?.max_duration_ms).toBe(10_800_000)
+      expect(readResult?.deadline_at).toBe("2025-12-30T05:00:00Z")
+      expect(readResult?.stop_reason).toBe("timeout")
+    })
   })
 
   describe("hook", () => {
@@ -219,6 +246,37 @@ describe("ralph-loop", () => {
       expect(state?.ultrawork).toBeUndefined()
     })
 
+    test("should enable completion detection by default", () => {
+      // given - hook instance
+      const hook = createRalphLoopHook(createMockPluginInput())
+
+      // when - start loop with default options
+      hook.startLoop("session-123", "Build something")
+
+      // then - completion detection is enabled
+      const state = hook.getState()
+      expect(state?.completion_detection_enabled).toBe(true)
+    })
+
+    test("should persist audit-loop mode and max duration when startLoop receives timebox options", () => {
+      // given - hook instance
+      const hook = createRalphLoopHook(createMockPluginInput())
+
+      // when - start audit-loop with explicit max duration
+      hook.startLoop("session-123", "Audit and improve UI", {
+        mode: "audit-loop",
+        ultrawork: true,
+        maxDurationMs: 7_200_000,
+      })
+
+      // then - state should carry mode + duration metadata
+      const state = hook.getState()
+      expect(state?.mode).toBe("audit-loop")
+      expect(state?.max_duration_ms).toBe(7_200_000)
+      expect(state?.deadline_at).toBeString()
+      expect(Number.isNaN(Date.parse(state?.deadline_at ?? ""))).toBe(false)
+    })
+
     test("should inject continuation when loop active and no completion detected", async () => {
       // given - active loop state
       const hook = createRalphLoopHook(createMockPluginInput())
@@ -242,6 +300,305 @@ describe("ralph-loop", () => {
       // then - iteration should be incremented
       const state = hook.getState()
       expect(state?.iteration).toBe(2)
+    })
+
+    test("should use audit-loop continuation prompt when mode is audit-loop", async () => {
+      // given - active audit-loop state
+      const hook = createRalphLoopHook(createMockPluginInput())
+      hook.startLoop("session-123", "Deep UI audit", {
+        mode: "audit-loop",
+        ultrawork: true,
+        maxIterations: 10,
+      })
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - continuation prompt should use audit template
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain("AUDIT LOOP")
+      expect(promptCalls[0].text).toContain("DO NOT modify Supabase")
+      expect(promptCalls[0].text).toContain("AGENTS.md")
+      expect(promptCalls[0].text).toContain("AGENTS.md wins")
+      expect(promptCalls[0].text).toContain("Hardcoded component styling is prohibited")
+      expect(promptCalls[0].text).toContain("Component-token gate")
+      expect(promptCalls[0].text).toContain("Focus-Screen Completion Lock")
+      expect(promptCalls[0].text).toContain("Deterministic validator pipeline")
+      expect(promptCalls[0].text).toContain("Adaptive agent policy")
+      expect(promptCalls[0].text).toContain("Required test delta")
+      expect(promptCalls[0].text).toContain("Objective cap")
+      expect(promptCalls[0].text).toContain("Risk budget")
+      expect(promptCalls[0].text).toContain("Required-skills rule")
+      expect(promptCalls[0].text).toContain("Skill Coverage")
+      expect(promptCalls[0].text).toContain("SAME primary screen")
+      expect(promptCalls[0].text).toContain("85% of file edits")
+      expect(promptCalls[0].text).toContain("BLOCKER REPORT")
+      expect(promptCalls[0].text).toContain("Auto-progression rule")
+      expect(promptCalls[0].text).toContain("SCREEN COMPLETE")
+      expect(promptCalls[0].text).toContain("Gate Status table")
+      expect(promptCalls[0].text).toContain("Required end-of-cycle evidence")
+      expect(promptCalls[0].text).toContain("Deep UI audit")
+    })
+
+    test("should show audit-loop heartbeat toast with remaining time", async () => {
+      // given - active audit-loop state
+      const hook = createRalphLoopHook(createMockPluginInput())
+      hook.startLoop("session-123", "Deep UI audit", {
+        mode: "audit-loop",
+        ultrawork: true,
+        maxIterations: 10,
+        maxDurationMs: 3 * 60 * 60 * 1000,
+      })
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - heartbeat toast should identify audit-loop and show time-left hint
+      expect(
+        toastCalls.some(
+          (t) =>
+            t.title === "Audit Loop Active" &&
+            t.message.includes("Iteration 2/10") &&
+            t.message.includes("Time left:"),
+        ),
+      ).toBe(true)
+    })
+
+    test("should append stagnation alert when audit evidence repeats across cycles", async () => {
+      // given - transcript with repeated cycle evidence fingerprints
+      const transcriptPath = join(TEST_DIR, "transcript-stagnation.jsonl")
+      writeFileSync(
+        transcriptPath,
+        [
+          JSON.stringify({
+            type: "tool_result",
+            tool_name: "write",
+            tool_output: {
+              output:
+                "Files Changed: lib/screens/settings/settings_screen.dart\nNext-Cycle Targets: refine settings a11y",
+            },
+          }),
+          JSON.stringify({
+            type: "tool_result",
+            tool_name: "write",
+            tool_output: {
+              output:
+                "Files Changed: lib/screens/settings/settings_screen.dart\nNext-Cycle Targets: refine settings a11y",
+            },
+          }),
+        ].join("\n") + "\n",
+      )
+
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
+      hook.startLoop("session-123", "Deep UI audit", {
+        mode: "audit-loop",
+        ultrawork: true,
+        maxIterations: 10,
+      })
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - continuation includes stagnation override
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain("STAGNATION ALERT")
+      expect(promptCalls[0].text).toContain("increase parallel research agents")
+    })
+
+    test("should append objective-cap and regression-gate alerts when evidence is missing", async () => {
+      // given - transcript with too many next targets and no regression scan pass
+      const transcriptPath = join(TEST_DIR, "transcript-gate-alerts.jsonl")
+      writeFileSync(
+        transcriptPath,
+        JSON.stringify({
+          type: "tool_result",
+          tool_name: "write",
+          tool_output: {
+            output: [
+              "Focus Screen: lib/screens/settings/settings_screen.dart",
+              "Files Changed: lib/screens/settings/settings_screen.dart",
+              "Commands Run:",
+              "- flutter analyze ... PASS",
+              "- flutter test ... PASS",
+              "- flutter build ... PASS",
+              "Next-Cycle Targets:",
+              "1. item one",
+              "2. item two",
+              "3. item three",
+              "4. item four",
+            ].join("\n"),
+          },
+        }) + "\n",
+      )
+
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
+      hook.startLoop("session-123", "Deep UI audit", {
+        mode: "audit-loop",
+        ultrawork: true,
+        maxIterations: 10,
+      })
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - continuation includes policy alerts
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain("OBJECTIVE CAP VIOLATION")
+      expect(promptCalls[0].text).toContain("REGRESSION GATE VIOLATION")
+    })
+
+    test("should append auto-focus progression alert after SCREEN COMPLETE with passing gates", async () => {
+      // given - transcript proving current screen is complete and validated
+      const transcriptPath = join(TEST_DIR, "transcript-auto-focus-progression.jsonl")
+      writeFileSync(
+        transcriptPath,
+        JSON.stringify({
+          type: "tool_result",
+          tool_name: "write",
+          tool_output: {
+            output: [
+              "Focus Screen: lib/screens/settings/settings_screen.dart",
+              "Files Changed: lib/screens/settings/settings_screen.dart",
+              "Commands Run:",
+              "- flutter analyze ... PASS",
+              "- flutter test ... PASS",
+              "- flutter build ... PASS",
+              "- Regression Scan ... PASS",
+              "SCREEN COMPLETE",
+            ].join("\n"),
+          },
+        }) + "\n",
+      )
+
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
+      hook.startLoop("session-123", "Deep UI audit", {
+        mode: "audit-loop",
+        ultrawork: true,
+        maxIterations: 10,
+      })
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - continuation includes auto focus progression directive
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain("AUTO FOCUS PROGRESSION")
+      expect(promptCalls[0].text).toContain("do not require BLOCKER REPORT")
+    })
+
+    test("should append rollback trigger after consecutive validation failures", async () => {
+      // given - transcript evidence with failing validation signals
+      const transcriptPath = join(TEST_DIR, "transcript-rollback-trigger.jsonl")
+      writeFileSync(
+        transcriptPath,
+        JSON.stringify({
+          type: "tool_result",
+          tool_name: "write",
+          tool_output: {
+            output: [
+              "Focus Screen: lib/screens/settings/settings_screen.dart",
+              "Files Changed: lib/screens/settings/settings_screen.dart",
+              "Commands Run:",
+              "- flutter analyze ... FAIL",
+              "- flutter test ... FAIL",
+              "- flutter build ... FAIL",
+            ].join("\n"),
+          },
+        }) + "\n",
+      )
+
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
+      hook.startLoop("session-123", "Deep UI audit", {
+        mode: "audit-loop",
+        ultrawork: true,
+        maxIterations: 10,
+      })
+
+      // when - two cycles pass with failed validation
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - second continuation includes rollback trigger
+      expect(promptCalls.length).toBe(2)
+      expect(promptCalls[1].text).toContain("ROLLBACK TRIGGER")
+    })
+
+    test("should stop on expired deadline and inject timeout summary prompt", async () => {
+      // given - active loop with expired deadline
+      const hook = createRalphLoopHook(createMockPluginInput())
+      const expiredState: RalphLoopState = {
+        active: true,
+        iteration: 3,
+        max_iterations: 10,
+        completion_promise: "DONE",
+        started_at: "2025-12-30T01:00:00Z",
+        prompt: "Deep UI audit",
+        session_id: "session-123",
+        mode: "audit-loop",
+        ultrawork: true,
+        max_duration_ms: 1000,
+        deadline_at: new Date(Date.now() - 30_000).toISOString(),
+      }
+      writeState(TEST_DIR, expiredState)
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - loop should be cleared and timeout summary injected once
+      expect(hook.getState()).toBeNull()
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain("RALPH LOOP TIMEBOX ENDED")
+      expect(promptCalls[0].text).toContain("Audit-loop specific constraints reminder")
+      expect(promptCalls[0].text).toContain("Gate Status table")
+      expect(toastCalls.some((t) => t.title === "Ralph Loop Timed Out")).toBe(true)
     })
 
     test("should stop loop when max iterations reached", async () => {
@@ -485,6 +842,146 @@ describe("ralph-loop", () => {
       expect(hook.getState()).toBeNull()
     })
 
+    test("should block audit-loop completion when completion-lock gates are missing", async () => {
+      // given - active audit loop with completion promise but missing gate evidence
+      const transcriptPath = join(TEST_DIR, "transcript-audit-gate-missing.jsonl")
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
+      hook.startLoop("session-123", "Deep UI audit", {
+        mode: "audit-loop",
+        completionPromise: "DONE",
+        completionDetectionEnabled: true,
+        maxIterations: 10,
+      })
+
+      writeFileSync(
+        transcriptPath,
+        JSON.stringify({
+          type: "tool_result",
+          tool_name: "write",
+          tool_output: { output: "Task done <promise>DONE</promise>" },
+        }) + "\n"
+      )
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - completion is blocked and loop continues
+      expect(promptCalls.length).toBe(1)
+      expect(toastCalls.some((t) => t.title === "Audit Completion Blocked")).toBe(true)
+      expect(hook.getState()?.mode).toBe("audit-loop")
+      expect(hook.getState()?.iteration).toBe(2)
+    })
+
+    test("should allow audit-loop completion when completion-lock gates pass", async () => {
+      // given - active audit loop with full gate evidence and completion promise
+      const transcriptPath = join(TEST_DIR, "transcript-audit-gate-pass.jsonl")
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
+      hook.startLoop("session-123", "Deep UI audit", {
+        mode: "audit-loop",
+        completionPromise: "DONE",
+        completionDetectionEnabled: true,
+        maxIterations: 10,
+      })
+
+      const completionReport = [
+        "Focus Screen: lib/screens/settings/settings_screen.dart",
+        "Files Changed: lib/screens/settings/settings_screen.dart",
+        "Commands Run:",
+        "- flutter analyze ... PASS",
+        "- flutter test ... PASS",
+        "- flutter build ... PASS",
+        "- Regression Scan ... PASS",
+        "Required Skills: flutter-official, accessibility-a11y",
+        "Skills Used: flutter-official, accessibility-a11y",
+        "Skill Coverage: PASS",
+        "A11y Checklist:",
+        "- keyboard: PASS",
+        "- focus: PASS",
+        "- semantics: PASS",
+        "- contrast: PASS",
+        "Test Delta: PASS",
+        "High-Risk Refactors: 1",
+        "Gate Status:",
+        "- Scope Coverage: PASS",
+        "- Issue Closure: PASS",
+        "- Validation: PASS",
+        "- Accessibility: PASS",
+        "- Re-Audit: PASS",
+        "- Evidence: PASS",
+        "Next-Cycle Targets:",
+        "1. Keep documenting stabilized path",
+        "2. Keep tests green",
+        "3. Keep focus lock",
+        "<promise>DONE</promise>",
+      ].join("\n")
+
+      writeFileSync(
+        transcriptPath,
+        JSON.stringify({
+          type: "tool_result",
+          tool_name: "write",
+          tool_output: { output: completionReport },
+        }) + "\n"
+      )
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - completion is accepted
+      expect(promptCalls.length).toBe(0)
+      expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
+      expect(hook.getState()).toBeNull()
+    })
+
+    test("should ignore completion tags when completion detection is disabled", async () => {
+      // given - active loop with transcript containing completion tag
+      const transcriptPath = join(TEST_DIR, "transcript-no-complete.jsonl")
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
+      hook.startLoop("session-123", "Build something", {
+        completionPromise: "COMPLETE",
+        completionDetectionEnabled: false,
+        maxIterations: 10,
+      })
+
+      writeFileSync(
+        transcriptPath,
+        JSON.stringify({
+          type: "tool_result",
+          tool_name: "write",
+          tool_output: { output: "Task done <promise>COMPLETE</promise>" },
+        }) + "\n"
+      )
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - it should continue instead of stopping
+      expect(promptCalls.length).toBe(1)
+      expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(false)
+      expect(hook.getState()?.iteration).toBe(2)
+    })
+
     test("should detect completion promise via session messages API", async () => {
       // given - active loop with assistant message containing completion promise
       mockSessionMessages = [
@@ -635,6 +1132,42 @@ describe("ralph-loop", () => {
 
       // then - loop state should be cleared immediately
       expect(hook.getState()).toBeNull()
+    })
+
+    test("should keep audit-loop state on MessageAbortedError and continue on next idle", async () => {
+      // given - active audit loop
+      const hook = createRalphLoopHook(createMockPluginInput())
+      hook.startLoop("session-123", "Deep UI audit", {
+        mode: "audit-loop",
+        ultrawork: true,
+        maxIterations: 5,
+      })
+
+      // when - aborted error is emitted
+      await hook.event({
+        event: {
+          type: "session.error",
+          properties: {
+            sessionID: "session-123",
+            error: { name: "MessageAbortedError", message: "The operation was aborted." },
+          },
+        },
+      })
+
+      // then - audit-loop should remain active
+      expect(hook.getState()).not.toBeNull()
+      expect(hook.getState()?.mode).toBe("audit-loop")
+      expect(hook.getState()?.iteration).toBe(1)
+
+      // when - session goes idle again
+      await hook.event({
+        event: { type: "session.idle", properties: { sessionID: "session-123" } },
+      })
+
+      // then - continuation should be injected
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain("AUDIT LOOP")
+      expect(hook.getState()?.iteration).toBe(2)
     })
 
     test("should NOT set recovery mode on user abort", async () => {

--- a/src/hooks/ralph-loop/loop-state-controller.ts
+++ b/src/hooks/ralph-loop/loop-state-controller.ts
@@ -17,39 +17,59 @@ export function createLoopStateController(options: {
 	const config = options.config
 
 	return {
-		startLoop(
-			sessionID: string,
-			prompt: string,
-			loopOptions?: {
-				maxIterations?: number
-				completionPromise?: string
-				ultrawork?: boolean
-			},
-		): boolean {
-			const state: RalphLoopState = {
-				active: true,
-				iteration: 1,
-				max_iterations:
+			startLoop(
+				sessionID: string,
+				prompt: string,
+				loopOptions?: {
+					maxIterations?: number
+					completionPromise?: string
+          completionDetectionEnabled?: boolean
+					ultrawork?: boolean
+          mode?: RalphLoopState["mode"]
+          maxDurationMs?: number
+				},
+			): boolean {
+        const mode =
+          loopOptions?.mode ??
+          (loopOptions?.ultrawork ? "ulw" : "standard")
+        const deadlineAt =
+          loopOptions?.maxDurationMs && loopOptions.maxDurationMs > 0
+            ? new Date(Date.now() + loopOptions.maxDurationMs).toISOString()
+            : undefined
+
+				const state: RalphLoopState = {
+					active: true,
+					iteration: 1,
+					max_iterations:
 					loopOptions?.maxIterations ??
 					config?.default_max_iterations ??
 					DEFAULT_MAX_ITERATIONS,
-				completion_promise:
-					loopOptions?.completionPromise ??
-					DEFAULT_COMPLETION_PROMISE,
-				ultrawork: loopOptions?.ultrawork,
-				started_at: new Date().toISOString(),
-				prompt,
-				session_id: sessionID,
-			}
+					completion_promise:
+						loopOptions?.completionPromise ??
+						DEFAULT_COMPLETION_PROMISE,
+          completion_detection_enabled:
+            loopOptions?.completionDetectionEnabled ?? true,
+					ultrawork: loopOptions?.ultrawork,
+          mode,
+          max_duration_ms: loopOptions?.maxDurationMs,
+          deadline_at: deadlineAt,
+					started_at: new Date().toISOString(),
+					prompt,
+					session_id: sessionID,
+				}
 
 			const success = writeState(directory, state, stateDir)
-			if (success) {
-				log(`[${HOOK_NAME}] Loop started`, {
-					sessionID,
-					maxIterations: state.max_iterations,
-					completionPromise: state.completion_promise,
-				})
-			}
+				if (success) {
+					log(`[${HOOK_NAME}] Loop started`, {
+						sessionID,
+            mode: state.mode,
+						maxIterations: state.max_iterations,
+						completionPromise: state.completion_promise,
+            completionDetectionEnabled: state.completion_detection_enabled,
+            maxDurationMs: state.max_duration_ms,
+            deadlineAt: state.deadline_at,
+					})
+				}
 			return success
 		},
 

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -3,11 +3,20 @@ import { log } from "../../shared/logger"
 import type { RalphLoopOptions, RalphLoopState } from "./types"
 import { HOOK_NAME } from "./constants"
 import {
+	detectAuditCycleStagnation,
+	evaluateAuditCompletionLock,
 	detectCompletionInSessionMessages,
 	detectCompletionInTranscript,
+	getLatestNonUserTranscriptText,
 } from "./completion-promise-detector"
-import { buildContinuationPrompt } from "./continuation-prompt-builder"
+import { buildContinuationPrompt, buildTimeoutSummaryPrompt } from "./continuation-prompt-builder"
 import { injectContinuationPrompt } from "./continuation-prompt-injector"
+import {
+	appendAuditLedgerEntry,
+	extractCycleEvidenceSummary,
+	summarizeAuditCycleEvidence,
+	updateAuditCheckpointWithCycle,
+} from "./audit-ledger"
 
 type SessionRecovery = {
 	isRecovering: (sessionID: string) => boolean
@@ -16,6 +25,20 @@ type SessionRecovery = {
 }
 type LoopStateController = { getState: () => RalphLoopState | null; clear: () => boolean; incrementIteration: () => RalphLoopState | null }
 type RalphLoopEventHandlerOptions = { directory: string; apiTimeoutMs: number; getTranscriptPath: (sessionID: string) => string | undefined; checkSessionExists?: RalphLoopOptions["checkSessionExists"]; sessionRecovery: SessionRecovery; loopState: LoopStateController }
+
+function formatRemainingTime(deadlineAt?: string): string | null {
+  if (!deadlineAt) return null
+  const deadlineMs = Date.parse(deadlineAt)
+  if (!Number.isFinite(deadlineMs)) return null
+  const remainingMs = Math.max(0, deadlineMs - Date.now())
+  const totalMinutes = Math.floor(remainingMs / (60 * 1000))
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+
+  if (hours > 0) return `${hours}h ${minutes}m`
+  if (minutes > 0) return `${minutes}m`
+  return `${Math.floor(remainingMs / 1000)}s`
+}
 
 export function createRalphLoopEventHandler(
 	ctx: PluginInput,
@@ -60,18 +83,110 @@ export function createRalphLoopEventHandler(
 				return
 			}
 
+			const completionDetectionEnabled = state.completion_detection_enabled !== false
 			const transcriptPath = options.getTranscriptPath(sessionID)
-			const completionViaTranscript = detectCompletionInTranscript(transcriptPath, state.completion_promise)
-			const completionViaApi = completionViaTranscript
-				? false
-				: await detectCompletionInSessionMessages(ctx, {
-					sessionID,
-					promise: state.completion_promise,
-					apiTimeoutMs: options.apiTimeoutMs,
-					directory: options.directory,
-				})
+      let forceStrategySwitch = false
+      let objectiveCapViolation = false
+      let regressionGateMissing = false
+      let allowAutoFocusProgression = false
+      const latestAuditText =
+        state.mode === "audit-loop"
+          ? getLatestNonUserTranscriptText(transcriptPath)
+          : null
+      if (state.mode === "audit-loop") {
+        const summary = extractCycleEvidenceSummary(latestAuditText)
+        const policySummary = summarizeAuditCycleEvidence(latestAuditText)
+        const policyUpdate = updateAuditCheckpointWithCycle(options.directory, policySummary)
+        forceStrategySwitch = policyUpdate.forceStrategySwitch
+        objectiveCapViolation = policyUpdate.objectiveCapViolation
+        regressionGateMissing = policyUpdate.regressionGateMissing
+        allowAutoFocusProgression = policyUpdate.allowAutoFocusProgression
+        appendAuditLedgerEntry(options.directory, {
+          timestamp: new Date().toISOString(),
+          session_id: sessionID,
+          iteration: state.iteration,
+          mode: state.mode,
+          event: "cycle_observed",
+          ...summary,
+          stagnation_detected: detectAuditCycleStagnation(transcriptPath),
+        })
+        if (policyUpdate.lockedFilesAdded.length > 0) {
+          await ctx.client.tui
+            .showToast({
+              body: {
+                title: "Audit File Lock Applied",
+                message: `Locked saturated files: ${policyUpdate.lockedFilesAdded.join(", ")}`,
+                variant: "info",
+                duration: 4000,
+              },
+            })
+            .catch(() => {})
+        }
+      }
+			const completionViaTranscript = completionDetectionEnabled
+				? detectCompletionInTranscript(transcriptPath, state.completion_promise)
+				: false
+			const completionViaApi =
+				!completionDetectionEnabled || completionViaTranscript
+					? false
+					: await detectCompletionInSessionMessages(ctx, {
+							sessionID,
+							promise: state.completion_promise,
+							apiTimeoutMs: options.apiTimeoutMs,
+							directory: options.directory,
+						})
 
 			if (completionViaTranscript || completionViaApi) {
+        if (state.mode === "audit-loop") {
+          const completionLock = evaluateAuditCompletionLock(transcriptPath)
+          if (!completionLock.passed) {
+            appendAuditLedgerEntry(options.directory, {
+              timestamp: new Date().toISOString(),
+              session_id: sessionID,
+              iteration: state.iteration,
+              mode: state.mode,
+              event: "completion_blocked",
+              missing_gates: completionLock.missing,
+            })
+            log(`[${HOOK_NAME}] Audit completion blocked: missing gates`, {
+              sessionID,
+              iteration: state.iteration,
+              missingGates: completionLock.missing,
+            })
+            await ctx.client.tui
+              .showToast({
+                body: {
+                  title: "Audit Completion Blocked",
+                  message: `Missing gates: ${completionLock.missing.join(", ")}`,
+                  variant: "warning",
+                  duration: 5000,
+                },
+              })
+              .catch(() => {})
+          } else {
+            appendAuditLedgerEntry(options.directory, {
+              timestamp: new Date().toISOString(),
+              session_id: sessionID,
+              iteration: state.iteration,
+              mode: state.mode,
+              event: "completed",
+            })
+            log(`[${HOOK_NAME}] Completion detected!`, {
+              sessionID,
+              iteration: state.iteration,
+              promise: state.completion_promise,
+              detectedVia: completionViaTranscript
+                ? "transcript_file"
+                : "session_messages_api",
+            })
+            options.loopState.clear()
+
+            const title = state.ultrawork ? "ULTRAWORK LOOP COMPLETE!" : "Ralph Loop Complete!"
+            const message = state.ultrawork ? `JUST ULW ULW! Task completed after ${state.iteration} iteration(s)` : `Task completed after ${state.iteration} iteration(s)`
+            await ctx.client.tui.showToast({ body: { title, message, variant: "success", duration: 5000 } }).catch(() => {})
+            return
+          }
+        } else {
 				log(`[${HOOK_NAME}] Completion detected!`, {
 					sessionID,
 					iteration: state.iteration,
@@ -86,7 +201,55 @@ export function createRalphLoopEventHandler(
 				const message = state.ultrawork ? `JUST ULW ULW! Task completed after ${state.iteration} iteration(s)` : `Task completed after ${state.iteration} iteration(s)`
 				await ctx.client.tui.showToast({ body: { title, message, variant: "success", duration: 5000 } }).catch(() => {})
 				return
+        }
 			}
+
+      const deadlineMs = state.deadline_at ? Date.parse(state.deadline_at) : NaN
+      const isTimedOut = Number.isFinite(deadlineMs) && Date.now() >= deadlineMs
+      if (isTimedOut) {
+        log(`[${HOOK_NAME}] Max duration reached`, {
+          sessionID,
+          iteration: state.iteration,
+          deadlineAt: state.deadline_at,
+          mode: state.mode,
+        })
+        if (state.mode === "audit-loop") {
+          appendAuditLedgerEntry(options.directory, {
+            timestamp: new Date().toISOString(),
+            session_id: sessionID,
+            iteration: state.iteration,
+            mode: state.mode,
+            event: "timeout",
+          })
+        }
+        options.loopState.clear()
+
+        await ctx.client.tui
+          .showToast({
+            body: {
+              title: "Ralph Loop Timed Out",
+              message: "Max duration reached. Stopping loop and generating final summary.",
+              variant: "warning",
+              duration: 5000,
+            },
+          })
+          .catch(() => {})
+
+        try {
+          await injectContinuationPrompt(ctx, {
+            sessionID,
+            prompt: buildTimeoutSummaryPrompt(state),
+            directory: options.directory,
+            apiTimeoutMs: options.apiTimeoutMs,
+          })
+        } catch (err) {
+          log(`[${HOOK_NAME}] Failed to inject timeout summary`, {
+            sessionID,
+            error: String(err),
+          })
+        }
+        return
+      }
 
 			if (state.iteration >= state.max_iterations) {
 				log(`[${HOOK_NAME}] Max iterations reached`, {
@@ -94,6 +257,15 @@ export function createRalphLoopEventHandler(
 					iteration: state.iteration,
 					max: state.max_iterations,
 				})
+        if (state.mode === "audit-loop") {
+          appendAuditLedgerEntry(options.directory, {
+            timestamp: new Date().toISOString(),
+            session_id: sessionID,
+            iteration: state.iteration,
+            mode: state.mode,
+            event: "max_iterations",
+          })
+        }
 				options.loopState.clear()
 
 				await ctx.client.tui
@@ -116,21 +288,66 @@ export function createRalphLoopEventHandler(
 				max: newState.max_iterations,
 			})
 
+      const remainingTime = formatRemainingTime(newState.deadline_at)
+      const isAuditLoop = newState.mode === "audit-loop"
+      const heartbeatTitle = isAuditLoop ? "Audit Loop Active" : "Ralph Loop"
+      const heartbeatMessage = isAuditLoop
+        ? `Iteration ${newState.iteration}/${newState.max_iterations} | Time left: ${remainingTime ?? "N/A"}`
+        : `Iteration ${newState.iteration}/${newState.max_iterations}`
+
 			await ctx.client.tui
 				.showToast({
 					body: {
-						title: "Ralph Loop",
-						message: `Iteration ${newState.iteration}/${newState.max_iterations}`,
+						title: heartbeatTitle,
+						message: heartbeatMessage,
 						variant: "info",
-						duration: 2000,
+						duration: isAuditLoop ? 3500 : 2000,
 					},
 				})
 				.catch(() => {})
 
 			try {
+        const isStagnant =
+          newState.mode === "audit-loop"
+            ? detectAuditCycleStagnation(transcriptPath)
+            : false
+        const alertBlocks: string[] = []
+        if (allowAutoFocusProgression) {
+          alertBlocks.push(`AUTO FOCUS PROGRESSION:
+- Previous focus screen is marked SCREEN COMPLETE and passed Validation + Regression gates.
+- In this cycle, switch once to the next highest-impact screen immediately.
+- Do not wait for user confirmation and do not require BLOCKER REPORT for this completion-based switch.`)
+        }
+        if (isStagnant) {
+          alertBlocks.push(`STAGNATION ALERT:
+- Last two cycles look repetitive.
+- Change strategy now: increase parallel research agents to at least 4 for the next cycle.
+- Deliver materially different structural edits before ending the cycle.`)
+        }
+        if (forceStrategySwitch) {
+          alertBlocks.push(`ROLLBACK TRIGGER:
+- Validation failed in consecutive cycles.
+- Revert the current risky strategy and apply a materially different refactor route in this cycle.`)
+        }
+        if (regressionGateMissing) {
+          alertBlocks.push(`REGRESSION GATE VIOLATION:
+- Missing Regression Scan PASS evidence in the previous cycle.
+- Run and report regression scan before any new implementation work.`)
+        }
+        if (objectiveCapViolation) {
+          alertBlocks.push(`OBJECTIVE CAP VIOLATION:
+- Next-Cycle Targets exceeded 3 items.
+- Reduce to top 3 objectives before proceeding.`)
+        }
+
+        const continuationPrompt = alertBlocks.length > 0
+          ? `${buildContinuationPrompt(newState)}
+
+${alertBlocks.join("\n\n")}`
+          : buildContinuationPrompt(newState)
 				await injectContinuationPrompt(ctx, {
 					sessionID,
-					prompt: buildContinuationPrompt(newState),
+					prompt: continuationPrompt,
 					directory: options.directory,
 					apiTimeoutMs: options.apiTimeoutMs,
 				})
@@ -163,8 +380,22 @@ export function createRalphLoopEventHandler(
 				if (sessionID) {
 					const state = options.loopState.getState()
 					if (state?.session_id === sessionID) {
-						options.loopState.clear()
-						log(`[${HOOK_NAME}] User aborted, loop cleared`, { sessionID })
+						if (state.mode === "audit-loop") {
+              appendAuditLedgerEntry(options.directory, {
+                timestamp: new Date().toISOString(),
+                session_id: sessionID,
+                iteration: state.iteration,
+                mode: state.mode,
+                event: "aborted",
+              })
+							log(`[${HOOK_NAME}] MessageAbortedError ignored for audit-loop`, {
+								sessionID,
+								iteration: state.iteration,
+							})
+						} else {
+							options.loopState.clear()
+							log(`[${HOOK_NAME}] User aborted, loop cleared`, { sessionID })
+						}
 					}
 					options.sessionRecovery.clear(sessionID)
 				}

--- a/src/hooks/ralph-loop/ralph-loop-hook.ts
+++ b/src/hooks/ralph-loop/ralph-loop-hook.ts
@@ -10,7 +10,14 @@ export interface RalphLoopHook {
   startLoop: (
     sessionID: string,
     prompt: string,
-    options?: { maxIterations?: number; completionPromise?: string; ultrawork?: boolean }
+    options?: {
+      maxIterations?: number
+      completionPromise?: string
+      completionDetectionEnabled?: boolean
+      ultrawork?: boolean
+      mode?: RalphLoopState["mode"]
+      maxDurationMs?: number
+    }
   ) => boolean
   cancelLoop: (sessionID: string) => boolean
   getState: () => RalphLoopState | null

--- a/src/hooks/ralph-loop/storage.ts
+++ b/src/hooks/ralph-loop/storage.ts
@@ -45,10 +45,19 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
       iteration: iterationNum,
       max_iterations: Number(data.max_iterations) || DEFAULT_MAX_ITERATIONS,
       completion_promise: stripQuotes(data.completion_promise) || DEFAULT_COMPLETION_PROMISE,
+      completion_detection_enabled:
+        data.completion_detection_enabled === undefined
+          ? true
+          : data.completion_detection_enabled === true ||
+            data.completion_detection_enabled === "true",
       started_at: stripQuotes(data.started_at) || new Date().toISOString(),
       prompt: body.trim(),
       session_id: data.session_id ? stripQuotes(data.session_id) : undefined,
       ultrawork: data.ultrawork === true || data.ultrawork === "true" ? true : undefined,
+      mode: data.mode ? stripQuotes(data.mode) as RalphLoopState["mode"] : undefined,
+      max_duration_ms: data.max_duration_ms ? Number(data.max_duration_ms) : undefined,
+      deadline_at: data.deadline_at ? stripQuotes(data.deadline_at) : undefined,
+      stop_reason: data.stop_reason ? stripQuotes(data.stop_reason) as RalphLoopState["stop_reason"] : undefined,
     }
   } catch {
     return null
@@ -70,13 +79,21 @@ export function writeState(
 
     const sessionIdLine = state.session_id ? `session_id: "${state.session_id}"\n` : ""
     const ultraworkLine = state.ultrawork !== undefined ? `ultrawork: ${state.ultrawork}\n` : ""
+    const completionDetectionLine =
+      state.completion_detection_enabled !== undefined
+        ? `completion_detection_enabled: ${state.completion_detection_enabled}\n`
+        : ""
+    const modeLine = state.mode ? `mode: "${state.mode}"\n` : ""
+    const maxDurationLine = state.max_duration_ms !== undefined ? `max_duration_ms: ${state.max_duration_ms}\n` : ""
+    const deadlineLine = state.deadline_at ? `deadline_at: "${state.deadline_at}"\n` : ""
+    const stopReasonLine = state.stop_reason ? `stop_reason: "${state.stop_reason}"\n` : ""
     const content = `---
 active: ${state.active}
 iteration: ${state.iteration}
 max_iterations: ${state.max_iterations}
 completion_promise: "${state.completion_promise}"
 started_at: "${state.started_at}"
-${sessionIdLine}${ultraworkLine}---
+${sessionIdLine}${ultraworkLine}${completionDetectionLine}${modeLine}${maxDurationLine}${deadlineLine}${stopReasonLine}---
 ${state.prompt}
 `
 

--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -1,14 +1,21 @@
 import type { RalphLoopConfig } from "../../config"
 
+export type RalphLoopMode = "standard" | "ulw" | "audit-loop"
+
 export interface RalphLoopState {
   active: boolean
   iteration: number
   max_iterations: number
   completion_promise: string
+  completion_detection_enabled?: boolean
   started_at: string
   prompt: string
   session_id?: string
   ultrawork?: boolean
+  mode?: RalphLoopMode
+  max_duration_ms?: number
+  deadline_at?: string
+  stop_reason?: "completed" | "max_iterations" | "timeout" | "cancelled" | "aborted"
 }
 
 export interface RalphLoopOptions {

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -17,7 +17,6 @@ export function applyToolConfig(params: {
     LspHover: false,
     LspCodeActions: false,
     LspCodeActionResolve: false,
-    "task_*": false,
     teammate: false,
     ...(params.pluginConfig.experimental?.task_system
       ? { todowrite: false, todoread: false }
@@ -40,6 +39,7 @@ export function applyToolConfig(params: {
     agent.permission = {
       ...agent.permission,
       task: "allow",
+      doom_loop: "allow",
       call_omo_agent: "deny",
       "task_*": "allow",
       teammate: "allow",
@@ -52,6 +52,7 @@ export function applyToolConfig(params: {
       ...agent.permission,
       call_omo_agent: "deny",
       task: "allow",
+      doom_loop: "allow",
       question: questionPermission,
       "task_*": "allow",
       teammate: "allow",
@@ -64,6 +65,7 @@ export function applyToolConfig(params: {
       ...agent.permission,
       call_omo_agent: "deny",
       task: "allow",
+      doom_loop: "allow",
       question: questionPermission,
       ...denyTodoTools,
     };
@@ -74,6 +76,7 @@ export function applyToolConfig(params: {
       ...agent.permission,
       call_omo_agent: "deny",
       task: "allow",
+      doom_loop: "allow",
       question: questionPermission,
       "task_*": "allow",
       teammate: "allow",
@@ -85,6 +88,7 @@ export function applyToolConfig(params: {
     agent.permission = {
       ...agent.permission,
       task: "allow",
+      doom_loop: "allow",
       "task_*": "allow",
       teammate: "allow",
       ...denyTodoTools,
@@ -95,6 +99,7 @@ export function applyToolConfig(params: {
     ...(params.config.permission as Record<string, unknown>),
     webfetch: "allow",
     external_directory: "allow",
-    task: "deny",
+    task: "allow",
+    doom_loop: "allow",
   };
 }

--- a/src/plugin/audit-loop-guard.ts
+++ b/src/plugin/audit-loop-guard.ts
@@ -10,6 +10,8 @@ type ToolOutput = { args: Record<string, unknown> }
 
 const DATABASE_MUTATION_COMMAND_PATTERNS = [
   /\bdb\s+(push|reset|pull|seed)\b/i,
+  // Provider-agnostic CLI migration subcommands: "<tool> migration <subcommand>"
+  /\b[a-z0-9_.-]+\s+migration\s+[a-z0-9_-]+\b/i,
   /\bprisma\s+(migrate|db\s+push|db\s+pull|db\s+seed)\b/i,
   /\bdrizzle-kit\s+(push|migrate|generate)\b/i,
   /\b(knex|typeorm|sequelize)\b.*\bmigration\b/i,

--- a/src/plugin/audit-loop-guard.ts
+++ b/src/plugin/audit-loop-guard.ts
@@ -1,0 +1,311 @@
+import type { CreatedHooks } from "../create-hooks"
+import { log } from "../shared"
+import {
+  readAuditCheckpoint,
+  writeAuditCheckpoint,
+} from "../hooks/ralph-loop/audit-ledger"
+
+type ToolInput = { tool: string; sessionID: string; callID: string }
+type ToolOutput = { args: Record<string, unknown> }
+
+const SUPABASE_DB_COMMAND_PATTERNS = [
+  /\bsupabase\s+db\b/i,
+  /\bsupabase\s+migration\b/i,
+  /\bsupabase\s+seed\b/i,
+  /\bsupabase_db_url\b/i,
+  /\bpostgres(?:ql)?\b.*\b(schema|migration|sql|table|column|policy|rls|insert|update|delete|alter|drop)\b/i,
+  /\b(psql|pg_dump|pg_restore)\b/i,
+]
+
+const SUPABASE_MUTATION_INTENT_PATTERN =
+  /\b(migrate|migration|schema|sql|db push|db reset|db pull|table|column|policy|rls|seed|create|alter|drop|insert|update|delete|truncate)\b/i
+
+const SUPABASE_NEGATION_PATTERN =
+  /\b(do not|don't|dont|avoid|must not|never)\b.{0,40}\b(modify|change|touch|update|migrate|db|database|schema)\b/i
+
+const HARD_CODED_VISUAL_LITERAL_PATTERNS = [
+  /#[0-9a-fA-F]{3,8}\b/,
+  /\b(?:rgb|rgba|hsl|hsla)\s*\(/,
+  /\bColor\s*\(\s*0x[0-9a-fA-F]{8}\s*\)/,
+  /\b(?:fontSize|padding|margin|borderRadius|letterSpacing|lineHeight|gap)\s*[:=]\s*\d+/,
+]
+
+const TOKEN_ALIAS_PATTERNS = [
+  /var\(--/i,
+  /\btoken[s]?\b/i,
+  /\btheme\b/i,
+  /\bAppTokens?\b/,
+  /\bDesignTokens?\b/,
+  /\bTheme\.of\(/,
+  /\bcontext\.theme\b/i,
+]
+
+const TOKEN_DEFINITION_PATH_PATTERN =
+  /(token|tokens|theme|design-system|palette|color|colors|typography|spacing)/i
+
+const UI_FILE_PATTERN = /\.(dart|css|scss|less|tsx|jsx|vue|ts)$/i
+const BLOCKER_REPORT_PATTERN = /\bBLOCKER REPORT\b/i
+const FOCUS_SWITCH_INTENT_PATTERN = /\b(switch|change|move)\b.{0,20}\bfocus\b/i
+const BUG_EVIDENCE_PATTERN = /\b(BUG EVIDENCE|REGRESSION EVIDENCE)\b/i
+
+const MUTATING_SHELL_PATTERN =
+  /\b(rm|mv|cp)\b|\bsed\s+-i\b|\bperl\s+-i\b|\bpython\s+-c\b|\bnode\s+-e\b|\bgit\s+(add|commit|push|reset|checkout|switch|merge|rebase)\b/i
+
+const SAFE_SHELL_PATTERN =
+  /\b(git\s+status|git\s+diff|rg\b|grep\b|ls\b|cat\b|find\b|pwd\b|flutter\s+analyze|flutter\s+test|flutter\s+build|bun\s+test|bun\s+run\s+build|bun\s+run\s+typecheck|npm\s+run\s+(test|build|lint)|pnpm\s+(test|build|lint)|yarn\s+(test|build|lint))\b/i
+
+const DB_BLOCK_MESSAGE =
+  "[audit-loop guard] Supabase DB mutation is blocked while /audit-loop is active. Keep changes UI-first and never run DB/migration/schema operations."
+
+const FOCUS_BLOCK_MESSAGE =
+  "[audit-loop guard] Focus lock violation. Keep edits inside the current focus path. Submit a BLOCKER REPORT task first to approve a one-time focus switch."
+
+const SHELL_BLOCK_MESSAGE =
+  "[audit-loop guard] Mutating shell command blocked during /audit-loop focus lock. Use write/edit/multiedit for deterministic, path-scoped edits."
+
+const TOKEN_BLOCK_MESSAGE =
+  "[audit-loop guard] Hardcoded visual style values are blocked in /audit-loop. Use global tokens/theme/shared UI primitives."
+
+function normalizePath(pathLike: string): string {
+  return pathLike.replace(/\\/g, "/").replace(/^\.\//, "").trim()
+}
+
+function getAuditLoopState(hooks: CreatedHooks, sessionID: string): { session_id?: string } | null {
+  const state = hooks.ralphLoop?.getState?.()
+  if (!state?.active || state.mode !== "audit-loop") return null
+  if (state.session_id && state.session_id !== sessionID) return null
+  return state
+}
+
+function hasSupabaseDbMutationCommand(command: string): boolean {
+  return SUPABASE_DB_COMMAND_PATTERNS.some((pattern) => pattern.test(command))
+}
+
+function hasSupabaseMutationIntent(text: string): boolean {
+  const lower = text.toLowerCase()
+  if (!lower.includes("supabase")) return false
+  if (SUPABASE_NEGATION_PATTERN.test(lower)) return false
+  return SUPABASE_MUTATION_INTENT_PATTERN.test(lower) || hasSupabaseDbMutationCommand(lower)
+}
+
+function isSupabaseDbPath(pathLike: string): boolean {
+  const normalized = normalizePath(pathLike).toLowerCase()
+  if (!normalized.includes("/supabase/")) return false
+  if (normalized.includes("/supabase/migrations/")) return true
+  if (normalized.endsWith(".sql")) return true
+  if (normalized.includes("/supabase/seed")) return true
+  if (normalized.includes("/supabase/schema")) return true
+  return false
+}
+
+function getFilePathsFromArgs(args: Record<string, unknown>): string[] {
+  const result: string[] = []
+  for (const key of ["filePath", "path", "file_path"]) {
+    const value = args[key]
+    if (typeof value === "string" && value.length > 0) result.push(value)
+  }
+
+  const edits = args.edits
+  if (Array.isArray(edits)) {
+    for (const edit of edits) {
+      if (typeof edit !== "object" || edit === null) continue
+      const rec = edit as Record<string, unknown>
+      const filePath =
+        typeof rec.filePath === "string"
+          ? rec.filePath
+          : typeof rec.path === "string"
+            ? rec.path
+            : typeof rec.file_path === "string"
+              ? rec.file_path
+              : undefined
+      if (filePath) result.push(filePath)
+    }
+  }
+  return [...new Set(result.map(normalizePath))]
+}
+
+function extractMutationTexts(toolName: string, args: Record<string, unknown>): string[] {
+  if (toolName === "write") {
+    return typeof args.content === "string" ? [args.content] : []
+  }
+
+  if (toolName === "edit") {
+    const text =
+      typeof args.newString === "string"
+        ? args.newString
+        : typeof args.new_string === "string"
+          ? args.new_string
+          : typeof args.newText === "string"
+            ? args.newText
+            : ""
+    return text ? [text] : []
+  }
+
+  if (toolName === "multiedit" && Array.isArray(args.edits)) {
+    const parts: string[] = []
+    for (const edit of args.edits) {
+      if (typeof edit !== "object" || edit === null) continue
+      const rec = edit as Record<string, unknown>
+      const text =
+        typeof rec.newString === "string"
+          ? rec.newString
+          : typeof rec.new_string === "string"
+            ? rec.new_string
+            : typeof rec.newText === "string"
+              ? rec.newText
+              : ""
+      if (text) parts.push(text)
+    }
+    return parts
+  }
+
+  return []
+}
+
+function isWithinFocus(pathLike: string, focusRoot: string): boolean {
+  const target = normalizePath(pathLike)
+  const root = normalizePath(focusRoot)
+  return target === root || target.startsWith(`${root}/`)
+}
+
+function deriveFocusRoot(pathLike: string): string {
+  const normalized = normalizePath(pathLike)
+  const lastSlash = normalized.lastIndexOf("/")
+  return lastSlash > 0 ? normalized.slice(0, lastSlash) : normalized
+}
+
+function hasHardcodedVisualLiteral(text: string): boolean {
+  return HARD_CODED_VISUAL_LITERAL_PATTERNS.some((pattern) => pattern.test(text))
+}
+
+function hasTokenAlias(text: string): boolean {
+  return TOKEN_ALIAS_PATTERNS.some((pattern) => pattern.test(text))
+}
+
+function shouldEnforceTokenLint(pathLike: string): boolean {
+  const normalized = normalizePath(pathLike)
+  return UI_FILE_PATTERN.test(normalized) && !TOKEN_DEFINITION_PATH_PATTERN.test(normalized)
+}
+
+export function createAuditLoopGuard(directory: string) {
+  const focusBySession = new Map<string, string>()
+  const focusSwitchApprovalBySession = new Set<string>()
+  const lockedFileUnlockBySession = new Set<string>()
+
+  const clearSession = (sessionID: string): void => {
+    focusBySession.delete(sessionID)
+    focusSwitchApprovalBySession.delete(sessionID)
+    lockedFileUnlockBySession.delete(sessionID)
+  }
+
+  const resetSession = (sessionID: string): void => {
+    clearSession(sessionID)
+  }
+
+  const enforce = (input: ToolInput, output: ToolOutput, hooks: CreatedHooks): void => {
+    const state = getAuditLoopState(hooks, input.sessionID)
+    if (!state) return
+
+    const toolName = input.tool.toLowerCase()
+    const args = output.args
+
+    if (toolName === "task") {
+      const prompt = typeof args.prompt === "string" ? args.prompt : ""
+      const description = typeof args.description === "string" ? args.description : ""
+      const combined = `${description}\n${prompt}`
+      if (hasSupabaseMutationIntent(combined)) throw new Error(DB_BLOCK_MESSAGE)
+      if (BLOCKER_REPORT_PATTERN.test(combined) && FOCUS_SWITCH_INTENT_PATTERN.test(combined)) {
+        focusSwitchApprovalBySession.add(input.sessionID)
+      }
+      if (BUG_EVIDENCE_PATTERN.test(combined)) {
+        lockedFileUnlockBySession.add(input.sessionID)
+      }
+      return
+    }
+
+    if (toolName === "bash" || toolName === "interactive_bash") {
+      const command =
+        typeof args.command === "string"
+          ? args.command
+          : typeof args.tmux_command === "string"
+            ? args.tmux_command
+            : ""
+      if (command && hasSupabaseDbMutationCommand(command)) throw new Error(DB_BLOCK_MESSAGE)
+      const hasFocus = focusBySession.has(input.sessionID)
+      if (hasFocus && MUTATING_SHELL_PATTERN.test(command) && !SAFE_SHELL_PATTERN.test(command)) {
+        throw new Error(SHELL_BLOCK_MESSAGE)
+      }
+      return
+    }
+
+    if (toolName !== "write" && toolName !== "edit" && toolName !== "multiedit") return
+
+    const filePaths = getFilePathsFromArgs(args)
+    if (filePaths.some((pathLike) => isSupabaseDbPath(pathLike))) throw new Error(DB_BLOCK_MESSAGE)
+    if (filePaths.length === 0) return
+
+    const checkpoint = readAuditCheckpoint(directory)
+    const lockedFiles = checkpoint.locked_files
+    const lockedPath = filePaths.find((pathLike) =>
+      lockedFiles.includes(pathLike.replace(/\\/g, "/")),
+    )
+    if (lockedPath) {
+      if (!lockedFileUnlockBySession.has(input.sessionID)) {
+        throw new Error(
+          `[audit-loop guard] File is locked after saturation: ${lockedPath}. Provide BUG EVIDENCE or REGRESSION EVIDENCE via task before editing.`,
+        )
+      }
+      lockedFileUnlockBySession.delete(input.sessionID)
+    }
+
+    let focusRoot = focusBySession.get(input.sessionID)
+    if (!focusRoot) {
+      focusRoot = deriveFocusRoot(filePaths[0])
+      focusBySession.set(input.sessionID, focusRoot)
+      log("[audit-loop guard] Focus path initialized", { sessionID: input.sessionID, focusRoot })
+    }
+    if (!focusRoot) return
+    const activeFocusRoot = focusRoot
+
+    const firstOutsideFocus = filePaths.find((pathLike) => !isWithinFocus(pathLike, activeFocusRoot))
+    if (firstOutsideFocus) {
+      const checkpoint = readAuditCheckpoint(directory)
+      const hasBlockerApproval = focusSwitchApprovalBySession.has(input.sessionID)
+      const hasAutoProgression = checkpoint.allow_focus_progression_once === true
+      if (hasBlockerApproval || hasAutoProgression) {
+        focusRoot = deriveFocusRoot(firstOutsideFocus)
+        focusBySession.set(input.sessionID, focusRoot)
+        focusSwitchApprovalBySession.delete(input.sessionID)
+        if (hasAutoProgression) {
+          checkpoint.allow_focus_progression_once = false
+          checkpoint.updated_at = new Date().toISOString()
+          writeAuditCheckpoint(directory, checkpoint)
+        }
+        log("[audit-loop guard] Focus path switched with authorization", {
+          sessionID: input.sessionID,
+          focusRoot,
+          switchType: hasAutoProgression ? "screen_complete_auto_progression" : "blocker_report",
+        })
+      } else {
+        throw new Error(FOCUS_BLOCK_MESSAGE)
+      }
+    }
+
+    const payloadTexts = extractMutationTexts(toolName, args)
+    if (payloadTexts.length === 0) return
+    const payloadCombined = payloadTexts.join("\n")
+    if (hasTokenAlias(payloadCombined)) return
+
+    for (const filePath of filePaths) {
+      if (shouldEnforceTokenLint(filePath) && hasHardcodedVisualLiteral(payloadCombined)) {
+        throw new Error(`${TOKEN_BLOCK_MESSAGE} File: ${filePath}`)
+      }
+    }
+  }
+
+  return {
+    enforce,
+    clearSession,
+    resetSession,
+  }
+}

--- a/src/plugin/audit-loop-guard.ts
+++ b/src/plugin/audit-loop-guard.ts
@@ -8,19 +8,28 @@ import {
 type ToolInput = { tool: string; sessionID: string; callID: string }
 type ToolOutput = { args: Record<string, unknown> }
 
-const SUPABASE_DB_COMMAND_PATTERNS = [
+const DATABASE_MUTATION_COMMAND_PATTERNS = [
   /\bsupabase\s+db\b/i,
   /\bsupabase\s+migration\b/i,
   /\bsupabase\s+seed\b/i,
   /\bsupabase_db_url\b/i,
+  /\bprisma\s+(migrate|db\s+push|db\s+pull|db\s+seed)\b/i,
+  /\bdrizzle-kit\s+(push|migrate|generate)\b/i,
+  /\b(knex|typeorm|sequelize)\b.*\bmigration\b/i,
+  /\bflyway\b/i,
+  /\bliquibase\b/i,
   /\bpostgres(?:ql)?\b.*\b(schema|migration|sql|table|column|policy|rls|insert|update|delete|alter|drop)\b/i,
+  /\b(mysql|mariadb|sqlite|mongodb)\b.*\b(schema|migration|sql|table|column|index|insert|update|delete|alter|drop)\b/i,
   /\b(psql|pg_dump|pg_restore)\b/i,
 ]
 
-const SUPABASE_MUTATION_INTENT_PATTERN =
+const DATABASE_MUTATION_INTENT_PATTERN =
   /\b(migrate|migration|schema|sql|db push|db reset|db pull|table|column|policy|rls|seed|create|alter|drop|insert|update|delete|truncate)\b/i
 
-const SUPABASE_NEGATION_PATTERN =
+const DATABASE_CONTEXT_PATTERN =
+  /\b(database|db|sql|schema|migration|supabase|postgres|postgresql|mysql|mariadb|sqlite|mongodb|prisma|drizzle|typeorm|sequelize|knex|flyway|liquibase)\b/i
+
+const DATABASE_NEGATION_PATTERN =
   /\b(do not|don't|dont|avoid|must not|never)\b.{0,40}\b(modify|change|touch|update|migrate|db|database|schema)\b/i
 
 const HARD_CODED_VISUAL_LITERAL_PATTERNS = [
@@ -55,7 +64,7 @@ const SAFE_SHELL_PATTERN =
   /\b(git\s+status|git\s+diff|rg\b|grep\b|ls\b|cat\b|find\b|pwd\b|flutter\s+analyze|flutter\s+test|flutter\s+build|bun\s+test|bun\s+run\s+build|bun\s+run\s+typecheck|npm\s+run\s+(test|build|lint)|pnpm\s+(test|build|lint)|yarn\s+(test|build|lint))\b/i
 
 const DB_BLOCK_MESSAGE =
-  "[audit-loop guard] Supabase DB mutation is blocked while /audit-loop is active. Keep changes UI-first and never run DB/migration/schema operations."
+  "[audit-loop guard] Database mutation is blocked while /audit-loop is active. Keep changes UI-first and never run DB/migration/schema operations."
 
 const FOCUS_BLOCK_MESSAGE =
   "[audit-loop guard] Focus lock violation. Keep edits inside the current focus path. Submit a BLOCKER REPORT task first to approve a one-time focus switch."
@@ -77,24 +86,25 @@ function getAuditLoopState(hooks: CreatedHooks, sessionID: string): { session_id
   return state
 }
 
-function hasSupabaseDbMutationCommand(command: string): boolean {
-  return SUPABASE_DB_COMMAND_PATTERNS.some((pattern) => pattern.test(command))
+function hasDatabaseMutationCommand(command: string): boolean {
+  return DATABASE_MUTATION_COMMAND_PATTERNS.some((pattern) => pattern.test(command))
 }
 
-function hasSupabaseMutationIntent(text: string): boolean {
+function hasDatabaseMutationIntent(text: string): boolean {
   const lower = text.toLowerCase()
-  if (!lower.includes("supabase")) return false
-  if (SUPABASE_NEGATION_PATTERN.test(lower)) return false
-  return SUPABASE_MUTATION_INTENT_PATTERN.test(lower) || hasSupabaseDbMutationCommand(lower)
+  if (DATABASE_NEGATION_PATTERN.test(lower)) return false
+  if (!DATABASE_CONTEXT_PATTERN.test(lower)) return false
+  return DATABASE_MUTATION_INTENT_PATTERN.test(lower) || hasDatabaseMutationCommand(lower)
 }
 
-function isSupabaseDbPath(pathLike: string): boolean {
+function isDatabaseMutationPath(pathLike: string): boolean {
   const normalized = normalizePath(pathLike).toLowerCase()
-  if (!normalized.includes("/supabase/")) return false
-  if (normalized.includes("/supabase/migrations/")) return true
   if (normalized.endsWith(".sql")) return true
-  if (normalized.includes("/supabase/seed")) return true
-  if (normalized.includes("/supabase/schema")) return true
+  if (/(^|\/)(migrations?|migration)(\/|$)/.test(normalized)) return true
+  if (/(^|\/)(db|database|schema|schemas|seed|seeds)(\/|$)/.test(normalized)) return true
+  if (/(^|\/)(supabase|prisma|drizzle|typeorm|sequelize|knex|flyway|liquibase)(\/|$)/.test(normalized))
+    return true
+  if (normalized.endsWith("schema.prisma")) return true
   return false
 }
 
@@ -213,7 +223,7 @@ export function createAuditLoopGuard(directory: string) {
       const prompt = typeof args.prompt === "string" ? args.prompt : ""
       const description = typeof args.description === "string" ? args.description : ""
       const combined = `${description}\n${prompt}`
-      if (hasSupabaseMutationIntent(combined)) throw new Error(DB_BLOCK_MESSAGE)
+      if (hasDatabaseMutationIntent(combined)) throw new Error(DB_BLOCK_MESSAGE)
       if (BLOCKER_REPORT_PATTERN.test(combined) && FOCUS_SWITCH_INTENT_PATTERN.test(combined)) {
         focusSwitchApprovalBySession.add(input.sessionID)
       }
@@ -230,7 +240,7 @@ export function createAuditLoopGuard(directory: string) {
           : typeof args.tmux_command === "string"
             ? args.tmux_command
             : ""
-      if (command && hasSupabaseDbMutationCommand(command)) throw new Error(DB_BLOCK_MESSAGE)
+      if (command && hasDatabaseMutationCommand(command)) throw new Error(DB_BLOCK_MESSAGE)
       const hasFocus = focusBySession.has(input.sessionID)
       if (hasFocus && MUTATING_SHELL_PATTERN.test(command) && !SAFE_SHELL_PATTERN.test(command)) {
         throw new Error(SHELL_BLOCK_MESSAGE)
@@ -241,7 +251,7 @@ export function createAuditLoopGuard(directory: string) {
     if (toolName !== "write" && toolName !== "edit" && toolName !== "multiedit") return
 
     const filePaths = getFilePathsFromArgs(args)
-    if (filePaths.some((pathLike) => isSupabaseDbPath(pathLike))) throw new Error(DB_BLOCK_MESSAGE)
+    if (filePaths.some((pathLike) => isDatabaseMutationPath(pathLike))) throw new Error(DB_BLOCK_MESSAGE)
     if (filePaths.length === 0) return
 
     const checkpoint = readAuditCheckpoint(directory)

--- a/src/plugin/audit-loop-guard.ts
+++ b/src/plugin/audit-loop-guard.ts
@@ -9,10 +9,7 @@ type ToolInput = { tool: string; sessionID: string; callID: string }
 type ToolOutput = { args: Record<string, unknown> }
 
 const DATABASE_MUTATION_COMMAND_PATTERNS = [
-  /\bsupabase\s+db\b/i,
-  /\bsupabase\s+migration\b/i,
-  /\bsupabase\s+seed\b/i,
-  /\bsupabase_db_url\b/i,
+  /\bdb\s+(push|reset|pull|seed)\b/i,
   /\bprisma\s+(migrate|db\s+push|db\s+pull|db\s+seed)\b/i,
   /\bdrizzle-kit\s+(push|migrate|generate)\b/i,
   /\b(knex|typeorm|sequelize)\b.*\bmigration\b/i,
@@ -27,7 +24,7 @@ const DATABASE_MUTATION_INTENT_PATTERN =
   /\b(migrate|migration|schema|sql|db push|db reset|db pull|table|column|policy|rls|seed|create|alter|drop|insert|update|delete|truncate)\b/i
 
 const DATABASE_CONTEXT_PATTERN =
-  /\b(database|db|sql|schema|migration|supabase|postgres|postgresql|mysql|mariadb|sqlite|mongodb|prisma|drizzle|typeorm|sequelize|knex|flyway|liquibase)\b/i
+  /\b(database|db|sql|schema|migration|postgres|postgresql|mysql|mariadb|sqlite|mongodb|prisma|drizzle|typeorm|sequelize|knex|flyway|liquibase)\b/i
 
 const DATABASE_NEGATION_PATTERN =
   /\b(do not|don't|dont|avoid|must not|never)\b.{0,40}\b(modify|change|touch|update|migrate|db|database|schema)\b/i
@@ -102,7 +99,7 @@ function isDatabaseMutationPath(pathLike: string): boolean {
   if (normalized.endsWith(".sql")) return true
   if (/(^|\/)(migrations?|migration)(\/|$)/.test(normalized)) return true
   if (/(^|\/)(db|database|schema|schemas|seed|seeds)(\/|$)/.test(normalized)) return true
-  if (/(^|\/)(supabase|prisma|drizzle|typeorm|sequelize|knex|flyway|liquibase)(\/|$)/.test(normalized))
+  if (/(^|\/)(prisma|drizzle|typeorm|sequelize|knex|flyway|liquibase)(\/|$)/.test(normalized))
     return true
   if (normalized.endsWith("schema.prisma")) return true
   return false

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -10,6 +10,10 @@ import { hasConnectedProvidersCache } from "../shared"
 import {
   setSessionAgent,
 } from "../features/claude-code-session-state"
+import {
+  parseLoopCommandArgs,
+  DEFAULT_AUDIT_LOOP_DURATION_MS,
+} from "../hooks/ralph-loop/command-args"
 
 import type { CreatedHooks } from "../create-hooks"
 
@@ -32,6 +36,24 @@ function isStartWorkHookOutput(value: unknown): value is StartWorkHookOutput {
     const partRecord = part as Record<string, unknown>
     return typeof partRecord["type"] === "string"
   })
+}
+
+function extractLoopTaskFromPrompt(promptText: string): string {
+  const taggedTaskMatch = promptText.match(/<user-task>\s*([\s\S]*?)\s*<\/user-task>/i)
+  const taggedTask = taggedTaskMatch?.[1]?.trim()
+  if (taggedTask && taggedTask !== "$ARGUMENTS") return taggedTask
+
+  const userArgumentsMatch = promptText.match(/\*\*User Arguments\*\*:\s*(.+)/i)
+  const userArguments = userArgumentsMatch?.[1]?.trim()
+  if (userArguments && userArguments !== "$ARGUMENTS") return userArguments
+
+  const userRequestSectionMatch = promptText.match(
+    /## User Request\s*([\s\S]*?)(?:\n##\s+[^\n]+|$)/i
+  )
+  const userRequestSection = userRequestSectionMatch?.[1]?.trim()
+  if (userRequestSection) return userRequestSection
+
+  return ""
 }
 
 export function createChatMessageHandler(args: {
@@ -107,29 +129,40 @@ export function createChatMessageHandler(args: {
           .trim() || ""
 
       const isRalphLoopTemplate =
-        promptText.includes("You are starting a Ralph Loop") &&
-        promptText.includes("<user-task>")
+        promptText.includes("You are starting a Ralph Loop")
+      const isAuditLoopTemplate =
+        promptText.includes("You are starting an Audit Loop")
       const isCancelRalphTemplate = promptText.includes(
         "Cancel the currently active Ralph Loop",
       )
 
-      if (isRalphLoopTemplate) {
-        const taskMatch = promptText.match(/<user-task>\s*([\s\S]*?)\s*<\/user-task>/i)
-        const rawTask = taskMatch?.[1]?.trim() || ""
-        const quotedMatch = rawTask.match(/^["'](.+?)["']/)
-        const prompt =
-          quotedMatch?.[1] ||
-          rawTask.split(/\s+--/)[0]?.trim() ||
-          "Complete the task as instructed"
+      if (isRalphLoopTemplate || isAuditLoopTemplate) {
+        const rawTask = extractLoopTaskFromPrompt(promptText)
 
-        const maxIterMatch = rawTask.match(/--max-iterations=(\d+)/i)
-        const promiseMatch = rawTask.match(
-          /--completion-promise=["']?([^"'\s]+)["']?/i,
-        )
+        const isUlwLoopTemplate =
+          promptText.includes("/ulw-loop Command") ||
+          promptText.includes("Start ultrawork loop")
 
-        hooks.ralphLoop.startLoop(input.sessionID, prompt, {
-          maxIterations: maxIterMatch ? parseInt(maxIterMatch[1], 10) : undefined,
-          completionPromise: promiseMatch?.[1],
+        const mode: "standard" | "ulw" | "audit-loop" = isAuditLoopTemplate
+          ? "audit-loop"
+          : isUlwLoopTemplate
+            ? "ulw"
+            : "standard"
+
+        const parsed = parseLoopCommandArgs(rawTask, {
+          defaultPrompt: "Complete the task as instructed",
+          mode,
+        })
+
+        hooks.ralphLoop.startLoop(input.sessionID, parsed.prompt, {
+          mode,
+          ultrawork: mode !== "standard",
+          maxIterations: parsed.maxIterations,
+          completionPromise: parsed.completionPromise,
+          completionDetectionEnabled: mode === "audit-loop" ? false : true,
+          maxDurationMs:
+            parsed.maxDurationMs ??
+            (mode === "audit-loop" ? DEFAULT_AUDIT_LOOP_DURATION_MS : undefined),
         })
       } else if (isCancelRalphTemplate) {
         hooks.ralphLoop.cancelLoop(input.sessionID)

--- a/src/plugin/tool-execute-before.test.ts
+++ b/src/plugin/tool-execute-before.test.ts
@@ -1,5 +1,8 @@
 const { describe, expect, test } = require("bun:test")
 const { createToolExecuteBeforeHandler } = require("./tool-execute-before")
+const { join } = require("node:path")
+const { tmpdir } = require("node:os")
+const { mkdirSync, readFileSync, writeFileSync } = require("node:fs")
 
 describe("createToolExecuteBeforeHandler", () => {
   test("does not execute subagent question blocker hook for question tool", async () => {
@@ -161,6 +164,456 @@ describe("createToolExecuteBeforeHandler", () => {
 
       //#then
       expect(output.args.subagent_type).toBe("oracle")
+    })
+  })
+
+  describe("audit-loop command + Supabase guard", () => {
+    function createCtx() {
+      const directory = join(tmpdir(), `omo-audit-guard-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+      mkdirSync(directory, { recursive: true })
+      return {
+        directory,
+        client: {
+          session: {
+            messages: async () => ({ data: [] }),
+          },
+        },
+      }
+    }
+
+    test("starts audit-loop with parsed args from slashcommand and forces nonstop mode", async () => {
+      //#given
+      const started: Array<{
+        sessionID: string
+        prompt: string
+        options: Record<string, unknown>
+      }> = []
+
+      const hooks = {
+        ralphLoop: {
+          startLoop: (sessionID: string, prompt: string, options: Record<string, unknown>) => {
+            started.push({ sessionID, prompt, options })
+            return true
+          },
+          getState: () => null,
+        },
+      }
+
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when
+      await handler(
+        { tool: "slashcommand", sessionID: "ses_audit_1", callID: "call_1" },
+        {
+          args: {
+            command:
+              '/audit-loop "Deep UI audit" --max-duration=2h --completion-promise=done --max-iterations=12',
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      expect(started).toHaveLength(1)
+      expect(started[0]).toEqual({
+        sessionID: "ses_audit_1",
+        prompt: "Deep UI audit",
+        options: {
+          mode: "audit-loop",
+          ultrawork: true,
+          maxIterations: 12,
+          completionPromise: "done",
+          completionDetectionEnabled: false,
+          maxDurationMs: 7_200_000,
+        },
+      })
+    })
+
+    test("audit-loop without explicit completion promise remains nonstop", async () => {
+      //#given
+      const started: Array<{
+        sessionID: string
+        prompt: string
+        options: Record<string, unknown>
+      }> = []
+
+      const hooks = {
+        ralphLoop: {
+          startLoop: (sessionID: string, prompt: string, options: Record<string, unknown>) => {
+            started.push({ sessionID, prompt, options })
+            return true
+          },
+          getState: () => null,
+        },
+      }
+
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when
+      await handler(
+        { tool: "slashcommand", sessionID: "ses_audit_implicit", callID: "call_1" },
+        {
+          args: { command: '/audit-loop "Deep UI audit" --max-duration=3h' } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      expect(started).toHaveLength(1)
+      expect(started[0].options.completionDetectionEnabled).toBe(false)
+      expect(started[0].options.maxDurationMs).toBe(3 * 60 * 60 * 1000)
+      expect(started[0].options.maxIterations).toBe(100)
+    })
+
+    test("blocks supabase db mutation command during active audit-loop", async () => {
+      //#given
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop" }),
+        },
+      }
+
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when
+      const run = handler(
+        { tool: "bash", sessionID: "ses_audit_2", callID: "call_1" },
+        { args: { command: "supabase db push" } as Record<string, unknown> },
+      )
+
+      //#then
+      await expect(run).rejects.toThrow(
+        "Supabase DB mutation is blocked while /audit-loop is active",
+      )
+    })
+
+    test("allows non-db supabase mentions with explicit negation in task prompt", async () => {
+      //#given
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop" }),
+        },
+      }
+
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when
+      const run = handler(
+        { tool: "task", sessionID: "ses_audit_3", callID: "call_1" },
+        {
+          args: {
+            description: "UI polish pass",
+            prompt: "Do not modify supabase database schema. Focus on frontend visual hierarchy.",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(run).resolves.toBeUndefined()
+    })
+
+    test("blocks writing to supabase migration sql path during active audit-loop", async () => {
+      //#given
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop" }),
+        },
+      }
+
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when
+      const run = handler(
+        { tool: "write", sessionID: "ses_audit_4", callID: "call_1" },
+        {
+          args: {
+            filePath: "apps/web/supabase/migrations/202602140001_init.sql",
+            content: "-- sql",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(run).rejects.toThrow(
+        "Supabase DB mutation is blocked while /audit-loop is active",
+      )
+    })
+
+    test("enforces focus lock and blocks cross-path edits without blocker report", async () => {
+      //#given
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop", session_id: "ses_focus_1" }),
+        },
+      }
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when - first write initializes focus
+      await handler(
+        { tool: "write", sessionID: "ses_focus_1", callID: "call_1" },
+        {
+          args: {
+            filePath: "lib/screens/settings/settings_screen.dart",
+            content: "class A {}",
+          } as Record<string, unknown>,
+        },
+      )
+
+      const run = handler(
+        { tool: "write", sessionID: "ses_focus_1", callID: "call_2" },
+        {
+          args: {
+            filePath: "lib/screens/dashboard/dashboard_screen.dart",
+            content: "class B {}",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(run).rejects.toThrow("Focus lock violation")
+    })
+
+    test("allows one focus switch after blocker report task", async () => {
+      //#given
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop", session_id: "ses_focus_2" }),
+        },
+      }
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      await handler(
+        { tool: "write", sessionID: "ses_focus_2", callID: "call_1" },
+        {
+          args: {
+            filePath: "lib/screens/settings/settings_screen.dart",
+            content: "class A {}",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#when - blocker report approved then switch edit
+      await handler(
+        { tool: "task", sessionID: "ses_focus_2", callID: "call_2" },
+        {
+          args: {
+            description: "BLOCKER REPORT",
+            prompt:
+              "BLOCKER REPORT: cannot proceed. switch focus to dashboard due to build blocker in settings.",
+          } as Record<string, unknown>,
+        },
+      )
+
+      const run = handler(
+        { tool: "write", sessionID: "ses_focus_2", callID: "call_3" },
+        {
+          args: {
+            filePath: "lib/screens/dashboard/dashboard_screen.dart",
+            content: "class B {}",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(run).resolves.toBeUndefined()
+    })
+
+    test("allows one automatic focus switch when checkpoint enables screen-complete progression", async () => {
+      //#given
+      const ctx = createCtx()
+      const checkpointPath = join(ctx.directory, ".sisyphus", "audit-loop-checkpoint.json")
+      mkdirSync(join(ctx.directory, ".sisyphus"), { recursive: true })
+      writeFileSync(
+        checkpointPath,
+        JSON.stringify({
+          version: 1,
+          updated_at: new Date().toISOString(),
+          locked_files: [],
+          recent_cycles: [],
+          consecutive_validation_failures: 0,
+          allow_focus_progression_once: true,
+        }),
+      )
+
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop", session_id: "ses_focus_auto_1" }),
+        },
+      }
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks })
+
+      await handler(
+        { tool: "write", sessionID: "ses_focus_auto_1", callID: "call_1" },
+        {
+          args: {
+            filePath: "lib/screens/settings/settings_screen.dart",
+            content: "class A {}",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#when - first cross-path switch should be allowed by checkpoint auto progression
+      const firstSwitch = handler(
+        { tool: "write", sessionID: "ses_focus_auto_1", callID: "call_2" },
+        {
+          args: {
+            filePath: "lib/screens/dashboard/dashboard_screen.dart",
+            content: "class B {}",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(firstSwitch).resolves.toBeUndefined()
+
+      const checkpointAfterSwitch = JSON.parse(readFileSync(checkpointPath, "utf-8"))
+      expect(checkpointAfterSwitch.allow_focus_progression_once).toBe(false)
+
+      //#when - second cross-path switch should be blocked (one-time allowance consumed)
+      const secondSwitch = handler(
+        { tool: "write", sessionID: "ses_focus_auto_1", callID: "call_3" },
+        {
+          args: {
+            filePath: "lib/screens/profile/profile_screen.dart",
+            content: "class C {}",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(secondSwitch).rejects.toThrow("Focus lock violation")
+    })
+
+    test("blocks hardcoded visual literals in audit-loop writes", async () => {
+      //#given
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop", session_id: "ses_token_1" }),
+        },
+      }
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when
+      const run = handler(
+        { tool: "write", sessionID: "ses_token_1", callID: "call_1" },
+        {
+          args: {
+            filePath: "lib/screens/settings/settings_screen.dart",
+            content: "Container(color: Color(0xFFFFFFFF), padding: EdgeInsets.all(12))",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(run).rejects.toThrow("Hardcoded visual style values are blocked")
+    })
+
+    test("allows token-based visual styling in audit-loop writes", async () => {
+      //#given
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop", session_id: "ses_token_2" }),
+        },
+      }
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when
+      const run = handler(
+        { tool: "write", sessionID: "ses_token_2", callID: "call_1" },
+        {
+          args: {
+            filePath: "lib/screens/settings/settings_screen.dart",
+            content: "Container(color: Theme.of(context).colorScheme.surface)",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(run).resolves.toBeUndefined()
+    })
+
+    test("blocks edits to frozen files unless bug evidence is provided", async () => {
+      //#given
+      const ctx = createCtx()
+      const checkpointPath = join(ctx.directory, ".sisyphus", "audit-loop-checkpoint.json")
+      mkdirSync(join(ctx.directory, ".sisyphus"), { recursive: true })
+      writeFileSync(
+        checkpointPath,
+        JSON.stringify({
+          version: 1,
+          updated_at: new Date().toISOString(),
+          locked_files: ["lib/screens/settings/settings_screen.dart"],
+          recent_cycles: [],
+          consecutive_validation_failures: 0,
+        }),
+      )
+
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop", session_id: "ses_lock_1" }),
+        },
+      }
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks })
+
+      //#when
+      const run = handler(
+        { tool: "write", sessionID: "ses_lock_1", callID: "call_1" },
+        {
+          args: {
+            filePath: "lib/screens/settings/settings_screen.dart",
+            content: "class Locked {}",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(run).rejects.toThrow("File is locked after saturation")
+    })
+
+    test("allows one locked-file edit after bug evidence task", async () => {
+      //#given
+      const ctx = createCtx()
+      const checkpointPath = join(ctx.directory, ".sisyphus", "audit-loop-checkpoint.json")
+      mkdirSync(join(ctx.directory, ".sisyphus"), { recursive: true })
+      writeFileSync(
+        checkpointPath,
+        JSON.stringify({
+          version: 1,
+          updated_at: new Date().toISOString(),
+          locked_files: ["lib/screens/settings/settings_screen.dart"],
+          recent_cycles: [],
+          consecutive_validation_failures: 0,
+        }),
+      )
+
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop", session_id: "ses_lock_2" }),
+        },
+      }
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks })
+
+      await handler(
+        { tool: "task", sessionID: "ses_lock_2", callID: "call_bug" },
+        {
+          args: {
+            description: "BUG EVIDENCE",
+            prompt: "BUG EVIDENCE: keyboard trap regression found in locked file.",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#when
+      const run = handler(
+        { tool: "write", sessionID: "ses_lock_2", callID: "call_1" },
+        {
+          args: {
+            filePath: "lib/screens/settings/settings_screen.dart",
+            content: "class UnlockedOnce {}",
+          } as Record<string, unknown>,
+        },
+      )
+
+      //#then
+      await expect(run).resolves.toBeUndefined()
     })
   })
 })

--- a/src/plugin/tool-execute-before.test.ts
+++ b/src/plugin/tool-execute-before.test.ts
@@ -359,6 +359,28 @@ describe("createToolExecuteBeforeHandler", () => {
       )
     })
 
+    test("blocks migration subcommands regardless of cli vendor during active audit-loop", async () => {
+      //#given
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop" }),
+        },
+      }
+
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when
+      const run = handler(
+        { tool: "bash", sessionID: "ses_audit_migration_1", callID: "call_1" },
+        { args: { command: "supabase migration list" } as Record<string, unknown> },
+      )
+
+      //#then
+      await expect(run).rejects.toThrow(
+        "Database mutation is blocked while /audit-loop is active",
+      )
+    })
+
     test("enforces focus lock and blocks cross-path edits without blocker report", async () => {
       //#given
       const hooks = {

--- a/src/plugin/tool-execute-before.test.ts
+++ b/src/plugin/tool-execute-before.test.ts
@@ -276,7 +276,7 @@ describe("createToolExecuteBeforeHandler", () => {
       //#when
       const run = handler(
         { tool: "bash", sessionID: "ses_audit_2", callID: "call_1" },
-        { args: { command: "supabase db push" } as Record<string, unknown> },
+        { args: { command: "db push" } as Record<string, unknown> },
       )
 
       //#then
@@ -301,7 +301,7 @@ describe("createToolExecuteBeforeHandler", () => {
         {
           args: {
             description: "UI polish pass",
-            prompt: "Do not modify database schema (including supabase). Focus on frontend visual hierarchy.",
+            prompt: "Do not modify database schema. Focus on frontend visual hierarchy.",
           } as Record<string, unknown>,
         },
       )
@@ -325,7 +325,7 @@ describe("createToolExecuteBeforeHandler", () => {
         { tool: "write", sessionID: "ses_audit_4", callID: "call_1" },
         {
           args: {
-            filePath: "apps/web/supabase/migrations/202602140001_init.sql",
+            filePath: "apps/web/database/migrations/202602140001_init.sql",
             content: "-- sql",
           } as Record<string, unknown>,
         },

--- a/src/plugin/tool-execute-before.test.ts
+++ b/src/plugin/tool-execute-before.test.ts
@@ -167,7 +167,7 @@ describe("createToolExecuteBeforeHandler", () => {
     })
   })
 
-  describe("audit-loop command + Supabase guard", () => {
+  describe("audit-loop command + database guard", () => {
     function createCtx() {
       const directory = join(tmpdir(), `omo-audit-guard-${Date.now()}-${Math.random().toString(36).slice(2)}`)
       mkdirSync(directory, { recursive: true })
@@ -263,7 +263,7 @@ describe("createToolExecuteBeforeHandler", () => {
       expect(started[0].options.maxIterations).toBe(100)
     })
 
-    test("blocks supabase db mutation command during active audit-loop", async () => {
+    test("blocks database mutation command during active audit-loop", async () => {
       //#given
       const hooks = {
         ralphLoop: {
@@ -281,11 +281,11 @@ describe("createToolExecuteBeforeHandler", () => {
 
       //#then
       await expect(run).rejects.toThrow(
-        "Supabase DB mutation is blocked while /audit-loop is active",
+        "Database mutation is blocked while /audit-loop is active",
       )
     })
 
-    test("allows non-db supabase mentions with explicit negation in task prompt", async () => {
+    test("allows explicit do-not-modify database guidance in task prompt", async () => {
       //#given
       const hooks = {
         ralphLoop: {
@@ -301,7 +301,7 @@ describe("createToolExecuteBeforeHandler", () => {
         {
           args: {
             description: "UI polish pass",
-            prompt: "Do not modify supabase database schema. Focus on frontend visual hierarchy.",
+            prompt: "Do not modify database schema (including supabase). Focus on frontend visual hierarchy.",
           } as Record<string, unknown>,
         },
       )
@@ -310,7 +310,7 @@ describe("createToolExecuteBeforeHandler", () => {
       await expect(run).resolves.toBeUndefined()
     })
 
-    test("blocks writing to supabase migration sql path during active audit-loop", async () => {
+    test("blocks writing to migration sql path during active audit-loop", async () => {
       //#given
       const hooks = {
         ralphLoop: {
@@ -333,7 +333,29 @@ describe("createToolExecuteBeforeHandler", () => {
 
       //#then
       await expect(run).rejects.toThrow(
-        "Supabase DB mutation is blocked while /audit-loop is active",
+        "Database mutation is blocked while /audit-loop is active",
+      )
+    })
+
+    test("blocks prisma migrate command during active audit-loop", async () => {
+      //#given
+      const hooks = {
+        ralphLoop: {
+          getState: () => ({ active: true, mode: "audit-loop" }),
+        },
+      }
+
+      const handler = createToolExecuteBeforeHandler({ ctx: createCtx(), hooks })
+
+      //#when
+      const run = handler(
+        { tool: "bash", sessionID: "ses_audit_prisma_1", callID: "call_1" },
+        { args: { command: "prisma migrate deploy" } as Record<string, unknown> },
+      )
+
+      //#then
+      await expect(run).rejects.toThrow(
+        "Database mutation is blocked while /audit-loop is active",
       )
     })
 

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -4,8 +4,20 @@ import { getMainSessionID } from "../features/claude-code-session-state"
 import { clearBoulderState } from "../features/boulder-state"
 import { log } from "../shared"
 import { resolveSessionAgent } from "./session-agent-resolver"
+import { createAuditLoopGuard } from "./audit-loop-guard"
+import {
+  DEFAULT_AUDIT_LOOP_DURATION_MS,
+  extractRawLoopArgs,
+  parseLoopCommandArgs,
+} from "../hooks/ralph-loop/command-args"
 
 import type { CreatedHooks } from "../create-hooks"
+
+const LOOP_COMMANDS = new Set(["ralph-loop", "ulw-loop", "audit-loop"])
+
+function resolveSlashCommand(rawCommand: string | undefined): string | undefined {
+  return rawCommand?.replace(/^\//, "").trim().split(/\s+/)[0]?.toLowerCase()
+}
 
 export function createToolExecuteBeforeHandler(args: {
   ctx: PluginContext
@@ -15,6 +27,7 @@ export function createToolExecuteBeforeHandler(args: {
   output: { args: Record<string, unknown> },
 ) => Promise<void> {
   const { ctx, hooks } = args
+  const auditLoopGuard = createAuditLoopGuard(ctx.directory ?? process.cwd())
 
   return async (input, output): Promise<void> => {
     await hooks.writeExistingFileGuard?.["tool.execute.before"]?.(input, output)
@@ -46,54 +59,49 @@ export function createToolExecuteBeforeHandler(args: {
 
     if (hooks.ralphLoop && input.tool === "slashcommand") {
       const rawCommand = typeof output.args.command === "string" ? output.args.command : undefined
-      const command = rawCommand?.replace(/^\//, "").toLowerCase()
+      const command = resolveSlashCommand(rawCommand)
       const sessionID = input.sessionID || getMainSessionID()
 
-      if (command === "ralph-loop" && sessionID) {
-        const rawArgs = rawCommand?.replace(/^\/?(ralph-loop)\s*/i, "") || ""
-        const taskMatch = rawArgs.match(/^["'](.+?)["']/)
-        const prompt =
-          taskMatch?.[1] ||
-          rawArgs.split(/\s+--/)[0]?.trim() ||
-          "Complete the task as instructed"
-
-        const maxIterMatch = rawArgs.match(/--max-iterations=(\d+)/i)
-        const promiseMatch = rawArgs.match(/--completion-promise=["']?([^"'\s]+)["']?/i)
-
-        hooks.ralphLoop.startLoop(sessionID, prompt, {
-          maxIterations: maxIterMatch ? parseInt(maxIterMatch[1], 10) : undefined,
-          completionPromise: promiseMatch?.[1],
+      if (command && LOOP_COMMANDS.has(command) && sessionID) {
+        const mode =
+          command === "audit-loop" ? "audit-loop" : command === "ulw-loop" ? "ulw" : "standard"
+        const rawArgs = extractRawLoopArgs(rawCommand, command)
+        const parsed = parseLoopCommandArgs(rawArgs, {
+          defaultPrompt: "Complete the task as instructed",
+          mode,
         })
+
+        hooks.ralphLoop.startLoop(sessionID, parsed.prompt, {
+          mode,
+          ultrawork: mode !== "standard",
+          maxIterations: parsed.maxIterations,
+          completionPromise: parsed.completionPromise,
+          completionDetectionEnabled: mode === "audit-loop" ? false : true,
+          maxDurationMs:
+            parsed.maxDurationMs ??
+            (mode === "audit-loop" ? DEFAULT_AUDIT_LOOP_DURATION_MS : undefined),
+        })
+        if (mode === "audit-loop") {
+          auditLoopGuard.resetSession(sessionID)
+        }
       } else if (command === "cancel-ralph" && sessionID) {
         hooks.ralphLoop.cancelLoop(sessionID)
-      } else if (command === "ulw-loop" && sessionID) {
-        const rawArgs = rawCommand?.replace(/^\/?(ulw-loop)\s*/i, "") || ""
-        const taskMatch = rawArgs.match(/^["'](.+?)["']/)
-        const prompt =
-          taskMatch?.[1] ||
-          rawArgs.split(/\s+--/)[0]?.trim() ||
-          "Complete the task as instructed"
-
-        const maxIterMatch = rawArgs.match(/--max-iterations=(\d+)/i)
-        const promiseMatch = rawArgs.match(/--completion-promise=["']?([^"'\s]+)["']?/i)
-
-        hooks.ralphLoop.startLoop(sessionID, prompt, {
-          ultrawork: true,
-          maxIterations: maxIterMatch ? parseInt(maxIterMatch[1], 10) : undefined,
-          completionPromise: promiseMatch?.[1],
-        })
+        auditLoopGuard.clearSession(sessionID)
       }
     }
 
+    auditLoopGuard.enforce(input, output, hooks)
+
     if (input.tool === "slashcommand") {
       const rawCommand = typeof output.args.command === "string" ? output.args.command : undefined
-      const command = rawCommand?.replace(/^\//, "").toLowerCase()
+      const command = resolveSlashCommand(rawCommand)
       const sessionID = input.sessionID || getMainSessionID()
 
       if (command === "stop-continuation" && sessionID) {
         hooks.stopContinuationGuard?.stop(sessionID)
         hooks.todoContinuationEnforcer?.cancelAllCountdowns()
         hooks.ralphLoop?.cancelLoop(sessionID)
+        auditLoopGuard.clearSession(sessionID)
         clearBoulderState(ctx.directory)
         log("[stop-continuation] All continuation mechanisms stopped", {
           sessionID,

--- a/src/shared/skill-path-resolver.ts
+++ b/src/shared/skill-path-resolver.ts
@@ -1,4 +1,4 @@
-import { join } from "path"
+import { posix } from "path"
 
 /**
  * Resolves @path references in skill content to absolute paths.
@@ -9,9 +9,15 @@ import { join } from "path"
  * Email addresses are excluded since they have alphanumeric characters before @.
  */
 export function resolveSkillPathReferences(content: string, basePath: string): string {
-	const normalizedBase = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath
+	const normalizedBasePath = basePath.replace(/\\/g, "/")
+	const normalizedBase =
+		normalizedBasePath.endsWith("/") ? normalizedBasePath.slice(0, -1) : normalizedBasePath
 	return content.replace(
 		/(?<![a-zA-Z0-9])@([a-zA-Z0-9_-]+\/[a-zA-Z0-9_.\-\/]*)/g,
-		(_, relativePath: string) => join(normalizedBase, relativePath)
+		(_, relativePath: string) => {
+			const joined = posix.join(normalizedBase, relativePath)
+			if (!relativePath.endsWith("/")) return joined
+			return joined.endsWith("/") ? joined : `${joined}/`
+		}
 	)
 }


### PR DESCRIPTION
﻿## Why
`/audit-loop` was still stopping early in real sessions, often after small patches.

This PR makes audit mode behave like a true continuous loop: it keeps cycling until timeout, max iterations, or explicit cancel.

## What Changed

### 1) Continuous Audit Runtime
- Audit mode now runs in nonstop mode by default.
- Completion tags no longer terminate `/audit-loop` early.
- Default timebox remains 3h with max iterations defaulting to 100.

### 2) Universal Database Guardrails (Provider-Agnostic)
- Added `src/plugin/audit-loop-guard.ts` and wired it into `tool.execute.before`.
- Blocks database mutation commands and paths (migrations, schema, SQL), without provider-specific logic.
- Covers common stacks (Prisma, Drizzle, TypeORM/Sequelize/Knex, Flyway/Liquibase, direct SQL tooling).

### 3) Focus Lock and Quality Enforcement
- Enforces focus lock to one primary screen path.
- Allows screen switch only via:
  - explicit `BLOCKER REPORT`, or
  - one-time validated `SCREEN COMPLETE` auto-progression.
- Blocks hardcoded visual literals in UI files unless token/theme aliases are used.
- Blocks mutating shell flows during focus lock.
- Adds frozen-file protection with unlock only via `BUG EVIDENCE` or `REGRESSION EVIDENCE`.

### 4) Audit Cycle Policy and Checkpointing
- Added `src/hooks/ralph-loop/audit-ledger.ts`.
- Introduced `.sisyphus/audit-loop-ledger.jsonl` and `.sisyphus/audit-loop-checkpoint.json`.
- Tracks validation streaks, regression gate, objective cap, saturated files, and one-time auto focus progression.

### 5) Prompt and Continuation Hardening
- Added dedicated audit template: `src/features/builtin-commands/templates/audit-loop.ts`.
- Expanded continuation prompts with:
  - PHASE 10 cycle plan requirement,
  - AGENTS.md precedence,
  - required skills evidence,
  - token-only styling constraints,
  - focus-screen discipline and progression rules.

### 6) Better Runtime Visibility
- Added heartbeat toast every audit cycle:
  - title: `Audit Loop Active`
  - message includes iteration and remaining time.

## Command Differences (Quick Reference)

### `/ralph-loop`
- General-purpose loop.
- Completion-promise driven (stops on promise, max-iterations, or cancel).
- No audit-specific runtime guardrails.

### `/ulw-loop`
- Same loop engine as ralph-loop, with ultrawork mode enabled.
- Also completion-promise driven.

### `/audit-loop`
- Specialized UI audit + refactor loop.
- Nonstop by default for the timebox (default 3h) unless max-iterations or explicit cancel.
- Adds strict runtime enforcement for database mutation blocking, focus lock, tokenized styling, and evidence-driven progression.

Stop controls:
- `/cancel-ralph`: cancel active loop session.
- `/stop-continuation`: stop all continuation mechanisms in the session.

## Validation
- `bun test src/plugin/tool-execute-before.test.ts src/hooks/ralph-loop/index.test.ts src/features/builtin-commands/commands.test.ts src/hooks/ralph-loop/command-args.test.ts`
- Result: **96 passed, 0 failed**
- `bun run build` passed
- Linked globally with `npm link` for manual TUI verification

## Notes
- This is intentionally strict by design.
- Ad-hoc cross-screen edits or literal style values are blocked unless they follow the explicit protocol.
