### PR TITLE
fix(abort-handling): extend abort window and use timestamp-based guard to prevent UI idle lock

### DIFF
--- a/src/hooks/atlas/event-handler.ts
+++ b/src/hooks/atlas/event-handler.ts
@@ -9,6 +9,30 @@ import { getLastAgentFromSession } from "./session-last-agent"
 import type { AtlasHookOptions, SessionState } from "./types"
 
 const CONTINUATION_COOLDOWN_MS = 5000
+const ABORT_WINDOW_MS = 10_000
+
+function getAbortClearSessionID(event: { type: string; properties?: unknown }): string | undefined {
+  const props = event.properties as Record<string, unknown> | undefined
+  if (!props) return undefined
+
+  if (event.type === "message.updated") {
+    const info = props.info as Record<string, unknown> | undefined
+    return info?.sessionID as string | undefined
+  }
+
+  if (event.type === "message.part.updated") {
+    const info = props.info as Record<string, unknown> | undefined
+    const role = info?.role as string | undefined
+    if (role !== "assistant") return undefined
+    return info?.sessionID as string | undefined
+  }
+
+  if (event.type === "tool.execute.before" || event.type === "tool.execute.after") {
+    return props.sessionID as string | undefined
+  }
+
+  return undefined
+}
 
 export function createAtlasEventHandler(input: {
   ctx: PluginInput
@@ -27,7 +51,9 @@ export function createAtlasEventHandler(input: {
 
       const state = getState(sessionID)
       const isAbort = isAbortError(props?.error)
-      state.lastEventWasAbortError = isAbort
+      if (isAbort) {
+        state.abortDetectedAt = Date.now()
+      }
 
       log(`[${HOOK_NAME}] session.error`, { sessionID, isAbort })
       return
@@ -53,10 +79,13 @@ export function createAtlasEventHandler(input: {
 
       const state = getState(sessionID)
 
-      if (state.lastEventWasAbortError) {
-        state.lastEventWasAbortError = false
-        log(`[${HOOK_NAME}] Skipped: abort error immediately before idle`, { sessionID })
-        return
+      if (state.abortDetectedAt) {
+        const timeSinceAbort = Date.now() - state.abortDetectedAt
+        if (timeSinceAbort < ABORT_WINDOW_MS) {
+          log(`[${HOOK_NAME}] Skipped: abort error ${timeSinceAbort}ms before idle`, { sessionID })
+          return
+        }
+        state.abortDetectedAt = undefined
       }
 
       if (state.promptFailureCount >= 2) {
@@ -140,39 +169,11 @@ export function createAtlasEventHandler(input: {
       return
     }
 
-    if (event.type === "message.updated") {
-      const info = props?.info as Record<string, unknown> | undefined
-      const sessionID = info?.sessionID as string | undefined
-      if (!sessionID) return
-
-      const state = sessions.get(sessionID)
+    const clearAbortSessionID = getAbortClearSessionID(event)
+    if (clearAbortSessionID) {
+      const state = sessions.get(clearAbortSessionID)
       if (state) {
-        state.lastEventWasAbortError = false
-      }
-      return
-    }
-
-    if (event.type === "message.part.updated") {
-      const info = props?.info as Record<string, unknown> | undefined
-      const sessionID = info?.sessionID as string | undefined
-      const role = info?.role as string | undefined
-
-      if (sessionID && role === "assistant") {
-        const state = sessions.get(sessionID)
-        if (state) {
-          state.lastEventWasAbortError = false
-        }
-      }
-      return
-    }
-
-    if (event.type === "tool.execute.before" || event.type === "tool.execute.after") {
-      const sessionID = props?.sessionID as string | undefined
-      if (sessionID) {
-        const state = sessions.get(sessionID)
-        if (state) {
-          state.lastEventWasAbortError = false
-        }
+        state.abortDetectedAt = undefined
       }
       return
     }

--- a/src/hooks/atlas/types.ts
+++ b/src/hooks/atlas/types.ts
@@ -23,7 +23,7 @@ export interface ToolExecuteAfterOutput {
 }
 
 export interface SessionState {
-  lastEventWasAbortError?: boolean
+  abortDetectedAt?: number
   lastContinuationInjectedAt?: number
   promptFailureCount: number
 }

--- a/src/hooks/todo-continuation-enforcer/constants.ts
+++ b/src/hooks/todo-continuation-enforcer/constants.ts
@@ -16,5 +16,5 @@ export const COUNTDOWN_SECONDS = 2
 export const TOAST_DURATION_MS = 900
 export const COUNTDOWN_GRACE_PERIOD_MS = 500
 
-export const ABORT_WINDOW_MS = 3000
+export const ABORT_WINDOW_MS = 10_000
 export const CONTINUATION_COOLDOWN_MS = 30_000

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -45,7 +45,6 @@ export async function handleSessionIdle(args: {
     const timeSinceAbort = Date.now() - state.abortDetectedAt
     if (timeSinceAbort < ABORT_WINDOW_MS) {
       log(`[${HOOK_NAME}] Skipped: abort detected via event ${timeSinceAbort}ms ago`, { sessionID })
-      state.abortDetectedAt = undefined
       return
     }
     state.abortDetectedAt = undefined

--- a/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import type { BackgroundManager } from "../../features/background-agent"
 import { setMainSession, subagentSessions, _resetForTesting } from "../../features/claude-code-session-state"
 import { createTodoContinuationEnforcer } from "."
-import { CONTINUATION_COOLDOWN_MS } from "./constants"
+import { ABORT_WINDOW_MS, CONTINUATION_COOLDOWN_MS } from "./constants"
 
 type TimerCallback = (...args: any[]) => void
 
@@ -910,8 +910,7 @@ describe("todo-continuation-enforcer", () => {
     expect(promptCalls).toHaveLength(0)
   })
 
-  test("should inject when abort flag is stale (>3s old)", async () => {
-    fakeTimers.restore()
+  test("should inject when abort flag is stale (>abort window)", async () => {
     // given - session with incomplete todos and old abort timestamp
     const sessionID = "main-stale-abort"
     setMainSession(sessionID)
@@ -930,18 +929,52 @@ describe("todo-continuation-enforcer", () => {
       },
     })
 
-    // when - wait >3s then idle fires
-    await wait(3100)
+    // when - wait past abort window then idle fires
+    await fakeTimers.advanceBy(ABORT_WINDOW_MS + 100, true)
 
     await hook.handler({
       event: { type: "session.idle", properties: { sessionID } },
     })
 
-    await wait(3000)
+    await fakeTimers.advanceBy(3000, true)
 
     // then - continuation injected (abort flag is stale)
     expect(promptCalls.length).toBeGreaterThan(0)
-  }, { timeout: 15000 })
+  })
+
+  test("should keep skipping when repeated idles occur within abort window", async () => {
+    // given - session with incomplete todos
+    const sessionID = "main-repeat-abort"
+    setMainSession(sessionID)
+    mockMessages = [
+      { info: { id: "msg-1", role: "user" } },
+      { info: { id: "msg-2", role: "assistant" } },
+    ]
+
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), {})
+
+    // when - abort error event fires
+    await hook.handler({
+      event: {
+        type: "session.error",
+        properties: { sessionID, error: { name: "MessageAbortedError" } },
+      },
+    })
+
+    // when - session goes idle, then idle again within abort window
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
+    await fakeTimers.advanceBy(Math.max(0, ABORT_WINDOW_MS - 500), true)
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
+
+    await fakeTimers.advanceBy(3000, true)
+
+    // then - no continuation injected
+    expect(promptCalls).toHaveLength(0)
+  })
 
   test("should clear abort flag on user message activity", async () => {
     fakeTimers.restore()


### PR DESCRIPTION
## Summary

- Fix prompt not returning after `MessageAbortedError` followed by rapid `session.idle` events
- Both `todo-continuation-enforcer` and `atlas` hooks had guards that only blocked the **first** idle after abort, allowing subsequent idles to trigger continuation injection and lock the UI

## Problem

When `MessageAbortedError` fires, OpenCode emits multiple `session.idle` events in quick succession (via both `session.idle` and synthetic idle from `session.status`). The existing abort guards had two bugs:

1. **todo-continuation-enforcer**: Cleared `abortDetectedAt` on the first idle within the window, so the 2nd+ idle passed through
2. **atlas**: Used a boolean `lastEventWasAbortError` flag that reset to `false` after the first idle check

## Evidence from logs

The following log excerpt from `oh-my-opencode.log` shows the actual incident at `2026-02-14T20:05:15Z`:

```
[20:05:15.071Z] [todo-continuation-enforcer] Abort detected via session.error
                 {"sessionID":"ses_...FFF","errorName":"MessageAbortedError"}
[20:05:15.074Z] [auto-compact] session.error received
                 {"error":{"name":"MessageAbortedError","data":{"message":"The operation was aborted."}}}
[20:05:15.075Z] [atlas] session.error {"sessionID":"ses_...FFF","isAbort":true}

--- 88ms later, 5 rapid session.idle events arrive within 50ms ---

[20:05:15.163Z] [todo-continuation-enforcer] session.idle  ← idle #1
[20:05:15.177Z] [todo-continuation-enforcer] Skipped: last assistant message was aborted (API fallback)
[20:05:15.177Z] [atlas] session.idle
[20:05:15.178Z] [atlas] Skipped: last agent does not match boulder agent

[20:05:15.178Z] [todo-continuation-enforcer] session.idle  ← idle #2
[20:05:15.190Z] [todo-continuation-enforcer] Skipped: last assistant message was aborted (API fallback)
[20:05:15.190Z] [atlas] session.idle
[20:05:15.191Z] [atlas] Skipped: last agent does not match boulder agent

[20:05:15.191Z] [todo-continuation-enforcer] session.idle  ← idle #3
[20:05:15.200Z] [todo-continuation-enforcer] Skipped: last assistant message was aborted (API fallback)
[20:05:15.200Z] [atlas] session.idle

[20:05:15.202Z] [todo-continuation-enforcer] session.idle  ← idle #4
[20:05:15.211Z] [todo-continuation-enforcer] Skipped: last assistant message was aborted (API fallback)
[20:05:15.212Z] [atlas] session.idle

--- 38 seconds later, another idle arrives ---

[20:05:53.936Z] [todo-continuation-enforcer] session.idle  ← idle #5 (38s after abort)
[20:05:53.946Z] [todo-continuation-enforcer] All todos complete  ← no injection (todos done)
[20:05:53.946Z] [atlas] session.idle
```

**Key observations:**

1. **5 `session.idle` events fired from a single `MessageAbortedError`** — the first 4 arrived within 50ms of each other at `20:05:15`, and a 5th arrived 38 seconds later at `20:05:53`
2. In this incident, `todo-continuation-enforcer` happened to skip via API fallback (checking last assistant message), and `atlas` skipped due to agent mismatch — but **neither** used the event-based `abortDetectedAt` guard, meaning the guard was already consumed or cleared
3. If the agent had matched and todos were pending, the 2nd+ idle would have triggered continuation injection because the abort flag was already cleared after the first idle
4. The **38-second gap** between idle #4 and #5 exceeds the old 3s `ABORT_WINDOW_MS`, so even the event-based guard would not have caught idle #5 — but the new 10s window still would not cover it. This is acceptable because by 38 seconds, real user activity should have occurred (and the idle #5 was correctly handled by "All todos complete")

## Changes

### `todo-continuation-enforcer` (constants.ts, idle-event.ts, test)
- Increase `ABORT_WINDOW_MS` from 3s → **10s** to cover all post-abort idle events
- **Stop clearing** `abortDetectedAt` within the window — flag now persists until window expires or real activity (user message, assistant response, tool execution) clears it
- Add test: repeated idles within abort window are all suppressed

### `atlas` (types.ts, event-handler.ts)
- Replace `lastEventWasAbortError: boolean` with `abortDetectedAt: number` (timestamp)
- Use same 10s `ABORT_WINDOW_MS` time-based guard — repeated idles suppressed throughout window
- Extract `getAbortClearSessionID()` helper to consolidate abort-clear logic across event types

## Verification

- `bun test src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts` — 43 pass, 0 fail
- `bun test src/hooks/atlas/index.test.ts` — 36 pass, 0 fail
- `bun run typecheck` — clean
- `lsp_diagnostics` — no errors on all modified files