### PR TITLE
refactor: extract dedicated status porcelain line parser

### DIFF
--- a/src/shared/git-worktree/index.ts
+++ b/src/shared/git-worktree/index.ts
@@ -1,4 +1,6 @@
 export type { GitFileStatus, GitFileStat } from "./types"
+export type { ParsedGitStatusPorcelainLine } from "./parse-status-porcelain-line"
+export { parseGitStatusPorcelainLine } from "./parse-status-porcelain-line"
 export { parseGitStatusPorcelain } from "./parse-status-porcelain"
 export { parseGitDiffNumstat } from "./parse-diff-numstat"
 export { collectGitDiffStats } from "./collect-git-diff-stats"

--- a/src/shared/git-worktree/parse-status-porcelain-line.test.ts
+++ b/src/shared/git-worktree/parse-status-porcelain-line.test.ts
@@ -1,0 +1,72 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { parseGitStatusPorcelainLine } from "./parse-status-porcelain-line"
+
+describe("parseGitStatusPorcelainLine", () => {
+	test("#given modified porcelain line #when parsing #then returns modified status", () => {
+		//#given
+		const line = " M src/a.ts"
+
+		//#when
+		const result = parseGitStatusPorcelainLine(line)
+
+		//#then
+		expect(result).toEqual({ filePath: "src/a.ts", status: "modified" })
+	})
+
+	test("#given added porcelain line #when parsing #then returns added status", () => {
+		//#given
+		const line = "A  src/b.ts"
+
+		//#when
+		const result = parseGitStatusPorcelainLine(line)
+
+		//#then
+		expect(result).toEqual({ filePath: "src/b.ts", status: "added" })
+	})
+
+	test("#given untracked porcelain line #when parsing #then returns added status", () => {
+		//#given
+		const line = "?? src/c.ts"
+
+		//#when
+		const result = parseGitStatusPorcelainLine(line)
+
+		//#then
+		expect(result).toEqual({ filePath: "src/c.ts", status: "added" })
+	})
+
+	test("#given deleted porcelain line #when parsing #then returns deleted status", () => {
+		//#given
+		const line = "D  src/d.ts"
+
+		//#when
+		const result = parseGitStatusPorcelainLine(line)
+
+		//#then
+		expect(result).toEqual({ filePath: "src/d.ts", status: "deleted" })
+	})
+
+	test("#given empty line #when parsing #then returns null", () => {
+		//#given
+		const line = ""
+
+		//#when
+		const result = parseGitStatusPorcelainLine(line)
+
+		//#then
+		expect(result).toBeNull()
+	})
+
+	test("#given malformed line without path #when parsing #then returns null", () => {
+		//#given
+		const line = " M "
+
+		//#when
+		const result = parseGitStatusPorcelainLine(line)
+
+		//#then
+		expect(result).toBeNull()
+	})
+})

--- a/src/shared/git-worktree/parse-status-porcelain-line.ts
+++ b/src/shared/git-worktree/parse-status-porcelain-line.ts
@@ -1,0 +1,27 @@
+import type { GitFileStatus } from "./types"
+
+export interface ParsedGitStatusPorcelainLine {
+	filePath: string
+	status: GitFileStatus
+}
+
+function toGitFileStatus(statusToken: string): GitFileStatus {
+	if (statusToken === "A" || statusToken === "??") return "added"
+	if (statusToken === "D") return "deleted"
+	return "modified"
+}
+
+export function parseGitStatusPorcelainLine(
+	line: string,
+): ParsedGitStatusPorcelainLine | null {
+	if (!line) return null
+
+	const statusToken = line.substring(0, 2).trim()
+	const filePath = line.substring(3)
+	if (!filePath) return null
+
+	return {
+		filePath,
+		status: toGitFileStatus(statusToken),
+	}
+}

--- a/src/shared/git-worktree/parse-status-porcelain.ts
+++ b/src/shared/git-worktree/parse-status-porcelain.ts
@@ -1,24 +1,14 @@
 import type { GitFileStatus } from "./types"
+import { parseGitStatusPorcelainLine } from "./parse-status-porcelain-line"
 
 export function parseGitStatusPorcelain(output: string): Map<string, GitFileStatus> {
   const map = new Map<string, GitFileStatus>()
   if (!output) return map
 
   for (const line of output.split("\n")) {
-    if (!line) continue
-
-    const status = line.substring(0, 2).trim()
-    const filePath = line.substring(3)
-
-    if (!filePath) continue
-
-    if (status === "A" || status === "??") {
-      map.set(filePath, "added")
-    } else if (status === "D") {
-      map.set(filePath, "deleted")
-    } else {
-      map.set(filePath, "modified")
-    }
+    const parsed = parseGitStatusPorcelainLine(line)
+    if (!parsed) continue
+    map.set(parsed.filePath, parsed.status)
   }
 
   return map


### PR DESCRIPTION
## Summary
- extract a dedicated `parseGitStatusPorcelainLine` parser for single-line porcelain entries
- add focused TDD coverage for modified/added/untracked/deleted/malformed line cases
- refactor `parseGitStatusPorcelain` to reuse the line parser and re-export it from the git-worktree barrel

## Testing
- `bun test src/shared/git-worktree/git-worktree.test.ts src/shared/git-worktree/parse-status-porcelain-line.test.ts src/shared/git-worktree/collect-git-diff-stats.test.ts`

## Notes
- there are unrelated pre-existing working tree changes in `src/agents/oracle.ts` and `src/agents/utils.test.ts`; they are intentionally excluded from this PR
- repository-wide `bun run typecheck` currently fails on pre-existing issue: `src/agents/oracle.ts(166,7): error TS2304: Cannot find name 'isGptModel'`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a dedicated parser for single-line git status porcelain entries and refactored the aggregate parser to use it. This simplifies maintenance and improves test coverage.

- **Refactors**
  - Added parseGitStatusPorcelainLine: maps A/?? to added, D to deleted, else modified; returns null for empty/malformed lines.
  - Updated parseGitStatusPorcelain to delegate per-line parsing to the new helper.
  - Re-exported ParsedGitStatusPorcelainLine and parseGitStatusPorcelainLine from git-worktree/index.
  - Added focused tests for modified, added, untracked, deleted, and malformed cases.

<sup>Written for commit b02721463ecf7f42b4890a85b4f5aecbb1b6f120. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

