### PR TITLE
refactor(mcp-oauth): consolidate duplicate port utilities into shared/port-utils

### DIFF
--- a/src/features/mcp-oauth/callback-server.test.ts
+++ b/src/features/mcp-oauth/callback-server.test.ts
@@ -1,37 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { findAvailablePort, startCallbackServer, type CallbackServer } from "./callback-server"
+import { startCallbackServer, type CallbackServer } from "./callback-server"
 
 const nativeFetch = Bun.fetch.bind(Bun)
-
-describe("findAvailablePort", () => {
-  it("returns the start port when it is available", async () => {
-    // given
-    const startPort = 19877
-
-    // when
-    const port = await findAvailablePort(startPort)
-
-    // then
-    expect(port).toBeGreaterThanOrEqual(startPort)
-    expect(port).toBeLessThan(startPort + 20)
-  })
-
-  it("skips busy ports and returns next available", async () => {
-    // given
-    const blocker = Bun.serve({
-      port: 19877,
-      hostname: "127.0.0.1",
-      fetch: () => new Response(),
-    })
-
-    // when
-    const port = await findAvailablePort(19877)
-
-    // then
-    expect(port).toBeGreaterThan(19877)
-    blocker.stop(true)
-  })
-})
 
 describe("startCallbackServer", () => {
   let server: CallbackServer | null = null

--- a/src/features/mcp-oauth/callback-server.ts
+++ b/src/features/mcp-oauth/callback-server.ts
@@ -1,5 +1,6 @@
+import { findAvailablePort as findAvailablePortShared } from "../../shared/port-utils"
+
 const DEFAULT_PORT = 19877
-const MAX_PORT_ATTEMPTS = 20
 const TIMEOUT_MS = 5 * 60 * 1000
 
 export type OAuthCallbackResult = {
@@ -33,28 +34,8 @@ const SUCCESS_HTML = `<!DOCTYPE html>
 </body>
 </html>`
 
-async function isPortAvailable(port: number): Promise<boolean> {
-  try {
-    const server = Bun.serve({
-      port,
-      hostname: "127.0.0.1",
-      fetch: () => new Response(),
-    })
-    server.stop(true)
-    return true
-  } catch {
-    return false
-  }
-}
-
 export async function findAvailablePort(startPort: number = DEFAULT_PORT): Promise<number> {
-  for (let attempt = 0; attempt < MAX_PORT_ATTEMPTS; attempt++) {
-    const port = startPort + attempt
-    if (await isPortAvailable(port)) {
-      return port
-    }
-  }
-  throw new Error(`No available port found in range ${startPort}-${startPort + MAX_PORT_ATTEMPTS - 1}`)
+  return findAvailablePortShared(startPort)
 }
 
 export async function startCallbackServer(startPort: number = DEFAULT_PORT): Promise<CallbackServer> {


### PR DESCRIPTION
## Summary

- Remove duplicated `MAX_PORT_ATTEMPTS`, `isPortAvailable()`, and `findAvailablePort()` from `callback-server.ts` by delegating to the existing `shared/port-utils.ts`
- Remove redundant `findAvailablePort` tests from `callback-server.test.ts` (already covered by `port-utils.test.ts`)
- Preserve the public API of `callback-server.ts` — `provider.ts` import path is unchanged

## Motivation

`callback-server.ts` and `shared/port-utils.ts` had identical port utility logic:
- Same `MAX_PORT_ATTEMPTS = 20` constant
- Same `isPortAvailable()` function (shared version is a strict superset with `hostname` parameter)
- Same `findAvailablePort()` function (only differing in default port)

The shared version is more flexible, so `callback-server.ts` now delegates to it via a thin wrapper that preserves the OAuth-specific default port (`19877`).

## Changes

| File | Change |
|------|--------|
| `src/features/mcp-oauth/callback-server.ts` | Import from `shared/port-utils`, remove duplicate `MAX_PORT_ATTEMPTS`, `isPortAvailable`, inline `findAvailablePort` logic (+3, -22) |
| `src/features/mcp-oauth/callback-server.test.ts` | Remove redundant `findAvailablePort` describe block (+1, -31) |

## Verification

- `bun run typecheck` ✅ (exit code 0)
- `bun test` ✅ (2,675 pass, 0 fail)
- `grep -r "MAX_PORT_ATTEMPTS" src/ --include="*.ts" -l` → only `shared/port-utils.ts`
- `provider.ts` import unchanged: `import { findAvailablePort } from "./callback-server"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated duplicate port utilities in mcp-oauth by delegating callback-server to shared/port-utils. Removes duplicate code while keeping behavior and public API unchanged.

- **Refactors**
  - callback-server now uses shared findAvailablePort; removed local MAX_PORT_ATTEMPTS and isPortAvailable.
  - Default port 19877 preserved; provider.ts import unchanged.
  - Removed redundant findAvailablePort tests in callback-server.test (covered by port-utils tests).

<sup>Written for commit e03169597520a1167ba0ea026e16f9b6dd4bd32a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

