### PR TITLE
fix(migration): remove non-existent gpt-5.3-codex migration from MODEL_VERSION_MAP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           bun test src/tools/call-omo-agent/session-creator.test.ts
           bun test src/tools/session-manager
           bun test src/features/opencode-skill-loader/loader.test.ts
+          bun test src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
 
       - name: Run remaining tests
         run: |
@@ -65,6 +66,7 @@ jobs:
           # that were already run in isolation above.
           # Excluded from src/cli: doctor/formatter.test.ts, doctor/format-default.test.ts
           # Excluded from src/tools: call-omo-agent/sync-executor.test.ts, call-omo-agent/session-creator.test.ts, session-manager (all)
+          # Excluded from src/hooks/anthropic-context-window-limit-recovery: recovery-hook.test.ts
           bun test bin script src/config src/mcp src/index.test.ts \
             src/agents src/shared \
             src/cli/run src/cli/config-manager src/cli/mcp-oauth \
@@ -78,7 +80,7 @@ jobs:
             src/tools/call-omo-agent/background-agent-executor.test.ts \
             src/tools/call-omo-agent/background-executor.test.ts \
             src/tools/call-omo-agent/subagent-session-creator.test.ts \
-            src/hooks/anthropic-context-window-limit-recovery \
+            src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.test.ts src/hooks/anthropic-context-window-limit-recovery/executor.test.ts src/hooks/anthropic-context-window-limit-recovery/parser.test.ts src/hooks/anthropic-context-window-limit-recovery/pruning-deduplication.test.ts src/hooks/anthropic-context-window-limit-recovery/recovery-deduplication.test.ts src/hooks/anthropic-context-window-limit-recovery/storage.test.ts \
             src/hooks/claude-code-compatibility \
             src/hooks/context-injection \
             src/hooks/provider-toast \

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,30 +1,26 @@
 > [!WARNING]
-> **セキュリティ警告：なりすましサイト**
+> **セキュリティ警告: 偽装サイトにご注意ください**
 >
-> **ohmyopencode.comは本プロジェクトとは一切関係ありません。** 当方はそのサイトを運営しておらず、推奨もしていません。
+> **ohmyopencode.com はこのプロジェクトとは一切関係がありません。** 私たちはそのサイトを運営したり承認したりしていません。
 >
-> OhMyOpenCodeは**無料かつオープンソース**です。「公式」を名乗るサードパーティサイトでインストーラーをダウンロードしたり、支払い情報を入力したり**しないでください**。
+> OhMyOpenCodeは**無料かつオープンソース**です。「公式」を名乗る第三者のサイトからインストーラーをダウンロードしたり、支払い情報を入力したり**しないでください。**
 >
-> なりすましサイトはペイウォールの裏にあるため、**何が配布されているか確認できません**。そこからのダウンロードは**潜在的に危険なもの**として扱ってください。
+> 偽装サイトはペイウォールの背後に隠れており、**どのような悪意あるプログラムを配布しているか検証できません**。そこからのダウンロードはすべて**潜在的に危険**であると見なしてください。
 >
-> ✅ 公式ダウンロード：https://github.com/code-yeongyu/oh-my-opencode/releases
+> ✅ 公式ダウンロード: https://github.com/code-yeongyu/oh-my-opencode/releases
 
 > [!NOTE]
 >
