### PR TITLE
fix(model-fallback): apply transformModelForProvider in getNextFallback

### DIFF
--- a/src/hooks/model-fallback/hook.test.ts
+++ b/src/hooks/model-fallback/hook.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, test } from "bun:test"
 import {
   clearPendingModelFallback,
   createModelFallbackHook,
+  setSessionFallbackChain,
   setPendingModelFallback,
 } from "./hook"
 
 describe("model fallback hook", () => {
   beforeEach(() => {
     clearPendingModelFallback("ses_model_fallback_main")
+    clearPendingModelFallback("ses_model_fallback_ghcp")
   })
 
   test("applies pending fallback on chat.message by overriding model", async () => {
@@ -137,5 +139,49 @@ describe("model fallback hook", () => {
     //#then
     expect(toastCalls.length).toBe(1)
     expect(toastCalls[0]?.title).toBe("Model fallback")
+  })
+
+  test("transforms model names for github-copilot provider via fallback chain", async () => {
+    //#given
+    const sessionID = "ses_model_fallback_ghcp"
+    clearPendingModelFallback(sessionID)
+
+    const hook = createModelFallbackHook() as unknown as {
+      "chat.message"?: (
+        input: { sessionID: string },
+        output: { message: Record<string, unknown>; parts: Array<{ type: string; text?: string }> },
+      ) => Promise<void>
+    }
+
+    // Set a custom fallback chain that routes through github-copilot
+    setSessionFallbackChain(sessionID, [
+      { providers: ["github-copilot"], model: "claude-sonnet-4-6" },
+    ])
+
+    const set = setPendingModelFallback(
+      sessionID,
+      "Atlas (Plan Executor)",
+      "github-copilot",
+      "claude-sonnet-4-6",
+    )
+    expect(set).toBe(true)
+
+    const output = {
+      message: {
+        model: { providerID: "github-copilot", modelID: "claude-sonnet-4-6" },
+      },
+      parts: [{ type: "text", text: "continue" }],
+    }
+
+    //#when
+    await hook["chat.message"]?.({ sessionID }, output)
+
+    //#then — model name should be transformed from hyphen to dot notation
+    expect(output.message["model"]).toEqual({
+      providerID: "github-copilot",
+      modelID: "claude-sonnet-4.6",
+    })
+
+    clearPendingModelFallback(sessionID)
   })
 })

--- a/src/hooks/model-fallback/hook.test.ts
+++ b/src/hooks/model-fallback/hook.test.ts
@@ -11,6 +11,7 @@ describe("model fallback hook", () => {
   beforeEach(() => {
     clearPendingModelFallback("ses_model_fallback_main")
     clearPendingModelFallback("ses_model_fallback_ghcp")
+    clearPendingModelFallback("ses_model_fallback_google")
   })
 
   test("applies pending fallback on chat.message by overriding model", async () => {
@@ -180,6 +181,50 @@ describe("model fallback hook", () => {
     expect(output.message["model"]).toEqual({
       providerID: "github-copilot",
       modelID: "claude-sonnet-4.6",
+    })
+
+    clearPendingModelFallback(sessionID)
+  })
+
+  test("transforms model names for google provider via fallback chain", async () => {
+    //#given
+    const sessionID = "ses_model_fallback_google"
+    clearPendingModelFallback(sessionID)
+
+    const hook = createModelFallbackHook() as unknown as {
+      "chat.message"?: (
+        input: { sessionID: string },
+        output: { message: Record<string, unknown>; parts: Array<{ type: string; text?: string }> },
+      ) => Promise<void>
+    }
+
+    // Set a custom fallback chain that routes through google
+    setSessionFallbackChain(sessionID, [
+      { providers: ["google"], model: "gemini-3-pro" },
+    ])
+
+    const set = setPendingModelFallback(
+      sessionID,
+      "Oracle",
+      "google",
+      "gemini-3-pro",
+    )
+    expect(set).toBe(true)
+
+    const output = {
+      message: {
+        model: { providerID: "google", modelID: "gemini-3-pro" },
+      },
+      parts: [{ type: "text", text: "continue" }],
+    }
+
+    //#when
+    await hook["chat.message"]?.({ sessionID }, output)
+
+    //#then — model name should be transformed from gemini-3-pro to gemini-3-pro-preview
+    expect(output.message["model"]).toEqual({
+      providerID: "google",
+      modelID: "gemini-3-pro-preview",
     })
 
     clearPendingModelFallback(sessionID)

--- a/src/hooks/model-fallback/hook.ts
+++ b/src/hooks/model-fallback/hook.ts
@@ -3,6 +3,7 @@ import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
 import { readConnectedProvidersCache, readProviderModelsCache } from "../../shared/connected-providers-cache"
 import { selectFallbackProvider } from "../../shared/model-error-classifier"
+import { transformModelForProvider } from "../../shared/provider-model-id-transform"
 import { log } from "../../shared/logger"
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import type { ChatMessageInput, ChatMessageHandlerOutput } from "../../plugin/chat-message"
@@ -145,7 +146,7 @@ export function getNextFallback(
 
     return {
       providerID,
-      modelID: fallback.model,
+      modelID: transformModelForProvider(providerID, fallback.model),
       variant: fallback.variant,
     }
   }


### PR DESCRIPTION
## Summary

`getNextFallback()` in the model-fallback hook returns raw model names from the hardcoded fallback chain without calling `transformModelForProvider()`. This causes fallback to fail silently for providers that require different model name formats:

- **`github-copilot`**: expects dot notation (`claude-sonnet-4.6`), but the chain stores hyphens (`claude-sonnet-4-6`)
- **`google`**: expects `-preview` suffix (`gemini-3-pro-preview`), but the chain stores plain names (`gemini-3-pro`)

## Root Cause

The `background-agent` retry handler (`src/features/background-agent/fallback-retry-handler.ts:94`) correctly calls `transformModelForProvider()` before returning the fallback model. However, the sync `chat.message` hook in `model-fallback/hook.ts` was missing this call — a copy-paste omission.

**Before (broken):**

```typescript
return {
  providerID,
  modelID: fallback.model,  // raw name → github-copilot and google reject it
  variant: fallback.variant,
}
```

**After (fixed):**

```typescript
return {
  providerID,
  modelID: transformModelForProvider(providerID, fallback.model),
  variant: fallback.variant,
}
```

## Affected Providers

| Provider | Raw Model Name | Expected by API | Transform Applied |
|----------|---------------|-----------------|-------------------|
| `github-copilot` | `claude-sonnet-4-6` | `claude-sonnet-4.6` | Hyphen → dot |
| `github-copilot` | `gemini-3-pro` | `gemini-3-pro-preview` | Add `-preview` suffix |
| `google` | `gemini-3-pro` | `gemini-3-pro-preview` | Add `-preview` suffix |
| `google` | `gemini-3-flash` | `gemini-3-flash-preview` | Add `-preview` suffix |
| `anthropic` | `claude-opus-4-6` | `claude-opus-4-6` | No transform needed |

## Changes

- **`src/hooks/model-fallback/hook.ts`**: Import `transformModelForProvider` and apply it in `getNextFallback()` return value
- **`src/hooks/model-fallback/hook.test.ts`**: Add tests verifying model name transformation for both `github-copilot` (`claude-sonnet-4-6` → `claude-sonnet-4.6`) and `google` (`gemini-3-pro` → `gemini-3-pro-preview`) providers through the fallback chain

## Scope

This fix targets only the **hardcoded agent fallback chain** (`model-fallback` hook). The `runtime-fallback` hook (`auto-retry.ts`) uses user-configured `fallback_models` where users specify provider-correct names directly, so no change is needed there.

## Testing

- ✅ TypeScript typecheck passes (`tsc --noEmit`)
- ✅ All 5 model-fallback hook tests pass (including the new github-copilot and google transform tests)