### PR TITLE
fix(tool-config): respect user external_directory permission

### DIFF
--- a/src/plugin-handlers/tool-config-handler.test.ts
+++ b/src/plugin-handlers/tool-config-handler.test.ts
@@ -80,4 +80,33 @@ describe("applyToolConfig", () => {
       })
     })
   })
+
+  describe("#given external_directory permission", () => {
+    it("#then should preserve user-configured external_directory value", () => {
+      const params = createParams({ taskSystem: false })
+      params.config.permission = {
+        external_directory: "ask",
+      }
+
+      applyToolConfig(params)
+
+      expect(params.config.permission).toEqual({
+        webfetch: "allow",
+        external_directory: "ask",
+        task: "deny",
+      })
+    })
+
+    it("#then should default external_directory to allow when unset", () => {
+      const params = createParams({ taskSystem: false })
+
+      applyToolConfig(params)
+
+      expect(params.config.permission).toEqual({
+        webfetch: "allow",
+        external_directory: "allow",
+        task: "deny",
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Fix `applyToolConfig()` so it no longer overwrites user-configured `permission.external_directory`.
- Preserve user-provided `ask`/`deny` values and only default to `allow` when unset.
- Add focused regression tests for both preserve and default behaviors.

## Changes
- Updated permission merge logic in `src/plugin-handlers/tool-config-handler.ts`.
- Added `src/plugin-handlers/tool-config-handler.test.ts` with two test cases:
  - preserves user-configured `external_directory`
  - defaults `external_directory` to `allow` when not configured

## Testing
```bash
bun test src/plugin-handlers/tool-config-handler.test.ts
```

## Related Issues
Closes #1973

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes applyToolConfig so it respects user-configured permission.external_directory; preserves ask/deny and only defaults to allow when unset. Addresses #1973.

- **Bug Fixes**
  - Preserve existing permission.external_directory in merge logic.
  - Default external_directory to allow only when unset.
  - Add tests covering preserve and default cases in tool-config-handler.test.ts.

<sup>Written for commit b2a8d2c490e9804372e7fb14cecef19dcb6a3b4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

