### PR TITLE
fix: cancel pending compaction timer on session.idle and add error logging (#1752)

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+
+const executeCompactMock = mock(async () => {})
+const getLastAssistantMock = mock(async () => ({
+  providerID: "anthropic",
+  modelID: "claude-sonnet-4-5",
+}))
+const parseAnthropicTokenLimitErrorMock = mock(() => ({
+  providerID: "anthropic",
+  modelID: "claude-sonnet-4-5",
+}))
+
+mock.module("./executor", () => ({
+  executeCompact: executeCompactMock,
+  getLastAssistant: getLastAssistantMock,
+}))
+
+mock.module("./parser", () => ({
+  parseAnthropicTokenLimitError: parseAnthropicTokenLimitErrorMock,
+}))
+
+mock.module("../../shared/logger", () => ({
+  log: () => {},
+}))
+
+function createMockContext(): PluginInput {
+  return {
+    client: {
+      session: {
+        messages: mock(() => Promise.resolve({ data: [] })),
+      },
+      tui: {
+        showToast: mock(() => Promise.resolve()),
+      },
+    },
+    directory: "/tmp",
+  } as PluginInput
+}
+
+function setupDelayedTimeoutMocks(): {
+  restore: () => void
+  getClearTimeoutCalls: () => Array<ReturnType<typeof setTimeout>>
+} {
+  const originalSetTimeout = globalThis.setTimeout
+  const originalClearTimeout = globalThis.clearTimeout
+  const clearTimeoutCalls: Array<ReturnType<typeof setTimeout>> = []
+  let timeoutCounter = 0
+
+  globalThis.setTimeout = ((_: () => void, _delay?: number) => {
+    timeoutCounter += 1
+    return timeoutCounter as ReturnType<typeof setTimeout>
+  }) as typeof setTimeout
+
+  globalThis.clearTimeout = ((timeoutID: ReturnType<typeof setTimeout>) => {
+    clearTimeoutCalls.push(timeoutID)
+  }) as typeof clearTimeout
+
+  return {
+    restore: () => {
+      globalThis.setTimeout = originalSetTimeout
+      globalThis.clearTimeout = originalClearTimeout
+    },
+    getClearTimeoutCalls: () => clearTimeoutCalls,
+  }
+}
+
+describe("createAnthropicContextWindowLimitRecoveryHook", () => {
+  beforeEach(() => {
+    executeCompactMock.mockClear()
+    getLastAssistantMock.mockClear()
+    parseAnthropicTokenLimitErrorMock.mockClear()
+  })
+
+  test("cancels pending timer when session.idle handles compaction first", async () => {
+    //#given
+    const { restore, getClearTimeoutCalls } = setupDelayedTimeoutMocks()
+    const { createAnthropicContextWindowLimitRecoveryHook } = await import("./recovery-hook")
+    const hook = createAnthropicContextWindowLimitRecoveryHook(createMockContext())
+
+    try {
+      //#when
+      await hook.event({
+        event: {
+          type: "session.error",
+          properties: { sessionID: "session-race", error: "prompt is too long" },
+        },
+      })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-race" },
+        },
+      })
+
+      //#then
+      expect(getClearTimeoutCalls()).toEqual([1 as ReturnType<typeof setTimeout>])
+      expect(executeCompactMock).toHaveBeenCalledTimes(1)
+      expect(executeCompactMock.mock.calls[0]?.[0]).toBe("session-race")
+    } finally {
+      restore()
+    }
+  })
+})

--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -1,3 +1,5 @@
+import { log } from "../shared/logger"
+
 const DEFAULT_ACTUAL_LIMIT = 200_000
 
 const ANTHROPIC_ACTUAL_LIMIT =
@@ -76,8 +78,8 @@ export function createPreemptiveCompactionHook(ctx: PluginInput) {
       })
 
       compactedSessions.add(sessionID)
-    } catch {
-      // best-effort; do not disrupt tool execution
+    } catch (error) {
+      log("[preemptive-compaction] Compaction failed", { sessionID, error: String(error) })
     } finally {
       compactionInProgress.delete(sessionID)
     }


### PR DESCRIPTION
## Summary
- Fixes the compaction race in `recovery-hook.ts` by tracking per-session 300ms timers, cancelling pending timers when `session.idle` compacts first, and cleaning timer references on `session.deleted`.
- Replaces the silent catch in `preemptive-compaction.ts` with structured logging via `log("[preemptive-compaction] Compaction failed", { sessionID, error: String(error) })`.
- Adds tests for timer cancellation behavior and preemptive compaction error logging, covering issue #1752 edge cases.

## Testing
- `bun run typecheck`
- `bun test src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts src/hooks/preemptive-compaction.test.ts`
- `bun test --timeout 20000`
- `bun run build`

## Issue
- Closes #1752


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the duplicate-compaction race by tracking per-session timers and canceling them when session.idle compacts first, plus structured error logging for preemptive compaction failures. Addresses #1752 with targeted tests.

- **Bug Fixes**
  - Recovery hook: track per-session 300ms timers; cancel on session.idle and clear on session.deleted to prevent double compaction.
  - Preemptive compaction: replace silent catch with structured logging including sessionID and error; tests cover timer cancellation and logging behavior.

<sup>Written for commit 6a90182503c1da59993d751e9ba9cf5aac4ecf78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

