### PR TITLE
fix(background-output): stop defaulting full_session=true for running tasks

### DIFF
--- a/src/tools/background-task/create-background-output.ts
+++ b/src/tools/background-task/create-background-output.ts
@@ -78,7 +78,7 @@ export function createBackgroundOutput(manager: BackgroundOutputManager, client:
         }
 
         const isActive = task.status === "pending" || task.status === "running"
-        const fullSession = args.full_session ?? isActive
+        const fullSession = args.full_session ?? false
         const includeThinking = isActive || (args.include_thinking ?? false)
         const includeToolResults = isActive || (args.include_tool_results ?? false)
 

--- a/src/tools/background-task/tools.test.ts
+++ b/src/tools/background-task/tools.test.ts
@@ -232,7 +232,7 @@ describe("background_output full_session", () => {
     expect(output).toContain("Has more: true")
   })
 
-  test("defaults to full_session when task is running", async () => {
+  test("defaults to compact status when task is running", async () => {
     // #given
     const task = createTask({ status: "running" })
     const manager = createMockManager(task)
@@ -241,6 +241,21 @@ describe("background_output full_session", () => {
 
     // #when
     const output = await tool.execute({ task_id: "task-1" }, mockContext)
+
+    // #then
+    expect(output).toContain("# Task Status")
+    expect(output).not.toContain("# Full Session Output")
+  })
+
+  test("returns full session when explicitly requested for running task", async () => {
+    // #given
+    const task = createTask({ status: "running" })
+    const manager = createMockManager(task)
+    const client = createMockClient({})
+    const tool = createBackgroundOutput(manager, client)
+
+    // #when
+    const output = await tool.execute({ task_id: "task-1", full_session: true }, mockContext)
 
     // #then
     expect(output).toContain("# Full Session Output")


### PR DESCRIPTION
## Summary

- `background_output` previously defaulted `full_session=true` when the queried task was still running/pending, returning the **entire session transcript** on every call
- When the parent agent had no other immediate work after launching background tasks, it would poll `background_output` in a tight loop — each iteration dumping thousands of tokens of full transcript into the conversation history
- This caused massive token waste that compounded with each poll (full transcript in tool output → becomes part of context → next poll adds another full transcript)

## Fix

Change the default from `args.full_session ?? isActive` to `args.full_session ?? false`.

Now running-task checks return a compact status table (~200 tokens) instead of the full session transcript. Callers who actually need the full transcript can still pass `full_session=true` explicitly.

## What stays the same

- Completed tasks still return full results via `formatTaskResult` (unaffected, separate code path)
- `full_session=true` still works when explicitly passed
- All other `background_output` behavior is unchanged

## Tests

- Updated existing test to reflect the new default behavior
- Added new test confirming `full_session=true` still works when explicitly set on running tasks
- Full suite: 3060 pass, 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop returning full session transcripts by default for running background tasks. This prevents repeated multi‑thousand‑token dumps on each poll and eliminates compounding token waste.

- **Bug Fixes**
  - Default changed from args.full_session ?? isActive to args.full_session ?? false.
  - Running tasks now return a compact status summary; completed tasks still return full results.
  - Explicit opt‑in preserved via full_session=true when needed.
  - Updated tests to cover new default and explicit full_session behavior.

<sup>Written for commit d556937c8e48775ae665ab7a97538e744f1459b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

