### PR TITLE
fix(tests): update atlas hook and auto-update-checker tests

### DIFF
--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -180,8 +180,8 @@ describe("atlas hook", () => {
 
       // then - standalone verification reminder appended
       expect(output.output).toContain("Task completed successfully")
-      expect(output.output).toContain("MANDATORY:")
-      expect(output.output).toContain("task(session_id=")
+      expect(output.output).toContain("LYING")
+      expect(output.output).toContain("PHASE 1")
       
       cleanupMessageStorage(sessionID)
     })
@@ -219,8 +219,8 @@ describe("atlas hook", () => {
       expect(output.output).toContain("Task completed successfully")
       expect(output.output).toContain("SUBAGENT WORK COMPLETED")
       expect(output.output).toContain("test-plan")
-      expect(output.output).toContain("LIE")
-      expect(output.output).toContain("task(session_id=")
+      expect(output.output).toContain("LYING")
+      expect(output.output).toContain("PHASE 1")
       
       cleanupMessageStorage(sessionID)
     })
@@ -401,10 +401,10 @@ describe("atlas hook", () => {
         output
       )
 
-      // then - should include session_id instructions and verification
-      expect(output.output).toContain("task(session_id=")
-      expect(output.output).toContain("[x]")
-      expect(output.output).toContain("MANDATORY:")
+      // then - should include verification instructions
+      expect(output.output).toContain("LYING")
+      expect(output.output).toContain("PHASE 1")
+      expect(output.output).toContain("PHASE 2")
       
       cleanupMessageStorage(sessionID)
     })

--- a/src/hooks/auto-update-checker/hook/background-update-check.test.ts
+++ b/src/hooks/auto-update-checker/hook/background-update-check.test.ts
@@ -16,6 +16,7 @@ mock.module("../checker", () => ({
   getCachedVersion: mockGetCachedVersion,
   getLatestVersion: mockGetLatestVersion,
   updatePinnedVersion: mockUpdatePinnedVersion,
+  revertPinnedVersion: mock(() => false),
 }))
 
 mock.module("../version-channel", () => ({


### PR DESCRIPTION
## Changes

- **atlas hook tests**: Update verification reminder assertions to match the new 4-phase QA system
  - `MANDATORY:` -> `PHASE 1` / `PHASE 2` (verification system was rewritten)
  - `LIE` -> `LYING` (wording changed in verification template)
  - `task(session_id=` -> no longer present in standalone reminders
  
- **auto-update-checker tests**: Add missing `revertPinnedVersion` mock export to fix `SyntaxError: Export named 'revertPinnedVersion' not found` when running tests

## Test Results

- **Typecheck**: Pass
- **Tests**: 2982 pass / 4 fail (pre-existing bun mock isolation issue, same in v3.7.3)

## Note

The 4 remaining `background-update-check.test.ts` failures are a pre-existing bun `mock.module` isolation issue that occurs when running alongside `checker.test.ts` (which imports the real module). These tests pass when run individually. This is confirmed to be the same in v3.7.3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated atlas hook tests to reflect the new 4-phase QA language and fixed auto-update-checker tests by adding a missing mock export to resolve an import error.

- **Bug Fixes**
  - Atlas hook: adjust verification assertions to use LYING and PHASE 1/2; remove the task(session_id=) expectation.
  - Auto-update-checker: mock revertPinnedVersion in background-update-check tests to prevent the “Export named 'revertPinnedVersion' not found” error.

<sup>Written for commit 6e160877792768e89290ec73dc091ac898634c2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

