### PR TITLE
fix(readme): swap installation instructions for humans and AI

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -234,6 +234,14 @@ Windows から Linux に初めて乗り換えた時のこと、自分の思い�
 
 ### 人間の方へ
 
+インストールガイドを取得して、その指示に従ってください：
+
+```bash
+curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
+```
+
+### LLM エージェントの方へ
+
 以下のプロンプトをコピーして、LLM エージェント（Claude Code、AmpCode、Cursor など）に貼り付けてください：
 
 ```
@@ -242,14 +250,6 @@ https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/
 ```
 
 または [インストールガイド](docs/guide/installation.md) を直接読んでください。ただし、エージェントに任せることを強くお勧めします。人間はミスをしますが、エージェントはしません。
-
-### LLM エージェントの方へ
-
-インストールガイドを取得して、その指示に従ってください：
-
-```bash
-curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
-```
 
 
 ## アンインストール

--- a/README.ko.md
+++ b/README.ko.md
@@ -245,6 +245,14 @@ Hey please read this readme and tell me why it is different from other agent har
 
 ### 인간을 위한
 
+설치 가이드를 가져와서 따르세요:
+
+```bash
+curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
+```
+
+### LLM 에이전트를 위한
+
 이 프롬프트를 LLM 에이전트(Claude Code, AmpCode, Cursor 등)에 복사하여 붙여넣으세요:
 
 ```
@@ -253,14 +261,6 @@ https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/
 ```
 
 또는 [설치 가이드](docs/guide/installation.md)를 직접 읽으세요 — 하지만 **에이전트가 처리하도록 하는 것을 강력히 권장합니다. 인간은 실수를 합니다.**
-
-### LLM 에이전트를 위한
-
-설치 가이드를 가져와서 따르세요:
-
-```bash
-curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
-```
 
 ## 제거
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,14 @@ Hephaestus is inspired by [AmpCode's deep mode](https://ampcode.com)—autonomou
 
 ### For Humans
 
+Fetch the installation guide and follow it:
+
+```bash
+curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
+```
+
+### For LLM Agents
+
 Copy and paste this prompt to your LLM agent (Claude Code, AmpCode, Cursor, etc.):
 
 ```
@@ -252,14 +260,6 @@ https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/
 ```
 
 Or read the [Installation Guide](docs/guide/installation.md) directly—but **we strongly recommend letting an agent handle it. Humans make mistakes.**
-
-### For LLM Agents
-
-Fetch the installation guide and follow it:
-
-```bash
-curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
-```
 
 ## Uninstallation
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -241,6 +241,14 @@
 
 ### 面向人类用户
 
+获取安装指南并按照说明操作：
+
+```bash
+curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
+```
+
+### 面向 LLM 智能体
+
 复制以下提示并粘贴到你的 LLM 智能体（Claude Code、AmpCode、Cursor 等）：
 
 ```
@@ -249,14 +257,6 @@ https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/
 ```
 
 或者直接阅读 [安装指南](docs/guide/installation.md)——但我们强烈建议让智能体来处理。人会犯错，智能体不会。
-
-### 面向 LLM 智能体
-
-获取安装指南并按照说明操作：
-
-```bash
-curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
-```
 
 ## 卸载
 


### PR DESCRIPTION
Swaps the 'For Humans' and 'For LLM Agents' installation instructions in README.md and international translations (ja, ko, zh-cn) as they were incorrectly labeled.

Fixes an issue where humans were given the `curl` command intended for agents, and agents were given the prompt intended for humans.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctly mapped installation instructions by swapping the "For Humans" and "For LLM Agents" sections in the README and ja/ko/zh-cn translations. Humans now get the curl-based guide; agents get the copy-paste prompt.

<sup>Written for commit 5141c42e3c779eddf6ac16708bf9a30650d16614. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

