### PR TITLE
feat(boulder): multi-boulder architecture for concurrent plan execution

### DIFF
--- a/src/cli/run/continuation-state.ts
+++ b/src/cli/run/continuation-state.ts
@@ -1,4 +1,4 @@
-import { getPlanProgress, readBoulderState } from "../../features/boulder-state"
+import { findBoulderForSession, getPlanProgress } from "../../features/boulder-state"
 import {
   getActiveContinuationMarkerReason,
   isContinuationMarkerActive,
@@ -29,10 +29,8 @@ export function getContinuationState(directory: string, sessionID: string): Cont
 }
 
 function hasActiveBoulderContinuation(directory: string, sessionID: string): boolean {
-  const boulder = readBoulderState(directory)
+  const boulder = findBoulderForSession(directory, sessionID)
   if (!boulder) return false
-  if (!boulder.session_ids.includes(sessionID)) return false
-
   const progress = getPlanProgress(boulder.active_plan)
   return !progress.isComplete
 }

--- a/src/features/boulder-state/constants.ts
+++ b/src/features/boulder-state/constants.ts
@@ -5,6 +5,8 @@
 export const BOULDER_DIR = ".sisyphus"
 export const BOULDER_FILE = "boulder.json"
 export const BOULDER_STATE_PATH = `${BOULDER_DIR}/${BOULDER_FILE}`
+export const BOULDERS_DIR = "boulders"
+export const BOULDERS_BASE_PATH = `${BOULDER_DIR}/${BOULDERS_DIR}`
 
 export const NOTEPAD_DIR = "notepads"
 export const NOTEPAD_BASE_PATH = `${BOULDER_DIR}/${NOTEPAD_DIR}`

--- a/src/features/boulder-state/index.ts
+++ b/src/features/boulder-state/index.ts
@@ -1,3 +1,4 @@
 export * from "./types"
 export * from "./constants"
 export * from "./storage"
+export * from "./plan-name-tracker"

--- a/src/features/boulder-state/plan-name-tracker.test.ts
+++ b/src/features/boulder-state/plan-name-tracker.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import {
+  setSessionPlanName,
+  getSessionPlanName,
+  clearSessionPlanName,
+  _resetPlanTrackerForTesting,
+} from "./plan-name-tracker"
+
+describe("plan-name-tracker", () => {
+  beforeEach(() => {
+    _resetPlanTrackerForTesting()
+  })
+
+  describe("#given session plan mapping", () => {
+    test("should store and retrieve plan name for session", () => {
+      // given
+      const sessionID = "session-123"
+      const planName = "my-plan"
+
+      // when
+      setSessionPlanName(sessionID, planName)
+      const result = getSessionPlanName(sessionID)
+
+      // then
+      expect(result).toBe(planName)
+    })
+
+    test("should return undefined for unknown session", () => {
+      // given
+      const unknownSessionID = "unknown-session"
+
+      // when
+      const result = getSessionPlanName(unknownSessionID)
+
+      // then
+      expect(result).toBeUndefined()
+    })
+
+    test("should clear plan name for session", () => {
+      // given
+      const sessionID = "session-456"
+      const planName = "another-plan"
+      setSessionPlanName(sessionID, planName)
+
+      // when
+      clearSessionPlanName(sessionID)
+      const result = getSessionPlanName(sessionID)
+
+      // then
+      expect(result).toBeUndefined()
+    })
+
+    test("should be idempotent on clear for unknown session", () => {
+      // given
+      const unknownSessionID = "unknown-session"
+
+      // when - clearing a session that was never set
+      clearSessionPlanName(unknownSessionID)
+      const result = getSessionPlanName(unknownSessionID)
+
+      // then - should not throw and return undefined
+      expect(result).toBeUndefined()
+    })
+
+    test("should not update plan name if already set", () => {
+      // given
+      const sessionID = "session-789"
+      const firstPlan = "first-plan"
+      const secondPlan = "second-plan"
+      setSessionPlanName(sessionID, firstPlan)
+
+      // when - attempt to set a different plan
+      setSessionPlanName(sessionID, secondPlan)
+      const result = getSessionPlanName(sessionID)
+
+      // then - should keep the first plan (idempotent)
+      expect(result).toBe(firstPlan)
+    })
+  })
+})

