### PR TITLE
fix: use shell.env hook instead of prepending export for Windows comp…

### DIFF
--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -1,153 +1,38 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { describe, test, expect } from "bun:test"
 import { createNonInteractiveEnvHook, NON_INTERACTIVE_ENV } from "./index"
 
 describe("non-interactive-env hook", () => {
   const mockCtx = {} as Parameters<typeof createNonInteractiveEnvHook>[0]
 
-  let originalPlatform: NodeJS.Platform
-  let originalEnv: Record<string, string | undefined>
-
-  beforeEach(() => {
-    originalPlatform = process.platform
-    originalEnv = {
-      SHELL: process.env.SHELL,
-      PSModulePath: process.env.PSModulePath,
-      CI: process.env.CI,
-      OPENCODE_NON_INTERACTIVE: process.env.OPENCODE_NON_INTERACTIVE,
-    }
-    // given clean Unix-like environment for all tests
-    // This prevents CI environments (which may have PSModulePath set) from
-    // triggering PowerShell detection in tests that expect Unix behavior
-    delete process.env.PSModulePath
-    process.env.SHELL = "/bin/bash"
-    process.env.OPENCODE_NON_INTERACTIVE = "true"
-  })
-
-  afterEach(() => {
-    Object.defineProperty(process, "platform", { value: originalPlatform })
-    for (const [key, value] of Object.entries(originalEnv)) {
-      if (value !== undefined) {
-        process.env[key] = value
-      } else {
-        delete process.env[key]
-      }
-    }
-  })
-
-  describe("git command modification", () => {
-    test("#given git command #when hook executes #then prepends export statement", async () => {
+  describe("shell.env hook", () => {
+    test("#given shell.env hook #when executes #then injects all NON_INTERACTIVE_ENV vars", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "git commit -m 'test'" },
-      }
+      const output: { env: Record<string, string> } = { env: {} }
 
-      await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
+      await hook["shell.env"](
+        { cwd: "/test" },
         output
       )
 
-      const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain("GIT_EDITOR=:")
-      expect(cmd).toContain("EDITOR=:")
-      expect(cmd).toContain("PAGER=cat")
-      expect(cmd).toContain("; git commit -m 'test'")
+      for (const [key, value] of Object.entries(NON_INTERACTIVE_ENV)) {
+        expect(output.env[key]).toBe(value)
+      }
     })
 
-    test("#given chained git commands #when hook executes #then export applies to all", async () => {
+    test("#given shell.env hook #when executes #then overwrites existing env vars", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "git add file && git rebase --continue" },
-      }
+      const output: { env: Record<string, string> } = { env: { CI: "false" } }
 
-      await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
+      await hook["shell.env"](
+        { cwd: "/test" },
         output
       )
 
-      const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain("; git add file && git rebase --continue")
-    })
-
-    test("#given non-git bash command #when hook executes #then command unchanged", async () => {
-      const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "ls -la" },
-      }
-
-      await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
-        output
-      )
-
-      expect(output.args.command).toBe("ls -la")
-    })
-
-    test("#given non-bash tool #when hook executes #then command unchanged", async () => {
-      const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "git status" },
-      }
-
-      await hook["tool.execute.before"](
-        { tool: "Read", sessionID: "test", callID: "1" },
-        output
-      )
-
-      expect(output.args.command).toBe("git status")
-    })
-
-    test("#given empty command #when hook executes #then no error", async () => {
-      const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: {},
-      }
-
-      await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
-        output
-      )
-
-      expect(output.args.command).toBeUndefined()
+      expect(output.env.CI).toBe("true")
     })
   })
 
