### PR TITLE
fix(tmux-deferred): add TTL/max-size guards, null-state exit, and spawn atomicity

### DIFF
--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -410,7 +410,6 @@ export class TmuxSessionManager {
         const closeActionSucceeded = result.results.some(
           ({ action, result: actionResult }) => action.type === "close" && actionResult.success,
         )
-        const spawnFailed = !result.success || !result.spawnedPaneId
 
         if (result.success && result.spawnedPaneId) {
           const sessionReady = await this.waitForSessionReady(sessionId)


### PR DESCRIPTION
## Summary
- **BUG-3**: Add `DEFERRED_SESSION_TTL_MS` (5min) and `MAX_DEFERRED_QUEUE_SIZE` (20) to prevent unbounded deferred queue growth
- **BUG-15**: Track consecutive null window states via `nullStateCount`, stop polling after 3 nulls to prevent immortal loop
- **BUG-6**: Track close+spawn failure and re-queue deferred session for retry instead of silently dropping

## Changes
- `src/features/tmux-subagent/manager.ts`: TTL expiry check, queue size guard, null-state counter, re-queue on close+spawn failure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the tmux deferred attach loop with TTL and max queue size, exits on repeated null window states, and makes spawn handling atomic with close to prevent dropped sessions.

- **Bug Fixes**
  - BUG-3: Add 5-minute TTL and cap deferred queue at 20.
  - BUG-15: Stop polling after 3 consecutive null window states; reset counter on start/stop and on valid state.
  - BUG-6: If close succeeds but spawn fails, re-queue the session for retry.

- **Refactors**
  - Remove unused spawnFailed variable.

<sup>Written for commit 148687c7fe185f8f76e93d245ee62eee27c3dd9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

