### PR TITLE
fix(hashline-edit): use diff library for generateUnifiedDiff()

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@opencode-ai/sdk": "^1.1.19",
         "commander": "^14.0.2",
         "detect-libc": "^2.0.0",
+        "diff": "^7.0.0",
         "js-yaml": "^4.1.1",
         "jsonc-parser": "^3.3.1",
         "picocolors": "^1.1.1",
@@ -22,19 +23,20 @@
         "zod": "^4.1.8",
       },
       "devDependencies": {
+        "@types/diff": "^5.2.3",
         "@types/js-yaml": "^4.0.9",
         "@types/picomatch": "^3.0.2",
         "bun-types": "1.3.6",
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.8.1",
-        "oh-my-opencode-darwin-x64": "3.8.1",
-        "oh-my-opencode-linux-arm64": "3.8.1",
-        "oh-my-opencode-linux-arm64-musl": "3.8.1",
-        "oh-my-opencode-linux-x64": "3.8.1",
-        "oh-my-opencode-linux-x64-musl": "3.8.1",
-        "oh-my-opencode-windows-x64": "3.8.1",
+        "oh-my-opencode-darwin-arm64": "3.8.3",
+        "oh-my-opencode-darwin-x64": "3.8.3",
+        "oh-my-opencode-linux-arm64": "3.8.3",
+        "oh-my-opencode-linux-arm64-musl": "3.8.3",
+        "oh-my-opencode-linux-x64": "3.8.3",
+        "oh-my-opencode-linux-x64-musl": "3.8.3",
+        "oh-my-opencode-windows-x64": "3.8.3",
       },
     },
   },
@@ -94,6 +96,8 @@
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.19", "", {}, "sha512-XhZhFuvlLCqDpvNtUEjOsi/wvFj3YCXb1dySp+OONQRMuHlorNYnNa7P2A2ntKuhRdGT1Xt5na0nFzlUyNw+4A=="],
 
+    "@types/diff": ["@types/diff@5.2.3", "", {}, "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ=="],
+
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
@@ -137,6 +141,8 @@
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -228,19 +234,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.8.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-vbtS0WUFOZpufKzlX2G83fIDry3rpiXej8zNuXNCkx7hF34rK04rj0zeBH9dL+kdNV0Ys0Wl1rR1Mjto28UcAw=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.8.3", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-wzqPzZ+sqN6NKR1qeIP89+prpjV8V72TYljoBf2IBkuRHqdgJeurJqbznBmJdfwbrTT5Tix3lBmF37b+6Pz5Qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.8.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-gLz6dLNg9hr7roqBjaqlxta6+XYCs032/FiE0CiwypIBtYOq5EAgDVJ95JY5DQ2M+3Un028d50yMfwsfNfGlSw=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.8.3", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/eA3/QPOT4CA71e6sYp9iy5aMUStzyggSCW8Uy0mrjWnL8ZpzRqbXs43rqzcpbzousiz+HWCgycc6ICl2BQrqw=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.8.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-teAIuHlR5xOAoUmA+e0bGzy3ikgIr+nCdyOPwHYm8jIp0aBUWAqbcdoQLeNTgenWpoM8vhHk+2xh4WcCeQzjEA=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.8.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-hRHCmN4WlcJImg3UwWYzJvEoZkBxJf655h84byAHJ4Pf3qlNctarA8zlb/8f0Hu8+i1+RmR/LINRlmzQNh5GyQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.8.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VzBEq1H5dllEloouIoLdbw1icNUW99qmvErFrNj66mX42DNXK+f1zTtvBG8U6eeFfUBRRJoUjdCsvO65f8BkFA=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.8.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-wWvHS1iMidqhsvdrNohNeiV+8dvYkd9OmRegrQtct49Vw6lbz7ZnT4ZWeolhXdQA9SX0cBBP6pq+7c/ns4fvGw=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.8.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-8hDcb8s+wdQpQObSmiyaaTV0P/js2Bs9Lu+HmzrkKjuMLXXj/Gk7K0kKWMoEnMbMGfj86GfBHHIWmu9juI/SjA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.8.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-WE/Wa9O76LeR1AFNCBJ6jbwoUAfNiSWFG37OEhgOx7+oW0KMbDLM9LgrGMo5hc4HfS9+YCXBiuoGlmTeXGtceg=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.8.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-idyH5bdYn7wrLkIkYr83omN83E2BjA/9DUHCX2we8VXbhDVbBgmMpUg8B8nKnd5NK/SyLHgRs5QqQJw8XBC0cQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.8.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-+/O7i74nZLAAiNB/W0DKiSUxn55Zb7dfLrxCncwguqZ0uT8QiyqG1zKLAWKrzhk9JuEWMTJr66YnPtqaCsC1xA=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.8.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-O30L1PUF9aq1vSOyadcXQOLnDFSTvYn6cGd5huh0LAK/us0hGezoahtXegMdFtDXPIIREJlkRQhyJiafza7YgA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.8.3", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-YVBV1kpe8woXFg3WjVM0ZwApugSJbEcWoGdFIP2g9EfDpk8wjFHNpFxNGsnQP1JAPwhRCflPa8cCq+pDW9zjsQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@opencode-ai/sdk": "^1.1.19",
     "commander": "^14.0.2",
     "detect-libc": "^2.0.0",
