### PR TITLE
fix: remove github-copilot from gpt-5.3-codex provider list

### DIFF
--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -750,10 +750,6 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
     "explore": {
       "model": "github-copilot/gpt-5-mini",
     },
-    "hephaestus": {
-      "model": "github-copilot/gpt-5.3-codex",
-      "variant": "medium",
-    },
     "librarian": {
       "model": "github-copilot/claude-sonnet-4.5",
     },
@@ -786,16 +782,12 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
       "model": "github-copilot/gemini-3-pro-preview",
       "variant": "high",
     },
-    "deep": {
-      "model": "github-copilot/gpt-5.3-codex",
-      "variant": "medium",
-    },
     "quick": {
       "model": "github-copilot/claude-haiku-4.5",
     },
     "ultrabrain": {
-      "model": "github-copilot/gpt-5.3-codex",
-      "variant": "xhigh",
+      "model": "github-copilot/gemini-3-pro-preview",
+      "variant": "high",
     },
     "unspecified-high": {
       "model": "github-copilot/claude-sonnet-4.5",
@@ -824,10 +816,6 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
     "explore": {
       "model": "github-copilot/gpt-5-mini",
     },
-    "hephaestus": {
-      "model": "github-copilot/gpt-5.3-codex",
-      "variant": "medium",
-    },
     "librarian": {
       "model": "github-copilot/claude-sonnet-4.5",
     },
@@ -860,16 +848,12 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
       "model": "github-copilot/gemini-3-pro-preview",
       "variant": "high",
     },
-    "deep": {
-      "model": "github-copilot/gpt-5.3-codex",
-      "variant": "medium",
-    },
     "quick": {
       "model": "github-copilot/claude-haiku-4.5",
     },
     "ultrabrain": {
-      "model": "github-copilot/gpt-5.3-codex",
-      "variant": "xhigh",
+      "model": "github-copilot/gemini-3-pro-preview",
+      "variant": "high",
     },
     "unspecified-high": {
       "model": "github-copilot/claude-opus-4.6",
@@ -1285,7 +1269,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
       "model": "opencode/claude-haiku-4-5",
     },
     "hephaestus": {
-      "model": "github-copilot/gpt-5.3-codex",
+      "model": "opencode/gpt-5.3-codex",
       "variant": "medium",
     },
     "librarian": {
@@ -1321,14 +1305,14 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
       "variant": "high",
     },
     "deep": {
-      "model": "github-copilot/gpt-5.3-codex",
+      "model": "opencode/gpt-5.3-codex",
       "variant": "medium",
     },
     "quick": {
       "model": "github-copilot/claude-haiku-4.5",
     },
     "ultrabrain": {
-      "model": "github-copilot/gpt-5.3-codex",
+      "model": "opencode/gpt-5.3-codex",
       "variant": "xhigh",
     },
     "unspecified-high": {

--- a/src/cli/model-fallback-requirements.ts
+++ b/src/cli/model-fallback-requirements.ts
@@ -17,9 +17,9 @@ export const CLI_AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   hephaestus: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
     ],
-    requiresProvider: ["openai", "github-copilot", "opencode"],
+    requiresProvider: ["openai", "opencode"],
   },
   oracle: {
     fallbackChain: [
@@ -100,14 +100,14 @@ export const CLI_CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> =
   },
   ultrabrain: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "xhigh" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "xhigh" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
     ],
   },
   deep: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
@@ -131,7 +131,7 @@ export const CLI_CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> =
   "unspecified-low": {
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-5" },
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-flash" },
     ],
   },

--- a/src/cli/model-fallback.test.ts
+++ b/src/cli/model-fallback.test.ts
@@ -421,16 +421,15 @@ describe("generateModelConfig", () => {
       expect(result.agents?.hephaestus?.variant).toBe("medium")
     })
 
