### PR TITLE
fix(background-agent): prevent formatForCompaction crash on undefined description

### DIFF
--- a/src/features/background-agent/task-history.test.ts
+++ b/src/features/background-agent/task-history.test.ts
@@ -166,5 +166,26 @@ describe("TaskHistory", () => {
       expect(result).not.toContain("\n\n")
       expect(result).toContain("Line1 Line2 Line3")
     })
+
+    it("handles entries with undefined description without throwing", () => {
+      //#given
+      const history = new TaskHistory()
+      history.record("parent-1", { id: "t1", agent: "explore", description: "", status: "pending" })
+      const state = history as unknown as {
+        entries: Map<string, Array<{ description?: string }>>
+      }
+      const list = state.entries.get("parent-1")
+      if (!list) {
+        throw new Error("Expected task history entries for parent-1")
+      }
+      list[0].description = undefined
+
+      //#when
+      const result = history.formatForCompaction("parent-1")
+
+      //#then
+      expect(result).toContain("**explore**")
+      expect(result).toContain("(pending)")
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Prevent `TaskHistory.formatForCompaction()` from crashing when a task entry has an undefined `description`.
- Keep compaction output formatting stable by defaulting missing descriptions to an empty string.
- Add a regression test that reproduces the undefined-description scenario.

## Changes
- Updated `src/features/background-agent/task-history.ts`:
  - Guarded description sanitization with `(e.description ?? "")` before `.replace()`.
- Updated `src/features/background-agent/task-history.test.ts`:
  - Added `handles entries with undefined description without throwing` test case.

## Testing
```bash
bun test src/features/background-agent/task-history.test.ts
bun run typecheck
bun run build
```

## Related Issues
Closes #1991

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent TaskHistory.formatForCompaction from crashing on undefined descriptions by defaulting to an empty string. Adds a regression test to cover the case; addresses #1991.

<sup>Written for commit ff9de5d7646d7429bc1ea4b51e53b2d8d6b25dd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