--- a/src/features/boulder-state/plan-name-tracker.ts
+++ b/src/features/boulder-state/plan-name-tracker.ts
@@ -1,0 +1,20 @@
+const sessionPlanMap = new Map<string, string>()
+
+export function setSessionPlanName(sessionID: string, planName: string): void {
+  if (!sessionPlanMap.has(sessionID)) {
+    sessionPlanMap.set(sessionID, planName)
+  }
+}
+
+export function getSessionPlanName(sessionID: string): string | undefined {
+  return sessionPlanMap.get(sessionID)
+}
+
+export function clearSessionPlanName(sessionID: string): void {
+  sessionPlanMap.delete(sessionID)
+}
+
+/** @internal For testing only */
+export function _resetPlanTrackerForTesting(): void {
+  sessionPlanMap.clear()
+}

--- a/src/features/boulder-state/storage.test.ts
+++ b/src/features/boulder-state/storage.test.ts
@@ -7,12 +7,15 @@ import {
   writeBoulderState,
   appendSessionId,
   clearBoulderState,
+  getBoulderFilePath,
+  findBoulderForSession,
   getPlanProgress,
   getPlanName,
   createBoulderState,
   findPrometheusPlans,
 } from "./storage"
 import type { BoulderState } from "./types"
+import { BOULDERS_DIR, BOULDER_DIR } from "./constants"
 
 describe("boulder-state", () => {
   const TEST_DIR = join(tmpdir(), "boulder-state-test-" + Date.now())
@@ -362,6 +365,152 @@ describe("boulder-state", () => {
 
       //#then - state should not have agent field (backward compatible)
       expect(state.agent).toBeUndefined()
+    })
+  })
+
+  describe("per-plan storage", () => {
+    test("getBoulderFilePath should return per-plan path when planName provided", () => {
+      //#given - directory and plan name
+      //#when
+      const result = getBoulderFilePath(TEST_DIR, "my-plan")
+      //#then
+      expect(result).toBe(join(TEST_DIR, BOULDER_DIR, BOULDERS_DIR, "my-plan.json"))
+    })
+
+    test("getBoulderFilePath should return default path when planName not provided", () => {
+      //#given - directory without plan name
+      //#when
+      const result = getBoulderFilePath(TEST_DIR)
+      //#then
+      expect(result).toBe(join(TEST_DIR, BOULDER_DIR, "boulder.json"))
+    })
+
+    test("writeBoulderState should write to per-plan path when planName provided", () => {
+      //#given - state and plan name
+      const state: BoulderState = {
+        active_plan: "/test/plan.md",
+        started_at: "2026-01-02T12:00:00Z",
+        session_ids: ["ses-123"],
+        plan_name: "my-plan",
+      }
+      //#when
+      const success = writeBoulderState(TEST_DIR, state, "my-plan")
+      //#then
+      expect(success).toBe(true)
+      const filePath = join(TEST_DIR, BOULDER_DIR, BOULDERS_DIR, "my-plan.json")
+      expect(existsSync(filePath)).toBe(true)
+    })
+
+    test("readBoulderState should read from per-plan path when planName provided", () => {
+      //#given - state written to per-plan path
+      const state: BoulderState = {
+        active_plan: "/test/plan.md",
+        started_at: "2026-01-02T12:00:00Z",
+        session_ids: ["ses-123"],
+        plan_name: "my-plan",
+      }
+      writeBoulderState(TEST_DIR, state, "my-plan")
+      //#when
+      const result = readBoulderState(TEST_DIR, "my-plan")
+      //#then
+      expect(result).not.toBeNull()
+      expect(result?.plan_name).toBe("my-plan")
+      expect(result?.session_ids).toEqual(["ses-123"])
+    })
+
+    test("clearBoulderState should delete only per-plan file when planName provided", () => {
+      //#given - multiple plan files
+      const state1: BoulderState = {
+        active_plan: "/test/plan1.md",
+        started_at: "2026-01-02T12:00:00Z",
+        session_ids: ["ses-1"],
+        plan_name: "plan-1",
+      }
+      const state2: BoulderState = {
+        active_plan: "/test/plan2.md",
+        started_at: "2026-01-02T12:00:00Z",
+        session_ids: ["ses-2"],
+        plan_name: "plan-2",
+      }
+      writeBoulderState(TEST_DIR, state1, "plan-1")
+      writeBoulderState(TEST_DIR, state2, "plan-2")
+      //#when
+      clearBoulderState(TEST_DIR, "plan-1")
+      //#then
+      expect(readBoulderState(TEST_DIR, "plan-1")).toBeNull()
+      expect(readBoulderState(TEST_DIR, "plan-2")).not.toBeNull()
+    })
+
+    test("appendSessionId should modify only per-plan file when planName provided", () => {
+      //#given - state with one session
+      const state: BoulderState = {
+        active_plan: "/test/plan.md",
+        started_at: "2026-01-02T12:00:00Z",
+        session_ids: ["ses-1"],
+        plan_name: "my-plan",
+      }
+      writeBoulderState(TEST_DIR, state, "my-plan")
+      //#when
+      const result = appendSessionId(TEST_DIR, "ses-2", "my-plan")
+      //#then
+      expect(result).not.toBeNull()
+      expect(result?.session_ids).toEqual(["ses-1", "ses-2"])
+    })
+
+    test("findBoulderForSession should return matching boulder state", () => {
+      //#given - multiple plan files with different sessions
+      const state1: BoulderState = {
+        active_plan: "/test/plan1.md",
+        started_at: "2026-01-02T12:00:00Z",
+        session_ids: ["ses-123"],
+        plan_name: "plan-1",
+      }
+      const state2: BoulderState = {
+        active_plan: "/test/plan2.md",
+        started_at: "2026-01-02T12:00:00Z",
+        session_ids: ["ses-456"],
+        plan_name: "plan-2",
+      }
+      writeBoulderState(TEST_DIR, state1, "plan-1")
+      writeBoulderState(TEST_DIR, state2, "plan-2")
+      //#when
+      const result = findBoulderForSession(TEST_DIR, "ses-123")
+      //#then
+      expect(result).not.toBeNull()
+      expect(result?.plan_name).toBe("plan-1")
+      expect(result?.session_ids).toContain("ses-123")
+    })
+
+    test("findBoulderForSession should return null when session not found", () => {
+      //#given - plan files without matching session
+      const state: BoulderState = {
+        active_plan: "/test/plan.md",
+        started_at: "2026-01-02T12:00:00Z",
+        session_ids: ["ses-123"],
+        plan_name: "my-plan",
+      }
+      writeBoulderState(TEST_DIR, state, "my-plan")
+      //#when
+      const result = findBoulderForSession(TEST_DIR, "unknown-ses")
+      //#then
+      expect(result).toBeNull()
+    })
+
+    test("backward compat: readBoulderState without planName reads from default boulder.json", () => {
+      //#given - state written to default boulder.json
+      const state: BoulderState = {
+        active_plan: "/test/plan.md",
+        started_at: "2026-01-02T12:00:00Z",
+        session_ids: ["ses-legacy"],
+        plan_name: "legacy-plan",
+      }
+      writeBoulderState(TEST_DIR, state)
+      //#when
+      const result = readBoulderState(TEST_DIR)
+      //#then
+      expect(result).not.toBeNull()
+      expect(result?.plan_name).toBe("legacy-plan")
+      expect(result?.session_ids).toContain("ses-legacy")
     })
   })
 })

