### PR TITLE
feat(hashline-edit): add anchor insert modes and strict insert validation

### DIFF
--- a/bun-test.d.ts
+++ b/bun-test.d.ts
@@ -1,0 +1,23 @@
+declare module "bun:test" {
+  export function describe(name: string, fn: () => void): void
+  export function it(name: string, fn: () => void | Promise<void>): void
+  export function beforeEach(fn: () => void | Promise<void>): void
+  export function afterEach(fn: () => void | Promise<void>): void
+  export function beforeAll(fn: () => void | Promise<void>): void
+  export function afterAll(fn: () => void | Promise<void>): void
+  export function mock<T extends (...args: never[]) => unknown>(fn: T): T
+
+  interface Matchers {
+    toBe(expected: unknown): void
+    toEqual(expected: unknown): void
+    toContain(expected: unknown): void
+    toMatch(expected: RegExp | string): void
+    toHaveLength(expected: number): void
+    toBeGreaterThan(expected: number): void
+    toThrow(expected?: RegExp | string): void
+    toStartWith(expected: string): void
+    not: Matchers
+  }
+
+  export function expect(received: unknown): Matchers
+}

--- a/src/tools/hashline-edit/edit-operations.test.ts
+++ b/src/tools/hashline-edit/edit-operations.test.ts
@@ -186,6 +186,14 @@ describe("hashline edit operations", () => {
     expect(result).toEqual(["line 1", "inserted", "line 2"])
   })
 
