### PR TITLE
fix(hashline-edit): restore leading indentation for first line in replace_lines

### DIFF
--- a/src/tools/hashline-edit/edit-operations.test.ts
+++ b/src/tools/hashline-edit/edit-operations.test.ts
@@ -128,7 +128,7 @@ describe("hashline edit operations", () => {
     expect(result).toEqual(["before", "new 1", "new 2", "after"])
   })
 
-  it("does not restore indentation for replace_lines", () => {
+  it("restores indentation for first replace_lines entry", () => {
     //#given
     const lines = ["if (x) {", "  return 1", "  return 2", "}"]
 
@@ -136,6 +136,6 @@ describe("hashline edit operations", () => {
     const result = applyReplaceLines(lines, anchorFor(lines, 2), anchorFor(lines, 3), ["return 3", "return 4"])
 
     //#then
-    expect(result).toEqual(["if (x) {", "return 3", "return 4", "}"])
+    expect(result).toEqual(["if (x) {", "  return 3", "return 4", "}"])
   })
 })

--- a/src/tools/hashline-edit/edit-operations.ts
+++ b/src/tools/hashline-edit/edit-operations.ts
@@ -124,7 +124,11 @@ export function applyReplaceLines(
 
   const result = [...lines]
   const stripped = stripRangeBoundaryEcho(lines, startLine, endLine, toNewLines(newText))
-  result.splice(startLine - 1, endLine - startLine + 1, ...stripped)
+  const restored = stripped.map((entry, idx) => {
+    if (idx !== 0) return entry
+    return restoreLeadingIndent(lines[startLine - 1], entry)
+  })
+  result.splice(startLine - 1, endLine - startLine + 1, ...restored)
   return result
 }
 


### PR DESCRIPTION
## Summary
- **BUG-21**: Apply `restoreLeadingIndent` to first entry of `replace_lines`, matching `set_line` behavior

## Changes
- `src/tools/hashline-edit/edit-operations.ts`: Map first stripped entry through `restoreLeadingIndent`
- `src/tools/hashline-edit/edit-operations.test.ts`: Update test to verify indentation preservation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore leading indentation for the first line in replace_lines to match set_line behavior, fixing BUG-21. Update tests to verify indentation is preserved.

<sup>Written for commit 07fa0560c243af5bfdcbdd3c9df7e076b0512e12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

