### PR TITLE
fix(config): normalize configured default_agent

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -112,15 +112,13 @@ export async function applyAgentConfig(params: {
   const shouldDemotePlan = plannerEnabled && replacePlan;
   const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
 
-  if (configuredDefaultAgent) {
-    (params.config as { default_agent?: string }).default_agent =
-      getAgentDisplayName(configuredDefaultAgent);
-  }
-
   const configAgent = params.config.agent as AgentConfigRecord | undefined;
 
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
-    if (!configuredDefaultAgent) {
+    if (configuredDefaultAgent) {
+      (params.config as { default_agent?: string }).default_agent =
+        getAgentDisplayName(configuredDefaultAgent);
+    } else {
       (params.config as { default_agent?: string }).default_agent =
         getAgentDisplayName("sisyphus");
     }

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -350,7 +350,7 @@ describe("Agent permission defaults", () => {
 })
 
 describe("default_agent behavior with Sisyphus orchestration", () => {
-  test("preserves existing default_agent when already set", async () => {
+  test("canonicalizes configured default_agent key to display name", async () => {
     // #given
     const pluginConfig: OhMyOpenCodeConfig = {}
     const config: Record<string, unknown> = {
@@ -371,7 +371,32 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // #then
-    expect(config.default_agent).toBe("hephaestus")
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
+  })
+
+  test("preserves existing display-name default_agent", async () => {
+    // #given
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const displayName = getAgentDisplayName("hephaestus")
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-6",
+      default_agent: displayName,
+      agent: {},
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // #when
+    await handler(config)
+
+    // #then
+    expect(config.default_agent).toBe(displayName)
   })
 
   test("sets default_agent to sisyphus when missing", async () => {


### PR DESCRIPTION
Agent keys are remapped to display names, so preserving `default_agent` values could still select a missing key at runtime.

This regression surfaced after d94a739203ae remapped `config.agent` keys to display names without canonicalizing configured defaults.

Normalize configured `default_agent` through display-name mapping before fallback logic and extend tests to cover canonical and display-name inputs.

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize configured default_agent to the agent display name during Sisyphus orchestration, before fallback logic. Prevents default_agent from pointing to a missing key after agent key remapping.

- **Bug Fixes**
  - Apply normalization only in Sisyphus mode; leave default_agent unchanged when Sisyphus is disabled.
  - Trim whitespace and canonicalize mixed-case keys; preserve display-name values and custom names.
  - Add tests covering whitespace, case, missing/empty values, and disabled mode.

<sup>Written for commit a2ad7ce6a782f44d3e803b943aa15a353b9948f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

