### PR TITLE
fix: plug resource leaks and add hook command timeout

### DIFF
--- a/src/shared/command-executor/execute-hook-command.ts
+++ b/src/shared/command-executor/execute-hook-command.ts
@@ -1,114 +1,116 @@
-import { spawn } from "node:child_process"
-import { getHomeDirectory } from "./home-directory"
-import { findBashPath, findZshPath } from "./shell-path"
+import { spawn } from "node:child_process";
+import { getHomeDirectory } from "./home-directory";
+import { findBashPath, findZshPath } from "./shell-path";
 
 export interface CommandResult {
-	exitCode: number
-	stdout?: string
-	stderr?: string
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
 }
 
-const DEFAULT_HOOK_TIMEOUT_MS = 30_000
-const SIGKILL_GRACE_MS = 5_000
+const DEFAULT_HOOK_TIMEOUT_MS = 30_000;
+const SIGKILL_GRACE_MS = 5_000;
 
 export interface ExecuteHookOptions {
-	forceZsh?: boolean
-	zshPath?: string
-	/** Timeout in milliseconds. Process is killed after this. Default: 30000 */
-	timeoutMs?: number
+  forceZsh?: boolean;
+  zshPath?: string;
+  /** Timeout in milliseconds. Process is killed after this. Default: 30000 */
+  timeoutMs?: number;
 }
 
 export async function executeHookCommand(
-	command: string,
-	stdin: string,
-	cwd: string,
-	options?: ExecuteHookOptions,
+  command: string,
+  stdin: string,
+  cwd: string,
+  options?: ExecuteHookOptions,
 ): Promise<CommandResult> {
-	const home = getHomeDirectory()
-	const timeoutMs = options?.timeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS
+  const home = getHomeDirectory();
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS;
 
-	const expandedCommand = command
-		.replace(/^~(?=\/|$)/g, home)
-		.replace(/\s~(?=\/)/g, ` ${home}`)
-		.replace(/\$CLAUDE_PROJECT_DIR/g, cwd)
-		.replace(/\$\{CLAUDE_PROJECT_DIR\}/g, cwd)
+  const expandedCommand = command
+    .replace(/^~(?=\/|$)/g, home)
+    .replace(/\s~(?=\/)/g, ` ${home}`)
+    .replace(/\$CLAUDE_PROJECT_DIR/g, cwd)
+    .replace(/\$\{CLAUDE_PROJECT_DIR\}/g, cwd);
 
-	let finalCommand = expandedCommand
+  let finalCommand = expandedCommand;
 
-	if (options?.forceZsh) {
-		const zshPath = findZshPath(options.zshPath)
-		const escapedCommand = expandedCommand.replace(/'/g, "'\\''")
-		if (zshPath) {
-			finalCommand = `${zshPath} -lc '${escapedCommand}'`
-		} else {
-			const bashPath = findBashPath()
-			if (bashPath) {
-				finalCommand = `${bashPath} -lc '${escapedCommand}'`
-			}
-		}
-	}
+  if (options?.forceZsh) {
+    const zshPath = findZshPath(options.zshPath);
+    const escapedCommand = expandedCommand.replace(/'/g, "'\\''");
+    if (zshPath) {
+      finalCommand = `${zshPath} -lc '${escapedCommand}'`;
+    } else {
+      const bashPath = findBashPath();
+      if (bashPath) {
+        finalCommand = `${bashPath} -lc '${escapedCommand}'`;
+      }
+    }
+  }
 
-	return new Promise((resolve) => {
-		let settled = false
-		let killTimer: ReturnType<typeof setTimeout> | null = null
+  return new Promise(resolve => {
+    let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
 
-		const proc = spawn(finalCommand, {
-			cwd,
-			shell: true,
-			env: { ...process.env, HOME: home, CLAUDE_PROJECT_DIR: cwd },
-		})
+    const proc = spawn(finalCommand, {
+      cwd,
+      shell: true,
+      env: { ...process.env, HOME: home, CLAUDE_PROJECT_DIR: cwd },
+    });
 
-		let stdout = ""
-		let stderr = ""
+    let stdout = "";
+    let stderr = "";
 
-		proc.stdout?.on("data", (data: Buffer) => {
-			stdout += data.toString()
-		})
+    proc.stdout?.on("data", (data: Buffer) => {
+      stdout += data.toString();
+    });
 
-		proc.stderr?.on("data", (data: Buffer) => {
-			stderr += data.toString()
-		})
+    proc.stderr?.on("data", (data: Buffer) => {
+      stderr += data.toString();
+    });
 
-		proc.stdin?.write(stdin)
-		proc.stdin?.end()
+    proc.stdin?.write(stdin);
+    proc.stdin?.end();
 
-		const settle = (result: CommandResult) => {
-			if (settled) return
-			settled = true
-			if (killTimer) clearTimeout(killTimer)
-			if (timeoutTimer) clearTimeout(timeoutTimer)
-			resolve(result)
-		}
+    const settle = (result: CommandResult) => {
+      if (settled) return;
+      settled = true;
+      if (killTimer) clearTimeout(killTimer);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      resolve(result);
+    };
 
-		proc.on("close", (code) => {
-			settle({
-				exitCode: code ?? 0,
-				stdout: stdout.trim(),
-				stderr: stderr.trim(),
-			})
-		})
+    proc.on("close", code => {
+      settle({
+        exitCode: code ?? 1,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+      });
+    });
 
-		proc.on("error", (err) => {
-			settle({ exitCode: 1, stderr: err.message })
-		})
+    proc.on("error", err => {
+      settle({ exitCode: 1, stderr: err.message });
+    });
 
-		const timeoutTimer = setTimeout(() => {
-			if (settled) return
-			// Try graceful shutdown first
-			proc.kill("SIGTERM")
-			killTimer = setTimeout(() => {
-				if (settled) return
-				try {
-					proc.kill("SIGKILL")
-				} catch {}
-			}, SIGKILL_GRACE_MS)
-			// Append timeout notice to stderr
-			stderr += `\nHook command timed out after ${timeoutMs}ms`
-		}, timeoutMs)
+    const timeoutTimer = setTimeout(() => {
+      if (settled) return;
+      // Try graceful shutdown first
+      try {
+        proc.kill("SIGTERM");
+      } catch {}
+      killTimer = setTimeout(() => {
+        if (settled) return;
+        try {
+          proc.kill("SIGKILL");
+        } catch {}
+      }, SIGKILL_GRACE_MS);
+      // Append timeout notice to stderr
+      stderr += `\nHook command timed out after ${timeoutMs}ms`;
+    }, timeoutMs);
 
-		// Don't let the timeout timer keep the process alive
-		if (timeoutTimer && typeof timeoutTimer === "object" && "unref" in timeoutTimer) {
-			timeoutTimer.unref()
-		}
-	})
+    // Don't let the timeout timer keep the process alive
+    if (timeoutTimer && typeof timeoutTimer === "object" && "unref" in timeoutTimer) {
+      timeoutTimer.unref();
+    }
+  });
 }

--- a/src/shared/command-executor/execute-hook-command.ts
+++ b/src/shared/command-executor/execute-hook-command.ts
@@ -98,7 +98,11 @@ export async function executeHookCommand(
     const killProcessGroup = (signal: NodeJS.Signals) => {
       try {
         if (!isWin32 && proc.pid) {
-          process.kill(-proc.pid, signal);
+          try {
+            process.kill(-proc.pid, signal);
+          } catch {
+            proc.kill(signal);
+          }
         } else {
           proc.kill(signal);
         }

--- a/src/shared/session-tools-store.ts
+++ b/src/shared/session-tools-store.ts
@@ -1,14 +1,18 @@
-const store = new Map<string, Record<string, boolean>>()
+const store = new Map<string, Record<string, boolean>>();
 
 export function setSessionTools(sessionID: string, tools: Record<string, boolean>): void {
-  store.set(sessionID, { ...tools })
+  store.set(sessionID, { ...tools });
 }
 
 export function getSessionTools(sessionID: string): Record<string, boolean> | undefined {
-  const tools = store.get(sessionID)
-  return tools ? { ...tools } : undefined
+  const tools = store.get(sessionID);
+  return tools ? { ...tools } : undefined;
+}
+
+export function deleteSessionTools(sessionID: string): void {
+  store.delete(sessionID);
 }
 
 export function clearSessionTools(): void {
-  store.clear()
+  store.clear();
 }

--- a/src/tools/lsp/lsp-manager-process-cleanup.ts
+++ b/src/tools/lsp/lsp-manager-process-cleanup.ts
@@ -1,45 +1,71 @@
 type ManagedClientForCleanup = {
   client: {
-    stop: () => Promise<void>
-  }
-}
+    stop: () => Promise<void>;
+  };
+};
 
 type ProcessCleanupOptions = {
-  getClients: () => IterableIterator<[string, ManagedClientForCleanup]>
-  clearClients: () => void
-  clearCleanupInterval: () => void
-}
+  getClients: () => IterableIterator<[string, ManagedClientForCleanup]>;
+  clearClients: () => void;
+  clearCleanupInterval: () => void;
+};
 
-export function registerLspManagerProcessCleanup(options: ProcessCleanupOptions): void {
+type RegisteredHandler = {
+  event: string;
+  listener: (...args: unknown[]) => void;
+};
+
+export type LspProcessCleanupHandle = {
+  unregister: () => void;
+};
+
+export function registerLspManagerProcessCleanup(options: ProcessCleanupOptions): LspProcessCleanupHandle {
+  const handlers: RegisteredHandler[] = [];
+
   // Synchronous cleanup for 'exit' event (cannot await)
   const syncCleanup = () => {
     for (const [, managed] of options.getClients()) {
       try {
         // Fire-and-forget during sync exit - process is terminating
-        void managed.client.stop().catch(() => {})
+        void managed.client.stop().catch(() => {});
       } catch {}
     }
-    options.clearClients()
-    options.clearCleanupInterval()
-  }
+    options.clearClients();
+    options.clearCleanupInterval();
+  };
 
   // Async cleanup for signal handlers - properly await all stops
   const asyncCleanup = async () => {
-    const stopPromises: Promise<void>[] = []
+    const stopPromises: Promise<void>[] = [];
     for (const [, managed] of options.getClients()) {
-      stopPromises.push(managed.client.stop().catch(() => {}))
+      stopPromises.push(managed.client.stop().catch(() => {}));
     }
-    await Promise.allSettled(stopPromises)
-    options.clearClients()
-    options.clearCleanupInterval()
-  }
+    await Promise.allSettled(stopPromises);
+    options.clearClients();
+    options.clearCleanupInterval();
+  };
 
-  process.on("exit", syncCleanup)
+  const registerHandler = (event: string, listener: (...args: unknown[]) => void) => {
+    handlers.push({ event, listener });
+    process.on(event, listener);
+  };
+
+  registerHandler("exit", syncCleanup);
 
   // Don't call process.exit() here; other handlers (background-agent manager) handle final exit.
-  process.on("SIGINT", () => void asyncCleanup().catch(() => {}))
-  process.on("SIGTERM", () => void asyncCleanup().catch(() => {}))
+  const signalCleanup = () => void asyncCleanup().catch(() => {});
+  registerHandler("SIGINT", signalCleanup);
+  registerHandler("SIGTERM", signalCleanup);
   if (process.platform === "win32") {
-    process.on("SIGBREAK", () => void asyncCleanup().catch(() => {}))
+    registerHandler("SIGBREAK", signalCleanup);
   }
+
+  return {
+    unregister: () => {
+      for (const { event, listener } of handlers) {
+        process.off(event, listener);
+      }
+      handlers.length = 0;
+    },
+  };
 }

--- a/src/tools/lsp/lsp-server.ts
+++ b/src/tools/lsp/lsp-server.ts
@@ -1,73 +1,74 @@
-import type { ResolvedServer } from "./types"
-import { registerLspManagerProcessCleanup } from "./lsp-manager-process-cleanup"
-import { cleanupTempDirectoryLspClients } from "./lsp-manager-temp-directory-cleanup"
-import { LSPClient } from "./lsp-client"
+import { LSPClient } from "./lsp-client";
+import { registerLspManagerProcessCleanup, type LspProcessCleanupHandle } from "./lsp-manager-process-cleanup";
+import { cleanupTempDirectoryLspClients } from "./lsp-manager-temp-directory-cleanup";
+import type { ResolvedServer } from "./types";
 interface ManagedClient {
-  client: LSPClient
-  lastUsedAt: number
-  refCount: number
-  initPromise?: Promise<void>
-  isInitializing: boolean
-  initializingSince?: number
+  client: LSPClient;
+  lastUsedAt: number;
+  refCount: number;
+  initPromise?: Promise<void>;
+  isInitializing: boolean;
+  initializingSince?: number;
 }
 class LSPServerManager {
-  private static instance: LSPServerManager
-  private clients = new Map<string, ManagedClient>()
-  private cleanupInterval: ReturnType<typeof setInterval> | null = null
-  private readonly IDLE_TIMEOUT = 5 * 60 * 1000
-  private readonly INIT_TIMEOUT = 60 * 1000
+  private static instance: LSPServerManager;
+  private clients = new Map<string, ManagedClient>();
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+  private readonly IDLE_TIMEOUT = 5 * 60 * 1000;
+  private readonly INIT_TIMEOUT = 60 * 1000;
+  private cleanupHandle: LspProcessCleanupHandle | null = null;
   private constructor() {
-    this.startCleanupTimer()
-    this.registerProcessCleanup()
+    this.startCleanupTimer();
+    this.registerProcessCleanup();
   }
   private registerProcessCleanup(): void {
-    registerLspManagerProcessCleanup({
+    this.cleanupHandle = registerLspManagerProcessCleanup({
       getClients: () => this.clients.entries(),
       clearClients: () => {
-        this.clients.clear()
+        this.clients.clear();
       },
       clearCleanupInterval: () => {
         if (this.cleanupInterval) {
-          clearInterval(this.cleanupInterval)
-          this.cleanupInterval = null
+          clearInterval(this.cleanupInterval);
+          this.cleanupInterval = null;
         }
       },
-    })
+    });
   }
 
   static getInstance(): LSPServerManager {
     if (!LSPServerManager.instance) {
-      LSPServerManager.instance = new LSPServerManager()
+      LSPServerManager.instance = new LSPServerManager();
     }
-    return LSPServerManager.instance
+    return LSPServerManager.instance;
   }
 
   private getKey(root: string, serverId: string): string {
-    return `${root}::${serverId}`
+    return `${root}::${serverId}`;
   }
 
   private startCleanupTimer(): void {
-    if (this.cleanupInterval) return
+    if (this.cleanupInterval) return;
     this.cleanupInterval = setInterval(() => {
-      this.cleanupIdleClients()
-    }, 60000)
+      this.cleanupIdleClients();
+    }, 60000);
   }
 
   private cleanupIdleClients(): void {
-    const now = Date.now()
+    const now = Date.now();
     for (const [key, managed] of this.clients) {
       if (managed.refCount === 0 && now - managed.lastUsedAt > this.IDLE_TIMEOUT) {
-        managed.client.stop()
-        this.clients.delete(key)
+        managed.client.stop();
+        this.clients.delete(key);
       }
     }
   }
 
   async getClient(root: string, server: ResolvedServer): Promise<LSPClient> {
-    const key = this.getKey(root, server.id)
-    let managed = this.clients.get(key)
+    const key = this.getKey(root, server.id);
+    let managed = this.clients.get(key);
     if (managed) {
-      const now = Date.now()
+      const now = Date.now();
       if (
         managed.isInitializing &&
         managed.initializingSince !== undefined &&
@@ -75,45 +76,45 @@ class LSPServerManager {
       ) {
         // Stale init can permanently block subsequent calls (e.g., LSP process hang)
         try {
-          await managed.client.stop()
+          await managed.client.stop();
         } catch {}
-        this.clients.delete(key)
-        managed = undefined
+        this.clients.delete(key);
+        managed = undefined;
       }
     }
     if (managed) {
       if (managed.initPromise) {
         try {
-          await managed.initPromise
+          await managed.initPromise;
         } catch {
           // Failed init should not keep the key blocked forever.
           try {
-            await managed.client.stop()
+            await managed.client.stop();
           } catch {}
-          this.clients.delete(key)
-          managed = undefined
+          this.clients.delete(key);
+          managed = undefined;
         }
       }
 
       if (managed) {
         if (managed.client.isAlive()) {
-          managed.refCount++
-          managed.lastUsedAt = Date.now()
-          return managed.client
+          managed.refCount++;
+          managed.lastUsedAt = Date.now();
+          return managed.client;
         }
         try {
-          await managed.client.stop()
+          await managed.client.stop();
         } catch {}
-        this.clients.delete(key)
+        this.clients.delete(key);
       }
     }
 
-    const client = new LSPClient(root, server)
+    const client = new LSPClient(root, server);
     const initPromise = (async () => {
-      await client.start()
-      await client.initialize()
-    })()
-    const initStartedAt = Date.now()
+      await client.start();
+      await client.initialize();
+    })();
+    const initStartedAt = Date.now();
     this.clients.set(key, {
       client,
       lastUsedAt: initStartedAt,
@@ -121,37 +122,37 @@ class LSPServerManager {
       initPromise,
       isInitializing: true,
       initializingSince: initStartedAt,
-    })
+    });
 
     try {
-      await initPromise
+      await initPromise;
     } catch (error) {
-      this.clients.delete(key)
+      this.clients.delete(key);
       try {
-        await client.stop()
+        await client.stop();
       } catch {}
-      throw error
+      throw error;
     }
