### PR TITLE
fix(background-agent): clean up TaskToastManager entries on error/delete/prune paths

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -1,5 +1,5 @@
 declare const require: (name: string) => any
-const { describe, test, expect, beforeEach, afterEach } = require("bun:test")
+const { describe, test, expect, beforeEach, afterEach, mock } = require("bun:test")
 import { tmpdir } from "node:os"
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundTask, ResumeInput } from "./types"
@@ -3452,5 +3452,130 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
 
     //#then - task should still be running (delta event refreshed lastUpdate)
     expect(task.status).toBe("running")
+  })
+})
+
+describe("BackgroundManager - toast cleanup on non-happy-path completion", () => {
+  let toastManager: { removeTask: ReturnType<typeof mock> }
+
+  beforeEach(() => {
+    toastManager = {
+      removeTask: mock(() => {}),
+    }
+    mock.module("../../features/task-toast-manager", () => ({
+      getTaskToastManager: () => toastManager,
+    }))
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test("session.error removes toast entry", async () => {
+    //#given - a running task with mocked toast manager
+    const manager = createBackgroundManager()
+    const concurrencyManager = getConcurrencyManager(manager)
+    const concurrencyKey = "test-provider/test-model"
+    await concurrencyManager.acquire(concurrencyKey)
+
+    const sessionID = "ses_error_toast"
+    const task = createMockTask({
+      id: "task-session-error-toast",
+      sessionID,
+      parentSessionID: "parent-session",
+      status: "running",
+      concurrencyKey,
+    })
+    getTaskMap(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionID, new Set([task.id]))
+
+    //#when - session.error event fires for that task's session
+    manager.handleEvent({
+      type: "session.error",
+      properties: {
+        sessionID,
+        error: {
+          name: "UnknownError",
+          data: { message: "boom" },
+        },
+      },
+    })
+
+    //#then - toastManager.removeTask(task.id) was called
+    expect(toastManager.removeTask).toHaveBeenCalledWith(task.id)
+
+    manager.shutdown()
+  })
+
+  test("session.deleted removes toast entry (via cancelTask skipNotification)", () => {
+    //#given - a running task, session deleted
+    const manager = createBackgroundManager()
+    const parentSessionID = "parent-session-deleted"
+    const task = createMockTask({
+      id: "task-session-deleted-toast",
+      sessionID: "session-child-deleted",
+      parentSessionID,
+      status: "running",
+    })
+    getTaskMap(manager).set(task.id, task)
+    getPendingByParent(manager).set(parentSessionID, new Set([task.id]))
+
+    //#when - session.deleted event fires for the task's parent session
+    manager.handleEvent({
+      type: "session.deleted",
+      properties: { info: { id: parentSessionID } },
+    })
+
+    //#then - toastManager.removeTask(task.id) was called
+    expect(toastManager.removeTask).toHaveBeenCalledWith(task.id)
+
+    manager.shutdown()
+  })
+
+  test("pruneStaleTasksAndNotifications removes toast entry", () => {
+    //#given - a stale task (startedAt > 30min ago)
+    const manager = createBackgroundManager()
+    const staleDate = new Date(Date.now() - 31 * 60 * 1000)
+    const task = createMockTask({
+      id: "task-stale-toast",
+      sessionID: "session-stale-toast",
+      parentSessionID: "parent-session",
+      status: "running",
+      startedAt: staleDate,
+    })
+    getTaskMap(manager).set(task.id, task)
+
+    //#when - pruneStaleTasksAndNotifications runs
+    pruneStaleTasksAndNotificationsForTest(manager)
+
+    //#then - toastManager.removeTask(task.id) was called
+    expect(toastManager.removeTask).toHaveBeenCalledWith(task.id)
+
+    manager.shutdown()
+  })
+
+  test("cancelTask with skipNotification removes toast entry", async () => {
+    //#given - a running task
+    const manager = createBackgroundManager()
+    const concurrencyManager = getConcurrencyManager(manager)
+    const concurrencyKey = "test-provider/test-model"
+    await concurrencyManager.acquire(concurrencyKey)
+    const task = createMockTask({
+      id: "task-cancel-toast",
+      sessionID: "session-cancel-toast",
+      parentSessionID: "parent-session",
+      status: "running",
+      concurrencyKey,
+    })
+    getTaskMap(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionID, new Set([task.id]))
+
+    //#when - cancelTask(taskId, { skipNotification: true }) is called
+    await manager.cancelTask(task.id, { source: "test", skipNotification: true })
+
+    //#then - toastManager.removeTask(task.id) was called
+    expect(toastManager.removeTask).toHaveBeenCalledWith(task.id)
+
+    manager.shutdown()
   })
 })

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -783,6 +783,7 @@ export class BackgroundManager {
       this.cleanupPendingByParent(task)
       this.tasks.delete(task.id)
       this.clearNotificationsForTask(task.id)
+      getTaskToastManager()?.removeTask(task.id)
       if (task.sessionID) {
         subagentSessions.delete(task.sessionID)
       }
@@ -1001,6 +1002,7 @@ export class BackgroundManager {
 
     if (options?.skipNotification) {
       log(`[background-agent] Task cancelled via ${source} (notification skipped):`, task.id)
+      getTaskToastManager()?.removeTask(task.id)
       return true
     }
 
@@ -1413,6 +1415,7 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
           }
         }
         this.clearNotificationsForTask(taskId)
+        getTaskToastManager()?.removeTask(task.id)
         this.tasks.delete(taskId)
         if (task.sessionID) {
           subagentSessions.delete(task.sessionID)


### PR DESCRIPTION
## Summary

Fixes #1866. `TaskToastManager.removeTask()` was only called on the happy-path completion flow (`tryCompleteTask → notifyParentSession → showCompletionToast → removeTask`). Tasks completing via `session.error`, `session.deleted`, `cancelTask(skipNotification)`, or `pruneStaleTasksAndNotifications` never had their toast entries removed, causing ghost "queued" entries to accumulate indefinitely (observed 107+ in production).

## Changes

**Implementation** (`src/features/background-agent/manager.ts`):
- Added `getTaskToastManager()?.removeTask(task.id)` to 3 locations:
  1. `session.error` handler — after task cleanup
  2. `cancelTask` with `skipNotification: true` — before early return (also covers `session.deleted` which delegates here)
  3. `pruneStaleTasksAndNotifications` — in the stale task cleanup loop

**Tests** (`src/features/background-agent/manager.test.ts`):
- Added 4 new tests in `"BackgroundManager - toast cleanup on non-happy-path completion"` describe block
- Uses `mock.module` to mock `getTaskToastManager()` and spy on `removeTask` calls
- Covers: session.error, session.deleted (via cancelTask), pruneStale, and direct cancelTask(skipNotification)

## Testing

- 95/95 tests pass in `manager.test.ts` (91 existing + 4 new)
- No regressions


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a toast leak by removing TaskToastManager entries when tasks end via error, deletion, cancel(skipNotification), or stale prune. Prevents ghost “queued” toasts and keeps the task queue accurate.

- **Bug Fixes**
  - Call removeTask in session.error after task cleanup.
  - Call removeTask in cancelTask when skipNotification is true (covers session.deleted).
  - Call removeTask for stale tasks during pruneStaleTasksAndNotifications.

<sup>Written for commit 9a1177c45e7c1ac20e62bd1e3fb9bcb705acb96a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

