### PR TITLE
fix(delegate-task): pass plugin agent overrides into task resolver

### DIFF
--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -61,6 +61,7 @@ export function createToolRegistry(args: {
     client: ctx.client,
     directory: ctx.directory,
     userCategories: pluginConfig.categories,
+    agentOverrides: pluginConfig.agents,
     gitMasterConfig: pluginConfig.git_master,
     sisyphusJuniorModel: pluginConfig.agents?.["sisyphus-junior"]?.model,
     browserProvider: skillContext.browserProvider,


### PR DESCRIPTION
## Summary
- pass `pluginConfig.agents` as `agentOverrides` when creating the `task` tool in `createToolRegistry`
- ensure `task(subagent_type=...)` resolves user-configured agent models instead of falling back to requirement defaults
- keep change minimal (single-line wiring fix in tool registry)

## Verification
- `bun run typecheck`
- `bun test src/plugin`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix delegate-task to respect plugin-defined agent models. task(subagent_type=...) now resolves user-configured agents instead of falling back to defaults.

- **Bug Fixes**
  - Wire agentOverrides: pluginConfig.agents into createToolRegistry when creating the task tool.

<sup>Written for commit eb6f093273ddc3873813fe44ed63c552fd9dbc4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

