### PR TITLE
fix(ralph-loop): fix race condition in --strategy=reset

### DIFF
--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -589,20 +589,22 @@ describe("createBuiltinAgents with requiresProvider gating (hephaestus)", () => 
     }
   })
 
-  test("hephaestus is created when github-copilot provider is connected", async () => {
-    // #given - github-copilot provider has models available
+  test("hephaestus is NOT created when only github-copilot is connected (gpt-5.3-codex unavailable via github-copilot)", async () => {
+    // #given - github-copilot provider has models available, but no cache
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
       new Set(["github-copilot/gpt-5.3-codex"])
     )
+    const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
 
     try {
       // #when
       const agents = await createBuiltinAgents([], {}, undefined, TEST_DEFAULT_MODEL, undefined, undefined, [], {})
 
-      // #then
-      expect(agents.hephaestus).toBeDefined()
+      // #then - hephaestus requires openai/opencode, github-copilot alone is insufficient
+      expect(agents.hephaestus).toBeUndefined()
     } finally {
       fetchSpy.mockRestore()
+      cacheSpy.mockRestore()
     }
   })
 

--- a/src/hooks/ralph-loop/iteration-continuation.ts
+++ b/src/hooks/ralph-loop/iteration-continuation.ts
@@ -33,15 +33,6 @@ export async function continueIteration(
       return
     }
 
-    const boundState = options.loopState.setSessionID(newSessionID)
-    if (!boundState) {
-      log(`[${HOOK_NAME}] Failed to bind loop state to new session`, {
-        previousSessionID: options.previousSessionID,
-        newSessionID,
-      })
-      return
-    }
-
     await injectContinuationPrompt(ctx, {
       sessionID: newSessionID,
       inheritFromSessionID: options.previousSessionID,
@@ -51,6 +42,16 @@ export async function continueIteration(
     })
 
     await selectSessionInTui(ctx.client, newSessionID)
+
+    const boundState = options.loopState.setSessionID(newSessionID)
+    if (!boundState) {
+      log(`[${HOOK_NAME}] Failed to bind loop state to new session`, {
+        previousSessionID: options.previousSessionID,
+        newSessionID,
+      })
+      return
+    }
+
     return
   }
 

--- a/src/hooks/ralph-loop/reset-strategy-race-condition.test.ts
+++ b/src/hooks/ralph-loop/reset-strategy-race-condition.test.ts
@@ -1,0 +1,113 @@
+/// <reference types="bun-types" />
+import { describe, expect, test } from "bun:test"
+import { createRalphLoopHook } from "./index"
+
+function createDeferred(): {
+  promise: Promise<void>
+  resolve: () => void
+} {
+  let resolvePromise: (() => void) | null = null
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve
+  })
+
+  return {
+    promise,
+    resolve: () => {
+      if (resolvePromise) {
+        resolvePromise()
+      }
+    },
+  }
+}
+
+async function waitUntil(condition: () => boolean): Promise<void> {
+  for (let index = 0; index < 100; index++) {
+    if (condition()) {
+      return
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0)
+    })
+  }
+
+  throw new Error("Condition was not met in time")
+}
+
+describe("ralph-loop reset strategy race condition", () => {
+  test("should continue iteration when old session idle arrives before TUI switch completes", async () => {
+    // given - reset strategy loop with blocked TUI session switch
+    const promptCalls: Array<{ sessionID: string; text: string }> = []
+    const createSessionCalls: Array<{ parentID?: string }> = []
+    let selectSessionCalls = 0
+    const selectSessionDeferred = createDeferred()
+
+    const hook = createRalphLoopHook({
+      directory: process.cwd(),
+      client: {
+        session: {
+          prompt: async (options: {
+            path: { id: string }
+            body: { parts: Array<{ type: string; text: string }> }
+          }) => {
+            promptCalls.push({
+              sessionID: options.path.id,
+              text: options.body.parts[0].text,
+            })
+            return {}
+          },
+          promptAsync: async (options: {
+            path: { id: string }
+            body: { parts: Array<{ type: string; text: string }> }
+          }) => {
+            promptCalls.push({
+              sessionID: options.path.id,
+              text: options.body.parts[0].text,
+            })
+            return {}
+          },
+          create: async (options: {
+            body: { parentID?: string; title?: string }
+            query?: { directory?: string }
+          }) => {
+            createSessionCalls.push({ parentID: options.body.parentID })
+            return { data: { id: `new-session-${createSessionCalls.length}` } }
+          },
+          messages: async () => ({ data: [] }),
+        },
+        tui: {
+          showToast: async () => ({}),
+          selectSession: async () => {
+            selectSessionCalls += 1
+            await selectSessionDeferred.promise
+            return {}
+          },
+        },
+      },
+    } as Parameters<typeof createRalphLoopHook>[0])
+
+    hook.startLoop("session-old", "Build feature", { strategy: "reset" })
+
+    // when - first idle is in-flight and old session fires idle again before TUI switch resolves
+    const firstIdleEvent = hook.event({
+      event: { type: "session.idle", properties: { sessionID: "session-old" } },
+    })
+
+    await waitUntil(() => selectSessionCalls > 0)
+
+    const secondIdleEvent = hook.event({
+      event: { type: "session.idle", properties: { sessionID: "session-old" } },
+    })
+
+    await waitUntil(() => selectSessionCalls > 1)
+
+    selectSessionDeferred.resolve()
+    await Promise.all([firstIdleEvent, secondIdleEvent])
+
+    // then - second idle should not be skipped during reset transition
+    expect(createSessionCalls.length).toBe(2)
+    expect(promptCalls.length).toBe(2)
+    expect(hook.getState()?.iteration).toBe(3)
+  })
+})

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -24,9 +24,9 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   hephaestus: {
     fallbackChain: [
-      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
     ],
-    requiresProvider: ["openai", "opencode"],
+    requiresProvider: ["openai", "github-copilot", "opencode"],
   },
   oracle: {
     fallbackChain: [

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -24,9 +24,9 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   hephaestus: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
+      { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
     ],
-    requiresProvider: ["openai", "github-copilot", "opencode"],
+    requiresProvider: ["openai", "opencode"],
   },
   oracle: {
     fallbackChain: [


### PR DESCRIPTION
## Summary
- Fix reset-strategy ordering in Ralph Loop so the TUI session switch runs before loop state is rebound to the new session ID.
- Prevent idle events from the previous session from being dropped during the transition window, which could skip an iteration and break loop coordination.
- Add a regression test that reproduces two old-session idle events while `tui.selectSession` is blocked and verifies the loop keeps progressing.

## Testing
- `bun test src/hooks/ralph-loop/ 2>&1`
- `bun run typecheck 2>&1`

## Issue
- Fixes #2100

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the reset strategy that could drop idle events and stall Ralph Loop during session switches (fixes #2100). We now bind loop state to the new session only after the TUI switch and add a regression test.

- **Bug Fixes**
  - Delay loopState.setSessionID until after tui.selectSession completes to avoid losing old-session idle events.
  - Revert adding github-copilot as a required provider for hephaestus and fix the test to expect hephaestus is not created when only github-copilot is connected; add cache mock to prevent test state leakage.

<sup>Written for commit adf62267aa788638960417297e823537530b5353. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

