### PR TITLE
fix(background-agent): fix tool permission spread order so agent restrictions are respected

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -163,9 +163,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -211,9 +208,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -301,9 +295,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -345,9 +336,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -393,9 +381,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -483,9 +468,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -527,9 +509,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -575,9 +554,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -665,9 +641,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -709,9 +682,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -757,9 +727,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -847,9 +814,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -891,9 +855,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -939,9 +900,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1029,9 +987,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1073,9 +1028,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1121,9 +1073,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1211,9 +1160,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1255,9 +1201,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1303,9 +1246,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1393,9 +1333,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1437,9 +1374,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1485,9 +1419,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1575,9 +1506,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1619,9 +1547,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1667,9 +1592,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1757,9 +1679,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1801,9 +1720,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -1849,9 +1765,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -1939,9 +1852,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -1983,9 +1893,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2031,9 +1938,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2121,9 +2025,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2165,9 +2066,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2213,9 +2111,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2303,9 +2198,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2347,9 +2239,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2395,9 +2284,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2485,9 +2371,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2529,9 +2412,6 @@
             },
             "tools": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {
                 "type": "boolean"
               }
@@ -2577,9 +2457,6 @@
                     },
                     {
                       "type": "object",
-                      "propertyNames": {
-                        "type": "string"
-                      },
                       "additionalProperties": {
                         "type": "string",
                         "enum": [
@@ -2667,9 +2544,6 @@
             },
             "providerOptions": {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
               "additionalProperties": {}
             }
           },
@@ -2680,9 +2554,6 @@
     },
     "categories": {
       "type": "object",
-      "propertyNames": {
-        "type": "string"
-      },
       "additionalProperties": {
         "type": "object",
         "properties": {
@@ -2746,9 +2617,6 @@
           },
           "tools": {
             "type": "object",
-            "propertyNames": {
-              "type": "string"
-            },
             "additionalProperties": {
               "type": "boolean"
             }
@@ -2789,9 +2657,6 @@
         },
         "plugins_override": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "boolean"
           }
@@ -3065,9 +2930,6 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string"
-                    },
                     "additionalProperties": {}
                   },
                   "allowed-tools": {
@@ -3119,9 +2981,6 @@
         },
         "providerConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0
@@ -3129,9 +2988,6 @@
         },
         "modelConcurrency": {
           "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
           "additionalProperties": {
             "type": "number",
             "minimum": 0

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -3779,3 +3779,96 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
     manager.shutdown()
   })
 })
