### PR TITLE
fix(tmux): prefer split-or-defer with FIFO deferred attach

### DIFF
--- a/src/features/tmux-subagent/decision-engine.test.ts
+++ b/src/features/tmux-subagent/decision-engine.test.ts
@@ -335,7 +335,7 @@ describe("decideSpawnActions", () => {
 
       // then
       expect(result.canSpawn).toBe(false)
-      expect(result.reason).toContain("too small")
+      expect(result.reason).toContain("defer attach")
     })
 
     it("spawns at exact minimum splittable width with 0 agent panes", () => {
@@ -634,7 +634,7 @@ describe("decideSpawnActions with custom agentPaneWidth", () => {
     }
   })
 
-	it("#given wider main pane #when capacity needs two evictions #then replace is chosen", () => {
+	it("#given wider main pane #when capacity needs two evictions #then defer is chosen", () => {
 		//#given
 		const config: CapacityConfig = { mainPaneMinWidth: 120, agentPaneWidth: 40 }
 		const state = createWindowState(220, 44, [
@@ -665,8 +665,8 @@ describe("decideSpawnActions with custom agentPaneWidth", () => {
 		const result = decideSpawnActions(state, "ses-new", "new task", config, mappings)
 
 		//#then
-		expect(result.canSpawn).toBe(true)
-		expect(result.actions).toHaveLength(1)
-		expect(result.actions[0].type).toBe("replace")
+		expect(result.canSpawn).toBe(false)
+		expect(result.actions).toHaveLength(0)
+		expect(result.reason).toContain("defer attach")
 	})
 })

--- a/src/features/tmux-subagent/grid-planning.ts
+++ b/src/features/tmux-subagent/grid-planning.ts
@@ -30,6 +30,9 @@ function resolveMinPaneWidth(options?: CapacityOptions): number {
 	if (typeof options === "number") {
 		return Math.max(1, options)
 	}
+	if (options && typeof options.agentPaneWidth === "number") {
+		return Math.max(1, options.agentPaneWidth)
+	}
 	return MIN_PANE_WIDTH
 }
 

--- a/src/features/tmux-subagent/layout-config.test.ts
+++ b/src/features/tmux-subagent/layout-config.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test"
+import { decideSpawnActions, findSpawnTarget, type SessionMapping } from "./decision-engine"
+import type { CapacityConfig, WindowState } from "./types"
+
+function createState(
+  windowWidth: number,
+  windowHeight: number,
+  agentPanes: WindowState["agentPanes"],
+): WindowState {
+  return {
+    windowWidth,
+    windowHeight,
+    mainPane: {
+      paneId: "%0",
+      width: Math.floor(windowWidth / 2),
+      height: windowHeight,
+      left: 0,
+      top: 0,
+      title: "main",
+      isActive: true,
+    },
+    agentPanes,
+  }
+}
+
+describe("tmux layout-aware split behavior", () => {
+  it("uses -v for first spawn in main-horizontal layout", () => {
+    const config: CapacityConfig = {
+      layout: "main-horizontal",
+      mainPaneSize: 60,
+      mainPaneMinWidth: 120,
+      agentPaneWidth: 40,
+    }
+    const state = createState(220, 44, [])
+
+    const decision = decideSpawnActions(state, "ses-1", "agent", config, [])
+
+    expect(decision.canSpawn).toBe(true)
+    expect(decision.actions[0]).toMatchObject({
+      type: "spawn",
+      splitDirection: "-v",
+    })
+  })
+
+  it("uses -h for first spawn in main-vertical layout", () => {
+    const config: CapacityConfig = {
+      layout: "main-vertical",
+      mainPaneSize: 60,
+      mainPaneMinWidth: 120,
+      agentPaneWidth: 40,
+    }
+    const state = createState(220, 44, [])
+
+    const decision = decideSpawnActions(state, "ses-1", "agent", config, [])
+
+    expect(decision.canSpawn).toBe(true)
+    expect(decision.actions[0]).toMatchObject({
+      type: "spawn",
+      splitDirection: "-h",
+    })
+  })
+
+  it("prefers horizontal split target in main-horizontal layout", () => {
+    const config: CapacityConfig = {
+      layout: "main-horizontal",
+      mainPaneSize: 60,
+      mainPaneMinWidth: 120,
+      agentPaneWidth: 40,
+    }
+    const state = createState(260, 60, [
+      {
+        paneId: "%1",
+        width: 120,
+        height: 30,
+        left: 0,
+        top: 30,
+        title: "agent",
+        isActive: false,
+      },
+    ])
+
+    const target = findSpawnTarget(state, config)
+
+    expect(target).toEqual({ targetPaneId: "%1", splitDirection: "-h" })
+  })
+
+  it("defers when strict main-horizontal cannot split", () => {
+    const config: CapacityConfig = {
+      layout: "main-horizontal",
+      mainPaneSize: 60,
+      mainPaneMinWidth: 120,
+      agentPaneWidth: 40,
+    }
+    const state = createState(220, 44, [
+      {
+        paneId: "%1",
+        width: 60,
+        height: 44,
+        left: 0,
+        top: 22,
+        title: "old",
+        isActive: false,
+      },
+    ])
+    const mappings: SessionMapping[] = [
+      { sessionId: "old-ses", paneId: "%1", createdAt: new Date("2024-01-01") },
+    ]
+
+    const decision = decideSpawnActions(state, "new-ses", "agent", config, mappings)
+
+    expect(decision.canSpawn).toBe(false)
+    expect(decision.actions).toHaveLength(0)
+    expect(decision.reason).toContain("defer")
+  })
+
+  it("still spawns in narrow main-vertical when vertical split is possible", () => {
+    const config: CapacityConfig = {
+      layout: "main-vertical",
+      mainPaneSize: 60,
+      mainPaneMinWidth: 120,
+      agentPaneWidth: 40,
+    }
+    const state = createState(169, 40, [
+      {
+        paneId: "%1",
+        width: 48,
+        height: 40,
+        left: 121,
+        top: 0,
+        title: "agent",
+        isActive: false,
+      },
+    ])
+
+    const decision = decideSpawnActions(state, "new-ses", "agent", config, [])
+
+    expect(decision.canSpawn).toBe(true)
+    expect(decision.actions).toHaveLength(1)
+    expect(decision.actions[0]).toMatchObject({
+      type: "spawn",
+      targetPaneId: "%1",
+      splitDirection: "-v",
+    })
+  })
+})

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -703,7 +703,7 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionDeleted({ sessionID: 'ses_timeout' })
 
       // then
-      expect(mockExecuteAction).toHaveBeenCalledTimes(0)
+      expect(mockExecuteAction).toHaveBeenCalledTimes(1)
     })
 
     test('closes pane when tracked session is deleted', async () => {

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -156,7 +156,15 @@ describe('TmuxSessionManager', () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
       const { TmuxSessionManager } = await import('./manager')
-      const ctx = createMockContext()
+      const ctx = createMockContext({
+        sessionStatusResult: {
+          data: {
+            ses_1: { type: 'running' },
+            ses_2: { type: 'running' },
+            ses_3: { type: 'running' },
+          },
+        },
+      })
       const config: TmuxConfig = {
         enabled: true,
         layout: 'main-vertical',
@@ -176,7 +184,13 @@ describe('TmuxSessionManager', () => {
       // given
       mockIsInsideTmux.mockReturnValue(false)
       const { TmuxSessionManager } = await import('./manager')
-      const ctx = createMockContext()
+      const ctx = createMockContext({
+        sessionStatusResult: {
+          data: {
+            ses_once: { type: 'running' },
+          },
+        },
+      })
       const config: TmuxConfig = {
         enabled: true,
         layout: 'main-vertical',
@@ -386,7 +400,7 @@ describe('TmuxSessionManager', () => {
       expect(mockExecuteActions).toHaveBeenCalledTimes(0)
     })
 
-    test('replaces oldest agent when unsplittable (small window)', async () => {
+    test('defers attach when unsplittable (small window)', async () => {
       // given - small window where split is not possible
       mockIsInsideTmux.mockReturnValue(true)
       mockQueryWindowState.mockImplementation(async () =>
@@ -423,13 +437,224 @@ describe('TmuxSessionManager', () => {
         createSessionCreatedEvent('ses_new', 'ses_parent', 'New Task')
       )
 
-      // then - with small window, replace action is used instead of close+spawn
-      expect(mockExecuteActions).toHaveBeenCalledTimes(1)
-      const call = mockExecuteActions.mock.calls[0]
-      expect(call).toBeDefined()
-      const actionsArg = call![0]
-      expect(actionsArg).toHaveLength(1)
-      expect(actionsArg[0].type).toBe('replace')
+      // then - with small window, manager defers instead of replacing
+      expect(mockExecuteActions).toHaveBeenCalledTimes(0)
+      expect((manager as any).deferredQueue).toEqual(['ses_new'])
+    })
+
+    test('keeps deferred queue idempotent for duplicate session.created events', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () =>
+        createWindowState({
+          windowWidth: 160,
+          windowHeight: 11,
+          agentPanes: [
+            {
+              paneId: '%1',
+              width: 80,
+              height: 11,
+              left: 80,
+              top: 0,
+              title: 'old',
+              isActive: false,
+            },
+          ],
+        })
+      )
+
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = createMockContext()
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 120,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      // when
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_dup', 'ses_parent', 'Duplicate Task')
+      )
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_dup', 'ses_parent', 'Duplicate Task')
+      )
+
+      // then
+      expect((manager as any).deferredQueue).toEqual(['ses_dup'])
+    })
+
+    test('auto-attaches deferred sessions in FIFO order', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () =>
+        createWindowState({
+          windowWidth: 160,
+          windowHeight: 11,
+          agentPanes: [
+            {
+              paneId: '%1',
+              width: 80,
+              height: 11,
+              left: 80,
+              top: 0,
+              title: 'old',
+              isActive: false,
+            },
+          ],
+        })
+      )
+
+      const attachOrder: string[] = []
+      mockExecuteActions.mockImplementation(async (actions) => {
+        for (const action of actions) {
+          if (action.type === 'spawn') {
+            attachOrder.push(action.sessionId)
+            trackedSessions.add(action.sessionId)
+            return {
+              success: true,
+              spawnedPaneId: `%${action.sessionId}`,
+              results: [{ action, result: { success: true, paneId: `%${action.sessionId}` } }],
+            }
+          }
+        }
+        return { success: true, results: [] }
+      })
+
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = createMockContext()
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 120,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_1', 'ses_parent', 'Task 1'))
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_2', 'ses_parent', 'Task 2'))
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_3', 'ses_parent', 'Task 3'))
+      expect((manager as any).deferredQueue).toEqual(['ses_1', 'ses_2', 'ses_3'])
+
+      // when
+      mockQueryWindowState.mockImplementation(async () => createWindowState())
+      await (manager as any).tryAttachDeferredSession()
+      await (manager as any).tryAttachDeferredSession()
+      await (manager as any).tryAttachDeferredSession()
+
+      // then
+      expect(attachOrder).toEqual(['ses_1', 'ses_2', 'ses_3'])
+      expect((manager as any).deferredQueue).toEqual([])
+    })
+
+    test('does not attach deferred session more than once across repeated retries', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () =>
+        createWindowState({
+          windowWidth: 160,
+          windowHeight: 11,
+          agentPanes: [
+            {
+              paneId: '%1',
+              width: 80,
+              height: 11,
+              left: 80,
+              top: 0,
+              title: 'old',
+              isActive: false,
+            },
+          ],
+        })
+      )
+
+      let attachCount = 0
+      mockExecuteActions.mockImplementation(async (actions) => {
+        for (const action of actions) {
+          if (action.type === 'spawn') {
+            attachCount += 1
+            trackedSessions.add(action.sessionId)
+            return {
+              success: true,
+              spawnedPaneId: `%${action.sessionId}`,
+              results: [{ action, result: { success: true, paneId: `%${action.sessionId}` } }],
+            }
+          }
+        }
+        return { success: true, results: [] }
+      })
+
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = createMockContext()
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 120,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_once', 'ses_parent', 'Task Once')
+      )
+
+      // when
+      mockQueryWindowState.mockImplementation(async () => createWindowState())
+      await (manager as any).tryAttachDeferredSession()
+      await (manager as any).tryAttachDeferredSession()
+
+      // then
+      expect(attachCount).toBe(1)
+      expect((manager as any).deferredQueue).toEqual([])
+    })
+
+    test('removes deferred session when session is deleted before attach', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      mockQueryWindowState.mockImplementation(async () =>
+        createWindowState({
+          windowWidth: 160,
+          windowHeight: 11,
+          agentPanes: [
+            {
+              paneId: '%1',
+              width: 80,
+              height: 11,
+              left: 80,
+              top: 0,
+              title: 'old',
+              isActive: false,
+            },
+          ],
+        })
+      )
+
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = createMockContext()
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 120,
+        agent_pane_min_width: 40,
+      }
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      await manager.onSessionCreated(
+        createSessionCreatedEvent('ses_pending', 'ses_parent', 'Pending Task')
+      )
+      expect((manager as any).deferredQueue).toEqual(['ses_pending'])
+
+      // when
+      await manager.onSessionDeleted({ sessionID: 'ses_pending' })
+
+      // then
+      expect((manager as any).deferredQueue).toEqual([])
+      expect(mockExecuteAction).toHaveBeenCalledTimes(0)
     })
   })
 
@@ -680,7 +905,7 @@ describe('DecisionEngine', () => {
       }
     })
 
