### PR TITLE
fix(config): preserve configured default_agent

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -23,6 +23,11 @@ type AgentConfigRecord = Record<string, Record<string, unknown> | undefined> & {
   plan?: Record<string, unknown>;
 };
 
+function hasConfiguredDefaultAgent(config: Record<string, unknown>): boolean {
+  const defaultAgent = config.default_agent;
+  return typeof defaultAgent === "string" && defaultAgent.trim().length > 0;
+}
+
 export async function applyAgentConfig(params: {
   config: Record<string, unknown>;
   pluginConfig: OhMyOpenCodeConfig;
@@ -106,7 +111,10 @@ export async function applyAgentConfig(params: {
   const configAgent = params.config.agent as AgentConfigRecord | undefined;
 
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
-    (params.config as { default_agent?: string }).default_agent = getAgentDisplayName("sisyphus");
+    if (!hasConfiguredDefaultAgent(params.config)) {
+      (params.config as { default_agent?: string }).default_agent =
+        getAgentDisplayName("sisyphus");
+    }
 
     const agentConfig: Record<string, unknown> = {
       sisyphus: builtinAgents.sisyphus,

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -349,6 +349,55 @@ describe("Agent permission defaults", () => {
   })
 })
 
+describe("default_agent behavior with Sisyphus orchestration", () => {
+  test("preserves existing default_agent when already set", async () => {
+    // #given
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-6",
+      default_agent: "hephaestus",
+      agent: {},
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler(config)
+
+    // #then
+    expect(config.default_agent).toBe("hephaestus")
+  })
+
+  test("sets default_agent to sisyphus when missing", async () => {
+    // #given
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-6",
+      agent: {},
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler(config)
+
+    // #then
+    expect(config.default_agent).toBe(getAgentDisplayName("sisyphus"))
+  })
+})
+
 describe("Prometheus category config resolution", () => {
   test("resolves ultrabrain category config", () => {
     // given


### PR DESCRIPTION
oh-my-opencode overwrote OpenCode's default_agent with sisyphus whenever Sisyphus orchestration was enabled. This made explicit defaults like Hephaestus ineffective and forced manual agent switching in new sessions.

Only assign sisyphus as default when default_agent is missing or blank, and preserve existing configured values. Add tests for both preservation and fallback behavior to prevent regressions.

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves user-configured default_agent when Sisyphus orchestration is enabled. Falls back to "sisyphus" only if default_agent is missing or blank.

- **Bug Fixes**
  - Added a guard in agent-config-handler to skip overwriting default_agent when a non-empty value exists.
  - Added tests to verify preservation of existing defaults and fallback to "sisyphus" when absent.

<sup>Written for commit 90ede4487b76a2fc1ec5592623b4c33cfd36ee80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

