### PR TITLE
feat(commands): add /resume command and persist /handoff to file

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -69,7 +69,9 @@
           "cancel-ralph",
           "refactor",
           "start-work",
-          "stop-continuation"
+          "stop-continuation",
+          "handoff",
+          "resume-handoff"
         ]
       }
     },
@@ -80,6 +82,9 @@
       }
     },
     "hashline_edit": {
+      "type": "boolean"
+    },
+    "model_fallback": {
       "type": "boolean"
     },
     "agents": {

--- a/src/config/schema/commands.ts
+++ b/src/config/schema/commands.ts
@@ -8,6 +8,8 @@ export const BuiltinCommandNameSchema = z.enum([
   "refactor",
   "start-work",
   "stop-continuation",
+  "handoff",
+  "resume-handoff",
 ])
 
 export type BuiltinCommandName = z.infer<typeof BuiltinCommandNameSchema>

--- a/src/features/builtin-commands/commands.ts
+++ b/src/features/builtin-commands/commands.ts
@@ -6,6 +6,7 @@ import { STOP_CONTINUATION_TEMPLATE } from "./templates/stop-continuation"
 import { REFACTOR_TEMPLATE } from "./templates/refactor"
 import { START_WORK_TEMPLATE } from "./templates/start-work"
 import { HANDOFF_TEMPLATE } from "./templates/handoff"
+import { RESUME_TEMPLATE } from "./templates/resume"
 
 const BUILTIN_COMMAND_DEFINITIONS: Record<BuiltinCommandName, Omit<CommandDefinition, "name">> = {
   "init-deep": {
@@ -93,6 +94,16 @@ Timestamp: $TIMESTAMP
 $ARGUMENTS
 </user-request>`,
     argumentHint: "[goal]",
+  },
+  "resume-handoff": {
+    description: "(builtin) Resume work from a previous /handoff session",
+    template: `<command-instruction>
+${RESUME_TEMPLATE}
+</command-instruction>
+<user-request>
+$ARGUMENTS
+</user-request>`,
+    argumentHint: "[task]",
   },
 }
 

--- a/src/features/builtin-commands/templates/handoff.ts
+++ b/src/features/builtin-commands/templates/handoff.ts
@@ -142,36 +142,47 @@ Rules for the summary:
 
 ---
 
-# PHASE 4: PROVIDE INSTRUCTIONS
+# PHASE 4: SAVE TO FILE
 
-After generating the summary, instruct the user:
+After generating the summary, save it to disk using the Write tool:
+
+Write the HANDOFF CONTEXT block (everything from "HANDOFF CONTEXT" through "CONTEXT FOR CONTINUATION" section) to \`.opencode/handoff.md\`.
+
+IMPORTANT:
+- Write ONLY the handoff content — not the format instructions or this command template
+- Overwrite any existing handoff.md from a previous session
+- The file must be self-contained and readable without this session
+
+---
+
+# PHASE 5: CONFIRM AND INSTRUCT
+
+After saving the file, inform the user:
 
 \`\`\`
 ---
 
-TO CONTINUE IN A NEW SESSION:
+Handoff saved to .opencode/handoff.md
 
-1. Press 'n' in OpenCode TUI to open a new session, or run 'opencode' in a new terminal
-2. Paste the HANDOFF CONTEXT above as your first message
-3. Add your request: "Continue from the handoff context above. [Your next task]"
-
-The new session will have all context needed to continue seamlessly.
+To continue in a new session:
+1. Start a new OpenCode session (press 'n' in TUI, or run 'opencode' in a new terminal)
+2. Type /resume-handoff to pick up where you left off
 \`\`\`
 
 ---
 
 # IMPORTANT CONSTRAINTS
-
 - DO NOT attempt to programmatically create new sessions (no API available to agents)
 - DO provide a self-contained summary that works without access to this session
 - DO include workspace-relative file paths
 - DO NOT include sensitive information (API keys, credentials, secrets)
 - DO NOT exceed 10 files in the KEY FILES section
 - DO keep the GOAL section to a single sentence or short paragraph
+- DO save the handoff to .opencode/handoff.md before presenting instructions
 
 ---
 
 # EXECUTE NOW
 
-Begin by gathering programmatic context, then synthesize the handoff summary.
+Begin by gathering programmatic context, then synthesize the handoff summary, save it to file, and confirm.
 `

--- a/src/features/builtin-commands/templates/resume.ts
+++ b/src/features/builtin-commands/templates/resume.ts
@@ -1,0 +1,60 @@
+export const RESUME_TEMPLATE = `# Resume from Handoff
+
+## Purpose
+
+Load the handoff context from a previous session and continue work seamlessly.
+
+---
+
+# PHASE 1: LOAD HANDOFF
+
+Read the handoff file at \`.opencode/handoff.md\`.
+
+If the file does not exist:
+- Inform the user: "No handoff found at .opencode/handoff.md. Run /handoff in your current session first to save context."
+- Stop here.
+
+---
+
+# PHASE 2: INTERNALIZE CONTEXT
+
+Parse the handoff content and internalize:
+- USER REQUESTS: What the user originally asked for
+- GOAL: What should be done next
+- WORK COMPLETED: What was already done (do not redo this)
+- CURRENT STATE: Build status, environment, configuration
+- PENDING TASKS: What still needs to be done
+- KEY FILES: Important files to be aware of
+- IMPORTANT DECISIONS: Technical decisions already made (follow these)
+- EXPLICIT CONSTRAINTS: Rules to follow (non-negotiable)
+- CONTEXT FOR CONTINUATION: Warnings, gotchas, references
+
+---
+
+# PHASE 3: PRESENT SUMMARY AND CONTINUE
+
+Present a brief status to the user:
+
+\`\`\`
+Resumed from handoff.
+
+Previous session: [1-2 sentence summary of what was done]
+Pending: [1-2 sentence summary of what remains]
+\`\`\`
+
+Then:
+- If $ARGUMENTS contains a specific task: Start working on that task immediately
+- If PENDING TASKS exist and no specific task given: Ask the user if they want to continue with the pending tasks
+- If no pending tasks and no specific task: Ask the user what they would like to work on
+
+---
+
+# IMPORTANT CONSTRAINTS
+
+- DO NOT re-read files already summarized in the handoff unless you need their current content
+- DO NOT re-verify or redo completed work
+- DO respect all EXPLICIT CONSTRAINTS and IMPORTANT DECISIONS from the handoff
+- DO treat the handoff as ground truth for what was already accomplished
+- DO focus on moving forward, not looking backward
+- If the handoff mentions uncommitted changes or broken builds, address those first
+`

--- a/src/features/builtin-commands/types.ts
+++ b/src/features/builtin-commands/types.ts
@@ -1,6 +1,6 @@
 import type { CommandDefinition } from "../claude-code-command-loader"
 
-export type BuiltinCommandName = "init-deep" | "ralph-loop" | "cancel-ralph" | "ulw-loop" | "refactor" | "start-work" | "stop-continuation" | "handoff"
+export type BuiltinCommandName = "init-deep" | "ralph-loop" | "cancel-ralph" | "ulw-loop" | "refactor" | "start-work" | "stop-continuation" | "handoff" | "resume-handoff"
 
 export interface BuiltinCommandConfig {
   disabled_commands?: BuiltinCommandName[]


### PR DESCRIPTION
## Summary

- **`/handoff` now saves to file** — writes the context summary to `.opencode/handoff.md` instead of instructing the user to copy-paste into a new session
- **New `/resume` command** — reads `.opencode/handoff.md` and restores session context automatically, enabling a seamless `/handoff` → `/resume` workflow
- **Schema fix** — adds `"handoff"` to `BuiltinCommandNameSchema` (was missing despite the command existing, preventing users from disabling it via config)

## Motivation

The existing `/handoff` command generates a context summary but requires manual copy-paste to continue in a new session. This is error-prone and friction-heavy. By persisting to a known file path and adding `/resume`, the handoff-resume cycle becomes a two-command workflow:

1. `/handoff` — saves context to `.opencode/handoff.md`
2. Start new session → `/resume` — picks up where you left off

## Changes

| File | Change |
|------|--------|
| `templates/handoff.ts` | Phase 4-5: save to `.opencode/handoff.md` + confirm |
| `templates/resume.ts` | New template: load handoff, internalize, present summary, continue |
| `commands.ts` | Register `/resume` command |
| `types.ts` | Add `"resume"` to `BuiltinCommandName` union |
| `schema/commands.ts` | Add `"handoff"` and `"resume"` to Zod enum |
| `oh-my-opencode.schema.json` | Regenerated via `build:schema` |

## Testing

- Typecheck: clean (`tsc --noEmit`)
- Build: clean (`bun run build`)
- Tests: 3304 pass (33 pre-existing failures, none in changed files)
- Manual: tested `/handoff` → `/resume` round-trip end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a seamless handoff→resume workflow. /handoff writes the session summary to .opencode/handoff.md, and /resume-handoff restores context and continues work.

- New Features
  - /handoff saves the HANDOFF CONTEXT to .opencode/handoff.md (overwrites, self-contained) and confirms save with next-step instructions.
  - New /resume-handoff reads .opencode/handoff.md, summarizes prior work, and continues from pending tasks or an optional task; renamed from /resume to avoid conflict with the TUI’s /resume alias.

- Bug Fixes
  - Added "handoff" and "resume-handoff" to the BuiltinCommandName schema and regenerated the JSON schema, enabling correct config validation and allowing these commands to be disabled (schema regen also adds a model_fallback boolean).

<sup>Written for commit 6aded42bd6282e5a78e34a520d0e97802107d8f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

