### PR TITLE
fix(tmux): allow initial pane spawn when no agent panes exist

### DIFF
--- a/src/features/tmux-subagent/spawn-action-decider.ts
+++ b/src/features/tmux-subagent/spawn-action-decider.ts
@@ -32,7 +32,7 @@ export function decideSpawnActions(
 	)
 	const currentCount = state.agentPanes.length
 
-	if (agentAreaWidth < minPaneWidth) {
+	if (agentAreaWidth < minPaneWidth && currentCount > 0) {
 		return {
 			canSpawn: false,
 			actions: [],


### PR DESCRIPTION
## Summary

- Fix `decideSpawnActions` blocking pane creation when 0 agent panes exist

## Problem

When `currentCount === 0` (no agent panes), `mainPane.width === windowWidth` because the main pane occupies the entire window. This means:

```
agentAreaWidth = max(0, windowWidth - mainPane.width - DIVIDER_SIZE) = 0
```

The early return at line 35 fires (`0 < minPaneWidth` → true), returning `canSpawn: false` with "window too small" — even though the window is 227+ columns wide.

The `currentCount === 0` handler at line 48, which correctly creates a `virtualMainPane` with full window width and uses `canSplitPane()`, is **never reached**.

## Fix

Add `&& currentCount > 0` guard to the early return so it only applies when agent panes already exist. When `currentCount === 0`, execution falls through to the dedicated initial-split handler which works correctly.

```diff
- if (agentAreaWidth < minPaneWidth) {
+ if (agentAreaWidth < minPaneWidth && currentCount > 0) {
```

## Testing

Verified with A/B testing:

| Version | Window | Result |
|---------|--------|--------|
| v3.7.3 (upstream, no patch) | 227x58, 0 agent panes | `canSpawn: false`, "window too small" ❌ |
| v3.7.3 + this fix | 227x58, 0 agent panes | `canSpawn: true`, pane spawned ✅ |

Log evidence (upstream):
```
[tmux-session-manager] window state queried {"windowWidth":227,"mainPane":"%0","agentPaneCount":0}
[tmux-session-manager] spawn decision {"canSpawn":false,"reason":"window too small for agent panes: 227x58"}
```

Log evidence (with fix):
```
[tmux-session-manager] spawn decision {"canSpawn":true,"actionCount":1,"actions":[{"type":"spawn"}]}
[spawnTmuxPane] all checks passed, spawning...
[tmux-session-manager] pane spawned and tracked {"paneId":"%1","sessionReady":true}
```

Fixes #1939

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in tmux pane sizing that blocked the very first agent pane from spawning. Initial splits now work on wide windows instead of falsely reporting “window too small.”

- **Bug Fixes**
  - Adjusted decideSpawnActions to only enforce the min-width early return when currentCount > 0, letting the zero-pane case reach the initial-split handler.
  - Verified on 227x58 window: upstream returned canSpawn:false; with fix returns canSpawn:true and spawns the pane.
  - Addresses issue #1939.

<sup>Written for commit a78ee23d76336d667ebf907a6f5ee5d9a8d62c4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