+
+describe("BackgroundManager - tool permission spread order", () => {
+  test("startTask respects explore agent restrictions", async () => {
+    //#given
+    let capturedTools: Record<string, unknown> | undefined
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/test/dir" } }),
+        create: async () => ({ data: { id: "session-1" } }),
+        promptAsync: async (args: { path: { id: string }; body: Record<string, unknown> }) => {
+          capturedTools = args.body.tools as Record<string, unknown>
+          return {}
+        },
+      },
+    }
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    const task: BackgroundTask = {
+      id: "task-1",
+      status: "pending",
+      queuedAt: new Date(),
+      description: "test task",
+      prompt: "test prompt",
+      agent: "explore",
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-message",
+    }
+    const input: import("./types").LaunchInput = {
+      description: task.description,
+      prompt: task.prompt,
+      agent: task.agent,
+      parentSessionID: task.parentSessionID,
+      parentMessageID: task.parentMessageID,
+    }
+
+    //#when
+    await (manager as unknown as { startTask: (item: { task: BackgroundTask; input: import("./types").LaunchInput }) => Promise<void> })
+      .startTask({ task, input })
+
+    //#then
+    expect(capturedTools).toBeDefined()
+    expect(capturedTools?.call_omo_agent).toBe(false)
+    expect(capturedTools?.task).toBe(false)
+    expect(capturedTools?.write).toBe(false)
+    expect(capturedTools?.edit).toBe(false)
+
+    manager.shutdown()
+  })
+
+  test("resume respects explore agent restrictions", async () => {
+    //#given
+    let capturedTools: Record<string, unknown> | undefined
+    const client = {
+      session: {
+        promptAsync: async (args: { path: { id: string }; body: Record<string, unknown> }) => {
+          capturedTools = args.body.tools as Record<string, unknown>
+          return {}
+        },
+        abort: async () => ({}),
+      },
+    }
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    const task: BackgroundTask = {
+      id: "task-2",
+      sessionID: "session-2",
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-message",
+      description: "resume task",
+      prompt: "resume prompt",
+      agent: "explore",
+      status: "completed",
+      startedAt: new Date(),
+      completedAt: new Date(),
+    }
+    getTaskMap(manager).set(task.id, task)
+
+    //#when
+    await manager.resume({
+      sessionId: "session-2",
+      prompt: "continue",
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-message",
+    })
+
+    //#then
+    expect(capturedTools).toBeDefined()
+    expect(capturedTools?.call_omo_agent).toBe(false)
+    expect(capturedTools?.task).toBe(false)
+    expect(capturedTools?.write).toBe(false)
+    expect(capturedTools?.edit).toBe(false)
+
+    manager.shutdown()
+  })
+})

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -336,10 +336,10 @@ export class BackgroundManager {
         system: input.skillContent,
         tools: (() => {
           const tools = {
-            ...getAgentToolRestrictions(input.agent),
             task: false,
             call_omo_agent: true,
             question: false,
+            ...getAgentToolRestrictions(input.agent),
           }
           setSessionTools(sessionID, tools)
           return tools
@@ -609,10 +609,10 @@ export class BackgroundManager {
         ...(resumeVariant ? { variant: resumeVariant } : {}),
         tools: (() => {
           const tools = {
-            ...getAgentToolRestrictions(existingTask.agent),
             task: false,
             call_omo_agent: true,
             question: false,
+            ...getAgentToolRestrictions(existingTask.agent),
           }
           setSessionTools(existingTask.sessionID!, tools)
           return tools

--- a/src/features/background-agent/spawner/task-starter.ts
+++ b/src/features/background-agent/spawner/task-starter.ts
@@ -82,10 +82,10 @@ export async function startTask(item: QueueItem, ctx: SpawnerContext): Promise<v
       system: input.skillContent,
       tools: (() => {
         const tools = {
-          ...getAgentToolRestrictions(input.agent),
           task: false,
           call_omo_agent: true,
           question: false,
+          ...getAgentToolRestrictions(input.agent),
         }
         setSessionTools(sessionID, tools)
         return tools


### PR DESCRIPTION
## Summary

Fixes the tool permission spread order in background task `startTask` and `resume` paths so that agent-specific restrictions take priority over defaults.

## Problem

In `BackgroundManager.startTask()` and the resume path, tool permissions were constructed with the defaults coming AFTER the agent restrictions:

```typescript
// BEFORE (buggy): defaults override restrictions
tools: {
  ...getAgentToolRestrictions(input.agent),  // e.g., explore: { call_omo_agent: false }
  task: false,
  call_omo_agent: true,   // ← stomps the restriction above
  question: false,
}
```

Due to JS spread semantics, later keys override earlier ones, meaning `call_omo_agent: true` would always win, even for agents like `explore` and `librarian` whose restrictions explicitly set `call_omo_agent: false`.

The correct pattern already existed in `sync-prompt-sender.ts`:

```typescript
// CORRECT: restrictions come last and win
tools: {
  task: allowTask,
  call_omo_agent: true,
  question: false,
  ...getAgentToolRestrictions(input.agentToUse),  // restrictions override defaults
}
```

## Changes

**Implementation** (`src/features/background-agent/manager.ts`):
- Reordered tool permission spread in `startTask` — defaults first, `...getAgentToolRestrictions()` last
- Same reorder in the `resume` path
- Preserved the `setSessionTools` IIFE wrapper

**Tests** (`src/features/background-agent/manager.test.ts`):
- Added 2 new tests in `"BackgroundManager - tool permission spread order"` describe block
- Captures `tools` passed to `promptWithModelSuggestionRetry` via mock
- Verifies `call_omo_agent`, `write`, `edit` are all `false` for explore agent (matching `EXPLORATION_AGENT_DENYLIST`)

## Context

Runtime logs show explore/librarian agents never actually invoked `call_omo_agent` despite having access (0 occurrences in 107MB of logs). This is a latent defect fix for correctness — the override contradicted the carefully defined restrictions in `agent-tool-restrictions.ts` and was inconsistent with the sync path.

## Testing

- 93/93 tests pass in `manager.test.ts` (91 existing + 2 new)
- No regressions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tool permission order across background agent launch and resume so agent-specific restrictions override defaults. Restricted agents (e.g., explore) no longer gain call_omo_agent, write, or edit when denied.

- **Bug Fixes**
  - Reordered tool spread to apply defaults first, then ...getAgentToolRestrictions() in BackgroundManager startTask/resume and spawner startTask.
  - Added tests confirming explore agent sets call_omo_agent, task, write, and edit to false in startTask and resume.

<sup>Written for commit 025eb14f6da394f9dfe6b7fa1993ca7ca0ee342f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

