### PR TITLE
fix(plugin-handlers): remove todo deny from prometheus and sisyphus-junior

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,13 +28,13 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.8.1",
-        "oh-my-opencode-darwin-x64": "3.8.1",
-        "oh-my-opencode-linux-arm64": "3.8.1",
-        "oh-my-opencode-linux-arm64-musl": "3.8.1",
-        "oh-my-opencode-linux-x64": "3.8.1",
-        "oh-my-opencode-linux-x64-musl": "3.8.1",
-        "oh-my-opencode-windows-x64": "3.8.1",
+        "oh-my-opencode-darwin-arm64": "3.8.3",
+        "oh-my-opencode-darwin-x64": "3.8.3",
+        "oh-my-opencode-linux-arm64": "3.8.3",
+        "oh-my-opencode-linux-arm64-musl": "3.8.3",
+        "oh-my-opencode-linux-x64": "3.8.3",
+        "oh-my-opencode-linux-x64-musl": "3.8.3",
+        "oh-my-opencode-windows-x64": "3.8.3",
       },
     },
   },
@@ -228,19 +228,19 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.8.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-vbtS0WUFOZpufKzlX2G83fIDry3rpiXej8zNuXNCkx7hF34rK04rj0zeBH9dL+kdNV0Ys0Wl1rR1Mjto28UcAw=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.8.3", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-wzqPzZ+sqN6NKR1qeIP89+prpjV8V72TYljoBf2IBkuRHqdgJeurJqbznBmJdfwbrTT5Tix3lBmF37b+6Pz5Qg=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.8.1", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-gLz6dLNg9hr7roqBjaqlxta6+XYCs032/FiE0CiwypIBtYOq5EAgDVJ95JY5DQ2M+3Un028d50yMfwsfNfGlSw=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.8.3", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/eA3/QPOT4CA71e6sYp9iy5aMUStzyggSCW8Uy0mrjWnL8ZpzRqbXs43rqzcpbzousiz+HWCgycc6ICl2BQrqw=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.8.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-teAIuHlR5xOAoUmA+e0bGzy3ikgIr+nCdyOPwHYm8jIp0aBUWAqbcdoQLeNTgenWpoM8vhHk+2xh4WcCeQzjEA=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.8.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-hRHCmN4WlcJImg3UwWYzJvEoZkBxJf655h84byAHJ4Pf3qlNctarA8zlb/8f0Hu8+i1+RmR/LINRlmzQNh5GyQ=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.8.1", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-VzBEq1H5dllEloouIoLdbw1icNUW99qmvErFrNj66mX42DNXK+f1zTtvBG8U6eeFfUBRRJoUjdCsvO65f8BkFA=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.8.3", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-wWvHS1iMidqhsvdrNohNeiV+8dvYkd9OmRegrQtct49Vw6lbz7ZnT4ZWeolhXdQA9SX0cBBP6pq+7c/ns4fvGw=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.8.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-8hDcb8s+wdQpQObSmiyaaTV0P/js2Bs9Lu+HmzrkKjuMLXXj/Gk7K0kKWMoEnMbMGfj86GfBHHIWmu9juI/SjA=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.8.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-WE/Wa9O76LeR1AFNCBJ6jbwoUAfNiSWFG37OEhgOx7+oW0KMbDLM9LgrGMo5hc4HfS9+YCXBiuoGlmTeXGtceg=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.8.1", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-idyH5bdYn7wrLkIkYr83omN83E2BjA/9DUHCX2we8VXbhDVbBgmMpUg8B8nKnd5NK/SyLHgRs5QqQJw8XBC0cQ=="],
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.8.3", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-+/O7i74nZLAAiNB/W0DKiSUxn55Zb7dfLrxCncwguqZ0uT8QiyqG1zKLAWKrzhk9JuEWMTJr66YnPtqaCsC1xA=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.8.1", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-O30L1PUF9aq1vSOyadcXQOLnDFSTvYn6cGd5huh0LAK/us0hGezoahtXegMdFtDXPIIREJlkRQhyJiafza7YgA=="],
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.8.3", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-YVBV1kpe8woXFg3WjVM0ZwApugSJbEcWoGdFIP2g9EfDpk8wjFHNpFxNGsnQP1JAPwhRCflPa8cCq+pDW9zjsQ=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -1207,8 +1207,8 @@ describe("per-agent todowrite/todoread deny when task_system enabled", () => {
       expect(agentResult[agentName]?.permission?.todoread).toBe("deny")
     }
     for (const agentName of AGENTS_WITHOUT_TODO_DENY) {
-      expect(agentResult[agentName]?.permission?.todowrite).toBeUndefined()
-      expect(agentResult[agentName]?.permission?.todoread).toBeUndefined()
+      expect(agentResult[agentName]?.permission?.todowrite).toBe("allow")
+      expect(agentResult[agentName]?.permission?.todoread).toBe("allow")
     }
   })
 