-    "diff": "^7.0.0",
+    "diff": "^8.0.2",
     "js-yaml": "^4.1.1",
     "jsonc-parser": "^3.3.1",
     "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "zod": "^4.1.8"
   },
   "devDependencies": {
-    "@types/diff": "^5.2.3",
+    "@types/diff": "^8.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/picomatch": "^3.0.2",
     "bun-types": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@opencode-ai/sdk": "^1.1.19",
     "commander": "^14.0.2",
     "detect-libc": "^2.0.0",
+    "diff": "^7.0.0",
     "js-yaml": "^4.1.1",
     "jsonc-parser": "^3.3.1",
     "picocolors": "^1.1.1",
@@ -68,6 +69,7 @@
     "zod": "^4.1.8"
   },
   "devDependencies": {
+    "@types/diff": "^5.2.3",
     "@types/js-yaml": "^4.0.9",
     "@types/picomatch": "^3.0.2",
     "bun-types": "1.3.6",

--- a/src/tools/hashline-edit/diff-utils.test.ts
+++ b/src/tools/hashline-edit/diff-utils.test.ts
@@ -129,4 +129,53 @@ describe("generateUnifiedDiff", () => {
 			})
 		})
 	})
+
+	describe("#given file content containing marker string", () => {
+		describe("#when added line contains literal \\ No newline at end of file", () => {
+			it("#then preserves the content and does not strip it from diff", () => {
+				const oldContent = "line1\n"
+				const newContent = "line1\n\\ No newline at end of file\n"
+				const filePath = "test.txt"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+
+				expect(result).toContain("+\\ No newline at end of file")
+			})
+		})
+	})
+	describe("#given filePath with special characters", () => {
+		describe("#when filePath contains $ characters", () => {
+			it("#then handles $ characters without interpreting them as capture groups", () => {
+				const oldContent = "line1\nline2\nline3"
+				const newContent = "line1\nmodified\nline3"
+				const filePath = "Component$1.js"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				// Verify the header contains the correct, unmodified filePath
+				expect(result).toContain("--- Component$1.js")
+				expect(result).toContain("+++ Component$1.js")
+				// Verify the $ character is NOT replaced (corrupted)
+				expect(result).not.toContain("--- Component--- .js")
+				expect(result).not.toContain("+++ Component+++ .js")
+			})
+		})
+
+		describe("#when filePath contains multiple $ characters", () => {
+			it("#then preserves all $ characters without corruption", () => {
+				const oldContent = "line1\nline2"
+				const newContent = "line1\nmodified"
+				const filePath = "file$$name$&$'$`$1$2.js"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				expect(result).toContain(`--- ${filePath}`)
+				expect(result).toContain(`+++ ${filePath}`)
+				// Verify no corruption occurred
+				expect(result).toContain("--- file$$name$&$'$`$1$2.js")
+			})
+		})
+	})
+
 })

