### PR TITLE
fix: preserve user-selected variant on first message instead of overriding with fallback chain default

### DIFF
--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from "bun:test"
+
+import { createChatMessageHandler } from "./chat-message"
+
+type ChatMessagePart = { type: string; text?: string; [key: string]: unknown }
+type ChatMessageHandlerOutput = { message: Record<string, unknown>; parts: ChatMessagePart[] }
+
+function createMockHandlerArgs(overrides?: {
+  pluginConfig?: Record<string, unknown>
+  shouldOverride?: boolean
+}) {
+  const appliedSessions: string[] = []
+  return {
+    ctx: { client: { tui: { showToast: async () => {} } } } as any,
+    pluginConfig: (overrides?.pluginConfig ?? {}) as any,
+    firstMessageVariantGate: {
+      shouldOverride: () => overrides?.shouldOverride ?? false,
+      markApplied: (sessionID: string) => { appliedSessions.push(sessionID) },
+    },
+    hooks: {
+      stopContinuationGuard: null,
+      keywordDetector: null,
+      claudeCodeHooks: null,
+      autoSlashCommand: null,
+      startWork: null,
+      ralphLoop: null,
+    } as any,
+    _appliedSessions: appliedSessions,
+  }
+}
+
+function createMockInput(agent?: string, model?: { providerID: string; modelID: string }) {
+  return {
+    sessionID: "test-session",
+    agent,
+    model,
+  }
+}
+
+function createMockOutput(variant?: string): ChatMessageHandlerOutput {
+  const message: Record<string, unknown> = {}
+  if (variant !== undefined) {
+    message["variant"] = variant
+  }
+  return { message, parts: [] }
+}
+
+describe("createChatMessageHandler - first message variant", () => {
+  test("first message: sets variant from fallback chain when user has no selection", async () => {
+    //#given - first message, no user-selected variant, hephaestus with medium in chain
+    const args = createMockHandlerArgs({ shouldOverride: true })
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+    const output = createMockOutput() // no variant set
+
+    //#when
+    await handler(input, output)
+
+    //#then - should set variant from fallback chain
+    expect(output.message["variant"]).toBeDefined()
+  })
+
+  test("first message: preserves user-selected variant when already set", async () => {
+    //#given - first message, user already selected "xhigh" variant in OpenCode UI
+    const args = createMockHandlerArgs({ shouldOverride: true })
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+    const output = createMockOutput("xhigh") // user selected xhigh
+
+    //#when
+    await handler(input, output)
+
+    //#then - user's xhigh must be preserved, not overwritten to "medium"
+    expect(output.message["variant"]).toBe("xhigh")
+  })
+
+  test("first message: preserves user-selected 'high' variant", async () => {
+    //#given - user selected "high" variant
+    const args = createMockHandlerArgs({ shouldOverride: true })
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+    const output = createMockOutput("high")
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.message["variant"]).toBe("high")
+  })
+
+  test("subsequent message: does not override existing variant", async () => {
+    //#given - not first message, variant already set
+    const args = createMockHandlerArgs({ shouldOverride: false })
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+    const output = createMockOutput("xhigh")
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.message["variant"]).toBe("xhigh")
+  })
+
+  test("first message: marks gate as applied regardless of variant presence", async () => {
+    //#given - first message with user-selected variant
+    const args = createMockHandlerArgs({ shouldOverride: true })
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+    const output = createMockOutput("xhigh")
+
+    //#when
+    await handler(input, output)
+
+    //#then - gate should still be marked as applied
+    expect(args._appliedSessions).toContain("test-session")
+  })
+})

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -56,12 +56,14 @@ export function createChatMessageHandler(args: {
     const message = output.message
 
     if (firstMessageVariantGate.shouldOverride(input.sessionID)) {
-      const variant =
-        input.model && input.agent
-          ? resolveVariantForModel(pluginConfig, input.agent, input.model)
-          : resolveAgentVariant(pluginConfig, input.agent)
-      if (variant !== undefined) {
-        message["variant"] = variant
+      if (message["variant"] === undefined) {
+        const variant =
+          input.model && input.agent
+            ? resolveVariantForModel(pluginConfig, input.agent, input.model)
+            : resolveAgentVariant(pluginConfig, input.agent)
+        if (variant !== undefined) {
+          message["variant"] = variant
+        }
       }
       firstMessageVariantGate.markApplied(input.sessionID)
     } else {


### PR DESCRIPTION
## Summary

Fixes #1861

The first-message variant gate was unconditionally overwriting `message.variant` with the value resolved from the agent's fallback chain (e.g. `"medium"` for Hephaestus), ignoring any variant the user had already selected via OpenCode's UI reasoning effort selector.

## Root Cause

In `src/plugin/chat-message.ts`, the `firstMessageVariantGate` path set `message["variant"] = variant` without checking if the user had already chosen a variant. Since Hephaestus's fallback chain defines `variant: "medium"` for `gpt-5.3-codex`, any user selection (e.g. `xhigh`) was silently overwritten on the very first message of every session.

## Fix

Added `message["variant"] === undefined` guard to the first-message path, matching the behavior already used for subsequent messages. This ensures:
- **User-selected variant is preserved** when set via OpenCode UI
- **Fallback chain variant applies** only when the user hasn't made a selection
- **Config-level overrides** continue to work as before (via `resolveVariantForModel`)

## Changes

- `src/plugin/chat-message.ts` — Added undefined check before setting variant on first message
- `src/plugin/chat-message.test.ts` — New test file with 5 test cases covering:
  - First message sets variant from fallback chain when no user selection
  - First message preserves user-selected `xhigh` variant
  - First message preserves user-selected `high` variant
  - Subsequent messages don't override existing variant
  - Gate is marked as applied regardless of variant presence

## Verification

- `bun test src/plugin/chat-message.test.ts` — 5/5 pass
- `bun run typecheck` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the user-selected variant on the first chat message and only applies the fallback variant when none is set. Prevents agents like Hephaestus from forcing "medium" on session start.

- **Bug Fixes**
  - Only set variant on first message when message.variant is undefined.
  - Fallback chain applies only if the user hasn't chosen a variant; config overrides still respected.
  - Added tests for first/subsequent messages and gate application.

<sup>Written for commit 7108d244d10efa9c1eefb4af37ba2ff545647800. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