--- a/src/plugin-handlers/tool-config-handler.test.ts
+++ b/src/plugin-handlers/tool-config-handler.test.ts
@@ -55,7 +55,7 @@ describe("applyToolConfig", () => {
       it.each([
         "prometheus",
         "sisyphus-junior",
-      ])("#then should NOT deny todo tools for %s agent when task_system enabled", (agentName) => {
+      ])("#then should explicitly allow todo tools for %s agent when task_system enabled", (agentName) => {
         const params = createParams({
           taskSystem: true,
           agents: [agentName],
@@ -66,8 +66,8 @@ describe("applyToolConfig", () => {
         const agent = params.agentResult[agentName] as {
           permission: Record<string, unknown>
         }
-        expect(agent.permission.todowrite).toBeUndefined()
-        expect(agent.permission.todoread).toBeUndefined()
+        expect(agent.permission.todowrite).toBe("allow")
+        expect(agent.permission.todoread).toBe("allow")
       })
     })
   })

--- a/src/plugin-handlers/tool-config-handler.test.ts
+++ b/src/plugin-handlers/tool-config-handler.test.ts
@@ -37,8 +37,6 @@ describe("applyToolConfig", () => {
         "atlas",
         "sisyphus",
         "hephaestus",
-        "prometheus",
-        "sisyphus-junior",
       ])("#then should deny todo tools for %s agent", (agentName) => {
         const params = createParams({
           taskSystem: true,
@@ -52,6 +50,24 @@ describe("applyToolConfig", () => {
         }
         expect(agent.permission.todowrite).toBe("deny")
         expect(agent.permission.todoread).toBe("deny")
+      })
+
+      it.each([
+        "prometheus",
+        "sisyphus-junior",
+      ])("#then should NOT deny todo tools for %s agent when task_system enabled", (agentName) => {
+        const params = createParams({
+          taskSystem: true,
+          agents: [agentName],
+        })
+
+        applyToolConfig(params)
+
+        const agent = params.agentResult[agentName] as {
+          permission: Record<string, unknown>
+        }
+        expect(agent.permission.todowrite).toBeUndefined()
+        expect(agent.permission.todoread).toBeUndefined()
       })
     })
   })

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -84,7 +84,6 @@ export function applyToolConfig(params: {
       question: questionPermission,
       "task_*": "allow",
       teammate: "allow",
-      ...denyTodoTools,
     };
   }
   const junior = agentByKey(params.agentResult, "sisyphus-junior");
@@ -94,7 +93,6 @@ export function applyToolConfig(params: {
       task: "allow",
       "task_*": "allow",
       teammate: "allow",
-      ...denyTodoTools,
     };
   }
 

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -17,6 +17,9 @@ export function applyToolConfig(params: {
   const denyTodoTools = params.pluginConfig.experimental?.task_system
     ? { todowrite: "deny", todoread: "deny" }
     : {}
+  const allowTodoTools = params.pluginConfig.experimental?.task_system
+    ? { todowrite: "allow", todoread: "allow" }
+    : {}
 
   params.config.tools = {
     ...(params.config.tools as Record<string, unknown>),
@@ -84,6 +87,7 @@ export function applyToolConfig(params: {
       question: questionPermission,
       "task_*": "allow",
       teammate: "allow",
+      ...allowTodoTools,
     };
   }
   const junior = agentByKey(params.agentResult, "sisyphus-junior");
@@ -93,6 +97,7 @@ export function applyToolConfig(params: {
       task: "allow",
       "task_*": "allow",
       teammate: "allow",
+      ...allowTodoTools,
     };
   }
 


### PR DESCRIPTION
## Summary
- Remove `...denyTodoTools` from prometheus and sisyphus-junior permission blocks in tool-config-handler
- Update tests to reflect that prometheus and sisyphus-junior should NOT have todowrite/todoread denied when task_system is enabled

These agents need todo access for planning and subtask execution coordination.

## Test plan
- All 63 tests in `src/plugin-handlers` pass
- `bun test src/plugin-handlers` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly allow todowrite/todoread for prometheus and sisyphus-junior when task_system is enabled, overriding the global deny so these agents can plan and coordinate subtasks.

- **Bug Fixes**
  - Added an allowTodoTools override in tool-config-handler and applied it to prometheus and sisyphus-junior under task_system.
  - Updated config-handler and tool-config-handler tests to assert "allow" for these agents; others remain denied.

<sup>Written for commit a6b65eb2daf9e7ecbda241162e5152a5224beb55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