-> [![Sisyphus Labs — Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)
-> > **Sisyphusの完全製品化バージョンを構築中です。フロンティアエージェントの未来を定義します。<br />[こちら](https://sisyphuslabs.ai)からウェイトリストに参加してください。**
+> [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)
+> > **私たちは、フロンティアエージェントの未来を定義するために、Sisyphusの完全なプロダクト版を構築しています。 <br />[こちら](https://sisyphuslabs.ai)からウェイトリストにご登録ください。**
 
 > [!TIP]
+> 私たちと一緒に！
 >
-> [![Oh My OpenCode 3.0が正式リリースされました！](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0)
-> > **Oh My OpenCode 3.0が正式リリースされました！`oh-my-opencode@latest`を使用してインストールしてください。**
->
-> 一緒に歩みましょう！
->
-> | [<img alt="Discord link" src="https://img.shields.io/discord/1452487457085063218?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/PUwSMR9XNk) | [Discordコミュニティ](https://discord.gg/PUwSMR9XNk)に参加して、コントリビューターや`oh-my-opencode`仲間とつながりましょう。 |
+> | [<img alt="Discord link" src="https://img.shields.io/discord/1452487457085063218?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/PUwSMR9XNk) | [Discordコミュニティ](https://discord.gg/PUwSMR9XNk)に参加して、コントリビューターや他の `oh-my-opencode` ユーザーと交流しましょう。 |
 > | :-----| :----- |
-> | [<img alt="X link" src="https://img.shields.io/badge/Follow-%40justsisyphus-00CED1?style=flat-square&logo=x&labelColor=black" width="156px" />](https://x.com/justsisyphus) | `oh-my-opencode`に関するニュースは私のXアカウントで投稿していましたが、無実の罪で凍結されたため、<br />[@justsisyphus](https://x.com/justsisyphus)が代わりに更新を投稿しています。 |
-> | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/code-yeongyu?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/code-yeongyu) | GitHubで[@code-yeongyu](https://github.com/code-yeongyu)をフォローして、他のプロジェクトもチェックしてください。 |
+> | [<img alt="X link" src="https://img.shields.io/badge/Follow-%40justsisyphus-00CED1?style=flat-square&logo=x&labelColor=black" width="156px" />](https://x.com/justsisyphus) | `oh-my-opencode` のニュースやアップデートは私のXアカウントで投稿されていましたが、 <br /> 誤って凍結されてしまったため、現在は [@justsisyphus](https://x.com/justsisyphus) が代わりにアップデートを投稿しています。 |
+> | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/code-yeongyu?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/code-yeongyu) | さらに多くのプロジェクトを見たい場合は、GitHubで [@code-yeongyu](https://github.com/code-yeongyu) をフォローしてください。 |
 
 <!-- <CENTERED SECTION FOR GITHUB DISPLAY> -->
 
@@ -34,34 +30,11 @@
 
 [![Preview](./.github/assets/omo.png)](https://github.com/code-yeongyu/oh-my-opencode#oh-my-opencode)
 
-
 </div>
 
-> `oh-my-opencode` をインストールして、ドーピングしたかのようにコーディングしましょう。バックグラウンドでエージェントを走らせ、oracle、librarian、frontend engineer のような専門エージェントを呼び出してください。丹精込めて作られた LSP/AST ツール、厳選された MCP、そして完全な Claude Code 互換レイヤーを、たった一行で手に入れましょう。
-
-# Claude OAuth アクセスに関するお知らせ
-
-## TL;DR
-
-> Q. oh-my-opencodeを使用できますか？
-
-はい。
-
-> Q. Claude Codeのサブスクリプションで使用できますか？
-
-はい、技術的には可能です。ただし、使用を推奨することはできません。
-
-## 詳細
-
-> 2026年1月より、AnthropicはToS違反を理由にサードパーティのOAuthアクセスを制限しました。
+> これはステロイドを打ったコーディングです。一つのモデルのステロイドじゃない——薬局丸ごとです。
 >
-> [**Anthropicはこのプロジェクト oh-my-opencode を、opencodeをブロックする正当化の根拠として挙げています。**](https://x.com/thdxr/status/2010149530486911014)
->
-> 実際、Claude CodeのOAuthリクエストシグネチャを偽装するプラグインがコミュニティに存在します。
->
-> これらのツールは技術的な検出可能性に関わらず動作する可能性がありますが、ユーザーはToSへの影響を認識すべきであり、私個人としてはそれらの使用を推奨できません。
->
-> このプロジェクトは非公式ツールの使用に起因するいかなる問題についても責任を負いません。また、**私たちはそれらのOAuthシステムのカスタム実装を一切持っていません。**
+> Claudeでオーケストレーションし、GPTで推論し、Kimiでスピードを出し、Geminiでビジョンを処理する。モデルはどんどん安くなり、どんどん賢くなる。特定のプロバイダーが独占することはない。私たちはその開かれた市場のために構築している。Anthropicの牢獄は素敵だ。だが、私たちはそこに住まない。
 
 <div align="center">
 
@@ -72,210 +45,252 @@
 [![GitHub Stars](https://img.shields.io/github/stars/code-yeongyu/oh-my-opencode?color=ffcb47&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/stargazers)
 [![GitHub Issues](https://img.shields.io/github/issues/code-yeongyu/oh-my-opencode?color=ff80eb&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/issues)
 [![License](https://img.shields.io/badge/license-SUL--1.0-white?labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/blob/master/LICENSE.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/code-yeongyu/oh-my-opencode)
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-cn.md)
-
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/code-yeongyu/oh-my-opencode)
 
 </div>
 
 <!-- </CENTERED SECTION FOR GITHUB DISPLAY> -->
 
-## ユーザーレビュー
+## レビュー
 
-> "Cursorのサブスクリプションを解約しました。オープンソースコミュニティで信じられないことが起きています。" - [Arthur Guiot](https://x.com/arthur_guiot/status/2008736347092382053?s=20)
+> 「これのおかげで Cursor のサブスクリプションを解約しました。オープンソースコミュニティで信じられないことが起きています。」 - [Arthur Guiot](https://x.com/arthur_guiot/status/2008736347092382053?s=20)
 
-> "人間が3ヶ月かかる仕事をClaude Codeが7日でやるなら、Sisyphusは1時間でやります。タスクが完了するまでただ動き続ける。It is a discipline agent." — B, Quant Researcher
+> 「Claude Codeが人間なら3ヶ月かかることを7日でやるとしたら、Sisyphusはそれを1時間でやってのけます。タスクが終わるまでひたすら働き続けます。まさに規律あるエージェントです。」 <br/>- B, Quant Researcher
 
-> "Oh My Opencodeを使って、たった1日で8000個のeslint警告を解消しました" — [Jacob Ferrari](https://x.com/jacobferrari_/status/2003258761952289061)
+> 「Oh My Opencodeを使って、たった1日で8000個の eslint 警告を叩き潰しました。」 <br/>- [Jacob Ferrari](https://x.com/jacobferrari_/status/2003258761952289061)
 
-> "Ohmyopencodeとralph loopを使って、一晩で45,000行のtauriアプリをSaaSウェブアプリに変換しました。インタビュープロンプトから始めて、質問に対する評価と推奨を求めました。作業する様子を見ているのは驚きでしたし、朝起きたらほぼ完成したウェブサイトがありました！" - [James Hargis](https://x.com/hargabyte/status/2007299688261882202)
+> 「Ohmyopencodeとralph loopを使って、45k行のtauriアプリを一晩でSaaSウェブアプリに変換しました。インタビューモードから始めて、私のプロンプトに対して質問や推奨事項を尋ねました。勝手に作業していくのを見るのは楽しかったし、今朝起きたらウェブサイトがほぼ動いているのを見て驚愕しました！」 - [James Hargis](https://x.com/hargabyte/status/2007299688261882202)
 
-> "oh-my-opencodeを使ってください、もう戻れませんよ" — [d0t3ch](https://x.com/d0t3ch/status/2001685618200580503)
+> 「oh-my-opencodeを使ってください。もう二度と元には戻れません。」 <br/>- [d0t3ch](https://x.com/d0t3ch/status/2001685618200580503)
 
-> "何どうすごいのかあまり言語化できてないけど、開発体験が異次元に上がった。" - [苔硯:こけすずり](https://x.com/kokesuzuri/status/2008532913961529372?s=20)
+> 「何がどうすごいのかまだ上手く言語化できないんですが、開発体験が完全に異次元に到達してしまいました。」 - [苔硯:こけすずり](https://x.com/kokesuzuri/status/2008532913961529372?s=20)
 
-> "今週末はopen code、oh my opencode、supermemoryでマインクラフト/ソウルライクな何かを作る実験をしています。"
-> "昼食後の散歩に行く間に、しゃがみアニメーションを追加するよう頼みました。[動画]" - [MagiMetal](https://x.com/MagiMetal/status/2005374704178373023)
+> 「週末にマインクラフト/ソウルライクな化け物を作ろうと、open code、oh my opencode、supermemoryで実験中です。昼食後の散歩に行っている間に、しゃがむアニメーションを追加するように指示しておきました。[動画]」 - [MagiMetal](https://x.com/MagiMetal/status/2005374704178373023)
 
-> "これをコアに取り入れて彼を採用すべきです。マジで。本当に、本当に、本当に良いです" — Henning Kilset
+> 「これをコアに取り込んで彼を採用すべきだ。マジで。これ、本当に、本当に、本当に良い。」 <br/>- Henning Kilset
 
-> "@yeon_gyu_kimを説得できるなら雇うべきです。彼はopencodeに革命を起こしました" — [mysticaltech](https://x.com/mysticaltech/status/2001858758608376079)
+> 「彼を説得できるなら @yeon_gyu_kim を雇ってください。彼がopencodeに革命を起こしました。」 <br/>- [mysticaltech](https://x.com/mysticaltech/status/2001858758608376079)
 
-> "Oh My OpenCode Is Actually Insane" - [YouTube - Darren Builds AI](https://www.youtube.com/watch?v=G_Snfh2M41M)
+> 「Oh My OpenCodeはマジでヤバい」 - [YouTube - Darren Builds AI](https://www.youtube.com/watch?v=G_Snfh2M41M)
 
 ---
 
-## 目次
-
-- [Oh My OpenCode](#oh-my-opencode)
-  - [この Readme は読まなくていいです](#この-readme-は読まなくていいです)
-    - [エージェントの時代ですから](#エージェントの時代ですから)
-    - [🪄 魔法の言葉：`ultrawork`](#-魔法の言葉ultrawork)
-    - [読みたい方のために：シジフォスに会う](#読みたい方のためにシジフォスに会う)
-    - [自律性を求めるなら: ヘパイストスに会おう](#自律性を求めるなら-ヘパイストスに会おう)
-      - [インストールするだけで。](#インストールするだけで)
-  - [インストール](#インストール)
-    - [人間の方へ](#人間の方へ)
-    - [LLM エージェントの方へ](#llm-エージェントの方へ)
-  - [アンインストール](#アンインストール)
-  - [機能](#機能)
-  - [設定](#設定)
-  - [作者のノート](#作者のノート)
-  - [注意](#注意)
-  - [こちらの企業の専門家にご愛用いただいています](#こちらの企業の専門家にご愛用いただいています)
-  - [スポンサー](#スポンサー)
-
 # Oh My OpenCode
 
-oMoMoMoMoMo···
+最初はこれを「Claude Codeにステロイドを打ったもの」と呼んでいました。それは過小評価でした。
 
+一つのモデルに薬を盛るのではありません。カルテルを動かすんです。Claude、GPT、Kimi、Gemini——それぞれが得意なことを、並列で、止まらずに。モデルは毎月安くなっており、どのプロバイダーも独占できません。私たちはすでにその世界に生きています。
 
-[Claude Code](https://www.claude.com/product/claude-code) は素晴らしいですよね。
-でも、もしあなたがハッカーなら、[OpenCode](https://github.com/sst/opencode) と恋に落ちることになるでしょう。
-**今すぐ始めましょう。ChatGPT、Claude、Gemini のサブスクリプション、OpenCode がすべてサポートしています。**
+その泥臭い作業をすべてやっておきました。すべてをテストし、実際に機能するものだけを残しました。
 
-- 無限に拡張可能で、無限にカスタマイズ可能です。
-- 画面のチラつき（フリッカー）がありません。
-- 編集するファイルに合わせて [LSP](https://opencode.ai/docs/lsp/)、[Linter、Formatter](https://opencode.ai/docs/formatters/) が自動的に有効化され、すべて調整可能です。
-- 複数のモデルを組み合わせて使用でき、**用途に応じてオーケストレーションできます。**
-- 機能が豊富で、美しい。ターミナルが描画に苦しむことはありません。高パフォーマンスです。
+OmOをインストールして、`ultrawork`とタイプしてください。狂ったようにコーディングしてください。
 
-Windows から Linux に初めて乗り換えた時のこと、自分の思い通りに設定して興奮したあの感覚を覚えていますか？
-そんな魔法が失われたかのような今の時代に、OpenCode はその感覚を取り戻してくれます。
-コーディングとコンピュータを愛するあなたにとって、OpenCode はまさに「Windows の後の Linux」のような瞬間になるはずです。
-
-**しかし問題は、学ぶべきことが多すぎること、複雑であること、そしてあなたの時間は高価だということです。**
-
-私がその問題を解決しました。
-あなたがハッカーでなくても構いません。数分の投資で、スキルと生産性を何倍にもブーストしてください。
-このドキュメントをエージェントに渡して、セットアップを任せましょう。
-
-## この Readme は読まなくていいです
-
-### エージェントの時代ですから
-- **ただこのリンクを Claude Code / AmpCode / Factory Droid / Cursor に貼り付けて、説明を求めてください。**
-  - なぜこれが良いのか、単なるボイラープレートではないのか、具体的に何が良くなるのか聞いてみてください。
-  - もしあなたが LLM エージェントなら、このプロジェクトによって今すぐ何が可能になるのか、ユーザーに説明してください。
-
-### 🪄 魔法の言葉：`ultrawork`
-
-**これ全部読みたくない？プロンプトに `ultrawork`（または `ulw`）を入れるだけでOK。**
-
-それだけです。私たちが提供するすべての機能が魔法のように動作します—並列エージェント、バックグラウンドタスク、深い探索、そして完了するまで止まらない実行。エージェントが自動的にすべてを処理します。
-
-### 読みたい方のために：シジフォスに会う
-
-![Meet Sisyphus](.github/assets/sisyphus.png)
-
-神話の中のシジフォスは、神々を欺いた罪として、永遠に岩を転がし続けなければなりませんでした。LLMエージェントたちは特に悪いことをしたわけではありませんが、毎日その頭（思考）をフル回転させています。
-私の人生もそうです。振り返ってみれば、私たち人間と何ら変わりありません。
-**はい！LLMエージェントたちは私たちと変わりません。優れたツールと最高の仲間がいれば、彼らも私たちと同じくらい優れたコードを書き、立派に仕事をこなすことができます。**
-
-私たちのメインエージェント、Sisyphus（Opus 4.6）を紹介します。以下は、シジフォスが岩を転がすために使用するツールです。
-
-*以下の内容はすべてカスタマイズ可能です。必要なものだけを使ってください。デフォルトではすべての機能が有効になっています。何もしなくても大丈夫です。*
-
-- シジフォスのチームメイト (Curated Agents)
-  - Hephaestus: 自律型ディープワーカー、目標指向実行 (GPT 5.3 Codex Medium) — *正当な職人*
-  - Oracle: 設計、デバッグ (GPT 5.2)
-  - Frontend UI/UX Engineer: フロントエンド開発 (Gemini 3 Pro)
-  - Librarian: 公式ドキュメント、オープンソース実装、コードベース探索 (GLM-4.7)
-   - Explore: 超高速コードベース探索 (Contextual Grep) (Grok Code Fast 1)
-- Full LSP / AstGrep Support: 決定的にリファクタリングしましょう。
-- ハッシュアンカード編集ツール: `LINE#ID` 形式で変更前にコンテンツハッシュを検証します。古い行の編集はもう不要です。
-- Todo Continuation Enforcer: 途中で諦めたら、続行を強制します。これがシジフォスに岩を転がし続けさせる秘訣です。
-- Comment Checker: AIが過剰なコメントを付けないようにします。シジフォスが生成したコードは、人間が書いたものと区別がつかないべきです。
-- Claude Code Compatibility: Command, Agent, Skill, MCP, Hook(PreToolUse, PostToolUse, UserPromptSubmit, Stop)
-- Curated MCPs:
-  - Exa (Web Search)
-  - Context7 (Official Documentation)
-  - Grep.app (GitHub Code Search)
-- Interactive Terminal Supported - Tmux Integration
-- Async Agents
-- ...
-
-### 自律性を求めるなら: ヘパイストスに会おう
-
-![Meet Hephaestus](.github/assets/hephaestus.png)
-
-ギリシャ神話において、ヘパイストスは鍛冶、火、金属加工、職人技の神でした—比類のない精密さと献身で神々の武器を作り上げた神聖な鍛冶師です。
-**自律型ディープワーカーを紹介します: ヘパイストス (GPT 5.3 Codex Medium)。正当な職人エージェント。**
-
-*なぜ「正当な」なのか？Anthropicがサードパーティアクセスを利用規約違反を理由にブロックした時、コミュニティで「正当な」使用についてのジョークが始まりました。ヘパイストスはこの皮肉を受け入れています—彼は近道をせず、正しい方法で、体系的かつ徹底的に物を作る職人です。*
-
-ヘパイストスは[AmpCodeのディープモード](https://ampcode.com)にインスパイアされました—決定的な行動の前に徹底的な調査を行う自律的問題解決。ステップバイステップの指示は必要ありません；目標を与えれば、残りは自分で考えます。
-
-**主な特徴:**
-- **目標指向**: レシピではなく目標を与えてください。ステップは自分で決めます。
-- **行動前の探索**: コードを1行書く前に、2-5個のexplore/librarianエージェントを並列で起動します。
-- **エンドツーエンドの完了**: 検証の証拠とともに100%完了するまで止まりません。
-- **パターンマッチング**: 既存のコードベースを検索してプロジェクトのスタイルに合わせます—AIスロップなし。
-- **正当な精密さ**: マスター鍛冶師のようにコードを作ります—外科的に、最小限に、必要なものだけを正確に。
-
-#### インストールするだけで。
-
-[overview page](docs/guide/overview.md) を読めば多くのことが学べますが、以下はワークフローの例です。
-
-インストールするだけで、エージェントは以下のようなワークフローで働けるようになります：
-
-1. Sisyphusは自分自身でファイルを探し回るような時間の無駄はしません。メインエージェントのコンテキストを軽量に保つため、より高速で安価なモデルへ並列でバックグラウンドタスクを飛ばし、自身の代わりに領域の調査を完了させます。
-1. SisyphusはリファクタリングにLSPを活用します。その方が確実で、安全、かつ的確だからです。
-1. UIに関わる重い作業が必要な場合、SisyphusはフロントエンドのタスクをGemini 3 Proに直接デリゲートします。
-1. もしSisyphusがループに陥ったり壁にぶつかったりしても、無駄に悩み続けることはありません。高IQな戦略的バックアップとしてGPT 5.2を呼び出します。
-1. 複雑なオープンソースフレームワークを扱っていますか？Sisyphusはサブエージェントを生成し、生のソースコードやドキュメントをリアルタイムで消化します。彼は完全なコンテキスト認識を持って動作します。
-1. Sisyphusがコメントに触れるとき、その存在意義を証明するか、さもなくば削除します。あなたのコードベースを常にクリーンに保ちます。
-1. Sisyphusは自身のTODOリストに縛られています。もし始めたことを終わらせられなければ、システムは彼を強制的に「bouldering」モードに戻します。あなたのタスクは、何があろうと完了します。
-1. 正直、ドキュメントなんて読む必要はありません。ただプロンプトを書いてください。「ultrawork」というキーワードを含めるだけで十分です。Sisyphusが構造を分析し、コンテキストを集め、外部のソースコードまで掘り下げ、仕事が100%完了するまでboulderingを続けます。
-1. ぶっちゃけ、「ultrawork」と打つのすら面倒ですよね。それなら「ulw」だけでOKです。ただulwと打ち、コーヒーでも飲んでいてください。仕事は終わっています。
-
-このような機能が不要であれば、前述の通り、特定の機能だけを選んで使うことができます。
 
 ## インストール
 
-### 人間の方へ
+### 人間向け
 
-以下のプロンプトをコピーして、LLM エージェント（Claude Code、AmpCode、Cursor など）に貼り付けてください：
+以下のプロンプトをコピーして、あなたのLLMエージェント（Claude Code、AmpCode、Cursorなど）に貼り付けてください：
 
 ```
-oh-my-opencode をインストールして設定してください。以下の手順に従ってください：
+Install and configure oh-my-opencode by following the instructions here:
 https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
 ```
 
-または [インストールガイド](docs/guide/installation.md) を直接読んでください。ただし、エージェントに任せることを強くお勧めします。人間はミスをしますが、エージェントはしません。
+もしくは[インストールガイド](docs/guide/installation.md)を直接読んでもいいですが、マジでエージェントにやらせてください。人間は設定で必ずタイポします。
 
-### LLM エージェントの方へ
+### LLMエージェント向け
 
-インストールガイドを取得して、その指示に従ってください：
+インストールガイドを取得して、それに従ってください：
 
 ```bash
 curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
 ```
 
+---
 
-## アンインストール
+## このREADMEをスキップする
 
-oh-my-opencode を削除するには：
+ドキュメントを読む時代は終わりました。このテキストをエージェントに貼り付けるだけです：
 
-1. **OpenCode 設定からプラグインを削除**
+```
+Read this and tell me why it's not just another boilerplate: https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/dev/README.md
+```
 
-   `~/.config/opencode/opencode.json` (または `opencode.jsonc`) を編集し、`plugin` 配列から `"oh-my-opencode"` を削除します：
+## ハイライト
+
+### 🪄 `ultrawork`
+
+本当にこれを全部読んでるんですか？信じられない。
+
+インストールして、`ultrawork`（または `ulw`）とタイプする。完了です。
+
+以下の内容、すべての機能、すべての最適化、何も知る必要はありません。ただ勝手に動きます。
+
+以下のサブスクリプションだけでも、ultraworkは十分に機能します（このプロジェクトとは無関係であり、個人的な推奨にすぎません）：
+- [ChatGPT サブスクリプション ($20)](https://chatgpt.com/)
+- [Kimi Code サブスクリプション ($0.99) (*今月限定)](https://www.kimi.com/membership/pricing?track_id=5cdeca93-66f0-4d35-aabb-b6df8fcea328)
+- [GLM Coding プラン ($10)](https://z.ai/subscribe)
+- 従量課金（pay-per-token）の対象であれば、kimiやgeminiモデルを使っても費用はほとんどかかりません。
+- [quotio](https://github.com/nguyenphutrong/quotio)や[cliproxyapi](https://github.com/router-for-me/CLIProxyAPI)のようなプロジェクトもあります。プロバイダーの規約違反になる可能性もありますが、コミュニティのユーザーの一部はよく使用しています。
+
+|       | 機能                      | 何をするのか                                                                                                                        |
+| :---: | :--------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- |
+|   🤖   | **規律あるエージェント (Discipline Agents)** | Sisyphusが Hephaestus、Oracle、Librarian、Exploreをオーケストレーションします。完全なAI開発チームが並列で動きます。 |
+|   ⚡   | **`ultrawork` / `ulw`**      | 一言でOK。すべてのエージェントがアクティブになり、終わるまで止まりません。 |
+|   🚪   | **[IntentGate](https://factory.ai/news/terminal-bench)**                 | ユーザーの真の意図を分析してから分類・行動します。もう文字通りに誤解して的外れなことをすることはありません。 |
+|   🔗   | **ハッシュベースの編集ツール**  | `LINE#ID` のコンテンツハッシュですべての変更を検証します。stale-lineエラー0%。[oh-my-pi](https://github.com/can1357/oh-my-pi)にインスパイアされています。[ハーネス問題 →](https://blog.can.ac/2026/02/12/the-harness-problem/) |
+|   🛠️   | **LSP + AST-Grep**           | ワークスペース単位のリネーム、ビルド前の診断、ASTを考慮した書き換え。エージェントにIDEレベルの精度を提供します。 |
+|   🧠   | **バックグラウンドエージェント**        | 5人以上の専門家を並列で投入します。コンテキストは軽く保ち、結果は準備ができ次第受け取ります。 |
+|   📚   | **組み込みMCP**            | Exa（Web検索）、Context7（公式ドキュメント）、Grep.app（GitHub検索）。常にオンです。 |
+|   🔁   | **Ralph Loop / `/ulw-loop`** | 自己参照ループ。100%完了するまで絶対に止まりません。 |
+|   ✅   | **Todoの強制執行**            | エージェントがサボる？システムが首根っこを掴んで戻します。あなたのタスクは必ず終わります。 |
+|   💬   | **コメントチェッカー**          | コメントからAI臭い無駄話を排除します。シニアエンジニアが書いたようなコードになります。 |
+|   🖥️   | **Tmux統合**         | 完全なインタラクティブターミナル。REPL、デバッガー、TUIアプリがすべてリアルタイムで動きます。 |
+|   🔌   | **Claude Code互換性**   | 既存のフック、コマンド、スキル、MCP、プラグイン？すべてここでそのまま動きます。 |
+|   🎯   | **スキル内蔵MCP**      | スキルが独自のMCPサーバーを持ち歩きます。コンテキストが肥大化しません。 |
+|   📋   | **Prometheusプランナー**       | インタビューモードで、コードを1行触る前に戦略的な計画から立てます。 |
+|   🔍   | **`/init-deep`**             | プロジェクト全体にわたって階層的な `AGENTS.md` ファイルを自動生成します。トークン効率とエージェントのパフォーマンスの両方を向上させます。 |
+
+### 規律あるエージェント (Discipline Agents)
+
+<table><tr>
+<td align="center"><img src=".github/assets/sisyphus.png" height="300" /></td>
+<td align="center"><img src=".github/assets/hephaestus.png" height="300" /></td>
+</tr></table>
+
+**Sisyphus** (`claude-opus-4-6` / **`kimi-k2.5`** / **`glm-5`**) はあなたのメインのオーケストレーターです。計画を立て、専門家に委任し、攻撃的な並列実行でタスクを完了まで推進します。途中で投げ出すことはありません。
+
+**Hephaestus** (`gpt-5.3-codex`) はあなたの自律的なディープワーカーです。レシピではなく、目標を与えてください。手取り足取り教えなくても、コードベースを探索し、パターンを研究し、端から端まで実行します。*正当なる職人 (The Legitimate Craftsman).*
+
+**Prometheus** (`claude-opus-4-6` / **`kimi-k2.5`** / **`glm-5`**) はあなたの戦略プランナーです。インタビューモードで動作し、コードに触れる前に質問をしてスコープを特定し、詳細な計画を構築します。
+
+すべてのエージェントは、それぞれのモデルの強みに合わせてチューニングされています。手動でモデルを切り替える必要はありません。[詳しくはこちら →](docs/guide/overview.md)
+
+> Anthropicが[私たちのせいでOpenCodeをブロックしました。](https://x.com/thdxr/status/2010149530486911014) だからこそHephaestusは「正当なる職人 (The Legitimate Craftsman)」と呼ばれているのです。皮肉を込めています。
+>
+> Opusで最もよく動きますが、Kimi K2.5 + GPT-5.3 Codexの組み合わせだけでも、バニラのClaude Codeを軽く凌駕します。設定は一切不要です。
+
+### エージェントの��ーケストレーション
+
+Sisyphusがサブエージェントにタスクを委任する際、モデルを直接選ぶことはありません。**カテゴリー**を選びます。カテゴリーは自動的に適切なモデルにマッピングされます：
+
+| カテゴリー             | 用途                      |
+| :------------------- | :--------------------------------- |
+| `visual-engineering` | フロントエンド、UI/UX、デザイン            |
+| `deep`               | 自律的なリサーチと実行    |
+| `quick`              | 単一ファイルの変更、タイポの修正         |
+| `ultrabrain`         | ハードロジック、アーキテクチャの決定 |
+
+エージェントがどのような種類の作業かを伝え、ハーネスが適切なモデルを選択します。あなたは何も触る必要はありません。
+
+### Claude Code互換性
+
+Claude Codeの設定を頑張りましたね。素晴らしい。
+
+すべてのフック、コマンド、スキル、MCP、プラグインが、変更なしでここで動きます。プラグインも含めて完全互換です。
+
+### エージェントのためのワールドクラスのツール
+
+LSP、AST-Grep、Tmux、MCPが、ただテープで貼り付けただけでなく、本当に「統合」されています。
+
+- **LSP**: `lsp_rename`、`lsp_goto_definition`、`lsp_find_references`、`lsp_diagnostics`。エージェントにIDEレベルの精度を提供。
+- **AST-Grep**: 25言語に対応したパターン認識コード検索と書き換え。
+- **Tmux**: 完全なインタラクティブターミナル。REPL、デバッガー、TUIアプリ。エージェントがセッション内で動きます。
+- **MCP**: Web検索、公式ドキュメント、GitHubコード検索がすべて組み込まれています。
+
+### スキル内蔵MCP
+
+MCPサーバーがあなたのコンテキスト予算を食いつぶしています。私たちがそれを修正しました。
+
+スキルが独自のMCPサーバーを持ち歩きます。必要なときだけ起動し、終われば消えます。コンテキストウィンドウがきれいに保たれます。
+
+### ハッシュベースの編集 (Codes Better. Hash-Anchored Edits)
+
+ハーネスの問題は深刻です。エージェントが失敗する原因の大半はモデルではなく、編集ツールにあります。
+
+> *「どのツールも、モデルに変更したい行に対する安定して検証可能な識別子を提供していません... すべてのツールが、モデルがすでに見た内容を正確に再現することに依存しています。それができないとき——そして大抵はできないのですが——ユーザーはモデルのせいにします。」*
+>
+> <br/>- [Can Bölük, ハーネス問題 (The Harness Problem)](https://blog.can.ac/2026/02/12/the-harness-problem/)
+
+[oh-my-pi](https://github.com/can1357/oh-my-pi) に触発され、**Hashline**を実装しました。エージェントが読むすべての行にコンテンツハッシュがタグ付けされて返されます：
+
+```
+11#VK: function hello() {
+22#XJ:   return "world";
+33#MB: }
+```
+
+エージェントはこのタグを参照して編集します。最後に読んだ後でファイルが変更されていた場合、ハッシュが一致せず、コードが壊れる前に編集が拒否されます。空白を正確に再現する必要もなく、間違った行を編集するエラー (stale-line) もありません。
+
+Grok Code Fast 1 で、成功率が **6.7% → 68.3%** に上昇しました。編集ツールを1つ変えただけで、です。
+
+### 深い初期化。`/init-deep`
+
+`/init-deep` を実行してください。階層的な `AGENTS.md` ファイルを生成します：
+
+```
+project/
+├── AGENTS.md              ← プロジェクト全体のコンテキスト
+├── src/
+│   ├── AGENTS.md          ← src 専用のコンテキスト
+│   └── components/
+│       └── AGENTS.md      ← コンポーネント専用のコンテキスト
+```
+
+エージェントが関連するコンテキストだけを自動で読み込みます。手動での管理はゼロです。
+
+### プランニング。Prometheus
+
+複雑なタスクですか？プロンプトを投げて祈るのはやめましょう。
+
+`/start-work` で Prometheus が呼び出されます。**本物のエンジニアのようにあなたにインタビューし**、スコープと曖昧さを特定し、コードに触れる前に検証済みの計画を構築します。エージェントは作業を始める前に、自分が何を作るべきか正確に理解します。
+
+### スキル (Skills)
+
+スキルは単なるプロンプトではありません。それぞれ以下をもたらします：
+
+- ドメインに最適化されたシステム命令
+- 必要なときに起動する組み込みMCPサーバー
+- スコープ制限された権限（エージェントが境界を越えないようにする）
+
+組み込み：`playwright`（ブラウザ自動化）、`git-master`（アトミックなコミット、リベース手術）、`frontend-ui-ux`（デザイン重視のUI）。
+
+独自に追加するには：`.opencode/skills/*/SKILL.md` または `~/.config/opencode/skills/*/SKILL.md`。
+
+**全機能を知りたいですか？** エージェント、フック、ツール、MCPなどの詳細は **[機能ドキュメント (Features)](docs/reference/features.md)** をご覧ください。
+
+---
+
+> **背景のストーリーを知りたいですか？** なぜSisyphusは岩を転がすのか、なぜHephaestusは「正当なる職人」なのか、そして[オーケストレーションガイド](docs/guide/orchestration.md)をお読みください。
+>
+> oh-my-opencodeは初めてですか？どのモデルを使うべきかについては、**[インストールガイド](docs/guide/installation.md#step-5-understand-your-model-setup)** で推奨モデルを確認してください。
+
+## アンインストール (Uninstallation)
+
+oh-my-opencodeを削除するには：
+
+1. **OpenCodeの設定からプラグインを削除する**
+
+   `~/.config/opencode/opencode.json`（または `opencode.jsonc`）を編集し、`plugin` 配列から `"oh-my-opencode"` を削除します：
 
    ```bash
-   # jq を使用する例
+   # jq を使用する場合
    jq '.plugin = [.plugin[] | select(. != "oh-my-opencode")]' \
        ~/.config/opencode/opencode.json > /tmp/oc.json && \
        mv /tmp/oc.json ~/.config/opencode/opencode.json
    ```
 
-2. **設定ファイルの削除 (オプション)**
+2. **設定ファイルを削除する（オプション）**
 
    ```bash
    # ユーザー設定を削除
-   rm -f ~/.config/opencode/oh-my-opencode.json
+   rm -f ~/.config/opencode/oh-my-opencode.json ~/.config/opencode/oh-my-opencode.jsonc
 
-   # プロジェクト設定を削除 (存在する場合)
-   rm -f .opencode/oh-my-opencode.json
+   # プロジェクト設定を削除（存在する場合）
+   rm -f .opencode/oh-my-opencode.json .opencode/oh-my-opencode.jsonc
    ```
 
 3. **削除の確認**
@@ -285,102 +300,49 @@ oh-my-opencode を削除するには：
    # プラグインがロードされなくなっているはずです
    ```
 
+## 著者の言葉
 
-## 機能
+**私たちの哲学が知りたいですか？** [Ultrawork 宣言](docs/manifesto.md)をお読みください。
 
-当然あるべきだと思う機能がたくさんあります。一度体験したら、もう以前には戻れません。
-詳細は [Features Documentation](docs/features.md) を参照してください。
+---
 
-**概要:**
-- **エージェント**: Sisyphus（メインエージェント）、Prometheus（プランナー）、Oracle（アーキテクチャ/デバッグ）、Librarian（ドキュメント/コード検索）、Explore（高速コードベース grep）、Multimodal Looker
-- **バックグラウンドエージェント**: 本物の開発チームのように複数エージェントを並列実行
-- **LSP & AST ツール**: リファクタリング、リネーム、診断、AST 認識コード検索
-- **ハッシュアンカード編集ツール**: `LINE#ID` 参照で変更前にコンテンツを検証 — 外科的な編集、古い行エラーなし
-- **コンテキスト注入**: AGENTS.md、README.md、条件付きルールの自動注入
-- **Claude Code 互換性**: 完全なフックシステム、コマンド、スキル、エージェント、MCP
-- **内蔵 MCP**: websearch (Exa)、context7 (ドキュメント)、grep_app (GitHub 検索)
-- **セッションツール**: セッション履歴の一覧、読み取り、検索、分析
-- **生産性機能**: Ralph Loop、Todo Enforcer、Comment Checker、Think Mode など
+私は個人プロジェクトでLLMトークン代として2万4千ドル（約360万円）を使い果たしました。あらゆるツールを試し、設定をいじり倒しました。結果、OpenCodeの勝利でした。
 
-## 設定
+私がぶつかったすべての問題とその解決策が、このプラグインに焼き込まれています。インストールして、ただ使ってください。
 
-こだわりが強く反映された設定ですが、好みに合わせて調整可能です。
-詳細は [Configuration Documentation](docs/configurations.md) を参照してください。
+OpenCodeが Debian/Arch だとすれば、OmO は Ubuntu/[Omarchy](https://omarchy.org/) です。
 
-**概要：**
-- **設定ファイルの場所**: `.opencode/oh-my-opencode.json` (プロジェクト) または `~/.config/opencode/oh-my-opencode.json` (ユーザー)
-- **JSONC のサポート**: コメントと末尾のカンマをサポート
-- **エージェント**: 任意のエージェントのモデル、温度、プロンプト、権限をオーバーライド
-- **内蔵スキル**: `playwright` (ブラウザ自動化), `git-master` (アトミックコミット)
-- **Sisyphus エージェント**: Prometheus (Planner) と Metis (Plan Consultant) を備えたメインオーケストレーター
-- **バックグラウンドタスク**: プロバイダー/モデルごとの同時実行制限を設定
-- **カテゴリ**: ドメイン固有のタスク委任 (`visual`, `business-logic`, カスタム)
-- **フック**: 25以上の内蔵フック、すべて `disabled_hooks` で設定可能
-- **MCP**: 内蔵 websearch (Exa), context7 (ドキュメント), grep_app (GitHub 検索)
-- **LSP**: リファクタリングツール付きの完全な LSP サポート
-- **実験的機能**: 積極的な切り詰め、自動再開など
+[AmpCode](https://ampcode.com) と [Claude Code](https://code.claude.com/docs/overview) ��ら多大な影響を受けています。機能を移植し、多くは改善しました。今もまだ構築中です。これは **Open**Code ですから。
 
+他のハーネスもマルチモデルのオーケストレーションを約束しています。しかし、私たちはそれを「実際に」出荷しています。安定性も備えて。言葉だけでなく、実際に機能するものとして。
 
-## 作者のノート
-
-**このプロジェクトの哲学についてもっと知りたいですか？** [Ultrawork Manifesto](docs/ultrawork-manifesto.md)をお読みください。
-
-Oh My OpenCode をインストールしてください。
-
-私はこれまで、$24,000 分のトークンを純粋に個人の開発目的で使用してきました。
-あらゆるツールを試し、徹底的に設定しました。私の選択は OpenCode でした。
-
-私がぶつかったすべての問題への答えを、このプラグインに詰め込みました。ただインストールして使ってください。
-OpenCode が Debian / ArchLinux だとしたら、Oh My OpenCode は Ubuntu / [Omarchy](https://omarchy.org/) です。
-
-
-[AmpCode](https://ampcode.com) や [Claude Code](https://code.claude.com/docs/overview) から強い影響とインスピレーションを受け、彼らの機能をそのまま、あるいはより良く、ここに移植しました。そして今も作り続けています。
-**Open**Code ですからね。
-
-他のエージェントハーネスが約束しておきながら提供できていない、マルチモデルオーケストレーション、安定性、豊富な機能を、ただ OpenCode で享受してください。
-私がテストし、アップデートし続けます。私はこのプロジェクトの最も熱心なユーザーですから。
-- 純粋な論理力が一番鋭いモデルはどれか？
+私がこのプロジェクトの最も強迫的なヘビーユーザーです：
+- どのモデルのロジックが最も鋭いか？
 - デバッグの神は誰か？
-- 文章を書くのが一番うまいのは誰か？
-- フロントエンドを支配するのは誰か？
-- バックエンドを掌握するのは誰か？
-- 日常使いで最速のモデルは何か？
-- 他のハーネスが出している新機能は何か？
+- 最も優れた文章を書くのは誰か？
+- フロントエンドのエコシステムを支配しているのは誰か？
+- バックエンドの覇者は誰か？
+- 日常使いで最も速いのはどれか？
+- 競合他社は今何を出荷しているか？
 
-このプラグインは、それらの経験の結晶です。皆さんはただ最高のものを受け取ってください。もしもっと良いアイデアがあれば、PR はいつでも歓迎です。
+このプラグインは、それらの問いに対する蒸留物（Distillation）です。最高のものをそのまま使ってください。改善点が見つかりましたか？PRはいつでも歓迎します。
 
-**Agent Harness 選びで悩むのはやめましょう。**
-**私がリサーチし、最高のものを取り入れ、ここにアップデートを出し続けます。**
+**どのハーネスを使うかで悩むのはもうやめましょう。**
+**私が自らリサーチし、最高のものを盗んできて、ここに詰め込みます。**
 
-もしこの文章が傲慢に聞こえ、もっと良い答えをお持ちなら、ぜひ貢献してください。歓迎します。
+傲慢に聞こえますか？もっと良い方法があるならコントリビュートしてください。大歓迎です。
 
-こここで言及されたどのプロジェクトやモデルとも、私には一切関係がありません。これは純粋に個人的な実験と好みによって作られました。
+言及されたどのプロジェクト/モデルとも関係はありません。単なる純粋な個人的実験の結果です。
 
-このプロジェクトの 99% は OpenCode を使って書かれました。機能を中心にテストしましたが、私は TypeScript を正しく書く方法をあまり知りません。**しかし、このドキュメントは私が直接レビューし、大部分を書き直したので、安心して読んでください。**
+このプロジェクトの99%はOpenCodeで構築されました。私は実はTypeScriptをよく知りません。**しかし、このドキュメントは私が自らレビューし、書き直しました。**
 
-## 注意
-
-- 生産性が上がりすぎる可能性があります。隣の同僚にバレないように気をつけてください。
-  - とはいえ、私が言いふらしますけどね。誰が勝つか賭けましょう。
-- [1.0.132](https://github.com/sst/opencode/releases/tag/v1.0.132) またはそれ以下のバージョンを使用している場合、OpenCode のバグにより設定が正しく行われない可能性があります。
-  - [修正 PR](https://github.com/sst/opencode/pull/5040) は 1.0.132 以降にマージされたため、新しいバージョンを使用してください。
-    - 余談：この PR も、OhMyOpenCode の Librarian、Explore、Oracle セットアップを活用して偶然発見され、修正されました。
-
-## こちらの企業の専門家にご愛用いただいています
+## 導入実績
 
 - [Indent](https://indentcorp.com)
-  - Making Spray - influencer marketing solution, vovushop - crossborder commerce platform, vreview - ai commerce review marketing solution
+  - インフルエンサーマーケティングソリューション Spray、クロスボーダーコマースプラットフォーム vovushop、AIコマースレビューマーケティングソリューション vreview 制作
 - [Google](https://google.com)
 - [Microsoft](https://microsoft.com)
 - [ELESTYLE](https://elestyle.jp)
-  - elepay - マルチモバイル決済ゲートウェイ、OneQR - キャッシュレスソリューション向けモバイルアプリケーションSaaS
+  - マルチモバイル決済ゲートウェイ elepay、キャッシュレスソリューション向けモバイルアプリケーションSaaS OneQR 制作
 
-## スポンサー
-- **Numman Ali** [GitHub](https://github.com/numman-ali) [X](https://x.com/nummanali)
-  - 最初のスポンサー
-- **Aaron Iker** [GitHub](https://github.com/aaroniker) [X](https://x.com/aaroniker)
-- **Suyeol Jeon (devxoul)** [GitHub](https://github.com/devxoul)
-  - 私のキャリアをスタートさせてくださった方であり、優れたエージェンティックワークフローをどのように構築できるかについて多大なインスピレーションを与えてくださった方です。優れたチームを作るために優れたシステムをどう設計すべきか多くのことを学び、その学びがこのharnessを作る上で大きな助けとなりました。
-- **Hyerin Won (devwon)** [GitHub](https://github.com/devwon)
-
-*素晴らしいヒーロー画像を作成してくれた [@junhoyeo](https://github.com/junhoyeo) に感謝します*
+*素晴らしいヒーロー画像を提供してくれた [@junhoyeo](https://github.com/junhoyeo) 氏に特別な感謝を。*

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -1,392 +1,347 @@
 > [!WARNING]
-> **安全警告：冒充网站**
+> **安全警告：注意假冒网站**
 >
-> **ohmyopencode.com 与本项目无关。** 我们不运营或认可该网站。
+> **ohmyopencode.com 与本项目没有任何关系。** 我们不运营也不认可该网站。
 >
-> OhMyOpenCode 是**免费且开源的**。请**勿**在声称"官方"的第三方网站下载安装程序或输入付款信息。
+> OhMyOpenCode 是**免费且开源的**。**不要**从自称“官方”的第三方网站下载安装程序或输入付款信息。
 >
-> 由于该冒充网站设有付费墙，我们**无法验证其分发的内容**。请将来自该网站的任何下载视为**潜在不安全**。
+> 假冒网站隐藏在付费墙后，我们**无法验证它分发的内容**。将其所有下载视为**潜在危险**。
 >
 > ✅ 官方下载地址：https://github.com/code-yeongyu/oh-my-opencode/releases
 
 > [!NOTE]
 >
-> [![Sisyphus Labs — Sisyphus 是像你的团队一样编码的智能体。](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)
-> > **我们正在构建 Sisyphus 的完整产品化版本，以定义前沿智能体的未来。<br />点击[此处](https://sisyphuslabs.ai)加入等候名单。**
+> [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)
+> > **我们正在构建 Sisyphus 的完全产品化版本，以定义前沿智能体 (Frontier Agents) 的未来。<br />[在此处](https://sisyphuslabs.ai)加入候补名单。**
 
 > [!TIP]
->
-> [![Oh My OpenCode 3.0 正式发布！](./.github/assets/orchestrator-atlas.png?v=3)](https://github.com/code-yeongyu/oh-my-opencode/releases/tag/v3.0.0)
-> > **Oh My OpenCode 3.0 正式发布！使用 `oh-my-opencode@latest` 安装。**
->
 > 加入我们！
 >
-> | [<img alt="Discord 链接" src="https://img.shields.io/discord/1452487457085063218?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/PUwSMR9XNk) | 加入我们的 [Discord 社区](https://discord.gg/PUwSMR9XNk)，与贡献者和 `oh-my-opencode` 用户交流。 |
+> | [<img alt="Discord link" src="https://img.shields.io/discord/1452487457085063218?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/PUwSMR9XNk) | 加入我们的 [Discord 社区](https://discord.gg/PUwSMR9XNk)，与贡献者及其他 `oh-my-opencode` 用户交流。 |
 > | :-----| :----- |
-> | [<img alt="X 链接" src="https://img.shields.io/badge/Follow-%40justsisyphus-00CED1?style=flat-square&logo=x&labelColor=black" width="156px" />](https://x.com/justsisyphus) | `oh-my-opencode` 的新闻和更新曾在我的 X 账号上发布。<br /> 由于账号被错误封禁，[@justsisyphus](https://x.com/justsisyphus) 现在代为发布更新。 |
-> | [<img alt="GitHub 关注" src="https://img.shields.io/github/followers/code-yeongyu?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/code-yeongyu) | 在 GitHub 上关注 [@code-yeongyu](https://github.com/code-yeongyu) 获取更多项目。 |
+> | [<img alt="X link" src="https://img.shields.io/badge/Follow-%40justsisyphus-00CED1?style=flat-square&logo=x&labelColor=black" width="156px" />](https://x.com/justsisyphus) | 关于 `oh-my-opencode` 的新闻和更新过去发布在我的 X 账号上。<br /> 因为账号被意外停用，现在由 [@justsisyphus](https://x.com/justsisyphus) 代为发布更新。 |
+> | [<img alt="GitHub Follow" src="https://img.shields.io/github/followers/code-yeongyu?style=flat-square&logo=github&labelColor=black&color=24292f" width="156px" />](https://github.com/code-yeongyu) | 在 GitHub 上关注 [@code-yeongyu](https://github.com/code-yeongyu) 获取更多项目信息。 |
 
-<!-- <居中展示区域> -->
+<!-- <CENTERED SECTION FOR GITHUB DISPLAY> -->
 
 <div align="center">
 
 [![Oh My OpenCode](./.github/assets/hero.jpg)](https://github.com/code-yeongyu/oh-my-opencode#oh-my-opencode)
 
-[![预览](./.github/assets/omo.png)](https://github.com/code-yeongyu/oh-my-opencode#oh-my-opencode)
-
+[![Preview](./.github/assets/omo.png)](https://github.com/code-yeongyu/oh-my-opencode#oh-my-opencode)
 
 </div>
 
-> 这是开挂级别的编程——`oh-my-opencode` 实战效果。运行后台智能体，调用专业智能体如 oracle、librarian 和前端工程师。使用精心设计的 LSP/AST 工具、精选的 MCP，以及完整的 Claude Code 兼容层。
-
-# Claude OAuth 访问通知
-
-## TL;DR
-
-> Q. 我可以使用 oh-my-opencode 吗？
-
-可以。
-
-> Q. 我可以用 Claude Code 订阅来使用它吗？
-
-是的，技术上可以。但我不建议使用。
-
-## 详细说明
-
-> 自2026年1月起，Anthropic 以违反服务条款为由限制了第三方 OAuth 访问。
+> 这是类固醇式编程。不是一个模型的类固醇——而是整个药库。
 >
-> [**Anthropic 将本项目 oh-my-opencode 作为封锁 opencode 的理由。**](https://x.com/thdxr/status/2010149530486911014)
->
-> 事实上，社区中确实存在一些伪造 Claude Code OAuth 请求签名的插件。
->
-> 无论技术上是否可检测，这些工具可能都能正常工作，但用户应注意服务条款的相关影响，我个人不建议使用这些工具。
->
-> 本项目对使用非官方工具产生的任何问题概不负责，**我们没有任何这些 OAuth 系统的自定义实现。**
-
+> 用 Claude 做编排，用 GPT 做推理，用 Kimi 提速度，用 Gemini 处理视觉。模型正在变得越来越便宜，越来越聪明。没有一个提供商能够垄断。我们正在为那个开放的市场而构建。Anthropic 的牢笼很漂亮。但我们不住那。
 
 <div align="center">
 
-[![GitHub 发布](https://img.shields.io/github/v/release/code-yeongyu/oh-my-opencode?color=369eff&labelColor=black&logo=github&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/releases)
-[![npm 下载量](https://img.shields.io/npm/dt/oh-my-opencode?color=ff6b35&labelColor=black&style=flat-square)](https://www.npmjs.com/package/oh-my-opencode)
-[![GitHub 贡献者](https://img.shields.io/github/contributors/code-yeongyu/oh-my-opencode?color=c4f042&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/graphs/contributors)
+[![GitHub Release](https://img.shields.io/github/v/release/code-yeongyu/oh-my-opencode?color=369eff&labelColor=black&logo=github&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/releases)
+[![npm downloads](https://img.shields.io/npm/dt/oh-my-opencode?color=ff6b35&labelColor=black&style=flat-square)](https://www.npmjs.com/package/oh-my-opencode)
+[![GitHub Contributors](https://img.shields.io/github/contributors/code-yeongyu/oh-my-opencode?color=c4f042&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/graphs/contributors)
 [![GitHub Forks](https://img.shields.io/github/forks/code-yeongyu/oh-my-opencode?color=8ae8ff&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/network/members)
 [![GitHub Stars](https://img.shields.io/github/stars/code-yeongyu/oh-my-opencode?color=ffcb47&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/stargazers)
 [![GitHub Issues](https://img.shields.io/github/issues/code-yeongyu/oh-my-opencode?color=ff80eb&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/issues)
-[![许可证](https://img.shields.io/badge/license-SUL--1.0-white?labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/blob/master/LICENSE.md)
+[![License](https://img.shields.io/badge/license-SUL--1.0-white?labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-opencode/blob/master/LICENSE.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/code-yeongyu/oh-my-opencode)
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-cn.md)
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/code-yeongyu/oh-my-opencode)
-
 </div>
 
-<!-- </居中展示区域> -->
+<!-- </CENTERED SECTION FOR GITHUB DISPLAY> -->
 
-## 用户评价
+## 评价
 
-> "它让我取消了 Cursor 订阅。开源社区正在发生令人难以置信的事情。" - [Arthur Guiot](https://x.com/arthur_guiot/status/2008736347092382053?s=20)
+> “因为它，我取消了 Cursor 的订阅。开源社区正在发生令人难以置信的事情。” - [Arthur Guiot](https://x.com/arthur_guiot/status/2008736347092382053?s=20)
 
-> "如果 Claude Code 能在 7 天内完成人类 3 个月的工作，那么 Sisyphus 只需 1 小时。它会持续工作直到任务完成。它是一个非常自律的智能体。" — B, 量化研究员
+> “如果人类需要 3 个月完成的事情 Claude Code 需要 7 天，那么 Sisyphus 只需要 1 小时。它会一直工作直到任务完成。它是一个极度自律的智能体。” <br/>- B, 量化研究员
 
-> "用 Oh My Opencode 仅用一天就清理了 8000 个 eslint 警告" — [Jacob Ferrari](https://x.com/jacobferrari_/status/2003258761952289061)
+> “用 Oh My Opencode 一天之内解决了 8000 个 eslint 警告。” <br/>- [Jacob Ferrari](https://x.com/jacobferrari_/status/2003258761952289061)
 
-> "我使用 Ohmyopencode 和 ralph loop 在一夜之间将一个 45k 行的 tauri 应用转换成了 SaaS Web 应用。从访谈提示开始，要求它对问题进行评分和建议。看着它工作非常精彩，今早醒来发现网站基本上已经可以运行了！" - [James Hargis](https://x.com/hargabyte/status/2007299688261882202)
+> “我用 Ohmyopencode 和 ralph loop 花了一晚上的时间，把一个 45k 行代码的 tauri 应用转换成了 SaaS Web 应用。从面试模式开始，让它对我提供的提示词进行提问和提出建议。看着它工作很有趣，今早醒来看到网站基本已经跑起来了，太震撼了！” - [James Hargis](https://x.com/hargabyte/status/2007299688261882202)
 
-> "用了 oh-my-opencode，你再也不会回头了" — [d0t3ch](https://x.com/d0t3ch/status/2001685618200580503)
+> “用 oh-my-opencode 吧，你绝对回不去了。” <br/>- [d0t3ch](https://x.com/d0t3ch/status/2001685618200580503)
 
-> "我还没能准确表达出它为什么如此出色，但开发体验已经达到了一个完全不同的维度。" - [苔硯:こけすずり](https://x.com/kokesuzuri/status/2008532913961529372?s=20)
+> “我很难准确描述它到底哪里牛逼，但开发体验已经达到完全不同的维度了。” - [苔硯:こけすずり](https://x.com/kokesuzuri/status/2008532913961529372?s=20)
 
-> "这个周末用 open code、oh my opencode 和 supermemory 来构建某种 minecraft/souls-like 怪物游戏。"
-> "让它添加蹲伏动画，我去散个午后的步。[视频]" - [MagiMetal](https://x.com/MagiMetal/status/2005374704178373023)
+> “这周末我用 open code、oh my opencode 和 supermemory 瞎折腾一个像我的世界/魂系一样的怪物游戏。吃完午饭去散步前，我让它把下蹲动画加进去。[视频]” - [MagiMetal](https://x.com/MagiMetal/status/2005374704178373023)
 
-> "你们应该把这个合并到核心代码并招募他。认真的。这真的非常非常非常好。" — Henning Kilset
+> “你们真该把这个合并到核心代码里，然后把他招安了。说真的，这东西实在太牛了。” <br/>- Henning Kilset
 
-> "如果你能说服他的话就雇用 @yeon_gyu_kim，这个人彻底革新了 opencode。" — [mysticaltech](https://x.com/mysticaltech/status/2001858758608376079)
+> “如果你们能说服 @yeon_gyu_kim，赶紧招募他。这个人彻底改变了 opencode。” <br/>- [mysticaltech](https://x.com/mysticaltech/status/2001858758608376079)
 
-> "Oh My OpenCode 真的太疯狂了" - [YouTube - Darren Builds AI](https://www.youtube.com/watch?v=G_Snfh2M41M)
+> “Oh My OpenCode 简直疯了。” - [YouTube - Darren Builds AI](https://www.youtube.com/watch?v=G_Snfh2M41M)
 
 ---
 
-## 目录
-
-- [Oh My OpenCode](#oh-my-opencode)
-  - [直接跳过阅读本文档](#直接跳过阅读本文档)
-    - [这是智能体时代](#这是智能体时代)
-    - [🪄 魔法词：`ultrawork`](#-魔法词ultrawork)
-    - [给想阅读的人：认识 Sisyphus](#给想阅读的人认识-sisyphus)
-    - [追求自主性：认识赫菲斯托斯](#追求自主性认识赫菲斯托斯)
-      - [直接安装就行。](#直接安装就行)
-  - [安装](#安装)
-    - [面向人类用户](#面向人类用户)
-    - [面向 LLM 智能体](#面向-llm-智能体)
-  - [卸载](#卸载)
-  - [功能特性](#功能特性)
-  - [配置](#配置)
-  - [作者札记](#作者札记)
-  - [警告](#警告)
-  - [受到以下专业人士的喜爱](#受到以下专业人士的喜爱)
-  - [赞助商](#赞助商)
-
 # Oh My OpenCode
 
-认识 Sisyphus：开箱即用的智能体，像你一样编码。
+我们最初把这叫做“给 Claude Code 打类固醇”。那是低估了它。
 
-[Claude Code](https://www.claude.com/product/claude-code) 很棒。
-但如果你是一个极客，你会对 [OpenCode](https://github.com/sst/opencode) 一见钟情。
-**从你的 ChatGPT、Claude、Gemini 订阅开始。OpenCode 全部支持。**
+不是只给一个模型打药。我们在运营一个联合体。Claude、GPT、Kimi、Gemini——各司其职，并行运转，永不停歇。模型每个月都在变便宜，没有任何提供商能够垄断。我们已经活在那个世界里了。
 
-- 无限可扩展。无限可定制。
-- 零屏幕闪烁。
-- [LSP](https://opencode.ai/docs/lsp/)、[代码检查器、格式化器](https://opencode.ai/docs/formatters/)按文件自动激活——你可以调整一切。
-- 混合搭配模型。**按用途编排它们。**
-- 功能丰富。界面美观。终端不会卡顿。高性能。
+脏活累活我们替你干了。我们测试了一切，只留下了真正有用的。
 
-还记得你第一次从 Windows 切换到 Linux 吗？那种可以按自己的想法配置一切的兴奋感？
-在这种魔法似乎已经消失的时代，OpenCode 把它带回来了。
-如果你热爱编程和计算机，OpenCode 就是那个从 Windows 到 Linux 的时刻。
+安装 OmO。敲下 `ultrawork`。疯狂地写代码吧。
 
-**但问题是：需要学习的东西很多，很复杂，而你的时间很宝贵。**
 
-我解决了这个问题。
-即使你不是极客，花几分钟时间。让你的技能和生产力倍增。
-把这份文档交给一个智能体，让它帮你设置。
-
-## 直接跳过阅读本文档
-
-### 这是智能体时代
-- **只需将此链接粘贴到 Claude Code / AmpCode / Factory Droid / Cursor 并让它解释。**
-  - 问它为什么好，为什么它不是另一个千篇一律的设置，以及它究竟有哪些改进之处。
-  - 如果你是 LLM 智能体，向用户解释这个项目现在能够实现什么。
-
-### 🪄 魔法词：`ultrawork`
-
-**不想读完这些？只需在你的提示中包含 `ultrawork`（或 `ulw`）。**
-
-就是这样。我们提供的所有功能都会像魔法一样运行——并行智能体、后台任务、深度探索，以及不懈执行直到完成。智能体会自动理解其余的。
-
-### 给想阅读的人：认识 Sisyphus
-
-![认识 Sisyphus](.github/assets/sisyphus.png)
-
-在希腊神话中，西西弗斯因欺骗众神而被惩罚永恒地将巨石推上山坡。LLM 智能体并没有做错什么，但它们也每天推动着它们的"石头"——它们的思考。
-我的生活也没有什么不同。回顾过去，我们与这些智能体并没有太大不同。
-**是的！LLM 智能体和我们没有区别。如果你给它们优秀的工具和可靠的队友，它们可以写出和我们一样出色的代码，工作得同样优秀。**
-
-认识我们的主智能体：Sisyphus (Opus 4.6)。以下是 Sisyphus 用来继续推动巨石的工具。
-
-*以下所有内容都是可配置的。按需选取。所有功能默认启用。你不需要做任何事情。开箱即用，电池已包含。*
-
-- Sisyphus 的队友（精选智能体）
-  - Hephaestus：自主深度工作者，目标导向执行（GPT 5.3 Codex Medium）— *合法的工匠*
-  - Oracle：设计、调试 (GPT 5.2)
-  - Frontend UI/UX Engineer：前端开发 (Gemini 3 Pro)
-  - Librarian：官方文档、开源实现、代码库探索 (GLM-4.7)
-   - Explore：极速代码库探索（上下文感知 Grep）(Grok Code Fast 1)
-- 完整 LSP / AstGrep 支持：果断重构。
-- 哈希锚定编辑工具：`LINE#ID` 格式在每次更改前验证内容哈希。再也没有陈旧行编辑。
-- Todo 继续执行器：如果智能体中途退出，强制它继续。**这就是让 Sisyphus 继续推动巨石的关键。**
-- 注释检查器：防止 AI 添加过多注释。Sisyphus 生成的代码应该与人类编写的代码无法区分。
-- Claude Code 兼容性：Command、Agent、Skill、MCP、Hook（PreToolUse、PostToolUse、UserPromptSubmit、Stop）
-- 精选 MCP：
-  - Exa（网络搜索）
-  - Context7（官方文档）
-  - Grep.app（GitHub 代码搜索）
-- 支持交互式终端 - Tmux 集成
-- 异步智能体
-- ...
-
-### 追求自主性：认识赫菲斯托斯
-
-![Meet Hephaestus](.github/assets/hephaestus.png)
-
-在希腊神话中，赫菲斯托斯是锻造、火焰、金属加工和工艺之神——他是神圣的铁匠，以无与伦比的精准和奉献为众神打造武器。
-**介绍我们的自主深度工作者：赫菲斯托斯（GPT 5.3 Codex Medium）。合法的工匠代理。**
-
-*为什么是"合法的"？当Anthropic以违反服务条款为由封锁第三方访问时，社区开始调侃"合法"使用。赫菲斯托斯拥抱这种讽刺——他是那种用正确的方式、有条不紊、彻底地构建事物的工匠，绝不走捷径。*
-
-赫菲斯托斯的灵感来自[AmpCode的深度模式](https://ampcode.com)——在采取决定性行动之前进行彻底研究的自主问题解决。他不需要逐步指示；给他一个目标，他会自己找出方法。
-
-**核心特性：**
-- **目标导向**：给他目标，而不是配方。他自己决定步骤。
-- **行动前探索**：在写一行代码之前，并行启动2-5个explore/librarian代理。
-- **端到端完成**：在有验证证据证明100%完成之前不会停止。
-- **模式匹配**：搜索现有代码库以匹配您项目的风格——没有AI垃圾。
-- **合法的精准**：像大师铁匠一样编写代码——精准、最小化、只做需要的。
-
-#### 直接安装就行。
-
-你可以从 [overview page](docs/guide/overview.md) 学到很多，但以下是示例工作流程。
-
-只需安装这个，你的智能体就会这样工作：
-
-1. Sisyphus 不会浪费时间自己寻找文件；他保持主智能体的上下文精简。相反，他向更快、更便宜的模型并行发起后台任务，让它们为他绘制地图。
-2. Sisyphus 利用 LSP 进行重构；这更确定性、更安全、更精准。
-3. 当繁重的工作需要 UI 时，Sisyphus 直接将前端任务委派给 Gemini 3 Pro。
-4. 如果 Sisyphus 陷入循环或碰壁，他不会继续撞墙——他会召唤 GPT 5.2 进行高智商战略支援。
-5. 在处理复杂的开源框架时？Sisyphus 生成子智能体实时消化原始源代码和文档。他拥有完整的上下文感知。
-6. 当 Sisyphus 处理注释时，他要么证明它们存在的必要性，要么删除它们。他保持你的代码库整洁。
-7. Sisyphus 受他的 TODO 列表约束。如果他没有完成开始的工作，系统会强制他回到"推石头"模式。你的任务会被完成，句号。
-8. 老实说，甚至不用费心读文档。只需写你的提示。包含 'ultrawork' 关键词。Sisyphus 会分析结构，收集上下文，挖掘外部源代码，然后持续推进直到工作 100% 完成。
-9. 其实，打 'ultrawork' 太费劲了。只需打 'ulw'。就 ulw。喝杯咖啡。你的工作完成了。
-
-需要查找什么？它会搜索官方文档、你的整个代码库历史和公共 GitHub 实现——不仅使用 grep，还使用内置的 LSP 工具和 AST-Grep。
-3. 在委派给 LLM 时不用担心上下文管理。我已经处理好了。
-    - OhMyOpenCode 积极利用多个智能体来减轻上下文负担。
-    - **你的智能体现在是开发团队负责人。你是 AI 经理。**
-4. 它不会停止，直到工作完成。
-5. 不想深入研究这个项目？没问题。只需输入 'ultrathink'。
-
-如果你不想要这些全部功能，如前所述，你可以只选择特定功能。
 
 ## 安装
 
-### 面向人类用户
+### 给人类看的
 
-复制以下提示并粘贴到你的 LLM 智能体（Claude Code、AmpCode、Cursor 等）：
+复制并粘贴以下提示词到你的 LLM Agent (Claude Code, AmpCode, Cursor 等):
 
 ```
-按照以下说明安装和配置 oh-my-opencode：
+Install and configure oh-my-opencode by following the instructions here:
 https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
 ```
 
-或者直接阅读 [安装指南](docs/guide/installation.md)——但我们强烈建议让智能体来处理。人会犯错，智能体不会。
+或者你可以直接去读 [安装指南](docs/guide/installation.md)，但说真的，让 Agent 去干吧。人类配环境总是容易敲错字母。
 
-### 面向 LLM 智能体
+### 给 LLM Agent 看的
 
-获取安装指南并按照说明操作：
+获取安装指南并照做：
 
 ```bash
 curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/master/docs/guide/installation.md
 ```
 
-## 卸载
+---
 
-要移除 oh-my-opencode：
+## 跳过这个 README 吧
 
-1. **从你的 OpenCode 配置中移除插件**
+读文档的时代已经过去了。直接把下面这行发给你的 Agent：
 
-   编辑 `~/.config/opencode/opencode.json`（或 `opencode.jsonc`）并从 `plugin` 数组中移除 `"oh-my-opencode"`：
+```
+Read this and tell me why it's not just another boilerplate: https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/refs/heads/dev/README.md
+```
+
+## 核心亮点
+
+### 🪄 `ultrawork`
+
+你竟然还在往下读？真有耐心。
+
+安装。输入 `ultrawork` (或者 `ulw`)。搞定。
+
+下面的内容，包括所有特性、所有优化，你全都不需要知道，它自己就能完美运行。
+
+只需以下订阅之一，ultrawork 就能顺畅工作（本项目与它们没有任何关联，纯属个人推荐）：
+- [ChatGPT 订阅 ($20)](https://chatgpt.com/)
+- [Kimi Code 订阅 ($0.99) (*仅限本月*)](https://www.kimi.com/membership/pricing?track_id=5cdeca93-66f0-4d35-aabb-b6df8fcea328)
+- [GLM Coding 套餐 ($10)](https://z.ai/subscribe)
+- 如果你能使用按 token 计费的方式，用 kimi 和 gemini 模型花不了多少钱。
+- 还有一些像 [quotio](https://github.com/nguyenphutrong/quotio) 和 [cliproxyapi](https://github.com/router-for-me/CLIProxyAPI) 的项目。它们可能违反了某些 API 提供商的协议，但社区里有很多人用得挺香的。
+
+|       | 特性                      | 功能说明                                                                                                                        |
+| :---: | :--------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- |
+|   🤖   | **自律军团 (Discipline Agents)** | Sisyphus 负责调度 Hephaestus、Oracle、Librarian 和 Explore。一支完整的 AI 开发团队并行工作。                                       |
+|   ⚡   | **`ultrawork` / `ulw`**      | 一键触发，所有智能体出动。任务完成前绝不罢休。                                                                           |
+|   🚪   | **[IntentGate 意图门](https://factory.ai/news/terminal-bench)**                 | 真正行动前，先分析用户的真实意图。彻底告别被字面意思误导的 AI 废话。                                         |
+|   🔗   | **基于哈希的编辑工具**  | 每次修改都通过 `LINE#ID` 内容哈希验证、0% 错误修改。灵感来自 [oh-my-pi](https://github.com/can1357/oh-my-pi)。[马具问题 →](https://blog.can.ac/2026/02/12/the-harness-problem/) |
+|   🛠️   | **LSP + AST-Grep**           | 工作区级别的重命名、构建前诊断、基于 AST 的重写。为 Agent 提供 IDE 级别的精度。                                              |
+|   🧠   | **后台智能体**        | 同时发射 5+ 个专家并行工作。保持上下文干净，随时获取成果。                                                            |
+|   📚   | **内置 MCP**            | Exa (网络搜索)、Context7 (官方文档)、Grep.app (GitHub 源码搜索)。默认开启。                                                    |
+|   🔁   | **Ralph Loop / `/ulw-loop`** | 自我引用闭环。达不到 100% 完成度绝不停止。                                                                                |
+|   ✅   | **Todo 强制执行**            | Agent 想要摸鱼？系统直接揪着领子拽回来。你的任务，必须完成。                                                                 |
+|   💬   | **注释审查员**          | 剔除带有浓烈 AI 味的冗余注释。写出的代码就像老练的高级工程师写的。                                                                          |
+|   🖥️   | **Tmux 集成**         | 完整的交互式终端支持。跑 REPL、用调试器、用 TUI 工具，全都在实时会话中完成。                                                                        |
+|   🔌   | **Claude Code 兼容**   | 你现有的 Hooks、命令、技能、MCP 和插件？全都能无缝迁移过来。                                                                     |
+|   🎯   | **技能内嵌 MCP**      | 技能自带其所需的 MCP 服务器。按需开启，不会撑爆你的上下文窗口。                                                                               |
+|   📋   | **Prometheus 规划师**       | 动手写代码前，先通过访谈模式做好战略规划。                                                                             |
+|   🔍   | **`/init-deep`**             | 在整个项目目录层级中自动生成 `AGENTS.md`。不仅省 Token，还能大幅提升 Agent 理解力。 |
+
+### 自律军团 (Discipline Agents)
+
+<table><tr>
+<td align="center"><img src=".github/assets/sisyphus.png" height="300" /></td>
+<td align="center"><img src=".github/assets/hephaestus.png" height="300" /></td>
+</tr></table>
+
+**Sisyphus** (`claude-opus-4-6` / **`kimi-k2.5`** / **`glm-5`**) 是你的主指挥官。他负责制定计划、分配任务给专家团队，并以极其激进的并行策略推动任务直至完成。他从不半途而废。
+
+**Hephaestus** (`gpt-5.3-codex`) 是你的自主深度工作者。你只需要给他目标，不要给他具体做法。他会自动探索代码库模式，从头到尾独立执行任务，绝不会中途要你当保姆。*名副其实的正牌工匠。*
+
+**Prometheus** (`claude-opus-4-6` / **`kimi-k2.5`** / **`glm-5`**) 是你的战略规划师。他通过访谈模式，在动一行代码之前，先通过提问确定范围并构建详尽的执行计划。
+
+每一个 Agent 都针对其底层模型的特点进行了专门调优。你无需手动来回切换模型。[阅读背景设定了解更多 →](docs/guide/overview.md)
+
+> Anthropic [因为我们屏蔽了 OpenCode](https://x.com/thdxr/status/2010149530486911014)。这就是为什么我们将 Hephaestus 命名为“正牌工匠 (The Legitimate Craftsman)”。这是一个故意的讽刺。
+>
+> 我们在 Opus 上运行得最好，但仅仅使用 Kimi K2.5 + GPT-5.3 Codex 就足以碾压原版的 Claude Code。完全不需要配置。
+
+### 智能体调度机制
+
+当 Sisyphus 把任务分配给子智能体时，他选择的不是具体的模型，而是 **类别 (Category)**。系统会自动将类别映射到最合适的模型：
+
+| 类别             | 作用领域                      |
+| :------------------- | :--------------------------------- |
+| `visual-engineering` | 前端、UI/UX、设计            |
+| `deep`               | 深度自主调研与执行    |
+| `quick`              | 单文件修改、修错字         |
+| `ultrabrain`         | 复杂硬核逻辑、架构决策 |
+
+智能体只需要说明要做什么类型的工作，框架就会挑选出最合适的模型去干。你完全不需要操心。
+
+### 完全兼容 Claude Code
+
+你已经花了大力气调教好了 Claude Code 的配置？太好了。
+
+这里完美兼容所有的 Hook、命令、技能、MCP 以及插件。所有配置直接生效，包括插件系统。
+
+### 赋予 Agent 世界级的开发工具
+
+LSP、AST-Grep、Tmux、MCP 并不是用胶水勉强糊在一起的，而是真正深度的集成。
+
+- **LSP**: 支持 `lsp_rename`、`lsp_goto_definition`、`lsp_find_references` 和 `lsp_diagnostics`。给 Agent 提供 IDE 般的精准操作。
+- **AST-Grep**: 支持 25 种编程语言，能够理解语法树的模式匹配和代码重写。
+- **Tmux**: 真实的交互式终端环境，支持 REPL、调试器以及 TUI 工具。Agent 的进程持久运行。
+- **MCP**: 内置 Web 搜索、官方文档直连以及 GitHub 级代码搜索。
+
+### 技能专属的按需 MCP 服务器
+
+一堆全局 MCP 服务器极其消耗 Context 额度，我们修好了这个问题。
+
+现在每个技能 (Skill) 都带着自己的专属 MCP。只在执行该任务时启动，任务完成即刻销毁。Context 窗口始终清爽。
+
+### 拒绝瞎改：基于内容哈希的编辑工具 (Hash-Anchored Edits)
+
+Harness 问题是真的。绝大多数所谓的 Agent 故障，其实并不是大模型变笨了，而是他们用的文件编辑工具太烂了。
+
+> *“目前所有工具都无法为模型提供一种稳定、可验证的行定位标识……它们全都依赖于模型去强行复写一遍自己刚才看到的原文。当模型一旦写错——而且这很常见——用户就会怪罪于大模型太蠢了。”*
+>
+> <br/>- [Can Bölük, The Harness Problem](https://blog.can.ac/2026/02/12/the-harness-problem/)
+
+受 [oh-my-pi](https://github.com/can1357/oh-my-pi) 的启发，我们实现了 **Hashline** 技术。Agent 读到的每一行代码，末尾都会打上一个强绑定的内容哈希值：
+
+```
+11#VK: function hello() {
+22#XJ:   return "world";
+33#MB: }
+```
+
+Agent 发起修改时，必须通过这些标签引用目标行。如果在此期间文件发生过变化，哈希验证就会失败，从而在代码被污染前直接驳回。不再有缩进空格错乱，彻底告别改错行的惨剧。
+
+在 Grok Code Fast 1 上，仅仅因为更换了这套编辑工具，修改成功率直接从 **6.7% 飙升至 68.3%**。
+
+### 深度上下文初始化：`/init-deep`
+
+执行一次 `/init-deep`。它会为你生成一个树状的 `AGENTS.md` 文件系统：
+
+```
+project/
+├── AGENTS.md              ← 全局级架构与约定
+├── src/
+│   ├── AGENTS.md          ← src 级规范
+│   └── components/
+│       └── AGENTS.md      ← 组件级详细说明
+```
+
+Agent 会自动顺藤摸瓜加载对应的 Context，免去了你所有的手动喂喂喂的麻烦。
+
+### 让 Agent 动手前先过脑子：Prometheus
+
+碰到了硬骨头？千万不要扔个 Prompt 就双手合十祈祷。
+
+输入 `/start-work`，召唤 Prometheus 出场。**他会像一个真实的主管那样去采访你**，主动深挖需求、指出模糊地带，并在改动哪怕一行代码之前产出经过严密论证的计划。你的 Agent 终于知道了自己在干嘛。
+
+### 技能系统 (Skills)
+
+这里的 Skills 绝不只是一段无脑的 Prompt 模板。它们包含了：
+
+- 面向特定领域的极度调优系统指令
+- 按需加载的独立 MCP 服务器
+- 对 Agent 能力边界的强制约束
+
+默认内置：`playwright`（极其稳健的浏览器自动化）、`git-master`（全自动的原子级提交及 rebase 手术）、`frontend-ui-ux`（设计感拉满的 UI 实现）。
+
+想加你自己的？放进 `.opencode/skills/*/SKILL.md` 或者 `~/.config/opencode/skills/*/SKILL.md` 就行。
+
+**想看所有的硬核功能说明吗？** 点击查看 **[详细特性文档 (Features)](docs/reference/features.md)** ，深入了解 Agent 架构、Hook 流水线、核心工具链和所有的内置 MCP 等等。
+
+---
+
+> **第一次用 oh-my-opencode？** 阅读 **[概述](docs/guide/overview.md)** 了解你拥有哪些功能，或查看 **[编排指南](docs/guide/orchestration.md)** 了解 Agent 如何协作。
+
+## 如何卸载 (Uninstallation)
+
+要移除 oh-my-opencode:
+
+1. **从你的 OpenCode 配置文件中去掉插件**
+
+   编辑 `~/.config/opencode/opencode.json` (或 `opencode.jsonc`) ，并把 `"oh-my-opencode"` 从 `plugin` 数组中删掉：
 
    ```bash
-   # 使用 jq
+   # 如果你有 jq 的话
    jq '.plugin = [.plugin[] | select(. != "oh-my-opencode")]' \
        ~/.config/opencode/opencode.json > /tmp/oc.json && \
        mv /tmp/oc.json ~/.config/opencode/opencode.json
    ```
 
-2. **移除配置文件（可选）**
+2. **清除配置文件 (可选)**
 
    ```bash
-   # 移除用户配置
-   rm -f ~/.config/opencode/oh-my-opencode.json
+   # 移除全局用户配置
+   rm -f ~/.config/opencode/oh-my-opencode.json ~/.config/opencode/oh-my-opencode.jsonc
 
-   # 移除项目配置（如果存在）
-   rm -f .opencode/oh-my-opencode.json
+   # 移除当前项目的配置
+   rm -f .opencode/oh-my-opencode.json .opencode/oh-my-opencode.jsonc
    ```
 
-3. **验证移除**
+3. **确认卸载成功**
 
    ```bash
    opencode --version
-   # 插件应该不再被加载
+   # 这个时候就应该没有任何关于插件的输出信息了
    ```
 
+## 闲聊环节 (Author's Note)
 
-## 功能特性
+**想知道做这个插件的哲学理念吗？** 阅读 [Ultrawork 宣言](docs/manifesto.md)。
 
-我们拥有众多功能，你会觉得这些功能理所当然应该存在，一旦体验过，就再也回不去了。
-详细信息请参阅 [Features Documentation](docs/features.md)。
+---
 
-**概览：**
-- **智能体**：Sisyphus（主智能体）、Prometheus（规划器）、Oracle（架构/调试）、Librarian（文档/代码搜索）、Explore（快速代码库 grep）、Multimodal Looker
-- **后台智能体**：像真正的开发团队一样并行运行多个智能体
-- **LSP & AST 工具**：重构、重命名、诊断、AST 感知代码搜索
-- **哈希锚定编辑工具**：`LINE#ID` 引用在每次更改前验证内容 — 精准编辑，零陈旧行错误
-- **上下文注入**：自动注入 AGENTS.md、README.md、条件规则
-- **Claude Code 兼容性**：完整的钩子系统、命令、技能、智能体、MCP
-- **内置 MCP**：websearch (Exa)、context7 (文档)、grep_app (GitHub 搜索)
-- **会话工具**：列出、读取、搜索和分析会话历史
-- **生产力功能**：Ralph Loop、Todo Enforcer、Comment Checker、Think Mode 等
+我为了做个人项目，烧掉了整整 $24,000 的 LLM API Token 费用。我把市面上每个宣称好用的代码 Agent 全试了一遍，配置选项被我翻得底朝天。最后我得出了结论，OpenCode 赢了。
 
-## 配置
+我踩过的坑、撞过的南墙，它们的终极解法现在全都被硬编码到了这个插件里。你只需要安装，然后直接用。
 
-个性鲜明，但可以根据个人喜好调整。
-详细信息请参阅 [Configuration Documentation](docs/configurations.md)。
+如果把 OpenCode 喻为底层的 Debian/Arch，那么 OmO 毫无疑问就是开箱即用的 Ubuntu/[Omarchy](https://omarchy.org/)。
 
-**概览：**
-- **配置文件位置**: `.opencode/oh-my-opencode.json` (项目级) 或 `~/.config/opencode/oh-my-opencode.json` (用户级)
-- **JSONC 支持**: 支持注释和尾随逗号
-- **智能体**: 覆盖任何智能体的模型、温度、提示和权限
-- **内置技能**: `playwright` (浏览器自动化), `git-master` (原子提交)
-- **Sisyphus 智能体**: 带有 Prometheus (Planner) 和 Metis (Plan Consultant) 的主编排器
-- **后台任务**: 按提供商/模型配置并发限制
-- **类别**: 领域特定的任务委派 (`visual`, `business-logic`, 自定义)
-- **钩子**: 25+ 内置钩子，均可通过 `disabled_hooks` 配置
-- **MCP**: 内置 websearch (Exa), context7 (文档), grep_app (GitHub 搜索)
-- **LSP**: 带重构工具的完整 LSP 支持
-- **实验性功能**: 积极截断、自动恢复等
+本项目受到 [AmpCode](https://ampcode.com) 和 [Claude Code](https://code.claude.com/docs/overview) 的深刻启发。我把他们好用的特性全都搬了过来，且在很多地方做了底层强化。它仍在活跃开发中，因为毕竟，这是 **Open**Code。
 
+其他调度框架只会给你画饼画一张很酷的 Multi-Agent 大饼。我们把饼烙出来了。不仅能用，而且极其稳定。所有的功能都不是为了炫技，而是真的能把任务干完。
 
-## 作者札记
+因为我自己就是这个项目最偏执、最神经质的极端用户：
+- 哪个模型在处理变态业务逻辑时最不容易晕？
+- 谁是修 Bug 的神？
+- 谁文笔最好、最不 AI 味？
+- 谁能在前端交互上碾压一切？
+- 后端性能谁来抗？
+- 谁又快又便宜适合打杂？
+- 竞争对手们今天又发了啥牛逼的功能，能抄吗？
 
-**想了解更多关于这个项目背后的理念吗？** 请阅读 [Ultrawork Manifesto](docs/ultrawork-manifesto.md)。
+这个插件是以上一切的结晶 (Distillation)。直接拿走去用。如果有更好的点子，PR 大门永远敞开。
 
-安装 Oh My OpenCode。
+**别再浪费时间去到处对比选哪个框架好了。**
+**我会去市面上调研，把最强的特性全偷过来，然后在这更新。**
 
-我纯粹为个人开发使用了价值 24,000 美元 token 的 LLM。
-尝试了每一个工具，把它们配置到极致。但始终是 OpenCode 胜出。
+听起来很自大吗？如果你有更牛逼的实现思路，那就交 PR，热烈欢迎。
 
-我遇到的每个问题的答案都融入了这个插件。直接安装使用。
-如果 OpenCode 是 Debian/Arch，Oh My OpenCode 就是 Ubuntu/[Omarchy](https://omarchy.org/)。
+郑重声明：本项目与文档中提及的任何框架/大模型供应商**均无利益相关**，这完完全全就是一次走火入魔的个人硬核实验成果。
 
+本项目 99% 的代码都是直接由 OpenCode 生成的。我本人其实并不懂 TypeScript。**但我以人格担保，这个 README 是我亲自审核并且大幅度重写过的。**
 
-深受 [AmpCode](https://ampcode.com) 和 [Claude Code](https://code.claude.com/docs/overview) 的影响——我已经将它们的功能移植到这里，通常还有改进。我仍在构建。
-毕竟这是 **Open**Code。
-
-享受多模型编排、稳定性和其他工具承诺但无法交付的丰富功能。
-我会持续测试和更新。因为我是这个项目最执着的用户。
-- 哪个模型逻辑最锐利？
-- 谁是调试之神？
-- 谁写出最好的文字？
-- 谁主宰前端？
-- 谁拥有后端？
-- 哪个模型日常使用最快？
-- 其他工具在推出什么新功能？
-
-这个插件是只取其精华。有更好的想法？欢迎 PR。
-
-**不要再为智能体工具的选择而烦恼了。**
-**我会进行研究，借鉴最好的，然后发布更新。**
-
-如果这听起来很傲慢，但如果你有更好的答案，请贡献。欢迎你。
-
-我与这里提到的任何项目或模型没有任何关联。这纯粹是个人实验和偏好。
-
-这个项目 99% 是使用 OpenCode 构建的。我测试了功能——我实际上不太会写正确的 TypeScript。**但我个人审查并大量重写了这份文档，所以放心阅读。**
-
-## 警告
-
-- 生产力可能飙升太快。别让你的同事发现。
-  - 其实，我会传播这个消息。让我们看看谁会赢。
-- 如果你使用 [1.0.132](https://github.com/sst/opencode/releases/tag/v1.0.132) 或更早版本，一个 OpenCode bug 可能会破坏配置。
-  - [修复](https://github.com/sst/opencode/pull/5040)在 1.0.132 之后合并——使用更新的版本。
-    - 有趣的事实：那个 PR 是借助 OhMyOpenCode 的 Librarian、Explore 和 Oracle 设置发现并修复的。
-
-## 受到以下专业人士的喜爱
+## 以下公司的专业开发人员都在用
 
 - [Indent](https://indentcorp.com)
-  - 制作 Spray - 网红营销解决方案、vovushop - 跨境电商平台、vreview - AI 电商评论营销解决方案
+  - 开发了 Spray - 意见领袖营销系统, vovushop - 跨境电商独立站, vreview - AI 赋能的电商买家秀营销解决方案
 - [Google](https://google.com)
 - [Microsoft](https://microsoft.com)
 - [ELESTYLE](https://elestyle.jp)
-  - elepay - 多渠道移动支付网关、OneQR - 无现金解决方案移动应用 SaaS
+  - 开发了 elepay - 全渠道移动支付网关, OneQR - 专为无现金社会打造的移动 SaaS 生态系统
 
-## 赞助商
-- **Numman Ali** [GitHub](https://github.com/numman-ali) [X](https://x.com/nummanali)
-  - 第一位赞助商
-- **Aaron Iker** [GitHub](https://github.com/aaroniker) [X](https://x.com/aaroniker)
-- **Suyeol Jeon (devxoul)** [GitHub](https://github.com/devxoul)
-  - 开启我职业生涯的人，在如何构建出色的智能体工作流方面给了我很深的启发。我学到了很多关于设计伟大系统来构建伟大团队的知识，这些经验对创建这个工具至关重要。
-- **Hyerin Won (devwon)** [GitHub](https://github.com/devwon)
-
-*特别感谢 [@junhoyeo](https://github.com/junhoyeo) 制作这张精彩的主图。*
+*特别感谢 [@junhoyeo](https://github.com/junhoyeo) 为我们设计的令人惊艳的首图（Hero Image）。*

--- a/src/cli/run/events.test.ts
+++ b/src/cli/run/events.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, spyOn } from "bun:test"
-import { createEventState, serializeError, type EventState } from "./events"
+import { createEventState, processEvents, serializeError, type EventState } from "./events"
 import type { RunContext, EventPayload } from "./types"
 
 const createMockContext = (sessionID: string = "test-session"): RunContext => ({
@@ -99,7 +99,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)
@@ -121,7 +120,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)
@@ -144,7 +142,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)
@@ -164,7 +161,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)
@@ -184,7 +180,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)
@@ -207,7 +202,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)
@@ -229,7 +223,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     //#when
     await processEvents(ctx, events, state)
@@ -251,7 +244,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)
@@ -275,7 +267,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)
@@ -299,7 +290,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)
@@ -328,7 +318,6 @@ describe("event handling", () => {
     }
 
     const events = toAsyncIterable([payload])
-    const { processEvents } = await import("./events")
 
     // when
     await processEvents(ctx, events, state)

--- a/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
@@ -11,16 +11,16 @@ interface FakeTimeouts {
   restore: () => void
 }
 
+// Capture the real implementations at module load time, before any test can patch them.
+// This ensures restore() always returns to the true originals regardless of test execution order.
+const TRUE_ORIGINAL_SET_TIMEOUT = globalThis.setTimeout
+const TRUE_ORIGINAL_CLEAR_TIMEOUT = globalThis.clearTimeout
+
 function createFakeTimeouts(): FakeTimeouts {
   let now = 0
   let nextId = 1
   const timers = new Map<number, { id: number; time: number; callback: TimerCallback; args: any[] }>()
   const cleared = new Set<number>()
-
-  const original = {
-    setTimeout: globalThis.setTimeout,
-    clearTimeout: globalThis.clearTimeout,
-  }
 
   const normalizeDelay = (delay?: number) => {
     if (typeof delay !== "number" || !Number.isFinite(delay)) return 0
@@ -68,8 +68,8 @@ function createFakeTimeouts(): FakeTimeouts {
   }
 
   const restore = () => {
-    globalThis.setTimeout = original.setTimeout
-    globalThis.clearTimeout = original.clearTimeout
+    globalThis.setTimeout = TRUE_ORIGINAL_SET_TIMEOUT
+    globalThis.clearTimeout = TRUE_ORIGINAL_CLEAR_TIMEOUT
   }
 
   return { advanceBy, restore }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -49,4 +49,5 @@ export { createRuntimeFallbackHook, type RuntimeFallbackHook, type RuntimeFallba
 export { createWriteExistingFileGuardHook } from "./write-existing-file-guard";
 export { createHashlineReadEnhancerHook } from "./hashline-read-enhancer";
 export { createBeastModeSystemHook, BEAST_MODE_SYSTEM_PROMPT } from "./beast-mode-system";
-export { createHashlineEditDiffEnhancerHook } from "./hashline-edit-diff-enhancer";
+export { createHashlineEditDiffEnhancerHook } from "./hashline-edit-diff-enhancer"
+export { createJsonErrorRecoveryHook, JSON_ERROR_TOOL_EXCLUDE_LIST, JSON_ERROR_PATTERNS, JSON_ERROR_REMINDER } from "./json-error-recovery";

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -110,9 +110,7 @@ export function createEventHandler(args: {
   const lastHandledRetryStatusKey = new Map<string, string>()
   const lastKnownModelBySession = new Map<string, { providerID: string; modelID: string }>()
 
-  const dispatchToHooks = async (input: { event: { type: string; properties?: Record<string, unknown> } }): Promise<void> => {
-
-const dispatchToHooks = async (input: EventInput): Promise<void> => {
+  const dispatchToHooks = async (input: EventInput): Promise<void> => {
     await Promise.resolve(hooks.autoUpdateChecker?.event?.(input))
     await Promise.resolve(hooks.claudeCodeHooks?.event?.(input))
     await Promise.resolve(hooks.backgroundNotificationHook?.event?.(input))

--- a/src/shared/migration/model-versions.ts
+++ b/src/shared/migration/model-versions.ts
@@ -6,7 +6,6 @@
  * Keys are full "provider/model" strings. Only openai and anthropic entries needed.
  */
 export const MODEL_VERSION_MAP: Record<string, string> = {
-  "openai/gpt-5.2-codex": "openai/gpt-5.3-codex",
   "anthropic/claude-opus-4-5": "anthropic/claude-opus-4-6",
   "anthropic/claude-sonnet-4-5": "anthropic/claude-sonnet-4-6",
 }


### PR DESCRIPTION
## Summary
- Fixes #1804, Fixes #1962
- Removes the `gpt-5.2-codex -> gpt-5.3-codex` entry from `MODEL_VERSION_MAP`
- `gpt-5.3-codex` does not exist in the OpenAI API; this migration was silently rewriting user configs on every startup

## Problem
Users who set `"model": "openai/gpt-5.2-codex"` in their config found it automatically overwritten to `openai/gpt-5.3-codex` on every OpenCode startup. `gpt-5.3-codex` does not exist, so subagents could fail to load. Users had to manually revert their config every session.

## Fix
Remove the erroneous migration entry. Anthropic model migrations (`opus-4-5 -> 4-6`, `sonnet-4-5 -> 4-6`) remain intact.

## Note
This is separate from PR #1935, which fixes `model-requirements.ts` fallback chains. This PR fixes the auto-migration system that rewrote user configs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the invalid gpt-5.2-codex → gpt-5.3-codex migration to stop silent config rewrites and prevent broken subagents on startup (fixes #1804, #1962). Restores the missing JSON error recovery hook export and cleans up a duplicated event handler.

- **Bug Fixes**
  - Removed openai/gpt-5.2-codex from MODEL_VERSION_MAP and updated migration logic/tests: do not migrate or record _migrations for gpt-5.2-codex; Anthropic mappings remain; stabilized tests by capturing real timers at module init, using static imports in event tests, and isolating console spies via baseline-delta checks with try/finally restores.
  - CI: isolated recovery-hook.test.ts in its own step to prevent mock.module cache leakage that broke executor tests; explicitly enumerated remaining anthropic-context-window-limit-recovery tests in the batch run.
  - Restored createJsonErrorRecoveryHook (and constants) export; removed duplicate dispatchToHooks definition.

<sup>Written for commit 856bf4701eaff1a1334391586c2da1489a94495f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