+  it("throws when insert_after payload only repeats anchor line", () => {
+    //#given
+    const lines = ["line 1", "line 2"]
+
+    //#when / #then
+    expect(() => applyInsertAfter(lines, anchorFor(lines, 1), ["line 1"])).toThrow(/non-empty/i)
+  })
+
   it("restores indentation for paired single-line replacement", () => {
     //#given
     const lines = ["if (x) {", "  return 1", "}"]
@@ -211,6 +219,23 @@ describe("hashline edit operations", () => {
 
     //#then
     expect(result).toEqual(["before", "new 1", "new 2", "after"])
+  })
+
+  it("throws when insert_between payload contains only boundary echoes", () => {
+    //#given
+    const lines = ["line 1", "line 2", "line 3"]
+
+    //#when / #then
+    expect(() =>
+      applyHashlineEdits(lines.join("\n"), [
+        {
+          type: "insert_between",
+          after_line: anchorFor(lines, 1),
+          before_line: anchorFor(lines, 2),
+          text: ["line 1", "line 2"],
+        },
+      ])
+    ).toThrow(/non-empty/i)
   })
 
   it("restores indentation for first replace_lines entry", () => {

--- a/src/tools/hashline-edit/edit-operations.test.ts
+++ b/src/tools/hashline-edit/edit-operations.test.ts
@@ -41,6 +41,75 @@ describe("hashline edit operations", () => {
     expect(result).toEqual(["line 1", "line 2", "inserted", "line 3"])
   })
 
+  it("applies insert_before with LINE#ID anchor", () => {
+    //#given
+    const lines = ["line 1", "line 2", "line 3"]
+
+    //#when
+    const result = applyHashlineEdits(
+      lines.join("\n"),
+      [{ type: "insert_before", line: anchorFor(lines, 2), text: "before 2" }]
+    )
+
+    //#then
+    expect(result).toEqual("line 1\nbefore 2\nline 2\nline 3")
+  })
+
+  it("applies insert_between with dual anchors", () => {
+    //#given
+    const lines = ["line 1", "line 2", "line 3"]
+
+    //#when
+    const result = applyHashlineEdits(
+      lines.join("\n"),
+      [{
+        type: "insert_between",
+        after_line: anchorFor(lines, 1),
+        before_line: anchorFor(lines, 2),
+        text: ["between"],
+      }]
+    )
+
+    //#then
+    expect(result).toEqual("line 1\nbetween\nline 2\nline 3")
+  })
+
+  it("throws when insert_after receives empty text array", () => {
+    //#given
+    const lines = ["line 1", "line 2"]
+
+    //#when / #then
+    expect(() => applyInsertAfter(lines, anchorFor(lines, 1), [])).toThrow(/non-empty/i)
+  })
+
+  it("throws when insert_before receives empty text array", () => {
+    //#given
+    const lines = ["line 1", "line 2"]
+
+    //#when / #then
+    expect(() =>
+      applyHashlineEdits(lines.join("\n"), [{ type: "insert_before", line: anchorFor(lines, 1), text: [] }])
+    ).toThrow(/non-empty/i)
+  })
+
+  it("throws when insert_between receives empty text array", () => {
+    //#given
+    const lines = ["line 1", "line 2"]
+
+    //#when / #then
+    expect(() =>
+      applyHashlineEdits(
+        lines.join("\n"),
+        [{
+          type: "insert_between",
+          after_line: anchorFor(lines, 1),
+          before_line: anchorFor(lines, 2),
+          text: [],
+        }]
+      )
+    ).toThrow(/non-empty/i)
+  })
+
   it("applies replace operation", () => {
     //#given
     const content = "hello world foo"
@@ -66,6 +135,22 @@ describe("hashline edit operations", () => {
 
     //#then
     expect(result).toEqual("line 1\ninserted\nline 2\nmodified")
+  })
+
+  it("deduplicates identical insert edits in one pass", () => {
+    //#given
+    const content = "line 1\nline 2"
+    const lines = content.split("\n")
+    const edits: HashlineEdit[] = [
+      { type: "insert_after", line: anchorFor(lines, 1), text: "inserted" },
+      { type: "insert_after", line: anchorFor(lines, 1), text: "inserted" },
+    ]
+
+    //#when
+    const result = applyHashlineEdits(content, edits)
+
+    //#then
+    expect(result).toEqual("line 1\ninserted\nline 2")
   })
 
   it("keeps literal backslash-n in plain string text", () => {

--- a/src/tools/hashline-edit/edit-text-normalization.ts
+++ b/src/tools/hashline-edit/edit-text-normalization.ts
@@ -1,0 +1,109 @@
+const HASHLINE_PREFIX_RE = /^\s*(?:>>>|>>)?\s*\d+#[A-Z]{2}:/
+const DIFF_PLUS_RE = /^[+-](?![+-])/
+
+function equalsIgnoringWhitespace(a: string, b: string): boolean {
+  if (a === b) return true
+  return a.replace(/\s+/g, "") === b.replace(/\s+/g, "")
+}
+
+function leadingWhitespace(text: string): string {
+  const match = text.match(/^\s*/)
+  return match ? match[0] : ""
+}
+
+export function stripLinePrefixes(lines: string[]): string[] {
+  let hashPrefixCount = 0
+  let diffPlusCount = 0
+  let nonEmpty = 0
+
+  for (const line of lines) {
+    if (line.length === 0) continue
+    nonEmpty += 1
+    if (HASHLINE_PREFIX_RE.test(line)) hashPrefixCount += 1
+    if (DIFF_PLUS_RE.test(line)) diffPlusCount += 1
+  }
+
+  if (nonEmpty === 0) {
+    return lines
+  }
+
+  const stripHash = hashPrefixCount > 0 && hashPrefixCount >= nonEmpty * 0.5
+  const stripPlus = !stripHash && diffPlusCount > 0 && diffPlusCount >= nonEmpty * 0.5
+
+  if (!stripHash && !stripPlus) {
+    return lines
+  }
+
+  return lines.map((line) => {
+    if (stripHash) return line.replace(HASHLINE_PREFIX_RE, "")
+    if (stripPlus) return line.replace(DIFF_PLUS_RE, "")
+    return line
+  })
+}
+
+export function toNewLines(input: string | string[]): string[] {
+  if (Array.isArray(input)) {
+    return stripLinePrefixes(input)
+  }
+  return stripLinePrefixes(input.split("\n"))
+}
+
+export function restoreLeadingIndent(templateLine: string, line: string): string {
+  if (line.length === 0) return line
+  const templateIndent = leadingWhitespace(templateLine)
+  if (templateIndent.length === 0) return line
+  if (leadingWhitespace(line).length > 0) return line
+  return `${templateIndent}${line}`
+}
+
+export function stripInsertAnchorEcho(anchorLine: string, newLines: string[]): string[] {
+  if (newLines.length <= 1) return newLines
+  if (equalsIgnoringWhitespace(newLines[0], anchorLine)) {
+    return newLines.slice(1)
+  }
+  return newLines
+}
+
+export function stripInsertBeforeEcho(anchorLine: string, newLines: string[]): string[] {
+  if (newLines.length <= 1) return newLines
+  if (equalsIgnoringWhitespace(newLines[newLines.length - 1], anchorLine)) {
+    return newLines.slice(0, -1)
+  }
+  return newLines
+}
+
+export function stripInsertBoundaryEcho(afterLine: string, beforeLine: string, newLines: string[]): string[] {
+  let out = newLines
+  if (out.length > 1 && equalsIgnoringWhitespace(out[0], afterLine)) {
+    out = out.slice(1)
+  }
+  if (out.length > 1 && equalsIgnoringWhitespace(out[out.length - 1], beforeLine)) {
+    out = out.slice(0, -1)
+  }
+  return out
+}
+
+export function stripRangeBoundaryEcho(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+  newLines: string[]
+): string[] {
+  const replacedCount = endLine - startLine + 1
+  if (newLines.length <= 1 || newLines.length <= replacedCount) {
+    return newLines
+  }
+
+  let out = newLines
+  const beforeIdx = startLine - 2
+  if (beforeIdx >= 0 && equalsIgnoringWhitespace(out[0], lines[beforeIdx])) {
+    out = out.slice(1)
+  }
+
+  const afterIdx = endLine
+  if (afterIdx < lines.length && out.length > 0 && equalsIgnoringWhitespace(out[out.length - 1], lines[afterIdx])) {
+    out = out.slice(0, -1)
+  }
+
+  return out
+}

--- a/src/tools/hashline-edit/edit-text-normalization.ts
+++ b/src/tools/hashline-edit/edit-text-normalization.ts
@@ -57,7 +57,7 @@ export function restoreLeadingIndent(templateLine: string, line: string): string
 }
 
 export function stripInsertAnchorEcho(anchorLine: string, newLines: string[]): string[] {
-  if (newLines.length <= 1) return newLines
+  if (newLines.length === 0) return newLines
   if (equalsIgnoringWhitespace(newLines[0], anchorLine)) {
     return newLines.slice(1)
   }
@@ -74,10 +74,10 @@ export function stripInsertBeforeEcho(anchorLine: string, newLines: string[]): s
 
 export function stripInsertBoundaryEcho(afterLine: string, beforeLine: string, newLines: string[]): string[] {
   let out = newLines
-  if (out.length > 1 && equalsIgnoringWhitespace(out[0], afterLine)) {
+  if (out.length > 0 && equalsIgnoringWhitespace(out[0], afterLine)) {
     out = out.slice(1)
   }
-  if (out.length > 1 && equalsIgnoringWhitespace(out[out.length - 1], beforeLine)) {
+  if (out.length > 0 && equalsIgnoringWhitespace(out[out.length - 1], beforeLine)) {
     out = out.slice(0, -1)
   }
   return out

--- a/src/tools/hashline-edit/hash-computation.test.ts
+++ b/src/tools/hashline-edit/hash-computation.test.ts
@@ -116,4 +116,26 @@ describe("streamHashLinesFrom*", () => {
     //#then
     expect(result).toBe(formatHashLines(content))
   })
+
+  it("matches formatHashLines for empty utf8 stream input", async () => {
+    //#given
+    const content = ""
+
+    //#when
+    const result = await collectStream(streamHashLinesFromUtf8(utf8Chunks(content, 1), { maxChunkLines: 1 }))
+
+    //#then
+    expect(result).toBe(formatHashLines(content))
+  })
+
+  it("matches formatHashLines for empty line iterable input", async () => {
+    //#given
+    const content = ""
+
+    //#when
+    const result = await collectStream(streamHashLinesFromLines([], { maxChunkLines: 1 }))
+
+    //#then
+    expect(result).toBe(formatHashLines(content))
+  })
 })

--- a/src/tools/hashline-edit/hashline-chunk-formatter.ts
+++ b/src/tools/hashline-edit/hashline-chunk-formatter.ts
@@ -1,0 +1,52 @@
+export interface HashlineChunkFormatter {
+  push(formattedLine: string): string[]
+  flush(): string | undefined
+}
+
+interface HashlineChunkFormatterOptions {
+  maxChunkLines: number
+  maxChunkBytes: number
+}
+
+export function createHashlineChunkFormatter(options: HashlineChunkFormatterOptions): HashlineChunkFormatter {
+  const { maxChunkLines, maxChunkBytes } = options
+  let outputLines: string[] = []
+  let outputBytes = 0
+
+  const flush = (): string | undefined => {
+    if (outputLines.length === 0) return undefined
+    const chunk = outputLines.join("\n")
+    outputLines = []
+    outputBytes = 0
+    return chunk
+  }
+
+  const push = (formattedLine: string): string[] => {
+    const chunksToYield: string[] = []
+    const separatorBytes = outputLines.length === 0 ? 0 : 1
+    const lineBytes = Buffer.byteLength(formattedLine, "utf-8")
+
+    if (
+      outputLines.length > 0 &&
+      (outputLines.length >= maxChunkLines || outputBytes + separatorBytes + lineBytes > maxChunkBytes)
+    ) {
+      const flushed = flush()
+      if (flushed) chunksToYield.push(flushed)
+    }
+
+    outputLines.push(formattedLine)
+    outputBytes += (outputLines.length === 1 ? 0 : 1) + lineBytes
+
+    if (outputLines.length >= maxChunkLines || outputBytes >= maxChunkBytes) {
+      const flushed = flush()
+      if (flushed) chunksToYield.push(flushed)
+    }
+
+    return chunksToYield
+  }
+
+  return {
+    push,
+    flush,
+  }
+}

--- a/src/tools/hashline-edit/index.ts
+++ b/src/tools/hashline-edit/index.ts
@@ -1,11 +1,19 @@
-export { computeLineHash, formatHashLine, formatHashLines } from "./hash-computation"
+export {
+  computeLineHash,
+  formatHashLine,
+  formatHashLines,
+  streamHashLinesFromLines,
+  streamHashLinesFromUtf8,
+} from "./hash-computation"
 export { parseLineRef, validateLineRef } from "./validation"
 export type { LineRef } from "./validation"
-export type { SetLine, ReplaceLines, InsertAfter, Replace, HashlineEdit } from "./types"
+export type { SetLine, ReplaceLines, InsertAfter, InsertBefore, InsertBetween, Replace, HashlineEdit } from "./types"
 export { NIBBLE_STR, HASHLINE_DICT, HASHLINE_REF_PATTERN, HASHLINE_OUTPUT_PATTERN } from "./constants"
 export {
   applyHashlineEdits,
   applyInsertAfter,
+  applyInsertBefore,
+  applyInsertBetween,
   applyReplace,
   applyReplaceLines,
   applySetLine,

--- a/src/tools/hashline-edit/tool-description.ts
+++ b/src/tools/hashline-edit/tool-description.ts
@@ -1,0 +1,34 @@
+export const HASHLINE_EDIT_DESCRIPTION = `Edit files using LINE#ID format for precise, safe modifications.
+
+WORKFLOW:
+1. Read the file and copy exact LINE#ID anchors.
+2. Submit one edit call with all related operations for that file.
+3. If more edits are needed after success, use the latest anchors from read/edit output.
+4. Use anchors as "LINE#ID" only (never include trailing ":content").
+
+VALIDATION:
+- Payload shape: { "filePath": string, "edits": [...], "delete"?: boolean, "rename"?: string }
+- Each edit must be one of: set_line, replace_lines, insert_after, insert_before, insert_between, replace
+- text/new_text must contain plain replacement text only (no LINE#ID prefixes, no diff + markers)
+
+LINE#ID FORMAT (CRITICAL - READ CAREFULLY):
+Each line reference must be in "LINE#ID" format where:
+- LINE: 1-based line number
+- ID: Two CID letters from the set ZPMQVRWSNKTXJBYH
+
+OPERATION TYPES:
+1. set_line
+2. replace_lines
+3. insert_after
+4. insert_before
+5. insert_between
+6. replace
+
+FILE MODES:
+- delete=true deletes file and requires edits=[] with no rename
+- rename moves final content to a new path and removes old path
+
+CONTENT FORMAT:
+- text/new_text can be a string (single line) or string[] (multi-line, preferred).
+- If you pass a multi-line string, it is split by real newline characters.
+- Literal "\\n" is preserved as text.`

--- a/src/tools/hashline-edit/tools.test.ts
+++ b/src/tools/hashline-edit/tools.test.ts
@@ -11,12 +11,10 @@ function createMockContext(): ToolContext {
     sessionID: "test",
     messageID: "test",
     agent: "test",
-    directory: "/tmp",
-    worktree: "/tmp",
     abort: new AbortController().signal,
     metadata: mock(() => {}),
     ask: async () => {},
-  }
+  } as unknown as ToolContext
 }
 
 describe("createHashlineEditTool", () => {
@@ -103,7 +101,7 @@ describe("createHashlineEditTool", () => {
 
     //#then
     expect(result).toContain("Error")
-    expect(result).toContain("hash")
+    expect(result).toContain(">>>")
   })
 
   it("preserves literal backslash-n and supports string[] payload", async () => {
@@ -131,5 +129,91 @@ describe("createHashlineEditTool", () => {
 
     //#then
     expect(fs.readFileSync(filePath, "utf-8")).toBe("join(\\n)\na\nb\nline2")
+  })
+
+  it("supports insert_before and insert_between", async () => {
+    //#given
+    const filePath = path.join(tempDir, "test.txt")
+    fs.writeFileSync(filePath, "line1\nline2\nline3")
+    const line1 = computeLineHash(1, "line1")
+    const line2 = computeLineHash(2, "line2")
+    const line3 = computeLineHash(3, "line3")
+
+    //#when
+    await tool.execute(
+      {
+        filePath,
+        edits: [
+          { type: "insert_before", line: `3#${line3}`, text: ["before3"] },
+          { type: "insert_between", after_line: `1#${line1}`, before_line: `2#${line2}`, text: ["between"] },
+        ],
+      },
+      createMockContext(),
+    )
+
+    //#then
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("line1\nbetween\nline2\nbefore3\nline3")
+  })
+
+  it("returns error when insert text is empty array", async () => {
+    //#given
+    const filePath = path.join(tempDir, "test.txt")
+    fs.writeFileSync(filePath, "line1\nline2")
+    const line1 = computeLineHash(1, "line1")
+
+    //#when
+    const result = await tool.execute(
+      {
+        filePath,
+        edits: [{ type: "insert_after", line: `1#${line1}`, text: [] }],
+      },
+      createMockContext(),
+    )
+
+    //#then
+    expect(result).toContain("Error")
+    expect(result).toContain("non-empty")
+  })
+
+  it("supports file rename with edits", async () => {
+    //#given
+    const filePath = path.join(tempDir, "source.txt")
+    const renamedPath = path.join(tempDir, "renamed.txt")
+    fs.writeFileSync(filePath, "line1\nline2")
+    const line2 = computeLineHash(2, "line2")
+
+    //#when
+    await tool.execute(
+      {
+        filePath,
+        rename: renamedPath,
+        edits: [{ type: "set_line", line: `2#${line2}`, text: "line2-updated" }],
+      },
+      createMockContext(),
+    )
+
+    //#then
+    expect(fs.existsSync(filePath)).toBe(false)
+    expect(fs.readFileSync(renamedPath, "utf-8")).toBe("line1\nline2-updated")
+  })
+
+  it("supports file delete mode", async () => {
+    //#given
+    const filePath = path.join(tempDir, "delete-me.txt")
+    fs.writeFileSync(filePath, "line1")
+
+    //#when
+    const result = await tool.execute(
+      {
+        filePath,
+        delete: true,
+        edits: [],
+      },
+      createMockContext(),
+    )
+
+    //#then
+    expect(fs.existsSync(filePath)).toBe(false)
+    expect(result).toContain("Successfully deleted")
   })
 })

--- a/src/tools/hashline-edit/types.ts
+++ b/src/tools/hashline-edit/types.ts
@@ -17,10 +17,23 @@ export interface InsertAfter {
   text: string | string[]
 }
 
+export interface InsertBefore {
+  type: "insert_before"
+  line: string
+  text: string | string[]
+}
+
+export interface InsertBetween {
+  type: "insert_between"
+  after_line: string
+  before_line: string
+  text: string | string[]
+}
+
 export interface Replace {
   type: "replace"
   old_text: string
   new_text: string | string[]
 }
 
-export type HashlineEdit = SetLine | ReplaceLines | InsertAfter | Replace
+export type HashlineEdit = SetLine | ReplaceLines | InsertAfter | InsertBefore | InsertBetween | Replace

--- a/src/tools/hashline-edit/validation.test.ts
+++ b/src/tools/hashline-edit/validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { computeLineHash } from "./hash-computation"
-import { parseLineRef, validateLineRef } from "./validation"
+import { parseLineRef, validateLineRef, validateLineRefs } from "./validation"
 
 describe("parseLineRef", () => {
   it("parses valid LINE#ID reference", () => {
@@ -49,7 +49,16 @@ describe("validateLineRef", () => {
     const lines = ["function hello() {"]
 
     //#when / #then
-    expect(() => validateLineRef(lines, "1#ZZ")).toThrow(/current hash/)
+    expect(() => validateLineRef(lines, "1#ZZ")).toThrow(/>>>\s+1#[ZPMQVRWSNKTXJBYH]{2}:/)
+  })
+
+  it("shows >>> mismatch context in batched validation", () => {
+    //#given
+    const lines = ["one", "two", "three", "four"]
+
+    //#when / #then
+    expect(() => validateLineRefs(lines, ["2#ZZ"]))
+      .toThrow(/>>>\s+2#[ZPMQVRWSNKTXJBYH]{2}:two/)
   })
 })
 
@@ -81,7 +90,7 @@ describe("legacy LINE:HEX backward compatibility", () => {
     const lines = ["function hello() {"]
 
     //#when / #then
-    expect(() => validateLineRef(lines, "1:ab")).toThrow(/Hash mismatch|current hash/)
+    expect(() => validateLineRef(lines, "1:ab")).toThrow(/>>>\s+1#[ZPMQVRWSNKTXJBYH]{2}:/)
   })
 
   it("extracts legacy ref from content with markers", () => {

--- a/src/tools/hashline-edit/validation.ts
+++ b/src/tools/hashline-edit/validation.ts
@@ -6,6 +6,13 @@ export interface LineRef {
   hash: string
 }
 
+interface HashMismatch {
+  line: number
+  expected: string
+}
+
+const MISMATCH_CONTEXT = 2
+
 const LINE_REF_EXTRACT_PATTERN = /([0-9]+#[ZPMQVRWSNKTXJBYH]{2}|[0-9]+:[0-9a-fA-F]{2,})/
 
 function normalizeLineRef(ref: string): string {
@@ -59,34 +66,85 @@ export function validateLineRef(lines: string[], ref: string): void {
   const currentHash = computeLineHash(line, content)
 
   if (currentHash !== hash) {
-    throw new Error(
-      `Hash mismatch at line ${line}. Expected hash: ${hash}, current hash: ${currentHash}. ` +
-        `Line content may have changed. Current content: "${content}"`
+    throw new HashlineMismatchError([{ line, expected: hash }], lines)
+  }
+}
+
+export class HashlineMismatchError extends Error {
+  readonly remaps: ReadonlyMap<string, string>
+
+  constructor(
+    private readonly mismatches: HashMismatch[],
+    private readonly fileLines: string[]
+  ) {
+    super(HashlineMismatchError.formatMessage(mismatches, fileLines))
+    this.name = "HashlineMismatchError"
+    const remaps = new Map<string, string>()
+    for (const mismatch of mismatches) {
+      const actual = computeLineHash(mismatch.line, fileLines[mismatch.line - 1] ?? "")
+      remaps.set(`${mismatch.line}#${mismatch.expected}`, `${mismatch.line}#${actual}`)
+    }
+    this.remaps = remaps
+  }
+
+  static formatMessage(mismatches: HashMismatch[], fileLines: string[]): string {
+    const mismatchByLine = new Map<number, HashMismatch>()
+    for (const mismatch of mismatches) mismatchByLine.set(mismatch.line, mismatch)
+
+    const displayLines = new Set<number>()
+    for (const mismatch of mismatches) {
+      const low = Math.max(1, mismatch.line - MISMATCH_CONTEXT)
+      const high = Math.min(fileLines.length, mismatch.line + MISMATCH_CONTEXT)
+      for (let line = low; line <= high; line++) displayLines.add(line)
+    }
+
+    const sortedLines = [...displayLines].sort((a, b) => a - b)
+    const output: string[] = []
+    output.push(
+      `${mismatches.length} line${mismatches.length > 1 ? "s have" : " has"} changed since last read. ` +
+        "Use updated LINE#ID references below (>>> marks changed lines)."
     )
+    output.push("")
+
+    let previousLine = -1
+    for (const line of sortedLines) {
+      if (previousLine !== -1 && line > previousLine + 1) {
+        output.push("    ...")
+      }
+      previousLine = line
+
+      const content = fileLines[line - 1] ?? ""
+      const hash = computeLineHash(line, content)
+      const prefix = `${line}#${hash}:${content}`
+      if (mismatchByLine.has(line)) {
+        output.push(`>>> ${prefix}`)
+      } else {
+        output.push(`    ${prefix}`)
+      }
+    }
+
+    return output.join("\n")
   }
 }
 
 export function validateLineRefs(lines: string[], refs: string[]): void {
-  const mismatches: string[] = []
+  const mismatches: HashMismatch[] = []
 
   for (const ref of refs) {
     const { line, hash } = parseLineRef(ref)
 
     if (line < 1 || line > lines.length) {
-      mismatches.push(`Line number ${line} out of bounds (file has ${lines.length} lines)`) 
-      continue
+      throw new Error(`Line number ${line} out of bounds (file has ${lines.length} lines)`)
     }
 
     const content = lines[line - 1]
     const currentHash = computeLineHash(line, content)
     if (currentHash !== hash) {
-      mismatches.push(
-        `line ${line}: expected ${hash}, current ${currentHash} (${line}#${currentHash}) content: "${content}"`
-      )
+      mismatches.push({ line, expected: hash })
     }
   }
 
   if (mismatches.length > 0) {
-    throw new Error(`Hash mismatches:\n- ${mismatches.join("\n- ")}`)
+    throw new HashlineMismatchError(mismatches, lines)
   }
 }


### PR DESCRIPTION
## Summary
- Add `insert_before` and `insert_between` hashline edit operations with dual-anchor validation.
- Enforce non-empty insert payloads for all insert operations, align with strict empty-insert error behavior.
- Improve hash mismatch errors with `>>>` context output, add edit dedup/noop reporting, and support delete/rename edit modes in tool args.
- Add streaming hashline formatters and expand tests for new operations and error behavior.

## Verification
- `bun test src/tools/hashline-edit/edit-operations.test.ts src/tools/hashline-edit/validation.test.ts src/tools/hashline-edit/hash-computation.test.ts src/tools/hashline-edit/tools.test.ts`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds precise anchor insert modes with strict validation and improved mismatch context, plus consistent chunked hashline streaming. Reports dedup/no-op edits and supports file delete/rename.

- **Bug Fixes**
  - Fixed anchor-echo stripping for single-line inserts and boundary-only insert_between payloads (empty inserts now error).
  - Aligned streamHashLines* with formatHashLines for empty inputs using a shared chunk formatter for consistent chunking.
  - Added regression tests for the above cases.

<sup>Written for commit 7e68690c700bb23951b518a61f7a564e15686b97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

