### PR TITLE
fix(run): prevent exit code 130 timeout in CI environments

### DIFF
--- a/src/cli/run/event-state.ts
+++ b/src/cli/run/event-state.ts
@@ -7,6 +7,8 @@ export interface EventState {
   currentTool: string | null
   /** Set to true when the main session has produced meaningful work (text, tool call, or tool result) */
   hasReceivedMeaningfulWork: boolean
+  /** Timestamp of the last received event (for watchdog detection) */
+  lastEventTimestamp: number
   /** Count of assistant messages for the main session */
   messageCount: number
   /** Current agent name from the latest assistant message */
@@ -54,6 +56,7 @@ export function createEventState(): EventState {
     lastPartText: "",
     currentTool: null,
     hasReceivedMeaningfulWork: false,
+    lastEventTimestamp: Date.now(),
     messageCount: 0,
     currentAgent: null,
     currentModel: null,

--- a/src/cli/run/event-stream-processor.ts
+++ b/src/cli/run/event-stream-processor.ts
@@ -35,6 +35,9 @@ export async function processEvents(
         logEventVerbose(ctx, payload)
       }
 
+      // Update last event timestamp for watchdog detection
+      state.lastEventTimestamp = Date.now()
+
       handleSessionError(ctx, payload, state)
       handleSessionIdle(ctx, payload, state)
       handleSessionStatus(ctx, payload, state)

--- a/src/cli/run/poll-for-completion.ts
+++ b/src/cli/run/poll-for-completion.ts
@@ -8,11 +8,15 @@ const DEFAULT_POLL_INTERVAL_MS = 500
 const DEFAULT_REQUIRED_CONSECUTIVE = 1
 const ERROR_GRACE_CYCLES = 3
 const MIN_STABILIZATION_MS = 1_000
+const DEFAULT_EVENT_WATCHDOG_MS = 30_000 // 30 seconds
+const DEFAULT_SECONDARY_MEANINGFUL_WORK_TIMEOUT_MS = 60_000 // 60 seconds
 
 export interface PollOptions {
   pollIntervalMs?: number
   requiredConsecutive?: number
   minStabilizationMs?: number
+  eventWatchdogMs?: number
+  secondaryMeaningfulWorkTimeoutMs?: number
 }
 
 export async function pollForCompletion(
@@ -28,6 +32,11 @@ export async function pollForCompletion(
     options.minStabilizationMs ?? MIN_STABILIZATION_MS
   const minStabilizationMs =
     rawMinStabilizationMs > 0 ? rawMinStabilizationMs : MIN_STABILIZATION_MS
+  const eventWatchdogMs =
+    options.eventWatchdogMs ?? DEFAULT_EVENT_WATCHDOG_MS
+  const secondaryMeaningfulWorkTimeoutMs =
+    options.secondaryMeaningfulWorkTimeoutMs ??
+    DEFAULT_SECONDARY_MEANINGFUL_WORK_TIMEOUT_MS
   let consecutiveCompleteChecks = 0
   let errorCycleCount = 0
   let firstWorkTimestamp: number | null = null
@@ -59,6 +68,32 @@ export async function pollForCompletion(
       errorCycleCount = 0
     }
 
+    // Watchdog: if no events received for N seconds, verify session status via API
+    if (eventState.lastEventTimestamp !== null) {
+      const timeSinceLastEvent = Date.now() - eventState.lastEventTimestamp
+      if (timeSinceLastEvent > eventWatchdogMs) {
+        // Events stopped coming - verify actual session state
+        console.log(
+          pc.yellow(
+            `\n  No events for ${Math.round(
+              timeSinceLastEvent / 1000
+            )}s, verifying session status...`
+          )
+        )
+
+        // Force check session status directly
+        const directStatus = await getMainSessionStatus(ctx)
+        if (directStatus === "idle") {
+          eventState.mainSessionIdle = true
+        } else if (directStatus === "busy" || directStatus === "retry") {
+          eventState.mainSessionIdle = false
+        }
+
+        // Reset timestamp to avoid repeated checks
+        eventState.lastEventTimestamp = Date.now()
+      }
+    }
+
     const mainSessionStatus = await getMainSessionStatus(ctx)
     if (mainSessionStatus === "busy" || mainSessionStatus === "retry") {
       eventState.mainSessionIdle = false
@@ -80,6 +115,47 @@ export async function pollForCompletion(
       if (Date.now() - pollStartTimestamp < minStabilizationMs) {
         consecutiveCompleteChecks = 0
         continue
+      }
+
+      // Secondary timeout: if we've been polling for reasonable time but haven't
+      // received meaningful work via events, check if there's active work via API
+      if (Date.now() - pollStartTimestamp > secondaryMeaningfulWorkTimeoutMs) {
+        // Check if session actually has pending work (children, todos, etc.)
+        const childrenRes = await ctx.client.session.children({
+          path: { id: ctx.sessionID },
+          query: { directory: ctx.directory },
+        })
+        const children = normalizeSDKResponse(childrenRes, [] as unknown[])
+        const todosRes = await ctx.client.session.todo({
+          path: { id: ctx.sessionID },
+          query: { directory: ctx.directory },
+        })
+        const todos = normalizeSDKResponse(todosRes, [] as unknown[])
+
+        const hasActiveWork =
+          Array.isArray(children)
+            ? children.length > 0
+            : false || Array.isArray(todos)
+            ? todos.some(
+                (
+                  t: unknown
+                ) =>
+                  (t as { status?: string })?.status !== "completed" &&
+                  (t as { status?: string })?.status !== "cancelled"
+              )
+            : false
+
+        if (hasActiveWork) {
+          // Assume meaningful work is happening even without events
+          eventState.hasReceivedMeaningfulWork = true
+          console.log(
+            pc.yellow(
+              `\n  No meaningful work events for ${Math.round(
+                secondaryMeaningfulWorkTimeoutMs / 1000
+              )}s but session has active work - assuming in progress`
+            )
+          )
+        }
       }
     } else {
       // Track when first meaningful work was received

--- a/src/cli/run/poll-for-completion.ts
+++ b/src/cli/run/poll-for-completion.ts
@@ -40,6 +40,7 @@ export async function pollForCompletion(
   let consecutiveCompleteChecks = 0
   let errorCycleCount = 0
   let firstWorkTimestamp: number | null = null
+  let secondaryTimeoutChecked = false
   const pollStartTimestamp = Date.now()
 
   while (!abortController.signal.aborted) {
@@ -69,6 +70,7 @@ export async function pollForCompletion(
     }
 
     // Watchdog: if no events received for N seconds, verify session status via API
+    let mainSessionStatus: "idle" | "busy" | "retry" | null = null
     if (eventState.lastEventTimestamp !== null) {
       const timeSinceLastEvent = Date.now() - eventState.lastEventTimestamp
       if (timeSinceLastEvent > eventWatchdogMs) {
@@ -82,10 +84,10 @@ export async function pollForCompletion(
         )
 
         // Force check session status directly
-        const directStatus = await getMainSessionStatus(ctx)
-        if (directStatus === "idle") {
+        mainSessionStatus = await getMainSessionStatus(ctx)
+        if (mainSessionStatus === "idle") {
           eventState.mainSessionIdle = true
-        } else if (directStatus === "busy" || directStatus === "retry") {
+        } else if (mainSessionStatus === "busy" || mainSessionStatus === "retry") {
           eventState.mainSessionIdle = false
         }
 
@@ -94,7 +96,10 @@ export async function pollForCompletion(
       }
     }
 
-    const mainSessionStatus = await getMainSessionStatus(ctx)
+    // Only call getMainSessionStatus if watchdog didn't already check
+    if (mainSessionStatus === null) {
+      mainSessionStatus = await getMainSessionStatus(ctx)
+    }
     if (mainSessionStatus === "busy" || mainSessionStatus === "retry") {
       eventState.mainSessionIdle = false
     } else if (mainSessionStatus === "idle") {
@@ -119,7 +124,12 @@ export async function pollForCompletion(
 
       // Secondary timeout: if we've been polling for reasonable time but haven't
       // received meaningful work via events, check if there's active work via API
-      if (Date.now() - pollStartTimestamp > secondaryMeaningfulWorkTimeoutMs) {
+      // Only check once to avoid unnecessary API calls every poll cycle
+      if (
+        Date.now() - pollStartTimestamp > secondaryMeaningfulWorkTimeoutMs &&
+        !secondaryTimeoutChecked
+      ) {
+        secondaryTimeoutChecked = true
         // Check if session actually has pending work (children, todos, etc.)
         const childrenRes = await ctx.client.session.children({
           path: { id: ctx.sessionID },
@@ -132,18 +142,16 @@ export async function pollForCompletion(
         })
         const todos = normalizeSDKResponse(todosRes, [] as unknown[])
 
-        const hasActiveWork =
-          Array.isArray(children)
-            ? children.length > 0
-            : false || Array.isArray(todos)
-            ? todos.some(
-                (
-                  t: unknown
-                ) =>
-                  (t as { status?: string })?.status !== "completed" &&
-                  (t as { status?: string })?.status !== "cancelled"
-              )
-            : false
+        const hasActiveChildren =
+          Array.isArray(children) && children.length > 0
+        const hasActiveTodos =
+          Array.isArray(todos) &&
+          todos.some(
+            (t: unknown) =>
+              (t as { status?: string })?.status !== "completed" &&
+              (t as { status?: string })?.status !== "cancelled"
+          )
+        const hasActiveWork = hasActiveChildren || hasActiveTodos
 
         if (hasActiveWork) {
           // Assume meaningful work is happening even without events


### PR DESCRIPTION
## Summary

Implements fixes from issue #1880 and #1934 to prevent exit code 130 timeout in CI environments (GitHub Actions).

### Problem

When the SSE event stream drops silently without a clean close (common in CI with network instability), the poll loop waits for the full 600s timeout before exiting with code 130.

### Solution

1. **Add `lastEventTimestamp` to EventState** - Tracks when events were last received for watchdog detection

2. **Add event watchdog (30s)** - If no events received for 30 seconds, verify session status via direct API call instead of waiting indefinitely

3. **Add secondary timeout (60s)** - After 60 seconds without meaningful work events, check for active children/todos via API and assume work is in progress if found

This prevents the poll loop from waiting for the full 600s timeout when:
- Event stream drops silently (network instability in CI)
- Main session delegates to children without producing meaningful work on main session

### Files Changed

- `src/cli/run/event-state.ts` - Added `lastEventTimestamp` field
- `src/cli/run/event-stream-processor.ts` - Update timestamp on each event
- `src/cli/run/poll-for-completion.ts` - Watchdog and secondary timeout logic

### Related Issues

- Fixes #1934
- Related to #1880

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents exit code 130 timeouts in CI by detecting stalled event streams and confirming session state directly. Fixes #1934 and aligns with #1880.

- **Bug Fixes**
  - Track lastEventTimestamp in EventState.
  - Event watchdog (30s): verify session status via API and reuse the result to avoid duplicate calls.
  - Secondary timeout (60s): check children/todos once; fix operator precedence in hasActiveWork.
  - Avoids waiting the full 600s when SSE drops or work runs in child sessions.

<sup>Written for commit 6cc7535a804fd365ba9848522971037afa03876b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