-  describe("shell escaping", () => {
-    test("#given git command #when building prefix #then VISUAL properly escaped", async () => {
-      const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "git status" },
-      }
-
-      await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
-        output
-      )
-
-      const cmd = output.args.command as string
-      expect(cmd).toContain("VISUAL=''")
-    })
-
-    test("#given git command #when building prefix #then all NON_INTERACTIVE_ENV vars included", async () => {
-      const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "git log" },
-      }
-
-      await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
-        output
-      )
-
-      const cmd = output.args.command as string
-      for (const key of Object.keys(NON_INTERACTIVE_ENV)) {
-        expect(cmd).toContain(`${key}=`)
-      }
-    })
-  })
-
-  describe("banned command detection", () => {
+  describe("tool.execute.before hook - banned command detection", () => {
     test("#given vim command #when hook executes #then warning message set", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
       const output: { args: Record<string, unknown>; message?: string } = {
@@ -176,40 +61,8 @@ describe("non-interactive-env hook", () => {
 
       expect(output.message).toBeUndefined()
     })
-  })
 
-  describe("bash tool always uses unix shell syntax", () => {
-    // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
-    // (via Git Bash, WSL, etc.), so we should always use unix export syntax.
-    // This fixes GitHub issues #983 and #889.
-
-    test("#given macOS platform #when git command executes #then uses unix export syntax", async () => {
-      delete process.env.PSModulePath
-      process.env.SHELL = "/bin/zsh"
-      Object.defineProperty(process, "platform", { value: "darwin" })
-
-      const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "git status" },
-      }
-
-      await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
-        output
-      )
-
-      const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain(";")
-      expect(cmd).not.toContain("$env:")
-      expect(cmd).not.toContain("set ")
-    })
-
-    test("#given Linux platform #when git command executes #then uses unix export syntax", async () => {
-      delete process.env.PSModulePath
-      process.env.SHELL = "/bin/bash"
-      Object.defineProperty(process, "platform", { value: "linux" })
-
+    test("#given git command #when hook executes #then no modification (env via shell.env)", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git commit -m 'test'" },
@@ -220,45 +73,27 @@ describe("non-interactive-env hook", () => {
         output
       )
 
-      const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain("; git commit")
+      expect(output.args.command).toBe("git commit -m 'test'")
     })
 
-    test("#given Windows with PowerShell env #when bash tool git command executes #then still uses unix export syntax", async () => {
-      // Even when PSModulePath is set (indicating PowerShell environment),
-      // the bash tool runs in a Unix-like shell, so we use export syntax
-      process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
-      Object.defineProperty(process, "platform", { value: "win32" })
-
+    test("#given non-bash tool #when hook executes #then command unchanged", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
       const output: { args: Record<string, unknown>; message?: string } = {
         args: { command: "git status" },
       }
 
       await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
+        { tool: "Read", sessionID: "test", callID: "1" },
         output
       )
 
-      const cmd = output.args.command as string
-      // Should use unix export syntax, NOT PowerShell $env: syntax
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain("; git status")
-      expect(cmd).not.toContain("$env:")
-      expect(cmd).not.toContain("set ")
+      expect(output.args.command).toBe("git status")
     })
 
-    test("#given Windows without SHELL env #when bash tool git command executes #then still uses unix export syntax", async () => {
-      // Even when detectShellType() would return "cmd" (no SHELL, no PSModulePath, win32),
-      // the bash tool runs in a Unix-like shell, so we use export syntax
-      delete process.env.PSModulePath
-      delete process.env.SHELL
-      Object.defineProperty(process, "platform", { value: "win32" })
-
+    test("#given empty command #when hook executes #then no error", async () => {
       const hook = createNonInteractiveEnvHook(mockCtx)
       const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "git log" },
+        args: {},
       }
 
       await hook["tool.execute.before"](
@@ -266,55 +101,7 @@ describe("non-interactive-env hook", () => {
         output
       )
 
-      const cmd = output.args.command as string
-      // Should use unix export syntax, NOT cmd.exe set syntax
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain("; git log")
-      expect(cmd).not.toContain("set ")
-      expect(cmd).not.toContain("&&")
-      expect(cmd).not.toContain("$env:")
-    })
-
-    test("#given Windows Git Bash environment #when git command executes #then uses unix export syntax", async () => {
-      // Simulating Git Bash on Windows: SHELL might be set to /usr/bin/bash
-      delete process.env.PSModulePath
-      process.env.SHELL = "/usr/bin/bash"
-      Object.defineProperty(process, "platform", { value: "win32" })
-
-      const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "git status" },
-      }
-
-      await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
-        output
-      )
-
-      const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain("; git status")
-    })
-
-    test("#given any platform #when chained git commands via bash tool #then uses unix export syntax", async () => {
-      // Even on Windows, chained commands should use unix syntax
-      delete process.env.PSModulePath
-      delete process.env.SHELL
-      Object.defineProperty(process, "platform", { value: "win32" })
-
-      const hook = createNonInteractiveEnvHook(mockCtx)
-      const output: { args: Record<string, unknown>; message?: string } = {
-        args: { command: "git add file && git commit -m 'test'" },
-      }
-
-      await hook["tool.execute.before"](
-        { tool: "bash", sessionID: "test", callID: "1" },
-        output
-      )
-
-      const cmd = output.args.command as string
-      expect(cmd).toStartWith("export ")
-      expect(cmd).toContain("; git add file && git commit")
+      expect(output.args.command).toBeUndefined()
     })
   })
 })

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
-import { log, buildEnvPrefix } from "../../shared"
+import { log } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -21,6 +21,20 @@ function detectBannedCommand(command: string): string | undefined {
 
 export function createNonInteractiveEnvHook(_ctx: PluginInput) {
   return {
+    "shell.env": async (
+      input: { cwd: string },
+      output: { env: Record<string, string> }
+    ): Promise<void> => {
+      for (const [key, value] of Object.entries(NON_INTERACTIVE_ENV)) {
+        output.env[key] = value
+      }
+
+      log(`[${HOOK_NAME}] Injected non-interactive env vars`, {
+        cwd: input.cwd,
+        envCount: Object.keys(NON_INTERACTIVE_ENV).length,
+      })
+    },
+
     "tool.execute.before": async (
       input: { tool: string; sessionID: string; callID: string },
       output: { args: Record<string, unknown>; message?: string }
@@ -38,29 +52,6 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       if (bannedCmd) {
         output.message = `Warning: '${bannedCmd}' is an interactive command that may hang in non-interactive environments.`
       }
-
-      // Only prepend env vars for git commands (editor blocking, pager, etc.)
-      const isGitCommand = /\bgit\b/.test(command)
-      if (!isGitCommand) {
-        return
-      }
-
-      // NOTE: We intentionally removed the isNonInteractive() check here.
-      // Even when OpenCode runs in a TTY, the agent cannot interact with
-      // spawned bash processes. Git commands like `git rebase --continue`
-      // would open editors (vim/nvim) that hang forever.
-      // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
-      // for git commands to prevent interactive prompts.
-
-      // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
-      // (via Git Bash, WSL, etc.), so always use unix export syntax.
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
-      output.args.command = `${envPrefix} ${command}`
-
-      log(`[${HOOK_NAME}] Prepended non-interactive env vars to git command`, {
-        sessionID: input.sessionID,
-        envPrefix,
-      })
     },
   }
 }


### PR DESCRIPTION

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- Fix Windows cmd.exe compatibility by using `shell.env` hook instead of prepending `export` to commands
- The `non-interactive-env` hook now injects environment variables via spawn's env parameter (cross-platform compatible)
- Keeps banned command detection via `tool.execute.before` hook for warning messages

## Changes

<!-- What was changed and how. List specific modifications. -->

- `src/hooks/non-interactive-env/non-interactive-env-hook.ts`:
  - Added `shell.env` hook to inject non-interactive environment variables through spawn's env parameter
  - Removed hardcoded Unix export syntax that broke Windows cmd.exe
  - Kept `tool.execute.before` for banned command detection only (no longer modifies commands)
- `src/hooks/non-interactive-env/index.test.ts`:
  - Rewrote tests to match new behavior (shell.env injects env vars, tool.execute.before only warns)


## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inject non-interactive env vars via the shell.env hook instead of prepending export, fixing Windows cmd.exe compatibility. Commands are no longer modified; interactive command warnings remain.

- **Refactors**
  - non-interactive-env now populates output.env with NON_INTERACTIVE_ENV (cross-platform).
  - tool.execute.before only detects and warns on banned interactive commands.
  - Tests updated to reflect env injection via shell.env and no command mutation.

<sup>Written for commit a14b7996dac5ee811fc061e47085da0f7d520f4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

