### PR TITLE
fix(session-notification): add grace period to prevent late events from cancelling idle notifications

### DIFF
--- a/src/hooks/session-notification-scheduler.ts
+++ b/src/hooks/session-notification-scheduler.ts
@@ -9,6 +9,8 @@ type SessionNotificationConfig = {
   idleConfirmationDelay: number
   skipIfIncompleteTodos: boolean
   maxTrackedSessions: number
+  /** Grace period in ms to ignore late-arriving activity events after scheduling (default: 100) */
+  activityGracePeriodMs?: number
 }
 
 export function createIdleNotificationScheduler(options: {
@@ -24,8 +26,11 @@ export function createIdleNotificationScheduler(options: {
   const sessionActivitySinceIdle = new Set<string>()
   const notificationVersions = new Map<string, number>()
   const executingNotifications = new Set<string>()
+  const scheduledAt = new Map<string, number>()
 
-  function cleanupOldSessions(): void {
+  const activityGracePeriodMs = options.config.activityGracePeriodMs ?? 100
+
+function cleanupOldSessions(): void {
     const maxSessions = options.config.maxTrackedSessions
     if (notifiedSessions.size > maxSessions) {
       const sessionsToRemove = Array.from(notifiedSessions).slice(0, notifiedSessions.size - maxSessions)
@@ -43,44 +48,58 @@ export function createIdleNotificationScheduler(options: {
       const sessionsToRemove = Array.from(executingNotifications).slice(0, executingNotifications.size - maxSessions)
       sessionsToRemove.forEach((id) => executingNotifications.delete(id))
     }
+    if (scheduledAt.size > maxSessions) {
+      const sessionsToRemove = Array.from(scheduledAt.keys()).slice(0, scheduledAt.size - maxSessions)
+      sessionsToRemove.forEach((id) => scheduledAt.delete(id))
+    }
   }
 
-  function cancelPendingNotification(sessionID: string): void {
+function cancelPendingNotification(sessionID: string): void {
     const timer = pendingTimers.get(sessionID)
     if (timer) {
       clearTimeout(timer)
       pendingTimers.delete(sessionID)
     }
+    scheduledAt.delete(sessionID)
     sessionActivitySinceIdle.add(sessionID)
     notificationVersions.set(sessionID, (notificationVersions.get(sessionID) ?? 0) + 1)
   }
 
-  function markSessionActivity(sessionID: string): void {
+function markSessionActivity(sessionID: string): void {
+    const scheduledTime = scheduledAt.get(sessionID)
+    if (scheduledTime && Date.now() - scheduledTime < activityGracePeriodMs) {
+      return
+    }
+
     cancelPendingNotification(sessionID)
     if (!executingNotifications.has(sessionID)) {
       notifiedSessions.delete(sessionID)
     }
   }
 
-  async function executeNotification(sessionID: string, version: number): Promise<void> {
+async function executeNotification(sessionID: string, version: number): Promise<void> {
     if (executingNotifications.has(sessionID)) {
       pendingTimers.delete(sessionID)
+      scheduledAt.delete(sessionID)
       return
     }
 
     if (notificationVersions.get(sessionID) !== version) {
       pendingTimers.delete(sessionID)
+      scheduledAt.delete(sessionID)
       return
     }
 
     if (sessionActivitySinceIdle.has(sessionID)) {
       sessionActivitySinceIdle.delete(sessionID)
       pendingTimers.delete(sessionID)
+      scheduledAt.delete(sessionID)
       return
     }
 
     if (notifiedSessions.has(sessionID)) {
       pendingTimers.delete(sessionID)
+      scheduledAt.delete(sessionID)
       return
     }
 
@@ -113,6 +132,7 @@ export function createIdleNotificationScheduler(options: {
     } finally {
       executingNotifications.delete(sessionID)
       pendingTimers.delete(sessionID)
+      scheduledAt.delete(sessionID)
       if (sessionActivitySinceIdle.has(sessionID)) {
         notifiedSessions.delete(sessionID)
         sessionActivitySinceIdle.delete(sessionID)
@@ -120,12 +140,13 @@ export function createIdleNotificationScheduler(options: {
     }
   }
 
-  function scheduleIdleNotification(sessionID: string): void {
+function scheduleIdleNotification(sessionID: string): void {
     if (notifiedSessions.has(sessionID)) return
     if (pendingTimers.has(sessionID)) return
     if (executingNotifications.has(sessionID)) return
 
     sessionActivitySinceIdle.delete(sessionID)
+    scheduledAt.set(sessionID, Date.now())
 
     const currentVersion = (notificationVersions.get(sessionID) ?? 0) + 1
     notificationVersions.set(sessionID, currentVersion)
@@ -138,12 +159,13 @@ export function createIdleNotificationScheduler(options: {
     cleanupOldSessions()
   }
 
-  function deleteSession(sessionID: string): void {
+function deleteSession(sessionID: string): void {
     cancelPendingNotification(sessionID)
     notifiedSessions.delete(sessionID)
     sessionActivitySinceIdle.delete(sessionID)
     notificationVersions.delete(sessionID)
     executingNotifications.delete(sessionID)
+    scheduledAt.delete(sessionID)
   }
 
   return {

--- a/src/hooks/session-notification.test.ts
+++ b/src/hooks/session-notification.test.ts
@@ -183,14 +183,15 @@ describe("session-notification", () => {
     expect(notificationCalls).toHaveLength(0)
   })
 
-  test("should cancel pending notification on session activity", async () => {
+test("should cancel pending notification on session activity", async () => {
     // given - main session is set
     const mainSessionID = "main-cancel"
     setMainSession(mainSessionID)
 
     const hook = createSessionNotification(createMockPluginInput(), {
-      idleConfirmationDelay: 100, // Long delay
+      idleConfirmationDelay: 100,
       skipIfIncompleteTodos: false,
+      activityGracePeriodMs: 0,
     })
 
     // when - session goes idle
@@ -258,7 +259,7 @@ describe("session-notification", () => {
     expect(notificationCalls).toHaveLength(0)
   })
 
-  test("should mark session activity on message.updated event", async () => {
+test("should mark session activity on message.updated event", async () => {
     // given - main session is set
     const mainSessionID = "main-message"
     setMainSession(mainSessionID)
@@ -266,6 +267,7 @@ describe("session-notification", () => {
     const hook = createSessionNotification(createMockPluginInput(), {
       idleConfirmationDelay: 50,
       skipIfIncompleteTodos: false,
+      activityGracePeriodMs: 0,
     })
 
     // when - session goes idle, then message.updated fires
@@ -292,7 +294,7 @@ describe("session-notification", () => {
     expect(notificationCalls).toHaveLength(0)
   })
 
-  test("should mark session activity on tool.execute.before event", async () => {
+test("should mark session activity on tool.execute.before event", async () => {
     // given - main session is set
     const mainSessionID = "main-tool"
     setMainSession(mainSessionID)
@@ -300,6 +302,7 @@ describe("session-notification", () => {
     const hook = createSessionNotification(createMockPluginInput(), {
       idleConfirmationDelay: 50,
       skipIfIncompleteTodos: false,
+      activityGracePeriodMs: 0,
     })
 
     // when - session goes idle, then tool.execute.before fires
@@ -324,7 +327,7 @@ describe("session-notification", () => {
     expect(notificationCalls).toHaveLength(0)
   })
 
-  test("should not send duplicate notification for same session", async () => {
+test("should not send duplicate notification for same session", async () => {
     // given - main session is set
     const mainSessionID = "main-dup"
     setMainSession(mainSessionID)
@@ -357,5 +360,76 @@ describe("session-notification", () => {
 
     // then - only one notification should be sent
     expect(notificationCalls).toHaveLength(1)
+  })
+
+  test("should ignore activity events within grace period", async () => {
+    // given - main session is set
+    const mainSessionID = "main-grace"
+    setMainSession(mainSessionID)
+
+    const hook = createSessionNotification(createMockPluginInput(), {
+      idleConfirmationDelay: 50,
+      skipIfIncompleteTodos: false,
+      activityGracePeriodMs: 100,
+    })
+
+    // when - session goes idle
+    await hook({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: mainSessionID },
+      },
+    })
+
+    // when - activity happens immediately (within grace period)
+    await hook({
+      event: {
+        type: "tool.execute.before",
+        properties: { sessionID: mainSessionID },
+      },
+    })
+
+    // Wait for idle delay to pass
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // then - notification SHOULD be sent (activity was within grace period, ignored)
+    expect(notificationCalls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test("should cancel notification for activity after grace period", async () => {
+    // given - main session is set
+    const mainSessionID = "main-grace-cancel"
+    setMainSession(mainSessionID)
+
+    const hook = createSessionNotification(createMockPluginInput(), {
+      idleConfirmationDelay: 200,
+      skipIfIncompleteTodos: false,
+      activityGracePeriodMs: 50,
+    })
+
+    // when - session goes idle
+    await hook({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: mainSessionID },
+      },
+    })
+
+    // when - wait for grace period to pass
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    // when - activity happens after grace period
+    await hook({
+      event: {
+        type: "tool.execute.before",
+        properties: { sessionID: mainSessionID },
+      },
+    })
+
+    // Wait for original delay to pass
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    // then - notification should NOT be sent (activity cancelled it after grace period)
+    expect(notificationCalls).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## Summary

- Fixed a bug where session notifications appeared on user interrupt but not when the agent idled naturally
- Added a 100ms grace period to ignore late-arriving activity events that incorrectly cancelled pending notifications
- Introduced activityGracePeriodMs config option (default: 100ms, configurable)

## Changes

- src/hooks/session-notification-scheduler.ts
  - Added scheduledAt Map to track when notifications are scheduled
  - Added activityGracePeriodMs config option with 100ms default
  - Modified markSessionActivity() to return early if activity happens within grace period
  - Updated cleanupOldSessions(), cancelPendingNotification(), executeNotification(), deleteSession() to manage scheduledAt state

- src/hooks/session-notification.test.ts
  - Added test: "should ignore activity events within grace period"
  - Added test: "should cancel notification for activity after grace period"
  - Updated 3 existing tests to use activityGracePeriodMs: 0 for cancellation behavior

## Root Cause Analysis

When the agent idles naturally:
1. session.idle fires → notification scheduled (1500ms delay)
2. Late-arriving events fire (e.g., message.updated with final metadata, tool.execute.after)
3. These trigger markSessionActivity() which cancels the notification
4. No notification appears ❌

When user interrupts:
1. session.idle fires → notification scheduled
2. No late-arriving events (session was aborted)
3. Notification fires after 1500ms ✓

## Testing

`npx bun test src/hooks/session-notification.test.ts`

All 13 tests pass:
- 2 new grace period tests
- 11 existing tests (3 updated for explicit activityGracePeriodMs: 0)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes idle notifications being cancelled by late activity when a session idles naturally. Adds a 100ms grace period (configurable) so the notification still fires as expected.

- **Bug Fixes**
  - Ignore activity events that arrive within a short grace period after scheduling an idle notification.
  - Track scheduledAt timestamps and clean up timer/state on schedule, cancel, execute, and delete.

- **New Features**
  - New config: activityGracePeriodMs (default 100ms) to control the grace period.

<sup>Written for commit b41c05161bd7a8cd854d705a64557816975a379b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

