### PR TITLE
fix: add logging and validation to fallback chain model resolution (#1694)

### DIFF
--- a/src/shared/fallback-model-availability.ts
+++ b/src/shared/fallback-model-availability.ts
@@ -2,19 +2,54 @@ import { readConnectedProvidersCache } from "./connected-providers-cache"
 import { log } from "./logger"
 import { fuzzyMatchModel } from "./model-name-matcher"
 
-export function isAnyFallbackModelAvailable(
-	fallbackChain: Array<{ providers: string[]; model: string }>,
+type FallbackEntry = { providers: string[]; model: string }
+
+type ResolvedFallbackModel = {
+	provider: string
+	model: string
+}
+
+export function resolveFirstAvailableFallback(
+	fallbackChain: FallbackEntry[],
 	availableModels: Set<string>,
-): boolean {
-	if (availableModels.size > 0) {
-		for (const entry of fallbackChain) {
-			const hasAvailableProvider = entry.providers.some((provider) => {
-				return fuzzyMatchModel(entry.model, availableModels, [provider]) !== null
+): ResolvedFallbackModel | null {
+	for (const entry of fallbackChain) {
+		for (const provider of entry.providers) {
+			const matchedModel = fuzzyMatchModel(entry.model, availableModels, [provider])
+			log("[resolveFirstAvailableFallback] attempt", {
+				provider,
+				requestedModel: entry.model,
+				resolvedModel: matchedModel,
 			})
-			if (hasAvailableProvider) {
-				return true
+
+			if (matchedModel !== null) {
+				log("[resolveFirstAvailableFallback] resolved", {
+					provider,
+					requestedModel: entry.model,
+					resolvedModel: matchedModel,
+				})
+				return { provider, model: matchedModel }
 			}
 		}
+	}
+
+	log("[resolveFirstAvailableFallback] WARNING: no fallback model resolved", {
+		chain: fallbackChain.map((entry) => ({
+			model: entry.model,
+			providers: entry.providers,
+		})),
+		availableCount: availableModels.size,
+	})
+
+	return null
+}
+
+export function isAnyFallbackModelAvailable(
+	fallbackChain: FallbackEntry[],
+	availableModels: Set<string>,
+): boolean {
+	if (resolveFirstAvailableFallback(fallbackChain, availableModels) !== null) {
+		return true
 	}
 
 	const connectedProviders = readConnectedProvidersCache()
@@ -23,8 +58,8 @@ export function isAnyFallbackModelAvailable(
 		for (const entry of fallbackChain) {
 			if (entry.providers.some((p) => connectedSet.has(p))) {
 				log(
-					"[isAnyFallbackModelAvailable] model not in available set, but provider is connected",
-					{ model: entry.model, availableCount: availableModels.size },
+					"[isAnyFallbackModelAvailable] WARNING: No fuzzy match found for any model in fallback chain, but provider is connected. Agent may fail at runtime.",
+					{ chain: fallbackChain.map((entryItem) => entryItem.model), availableCount: availableModels.size },
 				)
 				return true
 			}

--- a/src/shared/model-availability.ts
+++ b/src/shared/model-availability.ts
@@ -69,6 +69,7 @@ export function fuzzyMatchModel(
 	log("[fuzzyMatchModel] substring matches", { targetNormalized, matchCount: matches.length, matches })
 
 	if (matches.length === 0) {
+		log("[fuzzyMatchModel] WARNING: no match found", { target, availableCount: available.size, providers })
 		return null
 	}
 


### PR DESCRIPTION
## Summary
- Add traced fallback resolution in `resolveFirstAvailableFallback()` so each provider/model attempt and final outcome are logged.
- Add explicit warning logs for silent-miss cases in both fuzzy matching and provider-connected fallback path.
- Add tests for unknown model miss, provider-connected fallback behavior, and first-resolved fallback selection.

## Testing
- `bun run typecheck`
- `bun test src/shared/model-availability.test.ts`
- `bun test` *(currently fails on pre-existing `src/hooks/auto-update-checker/hook/background-update-check.test.ts` assertions unrelated to this change)*

## Issue
- Closes #1694


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a traceable fallback resolver that returns the first available provider/model and logs every attempt, with warnings when no match is found. Improves visibility into fallback selection and reduces silent failures.

- **New Features**
  - Added resolveFirstAvailableFallback with per-attempt logging; returns {provider, model} or null.
  - Added warnings for no fuzzy match and for connected-provider-without-match; integrated into isAnyFallbackModelAvailable.
  - Added tests for unknown model miss, provider-connected fallback behavior, and first-resolved selection.

<sup>Written for commit ca06ce134f5736059c2922f7f5c1fc79ac547f06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

