### PR TITLE
feat(hooks): add json-error-recovery hook to prevent infinite retry loops

### DIFF
--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -33,6 +33,7 @@ export const HookNameSchema = z.enum([
   "claude-code-hooks",
   "auto-slash-command",
   "edit-error-recovery",
+  "json-error-recovery",
   "delegate-task-retry",
   "prometheus-md-only",
   "sisyphus-junior-notepad",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -29,6 +29,7 @@ export { createCategorySkillReminderHook } from "./category-skill-reminder";
 export { createRalphLoopHook, type RalphLoopHook } from "./ralph-loop";
 export { createAutoSlashCommandHook } from "./auto-slash-command";
 export { createEditErrorRecoveryHook } from "./edit-error-recovery";
+export { createJsonErrorRecoveryHook } from "./json-error-recovery";
 export { createPrometheusMdOnlyHook } from "./prometheus-md-only";
 export { createSisyphusJuniorNotepadHook } from "./sisyphus-junior-notepad";
 export { createTaskResumeInfoHook } from "./task-resume-info";

--- a/src/hooks/json-error-recovery/hook.ts
+++ b/src/hooks/json-error-recovery/hook.ts
@@ -1,0 +1,41 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+
+export const JSON_ERROR_PATTERNS = [
+  "json parse error",
+  "syntaxerror: unexpected token",
+  "expected '}'",
+  "unexpected eof",
+] as const
+
+export const JSON_ERROR_REMINDER = `
+[JSON PARSE ERROR - IMMEDIATE ACTION REQUIRED]
+
+You sent invalid JSON arguments. The system could not parse your tool call.
+STOP and do this NOW:
+
+1. LOOK at the error message above to see what was expected vs what you sent.
+2. CORRECT your JSON syntax (missing braces, unescaped quotes, trailing commas, etc).
+3. RETRY the tool call with valid JSON.
+
+DO NOT repeat the exact same invalid call.
+`
+
+export function createJsonErrorRecoveryHook(_ctx: PluginInput) {
+  return {
+    "tool.execute.after": async (
+      _input: { tool: string; sessionID: string; callID: string },
+      output: { title: string; output: string; metadata: unknown }
+    ) => {
+      if (typeof output.output !== "string") return
+
+      const outputLower = output.output.toLowerCase()
+      const hasJsonError = JSON_ERROR_PATTERNS.some((pattern) =>
+        outputLower.includes(pattern)
+      )
+
+      if (hasJsonError) {
+        output.output += `\n${JSON_ERROR_REMINDER}`
+      }
+    },
+  }
+}

--- a/src/hooks/json-error-recovery/index.test.ts
+++ b/src/hooks/json-error-recovery/index.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from "bun:test"
+
+import {
+  createJsonErrorRecoveryHook,
+  JSON_ERROR_PATTERNS,
+  JSON_ERROR_REMINDER,
+} from "./index"
+
+describe("createJsonErrorRecoveryHook", () => {
+  let hook: ReturnType<typeof createJsonErrorRecoveryHook>
+
+  beforeEach(() => {
+    hook = createJsonErrorRecoveryHook({} as any)
+  })
+
+  describe("tool.execute.after", () => {
+    const createInput = () => ({
+      tool: "Read",
+      sessionID: "test-session",
+      callID: "test-call-id",
+    })
+
+    const createOutput = (outputText: string) => ({
+      title: "Tool Error",
+      output: outputText,
+      metadata: {},
+    })
+
+    it("appends reminder when output includes JSON parse error", async () => {
+      const input = createInput()
+      const output = createOutput("JSON Parse error: Expected '}'")
+
+      await hook["tool.execute.after"](input, output)
+
+      expect(output.output).toContain(JSON_ERROR_REMINDER)
+    })
+
+    it("appends reminder when output includes SyntaxError", async () => {
+      const input = createInput()
+      const output = createOutput("SyntaxError: Unexpected token in JSON at position 10")
+
+      await hook["tool.execute.after"](input, output)
+
+      expect(output.output).toContain(JSON_ERROR_REMINDER)
+    })
+
+    it("does not append reminder for normal output", async () => {
+      const input = createInput()
+      const output = createOutput("Task completed successfully")
+
+      await hook["tool.execute.after"](input, output)
+
+      expect(output.output).toBe("Task completed successfully")
+    })
+  })
+
+  describe("JSON_ERROR_PATTERNS", () => {
+    it("contains known parse error patterns", () => {
+      expect(JSON_ERROR_PATTERNS).toContain("json parse error")
+      expect(JSON_ERROR_PATTERNS).toContain("syntaxerror: unexpected token")
+      expect(JSON_ERROR_PATTERNS).toContain("expected '}'")
+      expect(JSON_ERROR_PATTERNS).toContain("unexpected eof")
+    })
+  })
+})

--- a/src/hooks/json-error-recovery/index.test.ts
+++ b/src/hooks/json-error-recovery/index.test.ts
@@ -1,65 +1,196 @@
 import { beforeEach, describe, expect, it } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
 
 import {
   createJsonErrorRecoveryHook,
   JSON_ERROR_PATTERNS,
   JSON_ERROR_REMINDER,
+  JSON_ERROR_TOOL_EXCLUDE_LIST,
 } from "./index"
 
 describe("createJsonErrorRecoveryHook", () => {
   let hook: ReturnType<typeof createJsonErrorRecoveryHook>
 
+  type ToolExecuteAfterHandler = NonNullable<
+    ReturnType<typeof createJsonErrorRecoveryHook>["tool.execute.after"]
+  >
+  type ToolExecuteAfterInput = Parameters<ToolExecuteAfterHandler>[0]
+  type ToolExecuteAfterOutput = Parameters<ToolExecuteAfterHandler>[1]
+
+  const createMockPluginInput = (): PluginInput => {
+    return {
+      client: {} as PluginInput["client"],
+      directory: "/tmp/test",
+    } as PluginInput
+  }
+
   beforeEach(() => {
-    hook = createJsonErrorRecoveryHook({} as any)
+    hook = createJsonErrorRecoveryHook(createMockPluginInput())
   })
 
   describe("tool.execute.after", () => {
-    const createInput = () => ({
-      tool: "Read",
+    const createInput = (tool = "Edit"): ToolExecuteAfterInput => ({
+      tool,
       sessionID: "test-session",
       callID: "test-call-id",
     })
 
-    const createOutput = (outputText: string) => ({
+    const createOutput = (outputText: string): ToolExecuteAfterOutput => ({
       title: "Tool Error",
       output: outputText,
       metadata: {},
     })
 
-    it("appends reminder when output includes JSON parse error", async () => {
-      const input = createInput()
-      const output = createOutput("JSON Parse error: Expected '}'")
+    const createUnknownOutput = (value: unknown): { title: string; output: unknown; metadata: Record<string, unknown> } => ({
+      title: "Tool Error",
+      output: value,
+      metadata: {},
+    })
 
+    it("appends reminder when output includes JSON parse error", async () => {
+      // given
+      const input = createInput()
+      const output = createOutput("JSON parse error: expected '}' in JSON body")
+
+      // when
       await hook["tool.execute.after"](input, output)
 
+      // then
       expect(output.output).toContain(JSON_ERROR_REMINDER)
     })
 
     it("appends reminder when output includes SyntaxError", async () => {
+      // given
       const input = createInput()
       const output = createOutput("SyntaxError: Unexpected token in JSON at position 10")
 
+      // when
       await hook["tool.execute.after"](input, output)
 
+      // then
       expect(output.output).toContain(JSON_ERROR_REMINDER)
     })
 
     it("does not append reminder for normal output", async () => {
+      // given
       const input = createInput()
       const output = createOutput("Task completed successfully")
 
+      // when
       await hook["tool.execute.after"](input, output)
 
+      // then
       expect(output.output).toBe("Task completed successfully")
+    })
+
+    it("does not append reminder for empty output", async () => {
+      // given
+      const input = createInput()
+      const output = createOutput("")
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).toBe("")
+    })
+
+    it("does not append reminder for false positive non-JSON text", async () => {
+      // given
+      const input = createInput()
+      const output = createOutput("Template failed: expected '}' before newline")
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).toBe("Template failed: expected '}' before newline")
+    })
+
+    it("does not append reminder for excluded tools", async () => {
+      // given
+      const input = createInput("Read")
+      const output = createOutput("JSON parse error: unexpected end of JSON input")
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      expect(output.output).toBe("JSON parse error: unexpected end of JSON input")
+    })
+
+    it("does not append reminder when reminder already exists", async () => {
+      // given
+      const input = createInput()
+      const output = createOutput(`JSON parse error: invalid JSON\n${JSON_ERROR_REMINDER}`)
+
+      // when
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      const reminderCount = output.output.split("[JSON PARSE ERROR - IMMEDIATE ACTION REQUIRED]").length - 1
+      expect(reminderCount).toBe(1)
+    })
+
+    it("does not append duplicate reminder on repeated execution", async () => {
+      // given
+      const input = createInput()
+      const output = createOutput("JSON parse error: invalid JSON arguments")
+
+      // when
+      await hook["tool.execute.after"](input, output)
+      await hook["tool.execute.after"](input, output)
+
+      // then
+      const reminderCount = output.output.split("[JSON PARSE ERROR - IMMEDIATE ACTION REQUIRED]").length - 1
+      expect(reminderCount).toBe(1)
+    })
+
+    it("ignores non-string output values", async () => {
+      // given
+      const input = createInput()
+      const values: unknown[] = [42, null, undefined, { error: "invalid json" }]
+
+      // when
+      for (const value of values) {
+        const output = createUnknownOutput(value)
+        await hook["tool.execute.after"](input, output as ToolExecuteAfterOutput)
+
+        // then
+        expect(output.output).toBe(value)
+      }
     })
   })
 
   describe("JSON_ERROR_PATTERNS", () => {
     it("contains known parse error patterns", () => {
-      expect(JSON_ERROR_PATTERNS).toContain("json parse error")
-      expect(JSON_ERROR_PATTERNS).toContain("syntaxerror: unexpected token")
-      expect(JSON_ERROR_PATTERNS).toContain("expected '}'")
-      expect(JSON_ERROR_PATTERNS).toContain("unexpected eof")
+      // given
+      const output = "JSON parse error: unexpected end of JSON input"
+
+      // when
+      const isMatched = JSON_ERROR_PATTERNS.some((pattern) => pattern.test(output))
+
+      // then
+      expect(isMatched).toBe(true)
+    })
+  })
+
+  describe("JSON_ERROR_TOOL_EXCLUDE_LIST", () => {
+    it("contains content-heavy tools that should be excluded", () => {
+      // given
+      const expectedExcludedTools: Array<(typeof JSON_ERROR_TOOL_EXCLUDE_LIST)[number]> = [
+        "read",
+        "bash",
+        "webfetch",
+      ]
+
+      // when
+      const allExpectedToolsIncluded = expectedExcludedTools.every((toolName) =>
+        JSON_ERROR_TOOL_EXCLUDE_LIST.includes(toolName)
+      )
+
+      // then
+      expect(allExpectedToolsIncluded).toBe(true)
     })
   })
 })

--- a/src/hooks/json-error-recovery/index.ts
+++ b/src/hooks/json-error-recovery/index.ts
@@ -1,5 +1,6 @@
 export {
   createJsonErrorRecoveryHook,
+  JSON_ERROR_TOOL_EXCLUDE_LIST,
   JSON_ERROR_PATTERNS,
   JSON_ERROR_REMINDER,
 } from "./hook"

--- a/src/hooks/json-error-recovery/index.ts
+++ b/src/hooks/json-error-recovery/index.ts
@@ -1,0 +1,5 @@
+export {
+  createJsonErrorRecoveryHook,
+  JSON_ERROR_PATTERNS,
+  JSON_ERROR_REMINDER,
+} from "./hook"

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -13,6 +13,7 @@ import {
   createInteractiveBashSessionHook,
   createRalphLoopHook,
   createEditErrorRecoveryHook,
+  createJsonErrorRecoveryHook,
   createDelegateTaskRetryHook,
   createTaskResumeInfoHook,
   createStartWorkHook,
@@ -43,6 +44,7 @@ export type SessionHooks = {
   interactiveBashSession: ReturnType<typeof createInteractiveBashSessionHook> | null
   ralphLoop: ReturnType<typeof createRalphLoopHook> | null
   editErrorRecovery: ReturnType<typeof createEditErrorRecoveryHook> | null
+  jsonErrorRecovery: ReturnType<typeof createJsonErrorRecoveryHook> | null
   delegateTaskRetry: ReturnType<typeof createDelegateTaskRetryHook> | null
   startWork: ReturnType<typeof createStartWorkHook> | null
   prometheusMdOnly: ReturnType<typeof createPrometheusMdOnlyHook> | null
@@ -130,6 +132,10 @@ export function createSessionHooks(args: {
     ? safeHook("edit-error-recovery", () => createEditErrorRecoveryHook(ctx))
     : null
 
+  const jsonErrorRecovery = isHookEnabled("json-error-recovery")
+    ? safeHook("json-error-recovery", () => createJsonErrorRecoveryHook(ctx))
+    : null
+
   const delegateTaskRetry = isHookEnabled("delegate-task-retry")
     ? safeHook("delegate-task-retry", () => createDelegateTaskRetryHook(ctx))
     : null
@@ -166,6 +172,7 @@ export function createSessionHooks(args: {
     interactiveBashSession,
     ralphLoop,
     editErrorRecovery,
+    jsonErrorRecovery,
     delegateTaskRetry,
     startWork,
     prometheusMdOnly,

--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -40,6 +40,7 @@ export function createToolExecuteAfterHandler(args: {
     await hooks.categorySkillReminder?.["tool.execute.after"]?.(input, output)
     await hooks.interactiveBashSession?.["tool.execute.after"]?.(input, output)
     await hooks.editErrorRecovery?.["tool.execute.after"]?.(input, output)
+    await hooks.jsonErrorRecovery?.["tool.execute.after"]?.(input, output)
     await hooks.delegateTaskRetry?.["tool.execute.after"]?.(input, output)
     await hooks.atlasHook?.["tool.execute.after"]?.(input, output)
     await hooks.taskResumeInfo?.["tool.execute.after"]?.(input, output)


### PR DESCRIPTION
## Summary
- rebase branch on latest `dev` and resolve integration conflicts against the modular hook/plugin architecture
- add `json-error-recovery` hook wiring in current hook pipeline (`create-session-hooks` + `tool-execute-after`) and config schema enum
- include focused tests for the new hook under `src/hooks/json-error-recovery/index.test.ts`

## Context
Supersedes the closed/stale PR #741 with the same branch updated to current `dev`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a json-error-recovery hook that catches JSON parse errors in tool outputs and tells the agent to fix the JSON before retrying. Matching and scope are hardened to avoid false positives and duplicate reminders, preventing infinite retry loops.

- **New Features**
  - New tool.execute.after hook detects JSON parse errors and appends a fix-and-retry reminder.
  - Hook wired into create-session-hooks and tool-execute-after; added to HookNameSchema and exported.

- **Bug Fixes**
  - Hardened matching with stricter patterns, non-string output guard, and a marker to prevent duplicate reminders.
  - Limited scope by excluding content-heavy tools (bash, read, glob, grep, webfetch, etc.); tests cover exclusions and duplicate cases.

<sup>Written for commit 5f939f900a6233c95d48ded72bbecf697f57cd45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

