### PR TITLE
fix: use ModelCacheState for context window limit instead of env var (#1753)

### DIFF
--- a/src/create-hooks.ts
+++ b/src/create-hooks.ts
@@ -3,6 +3,7 @@ import type { HookName, OhMyOpenCodeConfig } from "./config"
 import type { LoadedSkill } from "./features/opencode-skill-loader/types"
 import type { BackgroundManager } from "./features/background-agent"
 import type { PluginContext } from "./plugin/types"
+import type { ModelCacheState } from "./plugin-state"
 
 import { createCoreHooks } from "./plugin/hooks/create-core-hooks"
 import { createContinuationHooks } from "./plugin/hooks/create-continuation-hooks"
@@ -13,6 +14,7 @@ export type CreatedHooks = ReturnType<typeof createHooks>
 export function createHooks(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
+  modelCacheState: ModelCacheState
   backgroundManager: BackgroundManager
   isHookEnabled: (hookName: HookName) => boolean
   safeHookEnabled: boolean
@@ -22,6 +24,7 @@ export function createHooks(args: {
   const {
     ctx,
     pluginConfig,
+    modelCacheState,
     backgroundManager,
     isHookEnabled,
     safeHookEnabled,
@@ -32,6 +35,7 @@ export function createHooks(args: {
   const core = createCoreHooks({
     ctx,
     pluginConfig,
+    modelCacheState,
     isHookEnabled,
     safeHookEnabled,
   })

--- a/src/hooks/context-window-monitor.test.ts
+++ b/src/hooks/context-window-monitor.test.ts
@@ -249,7 +249,9 @@ describe("context-window-monitor", () => {
 
   it("should use 1M limit when model cache flag is enabled", async () => {
     //#given
-    const hook = createContextWindowMonitorHook(ctx as never, true)
+    const hook = createContextWindowMonitorHook(ctx as never, {
+      anthropicContext1MEnabled: true,
+    })
     const sessionID = "ses_1m_flag"
 
     await hook.event({
@@ -286,7 +288,9 @@ describe("context-window-monitor", () => {
   it("should keep env var fallback when model cache flag is disabled", async () => {
     //#given
     process.env[ANTHROPIC_CONTEXT_ENV_KEY] = "true"
-    const hook = createContextWindowMonitorHook(ctx as never, false)
+    const hook = createContextWindowMonitorHook(ctx as never, {
+      anthropicContext1MEnabled: false,
+    })
     const sessionID = "ses_env_fallback"
 
     await hook.event({

--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -5,8 +5,12 @@ const ANTHROPIC_DISPLAY_LIMIT = 1_000_000
 const DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000
 const CONTEXT_WARNING_THRESHOLD = 0.70
 
-function getAnthropicActualLimit(anthropicContext1MEnabled: boolean): number {
-  return anthropicContext1MEnabled ||
+type ModelCacheStateLike = {
+  anthropicContext1MEnabled: boolean
+}
+
+function getAnthropicActualLimit(modelCacheState?: ModelCacheStateLike): number {
+  return (modelCacheState?.anthropicContext1MEnabled ?? false) ||
     process.env.ANTHROPIC_1M_CONTEXT === "true" ||
     process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
     ? 1_000_000
@@ -37,7 +41,7 @@ function isAnthropicProvider(providerID: string): boolean {
 
 export function createContextWindowMonitorHook(
   _ctx: PluginInput,
-  anthropicContext1MEnabled = false,
+  modelCacheState?: ModelCacheStateLike,
 ) {
   const remindedSessions = new Set<string>()
   const tokenCache = new Map<string, CachedTokenState>()
@@ -59,7 +63,7 @@ export function createContextWindowMonitorHook(
     const totalInputTokens = (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0)
 
     const actualUsagePercentage =
-      totalInputTokens / getAnthropicActualLimit(anthropicContext1MEnabled)
+      totalInputTokens / getAnthropicActualLimit(modelCacheState)
 
     if (actualUsagePercentage < CONTEXT_WARNING_THRESHOLD) return
 

--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -2,12 +2,16 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import { createSystemDirective, SystemDirectiveTypes } from "../shared/system-directive"
 
 const ANTHROPIC_DISPLAY_LIMIT = 1_000_000
-const ANTHROPIC_ACTUAL_LIMIT =
-  process.env.ANTHROPIC_1M_CONTEXT === "true" ||
-  process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
-    ? 1_000_000
-    : 200_000
+const DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000
 const CONTEXT_WARNING_THRESHOLD = 0.70
+
+function getAnthropicActualLimit(anthropicContext1MEnabled: boolean): number {
+  return anthropicContext1MEnabled ||
+    process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+    process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+    ? 1_000_000
+    : DEFAULT_ANTHROPIC_ACTUAL_LIMIT
+}
 
 const CONTEXT_REMINDER = `${createSystemDirective(SystemDirectiveTypes.CONTEXT_WINDOW_MONITOR)}
 
@@ -31,7 +35,10 @@ function isAnthropicProvider(providerID: string): boolean {
   return providerID === "anthropic" || providerID === "google-vertex-anthropic"
 }
 
-export function createContextWindowMonitorHook(_ctx: PluginInput) {
+export function createContextWindowMonitorHook(
+  _ctx: PluginInput,
+  anthropicContext1MEnabled = false,
+) {
   const remindedSessions = new Set<string>()
   const tokenCache = new Map<string, CachedTokenState>()
 
@@ -51,7 +58,8 @@ export function createContextWindowMonitorHook(_ctx: PluginInput) {
     const lastTokens = cached.tokens
     const totalInputTokens = (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0)
 
-    const actualUsagePercentage = totalInputTokens / ANTHROPIC_ACTUAL_LIMIT
+    const actualUsagePercentage =
+      totalInputTokens / getAnthropicActualLimit(anthropicContext1MEnabled)
 
     if (actualUsagePercentage < CONTEXT_WARNING_THRESHOLD) return
 

--- a/src/hooks/directory-agents-injector/hook.ts
+++ b/src/hooks/directory-agents-injector/hook.ts
@@ -29,10 +29,10 @@ interface EventInput {
 
 export function createDirectoryAgentsInjectorHook(
   ctx: PluginInput,
-  anthropicContext1MEnabled?: boolean,
+  modelCacheState?: { anthropicContext1MEnabled: boolean },
 ) {
   const sessionCaches = new Map<string, Set<string>>();
-  const truncator = createDynamicTruncator(ctx, anthropicContext1MEnabled);
+  const truncator = createDynamicTruncator(ctx, modelCacheState);
 
   const toolExecuteAfter = async (input: ToolExecuteInput, output: ToolExecuteOutput) => {
     const toolName = input.tool.toLowerCase();

--- a/src/hooks/directory-agents-injector/hook.ts
+++ b/src/hooks/directory-agents-injector/hook.ts
@@ -27,9 +27,12 @@ interface EventInput {
   };
 }
 
-export function createDirectoryAgentsInjectorHook(ctx: PluginInput) {
+export function createDirectoryAgentsInjectorHook(
+  ctx: PluginInput,
+  anthropicContext1MEnabled?: boolean,
+) {
   const sessionCaches = new Map<string, Set<string>>();
-  const truncator = createDynamicTruncator(ctx);
+  const truncator = createDynamicTruncator(ctx, anthropicContext1MEnabled);
 
   const toolExecuteAfter = async (input: ToolExecuteInput, output: ToolExecuteOutput) => {
     const toolName = input.tool.toLowerCase();

--- a/src/hooks/directory-readme-injector/hook.ts
+++ b/src/hooks/directory-readme-injector/hook.ts
@@ -27,9 +27,12 @@ interface EventInput {
   };
 }
 
-export function createDirectoryReadmeInjectorHook(ctx: PluginInput) {
+export function createDirectoryReadmeInjectorHook(
+  ctx: PluginInput,
+  anthropicContext1MEnabled?: boolean,
+) {
   const sessionCaches = new Map<string, Set<string>>();
-  const truncator = createDynamicTruncator(ctx);
+  const truncator = createDynamicTruncator(ctx, anthropicContext1MEnabled);
 
   const toolExecuteAfter = async (input: ToolExecuteInput, output: ToolExecuteOutput) => {
     const toolName = input.tool.toLowerCase();

--- a/src/hooks/directory-readme-injector/hook.ts
+++ b/src/hooks/directory-readme-injector/hook.ts
@@ -29,10 +29,10 @@ interface EventInput {
 
 export function createDirectoryReadmeInjectorHook(
   ctx: PluginInput,
-  anthropicContext1MEnabled?: boolean,
+  modelCacheState?: { anthropicContext1MEnabled: boolean },
 ) {
   const sessionCaches = new Map<string, Set<string>>();
-  const truncator = createDynamicTruncator(ctx, anthropicContext1MEnabled);
+  const truncator = createDynamicTruncator(ctx, modelCacheState);
 
   const toolExecuteAfter = async (input: ToolExecuteInput, output: ToolExecuteOutput) => {
     const toolName = input.tool.toLowerCase();

--- a/src/hooks/preemptive-compaction.test.ts
+++ b/src/hooks/preemptive-compaction.test.ts
@@ -269,7 +269,9 @@ describe("preemptive-compaction", () => {
 
   it("should use 1M limit when model cache flag is enabled", async () => {
     //#given
-    const hook = createPreemptiveCompactionHook(ctx as never, true)
+    const hook = createPreemptiveCompactionHook(ctx as never, {
+      anthropicContext1MEnabled: true,
+    })
     const sessionID = "ses_1m_flag"
 
     await hook.event({
@@ -306,7 +308,9 @@ describe("preemptive-compaction", () => {
   it("should keep env var fallback when model cache flag is disabled", async () => {
     //#given
     process.env[ANTHROPIC_CONTEXT_ENV_KEY] = "true"
-    const hook = createPreemptiveCompactionHook(ctx as never, false)
+    const hook = createPreemptiveCompactionHook(ctx as never, {
+      anthropicContext1MEnabled: false,
+    })
     const sessionID = "ses_env_fallback"
 
     await hook.event({

--- a/src/hooks/preemptive-compaction.test.ts
+++ b/src/hooks/preemptive-compaction.test.ts
@@ -1,4 +1,26 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test"
+/// <reference types="bun-types" />
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+
+const ANTHROPIC_CONTEXT_ENV_KEY = "ANTHROPIC_1M_CONTEXT"
+const VERTEX_CONTEXT_ENV_KEY = "VERTEX_ANTHROPIC_1M_CONTEXT"
+
+const originalAnthropicContextEnv = process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+const originalVertexContextEnv = process.env[VERTEX_CONTEXT_ENV_KEY]
+
+function resetContextLimitEnv(): void {
+  if (originalAnthropicContextEnv === undefined) {
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+  } else {
+    process.env[ANTHROPIC_CONTEXT_ENV_KEY] = originalAnthropicContextEnv
+  }
+
+  if (originalVertexContextEnv === undefined) {
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+  } else {
+    process.env[VERTEX_CONTEXT_ENV_KEY] = originalVertexContextEnv
+  }
+}
 
 const logMock = mock(() => {})
 
@@ -29,6 +51,12 @@ describe("preemptive-compaction", () => {
   beforeEach(() => {
     ctx = createMockCtx()
     logMock.mockClear()
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+  })
+
+  afterEach(() => {
+    resetContextLimitEnv()
   })
 
   // #given event caches token info from message.updated
@@ -237,5 +265,78 @@ describe("preemptive-compaction", () => {
       sessionID,
       error: String(summarizeError),
     })
+  })
+
+  it("should use 1M limit when model cache flag is enabled", async () => {
+    //#given
+    const hook = createPreemptiveCompactionHook(ctx as never, true)
+    const sessionID = "ses_1m_flag"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-5",
+            finish: true,
+            tokens: {
+              input: 300000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    //#when
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      { title: "", output: "test", metadata: null }
+    )
+
+    //#then
+    expect(ctx.client.session.summarize).not.toHaveBeenCalled()
+  })
+
+  it("should keep env var fallback when model cache flag is disabled", async () => {
+    //#given
+    process.env[ANTHROPIC_CONTEXT_ENV_KEY] = "true"
+    const hook = createPreemptiveCompactionHook(ctx as never, false)
+    const sessionID = "ses_env_fallback"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-5",
+            finish: true,
+            tokens: {
+              input: 300000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    //#when
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      { title: "", output: "test", metadata: null }
+    )
+
+    //#then
+    expect(ctx.client.session.summarize).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -2,8 +2,12 @@ import { log } from "../shared/logger"
 
 const DEFAULT_ACTUAL_LIMIT = 200_000
 
-function getAnthropicActualLimit(anthropicContext1MEnabled: boolean): number {
-  return anthropicContext1MEnabled ||
+type ModelCacheStateLike = {
+  anthropicContext1MEnabled: boolean
+}
+
+function getAnthropicActualLimit(modelCacheState?: ModelCacheStateLike): number {
+  return (modelCacheState?.anthropicContext1MEnabled ?? false) ||
     process.env.ANTHROPIC_1M_CONTEXT === "true" ||
     process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
     ? 1_000_000
@@ -47,7 +51,7 @@ type PluginInput = {
 
 export function createPreemptiveCompactionHook(
   ctx: PluginInput,
-  anthropicContext1MEnabled = false,
+  modelCacheState?: ModelCacheStateLike,
 ) {
   const compactionInProgress = new Set<string>()
   const compactedSessions = new Set<string>()
@@ -65,7 +69,7 @@ export function createPreemptiveCompactionHook(
 
     const actualLimit =
       isAnthropicProvider(cached.providerID)
-        ? getAnthropicActualLimit(anthropicContext1MEnabled)
+        ? getAnthropicActualLimit(modelCacheState)
         : DEFAULT_ACTUAL_LIMIT
 
     const lastTokens = cached.tokens

--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -2,11 +2,13 @@ import { log } from "../shared/logger"
 
 const DEFAULT_ACTUAL_LIMIT = 200_000
 
-const ANTHROPIC_ACTUAL_LIMIT =
-  process.env.ANTHROPIC_1M_CONTEXT === "true" ||
-  process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+function getAnthropicActualLimit(anthropicContext1MEnabled: boolean): number {
+  return anthropicContext1MEnabled ||
+    process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+    process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
     ? 1_000_000
     : DEFAULT_ACTUAL_LIMIT
+}
 
 const PREEMPTIVE_COMPACTION_THRESHOLD = 0.78
 
@@ -43,7 +45,10 @@ type PluginInput = {
   directory: string
 }
 
-export function createPreemptiveCompactionHook(ctx: PluginInput) {
+export function createPreemptiveCompactionHook(
+  ctx: PluginInput,
+  anthropicContext1MEnabled = false,
+) {
   const compactionInProgress = new Set<string>()
   const compactedSessions = new Set<string>()
   const tokenCache = new Map<string, CachedCompactionState>()
@@ -60,7 +65,7 @@ export function createPreemptiveCompactionHook(ctx: PluginInput) {
 
     const actualLimit =
       isAnthropicProvider(cached.providerID)
-        ? ANTHROPIC_ACTUAL_LIMIT
+        ? getAnthropicActualLimit(anthropicContext1MEnabled)
         : DEFAULT_ACTUAL_LIMIT
 
     const lastTokens = cached.tokens

--- a/src/hooks/rules-injector/hook.ts
+++ b/src/hooks/rules-injector/hook.ts
@@ -29,8 +29,11 @@ interface EventInput {
 
 const TRACKED_TOOLS = ["read", "write", "edit", "multiedit"];
 
-export function createRulesInjectorHook(ctx: PluginInput) {
-  const truncator = createDynamicTruncator(ctx);
+export function createRulesInjectorHook(
+  ctx: PluginInput,
+  anthropicContext1MEnabled?: boolean,
+) {
+  const truncator = createDynamicTruncator(ctx, anthropicContext1MEnabled);
   const { getSessionCache, clearSessionCache } = createSessionCacheStore();
   const { processFilePathForInjection } = createRuleInjectionProcessor({
     workspaceDirectory: ctx.directory,

--- a/src/hooks/rules-injector/hook.ts
+++ b/src/hooks/rules-injector/hook.ts
@@ -31,9 +31,9 @@ const TRACKED_TOOLS = ["read", "write", "edit", "multiedit"];
 
 export function createRulesInjectorHook(
   ctx: PluginInput,
-  anthropicContext1MEnabled?: boolean,
+  modelCacheState?: { anthropicContext1MEnabled: boolean },
 ) {
-  const truncator = createDynamicTruncator(ctx, anthropicContext1MEnabled);
+  const truncator = createDynamicTruncator(ctx, modelCacheState);
   const { getSessionCache, clearSessionCache } = createSessionCacheStore();
   const { processFilePathForInjection } = createRuleInjectionProcessor({
     workspaceDirectory: ctx.directory,

--- a/src/hooks/tool-output-truncator.ts
+++ b/src/hooks/tool-output-truncator.ts
@@ -27,12 +27,12 @@ const TOOL_SPECIFIC_MAX_TOKENS: Record<string, number> = {
 }
 
 interface ToolOutputTruncatorOptions {
-  anthropicContext1MEnabled?: boolean
+  modelCacheState?: { anthropicContext1MEnabled: boolean }
   experimental?: ExperimentalConfig
 }
 
 export function createToolOutputTruncatorHook(ctx: PluginInput, options?: ToolOutputTruncatorOptions) {
-  const truncator = createDynamicTruncator(ctx, options?.anthropicContext1MEnabled)
+  const truncator = createDynamicTruncator(ctx, options?.modelCacheState)
   const truncateAll = options?.experimental?.truncate_all_tool_outputs ?? false
 
   const toolExecuteAfter = async (

--- a/src/hooks/tool-output-truncator.ts
+++ b/src/hooks/tool-output-truncator.ts
@@ -27,11 +27,12 @@ const TOOL_SPECIFIC_MAX_TOKENS: Record<string, number> = {
 }
 
 interface ToolOutputTruncatorOptions {
+  anthropicContext1MEnabled?: boolean
   experimental?: ExperimentalConfig
 }
 
 export function createToolOutputTruncatorHook(ctx: PluginInput, options?: ToolOutputTruncatorOptions) {
-  const truncator = createDynamicTruncator(ctx)
+  const truncator = createDynamicTruncator(ctx, options?.anthropicContext1MEnabled)
   const truncateAll = options?.experimental?.truncate_all_tool_outputs ?? false
 
   const toolExecuteAfter = async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   const hooks = createHooks({
     ctx,
     pluginConfig,
+    modelCacheState,
     backgroundManager: managers.backgroundManager,
     isHookEnabled,
     safeHookEnabled,

--- a/src/plugin/hooks/create-core-hooks.ts
+++ b/src/plugin/hooks/create-core-hooks.ts
@@ -1,5 +1,6 @@
 import type { HookName, OhMyOpenCodeConfig } from "../../config"
 import type { PluginContext } from "../types"
+import type { ModelCacheState } from "../../plugin-state"
 
 import { createSessionHooks } from "./create-session-hooks"
 import { createToolGuardHooks } from "./create-tool-guard-hooks"
@@ -8,14 +9,16 @@ import { createTransformHooks } from "./create-transform-hooks"
 export function createCoreHooks(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
+  modelCacheState: ModelCacheState
   isHookEnabled: (hookName: HookName) => boolean
   safeHookEnabled: boolean
 }) {
-  const { ctx, pluginConfig, isHookEnabled, safeHookEnabled } = args
+  const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } = args
 
   const session = createSessionHooks({
     ctx,
     pluginConfig,
+    modelCacheState,
     isHookEnabled,
     safeHookEnabled,
   })
@@ -23,6 +26,7 @@ export function createCoreHooks(args: {
   const tool = createToolGuardHooks({
     ctx,
     pluginConfig,
+    modelCacheState,
     isHookEnabled,
     safeHookEnabled,
   })

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -66,14 +66,14 @@ export function createSessionHooks(args: {
 
   const contextWindowMonitor = isHookEnabled("context-window-monitor")
     ? safeHook("context-window-monitor", () =>
-        createContextWindowMonitorHook(ctx, modelCacheState.anthropicContext1MEnabled))
+        createContextWindowMonitorHook(ctx, modelCacheState))
     : null
 
   const preemptiveCompaction =
     isHookEnabled("preemptive-compaction") &&
     pluginConfig.experimental?.preemptive_compaction
       ? safeHook("preemptive-compaction", () =>
-          createPreemptiveCompactionHook(ctx, modelCacheState.anthropicContext1MEnabled))
+          createPreemptiveCompactionHook(ctx, modelCacheState))
       : null
 
   const sessionRecovery = isHookEnabled("session-recovery")

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -1,4 +1,5 @@
 import type { OhMyOpenCodeConfig, HookName } from "../../config"
+import type { ModelCacheState } from "../../plugin-state"
 import type { PluginContext } from "../types"
 
 import {
@@ -55,21 +56,24 @@ export type SessionHooks = {
 export function createSessionHooks(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
+  modelCacheState: ModelCacheState
   isHookEnabled: (hookName: HookName) => boolean
   safeHookEnabled: boolean
 }): SessionHooks {
-  const { ctx, pluginConfig, isHookEnabled, safeHookEnabled } = args
+  const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } = args
   const safeHook = <T>(hookName: HookName, factory: () => T): T | null =>
     safeCreateHook(hookName, factory, { enabled: safeHookEnabled })
 
   const contextWindowMonitor = isHookEnabled("context-window-monitor")
-    ? safeHook("context-window-monitor", () => createContextWindowMonitorHook(ctx))
+    ? safeHook("context-window-monitor", () =>
+        createContextWindowMonitorHook(ctx, modelCacheState.anthropicContext1MEnabled))
     : null
 
   const preemptiveCompaction =
     isHookEnabled("preemptive-compaction") &&
     pluginConfig.experimental?.preemptive_compaction
-      ? safeHook("preemptive-compaction", () => createPreemptiveCompactionHook(ctx))
+      ? safeHook("preemptive-compaction", () =>
+          createPreemptiveCompactionHook(ctx, modelCacheState.anthropicContext1MEnabled))
       : null
 
   const sessionRecovery = isHookEnabled("session-recovery")

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -1,4 +1,5 @@
 import type { HookName, OhMyOpenCodeConfig } from "../../config"
+import type { ModelCacheState } from "../../plugin-state"
 import type { PluginContext } from "../types"
 
 import {
@@ -35,10 +36,11 @@ export type ToolGuardHooks = {
 export function createToolGuardHooks(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
+  modelCacheState: ModelCacheState
   isHookEnabled: (hookName: HookName) => boolean
   safeHookEnabled: boolean
 }): ToolGuardHooks {
-  const { ctx, pluginConfig, isHookEnabled, safeHookEnabled } = args
+  const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } = args
   const safeHook = <T>(hookName: HookName, factory: () => T): T | null =>
     safeCreateHook(hookName, factory, { enabled: safeHookEnabled })
 
@@ -48,7 +50,10 @@ export function createToolGuardHooks(args: {
 
   const toolOutputTruncator = isHookEnabled("tool-output-truncator")
     ? safeHook("tool-output-truncator", () =>
-        createToolOutputTruncatorHook(ctx, { experimental: pluginConfig.experimental }))
+        createToolOutputTruncatorHook(ctx, {
+          anthropicContext1MEnabled: modelCacheState.anthropicContext1MEnabled,
+          experimental: pluginConfig.experimental,
+        }))
     : null
 
   let directoryAgentsInjector: ReturnType<typeof createDirectoryAgentsInjectorHook> | null = null
@@ -62,12 +67,14 @@ export function createToolGuardHooks(args: {
         nativeVersion: OPENCODE_NATIVE_AGENTS_INJECTION_VERSION,
       })
     } else {
-      directoryAgentsInjector = safeHook("directory-agents-injector", () => createDirectoryAgentsInjectorHook(ctx))
+      directoryAgentsInjector = safeHook("directory-agents-injector", () =>
+        createDirectoryAgentsInjectorHook(ctx, modelCacheState.anthropicContext1MEnabled))
     }
   }
 
   const directoryReadmeInjector = isHookEnabled("directory-readme-injector")
-    ? safeHook("directory-readme-injector", () => createDirectoryReadmeInjectorHook(ctx))
+    ? safeHook("directory-readme-injector", () =>
+        createDirectoryReadmeInjectorHook(ctx, modelCacheState.anthropicContext1MEnabled))
     : null
 
   const emptyTaskResponseDetector = isHookEnabled("empty-task-response-detector")
@@ -75,7 +82,8 @@ export function createToolGuardHooks(args: {
     : null
 
   const rulesInjector = isHookEnabled("rules-injector")
-    ? safeHook("rules-injector", () => createRulesInjectorHook(ctx))
+    ? safeHook("rules-injector", () =>
+        createRulesInjectorHook(ctx, modelCacheState.anthropicContext1MEnabled))
     : null
 
   const tasksTodowriteDisabler = isHookEnabled("tasks-todowrite-disabler")

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -51,7 +51,7 @@ export function createToolGuardHooks(args: {
   const toolOutputTruncator = isHookEnabled("tool-output-truncator")
     ? safeHook("tool-output-truncator", () =>
         createToolOutputTruncatorHook(ctx, {
-          anthropicContext1MEnabled: modelCacheState.anthropicContext1MEnabled,
+          modelCacheState,
           experimental: pluginConfig.experimental,
         }))
     : null
@@ -68,13 +68,13 @@ export function createToolGuardHooks(args: {
       })
     } else {
       directoryAgentsInjector = safeHook("directory-agents-injector", () =>
-        createDirectoryAgentsInjectorHook(ctx, modelCacheState.anthropicContext1MEnabled))
+        createDirectoryAgentsInjectorHook(ctx, modelCacheState))
     }
   }
 
   const directoryReadmeInjector = isHookEnabled("directory-readme-injector")
     ? safeHook("directory-readme-injector", () =>
-        createDirectoryReadmeInjectorHook(ctx, modelCacheState.anthropicContext1MEnabled))
+        createDirectoryReadmeInjectorHook(ctx, modelCacheState))
     : null
 
   const emptyTaskResponseDetector = isHookEnabled("empty-task-response-detector")
@@ -83,7 +83,7 @@ export function createToolGuardHooks(args: {
 
   const rulesInjector = isHookEnabled("rules-injector")
     ? safeHook("rules-injector", () =>
-        createRulesInjectorHook(ctx, modelCacheState.anthropicContext1MEnabled))
+        createRulesInjectorHook(ctx, modelCacheState))
     : null
 
   const tasksTodowriteDisabler = isHookEnabled("tasks-todowrite-disabler")

--- a/src/shared/dynamic-truncator.test.ts
+++ b/src/shared/dynamic-truncator.test.ts
@@ -60,7 +60,9 @@ describe("getContextWindowUsage", () => {
     const ctx = createContextUsageMockContext(300000)
 
     //#when
-    const usage = await getContextWindowUsage(ctx as never, "ses_1m_flag", true)
+    const usage = await getContextWindowUsage(ctx as never, "ses_1m_flag", {
+      anthropicContext1MEnabled: true,
+    })
 
     //#then
     expect(usage?.usagePercentage).toBe(0.3)
@@ -74,7 +76,9 @@ describe("getContextWindowUsage", () => {
     const ctx = createContextUsageMockContext(150000)
 
     //#when
-    const usage = await getContextWindowUsage(ctx as never, "ses_default", false)
+    const usage = await getContextWindowUsage(ctx as never, "ses_default", {
+      anthropicContext1MEnabled: false,
+    })
 
     //#then
     expect(usage?.usagePercentage).toBe(0.75)
@@ -87,7 +91,9 @@ describe("getContextWindowUsage", () => {
     const ctx = createContextUsageMockContext(300000)
 
     //#when
-    const usage = await getContextWindowUsage(ctx as never, "ses_env_fallback", false)
+    const usage = await getContextWindowUsage(ctx as never, "ses_env_fallback", {
+      anthropicContext1MEnabled: false,
+    })
 
     //#then
     expect(usage?.usagePercentage).toBe(0.3)

--- a/src/shared/dynamic-truncator.test.ts
+++ b/src/shared/dynamic-truncator.test.ts
@@ -1,0 +1,96 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it, afterEach } from "bun:test"
+
+import { getContextWindowUsage } from "./dynamic-truncator"
+
+const ANTHROPIC_CONTEXT_ENV_KEY = "ANTHROPIC_1M_CONTEXT"
+const VERTEX_CONTEXT_ENV_KEY = "VERTEX_ANTHROPIC_1M_CONTEXT"
+
+const originalAnthropicContextEnv = process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+const originalVertexContextEnv = process.env[VERTEX_CONTEXT_ENV_KEY]
+
+function resetContextLimitEnv(): void {
+  if (originalAnthropicContextEnv === undefined) {
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+  } else {
+    process.env[ANTHROPIC_CONTEXT_ENV_KEY] = originalAnthropicContextEnv
+  }
+
+  if (originalVertexContextEnv === undefined) {
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+  } else {
+    process.env[VERTEX_CONTEXT_ENV_KEY] = originalVertexContextEnv
+  }
+}
+
+function createContextUsageMockContext(inputTokens: number) {
+  return {
+    client: {
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: {
+                role: "assistant",
+                tokens: {
+                  input: inputTokens,
+                  output: 0,
+                  reasoning: 0,
+                  cache: { read: 0, write: 0 },
+                },
+              },
+            },
+          ],
+        }),
+      },
+    },
+  }
+}
+
+describe("getContextWindowUsage", () => {
+  afterEach(() => {
+    resetContextLimitEnv()
+  })
+
+  it("uses 1M limit when model cache flag is enabled", async () => {
+    //#given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+    const ctx = createContextUsageMockContext(300000)
+
+    //#when
+    const usage = await getContextWindowUsage(ctx as never, "ses_1m_flag", true)
+
+    //#then
+    expect(usage?.usagePercentage).toBe(0.3)
+    expect(usage?.remainingTokens).toBe(700000)
+  })
+
+  it("uses 200K limit when model cache flag is disabled and env vars are unset", async () => {
+    //#given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+    const ctx = createContextUsageMockContext(150000)
+
+    //#when
+    const usage = await getContextWindowUsage(ctx as never, "ses_default", false)
+
+    //#then
+    expect(usage?.usagePercentage).toBe(0.75)
+    expect(usage?.remainingTokens).toBe(50000)
+  })
+
+  it("keeps env var fallback when model cache flag is disabled", async () => {
+    //#given
+    process.env[ANTHROPIC_CONTEXT_ENV_KEY] = "true"
+    const ctx = createContextUsageMockContext(300000)
+
+    //#when
+    const usage = await getContextWindowUsage(ctx as never, "ses_env_fallback", false)
+
+    //#then
+    expect(usage?.usagePercentage).toBe(0.3)
+    expect(usage?.remainingTokens).toBe(700000)
+  })
+})

--- a/src/shared/dynamic-truncator.ts
+++ b/src/shared/dynamic-truncator.ts
@@ -1,13 +1,17 @@
 import type { PluginInput } from "@opencode-ai/plugin";
 import { normalizeSDKResponse } from "./normalize-sdk-response"
 
-const ANTHROPIC_ACTUAL_LIMIT =
-  process.env.ANTHROPIC_1M_CONTEXT === "true" ||
-  process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
-    ? 1_000_000
-    : 200_000;
+const DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000;
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 const DEFAULT_TARGET_MAX_TOKENS = 50_000;
+
+function getAnthropicActualLimit(anthropicContext1MEnabled = false): number {
+	return anthropicContext1MEnabled ||
+		process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+		process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+		? 1_000_000
+		: DEFAULT_ANTHROPIC_ACTUAL_LIMIT;
+}
 
 interface AssistantMessageInfo {
 	role: "assistant";
@@ -110,6 +114,7 @@ export function truncateToTokenLimit(
 export async function getContextWindowUsage(
 	ctx: PluginInput,
 	sessionID: string,
+	anthropicContext1MEnabled = false,
 ): Promise<{
 	usedTokens: number;
 	remainingTokens: number;
@@ -134,12 +139,13 @@ export async function getContextWindowUsage(
 			(lastTokens?.input ?? 0) +
 			(lastTokens?.cache?.read ?? 0) +
 			(lastTokens?.output ?? 0);
-		const remainingTokens = ANTHROPIC_ACTUAL_LIMIT - usedTokens;
+		const anthropicActualLimit = getAnthropicActualLimit(anthropicContext1MEnabled);
+		const remainingTokens = anthropicActualLimit - usedTokens;
 
 		return {
 			usedTokens,
 			remainingTokens,
-			usagePercentage: usedTokens / ANTHROPIC_ACTUAL_LIMIT,
+			usagePercentage: usedTokens / anthropicActualLimit,
 		};
 	} catch {
 		return null;
@@ -151,6 +157,7 @@ export async function dynamicTruncate(
 	sessionID: string,
 	output: string,
 	options: TruncationOptions = {},
+	anthropicContext1MEnabled = false,
 ): Promise<TruncationResult> {
 	if (typeof output !== 'string') {
 		return { result: String(output ?? ''), truncated: false };
@@ -161,7 +168,7 @@ export async function dynamicTruncate(
 		preserveHeaderLines = 3,
 	} = options;
 
-	const usage = await getContextWindowUsage(ctx, sessionID);
+	const usage = await getContextWindowUsage(ctx, sessionID, anthropicContext1MEnabled);
 
 	if (!usage) {
 		// Fallback: apply conservative truncation when context usage unavailable
@@ -183,15 +190,19 @@ export async function dynamicTruncate(
 	return truncateToTokenLimit(output, maxOutputTokens, preserveHeaderLines);
 }
 
-export function createDynamicTruncator(ctx: PluginInput) {
+export function createDynamicTruncator(
+	ctx: PluginInput,
+	anthropicContext1MEnabled?: boolean,
+) {
 	return {
 		truncate: (
 			sessionID: string,
 			output: string,
 			options?: TruncationOptions,
-		) => dynamicTruncate(ctx, sessionID, output, options),
+		) => dynamicTruncate(ctx, sessionID, output, options, anthropicContext1MEnabled),
 
-		getUsage: (sessionID: string) => getContextWindowUsage(ctx, sessionID),
+		getUsage: (sessionID: string) =>
+			getContextWindowUsage(ctx, sessionID, anthropicContext1MEnabled),
 
 		truncateSync: (
 			output: string,


### PR DESCRIPTION
## Summary
- Thread `ModelCacheState` through hook construction so session and tool hooks can consume `anthropicContext1MEnabled`.
- Replace hardcoded Anthropic 200K limit checks with logic that first uses `ModelCacheState.anthropicContext1MEnabled`, then falls back to `ANTHROPIC_1M_CONTEXT` / `VERTEX_ANTHROPIC_1M_CONTEXT`.
- Add tests for 1M flag behavior, default 200K behavior when unset, and env-var backward compatibility in context window monitor, preemptive compaction, and dynamic truncator.

## Testing
- `bun run typecheck`
- `bun test src/hooks/context-window-monitor.test.ts src/hooks/preemptive-compaction.test.ts src/shared/dynamic-truncator.test.ts`
- `bun test` *(currently fails on existing unrelated `src/hooks/auto-update-checker/hook/background-update-check.test.ts` expectations in this worktree)*

## Issue
- Closes #1753

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch context window limits to read ModelCacheState.anthropicContext1MEnabled at runtime, with env-var fallback. Unifies 1M/200K behavior across session and tool hooks, closing #1753.

- **Refactors**
  - Thread ModelCacheState through createHooks and core/session/tool-guard factories.
  - Replace hardcoded checks with a shared limit helper; pass the flag into context-window monitor, preemptive compaction, dynamic-truncator, tool-output-truncator, and directory agents/readme/rules injectors.
  - Wire modelCacheState through index and hook creators; preserve fallback to ANTHROPIC_1M_CONTEXT and VERTEX_ANTHROPIC_1M_CONTEXT.

- **Tests**
  - Add coverage for 1M flag behavior, 200K default when unset, and env fallback in context-window monitor, preemptive compaction, and dynamic-truncator.

<sup>Written for commit d78669126024c925c582f08b014b1db37326c587. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

