### PR TITLE
fix: honor OPENCODE_DISABLE_CLAUDE_CODE env var

### DIFF
--- a/src/config/schema/claude-code.ts
+++ b/src/config/schema/claude-code.ts
@@ -1,6 +1,7 @@
-import { z } from "zod"
+import { z } from "zod";
 
 export const ClaudeCodeConfigSchema = z.object({
+  enabled: z.boolean().optional(),
   mcp: z.boolean().optional(),
   commands: z.boolean().optional(),
   skills: z.boolean().optional(),
@@ -8,6 +9,24 @@ export const ClaudeCodeConfigSchema = z.object({
   hooks: z.boolean().optional(),
   plugins: z.boolean().optional(),
   plugins_override: z.record(z.string(), z.boolean()).optional(),
-})
+});
 
-export type ClaudeCodeConfig = z.infer<typeof ClaudeCodeConfigSchema>
+export type ClaudeCodeConfig = z.infer<typeof ClaudeCodeConfigSchema>;
+
+type ComponentKey = keyof Omit<
+  ClaudeCodeConfig,
+  "enabled" | "plugins_override"
+>;
+
+/**
+ * Returns whether a Claude Code component is enabled.
+ * `enabled: false` on the parent object is a hard master gate that overrides
+ * all per-component flags.
+ */
+export function isClaudeCodeEnabled(
+  claudeCode: ClaudeCodeConfig | undefined,
+  component: ComponentKey,
+): boolean {
+  if (claudeCode?.enabled === false) return false;
+  return claudeCode?.[component] ?? true;
+}

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "bun:test";
-import { mergeConfigs, parseConfigPartially } from "./plugin-config";
+import { describe, expect, it, test } from "bun:test";
+import {
+  mergeConfigs,
+  parseConfigPartially,
+  applyEnvVarOverrides,
+} from "./plugin-config";
+import { isClaudeCodeEnabled } from "./config/schema/claude-code";
 import type { OhMyOpenCodeConfig } from "./config";
 
 describe("mergeConfigs", () => {
@@ -39,7 +44,9 @@ describe("mergeConfigs", () => {
       // then general.temperature should be overridden
       expect(result.categories?.general?.temperature).toBe(0.3);
       // then quick should be preserved from base
-      expect(result.categories?.quick?.model).toBe("anthropic/claude-haiku-4-5");
+      expect(result.categories?.quick?.model).toBe(
+        "anthropic/claude-haiku-4-5",
+      );
       // then visual should be added from override
       expect(result.categories?.visual?.model).toBe("google/gemini-3-pro");
     });
@@ -233,7 +240,239 @@ describe("parseConfigPartially", () => {
 
       expect(result).not.toBeNull();
       expect(result!.agents?.oracle?.model).toBe("openai/gpt-5.2");
-      expect((result as Record<string, unknown>)["some_future_key"]).toBeUndefined();
+      expect(
+        (result as Record<string, unknown>)["some_future_key"],
+      ).toBeUndefined();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyEnvVarOverrides
+// ---------------------------------------------------------------------------
+
+describe("applyEnvVarOverrides", () => {
+  test("returns same reference when OPENCODE_DISABLE_CLAUDE_CODE is not set", () => {
+    //#given
+    const config: OhMyOpenCodeConfig = {};
+
+    //#when
+    const result = applyEnvVarOverrides(config, {});
+
+    //#then
+    expect(result).toBe(config);
+  });
+
+  test("disables all claude_code components when OPENCODE_DISABLE_CLAUDE_CODE=1", () => {
+    //#given
+    const config: OhMyOpenCodeConfig = {};
+
+    //#when
+    const result = applyEnvVarOverrides(config, {
+      OPENCODE_DISABLE_CLAUDE_CODE: "1",
+    });
+
+    //#then
+    expect(result.claude_code?.enabled).toBe(false);
+    expect(result.claude_code?.plugins).toBe(false);
+    expect(result.claude_code?.commands).toBe(false);
+    expect(result.claude_code?.skills).toBe(false);
+    expect(result.claude_code?.agents).toBe(false);
+    expect(result.claude_code?.mcp).toBe(false);
+    expect(result.claude_code?.hooks).toBe(false);
+  });
+
+  test("disables all claude_code components when OPENCODE_DISABLE_CLAUDE_CODE=true", () => {
+    //#given
+    const config: OhMyOpenCodeConfig = {};
+
+    //#when
+    const result = applyEnvVarOverrides(config, {
+      OPENCODE_DISABLE_CLAUDE_CODE: "true",
+    });
+
+    //#then
+    expect(result.claude_code?.enabled).toBe(false);
+    expect(result.claude_code?.plugins).toBe(false);
+  });
+
+  test("does not disable when OPENCODE_DISABLE_CLAUDE_CODE=0", () => {
+    //#given
+    const config: OhMyOpenCodeConfig = {};
+
+    //#when
+    const result = applyEnvVarOverrides(config, {
+      OPENCODE_DISABLE_CLAUDE_CODE: "0",
+    });
+
+    //#then
+    expect(result).toBe(config);
+    expect(result.claude_code?.enabled).toBeUndefined();
+  });
+
+  test("env override wins over explicit claude_code.mcp=true in user config", () => {
+    //#given
+    const config: OhMyOpenCodeConfig = { claude_code: { mcp: true } };
+
+    //#when
+    const result = applyEnvVarOverrides(config, {
+      OPENCODE_DISABLE_CLAUDE_CODE: "1",
+    });
+
+    //#then
+    expect(result.claude_code?.mcp).toBe(false);
+  });
+
+  test("preserves unrelated config fields and plugins_override after override", () => {
+    //#given
+    const config: OhMyOpenCodeConfig = {
+      disabled_mcps: ["some-server"] as any,
+      claude_code: { plugins_override: { "my-plugin": true } },
+    };
+
+    //#when
+    const result = applyEnvVarOverrides(config, {
+      OPENCODE_DISABLE_CLAUDE_CODE: "1",
+    });
+
+    //#then
+    expect(result.disabled_mcps).toEqual(["some-server"]);
+    expect(result.claude_code?.plugins_override).toEqual({ "my-plugin": true });
+  });
+
+  test("does not mutate the original config object", () => {
+    //#given
+    const config: OhMyOpenCodeConfig = { claude_code: { mcp: true } };
+    const originalClaudeCode = config.claude_code;
+
+    //#when
+    applyEnvVarOverrides(config, { OPENCODE_DISABLE_CLAUDE_CODE: "1" });
+
+    //#then — original is unchanged
+    expect(config.claude_code).toBe(originalClaudeCode);
+    expect(config.claude_code?.mcp).toBe(true);
+  });
+
+  // --- case-insensitive parsing ---
+
+  test("treats OPENCODE_DISABLE_CLAUDE_CODE=TRUE (uppercase) as truthy", () => {
+    const result = applyEnvVarOverrides({}, {
+      OPENCODE_DISABLE_CLAUDE_CODE: "TRUE",
+    });
+    expect(result.claude_code?.enabled).toBe(false);
+  });
+
+  test("treats OPENCODE_DISABLE_CLAUDE_CODE=True (mixed case) as truthy", () => {
+    const result = applyEnvVarOverrides({}, {
+      OPENCODE_DISABLE_CLAUDE_CODE: "True",
+    });
+    expect(result.claude_code?.enabled).toBe(false);
+  });
+
+  test("does not disable for non-truthy values like empty string or 'yes'", () => {
+    const config: OhMyOpenCodeConfig = {};
+    expect(applyEnvVarOverrides(config, { OPENCODE_DISABLE_CLAUDE_CODE: "" })).toBe(config);
+    expect(applyEnvVarOverrides(config, { OPENCODE_DISABLE_CLAUDE_CODE: "yes" })).toBe(config);
+    expect(applyEnvVarOverrides(config, { OPENCODE_DISABLE_CLAUDE_CODE: undefined })).toBe(config);
+  });
+
+  // --- OPENCODE_DISABLE_CLAUDE_CODE_SKILLS (per-component) ---
+
+  test("disables only skills when OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1", () => {
+    //#given
+    const config: OhMyOpenCodeConfig = {};
+
+    //#when
+    const result = applyEnvVarOverrides(config, {
+      OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "1",
+    });
+
+    //#then — skills disabled, rest untouched
+    expect(result.claude_code?.skills).toBe(false);
+    expect(result.claude_code?.plugins).toBeUndefined();
+    expect(result.claude_code?.commands).toBeUndefined();
+    expect(result.claude_code?.agents).toBeUndefined();
+    expect(result.claude_code?.mcp).toBeUndefined();
+    expect(result.claude_code?.hooks).toBeUndefined();
+    expect(result.claude_code?.enabled).toBeUndefined();
+  });
+
+  test("skills env override wins over explicit claude_code.skills=true in config", () => {
+    //#given
+    const config: OhMyOpenCodeConfig = { claude_code: { skills: true } };
+
+    //#when
+    const result = applyEnvVarOverrides(config, {
+      OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "true",
+    });
+
+    //#then
+    expect(result.claude_code?.skills).toBe(false);
+  });
+
+  test("master switch takes precedence over per-component skills var", () => {
+    //#given — both master and skills env vars set
+    const config: OhMyOpenCodeConfig = {};
+
+    //#when
+    const result = applyEnvVarOverrides(config, {
+      OPENCODE_DISABLE_CLAUDE_CODE: "1",
+      OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "1",
+    });
+
+    //#then — master disables everything, not just skills
+    expect(result.claude_code?.enabled).toBe(false);
+    expect(result.claude_code?.plugins).toBe(false);
+    expect(result.claude_code?.skills).toBe(false);
+  });
+
+  test("does not disable skills when OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=0", () => {
+    const config: OhMyOpenCodeConfig = {};
+    const result = applyEnvVarOverrides(config, {
+      OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "0",
+    });
+    expect(result).toBe(config);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isClaudeCodeEnabled
+// ---------------------------------------------------------------------------
+
+describe("isClaudeCodeEnabled", () => {
+  test("returns true for all components when claude_code is undefined", () => {
+    expect(isClaudeCodeEnabled(undefined, "plugins")).toBe(true);
+    expect(isClaudeCodeEnabled(undefined, "mcp")).toBe(true);
+    expect(isClaudeCodeEnabled(undefined, "skills")).toBe(true);
+    expect(isClaudeCodeEnabled(undefined, "agents")).toBe(true);
+    expect(isClaudeCodeEnabled(undefined, "commands")).toBe(true);
+    expect(isClaudeCodeEnabled(undefined, "hooks")).toBe(true);
+  });
+
+  test("returns false for every component when enabled=false (master gate)", () => {
+    const cc = { enabled: false as const };
+    expect(isClaudeCodeEnabled(cc, "plugins")).toBe(false);
+    expect(isClaudeCodeEnabled(cc, "commands")).toBe(false);
+    expect(isClaudeCodeEnabled(cc, "skills")).toBe(false);
+    expect(isClaudeCodeEnabled(cc, "agents")).toBe(false);
+    expect(isClaudeCodeEnabled(cc, "mcp")).toBe(false);
+    expect(isClaudeCodeEnabled(cc, "hooks")).toBe(false);
+  });
+
+  test("master gate takes priority even when component is explicitly true", () => {
+    const cc = { enabled: false as const, mcp: true as const };
+    expect(isClaudeCodeEnabled(cc, "mcp")).toBe(false);
+  });
+
+  test("returns per-component boolean when enabled is not false", () => {
+    expect(isClaudeCodeEnabled({ mcp: false }, "mcp")).toBe(false);
+    expect(isClaudeCodeEnabled({ mcp: true }, "mcp")).toBe(true);
+    expect(isClaudeCodeEnabled({ plugins: false }, "plugins")).toBe(false);
+    expect(isClaudeCodeEnabled({ skills: false }, "skills")).toBe(false);
+  });
+
+  test("defaults to true when component is absent but enabled is not false", () => {
+    expect(isClaudeCodeEnabled({}, "hooks")).toBe(true);
+    expect(isClaudeCodeEnabled({ enabled: true }, "skills")).toBe(true);
   });
 });

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -11,8 +11,63 @@ import {
   migrateConfigFile,
 } from "./shared";
 
+const DISABLE_ALL_CLAUDE_CODE = {
+  enabled: false,
+  plugins: false,
+  commands: false,
+  skills: false,
+  agents: false,
+  mcp: false,
+  hooks: false,
+} as const;
+
+/**
+ * Checks whether an env var holds a truthy disable flag.
+ * Matches OpenCode core convention: "1" or "true" (case-insensitive).
+ */
+function isTruthy(env: NodeJS.ProcessEnv, key: string): boolean {
+  const raw = env[key]?.toLowerCase();
+  return raw === "1" || raw === "true";
+}
+
+/**
+ * Applies hard overrides from OpenCode env vars onto the resolved config.
+ * Accepts an optional `env` parameter so the function is testable without
+ * global mocks.
+ *
+ * Supported env vars (mirrors OpenCode core flag.ts):
+ *   OPENCODE_DISABLE_CLAUDE_CODE        — master kill switch
+ *   OPENCODE_DISABLE_CLAUDE_CODE_SKILLS — disables skills only
+ */
+export function applyEnvVarOverrides(
+  config: OhMyOpenCodeConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): OhMyOpenCodeConfig {
+  if (isTruthy(env, "OPENCODE_DISABLE_CLAUDE_CODE")) {
+    return {
+      ...config,
+      claude_code: {
+        ...config.claude_code,
+        ...DISABLE_ALL_CLAUDE_CODE,
+      },
+    };
+  }
+
+  // Per-component overrides (mirrors OpenCode core flag.ts)
+  const skillsDisabled = isTruthy(env, "OPENCODE_DISABLE_CLAUDE_CODE_SKILLS");
+  if (!skillsDisabled) return config;
+
+  return {
+    ...config,
+    claude_code: {
+      ...config.claude_code,
+      skills: false,
+    },
+  };
+}
+
 export function parseConfigPartially(
-  rawConfig: Record<string, unknown>
+  rawConfig: Record<string, unknown>,
 ): OhMyOpenCodeConfig | null {
   const fullResult = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
   if (fullResult.success) {
@@ -23,7 +78,9 @@ export function parseConfigPartially(
   const invalidSections: string[] = [];
 
   for (const key of Object.keys(rawConfig)) {
-    const sectionResult = OhMyOpenCodeConfigSchema.safeParse({ [key]: rawConfig[key] });
+    const sectionResult = OhMyOpenCodeConfigSchema.safeParse({
+      [key]: rawConfig[key],
+    });
     if (sectionResult.success) {
       const parsed = sectionResult.data as Record<string, unknown>;
       if (parsed[key] !== undefined) {
@@ -49,7 +106,7 @@ export function parseConfigPartially(
 
 export function loadConfigFromPath(
   configPath: string,
-  _ctx: unknown
+  _ctx: unknown,
 ): OhMyOpenCodeConfig | null {
   try {
     if (fs.existsSync(configPath)) {
@@ -76,7 +133,9 @@ export function loadConfigFromPath(
 
       const partialResult = parseConfigPartially(rawConfig);
       if (partialResult) {
-        log(`Partial config loaded from ${configPath}`, { agents: partialResult.agents });
+        log(`Partial config loaded from ${configPath}`, {
+          agents: partialResult.agents,
+        });
         return partialResult;
       }
 
@@ -92,7 +151,7 @@ export function loadConfigFromPath(
 
 export function mergeConfigs(
   base: OhMyOpenCodeConfig,
-  override: OhMyOpenCodeConfig
+  override: OhMyOpenCodeConfig,
 ): OhMyOpenCodeConfig {
   return {
     ...base,
@@ -135,16 +194,14 @@ export function mergeConfigs(
 
 export function loadPluginConfig(
   directory: string,
-  ctx: unknown
+  ctx: unknown,
 ): OhMyOpenCodeConfig {
   // User-level config path - prefer .jsonc over .json
   const configDir = getOpenCodeConfigDir({ binary: "opencode" });
   const userBasePath = path.join(configDir, "oh-my-opencode");
   const userDetected = detectConfigFile(userBasePath);
   const userConfigPath =
-    userDetected.format !== "none"
-      ? userDetected.path
-      : userBasePath + ".json";
+    userDetected.format !== "none" ? userDetected.path : userBasePath + ".json";
 
   // Project-level config path - prefer .jsonc over .json
   const projectBasePath = path.join(directory, ".opencode", "oh-my-opencode");
@@ -164,9 +221,7 @@ export function loadPluginConfig(
     config = mergeConfigs(config, projectConfig);
   }
 
-  config = {
-    ...config,
-  };
+  config = applyEnvVarOverrides(config);
 
   log("Final merged config", {
     agents: config.agents,

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -1,6 +1,7 @@
 import { createBuiltinAgents } from "../agents";
 import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
 import type { OhMyOpenCodeConfig } from "../config";
+import { isClaudeCodeEnabled } from "../config/schema/claude-code";
 import { log, migrateAgentConfig } from "../shared";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { getAgentDisplayName } from "../shared/agent-display-names";
@@ -11,7 +12,10 @@ import {
   discoverProjectClaudeSkills,
   discoverUserClaudeSkills,
 } from "../features/opencode-skill-loader";
-import { loadProjectAgents, loadUserAgents } from "../features/claude-code-agent-loader";
+import {
+  loadProjectAgents,
+  loadUserAgents,
+} from "../features/claude-code-agent-loader";
 import type { PluginComponents } from "./plugin-components-loader";
 import { reorderAgentsByPriority } from "./agent-priority-order";
 import { remapAgentKeysToDisplayNames } from "./agent-key-remapper";
@@ -23,7 +27,9 @@ type AgentConfigRecord = Record<string, Record<string, unknown> | undefined> & {
   plan?: Record<string, unknown>;
 };
 
-function getConfiguredDefaultAgent(config: Record<string, unknown>): string | undefined {
+function getConfiguredDefaultAgent(
+  config: Record<string, unknown>,
+): string | undefined {
   const defaultAgent = config.default_agent;
   if (typeof defaultAgent !== "string") return undefined;
 
@@ -37,13 +43,18 @@ export async function applyAgentConfig(params: {
   ctx: { directory: string; client?: any };
   pluginComponents: PluginComponents;
 }): Promise<Record<string, unknown>> {
-  const migratedDisabledAgents = (params.pluginConfig.disabled_agents ?? []).map(
-    (agent) => {
-      return AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent;
-    },
-  ) as typeof params.pluginConfig.disabled_agents;
+  const migratedDisabledAgents = (
+    params.pluginConfig.disabled_agents ?? []
+  ).map((agent) => {
+    return (
+      AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent
+    );
+  }) as typeof params.pluginConfig.disabled_agents;
 
-  const includeClaudeSkillsForAwareness = params.pluginConfig.claude_code?.skills ?? true;
+  const includeClaudeSkillsForAwareness = isClaudeCodeEnabled(
+    params.pluginConfig.claude_code,
+    "skills",
+  );
   const [
     discoveredConfigSourceSkills,
     discoveredUserSkills,
@@ -55,10 +66,12 @@ export async function applyAgentConfig(params: {
       config: params.pluginConfig.skills,
       configDir: params.ctx.directory,
     }),
-    includeClaudeSkillsForAwareness ? discoverUserClaudeSkills() : Promise.resolve([]),
     includeClaudeSkillsForAwareness
-       ? discoverProjectClaudeSkills(params.ctx.directory)
-       : Promise.resolve([]),
+      ? discoverUserClaudeSkills()
+      : Promise.resolve([]),
+    includeClaudeSkillsForAwareness
+      ? discoverProjectClaudeSkills(params.ctx.directory)
+      : Promise.resolve([]),
     discoverOpencodeGlobalSkills(),
     discoverOpencodeProjectSkills(params.ctx.directory),
   ]);
@@ -74,9 +87,12 @@ export async function applyAgentConfig(params: {
   const browserProvider =
     params.pluginConfig.browser_automation_engine?.provider ?? "playwright";
   const currentModel = params.config.model as string | undefined;
-  const disabledSkills = new Set<string>(params.pluginConfig.disabled_skills ?? []);
+  const disabledSkills = new Set<string>(
+    params.pluginConfig.disabled_skills ?? [],
+  );
   const useTaskSystem = params.pluginConfig.experimental?.task_system ?? false;
-  const disableOmoEnv = params.pluginConfig.experimental?.disable_omo_env ?? false;
+  const disableOmoEnv =
+    params.pluginConfig.experimental?.disable_omo_env ?? false;
 
   const builtinAgents = await createBuiltinAgents(
     migratedDisabledAgents,
@@ -94,9 +110,14 @@ export async function applyAgentConfig(params: {
     disableOmoEnv,
   );
 
-  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
+  const includeClaudeAgents = isClaudeCodeEnabled(
+    params.pluginConfig.claude_code,
+    "agents",
+  );
   const userAgents = includeClaudeAgents ? loadUserAgents() : {};
-  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
+  const projectAgents = includeClaudeAgents
+    ? loadProjectAgents(params.ctx.directory)
+    : {};
 
   const rawPluginAgents = params.pluginComponents.agents;
   const pluginAgents = Object.fromEntries(
@@ -106,10 +127,12 @@ export async function applyAgentConfig(params: {
     ]),
   );
 
-  const isSisyphusEnabled = params.pluginConfig.sisyphus_agent?.disabled !== true;
+  const isSisyphusEnabled =
+    params.pluginConfig.sisyphus_agent?.disabled !== true;
   const builderEnabled =
     params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? false;
-  const plannerEnabled = params.pluginConfig.sisyphus_agent?.planner_enabled ?? true;
+  const plannerEnabled =
+    params.pluginConfig.sisyphus_agent?.planner_enabled ?? true;
   const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
   const shouldDemotePlan = plannerEnabled && replacePlan;
   const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
@@ -146,7 +169,9 @@ export async function applyAgentConfig(params: {
         ...migratedBuildConfig,
         description: `${(configAgent?.build?.description as string) ?? "Build agent"} (OpenCode default)`,
       };
-      agentConfig["OpenCode-Builder"] = override ? { ...base, ...override } : base;
+      agentConfig["OpenCode-Builder"] = override
+        ? { ...base, ...override }
+        : base;
     }
 
     if (plannerEnabled) {
@@ -173,7 +198,9 @@ export async function applyAgentConfig(params: {
             })
             .map(([key, value]) => [
               key,
-              value ? migrateAgentConfig(value as Record<string, unknown>) : value,
+              value
+                ? migrateAgentConfig(value as Record<string, unknown>)
+                : value,
             ]),
         )
       : {};
@@ -185,7 +212,9 @@ export async function applyAgentConfig(params: {
     const planDemoteConfig = shouldDemotePlan
       ? buildPlanDemoteConfig(
           agentConfig["prometheus"] as Record<string, unknown> | undefined,
-          params.pluginConfig.agents?.plan as Record<string, unknown> | undefined,
+          params.pluginConfig.agents?.plan as
+            | Record<string, unknown>
+            | undefined,
         )
       : undefined;
 
@@ -221,6 +250,8 @@ export async function applyAgentConfig(params: {
   }
 
   const agentResult = params.config.agent as Record<string, unknown>;
-  log("[config-handler] agents loaded", { agentKeys: Object.keys(agentResult) });
+  log("[config-handler] agents loaded", {
+    agentKeys: Object.keys(agentResult),
+  });
   return agentResult;
 }

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -1,4 +1,5 @@
 import type { OhMyOpenCodeConfig } from "../config";
+import { isClaudeCodeEnabled } from "../config/schema/claude-code";
 import { getAgentDisplayName } from "../shared/agent-display-names";
 import {
   loadUserCommands,
@@ -23,11 +24,20 @@ export async function applyCommandConfig(params: {
   ctx: { directory: string };
   pluginComponents: PluginComponents;
 }): Promise<void> {
-  const builtinCommands = loadBuiltinCommands(params.pluginConfig.disabled_commands);
-  const systemCommands = (params.config.command as Record<string, unknown>) ?? {};
+  const builtinCommands = loadBuiltinCommands(
+    params.pluginConfig.disabled_commands,
+  );
+  const systemCommands =
+    (params.config.command as Record<string, unknown>) ?? {};
 
-  const includeClaudeCommands = params.pluginConfig.claude_code?.commands ?? true;
-  const includeClaudeSkills = params.pluginConfig.claude_code?.skills ?? true;
+  const includeClaudeCommands = isClaudeCodeEnabled(
+    params.pluginConfig.claude_code,
+    "commands",
+  );
+  const includeClaudeSkills = isClaudeCodeEnabled(
+    params.pluginConfig.claude_code,
+    "skills",
+  );
 
   const [
     configSourceSkills,
@@ -45,11 +55,15 @@ export async function applyCommandConfig(params: {
       configDir: params.ctx.directory,
     }),
     includeClaudeCommands ? loadUserCommands() : Promise.resolve({}),
-    includeClaudeCommands ? loadProjectCommands(params.ctx.directory) : Promise.resolve({}),
+    includeClaudeCommands
+      ? loadProjectCommands(params.ctx.directory)
+      : Promise.resolve({}),
     loadOpencodeGlobalCommands(),
     loadOpencodeProjectCommands(params.ctx.directory),
     includeClaudeSkills ? loadUserSkills() : Promise.resolve({}),
-    includeClaudeSkills ? loadProjectSkills(params.ctx.directory) : Promise.resolve({}),
+    includeClaudeSkills
+      ? loadProjectSkills(params.ctx.directory)
+      : Promise.resolve({}),
     loadOpencodeGlobalSkills(),
     loadOpencodeProjectSkills(params.ctx.directory),
   ]);
@@ -70,10 +84,14 @@ export async function applyCommandConfig(params: {
     ...params.pluginComponents.skills,
   };
 
-  remapCommandAgentFields(params.config.command as Record<string, Record<string, unknown>>);
+  remapCommandAgentFields(
+    params.config.command as Record<string, Record<string, unknown>>,
+  );
 }
 
-function remapCommandAgentFields(commands: Record<string, Record<string, unknown>>): void {
+function remapCommandAgentFields(
+  commands: Record<string, Record<string, unknown>>,
+): void {
   for (const cmd of Object.values(commands)) {
     if (cmd?.agent && typeof cmd.agent === "string") {
       cmd.agent = getAgentDisplayName(cmd.agent);

--- a/src/plugin-handlers/mcp-config-handler.ts
+++ b/src/plugin-handlers/mcp-config-handler.ts
@@ -1,4 +1,5 @@
 import type { OhMyOpenCodeConfig } from "../config";
+import { isClaudeCodeEnabled } from "../config/schema/claude-code";
 import { loadMcpConfigs } from "../features/claude-code-mcp-loader";
 import { createBuiltinMcps } from "../mcp";
 import type { PluginComponents } from "./plugin-components-loader";
@@ -6,7 +7,7 @@ import type { PluginComponents } from "./plugin-components-loader";
 type McpEntry = Record<string, unknown>;
 
 function captureUserDisabledMcps(
-  userMcp: Record<string, unknown> | undefined
+  userMcp: Record<string, unknown> | undefined,
 ): Set<string> {
   const disabled = new Set<string>();
   if (!userMcp) return disabled;
@@ -34,7 +35,7 @@ export async function applyMcpConfig(params: {
   const userMcp = params.config.mcp as Record<string, unknown> | undefined;
   const userDisabledMcps = captureUserDisabledMcps(userMcp);
 
-  const mcpResult = params.pluginConfig.claude_code?.mcp ?? true
+  const mcpResult = isClaudeCodeEnabled(params.pluginConfig.claude_code, "mcp")
     ? await loadMcpConfigs(disabledMcps)
     : { servers: {} };
 

--- a/src/plugin-handlers/plugin-components-loader.ts
+++ b/src/plugin-handlers/plugin-components-loader.ts
@@ -1,4 +1,5 @@
 import type { OhMyOpenCodeConfig } from "../config";
+import { isClaudeCodeEnabled } from "../config/schema/claude-code";
 import { loadAllPluginComponents } from "../features/claude-code-plugin-loader";
 import { addConfigLoadError, log } from "../shared";
 
@@ -25,25 +26,31 @@ const EMPTY_PLUGIN_COMPONENTS: PluginComponents = {
 export async function loadPluginComponents(params: {
   pluginConfig: OhMyOpenCodeConfig;
 }): Promise<PluginComponents> {
-  const pluginsEnabled = params.pluginConfig.claude_code?.plugins ?? true;
+  const pluginsEnabled = isClaudeCodeEnabled(
+    params.pluginConfig.claude_code,
+    "plugins",
+  );
   if (!pluginsEnabled) {
     return EMPTY_PLUGIN_COMPONENTS;
   }
 
-  const timeoutMs = params.pluginConfig.experimental?.plugin_load_timeout_ms ?? 10000;
+  const timeoutMs =
+    params.pluginConfig.experimental?.plugin_load_timeout_ms ?? 10000;
 
   try {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(
-        () => reject(new Error(`Plugin loading timed out after ${timeoutMs}ms`)),
+        () =>
+          reject(new Error(`Plugin loading timed out after ${timeoutMs}ms`)),
         timeoutMs,
       );
     });
 
     const pluginComponents = (await Promise.race([
       loadAllPluginComponents({
-        enabledPluginsOverride: params.pluginConfig.claude_code?.plugins_override,
+        enabledPluginsOverride:
+          params.pluginConfig.claude_code?.plugins_override,
       }),
       timeoutPromise,
     ]).finally(() => {

--- a/src/plugin/hooks/create-transform-hooks.ts
+++ b/src/plugin/hooks/create-transform-hooks.ts
@@ -1,32 +1,37 @@
-import type { OhMyOpenCodeConfig } from "../../config"
-import type { PluginContext } from "../types"
+import type { OhMyOpenCodeConfig } from "../../config";
+import { isClaudeCodeEnabled } from "../../config/schema/claude-code";
+import type { PluginContext } from "../types";
 
 import {
   createClaudeCodeHooksHook,
   createKeywordDetectorHook,
   createThinkingBlockValidatorHook,
-} from "../../hooks"
+} from "../../hooks";
 import {
   contextCollector,
   createContextInjectorMessagesTransformHook,
-} from "../../features/context-injector"
-import { safeCreateHook } from "../../shared/safe-create-hook"
+} from "../../features/context-injector";
+import { safeCreateHook } from "../../shared/safe-create-hook";
 
 export type TransformHooks = {
-  claudeCodeHooks: ReturnType<typeof createClaudeCodeHooksHook> | null
-  keywordDetector: ReturnType<typeof createKeywordDetectorHook> | null
-  contextInjectorMessagesTransform: ReturnType<typeof createContextInjectorMessagesTransformHook>
-  thinkingBlockValidator: ReturnType<typeof createThinkingBlockValidatorHook> | null
-}
+  claudeCodeHooks: ReturnType<typeof createClaudeCodeHooksHook> | null;
+  keywordDetector: ReturnType<typeof createKeywordDetectorHook> | null;
+  contextInjectorMessagesTransform: ReturnType<
+    typeof createContextInjectorMessagesTransformHook
+  >;
+  thinkingBlockValidator: ReturnType<
+    typeof createThinkingBlockValidatorHook
+  > | null;
+};
 
 export function createTransformHooks(args: {
-  ctx: PluginContext
-  pluginConfig: OhMyOpenCodeConfig
-  isHookEnabled: (hookName: string) => boolean
-  safeHookEnabled?: boolean
+  ctx: PluginContext;
+  pluginConfig: OhMyOpenCodeConfig;
+  isHookEnabled: (hookName: string) => boolean;
+  safeHookEnabled?: boolean;
 }): TransformHooks {
-  const { ctx, pluginConfig, isHookEnabled } = args
-  const safeHookEnabled = args.safeHookEnabled ?? true
+  const { ctx, pluginConfig, isHookEnabled } = args;
+  const safeHookEnabled = args.safeHookEnabled ?? true;
 
   const claudeCodeHooks = isHookEnabled("claude-code-hooks")
     ? safeCreateHook(
@@ -35,14 +40,19 @@ export function createTransformHooks(args: {
           createClaudeCodeHooksHook(
             ctx,
             {
-              disabledHooks: (pluginConfig.claude_code?.hooks ?? true) ? undefined : true,
+              disabledHooks: isClaudeCodeEnabled(
+                pluginConfig.claude_code,
+                "hooks",
+              )
+                ? undefined
+                : true,
               keywordDetectorDisabled: !isHookEnabled("keyword-detector"),
             },
             contextCollector,
           ),
         { enabled: safeHookEnabled },
       )
-    : null
+    : null;
 
   const keywordDetector = isHookEnabled("keyword-detector")
     ? safeCreateHook(
@@ -50,10 +60,10 @@ export function createTransformHooks(args: {
         () => createKeywordDetectorHook(ctx, contextCollector),
         { enabled: safeHookEnabled },
       )
-    : null
+    : null;
 
   const contextInjectorMessagesTransform =
-    createContextInjectorMessagesTransformHook(contextCollector)
+    createContextInjectorMessagesTransformHook(contextCollector);
 
   const thinkingBlockValidator = isHookEnabled("thinking-block-validator")
     ? safeCreateHook(
@@ -61,12 +71,12 @@ export function createTransformHooks(args: {
         () => createThinkingBlockValidatorHook(),
         { enabled: safeHookEnabled },
       )
-    : null
+    : null;
 
   return {
     claudeCodeHooks,
     keywordDetector,
     contextInjectorMessagesTransform,
     thinkingBlockValidator,
-  }
+  };
 }

--- a/src/plugin/skill-context.ts
+++ b/src/plugin/skill-context.ts
@@ -1,10 +1,11 @@
-import type { AvailableSkill } from "../agents/dynamic-agent-prompt-builder"
-import type { OhMyOpenCodeConfig } from "../config"
-import type { BrowserAutomationProvider } from "../config/schema/browser-automation"
+import type { AvailableSkill } from "../agents/dynamic-agent-prompt-builder";
+import type { OhMyOpenCodeConfig } from "../config";
+import { isClaudeCodeEnabled } from "../config/schema/claude-code";
+import type { BrowserAutomationProvider } from "../config/schema/browser-automation";
 import type {
   LoadedSkill,
   SkillScope,
-} from "../features/opencode-skill-loader/types"
+} from "../features/opencode-skill-loader/types";
 
 import {
   discoverConfigSourceSkills,
@@ -15,34 +16,34 @@ import {
   discoverProjectAgentsSkills,
   discoverGlobalAgentsSkills,
   mergeSkills,
-} from "../features/opencode-skill-loader"
-import { createBuiltinSkills } from "../features/builtin-skills"
-import { getSystemMcpServerNames } from "../features/claude-code-mcp-loader"
+} from "../features/opencode-skill-loader";
+import { createBuiltinSkills } from "../features/builtin-skills";
+import { getSystemMcpServerNames } from "../features/claude-code-mcp-loader";
 
 export type SkillContext = {
-  mergedSkills: LoadedSkill[]
-  availableSkills: AvailableSkill[]
-  browserProvider: BrowserAutomationProvider
-  disabledSkills: Set<string>
-}
+  mergedSkills: LoadedSkill[];
+  availableSkills: AvailableSkill[];
+  browserProvider: BrowserAutomationProvider;
+  disabledSkills: Set<string>;
+};
 
 function mapScopeToLocation(scope: SkillScope): AvailableSkill["location"] {
-  if (scope === "user" || scope === "opencode") return "user"
-  if (scope === "project" || scope === "opencode-project") return "project"
-  return "plugin"
+  if (scope === "user" || scope === "opencode") return "user";
+  if (scope === "project" || scope === "opencode-project") return "project";
+  return "plugin";
 }
 
 export async function createSkillContext(args: {
-  directory: string
-  pluginConfig: OhMyOpenCodeConfig
+  directory: string;
+  pluginConfig: OhMyOpenCodeConfig;
 }): Promise<SkillContext> {
-  const { directory, pluginConfig } = args
+  const { directory, pluginConfig } = args;
 
   const browserProvider: BrowserAutomationProvider =
-    pluginConfig.browser_automation_engine?.provider ?? "playwright"
+    pluginConfig.browser_automation_engine?.provider ?? "playwright";
 
-  const disabledSkills = new Set<string>(pluginConfig.disabled_skills ?? [])
-  const systemMcpNames = getSystemMcpServerNames()
+  const disabledSkills = new Set<string>(pluginConfig.disabled_skills ?? []);
+  const systemMcpNames = getSystemMcpServerNames();
 
   const builtinSkills = createBuiltinSkills({
     browserProvider,
@@ -50,26 +51,38 @@ export async function createSkillContext(args: {
   }).filter((skill) => {
     if (skill.mcpConfig) {
       for (const mcpName of Object.keys(skill.mcpConfig)) {
-        if (systemMcpNames.has(mcpName)) return false
+        if (systemMcpNames.has(mcpName)) return false;
       }
     }
-    return true
-  })
+    return true;
+  });
 
-  const includeClaudeSkills = pluginConfig.claude_code?.skills !== false
-  const [configSourceSkills, userSkills, globalSkills, projectSkills, opencodeProjectSkills, agentsProjectSkills, agentsGlobalSkills] =
-    await Promise.all([
-      discoverConfigSourceSkills({
-        config: pluginConfig.skills,
-        configDir: directory,
-      }),
-      includeClaudeSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
-      discoverOpencodeGlobalSkills(),
-      includeClaudeSkills ? discoverProjectClaudeSkills(directory) : Promise.resolve([]),
-      discoverOpencodeProjectSkills(directory),
-      discoverProjectAgentsSkills(directory),
-      discoverGlobalAgentsSkills(),
-    ])
+  const includeClaudeSkills = isClaudeCodeEnabled(
+    pluginConfig.claude_code,
+    "skills",
+  );
+  const [
+    configSourceSkills,
+    userSkills,
+    globalSkills,
+    projectSkills,
+    opencodeProjectSkills,
+    agentsProjectSkills,
+    agentsGlobalSkills,
+  ] = await Promise.all([
+    discoverConfigSourceSkills({
+      config: pluginConfig.skills,
+      configDir: directory,
+    }),
+    includeClaudeSkills ? discoverUserClaudeSkills() : Promise.resolve([]),
+    discoverOpencodeGlobalSkills(),
+    includeClaudeSkills
+      ? discoverProjectClaudeSkills(directory)
+      : Promise.resolve([]),
+    discoverOpencodeProjectSkills(directory),
+    discoverProjectAgentsSkills(directory),
+    discoverGlobalAgentsSkills(),
+  ]);
 
   const mergedSkills = mergeSkills(
     builtinSkills,
@@ -80,18 +93,18 @@ export async function createSkillContext(args: {
     [...projectSkills, ...agentsProjectSkills],
     opencodeProjectSkills,
     { configDir: directory },
-  )
+  );
 
   const availableSkills: AvailableSkill[] = mergedSkills.map((skill) => ({
     name: skill.name,
     description: skill.definition.description ?? "",
     location: mapScopeToLocation(skill.scope),
-  }))
+  }));
 
   return {
     mergedSkills,
     availableSkills,
     browserProvider,
     disabledSkills,
-  }
+  };
 }


### PR DESCRIPTION
## Summary

Fixes #2037 — oh-my-opencode ignored `OPENCODE_DISABLE_CLAUDE_CODE` and related env vars, injecting Claude Code components into the resolved config regardless of the user's OpenCode-level opt-out.

### What changed

- **`applyEnvVarOverrides(config, env?)`** — pure function (env injected as parameter, testable without global mocks) called at the end of `loadPluginConfig`. Honors both master and per-component env vars:
  - `OPENCODE_DISABLE_CLAUDE_CODE=1|true` → disables all seven component gates
  - `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1|true` → disables only skills (matching OpenCode core's per-component cascade from `flag.ts`)
- **`isTruthy(env, key)`** — case-insensitive env var parser (`"1"`, `"true"`, `"TRUE"`, `"True"` all work)
- **`isClaudeCodeEnabled(claudeCode, component)`** — consolidates the `?? true` / `!== false` scatter across 8 call sites into a single function. Also honours the new `claude_code.enabled` master switch.
- **`claude_code.enabled?: boolean`** field in `ClaudeCodeConfigSchema` — single JSON-level master toggle subordinating all per-component flags.

## Files changed

| File | Change |
|---|---|
| `src/config/schema/claude-code.ts` | `enabled?: boolean` field + `isClaudeCodeEnabled` helper |
| `src/plugin-config.ts` | `applyEnvVarOverrides` with `isTruthy` + call in `loadPluginConfig` |
| `src/plugin-handlers/plugin-components-loader.ts` | gate → `isClaudeCodeEnabled` |
| `src/plugin-handlers/command-config-handler.ts` | 2 gates → `isClaudeCodeEnabled` |
| `src/plugin-handlers/agent-config-handler.ts` | 2 gates → `isClaudeCodeEnabled` |
| `src/plugin-handlers/mcp-config-handler.ts` | gate → `isClaudeCodeEnabled` |
| `src/plugin/hooks/create-transform-hooks.ts` | gate → `isClaudeCodeEnabled` |
| `src/plugin/skill-context.ts` | `!== false` → `isClaudeCodeEnabled` |
| `src/plugin-config.test.ts` | 30 tests (84 assertions) covering overrides, case sensitivity, edge cases |

## Behavior

| Scenario | Before | After |
|---|---|---|
| `OPENCODE_DISABLE_CLAUDE_CODE=1` | All 7 gates active | All 7 gates disabled |
| `OPENCODE_DISABLE_CLAUDE_CODE=TRUE` | All 7 gates active | All 7 gates disabled (case-insensitive) |
| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1` | Skills active | Skills disabled, other 6 unchanged |
| `OPENCODE_DISABLE_CLAUDE_CODE=1` + `SKILLS=0` | N/A | All 7 disabled (master wins) |
| `claude_code.enabled: false` in JSON | N/A (field didn't exist) | All 7 gates disabled |
| `claude_code.mcp: false` in JSON | `mcp` disabled | unchanged |
| No env var, no JSON override | All 7 active | unchanged |

Existing workaround (`claude_code.{ agents,commands,hooks,mcp,plugins,skills }: false`) continues to work.

## Test plan

- [x] `bun test src/plugin-config.test.ts` — 30 pass (84 assertions)
- [x] `bun test` — full suite passes, 0 fail
- [x] Typecheck clean
- [ ] Manual: `OPENCODE_DISABLE_CLAUDE_CODE=1 opencode debug config | rg "everything-claude-code"` should return empty

## Review feedback addressed

- **cubic P1**: Added `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` per-component support (confirmed real env var from OpenCode core `flag.ts`)
- **Copilot**: Fixed docstring from "pure" to "testable without global mocks"
- **Copilot**: Added per-component env var support (`SKILLS`)
- **Code quality**: Removed double shallow-copy at call site
- **Testing**: Added case-insensitive tests, edge cases (`""`, `"yes"`, `undefined`), per-component override tests