### PR TITLE
Update model references from "google/gemini-3-pro" to "google/gemini-…

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -186,7 +186,7 @@ See the [Orchestration System Guide](./orchestration.md) for how agents dispatch
     "quick": { "model": "opencode/gpt-5-nano" },
     "unspecified-low": { "model": "kimi-for-coding/k2p5" },
     "unspecified-high": { "model": "anthropic/claude-sonnet-4-6", "variant": "max" },
-    "visual-engineering": { "model": "google/gemini-3-pro", "variant": "high" },
+    "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
     "writing": { "model": "kimi-for-coding/k2p5" }
   },
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -167,7 +167,7 @@ The `opencode-antigravity-auth` plugin uses different model names than the built
 - `google/antigravity-claude-opus-4-5-thinking` — variants: `low`, `max`
 
 **Available models (Gemini CLI quota)**:
-- `google/gemini-2.5-flash`, `google/gemini-2.5-pro`, `google/gemini-3-flash-preview`, `google/gemini-3-pro-preview`
+- `google/gemini-2.5-flash`, `google/gemini-2.5-pro`, `google/gemini-3-flash-preview`, `google/gemini-3.1-pro-preview`
 
 > **Note**: Legacy tier-suffixed names like `google/antigravity-gemini-3-pro-high` still work but variants are recommended. Use `--variant=high` with the base model name instead.
 

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -186,7 +186,7 @@ You can override specific agents or categories in your config:
 
   "categories": {
     // Frontend work: Gemini dominates visual tasks
-    "visual-engineering": { "model": "google/gemini-3.1-pro, "variant": "high" },
+    "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
 
     // Quick tasks: use the cheapest models
     "quick": { "model": "anthropic/claude-haiku-4-5" },

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -186,7 +186,7 @@ You can override specific agents or categories in your config:
 
   "categories": {
     // Frontend work: Gemini dominates visual tasks
-    "visual-engineering": { "model": "google/gemini-3-pro", "variant": "high" },
+    "visual-engineering": { "model": "google/gemini-3.1-pro, "variant": "high" },
 
     // Quick tasks: use the cheapest models
     "quick": { "model": "anthropic/claude-haiku-4-5" },

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -215,7 +215,7 @@ Configuration files support **JSONC (JSON with Comments)** format. You can use c
   /* Category customization */
   "categories": {
     "visual-engineering": {
-      "model": "google/gemini-3-pro",
+      "model": "google/gemini-3.1-pro",
     },
   },
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -101,7 +101,7 @@ Here's a practical starting configuration:
     "writing": { "model": "kimi-for-coding/k2p5" },
 
     // visual-engineering — Gemini dominates visual tasks
-    "visual-engineering": { "model": "google/gemini-3-pro", "variant": "high" },
+    "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
 
     // Custom category for git operations
     "git": {
@@ -208,10 +208,10 @@ Domain-specific model delegation used by the `task()` tool. When Sisyphus delega
 
 | Category | Default Model | Description |
 |----------|---------------|-------------|
-| `visual-engineering` | `google/gemini-3-pro` (high) | Frontend, UI/UX, design, animation |
+| `visual-engineering` | `google/gemini-3.1-pro` (high) | Frontend, UI/UX, design, animation |
 | `ultrabrain` | `openai/gpt-5.3-codex` (xhigh) | Deep logical reasoning, complex architecture |
 | `deep` | `openai/gpt-5.3-codex` (medium) | Autonomous problem-solving, thorough research |
-| `artistry` | `google/gemini-3-pro` (high) | Creative/unconventional approaches |
+| `artistry` | `google/gemini-3.1-pro` (high) | Creative/unconventional approaches |
 | `quick` | `anthropic/claude-haiku-4-5` | Trivial tasks, typo fixes, single-file changes |
 | `unspecified-low` | `anthropic/claude-sonnet-4-6` | General tasks, low effort |
 | `unspecified-high` | `anthropic/claude-opus-4-6` (max) | General tasks, high effort |
@@ -565,7 +565,7 @@ Define `fallback_models` per agent or category:
   "agents": {
     "sisyphus": {
       "model": "anthropic/claude-opus-4-6",
-      "fallback_models": ["openai/gpt-5.2", "google/gemini-3-pro"]
+      "fallback_models": ["openai/gpt-5.2", "google/gemini-3.1-pro"]
     }
   }
 }

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -106,10 +106,10 @@ By combining these two concepts, you can generate optimal agents through `task`.
 
 | Category | Default Model | Use Cases |
 |----------|---------------|-----------|
-| `visual-engineering` | `google/gemini-3-pro` | Frontend, UI/UX, design, styling, animation |
+| `visual-engineering` | `google/gemini-3.1-pro` | Frontend, UI/UX, design, styling, animation |
 | `ultrabrain` | `openai/gpt-5.3-codex` (xhigh) | Deep logical reasoning, complex architecture decisions requiring extensive analysis |
 | `deep` | `openai/gpt-5.3-codex` (medium) | Goal-oriented autonomous problem-solving. Thorough research before action. For hairy problems requiring deep understanding. |
-| `artistry` | `google/gemini-3-pro` (max) | Highly creative/artistic tasks, novel ideas |
+| `artistry` | `google/gemini-3.1-pro` (max) | Highly creative/artistic tasks, novel ideas |
 | `quick` | `anthropic/claude-haiku-4-5` | Trivial tasks - single file changes, typo fixes, simple modifications |
 | `unspecified-low` | `anthropic/claude-sonnet-4-6` | Tasks that don't fit other categories, low effort required |
 | `unspecified-high` | `anthropic/claude-opus-4-6` (max) | Tasks that don't fit other categories, high effort required |

--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -39,7 +39,7 @@ describe("isGptModel", () => {
   });
 
   test("gemini models are not gpt", () => {
-    expect(isGptModel("google/gemini-3-pro")).toBe(false);
+    expect(isGptModel("google/gemini-3.1-pro")).toBe(false);
     expect(isGptModel("litellm/gemini-3-pro")).toBe(false);
   });
 
@@ -50,7 +50,7 @@ describe("isGptModel", () => {
 
 describe("isGeminiModel", () => {
   test("#given google provider models #then returns true", () => {
-    expect(isGeminiModel("google/gemini-3-pro")).toBe(true);
+    expect(isGeminiModel("google/gemini-3.1-pro")).toBe(true);
     expect(isGeminiModel("google/gemini-3-flash")).toBe(true);
     expect(isGeminiModel("google/gemini-2.5-pro")).toBe(true);
   });

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -986,7 +986,7 @@ describe("buildAgent with category and skills", () => {
     const agent = buildAgent(source["test-agent"], TEST_MODEL)
 
     // #then - category's built-in model is applied
-    expect(agent.model).toBe("google/gemini-3-pro")
+    expect(agent.model).toBe("google/gemini-3.1-pro")
   })
 
   test("agent with category and existing model keeps existing model", () => {

--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -325,7 +325,7 @@ exports[`generateModelConfig single native provider uses Gemini models when only
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
   "agents": {
     "atlas": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
     },
     "explore": {
       "model": "opencode/gpt-5-nano",
@@ -334,34 +334,34 @@ exports[`generateModelConfig single native provider uses Gemini models when only
       "model": "opencode/glm-4.7-free",
     },
     "metis": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "momus": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "multimodal-looker": {
       "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "prometheus": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
     },
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "quick": {
       "model": "google/gemini-3-flash-preview",
     },
     "ultrabrain": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "unspecified-high": {
@@ -371,7 +371,7 @@ exports[`generateModelConfig single native provider uses Gemini models when only
       "model": "google/gemini-3-flash-preview",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "writing": {
@@ -386,7 +386,7 @@ exports[`generateModelConfig single native provider uses Gemini models with isMa
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/master/assets/oh-my-opencode.schema.json",
   "agents": {
     "atlas": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
     },
     "explore": {
       "model": "opencode/gpt-5-nano",
@@ -395,44 +395,44 @@ exports[`generateModelConfig single native provider uses Gemini models with isMa
       "model": "opencode/glm-4.7-free",
     },
     "metis": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "momus": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "multimodal-looker": {
       "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "prometheus": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
     },
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "quick": {
       "model": "google/gemini-3-flash-preview",
     },
     "ultrabrain": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "unspecified-high": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
     },
     "unspecified-low": {
       "model": "google/gemini-3-flash-preview",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "writing": {
@@ -485,7 +485,7 @@ exports[`generateModelConfig all native providers uses preferred models from fal
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "deep": {
@@ -506,7 +506,7 @@ exports[`generateModelConfig all native providers uses preferred models from fal
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "writing": {
@@ -559,7 +559,7 @@ exports[`generateModelConfig all native providers uses preferred models with isM
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "deep": {
@@ -581,7 +581,7 @@ exports[`generateModelConfig all native providers uses preferred models with isM
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "writing": {
@@ -1233,7 +1233,7 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
       "model": "google/gemini-3-flash-preview",
     },
     "oracle": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "prometheus": {
@@ -1247,14 +1247,14 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "quick": {
       "model": "anthropic/claude-haiku-4-5",
     },
     "ultrabrain": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "unspecified-high": {
@@ -1264,7 +1264,7 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "writing": {
@@ -1391,7 +1391,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "deep": {
@@ -1412,7 +1412,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "writing": {
@@ -1465,7 +1465,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
   },
   "categories": {
     "artistry": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "deep": {
@@ -1487,7 +1487,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "model": "anthropic/claude-sonnet-4-5",
     },
     "visual-engineering": {
-      "model": "google/gemini-3-pro-preview",
+      "model": "google/gemini-3.1-pro-preview",
       "variant": "high",
     },
     "writing": {

--- a/src/features/background-agent/concurrency.test.ts
+++ b/src/features/background-agent/concurrency.test.ts
@@ -34,7 +34,7 @@ describe("ConcurrencyManager.getConcurrencyLimit", () => {
   test("should return provider limit even when modelConcurrency exists but doesn't match", () => {
     // given
     const config: BackgroundTaskConfig = {
-      modelConcurrency: { "google/gemini-3-pro": 5 },
+      modelConcurrency: { "google/gemini-3.1-pro": 5 },
       providerConcurrency: { anthropic: 3 }
     }
     const manager = new ConcurrencyManager(config)
@@ -95,7 +95,7 @@ describe("ConcurrencyManager.getConcurrencyLimit", () => {
     // when
     const modelLimit = manager.getConcurrencyLimit("anthropic/claude-sonnet-4-6")
     const providerLimit = manager.getConcurrencyLimit("anthropic/claude-opus-4-6")
-    const defaultLimit = manager.getConcurrencyLimit("google/gemini-3-pro")
+    const defaultLimit = manager.getConcurrencyLimit("google/gemini-3.1-pro")
 
     // then
     expect(modelLimit).toBe(10)

--- a/src/features/task-toast-manager/manager.test.ts
+++ b/src/features/task-toast-manager/manager.test.ts
@@ -162,7 +162,7 @@ describe("TaskToastManager", () => {
         description: "Task with category default model",
         agent: "sisyphus-junior",
         isBackground: false,
-        modelInfo: { model: "google/gemini-3-pro", type: "category-default" as const },
+        modelInfo: { model: "google/gemini-3.1-pro", type: "category-default" as const },
       }
 
       // when - addTask is called

--- a/src/hooks/runtime-fallback/index.test.ts
+++ b/src/hooks/runtime-fallback/index.test.ts
@@ -125,7 +125,7 @@ describe("runtime-fallback", () => {
       await hook.event({
         event: {
           type: "session.created",
-          properties: { info: { id: sessionID, model: "google/gemini-3-pro" } },
+          properties: { info: { id: sessionID, model: "google/gemini-3.1-pro" } },
         },
       })
 
@@ -1841,7 +1841,7 @@ describe("runtime-fallback", () => {
     test("should apply fallback model on next chat.message after error", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
-        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.2", "google/gemini-3-pro"]),
+        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.2", "google/gemini-3.1-pro"]),
       })
       const sessionID = "test-session-switch"
       SessionCategoryRegistry.register(sessionID, "test")
@@ -1916,7 +1916,7 @@ describe("runtime-fallback", () => {
       const input = createMockPluginInput()
       const hook = createRuntimeFallbackHook(input, {
         config: createMockConfig({ notify_on_fallback: false }),
-        pluginConfig: createMockPluginConfigWithAgentFallback("oracle", ["openai/gpt-5.2", "google/gemini-3-pro"]),
+        pluginConfig: createMockPluginConfigWithAgentFallback("oracle", ["openai/gpt-5.2", "google/gemini-3.1-pro"]),
       })
       const sessionID = "test-agent-fallback"
 

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -27,7 +27,7 @@ describe("mergeConfigs", () => {
             temperature: 0.3,
           },
           visual: {
-            model: "google/gemini-3-pro",
+            model: "google/gemini-3.1-pro",
           },
         },
       } as unknown as OhMyOpenCodeConfig;
@@ -41,7 +41,7 @@ describe("mergeConfigs", () => {
       // then quick should be preserved from base
       expect(result.categories?.quick?.model).toBe("anthropic/claude-haiku-4-5");
       // then visual should be added from override
-      expect(result.categories?.visual?.model).toBe("google/gemini-3-pro");
+      expect(result.categories?.visual?.model).toBe("google/gemini-3.1-pro");
     });
 
     it("should preserve base categories when override has no categories", () => {

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -570,7 +570,7 @@ describe("Prometheus category config resolution", () => {
 
     // then
     expect(config).toBeDefined()
-    expect(config?.model).toBe("google/gemini-3-pro")
+    expect(config?.model).toBe("google/gemini-3.1-pro")
   })
 
   test("user categories override default categories", () => {

--- a/src/shared/migration.test.ts
+++ b/src/shared/migration.test.ts
@@ -774,7 +774,7 @@ describe("migrateAgentConfigToCategory", () => {
   test("migrates model to category when mapping exists", () => {
     // given: Config with a model that has a category mapping
     const config = {
-      model: "google/gemini-3-pro",
+      model: "google/gemini-3.1-pro",
       temperature: 0.5,
       top_p: 0.9,
     }
@@ -823,7 +823,7 @@ describe("migrateAgentConfigToCategory", () => {
   test("handles all mapped models correctly", () => {
     // given: Configs for each mapped model
     const configs = [
-      { model: "google/gemini-3-pro" },
+      { model: "google/gemini-3.1-pro" },
       { model: "google/gemini-3-flash" },
       { model: "openai/gpt-5.2" },
       { model: "anthropic/claude-haiku-4-5" },
@@ -893,7 +893,7 @@ describe("shouldDeleteAgentConfig", () => {
     // given: Config with fields matching category defaults
     const config = {
       category: "visual-engineering",
-      model: "google/gemini-3-pro",
+      model: "google/gemini-3.1-pro",
     }
 
     // when: Check if config should be deleted
@@ -1021,7 +1021,7 @@ describe("migrateConfigFile with backup", () => {
       agents: {
         "multimodal-looker": { model: "anthropic/claude-haiku-4-5" },
         oracle: { model: "openai/gpt-5.2" },
-        "my-custom-agent": { model: "google/gemini-3-pro" },
+        "my-custom-agent": { model: "google/gemini-3.1-pro" },
       },
     }
 
@@ -1037,7 +1037,7 @@ describe("migrateConfigFile with backup", () => {
     const agents = rawConfig.agents as Record<string, Record<string, unknown>>
     expect(agents["multimodal-looker"].model).toBe("anthropic/claude-haiku-4-5")
     expect(agents.oracle.model).toBe("openai/gpt-5.2")
-    expect(agents["my-custom-agent"].model).toBe("google/gemini-3-pro")
+    expect(agents["my-custom-agent"].model).toBe("google/gemini-3.1-pro")
   })
 
   test("preserves category setting when explicitly set", () => {

--- a/src/shared/migration/agent-category.ts
+++ b/src/shared/migration/agent-category.ts
@@ -12,7 +12,7 @@
  * This map will be removed in a future major version once migration period ends.
  */
 export const MODEL_TO_CATEGORY_MAP: Record<string, string> = {
-  "google/gemini-3-pro": "visual-engineering",
+  "google/gemini-3.1-pro": "visual-engineering",
   "google/gemini-3-flash": "writing",
   "openai/gpt-5.2": "ultrabrain",
   "anthropic/claude-haiku-4-5": "quick",

--- a/src/shared/model-availability.test.ts
+++ b/src/shared/model-availability.test.ts
@@ -74,7 +74,7 @@ describe("fetchAvailableModels", () => {
     expect(result.size).toBe(3)
     expect(result.has("openai/gpt-5.2")).toBe(true)
     expect(result.has("anthropic/claude-opus-4-6")).toBe(true)
-    expect(result.has("google/gemini-3-pro")).toBe(true)
+    expect(result.has("google/gemini-3.1-pro")).toBe(true)
   })
 
   it("#given connectedProviders unknown #when fetchAvailableModels called without options #then returns empty Set", async () => {
@@ -107,7 +107,7 @@ describe("fetchAvailableModels", () => {
 
     expect(result).toBeInstanceOf(Set)
     expect(result.has("openai/gpt-5.3-codex")).toBe(true)
-    expect(result.has("google/gemini-3-pro")).toBe(false)
+    expect(result.has("google/gemini-3.1-pro")).toBe(false)
   })
 
   it("#given cache file not found #when fetchAvailableModels called with connectedProviders #then returns empty Set", async () => {
@@ -136,7 +136,7 @@ describe("fetchAvailableModels", () => {
 
     expect(result).toBeInstanceOf(Set)
     expect(result.has("openai/gpt-5.3-codex")).toBe(true)
-    expect(result.has("google/gemini-3-pro")).toBe(true)
+    expect(result.has("google/gemini-3.1-pro")).toBe(true)
   })
 
   it("#given cache read twice #when second call made with same providers #then reads fresh each time", async () => {
@@ -525,7 +525,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 		expect(result.size).toBe(1)
 		expect(result.has("anthropic/claude-opus-4-6")).toBe(true)
 		expect(result.has("openai/gpt-5.2")).toBe(false)
-		expect(result.has("google/gemini-3-pro")).toBe(false)
+		expect(result.has("google/gemini-3.1-pro")).toBe(false)
 	})
 
 	// given cache with multiple providers
@@ -544,7 +544,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 
 		expect(result.size).toBe(2)
 		expect(result.has("anthropic/claude-opus-4-6")).toBe(true)
-		expect(result.has("google/gemini-3-pro")).toBe(true)
+		expect(result.has("google/gemini-3.1-pro")).toBe(true)
 		expect(result.has("openai/gpt-5.2")).toBe(false)
 	})
 
@@ -771,7 +771,7 @@ describe("fetchAvailableModels with provider-models cache (whitelist-filtered)",
 		expect(result.size).toBe(1)
 		expect(result.has("opencode/big-pickle")).toBe(true)
 		expect(result.has("anthropic/claude-opus-4-6")).toBe(false)
-		expect(result.has("google/gemini-3-pro")).toBe(false)
+		expect(result.has("google/gemini-3.1-pro")).toBe(false)
 	})
 
 	it("should handle object[] format with metadata (Ollama-style)", async () => {
@@ -953,7 +953,7 @@ describe("fallback model availability", () => {
 			{ providers: ["openai"], model: "gpt-5.2" },
 			{ providers: ["anthropic"], model: "claude-opus-4-6" },
 		]
-		const availableModels = new Set(["google/gemini-3-pro"])
+		const availableModels = new Set(["google/gemini-3.1-pro"])
 
 		// when
 		const result = resolveFirstAvailableFallback(fallbackChain, availableModels)

--- a/src/shared/model-resolver.test.ts
+++ b/src/shared/model-resolver.test.ts
@@ -10,7 +10,7 @@ describe("resolveModel", () => {
       const input: ModelResolutionInput = {
         userModel: "anthropic/claude-opus-4-6",
         inheritedModel: "openai/gpt-5.2",
-        systemDefault: "google/gemini-3-pro",
+        systemDefault: "google/gemini-3.1-pro",
       }
 
       // when
@@ -25,7 +25,7 @@ describe("resolveModel", () => {
       const input: ModelResolutionInput = {
         userModel: undefined,
         inheritedModel: "openai/gpt-5.2",
-        systemDefault: "google/gemini-3-pro",
+        systemDefault: "google/gemini-3.1-pro",
       }
 
       // when
@@ -40,14 +40,14 @@ describe("resolveModel", () => {
       const input: ModelResolutionInput = {
         userModel: undefined,
         inheritedModel: undefined,
-        systemDefault: "google/gemini-3-pro",
+        systemDefault: "google/gemini-3.1-pro",
       }
 
       // when
       const result = resolveModel(input)
 
       // then
-      expect(result).toBe("google/gemini-3-pro")
+      expect(result).toBe("google/gemini-3.1-pro")
     })
   })
 
@@ -57,7 +57,7 @@ describe("resolveModel", () => {
       const input: ModelResolutionInput = {
         userModel: "",
         inheritedModel: "openai/gpt-5.2",
-        systemDefault: "google/gemini-3-pro",
+        systemDefault: "google/gemini-3.1-pro",
       }
 
       // when
@@ -72,14 +72,14 @@ describe("resolveModel", () => {
       const input: ModelResolutionInput = {
         userModel: "   ",
         inheritedModel: "",
-        systemDefault: "google/gemini-3-pro",
+        systemDefault: "google/gemini-3.1-pro",
       }
 
       // when
       const result = resolveModel(input)
 
       // then
-      expect(result).toBe("google/gemini-3-pro")
+      expect(result).toBe("google/gemini-3.1-pro")
     })
   })
 
@@ -89,7 +89,7 @@ describe("resolveModel", () => {
       const input: ModelResolutionInput = {
         userModel: "anthropic/claude-opus-4-6",
         inheritedModel: "openai/gpt-5.2",
-        systemDefault: "google/gemini-3-pro",
+        systemDefault: "google/gemini-3.1-pro",
       }
 
       // when
@@ -123,7 +123,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic", "github-copilot"], model: "claude-opus-4-6" },
         ],
         availableModels: new Set(["anthropic/claude-opus-4-6", "github-copilot/claude-opus-4-6-preview"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -141,7 +141,7 @@ describe("resolveModelWithFallback", () => {
         uiSelectedModel: "opencode/big-pickle",
         userModel: "anthropic/claude-opus-4-6",
         availableModels: new Set(["anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -158,7 +158,7 @@ describe("resolveModelWithFallback", () => {
         uiSelectedModel: "   ",
         userModel: "anthropic/claude-opus-4-6",
         availableModels: new Set(["anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -175,7 +175,7 @@ describe("resolveModelWithFallback", () => {
         uiSelectedModel: "",
         userModel: "anthropic/claude-opus-4-6",
         availableModels: new Set(["anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -195,7 +195,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic", "github-copilot"], model: "claude-opus-4-6" },
         ],
         availableModels: new Set(["anthropic/claude-opus-4-6", "github-copilot/claude-opus-4-6-preview"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -215,7 +215,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic"], model: "claude-opus-4-6" },
         ],
         availableModels: new Set(["anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -234,7 +234,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic"], model: "claude-opus-4-6" },
         ],
         availableModels: new Set(["anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -252,7 +252,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic"], model: "claude-opus-4-6" },
         ],
         availableModels: new Set(["anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -271,7 +271,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6" },
         ],
         availableModels: new Set(["github-copilot/claude-opus-4-6-preview", "opencode/claude-opus-4-7"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -294,8 +294,8 @@ describe("resolveModelWithFallback", () => {
         fallbackChain: [
           { providers: ["openai", "anthropic", "google"], model: "gpt-5.2" },
         ],
-        availableModels: new Set(["openai/gpt-5.2", "anthropic/claude-opus-4-6", "google/gemini-3-pro"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        availableModels: new Set(["openai/gpt-5.2", "anthropic/claude-opus-4-6", "google/gemini-3.1-pro"]),
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -313,7 +313,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic", "opencode"], model: "gpt-5-nano" },
         ],
         availableModels: new Set(["opencode/gpt-5-nano"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -331,7 +331,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic", "github-copilot"], model: "claude-opus" },
         ],
         availableModels: new Set(["anthropic/claude-opus-4-6", "github-copilot/claude-opus-4-6-preview"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -346,7 +346,7 @@ describe("resolveModelWithFallback", () => {
       // given
       const input: ExtendedModelResolutionInput = {
         availableModels: new Set(["anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -361,7 +361,7 @@ describe("resolveModelWithFallback", () => {
       const input: ExtendedModelResolutionInput = {
         fallbackChain: [],
         availableModels: new Set(["anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -378,7 +378,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic"], model: "CLAUDE-OPUS" },
         ],
         availableModels: new Set(["anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -397,7 +397,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic"], model: "claude-sonnet-4-6" },
         ],
         availableModels: new Set(["opencode/glm-5", "anthropic/claude-sonnet-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -420,7 +420,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["zai-coding-plan"], model: "glm-5" },
         ],
         availableModels: new Set(["zai-coding-plan/glm-5", "opencode/glm-5"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -438,7 +438,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["zai-coding-plan"], model: "glm-5", variant: "high" },
         ],
         availableModels: new Set(["opencode/glm-5"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -457,7 +457,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic"], model: "claude-sonnet-4-6" },
         ],
         availableModels: new Set(["anthropic/claude-sonnet-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -477,14 +477,14 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic"], model: "nonexistent-model" },
         ],
         availableModels: new Set(["openai/gpt-5.2", "anthropic/claude-opus-4-6"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
       const result = resolveModelWithFallback(input)
 
       // then
-      expect(result!.model).toBe("google/gemini-3-pro")
+      expect(result!.model).toBe("google/gemini-3.1-pro")
       expect(result!.source).toBe("system-default")
       expect(logSpy).toHaveBeenCalledWith("No available model found in fallback chain, falling through to system default")
     })
@@ -516,7 +516,7 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic", "openai"], model: "claude-opus-4-6" },
         ],
         availableModels: new Set(),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -577,14 +577,14 @@ describe("resolveModelWithFallback", () => {
           { providers: ["anthropic"], model: "claude-opus-4-6" },
         ],
         availableModels: new Set(),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
       const result = resolveModelWithFallback(input)
 
       // then - should fall through to system default
-      expect(result!.model).toBe("google/gemini-3-pro")
+      expect(result!.model).toBe("google/gemini-3.1-pro")
       expect(result!.source).toBe("system-default")
       cacheSpy.mockRestore()
     })
@@ -593,14 +593,14 @@ describe("resolveModelWithFallback", () => {
       // given
       const input: ExtendedModelResolutionInput = {
         availableModels: new Set(["openai/gpt-5.2"]),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
       const result = resolveModelWithFallback(input)
 
       // then
-      expect(result!.model).toBe("google/gemini-3-pro")
+      expect(result!.model).toBe("google/gemini-3.1-pro")
       expect(result!.source).toBe("system-default")
     })
   })
@@ -627,7 +627,7 @@ describe("resolveModelWithFallback", () => {
 
     test("tries all providers in first entry before moving to second entry", () => {
       // given
-      const availableModels = new Set(["google/gemini-3-pro"])
+      const availableModels = new Set(["google/gemini-3.1-pro"])
 
       // when
       const result = resolveModelWithFallback({
@@ -640,7 +640,7 @@ describe("resolveModelWithFallback", () => {
       })
 
       // then
-      expect(result!.model).toBe("google/gemini-3-pro")
+      expect(result!.model).toBe("google/gemini-3.1-pro")
       expect(result!.source).toBe("provider-fallback")
     })
 
@@ -693,7 +693,7 @@ describe("resolveModelWithFallback", () => {
       const input: ExtendedModelResolutionInput = {
         userModel: "anthropic/claude-opus-4-6",
         availableModels: new Set(),
-        systemDefaultModel: "google/gemini-3-pro",
+        systemDefaultModel: "google/gemini-3.1-pro",
       }
 
       // when
@@ -710,11 +710,11 @@ describe("resolveModelWithFallback", () => {
     test("applies fuzzy matching to categoryDefaultModel when userModel not provided", () => {
       // given - gemini-3-pro is the category default, but only gemini-3-pro-preview is available
       const input: ExtendedModelResolutionInput = {
-        categoryDefaultModel: "google/gemini-3-pro",
+        categoryDefaultModel: "google/gemini-3.1-pro",
         fallbackChain: [
           { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro" },
         ],
-        availableModels: new Set(["google/gemini-3-pro-preview", "anthropic/claude-opus-4-6"]),
+        availableModels: new Set(["google/gemini-3.1-pro-preview", "anthropic/claude-opus-4-6"]),
         systemDefaultModel: "anthropic/claude-sonnet-4-6",
       }
 
@@ -722,18 +722,18 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // then - should fuzzy match gemini-3-pro → gemini-3-pro-preview
-      expect(result!.model).toBe("google/gemini-3-pro-preview")
+      expect(result!.model).toBe("google/gemini-3.1-pro-preview")
       expect(result!.source).toBe("category-default")
     })
 
     test("categoryDefaultModel uses exact match when available", () => {
       // given - exact match exists
       const input: ExtendedModelResolutionInput = {
-        categoryDefaultModel: "google/gemini-3-pro",
+        categoryDefaultModel: "google/gemini-3.1-pro",
         fallbackChain: [
           { providers: ["google"], model: "gemini-3-pro" },
         ],
-        availableModels: new Set(["google/gemini-3-pro", "google/gemini-3-pro-preview"]),
+        availableModels: new Set(["google/gemini-3.1-pro", "google/gemini-3.1-pro-preview"]),
         systemDefaultModel: "anthropic/claude-sonnet-4-6",
       }
 
@@ -741,14 +741,14 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // then - should use exact match
-      expect(result!.model).toBe("google/gemini-3-pro")
+      expect(result!.model).toBe("google/gemini-3.1-pro")
       expect(result!.source).toBe("category-default")
     })
 
     test("categoryDefaultModel falls through to fallbackChain when no match in availableModels", () => {
       // given - categoryDefaultModel has no match, but fallbackChain does
       const input: ExtendedModelResolutionInput = {
-        categoryDefaultModel: "google/gemini-3-pro",
+        categoryDefaultModel: "google/gemini-3.1-pro",
         fallbackChain: [
           { providers: ["anthropic"], model: "claude-opus-4-6" },
         ],
@@ -768,11 +768,11 @@ describe("resolveModelWithFallback", () => {
       // given - both userModel and categoryDefaultModel provided
       const input: ExtendedModelResolutionInput = {
         userModel: "anthropic/claude-opus-4-6",
-        categoryDefaultModel: "google/gemini-3-pro",
+        categoryDefaultModel: "google/gemini-3.1-pro",
         fallbackChain: [
           { providers: ["google"], model: "gemini-3-pro" },
         ],
-        availableModels: new Set(["google/gemini-3-pro-preview", "anthropic/claude-opus-4-6"]),
+        availableModels: new Set(["google/gemini-3.1-pro-preview", "anthropic/claude-opus-4-6"]),
         systemDefaultModel: "system/default",
       }
 
@@ -788,7 +788,7 @@ describe("resolveModelWithFallback", () => {
       // given - no availableModels but connected provider cache exists
       const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["google"])
       const input: ExtendedModelResolutionInput = {
-        categoryDefaultModel: "google/gemini-3-pro",
+        categoryDefaultModel: "google/gemini-3.1-pro",
         availableModels: new Set(),
         systemDefaultModel: "anthropic/claude-sonnet-4-6",
       }
@@ -797,7 +797,7 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // then - should use transformed categoryDefaultModel since google is connected
-      expect(result!.model).toBe("google/gemini-3-pro-preview")
+      expect(result!.model).toBe("google/gemini-3.1-pro-preview")
       expect(result!.source).toBe("category-default")
       cacheSpy.mockRestore()
     })
@@ -824,7 +824,7 @@ describe("resolveModelWithFallback", () => {
       // given - category default already has -preview suffix
       const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["google"])
       const input: ExtendedModelResolutionInput = {
-        categoryDefaultModel: "google/gemini-3-pro-preview",
+        categoryDefaultModel: "google/gemini-3.1-pro-preview",
         availableModels: new Set(),
         systemDefaultModel: "anthropic/claude-sonnet-4-5",
       }
@@ -833,7 +833,7 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // then - should NOT become gemini-3-pro-preview-preview
-      expect(result!.model).toBe("google/gemini-3-pro-preview")
+      expect(result!.model).toBe("google/gemini-3.1-pro-preview")
       expect(result!.source).toBe("category-default")
       cacheSpy.mockRestore()
     })
@@ -853,7 +853,7 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // then - should transform to preview variant for google provider
-      expect(result!.model).toBe("google/gemini-3-pro-preview")
+      expect(result!.model).toBe("google/gemini-3.1-pro-preview")
       expect(result!.source).toBe("provider-fallback")
       cacheSpy.mockRestore()
     })

--- a/src/tools/delegate-task/constants.ts
+++ b/src/tools/delegate-task/constants.ts
@@ -208,10 +208,10 @@ You are NOT an interactive assistant. You are an autonomous problem-solver.
 
 
 export const DEFAULT_CATEGORIES: Record<string, CategoryConfig> = {
-  "visual-engineering": { model: "google/gemini-3-pro", variant: "high" },
+  "visual-engineering": { model: "google/gemini-3.1-pro", variant: "high" },
   ultrabrain: { model: "openai/gpt-5.3-codex", variant: "xhigh" },
   deep: { model: "openai/gpt-5.3-codex", variant: "medium" },
-  artistry: { model: "google/gemini-3-pro", variant: "high" },
+  artistry: { model: "google/gemini-3.1-pro", variant: "high" },
   quick: { model: "anthropic/claude-haiku-4-5" },
   "unspecified-low": { model: "anthropic/claude-sonnet-4-6" },
   "unspecified-high": { model: "anthropic/claude-opus-4-6", variant: "max" },

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -17,7 +17,7 @@ const TEST_AVAILABLE_MODELS = new Set([
   "anthropic/claude-opus-4-6",
   "anthropic/claude-sonnet-4-6",
   "anthropic/claude-haiku-4-5",
-  "google/gemini-3-pro",
+  "google/gemini-3.1-pro",
   "google/gemini-3-flash",
   "openai/gpt-5.2",
   "openai/gpt-5.3-codex",
@@ -73,7 +73,7 @@ describe("sisyphus-task", () => {
 
       // when / #then
       expect(category).toBeDefined()
-      expect(category.model).toBe("google/gemini-3-pro")
+      expect(category.model).toBe("google/gemini-3.1-pro")
       expect(category.variant).toBe("high")
     })
 
@@ -781,7 +781,7 @@ describe("sisyphus-task", () => {
 
       // then
       expect(result).not.toBeNull()
-      expect(result!.config.model).toBe("google/gemini-3-pro")
+      expect(result!.config.model).toBe("google/gemini-3.1-pro")
       expect(result!.promptAppend).toContain("VISUAL/UI")
     })
 
@@ -805,7 +805,7 @@ describe("sisyphus-task", () => {
       const categoryName = "visual-engineering"
       const userCategories = {
         "visual-engineering": {
-          model: "google/gemini-3-pro",
+          model: "google/gemini-3.1-pro",
           prompt_append: "Custom instructions here",
         },
       }
@@ -845,7 +845,7 @@ describe("sisyphus-task", () => {
       const categoryName = "visual-engineering"
       const userCategories = {
         "visual-engineering": {
-          model: "google/gemini-3-pro",
+          model: "google/gemini-3.1-pro",
           temperature: 0.3,
         },
       }
@@ -868,7 +868,7 @@ describe("sisyphus-task", () => {
 
       // then - category's built-in model wins over inheritedModel
       expect(result).not.toBeNull()
-      expect(result!.config.model).toBe("google/gemini-3-pro")
+      expect(result!.config.model).toBe("google/gemini-3.1-pro")
     })
 
     test("systemDefaultModel is used as fallback when custom category has no model", () => {
@@ -910,7 +910,7 @@ describe("sisyphus-task", () => {
 
       // then
       expect(result).not.toBeNull()
-      expect(result!.config.model).toBe("google/gemini-3-pro")
+      expect(result!.config.model).toBe("google/gemini-3.1-pro")
     })
   })
 
@@ -3028,7 +3028,7 @@ describe("sisyphus-task", () => {
       
       // then should use category's built-in model (gemini-3-pro for visual-engineering)
       expect(resolved).not.toBeNull()
-      expect(resolved!.model).toBe("google/gemini-3-pro")
+      expect(resolved!.model).toBe("google/gemini-3.1-pro")
     })
 
     test("systemDefaultModel is used when no other model is available", () => {


### PR DESCRIPTION
## Summary

- Changed model assertions in various test files to reflect the updated model version.
- Updated model configurations in snapshots and constants to use "google/gemini-3.1-pro".
- Ensured all instances of the old model reference are replaced to maintain consistency in tests and functionality.

- 

## Changes

updated all occurences from google/gemini-3-pro to google/gemini-3.1-pro

- 

## Related Issues

https://github.com/code-yeongyu/oh-my-opencode/issues/2065


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update all references from google/gemini-3-pro to google/gemini-3.1-pro (and -preview where applicable) across docs, configs, tests, and snapshots to align with the new model ID and keep defaults/fallbacks consistent. Addresses #2065.

- **Refactors**
  - Replaced model IDs in docs (overview, installation, guides), config examples, and CLI snapshots.
  - Updated category defaults, DEFAULT_CATEGORIES, and MODEL_TO_CATEGORY_MAP to 3.1.
  - Adjusted preview variants, fallback chains, availability/resolver logic, concurrency mappings, and related tests to use 3.1.

<sup>Written for commit 7eaa6c0f73684de980192af68d2e755a10e1a698. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