-    test("Hephaestus is created when Copilot is available (github-copilot provider connected)", () => {
+    test("Hephaestus is NOT created when only Copilot is available (gpt-5.3-codex unavailable on github-copilot)", () => {
       // #given
       const config = createConfig({ hasCopilot: true })
 
       // #when
       const result = generateModelConfig(config)
 
-      // #then
-      expect(result.agents?.hephaestus?.model).toBe("github-copilot/gpt-5.3-codex")
-      expect(result.agents?.hephaestus?.variant).toBe("medium")
+      // #then - hephaestus is omitted because gpt-5.3-codex is not available on github-copilot
+      expect(result.agents?.hephaestus).toBeUndefined()
     })
 
     test("Hephaestus is created when OpenCode Zen is available (opencode provider connected)", () => {

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -168,14 +168,14 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(primary.providers[0]).toBe("opencode")
   })
 
-  test("hephaestus requires openai/github-copilot/opencode provider", () => {
+  test("hephaestus requires openai/opencode provider (not github-copilot since gpt-5.3-codex unavailable there)", () => {
     // #given - hephaestus agent requirement
     const hephaestus = AGENT_MODEL_REQUIREMENTS["hephaestus"]
 
     // #when - accessing hephaestus requirement
-    // #then - requiresProvider is set to openai, github-copilot, opencode (not requiresModel)
+    // #then - requiresProvider is set to openai and opencode only (github-copilot removed)
     expect(hephaestus).toBeDefined()
-    expect(hephaestus.requiresProvider).toEqual(["openai", "github-copilot", "opencode"])
+    expect(hephaestus.requiresProvider).toEqual(["openai", "opencode"])
     expect(hephaestus.requiresModel).toBeUndefined()
   })
 
@@ -495,5 +495,37 @@ describe("requiresModel field in categories", () => {
 
     // when / #then
     expect(artistry.requiresModel).toBe("gemini-3-pro")
+  })
+})
+
+describe("gpt-5.3-codex provider restrictions", () => {
+  test("no gpt-5.3-codex entry in AGENT_MODEL_REQUIREMENTS includes github-copilot as provider", () => {
+    // given - all agent requirements
+    const allAgentEntries = Object.values(AGENT_MODEL_REQUIREMENTS).flatMap(
+      (req) => req.fallbackChain
+    )
+
+    // when - filtering entries with gpt-5.3-codex model
+    const codexEntries = allAgentEntries.filter((entry) => entry.model === "gpt-5.3-codex")
+
+    // then - none of them include github-copilot as a provider
+    for (const entry of codexEntries) {
+      expect(entry.providers).not.toContain("github-copilot")
+    }
+  })
+
+  test("no gpt-5.3-codex entry in CATEGORY_MODEL_REQUIREMENTS includes github-copilot as provider", () => {
+    // given - all category requirements
+    const allCategoryEntries = Object.values(CATEGORY_MODEL_REQUIREMENTS).flatMap(
+      (req) => req.fallbackChain
+    )
+
+    // when - filtering entries with gpt-5.3-codex model
+    const codexEntries = allCategoryEntries.filter((entry) => entry.model === "gpt-5.3-codex")
+
+    // then - none of them include github-copilot as a provider
+    for (const entry of codexEntries) {
+      expect(entry.providers).not.toContain("github-copilot")
+    }
   })
 })

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -24,9 +24,9 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   hephaestus: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
     ],
-    requiresProvider: ["openai", "github-copilot", "opencode"],
+    requiresProvider: ["openai", "opencode"],
   },
   oracle: {
     fallbackChain: [
@@ -101,14 +101,14 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   ultrabrain: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "xhigh" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "xhigh" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
     ],
   },
   deep: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-pro", variant: "high" },
     ],
@@ -132,7 +132,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   "unspecified-low": {
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-6" },
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3-flash" },
     ],
   },


### PR DESCRIPTION
## Background

\`gpt-5.3-codex\` is not available on GitHub Copilot. Confirmed from user's \`opencode models --refresh\` output — the latest Codex model on Copilot is \`gpt-5.2-codex\`. The fallback chains incorrectly listed \`github-copilot\` as a valid provider for \`gpt-5.3-codex\`, causing the doctor to report:

\`\`\`
Agent Hephaestus (Deep Agent)'s configured model github-copilot/gpt-5.3-codex is not valid
\`\`\`

Fixes #2047

## Changes

- **\`src/shared/model-requirements.ts\`**: Removed \`github-copilot\` from providers for all \`gpt-5.3-codex\` entries (\`hephaestus\`, \`ultrabrain\`, \`deep\`, \`unspecified-low\`). Updated \`hephaestus.requiresProvider\` from \`["openai", "github-copilot", "opencode"]\` to \`["openai", "opencode"]\`
- **\`src/cli/model-fallback-requirements.ts\`**: Same changes for CLI config generation
- **Tests**: Added \`gpt-5.3-codex provider restrictions\` describe block asserting no \`gpt-5.3-codex\` entry includes \`github-copilot\` as provider. Updated hephaestus test and snapshot for Copilot-only scenario (Hephaestus now correctly omitted)

## Effect on users

- **OpenAI / OpenCode Zen users**: No change — Hephaestus still works normally
- **Copilot-only users**: Hephaestus is now omitted instead of being configured with a non-existent model. Doctor check passes cleanly

## Testing

\`\`\`bash
bun test src/shared/model-requirements.test.ts src/cli/model-fallback.test.ts
# 69 pass, 0 fail
\`\`\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed GitHub Copilot from the provider list for gpt-5.3-codex to avoid configuring a non-existent Copilot model. This fixes doctor errors and corrects fallback behavior for Hephaestus and related categories.

- **Bug Fixes**
  - Removed github-copilot from gpt-5.3-codex providers in shared and CLI requirements (hephaestus, ultrabrain, deep, unspecified-low).
  - Updated hephaestus requiresProvider to ["openai", "opencode"].
  - Adjusted tests and snapshots to assert no gpt-5.3-codex entries use github-copilot; Copilot-only configs now omit Hephaestus and select valid fallbacks.

<sup>Written for commit 465f5e13a829db58ee0cb30d27b171935b44b16a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

