### PR TITLE
fix: make write-existing-file-guard read-gated with overwrite bypass

### DIFF
--- a/src/hooks/write-existing-file-guard/hook.ts
+++ b/src/hooks/write-existing-file-guard/hook.ts
@@ -1,50 +1,212 @@
 import type { Hooks, PluginInput } from "@opencode-ai/plugin"
 
-import { existsSync } from "fs"
-import { resolve, isAbsolute, join, normalize, sep } from "path"
+import { existsSync, realpathSync } from "fs"
+import { basename, dirname, isAbsolute, join, normalize, resolve, sep } from "path"
 
 import { log } from "../../shared"
 
+type GuardArgs = {
+  filePath?: string
+  path?: string
+  file_path?: string
+  overwrite?: boolean | string
+}
+
+const MAX_TRACKED_SESSIONS = 256
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined
+  }
+
+  return value as Record<string, unknown>
+}
+
+function getPathFromArgs(args: GuardArgs | undefined): string | undefined {
+  return args?.filePath ?? args?.path ?? args?.file_path
+}
+
+function resolveInputPath(ctx: PluginInput, inputPath: string): string {
+  return normalize(isAbsolute(inputPath) ? inputPath : resolve(ctx.directory, inputPath))
+}
+
+function toCanonicalPath(absolutePath: string): string {
+  let canonicalPath = absolutePath
+
+  if (existsSync(absolutePath)) {
+    try {
+      canonicalPath = realpathSync.native(absolutePath)
+    } catch {
+      canonicalPath = absolutePath
+    }
+  } else {
+    const absoluteDir = dirname(absolutePath)
+    const resolvedDir = existsSync(absoluteDir) ? realpathSync.native(absoluteDir) : absoluteDir
+    canonicalPath = join(resolvedDir, basename(absolutePath))
+  }
+
+  // Preserve canonical casing from the filesystem to avoid collapsing distinct
+  // files on case-sensitive volumes (supported on all major OSes).
+  return normalize(canonicalPath)
+}
+
+function isOverwriteEnabled(value: boolean | string | undefined): boolean {
+  if (value === true) {
+    return true
+  }
+
+  if (typeof value === "string") {
+    return value.toLowerCase() === "true"
+  }
+
+  return false
+}
+
 export function createWriteExistingFileGuardHook(ctx: PluginInput): Hooks {
+  const readPermissionsBySession = new Map<string, Set<string>>()
+  const sessionLastAccess = new Map<string, number>()
+  const canonicalSessionRoot = toCanonicalPath(resolveInputPath(ctx, ctx.directory))
+  const sisyphusRoot = join(canonicalSessionRoot, ".sisyphus") + sep
+
+  const touchSession = (sessionID: string): void => {
+    sessionLastAccess.set(sessionID, Date.now())
+  }
+
+  const evictLeastRecentlyUsedSession = (): void => {
+    let oldestSessionID: string | undefined
+    let oldestSeen = Number.POSITIVE_INFINITY
+
+    for (const [sessionID, lastSeen] of sessionLastAccess.entries()) {
+      if (lastSeen < oldestSeen) {
+        oldestSeen = lastSeen
+        oldestSessionID = sessionID
+      }
+    }
+
+    if (!oldestSessionID) {
+      return
+    }
+
+    readPermissionsBySession.delete(oldestSessionID)
+    sessionLastAccess.delete(oldestSessionID)
+  }
+
+  const ensureSessionReadSet = (sessionID: string): Set<string> => {
+    let readSet = readPermissionsBySession.get(sessionID)
+    if (!readSet) {
+      if (readPermissionsBySession.size >= MAX_TRACKED_SESSIONS) {
+        evictLeastRecentlyUsedSession()
+      }
+
+      readSet = new Set<string>()
+      readPermissionsBySession.set(sessionID, readSet)
+    }
+
+    touchSession(sessionID)
+    return readSet
+  }
+
+  const registerReadPermission = (sessionID: string, canonicalPath: string): void => {
+    const readSet = ensureSessionReadSet(sessionID)
+    readSet.add(canonicalPath)
+  }
+
+  const consumeReadPermission = (sessionID: string, canonicalPath: string): boolean => {
+    const readSet = readPermissionsBySession.get(sessionID)
+    if (!readSet || !readSet.has(canonicalPath)) {
+      return false
+    }
+
+    readSet.delete(canonicalPath)
+    touchSession(sessionID)
+    return true
+  }
+
+  const invalidateOtherSessions = (canonicalPath: string, writingSessionID?: string): void => {
+    for (const [sessionID, readSet] of readPermissionsBySession.entries()) {
+      if (writingSessionID && sessionID === writingSessionID) {
+        continue
+      }
+
+      if (readSet.delete(canonicalPath)) {
+        touchSession(sessionID)
+      }
+    }
+  }
+
   return {
     "tool.execute.before": async (input, output) => {
       const toolName = input.tool?.toLowerCase()
-      if (toolName !== "write") {
+      if (toolName !== "write" && toolName !== "read") {
         return
       }
 
-      const args = output.args as
-        | { filePath?: string; path?: string; file_path?: string }
-        | undefined
-      const filePath = args?.filePath ?? args?.path ?? args?.file_path
+      const argsRecord = asRecord(output.args)
+      const args = argsRecord as GuardArgs | undefined
+      const filePath = getPathFromArgs(args)
       if (!filePath) {
         return
       }
 
-      const resolvedPath = normalize(
-        isAbsolute(filePath) ? filePath : resolve(ctx.directory, filePath)
-      )
+      const resolvedPath = resolveInputPath(ctx, filePath)
+      const canonicalPath = toCanonicalPath(resolvedPath)
 
-      if (existsSync(resolvedPath)) {
-        const sisyphusRoot = join(ctx.directory, ".sisyphus") + sep
-        const isSisyphusMarkdown =
-          resolvedPath.startsWith(sisyphusRoot) && resolvedPath.endsWith(".md")
-        if (isSisyphusMarkdown) {
-          log("[write-existing-file-guard] Allowing .sisyphus/*.md overwrite", {
-            sessionID: input.sessionID,
-            filePath,
-          })
+      if (toolName === "read") {
+        if (!existsSync(resolvedPath) || !input.sessionID) {
           return
         }
 
-        log("[write-existing-file-guard] Blocking write to existing file", {
+        registerReadPermission(input.sessionID, canonicalPath)
+        return
+      }
+
+      const overwriteEnabled = isOverwriteEnabled(args?.overwrite)
+
+      if (argsRecord && "overwrite" in argsRecord) {
+        delete argsRecord.overwrite
+      }
+
+      if (!existsSync(resolvedPath)) {
+        return
+      }
+
+      const isSisyphusPath = canonicalPath.startsWith(sisyphusRoot)
+      if (isSisyphusPath) {
+        log("[write-existing-file-guard] Allowing .sisyphus/** overwrite", {
+          sessionID: input.sessionID,
+          filePath,
+        })
+        invalidateOtherSessions(canonicalPath, input.sessionID)
+        return
+      }
+
+      if (overwriteEnabled) {
+        log("[write-existing-file-guard] Allowing overwrite flag bypass", {
           sessionID: input.sessionID,
           filePath,
           resolvedPath,
         })
-
-        throw new Error("File already exists. Use edit tool instead.")
+        invalidateOtherSessions(canonicalPath, input.sessionID)
+        return
       }
+
+      if (input.sessionID && consumeReadPermission(input.sessionID, canonicalPath)) {
+        log("[write-existing-file-guard] Allowing overwrite after read", {
+          sessionID: input.sessionID,
+          filePath,
+          resolvedPath,
+        })
+        invalidateOtherSessions(canonicalPath, input.sessionID)
+        return
+      }
+
+      log("[write-existing-file-guard] Blocking write to existing file", {
+        sessionID: input.sessionID,
+        filePath,
+        resolvedPath,
+      })
+
+      throw new Error("File already exists. Use edit tool instead.")
     },
   }
 }

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -48,6 +48,7 @@ export function createEventHandler(args: {
     await Promise.resolve(hooks.ralphLoop?.event?.(input))
     await Promise.resolve(hooks.stopContinuationGuard?.event?.(input))
     await Promise.resolve(hooks.compactionTodoPreserver?.event?.(input))
+    await Promise.resolve(hooks.writeExistingFileGuard?.event?.(input))
     await Promise.resolve(hooks.atlasHook?.handler?.(input))
   }
 


### PR DESCRIPTION
## Summary
- replace unconditional existing-file write block with a read-gated overwrite policy
- allow one overwrite after same-session read, then consume the permission
- support explicit `overwrite: true` / `overwrite: "true"` bypass and strip `overwrite` before tool execution
- canonicalize paths with `realpathSync.native()` to handle symlinks and case-insensitive platforms
- invalidate other sessions' read permissions after write and keep bounded session state with LRU eviction

## Tests
- added focused coverage for write/read gate, cross-session invalidation, overwrite flag handling, path variants, relative/absolute paths, symlinks, case behavior and LRU retention
- `bun test src/hooks/write-existing-file-guard/index.test.ts`
- `bun run build`

Closes #1871

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the unconditional existing-file write block with a read-gated overwrite policy. Addresses #1871 with one-time overwrite after same-session read, explicit bypass, robust path handling, and blocking writes outside the session directory.

- **New Features**
  - Read grants a one-time overwrite for the same session; consumed on write and invalidates other sessions.
  - Supports overwrite: true (boolean or "true") to bypass; flag is stripped before execution.
  - Canonicalizes paths with realpathSync.native, resolves symlinks, handles rel/abs and case-aware matching, and supports filePath/path/file_path args.
  - Always allows writes under .sisyphus/** and blocks writes outside the session directory.
  - Tracks up to 256 sessions with LRU capping; clears per-session permissions on session.deleted via plugin event forwarding.

<sup>Written for commit 73d9e1f84799d69424bc929999f0d018b724c16b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

