### PR TITLE
fix: add toast cleanup to all BackgroundManager task removal paths

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -6,6 +6,7 @@ import type { BackgroundTask, ResumeInput } from "./types"
 import { MIN_IDLE_TIME_MS } from "./constants"
 import { BackgroundManager } from "./manager"
 import { ConcurrencyManager } from "./concurrency"
+import { initTaskToastManager, _resetTaskToastManagerForTesting } from "../task-toast-manager/manager"
 
 
 const TASK_TTL_MS = 30 * 60 * 1000
@@ -213,6 +214,23 @@ async function tryCompleteTaskForTest(manager: BackgroundManager, task: Backgrou
 
 function stubNotifyParentSession(manager: BackgroundManager): void {
   ;(manager as unknown as { notifyParentSession: () => Promise<void> }).notifyParentSession = async () => {}
+}
+
+function createToastRemoveTaskTracker(): { removeTaskCalls: string[]; resetToastManager: () => void } {
+  _resetTaskToastManagerForTesting()
+  const toastManager = initTaskToastManager({
+    tui: { showToast: async () => {} },
+  } as unknown as PluginInput["client"])
+  const removeTaskCalls: string[] = []
+  const originalRemoveTask = toastManager.removeTask.bind(toastManager)
+  toastManager.removeTask = (taskId: string): void => {
+    removeTaskCalls.push(taskId)
+    originalRemoveTask(taskId)
+  }
+  return {
+    removeTaskCalls,
+    resetToastManager: _resetTaskToastManagerForTesting,
+  }
 }
 
 function getCleanupSignals(): Array<NodeJS.Signals | "beforeExit" | "exit"> {
@@ -1770,6 +1788,32 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       const pendingSet = pendingByParent.get(task.parentSessionID)
       expect(pendingSet?.has(task.id) ?? false).toBe(false)
     })
