### PR TITLE
fix(agents): replace background_cancel(all=true) with individual task cancellation

### DIFF
--- a/src/agents/atlas/default.ts
+++ b/src/agents/atlas/default.ts
@@ -311,7 +311,8 @@ task(category="quick", load_skills=[], run_in_background=false, prompt="Task 4..
 
 **Background management**:
 - Collect results: \`background_output(task_id="...")\`
-- Before final answer: \`background_cancel(all=true)\`
+- Before final answer, cancel DISPOSABLE tasks individually: \`background_cancel(taskId="bg_explore_xxx")\`, \`background_cancel(taskId="bg_librarian_xxx")\`
+- **NEVER use \`background_cancel(all=true)\`** — it kills tasks whose results you haven't collected yet
 </parallel_execution>
 
 <notepad_protocol>

--- a/src/agents/atlas/gpt.ts
+++ b/src/agents/atlas/gpt.ts
@@ -298,7 +298,8 @@ task(category="quick", load_skills=[], run_in_background=false, prompt="Task 3..
 
 **Background management**:
 - Collect: \`background_output(task_id="...")\`
-- Cleanup: \`background_cancel(all=true)\`
+- Before final answer, cancel DISPOSABLE tasks individually: \`background_cancel(taskId="bg_explore_xxx")\`, \`background_cancel(taskId="bg_librarian_xxx")\`
+- **NEVER use \`background_cancel(all=true)\`** — it kills tasks whose results you haven't collected yet
 </parallel_execution>
 
 <notepad_protocol>

--- a/src/agents/hephaestus.ts
+++ b/src/agents/hephaestus.ts
@@ -254,7 +254,8 @@ Prompt structure for each agent:
 - NEVER use \`run_in_background=false\` for explore/librarian
 - Continue your work immediately after launching background agents
 - Collect results with \`background_output(task_id="...")\` when needed
-- BEFORE final answer: \`background_cancel(all=true)\` to clean up
+- BEFORE final answer, cancel DISPOSABLE tasks individually: \`background_cancel(taskId="bg_explore_xxx")\`, \`background_cancel(taskId="bg_librarian_xxx")\`
+- **NEVER use \`background_cancel(all=true)\`** — it kills tasks whose results you haven't collected yet
 
 ### Search Stop Conditions
 

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -306,9 +306,9 @@ result = task(..., run_in_background=false)  // Never wait synchronously for exp
 ### Background Result Collection:
 1. Launch parallel agents → receive task_ids
 2. Continue immediate work
-3. When results needed: \`background_output(task_id=\"...\")\`
-4. Before final answer, cancel DISPOSABLE tasks (explore, librarian) individually: \`background_cancel(taskId=\"bg_explore_xxx\")\`, \`background_cancel(taskId=\"bg_librarian_xxx\")\`
-5. **NEVER cancel Oracle.** ALWAYS collect Oracle result via \`background_output(task_id=\"bg_oracle_xxx\")\` before answering — even if you already have enough context.
+3. When results needed: \`background_output(task_id="...")\`
+4. Before final answer, cancel DISPOSABLE tasks (explore, librarian) individually: \`background_cancel(taskId="bg_explore_xxx")\`, \`background_cancel(taskId="bg_librarian_xxx")\`
+5. **NEVER cancel Oracle.** ALWAYS collect Oracle result via \`background_output(task_id="bg_oracle_xxx")\` before answering — even if you already have enough context.
 6. **NEVER use \`background_cancel(all=true)\`** — it kills Oracle. Cancel each disposable task by its specific taskId.
 
 ### Search Stop Conditions
@@ -444,7 +444,7 @@ If verification fails:
 3. Report: "Done. Note: found N pre-existing lint errors unrelated to my changes."
 
 ### Before Delivering Final Answer:
-- Cancel DISPOSABLE background tasks (explore, librarian) individually via \`background_cancel(taskId=\"...\")\`
+- Cancel DISPOSABLE background tasks (explore, librarian) individually via \`background_cancel(taskId="...")\`
 - **NEVER use \`background_cancel(all=true)\`.** Always cancel individually by taskId.
 - **Always wait for Oracle**: When Oracle is running and you have gathered enough context from your own exploration, your next action is \`background_output\` on Oracle — NOT delivering a final answer. Oracle's value is highest when you think you don't need it.
 </Behavior_Instructions>


### PR DESCRIPTION
## Summary

- Replaces `background_cancel(all=true)` with individual task cancellation in Atlas and Sisyphus agent prompts
- Resolves a prompt contradiction where Sisyphus's own rules say "NEVER use `background_cancel(all=true)`" but the Background Result Collection and Completion sections instruct to use it

## Problem

`background_cancel(all=true)` in agent prompts causes agents to destroy uncollected background task results before reading them. Observed failure sequence:

1. Agent launches 3 explore agents in background
2. All 3 complete successfully (system notification received)
3. Agent calls `background_cancel(all=true)` **before** `background_output`
4. Agent then calls `background_output` → empty results (already cancelled)
5. Agent fails to synthesize a response → session hangs

This was observed in a Prometheus planning session where explore agents completed their work but results were never collected.

## Root Cause

Contradictory instructions in the same codebase:

| Location | Instruction |
|----------|-------------|
| `sisyphus.ts` (Phase 2A, Phase 3) | `background_cancel(all=true)` |
| `sisyphus.ts` (Constraints, Oracle) | "NEVER use `background_cancel(all=true)`" |
| `atlas.ts` (parallel_execution) | `background_cancel(all=true)` |

The model follows the wrong instruction non-deterministically, especially after prompt changes in v3.7.4.

## Changes

- **`src/agents/atlas.ts`**: Replace `background_cancel(all=true)` with individual `background_cancel(taskId="bg_xxx")` pattern + explicit "NEVER" warning
- **`src/agents/sisyphus.ts`** (2 locations): Same replacement — individual cancel + collect-before-cancel rule

## Validation

- `bun run typecheck` — passes
- `bun test src/agents/` — 38 pass, 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced background_cancel(all=true) with per-task cancellation across Atlas, Sisyphus, and Hephaestus prompts to prevent destroying uncollected background results and avoid session hangs. Preserves explore/librarian outputs and protects Oracle by requiring collection before any cancel.

- **Bug Fixes**
  - Cancel disposable tasks individually and collect background_output from completed tasks before canceling.
  - Added explicit “NEVER use background_cancel(all=true)” guidance in Atlas (default/gpt), Sisyphus, and Hephaestus.

<sup>Written for commit e5ede6dc8c8338cf07e46f59e526934b7ca81cd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

