### PR TITLE
fix(keyword-detector): respect ultrawork config variant instead of hardcoding "max"

### DIFF
--- a/src/plugin/ultrawork-model-override.test.ts
+++ b/src/plugin/ultrawork-model-override.test.ts
@@ -279,6 +279,30 @@ describe("applyUltraworkModelOverrideOnMessage", () => {
     )
   })
 
+  test("should override keyword-detector variant with configured ultrawork variant on deferred path", () => {
+    //#given
+    const config = createConfig("sisyphus", {
+      model: "anthropic/claude-opus-4-6",
+      variant: "extended",
+    })
+    const output = createOutput("ultrawork do something", { messageId: "msg_123" })
+    output.message["variant"] = "max"
+    output.message["thinking"] = "max"
+    const tui = createMockTui()
+
+    //#when
+    applyUltraworkModelOverrideOnMessage(config, "sisyphus", output, tui)
+
+    //#then
+    expect(dbOverrideSpy).toHaveBeenCalledWith(
+      "msg_123",
+      { providerID: "anthropic", modelID: "claude-opus-4-6" },
+      "extended",
+    )
+    expect(output.message["variant"]).toBe("extended")
+    expect(output.message["thinking"]).toBe("extended")
+  })
+
   test("should NOT mutate output.message.model when message ID present", () => {
     //#given
     const sonnetModel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" }

--- a/src/plugin/ultrawork-model-override.ts
+++ b/src/plugin/ultrawork-model-override.ts
@@ -114,10 +114,12 @@ export function applyUltraworkModelOverrideOnMessage(
   const override = resolveUltraworkOverride(pluginConfig, inputAgentName, output, sessionID)
   if (!override) return
 
+  if (override.variant) {
+    output.message["variant"] = override.variant
+    output.message["thinking"] = override.variant
+  }
+
   if (!override.providerID || !override.modelID) {
-    if (override.variant) {
-      output.message["variant"] = override.variant
-    }
     return
   }
 
@@ -131,10 +133,8 @@ export function applyUltraworkModelOverrideOnMessage(
   if (!messageId) {
     log("[ultrawork-model-override] No message ID found, falling back to direct mutation")
     output.message.model = targetModel
-    if (override.variant) {
-      output.message["variant"] = override.variant
-    }
     return
+
   }
 
   const fromModel = (output.message.model as { modelID?: string } | undefined)?.modelID ?? "unknown"


### PR DESCRIPTION
## Summary

- Fixes #1966: when `<ultrawork-mode>` keyword is detected and the ultrawork config specifies a `variant` (e.g. `"extended"`), the keyword detector was silently overriding it with `"max"`, ignoring the user's config
- Root cause: `applyUltraworkModelOverrideOnMessage()` was not applying `override.variant` on the deferred path (when `messageId` is present), so the keyword-detector's temporary `"max"` was never overwritten
- Fix: apply `override.variant` immediately after resolving ultrawork config in `ultrawork-model-override.ts`
- Added regression test that reproduces the exact bug: keyword detector sets `"max"`, config says `"extended"`, final variant must be `"extended"`

Closes #1966

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1966: Respect the ultrawork config variant (e.g., "extended") instead of forcing "max". The variant is applied immediately on both direct and deferred paths so the user's setting always wins.

- **Bug Fixes**
  - Set override.variant on message.variant and message.thinking up front.
  - On deferred path, persist the configured variant to the DB override, replacing any temporary "max".
  - Add a regression test that reproduces the bug and asserts the configured variant is used.

<sup>Written for commit 4df69c58bf2e80bb3bbf3174b5f95a0f5714d1a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