-    const m = this.clients.get(key)
+    const m = this.clients.get(key);
     if (m) {
-      m.initPromise = undefined
-      m.isInitializing = false
-      m.initializingSince = undefined
+      m.initPromise = undefined;
+      m.isInitializing = false;
+      m.initializingSince = undefined;
     }
 
-    return client
+    return client;
   }
 
   warmupClient(root: string, server: ResolvedServer): void {
-    const key = this.getKey(root, server.id)
-    if (this.clients.has(key)) return
-    const client = new LSPClient(root, server)
+    const key = this.getKey(root, server.id);
+    if (this.clients.has(key)) return;
+    const client = new LSPClient(root, server);
     const initPromise = (async () => {
-      await client.start()
-      await client.initialize()
-    })()
+      await client.start();
+      await client.initialize();
+    })();
 
-    const initStartedAt = Date.now()
+    const initStartedAt = Date.now();
     this.clients.set(key, {
       client,
       lastUsedAt: initStartedAt,
@@ -159,53 +160,55 @@ class LSPServerManager {
       initPromise,
       isInitializing: true,
       initializingSince: initStartedAt,
-    })
+    });
 
     initPromise
       .then(() => {
-        const m = this.clients.get(key)
+        const m = this.clients.get(key);
         if (m) {
-          m.initPromise = undefined
-          m.isInitializing = false
-          m.initializingSince = undefined
+          m.initPromise = undefined;
+          m.isInitializing = false;
+          m.initializingSince = undefined;
         }
       })
       .catch(() => {
         // Warmup failures must not permanently block future initialization.
-        this.clients.delete(key)
-        void client.stop().catch(() => {})
-      })
+        this.clients.delete(key);
+        void client.stop().catch(() => {});
+      });
   }
 
   releaseClient(root: string, serverId: string): void {
-    const key = this.getKey(root, serverId)
-    const managed = this.clients.get(key)
+    const key = this.getKey(root, serverId);
+    const managed = this.clients.get(key);
     if (managed && managed.refCount > 0) {
-      managed.refCount--
-      managed.lastUsedAt = Date.now()
+      managed.refCount--;
+      managed.lastUsedAt = Date.now();
     }
   }
 
   isServerInitializing(root: string, serverId: string): boolean {
-    const key = this.getKey(root, serverId)
-    const managed = this.clients.get(key)
-    return managed?.isInitializing ?? false
+    const key = this.getKey(root, serverId);
+    const managed = this.clients.get(key);
+    return managed?.isInitializing ?? false;
   }
 
   async stopAll(): Promise<void> {
+    this.cleanupHandle?.unregister();
+    this.cleanupHandle = null;
     for (const [, managed] of this.clients) {
-      await managed.client.stop()
+      await managed.client.stop();
     }
-    this.clients.clear()
+    this.clients.clear();
     if (this.cleanupInterval) {
-      clearInterval(this.cleanupInterval)
-      this.cleanupInterval = null
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
     }
   }
 
   async cleanupTempDirectoryClients(): Promise<void> {
-    await cleanupTempDirectoryLspClients(this.clients)
+    await cleanupTempDirectoryLspClients(this.clients);
   }
 }
 