--- a/src/tools/hashline-edit/diff-utils.test.ts
+++ b/src/tools/hashline-edit/diff-utils.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "bun:test"
+import { generateUnifiedDiff } from "./diff-utils"
+
+describe("generateUnifiedDiff", () => {
+	describe("#given basic line change", () => {
+		describe("#when old and new content differ on a line", () => {
+			it("#then produces correct hunks with minus and plus markers", () => {
+				const oldContent = "line1\nline2\nline3"
+				const newContent = "line1\nmodified\nline3"
+				const filePath = "test.txt"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				expect(result).toContain("--- test.txt")
+				expect(result).toContain("+++ test.txt")
+				expect(result).toContain("@@")
+				expect(result).toContain("-line2")
+				expect(result).toContain("+modified")
+				expect(result).toContain(" line3")
+			})
+		})
+	})
+
+	describe("#given content with insertion", () => {
+		describe("#when a new line is added", () => {
+			it("#then produces hunks with plus marker for inserted line", () => {
+				const oldContent = "line1\nline3"
+				const newContent = "line1\nline2\nline3"
+				const filePath = "test.txt"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				expect(result).toContain("+line2")
+			})
+		})
+	})
+
+	describe("#given content with deletion", () => {
+		describe("#when a line is removed", () => {
+			it("#then produces hunks with minus marker for deleted line", () => {
+				const oldContent = "line1\nline2\nline3"
+				const newContent = "line1\nline3"
+				const filePath = "test.txt"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				expect(result).toContain("-line2")
+			})
+		})
+	})
+
+	describe("#given empty old content", () => {
+		describe("#when old content is empty string", () => {
+			it("#then produces diff showing all lines as added", () => {
+				const oldContent = ""
+				const newContent = "line1\nline2"
+				const filePath = "new-file.txt"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				expect(result).toContain("--- new-file.txt")
+				expect(result).toContain("+++ new-file.txt")
+				expect(result).toContain("+line1")
+				expect(result).toContain("+line2")
+			})
+		})
+	})
+
+	describe("#given empty new content", () => {
+		describe("#when new content is empty string", () => {
+			it("#then produces diff showing all lines as removed", () => {
+				const oldContent = "line1\nline2"
+				const newContent = ""
+				const filePath = "deleted-file.txt"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				expect(result).toContain("--- deleted-file.txt")
+				expect(result).toContain("+++ deleted-file.txt")
+				expect(result).toContain("-line1")
+				expect(result).toContain("-line2")
+			})
+		})
+	})
+
+	describe("#given identical content", () => {
+		describe("#when old and new content are exactly the same", () => {
+			it("#then produces header-only diff with no hunks", () => {
+				const oldContent = "line1\nline2\nline3"
+				const newContent = "line1\nline2\nline3"
+				const filePath = "unchanged.txt"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				expect(result).toBe("--- unchanged.txt\n+++ unchanged.txt\n")
+				expect(result).not.toContain("@@")
+			})
+		})
+	})
+
+	describe("#given content with trailing newline", () => {
+		describe("#when content ends with newline character", () => {
+			it("#then handles trailing newline correctly", () => {
+				const oldContent = "line1\nline2\n"
+				const newContent = "line1\nmodified\n"
+				const filePath = "trailing.txt"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				expect(result).toContain("-line2")
+				expect(result).toContain("+modified")
+			})
+		})
+	})
+
+	describe("#given multi-line changes", () => {
+		describe("#when multiple consecutive lines change", () => {
+			it("#then groups changes into single hunk", () => {
+				const oldContent = "line1\nline2\nline3\nline4"
+				const newContent = "line1\nnew2\nnew3\nline4"
+				const filePath = "multi.txt"
+
+				const result = generateUnifiedDiff(oldContent, newContent, filePath)
+
+				expect(result).toContain("-line2")
+				expect(result).toContain("-line3")
+				expect(result).toContain("+new2")
+				expect(result).toContain("+new3")
+			})
+		})
+	})
+})

--- a/src/tools/hashline-edit/diff-utils.ts
+++ b/src/tools/hashline-edit/diff-utils.ts
@@ -1,4 +1,5 @@
 import { computeLineHash } from "./hash-computation"
