### PR TITLE
fix: stabilize tmux split and session readiness handling

### DIFF
--- a/src/features/tmux-subagent/action-executor-core.ts
+++ b/src/features/tmux-subagent/action-executor-core.ts
@@ -22,9 +22,17 @@ export interface ActionExecutorDeps {
 	enforceMainPaneWidth: typeof enforceMainPaneWidth
 }
 
-async function enforceMainPane(windowState: WindowState, deps: ActionExecutorDeps): Promise<void> {
+async function enforceMainPane(
+	windowState: WindowState,
+	config: TmuxConfig,
+	deps: ActionExecutorDeps,
+): Promise<void> {
 	if (!windowState.mainPane) return
-	await deps.enforceMainPaneWidth(windowState.mainPane.paneId, windowState.windowWidth)
+	await deps.enforceMainPaneWidth(
+		windowState.mainPane.paneId,
+		windowState.windowWidth,
+		config.main_pane_size,
+	)
 }
 
 export async function executeActionWithDeps(
@@ -35,7 +43,7 @@ export async function executeActionWithDeps(
 	if (action.type === "close") {
 		const success = await deps.closeTmuxPane(action.paneId)
 		if (success) {
-			await enforceMainPane(ctx.windowState, deps)
+			await enforceMainPane(ctx.windowState, ctx.config, deps)
 		}
 		return { success }
 	}
@@ -65,7 +73,7 @@ export async function executeActionWithDeps(
 
 	if (result.success) {
 		await deps.applyLayout(ctx.config.layout, ctx.config.main_pane_size)
-		await enforceMainPane(ctx.windowState, deps)
+		await enforceMainPane(ctx.windowState, ctx.config, deps)
 	}
 
 	return {

--- a/src/features/tmux-subagent/action-executor.test.ts
+++ b/src/features/tmux-subagent/action-executor.test.ts
@@ -86,6 +86,7 @@ describe("executeAction", () => {
 		expect(mockApplyLayout).toHaveBeenCalledTimes(1)
 		expect(mockApplyLayout).toHaveBeenCalledWith("main-horizontal", 55)
 		expect(mockEnforceMainPaneWidth).toHaveBeenCalledTimes(1)
+		expect(mockEnforceMainPaneWidth).toHaveBeenCalledWith("%0", 220, 55)
 	})
 
 	test("does not apply layout when spawn fails", async () => {

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -213,10 +213,17 @@ export class TmuxSessionManager {
         const sessionReady = await this.waitForSessionReady(sessionId)
         
         if (!sessionReady) {
-          log("[tmux-session-manager] session not ready after timeout, tracking anyway", {
+          log("[tmux-session-manager] session not ready after timeout, closing spawned pane", {
             sessionId,
             paneId: result.spawnedPaneId,
           })
+
+          await executeAction(
+            { type: "close", paneId: result.spawnedPaneId, sessionId },
+            { config: this.tmuxConfig, serverUrl: this.serverUrl, windowState: state }
+          )
+
+          return
         }
         
         const now = Date.now()

--- a/src/features/tmux-subagent/pane-split-availability.ts
+++ b/src/features/tmux-subagent/pane-split-availability.ts
@@ -57,11 +57,21 @@ export function canSplitPane(
 }
 
 export function canSplitPaneAnyDirection(pane: TmuxPaneInfo): boolean {
-	return pane.width >= MIN_SPLIT_WIDTH || pane.height >= MIN_SPLIT_HEIGHT
+	return canSplitPaneAnyDirectionWithMinWidth(pane, MIN_PANE_WIDTH)
 }
 
-export function getBestSplitDirection(pane: TmuxPaneInfo): SplitDirection | null {
-	const canH = pane.width >= MIN_SPLIT_WIDTH
+export function canSplitPaneAnyDirectionWithMinWidth(
+	pane: TmuxPaneInfo,
+	minPaneWidth: number = MIN_PANE_WIDTH,
+): boolean {
+	return pane.width >= minSplitWidthFor(minPaneWidth) || pane.height >= MIN_SPLIT_HEIGHT
+}
+
+export function getBestSplitDirection(
+	pane: TmuxPaneInfo,
+	minPaneWidth: number = MIN_PANE_WIDTH,
+): SplitDirection | null {
+	const canH = pane.width >= minSplitWidthFor(minPaneWidth)
 	const canV = pane.height >= MIN_SPLIT_HEIGHT
 
 	if (!canH && !canV) return null

--- a/src/features/tmux-subagent/session-created-handler.ts
+++ b/src/features/tmux-subagent/session-created-handler.ts
@@ -135,10 +135,21 @@ export async function handleSessionCreated(
 
     const sessionReady = await deps.waitForSessionReady(sessionId)
     if (!sessionReady) {
-      log("[tmux-session-manager] session not ready after timeout, tracking anyway", {
+      log("[tmux-session-manager] session not ready after timeout, closing spawned pane", {
         sessionId,
         paneId: result.spawnedPaneId,
       })
+
+      await executeActions(
+        [{ type: "close", paneId: result.spawnedPaneId, sessionId }],
+        {
+          config: deps.tmuxConfig,
+          serverUrl: deps.serverUrl,
+          windowState: state,
+        },
+      )
+
+      return
     }
 
     const now = Date.now()

--- a/src/features/tmux-subagent/session-spawner.ts
+++ b/src/features/tmux-subagent/session-spawner.ts
@@ -129,10 +129,21 @@ export class SessionSpawner {
         const sessionReady = await this.waitForSessionReady(sessionId)
         
         if (!sessionReady) {
-          log("[tmux-session-manager] session not ready after timeout, tracking anyway", {
+          log("[tmux-session-manager] session not ready after timeout, closing spawned pane", {
             sessionId,
             paneId: result.spawnedPaneId,
           })
+
+          await executeActions(
+            [{ type: "close", paneId: result.spawnedPaneId, sessionId }],
+            {
+              config: this.tmuxConfig,
+              serverUrl: this.serverUrl,
+              windowState: state,
+            },
+          )
+
+          return
         }
         
         const now = Date.now()

--- a/src/features/tmux-subagent/spawn-action-decider.ts
+++ b/src/features/tmux-subagent/spawn-action-decider.ts
@@ -62,7 +62,7 @@ export function decideSpawnActions(
 	}
 
 	if (isSplittableAtCount(agentAreaWidth, currentCount, minPaneWidth)) {
-		const spawnTarget = findSpawnTarget(state)
+		const spawnTarget = findSpawnTarget(state, minPaneWidth)
 		if (spawnTarget) {
 			return {
 				canSpawn: true,
@@ -85,19 +85,14 @@ export function decideSpawnActions(
 			canSpawn: true,
 			actions: [
 				{
-					type: "close",
+					type: "replace",
 					paneId: oldestPane.paneId,
-					sessionId: oldestMapping?.sessionId || "",
-				},
-				{
-					type: "spawn",
-					sessionId,
+					oldSessionId: oldestMapping?.sessionId || "",
+					newSessionId: sessionId,
 					description,
-					targetPaneId: state.mainPane.paneId,
-					splitDirection: "-h",
 				},
 			],
-			reason: "closed 1 pane to make room for split",
+			reason: "replaced oldest pane to avoid split churn",
 		}
 	}
 

--- a/src/shared/tmux/tmux-utils/layout.ts
+++ b/src/shared/tmux/tmux-utils/layout.ts
@@ -29,13 +29,15 @@ export async function applyLayout(
 export async function enforceMainPaneWidth(
 	mainPaneId: string,
 	windowWidth: number,
+	mainPaneSize: number,
 ): Promise<void> {
 	const { log } = await import("../../logger")
 	const tmux = await getTmuxPath()
 	if (!tmux) return
 
 	const dividerWidth = 1
-	const mainWidth = Math.floor((windowWidth - dividerWidth) / 2)
+	const boundedMainPaneSize = Math.max(20, Math.min(80, mainPaneSize))
+	const mainWidth = Math.floor(((windowWidth - dividerWidth) * boundedMainPaneSize) / 100)
 
 	const proc = spawn([tmux, "resize-pane", "-t", mainPaneId, "-x", String(mainWidth)], {
 		stdout: "ignore",
@@ -47,5 +49,6 @@ export async function enforceMainPaneWidth(
 		mainPaneId,
 		mainWidth,
 		windowWidth,
+		mainPaneSize: boundedMainPaneSize,
 	})
 }


### PR DESCRIPTION
## Summary
- Align tmux split targeting with configured `agent_pane_min_width` and avoid close-then-spawn churn by replacing the oldest pane when eviction is needed.
- Make main pane resize use configured `main_pane_size` so layout enforcement no longer drifts to an implicit 50% width.
- Stop tracking sessions that fail readiness timeout by closing the spawned pane immediately to prevent stale session/pane mappings.

## Test
- `bun test src/features/tmux-subagent/decision-engine.test.ts src/features/tmux-subagent/action-executor.test.ts src/features/tmux-subagent/manager.test.ts`
- `bun run typecheck`
- `bun run build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes tmux splitting and session lifecycle by honoring configured pane widths and closing unready sessions. Keeps the main pane at the configured percentage to prevent layout drift.

- **Bug Fixes**
  - Use configured agent_pane_min_width for split targeting; replace the oldest pane with a single "replace" action to avoid close+spawn churn.
  - Resize the main pane using main_pane_size and pass it through enforceMainPaneWidth for consistent layout.
  - When session readiness times out, close the spawned pane and skip tracking to prevent stale session/pane mappings.

<sup>Written for commit 84a83922c3662a0497f48896dbf05a6bce2b5bd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

