### PR TITLE
fix(no-hephaestus-non-gpt): add opt-out for model enforcement

### DIFF
--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -589,20 +589,22 @@ describe("createBuiltinAgents with requiresProvider gating (hephaestus)", () => 
     }
   })
 
-  test("hephaestus is created when github-copilot provider is connected", async () => {
-    // #given - github-copilot provider has models available
+  test("hephaestus is NOT created when only github-copilot is connected (gpt-5.3-codex unavailable via github-copilot)", async () => {
+    // #given - github-copilot provider has models available, but no cache
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
       new Set(["github-copilot/gpt-5.3-codex"])
     )
+    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
 
     try {
       // #when
       const agents = await createBuiltinAgents([], {}, undefined, TEST_DEFAULT_MODEL, undefined, undefined, [], {})
 
-      // #then
-      expect(agents.hephaestus).toBeDefined()
+      // #then - hephaestus requires openai/opencode, github-copilot alone is insufficient
+      expect(agents.hephaestus).toBeUndefined()
     } finally {
       fetchSpy.mockRestore()
+      cacheSpy.mockRestore()
     }
   })
 

--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -59,7 +59,9 @@ export const AgentOverridesSchema = z.object({
   build: AgentOverrideConfigSchema.optional(),
   plan: AgentOverrideConfigSchema.optional(),
   sisyphus: AgentOverrideConfigSchema.optional(),
-  hephaestus: AgentOverrideConfigSchema.optional(),
+  hephaestus: AgentOverrideConfigSchema.extend({
+    allow_non_gpt_model: z.boolean().optional(),
+  }).optional(),
   "sisyphus-junior": AgentOverrideConfigSchema.optional(),
   "OpenCode-Builder": AgentOverrideConfigSchema.optional(),
   prometheus: AgentOverrideConfigSchema.optional(),

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -232,7 +232,10 @@ export function createSessionHooks(args: {
     : null
 
   const noHephaestusNonGpt = isHookEnabled("no-hephaestus-non-gpt")
-    ? safeHook("no-hephaestus-non-gpt", () => createNoHephaestusNonGptHook(ctx))
+    ? safeHook("no-hephaestus-non-gpt", () =>
+      createNoHephaestusNonGptHook(ctx, {
+        allowNonGptModel: pluginConfig.agents?.hephaestus?.allow_non_gpt_model,
+      }))
     : null
 
   const questionLabelTruncator = isHookEnabled("question-label-truncator")

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -24,9 +24,9 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   hephaestus: {
     fallbackChain: [
-      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
     ],
-    requiresProvider: ["openai", "opencode"],
+    requiresProvider: ["openai", "github-copilot", "opencode"],
   },
   oracle: {
     fallbackChain: [

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -24,9 +24,9 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   hephaestus: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
     ],
-    requiresProvider: ["openai", "github-copilot", "opencode"],
+    requiresProvider: ["openai", "opencode"],
   },
   oracle: {
     fallbackChain: [


### PR DESCRIPTION
## Summary
- Add `agents.hephaestus.allow_non_gpt_model` schema support (default behavior unchanged when unset/false).
- Update `no-hephaestus-non-gpt` hook to honor this option: still show toast, but only force-switch to Sisyphus when opt-out is disabled.
- Add hook test coverage for opt-out mode to verify warning toast and no forced agent switch.

## Testing
- `bun test src/hooks/no-hephaestus-non-gpt/`
- `bun run typecheck`

Fixes #2054

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑out so Hephaestus can run with non‑GPT models without forcing a switch, and updates provider gating so Hephaestus is not created when only GitHub Copilot is connected. Fixes #2054.

- New Features
  - Schema: agents.hephaestus.allow_non_gpt_model (optional boolean).
  - Hook: honors the setting. Unset/false → error toast and switch to Sisyphus. True → warning toast only, no switch.
  - Wiring/tests: passes the setting from plugin config and adds coverage for the opt‑out path.

- Bug Fixes
  - Provider gating: revert adding github-copilot to Hephaestus requiresProvider; update tests to expect Hephaestus is not created with Copilot-only and mock cache to fix flakiness.

<sup>Written for commit 9f64e2a8692c8c45fc08afe314ab72951e43bc14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

