### PR TITLE
fix: remove automatic antigravity plugin installation

### DIFF
--- a/src/cli/config-manager/auth-plugins.test.ts
+++ b/src/cli/config-manager/auth-plugins.test.ts
@@ -43,7 +43,7 @@ const testConfig: InstallConfig = {
 
 describe("addAuthPlugins", () => {
   describe("Test 1: JSONC with commented plugin line", () => {
-    it("preserves comment, updates actual plugin array", async () => {
+    it("preserves comment, does NOT add antigravity plugin", async () => {
       const content = `{
   // "plugin": ["old-plugin"]
   "plugin": ["existing-plugin"],
@@ -59,17 +59,18 @@ describe("addAuthPlugins", () => {
       const newContent = readFileSync(result.configPath, "utf-8")
       expect(newContent).toContain('// "plugin": ["old-plugin"]')
       expect(newContent).toContain('existing-plugin')
-      expect(newContent).toContain('opencode-antigravity-auth')
+      // antigravity plugin should NOT be auto-added anymore
+      expect(newContent).not.toContain('opencode-antigravity-auth')
 
       const parsed = parseJsonc<Record<string, unknown>>(newContent)
       const plugins = parsed.plugin as string[]
       expect(plugins).toContain('existing-plugin')
-      expect(plugins.some((p) => p.startsWith('opencode-antigravity-auth'))).toBe(true)
+      expect(plugins.some((p) => p.startsWith('opencode-antigravity-auth'))).toBe(false)
     })
   })
 
   describe("Test 2: Plugin array already contains antigravity", () => {
-    it("does not add duplicate", async () => {
+    it("preserves existing antigravity, does not add another", async () => {
       const content = `{
   "plugin": ["existing-plugin", "opencode-antigravity-auth"],
   "provider": {}
@@ -87,6 +88,7 @@ describe("addAuthPlugins", () => {
 
       const antigravityCount = plugins.filter((p) => p.startsWith('opencode-antigravity-auth')).length
       expect(antigravityCount).toBe(1)
+      expect(plugins).toContain('existing-plugin')
     })
   })
 
@@ -156,7 +158,7 @@ describe("addAuthPlugins", () => {
   })
 
   describe("Test 6: No existing plugin array", () => {
-    it("creates plugin array when none exists", async () => {
+    it("creates empty plugin array when none exists, does NOT add antigravity", async () => {
       const content = `{
   "provider": {}
 }`
@@ -172,7 +174,9 @@ describe("addAuthPlugins", () => {
       const parsed = parseJsonc<Record<string, unknown>>(newContent)
       expect(parsed).toHaveProperty('plugin')
       const plugins = parsed.plugin as string[]
-      expect(plugins.some((p) => p.startsWith('opencode-antigravity-auth'))).toBe(true)
+      // antigravity plugin should NOT be auto-added anymore
+      expect(plugins.some((p) => p.startsWith('opencode-antigravity-auth'))).toBe(false)
+      expect(plugins.length).toBe(0)
     })
   })
 
@@ -199,7 +203,7 @@ describe("addAuthPlugins", () => {
   })
 
   describe("Test 8: Multiple plugins in array", () => {
-    it("appends to existing plugins", async () => {
+    it("preserves existing plugins, does NOT add antigravity", async () => {
       const content = `{
   "plugin": ["plugin-1", "plugin-2", "plugin-3"],
   "provider": {}
@@ -218,7 +222,9 @@ describe("addAuthPlugins", () => {
       expect(plugins).toContain('plugin-1')
       expect(plugins).toContain('plugin-2')
       expect(plugins).toContain('plugin-3')
-      expect(plugins.some((p) => p.startsWith('opencode-antigravity-auth'))).toBe(true)
+      // antigravity plugin should NOT be auto-added anymore
+      expect(plugins.some((p) => p.startsWith('opencode-antigravity-auth'))).toBe(false)
+      expect(plugins.length).toBe(3)
     })
   })
 })

--- a/src/cli/config-manager/auth-plugins.ts
+++ b/src/cli/config-manager/auth-plugins.ts
@@ -50,13 +50,8 @@ export async function addAuthPlugins(config: InstallConfig): Promise<ConfigMerge
     const rawPlugins = existingConfig?.plugin
     const plugins: string[] = Array.isArray(rawPlugins) ? rawPlugins : []
 
-    if (config.hasGemini) {
-      const version = await fetchLatestVersion("opencode-antigravity-auth")
-      const pluginEntry = version ? `opencode-antigravity-auth@${version}` : "opencode-antigravity-auth"
-      if (!plugins.some((p) => p.startsWith("opencode-antigravity-auth"))) {
-        plugins.push(pluginEntry)
-      }
-    }
+    // Note: opencode-antigravity-auth plugin auto-installation has been removed
+    // Users can manually add auth plugins if needed
 
     const newConfig = { ...(existingConfig ?? {}), plugin: plugins }
 


### PR DESCRIPTION
## Summary

This PR removes the automatic installation of the `opencode-antigravity-auth` plugin when users have Gemini configured during setup.

## Problem

The automatic antigravity plugin installation has been causing several issues:

1. **Account bans**: The antigravity plugin is getting users' Google accounts banned
2. **Lack of transparency**: Users don't realize this plugin was automatically installed
3. **Unnecessary**: Google has built-in OAuth support for Gemini that doesn't require third-party plugins

## Changes

- Removed the code block in `src/cli/config-manager/auth-plugins.ts` that automatically added `opencode-antigravity-auth` when `config.hasGemini` was true
- Updated related tests to reflect the new behavior (antigravity plugin is no longer auto-added)

## Testing

- All existing tests pass
- Updated 3 tests that previously expected antigravity to be auto-added

## User Impact

Users who need the antigravity plugin can manually add it to their plugin configuration. This change prevents unexpected plugin installation and protects users from potential account issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed automatic installation of the opencode-antigravity-auth plugin when Gemini is configured. This prevents unexpected installs and reduces risk of Google account bans; users can add it manually if needed.

- **Bug Fixes**
  - Removed auto-add logic in src/cli/config-manager/auth-plugins.ts.
  - Updated tests to assert antigravity is not auto-added and no duplicates are introduced.
  - Preserves existing plugins/comments; creates an empty plugin array when none exists.

<sup>Written for commit 7027b55c5611fb27b73dbf1d7c1512ab3d468da2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