+
+    test("should remove task from toast manager when notification is skipped", async () => {
+      //#given
+      const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
+      const manager = createBackgroundManager()
+      const task = createMockTask({
+        id: "task-cancel-skip-notification",
+        sessionID: "session-cancel-skip-notification",
+        parentSessionID: "parent-cancel-skip-notification",
+        status: "running",
+      })
+      getTaskMap(manager).set(task.id, task)
+
+      //#when
+      const cancelled = await manager.cancelTask(task.id, {
+        source: "test",
+        skipNotification: true,
+      })
+
+      //#then
+      expect(cancelled).toBe(true)
+      expect(removeTaskCalls).toContain(task.id)
+
+      manager.shutdown()
+      resetToastManager()
+    })
   })
 
   describe("multiple keys process in parallel", () => {
@@ -2730,6 +2774,43 @@ describe("BackgroundManager.handleEvent - session.deleted cascade", () => {
 
     manager.shutdown()
   })
+
+  test("should remove tasks from toast manager when session is deleted", () => {
+    //#given
+    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
+    const manager = createBackgroundManager()
+    const parentSessionID = "session-parent-toast"
+    const childTask = createMockTask({
+      id: "task-child-toast",
+      sessionID: "session-child-toast",
+      parentSessionID,
+      status: "running",
+    })
+    const grandchildTask = createMockTask({
+      id: "task-grandchild-toast",
+      sessionID: "session-grandchild-toast",
+      parentSessionID: "session-child-toast",
+      status: "pending",
+      startedAt: undefined,
+      queuedAt: new Date(),
+    })
+    const taskMap = getTaskMap(manager)
+    taskMap.set(childTask.id, childTask)
+    taskMap.set(grandchildTask.id, grandchildTask)
+
+    //#when
+    manager.handleEvent({
+      type: "session.deleted",
+      properties: { info: { id: parentSessionID } },
+    })
+
+    //#then
+    expect(removeTaskCalls).toContain(childTask.id)
+    expect(removeTaskCalls).toContain(grandchildTask.id)
+
+    manager.shutdown()
+    resetToastManager()
+  })
 })
 
 describe("BackgroundManager.handleEvent - session.error", () => {
@@ -2775,6 +2856,35 @@ describe("BackgroundManager.handleEvent - session.error", () => {
     expect(getPendingByParent(manager).get(task.parentSessionID)).toBeUndefined()
 
     manager.shutdown()
+  })
+
+  test("removes errored task from toast manager", () => {
+    //#given
+    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
+    const manager = createBackgroundManager()
+    const sessionID = "ses_error_toast"
+    const task = createMockTask({
+      id: "task-session-error-toast",
+      sessionID,
+      parentSessionID: "parent-session",
+      status: "running",
+    })
+    getTaskMap(manager).set(task.id, task)
+
+    //#when
+    manager.handleEvent({
+      type: "session.error",
+      properties: {
+        sessionID,
+        error: { name: "UnknownError", message: "boom" },
+      },
+    })
+
+    //#then
+    expect(removeTaskCalls).toContain(task.id)
+
+    manager.shutdown()
+    resetToastManager()
   })
 
   test("ignores session.error for non-running tasks", () => {
@@ -2921,6 +3031,29 @@ describe("BackgroundManager.pruneStaleTasksAndNotifications - removes pruned tas
     expect(getQueuesByKey(manager).get(key)).toBeUndefined()
 
     manager.shutdown()
+  })
+
+  test("removes stale task from toast manager", () => {
+    //#given
+    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
+    const manager = createBackgroundManager()
+    const staleTask = createMockTask({
+      id: "task-stale-toast",
+      sessionID: "session-stale-toast",
+      parentSessionID: "parent-session",
+      status: "running",
+      startedAt: new Date(Date.now() - 31 * 60 * 1000),
+    })
+    getTaskMap(manager).set(staleTask.id, staleTask)
+
+    //#when
+    pruneStaleTasksAndNotificationsForTest(manager)
+
+    //#then
+    expect(removeTaskCalls).toContain(staleTask.id)
+
+    manager.shutdown()
+    resetToastManager()
   })
 })
 

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -783,6 +783,10 @@ export class BackgroundManager {
       this.cleanupPendingByParent(task)
       this.tasks.delete(task.id)
       this.clearNotificationsForTask(task.id)
+      const toastManager = getTaskToastManager()
+      if (toastManager) {
+        toastManager.removeTask(task.id)
+      }
       if (task.sessionID) {
         subagentSessions.delete(task.sessionID)
       }
@@ -830,6 +834,10 @@ export class BackgroundManager {
         this.cleanupPendingByParent(task)
         this.tasks.delete(task.id)
         this.clearNotificationsForTask(task.id)
+        const toastManager = getTaskToastManager()
+        if (toastManager) {
+          toastManager.removeTask(task.id)
+        }
         if (task.sessionID) {
           subagentSessions.delete(task.sessionID)
         }
@@ -1000,6 +1008,10 @@ export class BackgroundManager {
     }
 
     if (options?.skipNotification) {
+      const toastManager = getTaskToastManager()
+      if (toastManager) {
+        toastManager.removeTask(task.id)
+      }
       log(`[background-agent] Task cancelled via ${source} (notification skipped):`, task.id)
       return true
     }
@@ -1413,6 +1425,10 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
           }
         }
         this.clearNotificationsForTask(taskId)
+        const toastManager = getTaskToastManager()
+        if (toastManager) {
+          toastManager.removeTask(taskId)
+        }
         this.tasks.delete(taskId)
         if (task.sessionID) {
           subagentSessions.delete(task.sessionID)


### PR DESCRIPTION
## Summary

Fixes #1866

`TaskToastManager` entries were never removed when tasks completed via error, session deletion, stale pruning, or cancellation with `skipNotification`. Ghost entries accumulated indefinitely, causing the `Queued (N)` count in toast messages to grow without bound.

## Root Cause

`TaskToastManager.removeTask()` was **only** called from `showCompletionToast()`, which is only reached via the happy-path completion flow. Four cleanup paths in `BackgroundManager` removed tasks from `this.tasks` but never called `toastManager.removeTask()`:

1. **`session.error` handler** (L752-789) — task marked as error and deleted, toast entry persists
2. **`session.deleted` handler** (L791-837) — `cancelTask()` called with `skipNotification: true`, bypassing toast cleanup
3. **`cancelTask` with `skipNotification`** (L1002-1004) — early return before `notifyParentSession → showCompletionToast → removeTask`
4. **`pruneStaleTasksAndNotifications`** (L1371-1439) — stale tasks deleted, toast entries left behind

## Fix

Added `toastManager.removeTask(task.id)` to all 4 paths using the same guarded pattern already used elsewhere in the codebase:

```typescript
const toastManager = getTaskToastManager()
if (toastManager) {
  toastManager.removeTask(task.id)
}
```

## Changes

- `src/features/background-agent/manager.ts` — Added toast cleanup to 4 task removal paths
- `src/features/background-agent/manager.test.ts` — Added 4 test cases + helper for tracking removeTask calls:
  - `session.error` triggers toast removeTask
  - `session.deleted` triggers toast removeTask
  - `cancelTask(skipNotification)` triggers toast removeTask
  - `pruneStaleTasksAndNotifications` triggers toast removeTask

## Verification

- `bun test` — 2687 pass, 0 fail
- `bun run typecheck` — clean
- LSP diagnostics — clean on both changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures toast entries are cleaned up for all non-happy-path task endings, preventing ghost entries and the “Queued (N)” count from growing indefinitely. Fixes #1866.

- **Bug Fixes**
  - Call toastManager.removeTask in session.error, session.deleted, cancelTask(skipNotification), and pruneStaleTasksAndNotifications.
  - Add tests for each path with a helper to track removeTask calls.

<sup>Written for commit 33d290b3464eb82dcffcf49c6cc56c34d9a5b197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

