### PR TITLE
Update Kimi Code Subscription link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Everything below, every feature, every optimization, you don't need to know it. 
 
 Even only with following subscriptions, ultrawork will work well (this project is not affiliated, this is just personal recommendation):
 - [ChatGPT Subscription ($20)](https://chatgpt.com/)
-- [Kimi Code Subscription ($0.99) (*only this month)](https://www.kimi.com/membership/pricing?track_id=5cdeca93-66f0-4d35-aabb-b6df8fcea328)
+- [Kimi Code Subscription ($0.99) (*only this month)](https://www.kimi.com/kimiplus/sale)
 - [GLM Coding Plan ($10)](https://z.ai/subscribe)
 - If you are eligible for pay-per-token, using kimi and gemini models won't cost you that much.
 


### PR DESCRIPTION
The link does not work anymore. You can use your referral link if you'd like. This one I'm sharing is just a direct link.

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Kimi Code Subscription link in the README to the current Kimi Plus sale page to replace the broken URL.

<sup>Written for commit 584a82ea2033301949e002b18cfc59494488f210. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