+import { createTwoFilesPatch } from "diff"
 
 export function toHashlineContent(content: string): string {
 	if (!content) return content
@@ -15,59 +16,23 @@ export function toHashlineContent(content: string): string {
 }
 
 export function generateUnifiedDiff(oldContent: string, newContent: string, filePath: string): string {
-	const oldLines = oldContent.split("\n")
-	const newLines = newContent.split("\n")
-	const maxLines = Math.max(oldLines.length, newLines.length)
+	const patch = createTwoFilesPatch(filePath, filePath, oldContent, newContent, "", "", { context: 3 })
 
-	let diff = `--- ${filePath}\n+++ ${filePath}\n`
-	let inHunk = false
-	let oldStart = 1
-	let newStart = 1
-	let oldCount = 0
-	let newCount = 0
-	let hunkLines: string[] = []
+	// Strip "Index:" and "===..." header lines added by createTwoFilesPatch
+	let result = patch
+		.replace(/^Index: .*\n/, "")
+		.replace(/^===================================================================\n/, "")
+		// Strip trailing tabs from --- and +++ lines
+		.replace(/^(--- |\+\+\+ ).*\t$/gm, "$1" + filePath)
+		// Strip "\ No newline at end of file" markers if present
+		.replace(/\\ No newline at end of file\n?/g, "")
 
-	for (let i = 0; i < maxLines; i++) {
-		const oldLine = oldLines[i] ?? ""
-		const newLine = newLines[i] ?? ""
-
-		if (oldLine !== newLine) {
-			if (!inHunk) {
-				oldStart = i + 1
-				newStart = i + 1
-				oldCount = 0
-				newCount = 0
-				hunkLines = []
-				inHunk = true
-			}
-
-			if (oldLines[i] !== undefined) {
-				hunkLines.push(`-${oldLine}`)
-				oldCount++
-			}
-			if (newLines[i] !== undefined) {
-				hunkLines.push(`+${newLine}`)
-				newCount++
-			}
-		} else if (inHunk) {
-			hunkLines.push(` ${oldLine}`)
-			oldCount++
-			newCount++
-
-			if (hunkLines.length > 6) {
-				diff += `@@ -${oldStart},${oldCount} +${newStart},${newCount} @@\n`
-				diff += hunkLines.join("\n") + "\n"
-				inHunk = false
-			}
-		}
+	// Handle empty diff (no changes) - return just header
+	if (!result.includes("@@")) {
+		return `--- ${filePath}\n+++ ${filePath}\n`
 	}
 
-	if (inHunk && hunkLines.length > 0) {
-		diff += `@@ -${oldStart},${oldCount} +${newStart},${newCount} @@\n`
-		diff += hunkLines.join("\n") + "\n"
-	}
-
-	return diff || `--- ${filePath}\n+++ ${filePath}\n`
+	return result
 }
 
 export function countLineDiffs(oldContent: string, newContent: string): { additions: number; deletions: number } {

--- a/src/tools/hashline-edit/diff-utils.ts
+++ b/src/tools/hashline-edit/diff-utils.ts
@@ -23,9 +23,9 @@ export function generateUnifiedDiff(oldContent: string, newContent: string, file
 		.replace(/^Index: .*\n/, "")
 		.replace(/^===================================================================\n/, "")
 		// Strip trailing tabs from --- and +++ lines
-		.replace(/^(--- |\+\+\+ ).*\t$/gm, "$1" + filePath)
-		// Strip "\ No newline at end of file" markers if present
-		.replace(/\\ No newline at end of file\n?/g, "")
+		.replace(/^(--- |\+\+\+ ).*\t$/gm, (_, p1) => p1 + filePath)
+		// Strip "\ No newline at end of file" markers if present (only at line start)
+		.replace(/^\\ No newline at end of file\n?/gm, "")
 
 	// Handle empty diff (no changes) - return just header
 	if (!result.includes("@@")) {


### PR DESCRIPTION
## Summary

- Replace buggy custom implementation with diff library's createTwoFilesPatch()
- Add 3-line context windows (standard unified diff format)
- Fix oversized hunks issue - distant changes now produce separate hunks
- Add comprehensive test coverage for generateUnifiedDiff()
- Add diff and @types/diff dependencies

Fixes #2051

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the custom unified diff generator with diff.createTwoFilesPatch to produce correct 3-line-context diffs and properly separated hunks. Cleaned headers, preserved $ in file paths, safely handled standalone markers, and added tests.

- **Bug Fixes**
  - Use diff.createTwoFilesPatch with 3-line context
  - Split distant changes into separate hunks
  - Normalize ---/+++ headers; strip Index/=== lines and standalone "\ No newline..." markers
  - Preserve $ in filePath via function replacement
  - Return header-only when no changes
  - Add tests, including $-path and marker-content cases

- **Dependencies**
  - Add diff (^8.0.2) and @types/diff (^8.0.0)
  - Bump oh-my-opencode optional binaries to 3.8.3 (from dev merge)

<sup>Written for commit d64bcde1a91b4d8ae735342d4bd425b0ecbf1c6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