-    test('returns replace when split not possible', async () => {
+    test('returns canSpawn=false when split not possible', async () => {
       // given - small window where split is never possible
       const { decideSpawnActions } = await import('./decision-engine')
       const state: WindowState = {
@@ -720,10 +945,10 @@ describe('DecisionEngine', () => {
         sessionMappings
       )
 
-      // then - agent area (80) < MIN_SPLIT_WIDTH (105), so replace is used
-      expect(decision.canSpawn).toBe(true)
-      expect(decision.actions).toHaveLength(1)
-      expect(decision.actions[0].type).toBe('replace')
+      // then - agent area (80) < MIN_SPLIT_WIDTH (105), so attach is deferred
+      expect(decision.canSpawn).toBe(false)
+      expect(decision.actions).toHaveLength(0)
+      expect(decision.reason).toContain('defer')
     })
 
     test('returns canSpawn=false when window too small', async () => {

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -5,6 +5,7 @@ import { log, normalizeSDKResponse } from "../../shared"
 import {
   isInsideTmux as defaultIsInsideTmux,
   getCurrentPaneId as defaultGetCurrentPaneId,
+  POLL_INTERVAL_BACKGROUND_MS,
   SESSION_READY_POLL_INTERVAL_MS,
   SESSION_READY_TIMEOUT_MS,
 } from "../../shared/tmux"
@@ -398,10 +399,12 @@ export class TmuxSessionManager {
             })),
           })
 
-          await executeAction(
-            { type: "close", paneId: result.spawnedPaneId, sessionId },
-            { config: this.tmuxConfig, serverUrl: this.serverUrl, windowState: state }
-          )
+          if (result.spawnedPaneId) {
+            await executeAction(
+              { type: "close", paneId: result.spawnedPaneId, sessionId },
+              { config: this.tmuxConfig, serverUrl: this.serverUrl, windowState: state }
+            )
+          }
 
           return
         }

--- a/src/features/tmux-subagent/pane-split-availability.ts
+++ b/src/features/tmux-subagent/pane-split-availability.ts
@@ -1,14 +1,15 @@
-import { MIN_PANE_WIDTH } from "./types"
 import type { SplitDirection, TmuxPaneInfo } from "./types"
 import {
-  DIVIDER_SIZE,
-  MAX_COLS,
-  MAX_ROWS,
-  MIN_SPLIT_HEIGHT,
+	DIVIDER_SIZE,
+	MAX_COLS,
+	MAX_ROWS,
+	MIN_SPLIT_HEIGHT,
 } from "./tmux-grid-constants"
+import { MIN_PANE_WIDTH } from "./types"
 
-function minSplitWidthFor(minPaneWidth: number): number {
-	return 2 * minPaneWidth + DIVIDER_SIZE
+function getMinSplitWidth(minPaneWidth?: number): number {
+	const width = Math.max(1, minPaneWidth ?? MIN_PANE_WIDTH)
+	return 2 * width + DIVIDER_SIZE
 }
 
 export function getColumnCount(paneCount: number): number {
@@ -25,16 +26,16 @@ export function getColumnWidth(agentAreaWidth: number, paneCount: number): numbe
 export function isSplittableAtCount(
 	agentAreaWidth: number,
 	paneCount: number,
-	minPaneWidth: number = MIN_PANE_WIDTH,
+	minPaneWidth?: number,
 ): boolean {
 	const columnWidth = getColumnWidth(agentAreaWidth, paneCount)
-	return columnWidth >= minSplitWidthFor(minPaneWidth)
+	return columnWidth >= getMinSplitWidth(minPaneWidth)
 }
 
 export function findMinimalEvictions(
 	agentAreaWidth: number,
 	currentCount: number,
-	minPaneWidth: number = MIN_PANE_WIDTH,
+	minPaneWidth?: number,
 ): number | null {
 	for (let k = 1; k <= currentCount; k++) {
 		if (isSplittableAtCount(agentAreaWidth, currentCount - k, minPaneWidth)) {
@@ -47,30 +48,26 @@ export function findMinimalEvictions(
 export function canSplitPane(
 	pane: TmuxPaneInfo,
 	direction: SplitDirection,
-	minPaneWidth: number = MIN_PANE_WIDTH,
+	minPaneWidth?: number,
 ): boolean {
 	if (direction === "-h") {
-		return pane.width >= minSplitWidthFor(minPaneWidth)
+		return pane.width >= getMinSplitWidth(minPaneWidth)
 	}
 	return pane.height >= MIN_SPLIT_HEIGHT
 }
 
-export function canSplitPaneAnyDirection(pane: TmuxPaneInfo, minPaneWidth: number = MIN_PANE_WIDTH): boolean {
-	return canSplitPaneAnyDirectionWithMinWidth(pane, minPaneWidth)
-}
-
-export function canSplitPaneAnyDirectionWithMinWidth(
+export function canSplitPaneAnyDirection(
 	pane: TmuxPaneInfo,
-	minPaneWidth: number = MIN_PANE_WIDTH,
+	minPaneWidth?: number,
 ): boolean {
-	return pane.width >= minSplitWidthFor(minPaneWidth) || pane.height >= MIN_SPLIT_HEIGHT
+	return pane.width >= getMinSplitWidth(minPaneWidth) || pane.height >= MIN_SPLIT_HEIGHT
 }
 
 export function getBestSplitDirection(
 	pane: TmuxPaneInfo,
-	minPaneWidth: number = MIN_PANE_WIDTH,
+	minPaneWidth?: number,
 ): SplitDirection | null {
-	const canH = pane.width >= minSplitWidthFor(minPaneWidth)
+	const canH = pane.width >= getMinSplitWidth(minPaneWidth)
 	const canV = pane.height >= MIN_SPLIT_HEIGHT
 
 	if (!canH && !canV) return null

--- a/src/features/tmux-subagent/pane-state-querier.ts
+++ b/src/features/tmux-subagent/pane-state-querier.ts
@@ -14,7 +14,7 @@ export async function queryWindowState(sourcePaneId: string): Promise<WindowStat
       "-t",
       sourcePaneId,
       "-F",
-      "#{pane_id}\t#{pane_width}\t#{pane_height}\t#{pane_left}\t#{pane_top}\t#{pane_title}\t#{pane_active}\t#{window_width}\t#{window_height}",
+			"#{pane_id}\t#{pane_width}\t#{pane_height}\t#{pane_left}\t#{pane_top}\t#{pane_active}\t#{window_width}\t#{window_height}\t#{pane_title}",
     ],
     { stdout: "pipe", stderr: "pipe" }
   )
@@ -35,7 +35,11 @@ export async function queryWindowState(sourcePaneId: string): Promise<WindowStat
   const panes: TmuxPaneInfo[] = []
 
   for (const line of lines) {
-    const [paneId, widthStr, heightStr, leftStr, topStr, title, activeStr, windowWidthStr, windowHeightStr] = line.split("\t")
+		const fields = line.split("\t")
+		if (fields.length < 9) continue
+
+		const [paneId, widthStr, heightStr, leftStr, topStr, activeStr, windowWidthStr, windowHeightStr] = fields
+		const title = fields.slice(8).join("\t")
     const width = parseInt(widthStr, 10)
     const height = parseInt(heightStr, 10)
     const left = parseInt(leftStr, 10)

--- a/src/features/tmux-subagent/spawn-target-finder.ts
+++ b/src/features/tmux-subagent/spawn-target-finder.ts
@@ -1,11 +1,38 @@
-import type { SplitDirection, TmuxPaneInfo, WindowState } from "./types"
+import type { CapacityConfig, SplitDirection, TmuxPaneInfo, WindowState } from "./types"
+import { computeMainPaneWidth } from "./tmux-grid-constants"
 import { computeGridPlan, mapPaneToSlot } from "./grid-planning"
-import { canSplitPane, getBestSplitDirection } from "./pane-split-availability"
-import { MIN_PANE_WIDTH } from "./types"
+import { canSplitPane } from "./pane-split-availability"
 
 export interface SpawnTarget {
 	targetPaneId: string
 	splitDirection: SplitDirection
+}
+
+function isStrictMainVertical(config: CapacityConfig): boolean {
+	return config.layout === "main-vertical"
+}
+
+function isStrictMainHorizontal(config: CapacityConfig): boolean {
+	return config.layout === "main-horizontal"
+}
+
+function isStrictMainLayout(config: CapacityConfig): boolean {
+	return isStrictMainVertical(config) || isStrictMainHorizontal(config)
+}
+
+function getInitialSplitDirection(config: CapacityConfig): SplitDirection {
+	return isStrictMainHorizontal(config) ? "-v" : "-h"
+}
+
+function getStrictFollowupSplitDirection(config: CapacityConfig): SplitDirection {
+	return isStrictMainHorizontal(config) ? "-h" : "-v"
+}
+
+function sortPanesForStrictLayout(panes: TmuxPaneInfo[], config: CapacityConfig): TmuxPaneInfo[] {
+	if (isStrictMainHorizontal(config)) {
+		return [...panes].sort((a, b) => a.left - b.left || a.top - b.top)
+	}
+	return [...panes].sort((a, b) => a.top - b.top || a.left - b.left)
 }
 
 function buildOccupancy(
@@ -37,16 +64,29 @@ function findFirstEmptySlot(
 
 function findSplittableTarget(
 	state: WindowState,
-	minPaneWidth: number,
+	config: CapacityConfig,
 	_preferredDirection?: SplitDirection,
 ): SpawnTarget | null {
 	if (!state.mainPane) return null
 	const existingCount = state.agentPanes.length
+	const minAgentPaneWidth = config.agentPaneWidth
+	const initialDirection = getInitialSplitDirection(config)
 
 	if (existingCount === 0) {
 		const virtualMainPane: TmuxPaneInfo = { ...state.mainPane, width: state.windowWidth }
-		if (canSplitPane(virtualMainPane, "-h", minPaneWidth)) {
-			return { targetPaneId: state.mainPane.paneId, splitDirection: "-h" }
+		if (canSplitPane(virtualMainPane, initialDirection, minAgentPaneWidth)) {
+			return { targetPaneId: state.mainPane.paneId, splitDirection: initialDirection }
+		}
+		return null
+	}
+
+	if (isStrictMainLayout(config)) {
+		const followupDirection = getStrictFollowupSplitDirection(config)
+		const panesByPriority = sortPanesForStrictLayout(state.agentPanes, config)
+		for (const pane of panesByPriority) {
+			if (canSplitPane(pane, followupDirection, minAgentPaneWidth)) {
+				return { targetPaneId: pane.paneId, splitDirection: followupDirection }
+			}
 		}
 		return null
 	}
@@ -55,34 +95,44 @@ function findSplittableTarget(
 		state.windowWidth,
 		state.windowHeight,
 		existingCount + 1,
-		state.mainPane.width,
-		minPaneWidth,
+		config,
 	)
-	const mainPaneWidth = state.mainPane.width
+	const mainPaneWidth = computeMainPaneWidth(state.windowWidth, config)
 	const occupancy = buildOccupancy(state.agentPanes, plan, mainPaneWidth)
 	const targetSlot = findFirstEmptySlot(occupancy, plan)
 
 	const leftPane = occupancy.get(`${targetSlot.row}:${targetSlot.col - 1}`)
-	if (leftPane && canSplitPane(leftPane, "-h", minPaneWidth)) {
+	if (
+		!isStrictMainVertical(config) &&
+		leftPane &&
+		canSplitPane(leftPane, "-h", minAgentPaneWidth)
+	) {
 		return { targetPaneId: leftPane.paneId, splitDirection: "-h" }
 	}
 
 	const abovePane = occupancy.get(`${targetSlot.row - 1}:${targetSlot.col}`)
-	if (abovePane && canSplitPane(abovePane, "-v", minPaneWidth)) {
+	if (abovePane && canSplitPane(abovePane, "-v", minAgentPaneWidth)) {
 		return { targetPaneId: abovePane.paneId, splitDirection: "-v" }
 	}
 
-	const splittablePanes = state.agentPanes
-		.map((pane) => ({ pane, direction: getBestSplitDirection(pane, minPaneWidth) }))
-		.filter(
-			(item): item is { pane: TmuxPaneInfo; direction: SplitDirection } =>
-				item.direction !== null,
-		)
-		.sort((a, b) => b.pane.width * b.pane.height - a.pane.width * a.pane.height)
+	const panesByPosition = [...state.agentPanes].sort(
+		(a, b) => a.left - b.left || a.top - b.top,
+	)
 
-	const best = splittablePanes[0]
-	if (best) {
-		return { targetPaneId: best.pane.paneId, splitDirection: best.direction }
+	for (const pane of panesByPosition) {
+		if (canSplitPane(pane, "-v", minAgentPaneWidth)) {
+			return { targetPaneId: pane.paneId, splitDirection: "-v" }
+		}
+	}
+
+	if (isStrictMainVertical(config)) {
+		return null
+	}
+
+	for (const pane of panesByPosition) {
+		if (canSplitPane(pane, "-h", minAgentPaneWidth)) {
+			return { targetPaneId: pane.paneId, splitDirection: "-h" }
+		}
 	}
 
 	return null
@@ -90,7 +140,7 @@ function findSplittableTarget(
 
 export function findSpawnTarget(
 	state: WindowState,
-	minPaneWidth: number = MIN_PANE_WIDTH,
+	config: CapacityConfig,
 ): SpawnTarget | null {
-	return findSplittableTarget(state, minPaneWidth)
+	return findSplittableTarget(state, config)
 }

--- a/src/features/tmux-subagent/tmux-grid-constants.ts
+++ b/src/features/tmux-subagent/tmux-grid-constants.ts
@@ -1,6 +1,8 @@
 import { MIN_PANE_HEIGHT, MIN_PANE_WIDTH } from "./types"
+import type { CapacityConfig } from "./types"
 
 export const MAIN_PANE_RATIO = 0.5
+const DEFAULT_MAIN_PANE_SIZE = MAIN_PANE_RATIO * 100
 export const MAX_COLS = 2
 export const MAX_ROWS = 3
 export const MAX_GRID_SIZE = 4
@@ -8,3 +10,48 @@ export const DIVIDER_SIZE = 1
 
 export const MIN_SPLIT_WIDTH = 2 * MIN_PANE_WIDTH + DIVIDER_SIZE
 export const MIN_SPLIT_HEIGHT = 2 * MIN_PANE_HEIGHT + DIVIDER_SIZE
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value))
+}
+
+export function getMainPaneSizePercent(config?: CapacityConfig): number {
+	return clamp(config?.mainPaneSize ?? DEFAULT_MAIN_PANE_SIZE, 20, 80)
+}
+
+export function computeMainPaneWidth(
+	windowWidth: number,
+	config?: CapacityConfig,
+): number {
+	const safeWindowWidth = Math.max(0, windowWidth)
+	if (!config) {
+		return Math.floor(safeWindowWidth * MAIN_PANE_RATIO)
+	}
+
+	const dividerWidth = DIVIDER_SIZE
+	const minMainPaneWidth = config?.mainPaneMinWidth ?? Math.floor(safeWindowWidth * MAIN_PANE_RATIO)
+	const minAgentPaneWidth = config?.agentPaneWidth ?? MIN_PANE_WIDTH
+	const percentageMainPaneWidth = Math.floor(
+		(safeWindowWidth - dividerWidth) * (getMainPaneSizePercent(config) / 100),
+	)
+	const maxMainPaneWidth = Math.max(0, safeWindowWidth - dividerWidth - minAgentPaneWidth)
+
+	return clamp(
+		Math.max(percentageMainPaneWidth, minMainPaneWidth),
+		0,
+		maxMainPaneWidth,
+	)
+}
+
+export function computeAgentAreaWidth(
+	windowWidth: number,
+	config?: CapacityConfig,
+): number {
+	const safeWindowWidth = Math.max(0, windowWidth)
+	if (!config) {
+		return Math.floor(safeWindowWidth * (1 - MAIN_PANE_RATIO))
+	}
+
+	const mainPaneWidth = computeMainPaneWidth(safeWindowWidth, config)
+	return Math.max(0, safeWindowWidth - DIVIDER_SIZE - mainPaneWidth)
+}

--- a/src/features/tmux-subagent/types.ts
+++ b/src/features/tmux-subagent/types.ts
@@ -43,7 +43,7 @@ export interface SpawnDecision {
 }
 
 export interface CapacityConfig {
-	layout?: string
+  layout?: string
   mainPaneSize?: number
   mainPaneMinWidth: number
   agentPaneWidth: number

--- a/src/features/tmux-subagent/types.ts
+++ b/src/features/tmux-subagent/types.ts
@@ -43,6 +43,8 @@ export interface SpawnDecision {
 }
 
 export interface CapacityConfig {
+	layout?: string
+  mainPaneSize?: number
   mainPaneMinWidth: number
   agentPaneWidth: number
 }

--- a/src/shared/tmux/tmux-utils/layout.test.ts
+++ b/src/shared/tmux/tmux-utils/layout.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, mock } from "bun:test"
+
+const spawnCalls: string[][] = []
+const spawnMock = mock((args: string[]) => {
+  spawnCalls.push(args)
+  return { exited: Promise.resolve(0) }
+})
+
+describe("applyLayout", () => {
+  afterEach(() => {
+    spawnCalls.length = 0
+    spawnMock.mockClear()
+  })
+
+  it("applies main-vertical with main-pane-width option", async () => {
+    const { applyLayout } = await import("./layout")
+
+    await applyLayout("tmux", "main-vertical", 60, { spawnCommand: spawnMock })
+
+    expect(spawnCalls).toEqual([
+      ["tmux", "select-layout", "main-vertical"],
+      ["tmux", "set-window-option", "main-pane-width", "60%"],
+    ])
+  })
+
+  it("applies main-horizontal with main-pane-height option", async () => {
+    const { applyLayout } = await import("./layout")
+
+    await applyLayout("tmux", "main-horizontal", 55, { spawnCommand: spawnMock })
+
+    expect(spawnCalls).toEqual([
+      ["tmux", "select-layout", "main-horizontal"],
+      ["tmux", "set-window-option", "main-pane-height", "55%"],
+    ])
+  })
+
+  it("does not set main pane option for non-main layouts", async () => {
+    const { applyLayout } = await import("./layout")
+
+    await applyLayout("tmux", "tiled", 50, { spawnCommand: spawnMock })
+
+    expect(spawnCalls).toEqual([["tmux", "select-layout", "tiled"]])
+  })
+})


### PR DESCRIPTION
## Summary

- Prefer pane split when geometry allows, and defer attach when no safe split target exists.
- Add FIFO deferred attach queueing so deferred sessions are attached in creation order once capacity returns.
- Add/expand tmux subagent and layout tests covering split-or-defer decisions, queue idempotency, and deferred attach lifecycle.

## Why

Under constrained pane geometry, replacing active panes can evict in-progress work and reduce reliability.
Defer-and-reattach preserves active panes while still ensuring pending sessions are attached when pane capacity is available.

## Testing

- `bun test src/features/tmux-subagent` - Passed (56 pass, 0 fail)
- `bun run build` - Passed

## Notes

- Constrained pane geometry is handled via defer/reattach behavior (FIFO) instead of replacing active panes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer splitting panes when possible and defer attaching when not, using a FIFO queue that auto-attaches when capacity returns. After each spawn/close, we reapply the tmux layout and enforce main-pane sizing from config, and wait for the session to be ready before tracking.

- **New Features**
  - Layout-aware split-or-defer via CapacityConfig (layout, mainPaneSize, min widths).
  - Strict main layouts: deterministic initial/follow-up split directions and config-driven spawn target selection.
  - FIFO deferred attach with background polling; idempotent; attaches in order; removed on session delete; spawns serialized via an internal queue.
  - Reapply layout (applyLayout) and enforce main-pane width using computed sizes after actions.

- **Refactors**
  - Removed “replace oldest” fallback; defer attach instead. When non-strict layout allows a single eviction, use close+spawn.
  - Grid planning and split checks use computeMainPaneWidth/computeAgentAreaWidth and agent min width for thresholds.
  - Pane state query switches to tab-delimited parsing with deterministic main-pane selection.
  - Expanded tests for layout rules, target ordering, split-or-defer behavior, FIFO queue lifecycle, and layout utils.

<sup>Written for commit 5f78c071890e05c8dbe10278ecd71bb70478f063. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

