### PR TITLE
fix: report silent subagent delegation failures (#1283)

### DIFF
--- a/src/tools/delegate-task/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/subagent-resolver.test.ts
@@ -1,0 +1,82 @@
+declare const require: (name: string) => any
+const { describe, test, expect, beforeEach, afterEach, spyOn, mock } = require("bun:test")
+import { resolveSubagentExecution } from "./subagent-resolver"
+import type { DelegateTaskArgs } from "./types"
+import type { ExecutorContext } from "./executor-types"
+import * as logger from "../../shared/logger"
+
+function createBaseArgs(overrides?: Partial<DelegateTaskArgs>): DelegateTaskArgs {
+  return {
+    description: "Run review",
+    prompt: "Review the current changes",
+    run_in_background: false,
+    load_skills: [],
+    subagent_type: "oracle",
+    ...overrides,
+  }
+}
+
+function createExecutorContext(agentsFn: () => Promise<unknown>): ExecutorContext {
+  const client = {
+    app: {
+      agents: agentsFn,
+    },
+  } as ExecutorContext["client"]
+
+  return {
+    client,
+    manager: {} as ExecutorContext["manager"],
+    directory: "/tmp/test",
+  }
+}
+
+describe("resolveSubagentExecution", () => {
+  let logSpy: ReturnType<typeof spyOn> | undefined
+
+  beforeEach(() => {
+    mock.restore()
+    logSpy = spyOn(logger, "log").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy?.mockRestore()
+  })
+
+  test("returns delegation error when agent discovery fails instead of silently proceeding", async () => {
+    //#given
+    const resolverError = new Error("agents API unavailable")
+    const args = createBaseArgs()
+    const executorCtx = createExecutorContext(async () => {
+      throw resolverError
+    })
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.agentToUse).toBe("")
+    expect(result.categoryModel).toBeUndefined()
+    expect(result.error).toBe("Failed to delegate to agent \"oracle\": agents API unavailable")
+  })
+
+  test("logs failure details when subagent resolution throws", async () => {
+    //#given
+    const args = createBaseArgs({ subagent_type: "review" })
+    const executorCtx = createExecutorContext(async () => {
+      throw new Error("network timeout")
+    })
+
+    //#when
+    await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(logSpy).toHaveBeenCalledTimes(1)
+    const callArgs = logSpy?.mock.calls[0]
+    expect(callArgs?.[0]).toBe("[delegate-task] Failed to resolve subagent execution")
+    expect(callArgs?.[1]).toEqual({
+      requestedAgent: "review",
+      parentAgent: "sisyphus",
+      error: "network timeout",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Replace the silent catch in `resolveSubagentExecution` with explicit delegation error reporting so `/review-code` no longer fails without feedback.
- Log subagent resolution failures with requested agent + parent agent context for debugging.
- Add BDD tests proving resolver failures return meaningful user-facing errors and emit logs.

## Verification
- `bun run typecheck`
- `bun test`

Closes #1283


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop silent failures when delegating to subagents in /review-code. Errors are now surfaced to users and logged with context for easier debugging.

- **Bug Fixes**
  - resolveSubagentExecution now returns a clear delegation error instead of swallowing exceptions.
  - Logs failures with requestedAgent and parentAgent to help trace issues.
  - Added tests to verify user-facing error messages and logging behavior.

<sup>Written for commit d7a53e8a5b94a2d14bc96bc26f27a3bf57c84363. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