--- a/src/features/boulder-state/storage.ts
+++ b/src/features/boulder-state/storage.ts
@@ -7,14 +7,17 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs"
 import { dirname, join, basename } from "node:path"
 import type { BoulderState, PlanProgress } from "./types"
-import { BOULDER_DIR, BOULDER_FILE, PROMETHEUS_PLANS_DIR } from "./constants"
+import { BOULDER_DIR, BOULDER_FILE, BOULDERS_DIR, PROMETHEUS_PLANS_DIR } from "./constants"
 
-export function getBoulderFilePath(directory: string): string {
+export function getBoulderFilePath(directory: string, planName?: string): string {
+  if (planName) {
+    return join(directory, BOULDER_DIR, BOULDERS_DIR, `${planName}.json`)
+  }
   return join(directory, BOULDER_DIR, BOULDER_FILE)
 }
 
-export function readBoulderState(directory: string): BoulderState | null {
-  const filePath = getBoulderFilePath(directory)
+export function readBoulderState(directory: string, planName?: string): BoulderState | null {
+  const filePath = getBoulderFilePath(directory, planName)
 
   if (!existsSync(filePath)) {
     return null
@@ -35,8 +38,8 @@ export function readBoulderState(directory: string): BoulderState | null {
   }
 }
 
-export function writeBoulderState(directory: string, state: BoulderState): boolean {
-  const filePath = getBoulderFilePath(directory)
+export function writeBoulderState(directory: string, state: BoulderState, planName?: string): boolean {
+  const filePath = getBoulderFilePath(directory, planName)
 
   try {
     const dir = dirname(filePath)
@@ -51,8 +54,8 @@ export function writeBoulderState(directory: string, state: BoulderState): boole
   }
 }
 
-export function appendSessionId(directory: string, sessionId: string): BoulderState | null {
-  const state = readBoulderState(directory)
+export function appendSessionId(directory: string, sessionId: string, planName?: string): BoulderState | null {
+  const state = readBoulderState(directory, planName)
   if (!state) return null
 
   if (!state.session_ids?.includes(sessionId)) {
@@ -60,7 +63,7 @@ export function appendSessionId(directory: string, sessionId: string): BoulderSt
       state.session_ids = []
     }
     state.session_ids.push(sessionId)
-    if (writeBoulderState(directory, state)) {
+    if (writeBoulderState(directory, state, planName)) {
       return state
     }
   }
@@ -68,8 +71,8 @@ export function appendSessionId(directory: string, sessionId: string): BoulderSt
   return state
 }
 
-export function clearBoulderState(directory: string): boolean {
-  const filePath = getBoulderFilePath(directory)
+export function clearBoulderState(directory: string, planName?: string): boolean {
+  const filePath = getBoulderFilePath(directory, planName)
 
   try {
     if (existsSync(filePath)) {
@@ -80,6 +83,36 @@ export function clearBoulderState(directory: string): boolean {
   } catch {
     return false
   }
+}
+
+export function findBoulderForSession(directory: string, sessionID: string): BoulderState | null {
+  const bouldersDirectory = join(directory, BOULDER_DIR, BOULDERS_DIR)
+  if (!existsSync(bouldersDirectory)) return null
+
+  try {
+    const files = readdirSync(bouldersDirectory)
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue
+      try {
+        const content = readFileSync(join(bouldersDirectory, file), "utf-8")
+        const parsed = JSON.parse(content)
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          !Array.isArray(parsed) &&
+          Array.isArray(parsed.session_ids) &&
+          parsed.session_ids.includes(sessionID)
+        ) {
+          return parsed as BoulderState
+        }
+      } catch {
+        continue
+      }
+    }
+  } catch {
+    return null
+  }
+  return null
 }
 
 /**

--- a/src/features/boulder-state/storage.ts
+++ b/src/features/boulder-state/storage.ts
@@ -55,15 +55,16 @@ export function writeBoulderState(directory: string, state: BoulderState, planNa
 }
 
 export function appendSessionId(directory: string, sessionId: string, planName?: string): BoulderState | null {
-  const state = readBoulderState(directory, planName)
+  // If planName given but per-plan file doesn't exist, fall back to legacy path
+  const resolvedPlanName = planName && existsSync(getBoulderFilePath(directory, planName)) ? planName : undefined
+  const state = readBoulderState(directory, resolvedPlanName)
   if (!state) return null
-
   if (!state.session_ids?.includes(sessionId)) {
     if (!Array.isArray(state.session_ids)) {
       state.session_ids = []
     }
     state.session_ids.push(sessionId)
-    if (writeBoulderState(directory, state, planName)) {
+    if (writeBoulderState(directory, state, resolvedPlanName)) {
       return state
     }
   }
@@ -87,30 +88,38 @@ export function clearBoulderState(directory: string, planName?: string): boolean
 
 export function findBoulderForSession(directory: string, sessionID: string): BoulderState | null {
   const bouldersDirectory = join(directory, BOULDER_DIR, BOULDERS_DIR)
-  if (!existsSync(bouldersDirectory)) return null
 
-  try {
-    const files = readdirSync(bouldersDirectory)
-    for (const file of files) {
-      if (!file.endsWith(".json")) continue
-      try {
-        const content = readFileSync(join(bouldersDirectory, file), "utf-8")
-        const parsed = JSON.parse(content)
-        if (
-          parsed &&
-          typeof parsed === "object" &&
-          !Array.isArray(parsed) &&
-          Array.isArray(parsed.session_ids) &&
-          parsed.session_ids.includes(sessionID)
-        ) {
-          return parsed as BoulderState
+  // Check per-plan boulders first
+  if (existsSync(bouldersDirectory)) {
+    try {
+      const files = readdirSync(bouldersDirectory)
+      for (const file of files) {
+        if (!file.endsWith(".json")) continue
+        try {
+          const content = readFileSync(join(bouldersDirectory, file), "utf-8")
+          const parsed = JSON.parse(content)
+          if (
+            parsed &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed) &&
+            Array.isArray(parsed.session_ids) &&
+            parsed.session_ids.includes(sessionID)
+          ) {
+            return parsed as BoulderState
+          }
+        } catch {
+          continue
         }
-      } catch {
-        continue
       }
+    } catch {
+      // Fall through to legacy check
     }
-  } catch {
-    return null
+  }
+
+  // Fall back to legacy boulder.json
+  const legacyState = readBoulderState(directory)
+  if (legacyState?.session_ids?.includes(sessionID)) {
+    return legacyState
   }
   return null
 }

--- a/src/features/builtin-commands/templates/start-work.ts
+++ b/src/features/builtin-commands/templates/start-work.ts
@@ -4,10 +4,10 @@ export const START_WORK_TEMPLATE = `You are starting a Sisyphus work session.
 
 1. **Find available plans**: Search for Prometheus-generated plan files at \`.sisyphus/plans/\`
 
-2. **Check for active boulder state**: Read \`.sisyphus/boulder.json\` if it exists
+2. **Check for active boulder state**: Read \`.sisyphus/boulders/{plan-name}.json\` if it exists
 
 3. **Decision logic**:
-   - If \`.sisyphus/boulder.json\` exists AND plan is NOT complete (has unchecked boxes):
+   - If \`.sisyphus/boulders/{plan-name}.json\` exists AND plan is NOT complete (has unchecked boxes):
      - **APPEND** current session to session_ids
      - Continue work on existing plan
    - If no active plan OR plan is complete:
@@ -15,7 +15,7 @@ export const START_WORK_TEMPLATE = `You are starting a Sisyphus work session.
      - If ONE plan: auto-select it
      - If MULTIPLE plans: show list with timestamps, ask user to select
 
-4. **Create/Update boulder.json**:
+4. **Create/Update \`.sisyphus/boulders/{plan-name}.json\`:
    \`\`\`json
    {
      "active_plan": "/absolute/path/to/plan.md",
@@ -67,6 +67,6 @@ Reading plan and beginning execution...
 ## CRITICAL
 
 - The session_id is injected by the hook - use it directly
-- Always update boulder.json BEFORE starting work
+- Always update the boulder file BEFORE starting work
 - Read the FULL plan file before delegating any tasks
 - Follow atlas delegation protocols (7-section format)`

--- a/src/hooks/atlas/event-handler.ts
+++ b/src/hooks/atlas/event-handler.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { getPlanProgress, readBoulderState } from "../../features/boulder-state"
+import { findBoulderForSession, getPlanProgress, getSessionPlanName, readBoulderState } from "../../features/boulder-state"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { log } from "../../shared/logger"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
@@ -41,7 +41,10 @@ export function createAtlasEventHandler(input: {
       log(`[${HOOK_NAME}] session.idle`, { sessionID })
 
       // Read boulder state FIRST to check if this session is part of an active boulder
-      const boulderState = readBoulderState(ctx.directory)
+      const planName = getSessionPlanName(sessionID)
+      const boulderState = planName
+        ? readBoulderState(ctx.directory, planName)
+        : findBoulderForSession(ctx.directory, sessionID)
       const isBoulderSession = boulderState?.session_ids?.includes(sessionID) ?? false
 
       const isBackgroundTaskSession = subagentSessions.has(sessionID)

--- a/src/hooks/atlas/tool-execute-after.ts
+++ b/src/hooks/atlas/tool-execute-after.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { appendSessionId, getPlanProgress, readBoulderState } from "../../features/boulder-state"
+import { appendSessionId, findBoulderForSession, getPlanProgress, getSessionPlanName, readBoulderState } from "../../features/boulder-state"
 import { log } from "../../shared/logger"
 import { isCallerOrchestrator } from "../../shared/session-utils"
 import { collectGitDiffStats, formatFileChanges } from "../../shared/git-worktree"
@@ -61,18 +61,21 @@ export function createToolExecuteAfterHandler(input: {
       const fileChanges = formatFileChanges(gitStats)
       const subagentSessionId = extractSessionIdFromOutput(toolOutput.output)
 
-      const boulderState = readBoulderState(ctx.directory)
+      const planName = toolInput.sessionID ? getSessionPlanName(toolInput.sessionID) : undefined
+      const boulderState = planName
+        ? readBoulderState(ctx.directory, planName)
+        : toolInput.sessionID
+          ? (findBoulderForSession(ctx.directory, toolInput.sessionID) ?? readBoulderState(ctx.directory))
+          : readBoulderState(ctx.directory)
       if (boulderState) {
         const progress = getPlanProgress(boulderState.active_plan)
-
         if (toolInput.sessionID && !boulderState.session_ids?.includes(toolInput.sessionID)) {
-          appendSessionId(ctx.directory, toolInput.sessionID)
+          appendSessionId(ctx.directory, toolInput.sessionID, boulderState.plan_name)
           log(`[${HOOK_NAME}] Appended session to boulder`, {
             sessionID: toolInput.sessionID,
             plan: boulderState.plan_name,
           })
         }
-
         // Preserve original subagent response - critical for debugging failed tasks
         const originalResponse = toolOutput.output
 

--- a/src/hooks/prometheus-md-only/agent-resolution.ts
+++ b/src/hooks/prometheus-md-only/agent-resolution.ts
@@ -6,7 +6,7 @@ import {
   findNearestMessageWithFieldsFromSDK,
 } from "../../features/hook-message-injector"
 import { getSessionAgent } from "../../features/claude-code-session-state"
-import { readBoulderState } from "../../features/boulder-state"
+import { findBoulderForSession } from "../../features/boulder-state"
 import { getMessageDir } from "../../shared/opencode-message-dir"
 import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 
@@ -51,8 +51,8 @@ export async function getAgentFromSession(
   if (memoryAgent) return memoryAgent
 
   // Check boulder state (persisted across restarts) - fixes #927
-  const boulderState = readBoulderState(directory)
-  if (boulderState?.session_ids?.includes(sessionID) && boulderState.agent) {
+  const boulderState = findBoulderForSession(directory, sessionID)
+  if (boulderState?.agent) {
     return boulderState.agent
   }
 

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -8,6 +8,9 @@ import {
   createBoulderState,
   getPlanName,
   clearBoulderState,
+  findBoulderForSession,
+  setSessionPlanName,
+  getSessionPlanName,
 } from "../../features/boulder-state"
 import { log } from "../../shared/logger"
 import { updateSessionAgent } from "../../features/claude-code-session-state"
@@ -73,9 +76,12 @@ export function createStartWorkHook(ctx: PluginInput) {
 
       updateSessionAgent(input.sessionID, "atlas") // Always switch: fixes #1298
 
-      const existingState = readBoulderState(ctx.directory)
       const sessionId = input.sessionID
       const timestamp = new Date().toISOString()
+      const existingPlanName = getSessionPlanName(sessionId)
+      let existingState = existingPlanName
+        ? readBoulderState(ctx.directory, existingPlanName)
+        : findBoulderForSession(ctx.directory, sessionId) ?? readBoulderState(ctx.directory)
 
       let contextInfo = ""
       
@@ -100,10 +106,11 @@ The requested plan "${getPlanName(matchedPlan)}" has been completed.
 All ${progress.total} tasks are done. Create a new plan with: /plan "your task"`
           } else {
             if (existingState) {
-              clearBoulderState(ctx.directory)
+              clearBoulderState(ctx.directory, existingState.plan_name)
             }
             const newState = createBoulderState(matchedPlan, sessionId, "atlas")
-            writeBoulderState(ctx.directory, newState)
+            writeBoulderState(ctx.directory, newState, getPlanName(matchedPlan))
+            setSessionPlanName(sessionId, getPlanName(matchedPlan))
             
             contextInfo = `
 ## Auto-Selected Plan
@@ -145,7 +152,8 @@ No incomplete plans available. Create a new plan with: /plan "your task"`
         const progress = getPlanProgress(existingState.active_plan)
         
         if (!progress.isComplete) {
-          appendSessionId(ctx.directory, sessionId)
+          appendSessionId(ctx.directory, sessionId, existingState.plan_name)
+          setSessionPlanName(sessionId, existingState.plan_name)
           contextInfo = `
 ## Active Work Session Found
 
@@ -188,7 +196,8 @@ All ${plans.length} plan(s) are complete. Create a new plan with: /plan "your ta
           const planPath = incompletePlans[0]
           const progress = getPlanProgress(planPath)
           const newState = createBoulderState(planPath, sessionId, "atlas")
-          writeBoulderState(ctx.directory, newState)
+          writeBoulderState(ctx.directory, newState, getPlanName(planPath))
+          setSessionPlanName(sessionId, getPlanName(planPath))
 
           contextInfo += `
 

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -10,6 +10,7 @@ import {
   syncSubagentSessions,
   updateSessionAgent,
 } from "../features/claude-code-session-state";
+import { clearSessionPlanName } from "../features/boulder-state";
 import {
   clearPendingModelFallback,
   clearSessionFallbackChain,
@@ -237,6 +238,7 @@ export function createEventHandler(args: {
 
       if (sessionInfo?.id) {
         clearSessionAgent(sessionInfo.id);
+        clearSessionPlanName(sessionInfo.id);
         lastHandledModelErrorMessageID.delete(sessionInfo.id);
         lastHandledRetryStatusKey.delete(sessionInfo.id);
         lastKnownModelBySession.delete(sessionInfo.id);

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -1,7 +1,7 @@
 import type { PluginContext } from "./types"
 
 import { getMainSessionID } from "../features/claude-code-session-state"
-import { clearBoulderState } from "../features/boulder-state"
+import { clearBoulderState, clearSessionPlanName, findBoulderForSession, getSessionPlanName } from "../features/boulder-state"
 import { log } from "../shared"
 import { resolveSessionAgent } from "./session-agent-resolver"
 import { parseRalphLoopArguments } from "../hooks/ralph-loop/command-arguments"
@@ -102,7 +102,10 @@ export function createToolExecuteBeforeHandler(args: {
         hooks.stopContinuationGuard?.stop(sessionID)
         hooks.todoContinuationEnforcer?.cancelAllCountdowns()
         hooks.ralphLoop?.cancelLoop(sessionID)
-        clearBoulderState(ctx.directory)
+        const planName = getSessionPlanName(sessionID)
+          ?? findBoulderForSession(ctx.directory, sessionID)?.plan_name
+        clearBoulderState(ctx.directory, planName)
+        clearSessionPlanName(sessionID)
         log("[stop-continuation] All continuation mechanisms stopped", {
           sessionID,
         })


### PR DESCRIPTION
## Summary

- Migrates boulder state from singleton `.sisyphus/boulder.json` (last-write-wins) to per-plan `.sisyphus/boulders/{plan-name}.json` files, enabling multiple plans to execute concurrently without conflicts
- Adds an in-memory `Map<sessionID, planName>` tracker (`plan-name-tracker.ts`) with disk-scan fallback (`findBoulderForSession`) for the CLI `run` process (separate process, no shared memory)
- All 6 consumer hooks migrated to plan-aware storage; full backward compatibility preserved via optional `planName` parameter (existing API unchanged)

## Problem

The singleton `.sisyphus/boulder.json` is the only bottleneck preventing parallel multi-plan execution. When two plans run concurrently, the last writer wins and corrupts the other plan's state. Evidence and notepad paths are already plan-name isolated — only the boulder file was missing this isolation.

## Solution

Per-plan boulder files at `.sisyphus/boulders/{plan-name}.json`:
- `start-work` writes to the per-plan path and registers `sessionID → planName` in memory
- All consumers resolve the plan-aware path via `getSessionPlanName(sessionID)` (in-memory, fast) with `findBoulderForSession(dir, sessionID)` (disk scan) as fallback
- Legacy `.sisyphus/boulder.json` still works — `findBoulderForSession` and `appendSessionId` both fall back to it when no per-plan file exists

## Changes

**Storage layer** (`src/features/boulder-state/`):
- `constants.ts` — Added `BOULDERS_DIR = "boulders"` and `BOULDERS_BASE_PATH`
- `storage.ts` — Optional `planName?` on 5 I/O functions; new `findBoulderForSession()` with legacy fallback; `appendSessionId` falls back to legacy path when per-plan file doesn't exist
- `plan-name-tracker.ts` — New: in-memory `Map<sessionID, planName>` with `setSessionPlanName` / `getSessionPlanName` / `clearSessionPlanName`
- `index.ts` — Barrel export for `plan-name-tracker`

**Consumer hooks** (all migrated to plan-aware calls):
- `src/hooks/start-work/start-work-hook.ts` — Primary writer; calls `setSessionPlanName` + writes to per-plan path
- `src/hooks/atlas/event-handler.ts` — Reads via `getSessionPlanName → readBoulderState(dir, planName) ?? findBoulderForSession`
- `src/hooks/atlas/tool-execute-after.ts` — Same fallback chain + `appendSessionId` with plan name
- `src/hooks/prometheus-md-only/agent-resolution.ts` — Uses `findBoulderForSession` for agent resolution
- `src/cli/run/continuation-state.ts` — Uses `findBoulderForSession` (disk-only; CLI is a separate process)
- `src/plugin/tool-execute-before.ts` — `/stop-continuation` clears per-plan boulder + `clearSessionPlanName`

**Cleanup wiring**:
- `src/plugin/event.ts` — `session.deleted` now calls `clearSessionPlanName(sessionID)`
- `src/features/builtin-commands/templates/start-work.ts` — Updated path references from `boulder.json` to `boulders/{plan-name}.json`

## Backward Compatibility

- All 5 storage functions accept optional `planName?` as last parameter — omitting it reads/writes the legacy `.sisyphus/boulder.json` path unchanged
- `findBoulderForSession` scans per-plan files first, then falls back to legacy `boulder.json`
- `appendSessionId` falls back to legacy path when the per-plan file doesn't exist
- Zero breaking changes to existing consumers that don't pass `planName`

## Testing

- TDD approach: tests written RED → GREEN for all new storage functions
- **9 new tests** in `storage.test.ts` covering per-plan read/write/clear/append/find + legacy fallback
- **5 new tests** in `plan-name-tracker.test.ts` covering set/get/clear/reset
- All **31 storage tests** pass; all **36 atlas hook tests** pass; all **107 targeted tests** pass
- Full suite: **3299 pass** (52 pre-existing failures unchanged — none related to this change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable concurrent plan execution by moving boulder state to per-plan files and adding a session→plan tracker. All hooks now resolve plan-aware state with a legacy fallback; no breaking changes.

- **New Features**
  - Per-plan storage at .sisyphus/boulders/{plan}.json; all read/write/append/clear functions accept optional planName.
  - New findBoulderForSession scans per-plan files first, then falls back to legacy boulder.json.
  - In-memory session→plan Map with set/get/clear; cleared on session.deleted and /stop-continuation.
  - Consumers updated: start-work writes per-plan and registers mapping; atlas handlers resolve via tracker or disk scan; CLI continuation uses findBoulderForSession; template paths updated.

- **Migration**
  - No changes required; legacy .sisyphus/boulder.json remains supported.
  - To opt into concurrency in custom code, pass planName to storage functions.

<sup>Written for commit b38fbb8e7a6e200bb877a32b3dd591ab9218ea5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