-export const lspManager = LSPServerManager.getInstance()
+export const lspManager = LSPServerManager.getInstance();


### PR DESCRIPTION
## Summary

Fixes 3 resource lifecycle bugs found during an audit comparing oh-my-opencode against upstream opencode:

- **🔴 LSP signal handlers never removed** — `registerLspManagerProcessCleanup()` registered anonymous signal handlers on `process` with no way to remove them. Now returns a `LspProcessCleanupHandle` with `unregister()`, which `LSPServerManager.stopAll()` calls on shutdown.
- **🟡 Session-tools-store leak** — `session-tools-store` Map grew per-session with no per-session eviction. Added `deleteSessionTools(sessionID)` and wired it into the `session.deleted` handler in `event.ts`.
- **🟡 Hook command execution has no timeout** — `executeHookCommand()` spawned processes that could hang indefinitely. Added configurable `timeoutMs` (default: 30s) with SIGTERM → 5s grace → SIGKILL escalation, matching upstream's subprocess timeout pattern.

## Changed Files

| File | Change |
|------|--------|
| `src/tools/lsp/lsp-manager-process-cleanup.ts` | Store handler refs, return `LspProcessCleanupHandle` with `unregister()` |
| `src/tools/lsp/lsp-server.ts` | Import handle type, store it, call `unregister()` in `stopAll()` |
| `src/shared/session-tools-store.ts` | Add `deleteSessionTools(sessionID)` |
| `src/plugin/event.ts` | Call `deleteSessionTools()` in `session.deleted` handler |
| `src/shared/command-executor/execute-hook-command.ts` | Add timeout with SIGTERM→SIGKILL escalation |

## Testing

- `session-tools-store.test.ts` — 5/5 pass ✅
- `state.test.ts` — 11/11 pass ✅
- No breaking changes to public API (all new fields are optional)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plugged resource leaks and hardened hook execution with a safe timeout that cleans up entire process trees. Improves shutdown and session cleanup; timeouts and signal kills now correctly fail with a clear stderr message.

- **Bug Fixes**
  - LSP cleanup: track signal handler refs; provide unregister handle; stopAll() now unregisters handlers.
  - Session tools: added deleteSessionTools(sessionID) and call it on session.deleted; clean up temp-directory LSP clients.
  - Hook commands: timeoutMs (default 30s) with SIGTERM→5s→SIGKILL; kill whole process group (non-Windows) with proc.kill fallback; null exit codes treated as failures (code ?? 1); guarded SIGTERM; stdin EPIPE handling; append timeout notice to stderr.

<sup>Written for commit 116f17ed1101a2fa34e765b0b9ce06864f1847ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

