### PR TITLE
fix(tests): mock shared/opencode-message-dir in session-manager storage tests

### DIFF
--- a/src/tools/session-manager/storage.test.ts
+++ b/src/tools/session-manager/storage.test.ts
@@ -31,6 +31,34 @@ mock.module("../../shared/opencode-storage-detection", () => ({
   resetSqliteBackendCache: () => {},
 }))
 
+// getMessageDir was moved to shared/opencode-message-dir which imports MESSAGE_STORAGE
+// from shared/opencode-storage-paths (not ./constants). Mock it to use the test directory.
+mock.module("../../shared/opencode-message-dir", () => {
+  const { existsSync, readdirSync } = require("node:fs")
+  const { join } = require("node:path")
+  return {
+    getMessageDir: (sessionID: string): string | null => {
+      if (!sessionID.startsWith("ses_")) return null
+      if (/[/\\]|\.\./.test(sessionID)) return null
+      if (!existsSync(TEST_MESSAGE_STORAGE)) return null
+
+      const directPath = join(TEST_MESSAGE_STORAGE, sessionID)
+      if (existsSync(directPath)) return directPath
+
+      try {
+        for (const dir of readdirSync(TEST_MESSAGE_STORAGE)) {
+          const sessionPath = join(TEST_MESSAGE_STORAGE, dir, sessionID)
+          if (existsSync(sessionPath)) return sessionPath
+        }
+      } catch {
+        return null
+      }
+
+      return null
+    },
+  }
+})
+
 const { getAllSessions, getMessageDir, sessionExists, readSessionMessages, readSessionTodos, getSessionInfo } =
   await import("./storage")
 


### PR DESCRIPTION
## Summary

Fixes 4 broken tests on `dev` introduced by #1837 (OpenCode beta SQLite migration).

## Root Cause

PR #1837 moved `getMessageDir` from `storage.ts` to `shared/opencode-message-dir.ts`. The new module imports `MESSAGE_STORAGE` from `shared/opencode-storage-paths` — but the test only mocks `./constants`. This means `getMessageDir` uses the real (non-existent in CI) storage path instead of the test's temp directory, causing it to always return `null`.

**Failing tests:**
- `getMessageDir finds session in direct path`
- `sessionExists returns true for existing session`
- `readSessionMessages sorts messages by timestamp`
- `getSessionInfo aggregates session metadata correctly`

## Fix

Added a `mock.module("../../shared/opencode-message-dir")` that provides a `getMessageDir` implementation using `TEST_MESSAGE_STORAGE`, matching the real function's logic but pointed at the test directory.

## Verification

All 19 tests in `storage.test.ts` pass locally. This also unblocks CI for all open PRs (e.g. #1819, #1884).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four failing session-manager storage tests by mocking shared/opencode-message-dir to use the test message storage directory. Restores test isolation after getMessageDir moved in #1837 and unblocks CI.

- **Bug Fixes**
  - Root cause: getMessageDir now imports MESSAGE_STORAGE from shared/opencode-storage-paths, so the existing ./constants mock didn’t apply and CI used a real (missing) path.
  - Fix: Added a mock for shared/opencode-message-dir that implements getMessageDir using TEST_MESSAGE_STORAGE, mirroring the real lookup logic.

<sup>Written for commit 32c30505b1c73dee3e86039eac1564442c79778a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

