### PR TITLE
fix(doctor): point fix messages to actual OpenCode cache directory

### DIFF
--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -93,7 +93,7 @@ export async function checkSystem(): Promise<CheckResult> {
     issues.push({
       title: "Loaded plugin version mismatch",
       description: `Cache expects ${loadedInfo.expectedVersion} but loaded ${loadedInfo.loadedVersion}.`,
-      fix: "Reinstall plugin dependencies in OpenCode cache",
+      fix: `Reinstall: cd ${loadedInfo.cacheDir} && bun install`,
       severity: "warning",
       affects: ["plugin loading"],
     })
@@ -107,7 +107,7 @@ export async function checkSystem(): Promise<CheckResult> {
     issues.push({
       title: "Loaded plugin is outdated",
       description: `Loaded ${systemInfo.loadedVersion}, latest ${latestVersion}.`,
-      fix: "Update: cd ~/.config/opencode && bun update oh-my-opencode",
+      fix: `Update: cd ${loadedInfo.cacheDir} && bun add oh-my-opencode@latest`,
       severity: "warning",
       affects: ["plugin features"],
     })


### PR DESCRIPTION
## Summary

- Doctor's fix messages for "Loaded plugin is outdated" and "Loaded plugin version mismatch" were directing users to `~/.config/opencode` with `bun update`, but OpenCode loads plugins from its **cache directory** (`~/.cache/opencode` on Linux, `~/Library/Caches/opencode` on macOS).
- `bun update` is a no-op when the cache `package.json` pins an exact version (no `^` range). Changed to `bun add oh-my-opencode@latest`.
- Fix messages now use the dynamically resolved `loadedInfo.cacheDir` instead of a hardcoded path.

## Problem

Running `bun update oh-my-opencode` in `~/.config/opencode` (as the doctor suggested) updates the **config** directory — but OpenCode loads the plugin from its **cache** directory. Users follow the fix, see no change, and the warning persists.

## Changes

| Before | After |
|---|---|
| `cd ~/.config/opencode && bun update oh-my-opencode` | `cd ${cacheDir} && bun add oh-my-opencode@latest` |
| `Reinstall plugin dependencies in OpenCode cache` | `cd ${cacheDir} && bun install` |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the doctor’s fix messages to point to the actual plugin cache directory and use the correct Bun commands. Also fixed a metadata type error in hashline-edit.

- **Bug Fixes**
  - Doctor: fix messages now use loadedInfo.cacheDir. Update: cd ${loadedInfo.cacheDir} && bun add oh-my-opencode@latest. Reinstall: cd ${loadedInfo.cacheDir} && bun install.
  - Hashline-edit: extended ToolContext with optional metadata() and callID; used optional chaining to fix the type error.

<sup>Written for commit b94b193c21599d52648c54803a81dc0e85a3b960. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

