### PR TITLE
fix: address Oracle + Cubic review feedback for background-agent refactoring

### DIFF
--- a/src/features/background-agent/compaction-aware-message-resolver.test.ts
+++ b/src/features/background-agent/compaction-aware-message-resolver.test.ts
@@ -96,8 +96,8 @@ describe("findNearestMessageExcludingCompaction", () => {
         agent: "sisyphus",
         model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
       }
-      writeFileSync(join(tempDir, "001.json"), JSON.stringify(compactionMessage))
-      writeFileSync(join(tempDir, "002.json"), JSON.stringify(validMessage))
+      writeFileSync(join(tempDir, "002.json"), JSON.stringify(compactionMessage))
+      writeFileSync(join(tempDir, "001.json"), JSON.stringify(validMessage))
 
       // when
       const result = findNearestMessageExcludingCompaction(tempDir)
@@ -155,8 +155,8 @@ describe("findNearestMessageExcludingCompaction", () => {
         agent: "oracle",
         model: { providerID: "google", modelID: "gemini-2-flash" },
       }
-      writeFileSync(join(tempDir, "001.json"), invalidJson)
-      writeFileSync(join(tempDir, "002.json"), JSON.stringify(validMessage))
+      writeFileSync(join(tempDir, "002.json"), invalidJson)
+      writeFileSync(join(tempDir, "001.json"), JSON.stringify(validMessage))
 
       // when
       const result = findNearestMessageExcludingCompaction(tempDir)

--- a/src/features/background-agent/fallback-retry-handler.ts
+++ b/src/features/background-agent/fallback-retry-handler.ts
@@ -117,6 +117,7 @@ export function tryFallbackRetry(args: {
     model: task.model,
     fallbackChain: task.fallbackChain,
     category: task.category,
+    isUnstableAgent: task.isUnstableAgent,
   }
   queue.push({ task, input: retryInput })
   queuesByKey.set(key, queue)

--- a/src/features/background-agent/process-cleanup.test.ts
+++ b/src/features/background-agent/process-cleanup.test.ts
@@ -64,7 +64,9 @@ describe("process-cleanup", () => {
 
       registerManagerForCleanup(manager)
 
-      const [, listener] = processOnCalls[0]
+      const exitEntry = processOnCalls.find(([signal]) => signal === "exit")
+      expect(exitEntry).toBeDefined()
+      const [, listener] = exitEntry!
       listener()
 
       expect(mockShutdown).toHaveBeenCalled()
@@ -83,7 +85,9 @@ describe("process-cleanup", () => {
       registerManagerForCleanup(manager2)
       registerManagerForCleanup(manager3)
 
-      const [, listener] = processOnCalls[0]
+      const exitEntry = processOnCalls.find(([signal]) => signal === "exit")
+      expect(exitEntry).toBeDefined()
+      const [, listener] = exitEntry!
       listener()
 
       expect(shutdown1).toHaveBeenCalledTimes(1)
@@ -144,7 +148,9 @@ describe("process-cleanup", () => {
       registerManagerForCleanup(manager1)
       registerManagerForCleanup(manager2)
 
-      const [, listener] = processOnCalls[0]
+      const exitEntry = processOnCalls.find(([signal]) => signal === "exit")
+      expect(exitEntry).toBeDefined()
+      const [, listener] = exitEntry!
       unregisterManagerForCleanup(manager2)
 
       listener()

--- a/src/features/background-agent/process-cleanup.ts
+++ b/src/features/background-agent/process-cleanup.ts
@@ -11,7 +11,7 @@ function registerProcessSignal(
     handler()
     if (exitAfter) {
       process.exitCode = 0
-      setTimeout(() => process.exit(), 6000)
+      setTimeout(() => process.exit(), 6000).unref()
     }
   }
   process.on(signal, listener)


### PR DESCRIPTION
## Summary

Follow-up to PR #2034 (background-agent refactoring). Addresses all 7 feedback items from Oracle and Cubic reviews.

## Oracle Feedback (2 fixes)

1. **`getMessageDir` behavior change** — Reverted from shared `getMessageDir()` (which adds guards: null for non-`ses_` IDs, path traversal rejection, SQLite backend check, directory scanning) back to original `join(MESSAGE_STORAGE, task.parentSessionID)` to preserve exact original behavior in `notifyParentSession()`.

2. **Dead `subagentSessions.delete`** — `tryFallbackRetry()` clears `task.sessionID` internally, making the subsequent `subagentSessions.delete(task.sessionID)` a no-op. Fixed by capturing `previousSessionID` before the call.

## Cubic Feedback (5 fixes)

3. **P1: `process-cleanup.ts:14`** — Added `.unref()` to `setTimeout(() => process.exit(), 6000)` to prevent guaranteed 6-second hang on Ctrl-C.

4. **P1: `process-cleanup.test.ts`** — Tests were invoking `processOnCalls[0]` (SIGINT listener) which triggers `process.exit()` and mutates global exit code. Changed to find and use the `exit` listener instead.

5. **P2: `compaction-aware-message-resolver.test.ts:99`** — "skips compaction" test didn't exercise skip logic because reverse sort meant `002.json` (valid) was checked first, `001.json` (compaction) never processed. Swapped filenames so compaction message is `002.json` (checked first).

6. **P2: `compaction-aware-message-resolver.test.ts:158`** — Same reverse-sort issue for invalid JSON test. Swapped filenames.

7. **P2: `fallback-retry-handler.ts:119`** — `retryInput` mapping was missing `isUnstableAgent` property from task.

## Skipped

- **Cubic P2: dual-loop optimization** in `compaction-aware-message-resolver.ts` — Original code also used dual loops. Changing algorithm would violate "pure refactoring" constraint.

## Verification

- 265 tests pass, 0 failures across all 12 background-agent test files
- 0 LSP errors on all changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses Oracle and Cubic review feedback for the background-agent refactor. Restores original message lookup, fixes shutdown hang and session cleanup, and updates tests to cover compaction and exit paths.

- **Bug Fixes**
  - Restore original message dir in notifyParentSession(): join(MESSAGE_STORAGE, parentSessionID).
  - Clear subagentSessions after fallback retry by capturing previousSessionID before tryFallbackRetry.
  - Prevent 6s hang on Ctrl-C: add .unref() to the delayed process.exit() timer.
  - Include isUnstableAgent in fallback retry input mapping.
  - Tests: use the 'exit' listener (not SIGINT) in process-cleanup tests; swap filenames in compaction-aware-message-resolver tests to exercise compaction-skip and invalid-JSON paths.

<sup>Written for commit d1e5bd63c14a2abc8df8107e4a119caa41dae331. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

