### PR TITLE
fix(background-agent): queue notifications for idle parent sessions

### DIFF
--- a/src/hooks/background-notification/hook.ts
+++ b/src/hooks/background-notification/hook.ts
@@ -9,6 +9,14 @@ interface EventInput {
   event: Event
 }
 
+interface ChatMessageInput {
+  sessionID: string
+}
+
+interface ChatMessageOutput {
+  parts: Array<{ type: string; text?: string; [key: string]: unknown }>
+}
+
 /**
  * Background notification hook - handles event routing to BackgroundManager.
  *
@@ -20,7 +28,15 @@ export function createBackgroundNotificationHook(manager: BackgroundManager) {
     manager.handleEvent(event)
   }
 
+  const chatMessageHandler = async (
+    input: ChatMessageInput,
+    output: ChatMessageOutput,
+  ): Promise<void> => {
+    manager.injectPendingNotificationsIntoChatMessage(output, input.sessionID)
+  }
+
   return {
+    "chat.message": chatMessageHandler,
     event: eventHandler,
   }
 }

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -97,6 +97,7 @@ export function createChatMessageHandler(args: {
       setSessionModel(input.sessionID, input.model)
     }
     await hooks.stopContinuationGuard?.["chat.message"]?.(input)
+    await hooks.backgroundNotificationHook?.["chat.message"]?.(input, output)
     await hooks.runtimeFallback?.["chat.message"]?.(input, output)
     await hooks.keywordDetector?.["chat.message"]?.(input, output)
     await hooks.claudeCodeHooks?.["chat.message"]?.(input, output)


### PR DESCRIPTION
## Problem

When a background task (subagent) completes and the parent session is **idle** (waiting for user input), the completion notification is silently dropped.

`BackgroundManager.notifyParentSession()` calls `client.session.promptAsync()` on the parent session. If the parent is waiting for user input, this fails with `MessageAbortedError`. The code caught this specific error and just logged it — notification lost forever.

From Discord (`controlnet999`):
> "the reminder of the completion of sub-agent only works when the conversation is active, when the conversation is ended and waiting for user to input, the reminder of the completion of subagents will be fully disabled."

## Fix

Queue the notification text in-memory when `promptAsync` fails with an aborted/idle error. Deliver it on the user's next message to that session.

### Changes

**`BackgroundManager`** (`manager.ts`):
- Add `pendingNotifications: Map<string, string[]>` — per-session queue
- `queuePendingNotification(sessionID, text)` — called on aborted error path
- `injectPendingNotificationsIntoChatMessage(output, sessionID)` — prepends queued notifications to the first text part of the user's next message, then clears the queue
- `shutdown()` now clears `pendingNotifications`

**`createBackgroundNotificationHook`** (`hook.ts`):
- Add `"chat.message"` handler that calls `manager.injectPendingNotificationsIntoChatMessage()`

**`createChatMessageHandler`** (`chat-message.ts`):
- Wire `hooks.backgroundNotificationHook?.["chat.message"]?.(input, output)` early in the processing chain

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Session active when task completes | `promptAsync` → notification injected ✅ | Same ✅ |
| Session idle when task completes | Notification dropped ❌ | Queued → delivered on next user message ✅ |

## Tests

- `manager.test.ts`: queue-on-abort test + `injectPendingNotificationsIntoChatMessage` unit test
- `chat-message.test.ts`: integration test verifying the hook is called during message processing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped background-task completion notifications when the parent session is idle. Notifications are now queued and delivered with the user's next message.

- **Bug Fixes**
  - BackgroundManager: add per-session pendingNotifications queue; on MessageAbortedError from promptAsync, queue the notification.
  - Hook: new backgroundNotificationHook "chat.message" injects queued notifications into the first text part and clears the queue.
  - chat-message: wire the hook early in the pipeline; add tests for queueing and next-message delivery.

<sup>Written for commit 840c612be8c9b44db08b21eb8ef1aaab97128b26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

