### PR TITLE
fix(skill/command): add user_message param to skill tool, fix command priority order

### DIFF
--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -67,13 +67,12 @@
 | `session_search` | `createSessionManagerTools` | query, session_id, case_sensitive, limit |
 | `session_info` | `createSessionManagerTools` | session_id |
 
-### Skill/Command (3)
+### Skill/Command (2)
 
 | Tool | Factory | Parameters |
 |------|---------|------------|
-| `skill` | `createSkillTool` | name |
+| `skill` | `createSkillTool` | name, user_message |
 | `skill_mcp` | `createSkillMcpTool` | mcp_name, tool_name/resource_name/prompt_name, arguments, grep |
-| `slashcommand` | `createSlashcommandTool` | command, user_message |
 
 ### System (2)
 

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -224,6 +224,10 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
     },
     args: {
       name: tool.schema.string().describe("The skill or command name (e.g., 'code-review' or 'publish'). Use without leading slash for commands."),
+      user_message: tool.schema
+        .string()
+        .optional()
+        .describe("Optional arguments or context for command invocation. Example: name='publish', user_message='patch'"),
     },
     async execute(args: SkillArgs, ctx?: { agent?: string }) {
       const skills = await getSkills()
@@ -273,7 +277,7 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
       const matchedCommand = commands.find(c => c.name.toLowerCase() === requestedName.toLowerCase())
 
       if (matchedCommand) {
-        return await formatLoadedCommand(matchedCommand)
+        return await formatLoadedCommand(matchedCommand, args.user_message)
       }
 
       // No match found — provide helpful error with partial matches

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -5,6 +5,7 @@ import type { CommandInfo } from "../slashcommand/types"
 
 export interface SkillArgs {
   name: string
+  user_message?: string
 }
 
 export interface SkillInfo {

--- a/src/tools/slashcommand/command-discovery.ts
+++ b/src/tools/slashcommand/command-discovery.ts
@@ -76,10 +76,10 @@ export function discoverCommandsSync(directory?: string): CommandInfo[] {
   }))
 
   return [
-    ...builtinCommands,
-    ...opencodeProjectCommands,
-    ...projectCommands,
-    ...opencodeGlobalCommands,
     ...userCommands,
+    ...projectCommands,
+    ...opencodeProjectCommands,
+    ...opencodeGlobalCommands,
+    ...builtinCommands,
   ]
 }


### PR DESCRIPTION
## Summary
- **BUG-20**: Add optional `user_message` parameter to skill tool for command argument passing
- **BUG-19**: Fix command discovery priority: user > project > opencode-project > opencode-global > builtin

## Changes
- `src/tools/skill/tools.ts`: Add `user_message` param, pass to `formatLoadedCommand()`
- `src/tools/skill/types.ts`: Add `user_message?: string` to `SkillArgs`
- `src/tools/slashcommand/command-discovery.ts`: Reverse priority order
- `src/tools/AGENTS.md`: Documentation update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional user_message to the skill tool for passing command arguments (BUG-20) and fixes command discovery to prefer user and project commands (BUG-19).

- **Bug Fixes**
  - Skill tool: add optional user_message and pass it to command execution; update AGENTS.md to remove slashcommand and document the new param.
  - Command discovery: set priority to user > project > opencode-project > opencode-global > builtin.

<sup>Written for commit 945c7e658a8e5e596988e2b43fc6c2d754ca2c2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

