### PR TITLE
fix(ralph-loop): finalize continue/reset loop strategies and docs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -443,7 +443,7 @@ Configure `/ralph-loop` continuation behavior and defaults:
 | `enabled` | `false` | Enables `/ralph-loop` command behavior |
 | `default_max_iterations` | `100` | Default iteration limit when `--max-iterations` is omitted |
 | `default_strategy` | `continue` | Default strategy when `--strategy` is omitted. `continue` keeps iterating in the same session; `reset` creates a fresh top-level session each iteration. |
-| `state_dir` | `.opencode` (internal default path behavior) | Custom state-file directory relative to project root |
+| `state_dir` | `.sisyphus/ralph-loop.local.md` (when omitted) | Custom Ralph-loop state file path relative to project root (despite the name, this behaves as a file path, not just a directory) |
 
 Strategy philosophy matters:
 - `continue`: session continuity (hot context), same-thread iterative execution.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -433,7 +433,7 @@ Configure `/ralph-loop` continuation behavior and defaults:
     "enabled": true,
     "default_max_iterations": 100,
     "default_strategy": "continue",
-    "state_dir": ".opencode"
+    "state_dir": ".sisyphus/ralph-loop.local.md"
   }
 }
 ```

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -21,6 +21,7 @@ Complete reference for `oh-my-opencode.jsonc` configuration. This document cover
   - [Skills](#skills)
   - [Hooks](#hooks)
   - [Commands](#commands)
+  - [Ralph Loop](#ralph-loop)
   - [Browser Automation](#browser-automation)
   - [Tmux Integration](#tmux-integration)
   - [Git Master](#git-master)
@@ -421,6 +422,37 @@ Disable built-in commands via `disabled_commands`:
 ```
 
 Available commands: `init-deep`, `start-work`
+
+### Ralph Loop
+
+Configure `/ralph-loop` continuation behavior and defaults:
+
+```json
+{
+  "ralph_loop": {
+    "enabled": true,
+    "default_max_iterations": 100,
+    "default_strategy": "continue",
+    "state_dir": ".opencode"
+  }
+}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` | Enables `/ralph-loop` command behavior |
+| `default_max_iterations` | `100` | Default iteration limit when `--max-iterations` is omitted |
+| `default_strategy` | `continue` | Default strategy when `--strategy` is omitted. `continue` keeps iterating in the same session; `reset` creates a fresh top-level session each iteration. |
+| `state_dir` | `.opencode` (internal default path behavior) | Custom state-file directory relative to project root |
+
+Strategy philosophy matters:
+- `continue`: session continuity (hot context), same-thread iterative execution.
+- `reset`: fresh context each iteration (new top-level session), aligned with reset-style Ralph loops where each pass starts clean.
+
+Flag precedence:
+- Explicit command flag (`--strategy=...`) overrides config.
+- If no flag is provided, `ralph_loop.default_strategy` is used.
+- If config is omitted, fallback is `continue`.
 
 ### Browser Automation
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -390,13 +390,36 @@ project/
 
 **Purpose**: Self-referential development loop that runs until task completion
 
-**Named after**: Anthropic's Ralph Wiggum plugin
+**Named after**: the Ralph Wiggum loop pattern popularized by Geoffrey Huntley (this implementation supports both single-session continuation and fresh-session reset styles)
 
 **Usage**:
 ```
 /ralph-loop "Build a REST API with authentication"
 /ralph-loop "Refactor the payment module" --max-iterations=50
+/ralph-loop "Harden deployment pipeline" --strategy=reset --completion-promise=COMPLETE
 ```
+
+**Arguments / Flags**:
+
+| Flag | Values | Default | Description |
+|------|--------|---------|-------------|
+| `--max-iterations` | `1-1000` | `100` (or `ralph_loop.default_max_iterations`) | Maximum loop iterations before auto-stop |
+| `--completion-promise` | text | `DONE` | Completion marker detected as `<promise>TEXT</promise>` |
+| `--strategy` | `continue` \| `reset` | `ralph_loop.default_strategy` → `continue` | Controls whether each iteration continues in the same session or starts a fresh session |
+
+#### Ralph Loop Strategies: `continue` vs `reset`
+
+These are intentionally different techniques, not just minor modes.
+
+| Strategy | Philosophy | Iteration Behavior | Best For |
+|----------|------------|--------------------|----------|
+| `continue` | **Hot-context / session continuity** | Injects the next iteration prompt into the same session thread | HITL workflows, maintaining conversational context, debugging a single evolving thread |
+| `reset` | **Fresh-context / Ralph reset loop** | Creates a new top-level session for each iteration and replays the loop command for the next pass | Geoffrey Huntley-style looping to avoid context rot, longer AFK runs, stronger iteration isolation |
+
+**Important differences**:
+- `continue` keeps the same session history, so context accumulates across iterations.
+- `reset` starts each iteration in a fresh top-level session (with iteration titles) and passes the loop instructions forward, which is a fundamentally different looping approach.
+- If `--strategy` is omitted, the command uses `ralph_loop.default_strategy` from config. If config is also omitted, it defaults to `continue`.
 
 **Behavior**:
 - Agent works continuously toward the goal
@@ -404,7 +427,7 @@ project/
 - Auto-continues if agent stops without completion
 - Ends when: completion detected, max iterations reached (default 100), or `/cancel-ralph`
 
-**Configure**: `{ "ralph_loop": { "enabled": true, "default_max_iterations": 100 } }`
+**Configure**: `{ "ralph_loop": { "enabled": true, "default_max_iterations": 100, "default_strategy": "continue" } }`
 
 ### /ulw-loop
 

--- a/src/config/schema/ralph-loop.ts
+++ b/src/config/schema/ralph-loop.ts
@@ -5,7 +5,6 @@ export const RalphLoopConfigSchema = z.object({
   enabled: z.boolean().default(false),
   /** Default max iterations if not specified in command (default: 100) */
   default_max_iterations: z.number().min(1).max(1000).default(100),
-  /** Custom state file directory relative to project root (default: .opencode/) */
   state_dir: z.string().optional(),
   default_strategy: z.enum(["reset", "continue"]).default("continue"),
 })

--- a/src/create-hooks.ts
+++ b/src/create-hooks.ts
@@ -8,6 +8,7 @@ import type { ModelCacheState } from "./plugin-state"
 import { createCoreHooks } from "./plugin/hooks/create-core-hooks"
 import { createContinuationHooks } from "./plugin/hooks/create-continuation-hooks"
 import { createSkillHooks } from "./plugin/hooks/create-skill-hooks"
+import { normalizeSDKResponse } from "./shared"
 
 export type CreatedHooks = ReturnType<typeof createHooks>
 
@@ -63,6 +64,33 @@ export function createHooks(args: {
         }).catch(() => false)
       )
     )
+  })
+
+  core.ralphLoop?.setShouldDeferIteration(async (sessionID: string) => {
+    const hasRunningDescendantTasks = backgroundManager
+      .getAllDescendantTasks(sessionID)
+      .some((task) => task.status === "running" || task.status === "pending")
+
+    if (hasRunningDescendantTasks) {
+      return true
+    }
+
+    try {
+      const response = await ctx.client.session.todo({ path: { id: sessionID } })
+      const todos = normalizeSDKResponse(response, [] as Array<{ status?: string }>, {
+        preferResponseOnMissingData: true,
+      })
+
+      if (!todos || todos.length === 0) {
+        return false
+      }
+
+      return todos.some(
+        (todo) => todo.status !== "completed" && todo.status !== "cancelled"
+      )
+    } catch {
+      return true
+    }
   })
 
   const skill = createSkillHooks({

--- a/src/create-hooks.ts
+++ b/src/create-hooks.ts
@@ -49,6 +49,22 @@ export function createHooks(args: {
     sessionRecovery: core.sessionRecovery,
   })
 
+  core.ralphLoop?.setOnLoopCompleted(async (sessionID: string) => {
+    continuation.stopContinuationGuard?.stop(sessionID)
+
+    const tasks = backgroundManager.getAllDescendantTasks(sessionID)
+    const runningOrPendingTasks = tasks.filter((task) => task.status === "running" || task.status === "pending")
+    await Promise.all(
+      runningOrPendingTasks.map((task) =>
+        backgroundManager.cancelTask(task.id, {
+          source: "ralph-loop.completed",
+          reason: "Ralph loop completed",
+          skipNotification: true,
+        }).catch(() => false)
+      )
+    )
+  })
+
   const skill = createSkillHooks({
     ctx,
     isHookEnabled,

--- a/src/hooks/ralph-loop/command-arguments.ts
+++ b/src/hooks/ralph-loop/command-arguments.ts
@@ -21,6 +21,33 @@ type ParsedPrompt = {
   flagsSource: string
 }
 
+function isEscapedAt(input: string, index: number): boolean {
+  let backslashCount = 0
+  for (let cursor = index - 1; cursor >= 0; cursor--) {
+    if (input[cursor] !== "\\") {
+      break
+    }
+
+    backslashCount += 1
+  }
+
+  return backslashCount % 2 === 1
+}
+
+function findUnescapedQuoteBackward(input: string, quote: string, fromIndex: number): number {
+  for (let index = fromIndex; index >= 0; index--) {
+    if (input[index] !== quote) {
+      continue
+    }
+
+    if (!isEscapedAt(input, index)) {
+      return index
+    }
+  }
+
+  return -1
+}
+
 function decodeEscapedCharacter(char: string): string {
   if (char === "n") return "\\n"
   if (char === "r") return "\\r"
@@ -103,7 +130,7 @@ function parseQuotedPromptUsingTrailingFlags(
 
   if (firstFlagMatch) {
     const flagStart = firstNonWhitespace + 1 + (firstFlagMatch.index ?? 0)
-    const closingQuote = rawArguments.lastIndexOf(quote, flagStart - 1)
+    const closingQuote = findUnescapedQuoteBackward(rawArguments, quote, flagStart - 1)
     if (closingQuote > firstNonWhitespace) {
       const rawPrompt = rawArguments.slice(firstNonWhitespace + 1, closingQuote)
       return {
@@ -113,7 +140,7 @@ function parseQuotedPromptUsingTrailingFlags(
     }
   }
 
-  const closingQuote = rawArguments.lastIndexOf(quote)
+  const closingQuote = findUnescapedQuoteBackward(rawArguments, quote, rawArguments.length - 1)
   if (closingQuote > firstNonWhitespace) {
     const rawPrompt = rawArguments.slice(firstNonWhitespace + 1, closingQuote)
     return {

--- a/src/hooks/ralph-loop/command-arguments.ts
+++ b/src/hooks/ralph-loop/command-arguments.ts
@@ -8,23 +8,121 @@ export type ParsedRalphLoopArguments = {
 }
 
 const DEFAULT_PROMPT = "Complete the task as instructed"
+const RESET_PROMPT_BLOCK_START = "<ralph-prompt>"
+const RESET_PROMPT_BLOCK_END = "</ralph-prompt>"
+
+type ParsedQuoted = {
+  value: string
+  endIndex: number
+}
+
+function decodeEscapedCharacter(char: string): string {
+  if (char === "n") return "\n"
+  if (char === "r") return "\r"
+  if (char === "t") return "\t"
+  return char
+}
+
+function parseQuotedAt(input: string, startIndex: number): ParsedQuoted | null {
+  const quote = input[startIndex]
+  if (quote !== '"' && quote !== "'") {
+    return null
+  }
+
+  let value = ""
+  let escaped = false
+
+  for (let index = startIndex + 1; index < input.length; index++) {
+    const char = input[index]
+
+    if (escaped) {
+      value += decodeEscapedCharacter(char)
+      escaped = false
+      continue
+    }
+
+    if (char === "\\") {
+      escaped = true
+      continue
+    }
+
+    if (char === quote) {
+      return { value, endIndex: index + 1 }
+    }
+
+    value += char
+  }
+
+  return null
+}
+
+function parseLeadingPrompt(rawArguments: string): { prompt: string; flagsSource: string } {
+  let firstNonWhitespace = 0
+  while (firstNonWhitespace < rawArguments.length && /\s/.test(rawArguments[firstNonWhitespace] ?? "")) {
+    firstNonWhitespace += 1
+  }
+
+  const resetPromptBlockStart = rawArguments.indexOf(RESET_PROMPT_BLOCK_START, firstNonWhitespace)
+  if (resetPromptBlockStart === firstNonWhitespace) {
+    const promptStart = resetPromptBlockStart + RESET_PROMPT_BLOCK_START.length
+    const resetPromptBlockEnd = rawArguments.indexOf(RESET_PROMPT_BLOCK_END, promptStart)
+
+    if (resetPromptBlockEnd !== -1) {
+      const blockBody = rawArguments.slice(promptStart, resetPromptBlockEnd)
+      const prompt = blockBody.replace(/^\r?\n/, "").replace(/\r?\n$/, "") || DEFAULT_PROMPT
+      return {
+        prompt,
+        flagsSource: rawArguments.slice(resetPromptBlockEnd + RESET_PROMPT_BLOCK_END.length),
+      }
+    }
+  }
+
+  const leadingQuotedPrompt = parseQuotedAt(rawArguments, firstNonWhitespace)
+  if (leadingQuotedPrompt) {
+    return {
+      prompt: leadingQuotedPrompt.value || DEFAULT_PROMPT,
+      flagsSource: rawArguments.slice(leadingQuotedPrompt.endIndex),
+    }
+  }
+
+  if (rawArguments.slice(firstNonWhitespace).startsWith("--")) {
+    return {
+      prompt: DEFAULT_PROMPT,
+      flagsSource: rawArguments,
+    }
+  }
+
+  const promptSegment = rawArguments.split(/\s+--/)[0] ?? ""
+  const promptCandidate = promptSegment.trim()
+  return {
+    prompt: promptCandidate || DEFAULT_PROMPT,
+    flagsSource: rawArguments.slice(promptSegment.length),
+  }
+}
+
+function parseQuotedFlagValue(flagsSource: string, flagName: string): string | undefined {
+  const flagPattern = new RegExp(`(?:^|\\s)--${flagName}=`, "i")
+  const match = flagPattern.exec(flagsSource)
+  if (!match) {
+    return undefined
+  }
+
+  const valueStart = (match.index ?? 0) + match[0].length
+  const quoted = parseQuotedAt(flagsSource, valueStart)
+  if (quoted) {
+    return quoted.value
+  }
+
+  const unquotedSlice = flagsSource.slice(valueStart)
+  const unquoted = unquotedSlice.match(/^([^\s"']+)/)
+  return unquoted?.[1]
+}
 
 export function parseRalphLoopArguments(rawArguments: string): ParsedRalphLoopArguments {
-  const taskMatch = rawArguments.match(/^("|')(.+?)\1/)
-  const promptSegment = taskMatch?.[0] ?? (rawArguments.startsWith("--") ? "" : rawArguments.split(/\s+--/)[0] ?? "")
-  const promptCandidate = taskMatch?.[2] ?? promptSegment.trim()
-  const prompt = promptCandidate || DEFAULT_PROMPT
-
-  const flagsSource = taskMatch
-    ? rawArguments.slice(taskMatch[0].length)
-    : rawArguments.startsWith("--")
-      ? rawArguments
-      : rawArguments.slice(promptSegment.length)
+  const { prompt, flagsSource } = parseLeadingPrompt(rawArguments)
 
   const maxIterationMatch = flagsSource.match(/--max-iterations=(\d+)/i)
-  const completionPromiseQuoted = flagsSource.match(/--completion-promise=("|')(.+?)\1/i)
-  const completionPromiseUnquoted = flagsSource.match(/--completion-promise=([^\s"']+)/i)
-  const completionPromise = completionPromiseQuoted?.[2] ?? completionPromiseUnquoted?.[1]
+  const completionPromise = parseQuotedFlagValue(flagsSource, "completion-promise")
   const strategyMatch = flagsSource.match(/--strategy=(reset|continue)/i)
   const strategyValue = strategyMatch?.[1]?.toLowerCase()
 

--- a/src/hooks/ralph-loop/command-arguments.ts
+++ b/src/hooks/ralph-loop/command-arguments.ts
@@ -22,9 +22,9 @@ type ParsedPrompt = {
 }
 
 function decodeEscapedCharacter(char: string): string {
-  if (char === "n") return "\n"
-  if (char === "r") return "\r"
-  if (char === "t") return "\t"
+  if (char === "n") return "\\n"
+  if (char === "r") return "\\r"
+  if (char === "t") return "\\t"
   return char
 }
 

--- a/src/hooks/ralph-loop/command-arguments.ts
+++ b/src/hooks/ralph-loop/command-arguments.ts
@@ -10,15 +10,21 @@ export type ParsedRalphLoopArguments = {
 const DEFAULT_PROMPT = "Complete the task as instructed"
 
 export function parseRalphLoopArguments(rawArguments: string): ParsedRalphLoopArguments {
-  const taskMatch = rawArguments.match(/^(["'])(.+?)\1/)
+  const taskMatch = rawArguments.match(/^("|')(.+?)\1/)
   const promptCandidate = taskMatch?.[2] ?? (rawArguments.startsWith("--") ? "" : rawArguments.split(/\s+--/)[0]?.trim() ?? "")
   const prompt = promptCandidate || DEFAULT_PROMPT
 
-  const maxIterationMatch = rawArguments.match(/--max-iterations=(\d+)/i)
-  const completionPromiseQuoted = rawArguments.match(/--completion-promise=(["'])(.+?)\1/i)
-  const completionPromiseUnquoted = rawArguments.match(/--completion-promise=([^\s"']+)/i)
+  const flagsSource = taskMatch
+    ? rawArguments.slice(taskMatch[0].length)
+    : rawArguments.startsWith("--")
+      ? rawArguments
+      : rawArguments.slice(promptCandidate.length)
+
+  const maxIterationMatch = flagsSource.match(/--max-iterations=(\d+)/i)
+  const completionPromiseQuoted = flagsSource.match(/--completion-promise=("|')(.+?)\1/i)
+  const completionPromiseUnquoted = flagsSource.match(/--completion-promise=([^\s"']+)/i)
   const completionPromise = completionPromiseQuoted?.[2] ?? completionPromiseUnquoted?.[1]
-  const strategyMatch = rawArguments.match(/--strategy=(reset|continue)/i)
+  const strategyMatch = flagsSource.match(/--strategy=(reset|continue)/i)
   const strategyValue = strategyMatch?.[1]?.toLowerCase()
 
   return {

--- a/src/hooks/ralph-loop/command-arguments.ts
+++ b/src/hooks/ralph-loop/command-arguments.ts
@@ -11,14 +11,15 @@ const DEFAULT_PROMPT = "Complete the task as instructed"
 
 export function parseRalphLoopArguments(rawArguments: string): ParsedRalphLoopArguments {
   const taskMatch = rawArguments.match(/^("|')(.+?)\1/)
-  const promptCandidate = taskMatch?.[2] ?? (rawArguments.startsWith("--") ? "" : rawArguments.split(/\s+--/)[0]?.trim() ?? "")
+  const promptSegment = taskMatch?.[0] ?? (rawArguments.startsWith("--") ? "" : rawArguments.split(/\s+--/)[0] ?? "")
+  const promptCandidate = taskMatch?.[2] ?? promptSegment.trim()
   const prompt = promptCandidate || DEFAULT_PROMPT
 
   const flagsSource = taskMatch
     ? rawArguments.slice(taskMatch[0].length)
     : rawArguments.startsWith("--")
       ? rawArguments
-      : rawArguments.slice(promptCandidate.length)
+      : rawArguments.slice(promptSegment.length)
 
   const maxIterationMatch = flagsSource.match(/--max-iterations=(\d+)/i)
   const completionPromiseQuoted = flagsSource.match(/--completion-promise=("|')(.+?)\1/i)

--- a/src/hooks/ralph-loop/command-arguments.ts
+++ b/src/hooks/ralph-loop/command-arguments.ts
@@ -16,6 +16,11 @@ type ParsedQuoted = {
   endIndex: number
 }
 
+type ParsedPrompt = {
+  prompt: string
+  flagsSource: string
+}
+
 function decodeEscapedCharacter(char: string): string {
   if (char === "n") return "\n"
   if (char === "r") return "\r"
@@ -56,6 +61,70 @@ function parseQuotedAt(input: string, startIndex: number): ParsedQuoted | null {
   return null
 }
 
+function decodeQuotedValue(rawValue: string): string {
+  let value = ""
+  let escaped = false
+
+  for (let index = 0; index < rawValue.length; index++) {
+    const char = rawValue[index]
+
+    if (escaped) {
+      value += decodeEscapedCharacter(char)
+      escaped = false
+      continue
+    }
+
+    if (char === "\\") {
+      escaped = true
+      continue
+    }
+
+    value += char
+  }
+
+  if (escaped) {
+    value += "\\"
+  }
+
+  return value
+}
+
+function parseQuotedPromptUsingTrailingFlags(
+  rawArguments: string,
+  firstNonWhitespace: number,
+): ParsedPrompt | null {
+  const quote = rawArguments[firstNonWhitespace]
+  if (quote !== '"' && quote !== "'") {
+    return null
+  }
+
+  const afterOpeningQuote = rawArguments.slice(firstNonWhitespace + 1)
+  const firstFlagMatch = /\s--(?:completion-promise|max-iterations|strategy)=/i.exec(afterOpeningQuote)
+
+  if (firstFlagMatch) {
+    const flagStart = firstNonWhitespace + 1 + (firstFlagMatch.index ?? 0)
+    const closingQuote = rawArguments.lastIndexOf(quote, flagStart - 1)
+    if (closingQuote > firstNonWhitespace) {
+      const rawPrompt = rawArguments.slice(firstNonWhitespace + 1, closingQuote)
+      return {
+        prompt: decodeQuotedValue(rawPrompt) || DEFAULT_PROMPT,
+        flagsSource: rawArguments.slice(flagStart),
+      }
+    }
+  }
+
+  const closingQuote = rawArguments.lastIndexOf(quote)
+  if (closingQuote > firstNonWhitespace) {
+    const rawPrompt = rawArguments.slice(firstNonWhitespace + 1, closingQuote)
+    return {
+      prompt: decodeQuotedValue(rawPrompt) || DEFAULT_PROMPT,
+      flagsSource: rawArguments.slice(closingQuote + 1),
+    }
+  }
+
+  return null
+}
+
 function parseLeadingPrompt(rawArguments: string): { prompt: string; flagsSource: string } {
   let firstNonWhitespace = 0
   while (firstNonWhitespace < rawArguments.length && /\s/.test(rawArguments[firstNonWhitespace] ?? "")) {
@@ -75,6 +144,11 @@ function parseLeadingPrompt(rawArguments: string): { prompt: string; flagsSource
         flagsSource: rawArguments.slice(resetPromptBlockEnd + RESET_PROMPT_BLOCK_END.length),
       }
     }
+  }
+
+  const trailingFlagQuotedPrompt = parseQuotedPromptUsingTrailingFlags(rawArguments, firstNonWhitespace)
+  if (trailingFlagQuotedPrompt) {
+    return trailingFlagQuotedPrompt
   }
 
   const leadingQuotedPrompt = parseQuotedAt(rawArguments, firstNonWhitespace)

--- a/src/hooks/ralph-loop/completion-promise-detector.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.ts
@@ -9,6 +9,16 @@ interface OpenCodeSessionMessage {
 	parts?: Array<{ type: string; text?: string }>
 }
 
+type TranscriptEntry = {
+	type?: string
+	info?: { role?: string }
+	parts?: Array<{ type?: string; text?: string }>
+	content?: string
+	text?: string
+	tool_name?: string
+	tool_output?: { output?: string } | string
+}
+
 function escapeRegex(str: string): string {
 	return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
@@ -32,9 +42,55 @@ export function detectCompletionInTranscript(
 
 		for (const line of lines) {
 			try {
-				const entry = JSON.parse(line) as { type?: string }
-				if (entry.type === "user") continue
-				if (pattern.test(line)) return true
+				const entry = JSON.parse(line) as TranscriptEntry
+
+				if (entry.type === "user") {
+					continue
+				}
+
+				if (entry.type === "tool_result") {
+					if (entry.tool_name !== "write") {
+						continue
+					}
+
+					const toolOutput = entry.tool_output
+					const outputText =
+						typeof toolOutput === "string"
+							? toolOutput
+							: typeof toolOutput?.output === "string"
+								? toolOutput.output
+								: ""
+
+					if (outputText && pattern.test(outputText)) {
+						return true
+					}
+
+					continue
+				}
+
+				const isAssistantEntry = entry.type === "assistant" || entry.info?.role === "assistant"
+				if (!isAssistantEntry) {
+					continue
+				}
+
+				if (typeof entry.text === "string" && pattern.test(entry.text)) {
+					return true
+				}
+
+				if (typeof entry.content === "string" && pattern.test(entry.content)) {
+					return true
+				}
+
+				if (Array.isArray(entry.parts)) {
+					const responseText = entry.parts
+						.filter((part) => part?.type === "text" && typeof part.text === "string")
+						.map((part) => part.text ?? "")
+						.join("\n")
+
+					if (responseText && pattern.test(responseText)) {
+						return true
+					}
+				}
 			} catch {
 				continue
 			}

--- a/src/hooks/ralph-loop/continuation-prompt-builder.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-builder.ts
@@ -21,7 +21,7 @@ export function buildContinuationPrompt(state: RalphLoopState): string {
 	)
 		.replace("{{MAX}}", String(state.max_iterations))
 		.replace("{{PROMISE}}", state.completion_promise)
-		.replace("{{PROMPT}}", state.raw_task_arguments ?? state.prompt)
+		.replace("{{PROMPT}}", () => state.raw_task_arguments ?? state.prompt)
 
 	return state.ultrawork ? `ultrawork ${continuationPrompt}` : continuationPrompt
 }

--- a/src/hooks/ralph-loop/continuation-prompt-builder.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-builder.ts
@@ -21,7 +21,7 @@ export function buildContinuationPrompt(state: RalphLoopState): string {
 	)
 		.replace("{{MAX}}", String(state.max_iterations))
 		.replace("{{PROMISE}}", state.completion_promise)
-		.replace("{{PROMPT}}", () => state.raw_task_arguments ?? state.prompt)
+		.replace("{{PROMPT}}", () => state.prompt)
 
 	return state.ultrawork ? `ultrawork ${continuationPrompt}` : continuationPrompt
 }

--- a/src/hooks/ralph-loop/continuation-prompt-builder.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-builder.ts
@@ -21,7 +21,7 @@ export function buildContinuationPrompt(state: RalphLoopState): string {
 	)
 		.replace("{{MAX}}", String(state.max_iterations))
 		.replace("{{PROMISE}}", state.completion_promise)
-		.replace("{{PROMPT}}", state.prompt)
+		.replace("{{PROMPT}}", state.raw_task_arguments ?? state.prompt)
 
 	return state.ultrawork ? `ultrawork ${continuationPrompt}` : continuationPrompt
 }

--- a/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -11,9 +11,10 @@ import {
 
 type MessageInfo = {
 	agent?: string
-	model?: { providerID: string; modelID: string }
+	model?: { providerID: string; modelID: string; variant?: string }
 	modelID?: string
 	providerID?: string
+	variant?: string
 	tools?: Record<string, boolean | "allow" | "deny" | "ask">
 }
 
@@ -29,6 +30,7 @@ export async function injectContinuationPrompt(
 ): Promise<void> {
 	let agent: string | undefined
 	let model: { providerID: string; modelID: string } | undefined
+	let variant: string | undefined
 	let tools: Record<string, boolean | "allow" | "deny" | "ask"> | undefined
 	const sourceSessionID = options.inheritFromSessionID ?? options.sessionID
 
@@ -42,14 +44,38 @@ export async function injectContinuationPrompt(
 		const messages = normalizeSDKResponse(messagesResp, [] as Array<{ info?: MessageInfo }>)
 		for (let i = messages.length - 1; i >= 0; i--) {
 			const info = messages[i]?.info
-			if (info?.agent || info?.model || (info?.modelID && info?.providerID)) {
+			if (!info) {
+				continue
+			}
+
+			if (agent === undefined && typeof info.agent === "string") {
 				agent = info.agent
-				model =
-					info.model ??
-					(info.providerID && info.modelID
-						? { providerID: info.providerID, modelID: info.modelID }
-						: undefined)
+			}
+
+			if (model === undefined) {
+				if (info.model?.providerID && info.model?.modelID) {
+					model = {
+						providerID: info.model.providerID,
+						modelID: info.model.modelID,
+					}
+				} else if (info.providerID && info.modelID) {
+					model = { providerID: info.providerID, modelID: info.modelID }
+				}
+			}
+
+			if (variant === undefined) {
+				if (typeof info.variant === "string") {
+					variant = info.variant
+				} else if (typeof info.model?.variant === "string") {
+					variant = info.model.variant
+				}
+			}
+
+			if (tools === undefined && info.tools) {
 				tools = info.tools
+			}
+
+			if (agent !== undefined && model !== undefined && variant !== undefined && tools !== undefined) {
 				break
 			}
 		}
@@ -64,6 +90,7 @@ export async function injectContinuationPrompt(
 					modelID: currentMessage.model.modelID,
 				}
 				: undefined
+		variant = currentMessage?.model?.variant
 		tools = currentMessage?.tools
 	}
 
@@ -74,6 +101,7 @@ export async function injectContinuationPrompt(
 		body: {
 			...(agent !== undefined ? { agent } : {}),
 			...(model !== undefined ? { model } : {}),
+			...(variant !== undefined ? { variant } : {}),
 			...(inheritedTools ? { tools: inheritedTools } : {}),
 			parts: [createInternalAgentTextPart(options.prompt)],
 		},

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -264,6 +264,16 @@ describe("ralph-loop", () => {
       // then - strategy should be parsed as continue
       expect(parsedArguments.strategy).toBe("continue")
     })
+
+    test("should ignore strategy-like text inside quoted task prompt", () => {
+      const rawArguments = '"Fix docs mentioning --strategy=reset behavior" --max-iterations=5'
+
+      const parsedArguments = parseRalphLoopArguments(rawArguments)
+
+      expect(parsedArguments.prompt).toBe("Fix docs mentioning --strategy=reset behavior")
+      expect(parsedArguments.maxIterations).toBe(5)
+      expect(parsedArguments.strategy).toBeUndefined()
+    })
   })
 
   describe("hook", () => {
@@ -551,6 +561,21 @@ describe("ralph-loop", () => {
       expect(state?.strategy).toBe("continue")
     })
 
+    test("should default strategy to continue even when config default_strategy is reset", () => {
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        config: {
+          enabled: true,
+          default_max_iterations: 200,
+          default_strategy: "reset",
+        },
+      })
+
+      hook.startLoop("session-123", "Test task")
+
+      const state = hook.getState()
+      expect(state?.strategy).toBe("continue")
+    })
+
     test("should create new session for reset strategy", async () => {
       // given - hook with reset strategy
       const hook = createRalphLoopHook(createMockPluginInput())
@@ -654,6 +679,32 @@ describe("ralph-loop", () => {
       expect(promptCalls.length).toBe(0)
       expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
       expect(hook.getState()).toBeNull()
+    })
+
+    test("should run onLoopCompleted callback when loop finishes", async () => {
+      const transcriptPath = join(TEST_DIR, "transcript-callback.jsonl")
+      const completedSessions: string[] = []
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
+      hook.setOnLoopCompleted((sessionID) => {
+        completedSessions.push(sessionID)
+      })
+      hook.startLoop("session-123", "Build something", { completionPromise: "DONE" })
+
+      writeFileSync(
+        transcriptPath,
+        JSON.stringify({ type: "tool_result", tool_name: "write", tool_output: { output: "done <promise>DONE</promise>" } }) + "\n"
+      )
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(completedSessions).toEqual(["session-123"])
     })
 
     test("should detect completion promise via session messages API", async () => {
@@ -885,6 +936,62 @@ describe("ralph-loop", () => {
 
       // then - continuation should be injected (not blocked by recovery)
       expect(promptCalls.length).toBe(1)
+    })
+
+    test("should clear loop state on session.stop event", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      hook.startLoop("session-123", "Build something")
+      expect(hook.getState()).not.toBeNull()
+
+      await hook.event({
+        event: {
+          type: "session.stop",
+          properties: {
+            sessionID: "session-123",
+          },
+        },
+      })
+
+      expect(hook.getState()).toBeNull()
+    })
+
+    test("should clear loop state on user abort (AbortError)", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      hook.startLoop("session-123", "Build something")
+      expect(hook.getState()).not.toBeNull()
+
+      await hook.event({
+        event: {
+          type: "session.error",
+          properties: {
+            sessionID: "session-123",
+            error: { name: "AbortError", message: "The operation was aborted" },
+          },
+        },
+      })
+
+      expect(hook.getState()).toBeNull()
+    })
+
+    test("should clear loop state when abort appears in message.updated error", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      hook.startLoop("session-123", "Build something")
+      expect(hook.getState()).not.toBeNull()
+
+      await hook.event({
+        event: {
+          type: "message.updated",
+          properties: {
+            info: {
+              sessionID: "session-123",
+              role: "assistant",
+              error: { name: "MessageAbortedError", message: "Request interrupted" },
+            },
+          },
+        },
+      })
+
+      expect(hook.getState()).toBeNull()
     })
 
     test("should check last 3 assistant messages for completion", async () => {

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -872,7 +872,8 @@ If done, output: <promise>SINGLE_TASK_COMPLETE</promise>" --strategy=continue --
 
     test("should replay raw task arguments in continue prompt original task section when available", async () => {
       const hook = createRalphLoopHook(createMockPluginInput())
-      const rawArguments = `"Task with \"alpha\" and C:\\temp\\ralph\\test plus {\"x\":\"y\",\"n\":\"\\n\"}" --strategy=continue --max-iterations=2 --completion-promise=NEVER_MATCH`
+      const backtickSubstitutionToken = "$`"
+      const rawArguments = `"Task with \"alpha\" and C:\\temp\\ralph\\test plus {\"x\":\"y\",\"n\":\"\\n\"} and dollar tokens $$ $& ${backtickSubstitutionToken}" --strategy=continue --max-iterations=2 --completion-promise=NEVER_MATCH`
 
       hook.startLoop("session-123", "fallback prompt", {
         strategy: "continue",
@@ -890,6 +891,7 @@ If done, output: <promise>SINGLE_TASK_COMPLETE</promise>" --strategy=continue --
       expect(promptCalls[0].text).toContain(`Original task:\n${rawArguments}`)
       expect(promptCalls[0].text).toContain("C:\\temp\\ralph\\test")
       expect(promptCalls[0].text).toContain('{"x":"y","n":"\\n"}')
+      expect(promptCalls[0].text).toContain("dollar tokens $$ $& $`")
     })
 
     test("should inherit agent and variant from previous session during reset continuation", async () => {

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -771,6 +771,7 @@ Line two "quoted"
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].text).toContain(multilinePrompt)
       expect(promptCalls[0].text.includes("\\n")).toBe(false)
+      expect(promptCalls[0].text).not.toContain("<ralph-prompt>")
       expect(promptCalls[0].text.includes('"PRD file:')).toBe(false)
     })
 
@@ -1434,6 +1435,33 @@ Original task: Build something`
       expect(promptCalls.length).toBe(0)
       expect(toastCalls.some((t) => t.title === "Ralph Loop Complete!")).toBe(true)
       expect(hook.getState()).toBeNull()
+    })
+
+    test("should NOT detect completion from non-write tool_result output", async () => {
+      const transcriptPath = join(TEST_DIR, "transcript.jsonl")
+      const toolResultEntry = JSON.stringify({
+        type: "tool_result",
+        timestamp: new Date().toISOString(),
+        tool_name: "read",
+        tool_input: {},
+        tool_output: { output: "Do NOT output <promise>NEVER_MATCH</promise>." },
+      })
+      writeFileSync(transcriptPath, toolResultEntry + "\n")
+
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => transcriptPath,
+      })
+      hook.startLoop("session-123", "Build something", { completionPromise: "NEVER_MATCH" })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(promptCalls.length).toBe(1)
+      expect(hook.getState()?.iteration).toBe(2)
     })
 
     test("should check transcript BEFORE API to optimize performance", async () => {

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -307,6 +307,50 @@ describe("ralph-loop", () => {
       expect(parsedArguments.maxIterations).toBe(7)
       expect(parsedArguments.strategy).toBe("continue")
     })
+
+    test("should preserve multiline quoted prompts without literal escaped newlines", () => {
+      const rawArguments = '"Line one\nLine two" --max-iterations=5 --strategy=reset'
+
+      const parsedArguments = parseRalphLoopArguments(rawArguments)
+
+      expect(parsedArguments.prompt).toBe("Line one\nLine two")
+      expect(parsedArguments.prompt.includes("\\n")).toBe(false)
+      expect(parsedArguments.maxIterations).toBe(5)
+      expect(parsedArguments.strategy).toBe("reset")
+    })
+
+    test("should parse escaped quotes in quoted prompt", () => {
+      const rawArguments = '"Say \\\"hello\\\" to operator" --strategy=reset'
+
+      const parsedArguments = parseRalphLoopArguments(rawArguments)
+
+      expect(parsedArguments.prompt).toBe('Say "hello" to operator')
+      expect(parsedArguments.strategy).toBe("reset")
+    })
+
+    test("should parse escaped completion promise values", () => {
+      const rawArguments = '"Build feature" --completion-promise="ALL_\\\"DONE\\\"" --strategy=reset'
+
+      const parsedArguments = parseRalphLoopArguments(rawArguments)
+
+      expect(parsedArguments.completionPromise).toBe('ALL_"DONE"')
+      expect(parsedArguments.strategy).toBe("reset")
+    })
+
+    test("should parse reset prompt block format without quoting prompt text", () => {
+      const rawArguments = `<ralph-prompt>
+Line one
+Line two "quoted"
+</ralph-prompt>
+--completion-promise="SINGLE_TASK_COMPLETE" --max-iterations=50 --strategy=reset`
+
+      const parsedArguments = parseRalphLoopArguments(rawArguments)
+
+      expect(parsedArguments.prompt).toBe('Line one\nLine two "quoted"')
+      expect(parsedArguments.completionPromise).toBe("SINGLE_TASK_COMPLETE")
+      expect(parsedArguments.maxIterations).toBe(50)
+      expect(parsedArguments.strategy).toBe("reset")
+    })
   })
 
   describe("hook", () => {
@@ -709,6 +753,43 @@ describe("ralph-loop", () => {
       expect(promptCalls[0].text).toContain("[RALPH LOOP - Iteration 2/8]")
       expect(promptCalls[0].text).toContain("--completion-promise=\"ULW_DONE\"")
       expect(promptCalls[0].text).toContain("--strategy=reset")
+    })
+
+    test("should keep reset iteration prompt text unescaped for multiline tasks", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      const multilinePrompt = "PRD file: @.sisyphus/prd.md\nProgress file: @.sisyphus/progress.md\n1. Work one task"
+
+      hook.startLoop("session-123", multilinePrompt, { strategy: "reset" })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain(multilinePrompt)
+      expect(promptCalls[0].text.includes("\\n")).toBe(false)
+      expect(promptCalls[0].text.includes('"PRD file:')).toBe(false)
+    })
+
+    test("should keep continue iteration prompt text unescaped for multiline tasks", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      const multilinePrompt = "PRD file: @.sisyphus/prd.md\nProgress file: @.sisyphus/progress.md\n1. Work one task"
+
+      hook.startLoop("session-123", multilinePrompt, { strategy: "continue" })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain(multilinePrompt)
+      expect(promptCalls[0].text.includes("\\n")).toBe(false)
     })
 
     test("should inherit agent and variant from previous session during reset continuation", async () => {

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -82,6 +82,22 @@ describe("ralph-loop", () => {
             })
             return { data: { id: `new-session-${createSessionCalls.length}` } }
           },
+          update: async (opts: {
+            path?: { id: string }
+            body?: { title?: string }
+            query?: { directory?: string }
+            sessionID?: string
+            title?: string
+            directory?: string
+            pathSessionID?: string
+          }) => {
+            const pathRecord = opts.path as { id?: string; sessionID?: string } | undefined
+            const sessionID = pathRecord?.id ?? pathRecord?.sessionID ?? opts.sessionID
+            if (!sessionID) {
+              throw new Error("missing session id")
+            }
+            return {}
+          },
         },
         tui: {
           showToast: async (opts: { body: { title: string; message: string; variant: string } }) => {
@@ -357,6 +373,50 @@ describe("ralph-loop", () => {
       expect(state?.iteration).toBe(2)
     })
 
+    test("should defer iteration while shouldDeferIteration returns true", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        shouldDeferIteration: () => true,
+      })
+      hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(promptCalls.length).toBe(0)
+      expect(hook.getState()?.iteration).toBe(1)
+    })
+
+    test("should continue once shouldDeferIteration switches from true to false", async () => {
+      let shouldDefer = true
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        shouldDeferIteration: () => shouldDefer,
+      })
+      hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      shouldDefer = false
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(promptCalls.length).toBe(1)
+      expect(hook.getState()?.iteration).toBe(2)
+    })
+
     test("should stop loop when max iterations reached", async () => {
       // given - loop at max iteration
       const hook = createRalphLoopHook(createMockPluginInput())
@@ -603,7 +663,36 @@ describe("ralph-loop", () => {
       expect(createSessionCalls.length).toBe(1)
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].sessionID).toBe("new-session-1")
+      expect(promptCalls[0].text).toContain("<command-instruction>")
+      expect(promptCalls[0].text).toContain("You are starting a Ralph Loop")
+      expect(promptCalls[0].text).toContain("<user-task>")
+      expect(promptCalls[0].text).toContain("--strategy=reset")
+      expect(promptCalls[0].text).toContain("[RALPH LOOP - Iteration 2/")
       expect(hook.getState()?.session_id).toBe("new-session-1")
+    })
+
+    test("should replay full loop command for ULW reset iteration", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      hook.startLoop("session-123", "Ship CSS fixes", {
+        strategy: "reset",
+        ultrawork: true,
+        maxIterations: 8,
+        completionPromise: "ULW_DONE",
+      })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].sessionID).toBe("new-session-1")
+      expect(promptCalls[0].text).toMatch(/^ultrawork\s+/)
+      expect(promptCalls[0].text).toContain("[RALPH LOOP - Iteration 2/8]")
+      expect(promptCalls[0].text).toContain("--completion-promise=\"ULW_DONE\"")
+      expect(promptCalls[0].text).toContain("--strategy=reset")
     })
 
     test("should inherit agent and variant from previous session during reset continuation", async () => {
@@ -987,6 +1076,27 @@ describe("ralph-loop", () => {
       expect(hook.getState()).toBeNull()
     })
 
+    test("should clear loop state when message.updated error message is nested in data.message", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      hook.startLoop("session-123", "Build something")
+      expect(hook.getState()).not.toBeNull()
+
+      await hook.event({
+        event: {
+          type: "message.updated",
+          properties: {
+            info: {
+              sessionID: "session-123",
+              role: "assistant",
+              error: { data: { message: "Request was aborted by user" } },
+            },
+          },
+        },
+      })
+
+      expect(hook.getState()).toBeNull()
+    })
+
     test("should check last 3 assistant messages for completion", async () => {
       // given - multiple assistant messages, promise in recent (not last) assistant message
       mockSessionMessages = [
@@ -1338,7 +1448,7 @@ Original task: Build something`
           },
         },
       }
-      const hook = createRalphLoopHook(errorMock as any, {
+      const hook = createRalphLoopHook(errorMock as unknown as Parameters<typeof createRalphLoopHook>[0], {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
         apiTimeout: 100,
       })

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -274,6 +274,16 @@ describe("ralph-loop", () => {
       expect(parsedArguments.maxIterations).toBe(5)
       expect(parsedArguments.strategy).toBeUndefined()
     })
+
+    test("should parse flags correctly when unquoted prompt has leading spaces", () => {
+      const rawArguments = '   Build feature X --max-iterations=7 --strategy=continue'
+
+      const parsedArguments = parseRalphLoopArguments(rawArguments)
+
+      expect(parsedArguments.prompt).toBe("Build feature X")
+      expect(parsedArguments.maxIterations).toBe(7)
+      expect(parsedArguments.strategy).toBe("continue")
+    })
   })
 
   describe("hook", () => {
@@ -936,23 +946,6 @@ describe("ralph-loop", () => {
 
       // then - continuation should be injected (not blocked by recovery)
       expect(promptCalls.length).toBe(1)
-    })
-
-    test("should clear loop state on session.stop event", async () => {
-      const hook = createRalphLoopHook(createMockPluginInput())
-      hook.startLoop("session-123", "Build something")
-      expect(hook.getState()).not.toBeNull()
-
-      await hook.event({
-        event: {
-          type: "session.stop",
-          properties: {
-            sessionID: "session-123",
-          },
-        },
-      })
-
-      expect(hook.getState()).toBeNull()
     })
 
     test("should clear loop state on user abort (AbortError)", async () => {

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -21,6 +21,7 @@ describe("ralph-loop", () => {
   let toastCalls: Array<{ title: string; message: string; variant: string }>
   let messagesCalls: Array<{ sessionID: string }>
   let createSessionCalls: Array<{ parentID?: string; title?: string; directory?: string }>
+  let updateSessionCalls: Array<{ sessionID: string; title?: string; directory?: string }>
   let mockSessionMessages: Array<{
     info?: {
       role?: string
@@ -96,6 +97,11 @@ describe("ralph-loop", () => {
             if (!sessionID) {
               throw new Error("missing session id")
             }
+            updateSessionCalls.push({
+              sessionID,
+              title: opts.body?.title ?? opts.title,
+              directory: opts.query?.directory ?? opts.directory,
+            })
             return {}
           },
         },
@@ -120,6 +126,7 @@ describe("ralph-loop", () => {
     toastCalls = []
     messagesCalls = []
     createSessionCalls = []
+    updateSessionCalls = []
     mockSessionMessages = []
     mockMessagesApiResponseShape = "data"
 
@@ -367,6 +374,12 @@ describe("ralph-loop", () => {
       expect(promptCalls[0].text).toContain("RALPH LOOP")
       expect(promptCalls[0].text).toContain("Build a feature")
       expect(promptCalls[0].text).toContain("2/10")
+      expect(updateSessionCalls.length).toBe(1)
+      expect(updateSessionCalls[0]).toEqual({
+        sessionID: "session-123",
+        title: "Ralph loop iteration 2/10",
+        directory: TEST_DIR,
+      })
 
       // then - iteration should be incremented
       const state = hook.getState()
@@ -661,6 +674,7 @@ describe("ralph-loop", () => {
 
       // then - new session should be created and continuation injected there
       expect(createSessionCalls.length).toBe(1)
+      expect(createSessionCalls[0].title).toBe("Ralph loop iteration 2/100")
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].sessionID).toBe("new-session-1")
       expect(promptCalls[0].text).toContain("<command-instruction>")
@@ -688,6 +702,8 @@ describe("ralph-loop", () => {
       })
 
       expect(promptCalls.length).toBe(1)
+      expect(createSessionCalls.length).toBe(1)
+      expect(createSessionCalls[0].title).toBe("Ralph loop iteration 2/8")
       expect(promptCalls[0].sessionID).toBe("new-session-1")
       expect(promptCalls[0].text).toMatch(/^ultrawork\s+/)
       expect(promptCalls[0].text).toContain("[RALPH LOOP - Iteration 2/8]")

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -11,10 +11,27 @@ import { parseRalphLoopArguments } from "./command-arguments"
 describe("ralph-loop", () => {
   const TEST_DIR = join(tmpdir(), "ralph-loop-test-" + Date.now())
   let promptCalls: Array<{ sessionID: string; text: string }>
+  let promptAsyncCalls: Array<{
+    sessionID: string
+    text: string
+    agent?: string
+    model?: { providerID: string; modelID: string }
+    variant?: string
+  }>
   let toastCalls: Array<{ title: string; message: string; variant: string }>
   let messagesCalls: Array<{ sessionID: string }>
   let createSessionCalls: Array<{ parentID?: string; title?: string; directory?: string }>
-  let mockSessionMessages: Array<{ info?: { role?: string }; parts?: Array<{ type: string; text?: string }> }>
+  let mockSessionMessages: Array<{
+    info?: {
+      role?: string
+      agent?: string
+      variant?: string
+      model?: { providerID: string; modelID: string; variant?: string }
+      providerID?: string
+      modelID?: string
+    }
+    parts?: Array<{ type: string; text?: string }>
+  }>
   let mockMessagesApiResponseShape: "data" | "array"
 
   function createMockPluginInput() {
@@ -28,10 +45,25 @@ describe("ralph-loop", () => {
             })
             return {}
           },
-          promptAsync: async (opts: { path: { id: string }; body: { parts: Array<{ type: string; text: string }> } }) => {
+          promptAsync: async (opts: {
+            path: { id: string }
+            body: {
+              parts: Array<{ type: string; text: string }>
+              agent?: string
+              model?: { providerID: string; modelID: string }
+              variant?: string
+            }
+          }) => {
             promptCalls.push({
               sessionID: opts.path.id,
               text: opts.body.parts[0].text,
+            })
+            promptAsyncCalls.push({
+              sessionID: opts.path.id,
+              text: opts.body.parts[0].text,
+              agent: opts.body.agent,
+              model: opts.body.model,
+              variant: opts.body.variant,
             })
             return {}
           },
@@ -68,6 +100,7 @@ describe("ralph-loop", () => {
 
   beforeEach(() => {
     promptCalls = []
+    promptAsyncCalls = []
     toastCalls = []
     messagesCalls = []
     createSessionCalls = []
@@ -536,6 +569,51 @@ describe("ralph-loop", () => {
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].sessionID).toBe("new-session-1")
       expect(hook.getState()?.session_id).toBe("new-session-1")
+    })
+
+    test("should inherit agent and variant from previous session during reset continuation", async () => {
+      mockSessionMessages = [
+        {
+          info: {
+            role: "assistant",
+            agent: "hephaestus",
+            providerID: "openai",
+            modelID: "gpt-5.3-codex",
+          },
+          parts: [{ type: "text", text: "Working" }],
+        },
+        {
+          info: {
+            role: "assistant",
+            providerID: "openai",
+            modelID: "gpt-5.3-codex",
+            variant: "medium",
+          },
+          parts: [{ type: "text", text: "More work" }],
+        },
+      ]
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
+      })
+      hook.startLoop("session-123", "Build a feature", { strategy: "reset" })
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(createSessionCalls.length).toBe(1)
+      expect(promptAsyncCalls.length).toBe(1)
+      expect(promptAsyncCalls[0].sessionID).toBe("new-session-1")
+      expect(promptAsyncCalls[0].agent).toBe("hephaestus")
+      expect(promptAsyncCalls[0].model).toEqual({
+        providerID: "openai",
+        modelID: "gpt-5.3-codex",
+      })
+      expect(promptAsyncCalls[0].variant).toBe("medium")
     })
 
     test("should not inject when no loop is active", async () => {

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -213,6 +213,43 @@ describe("ralph-loop", () => {
       expect(readResult?.strategy).toBe("reset")
     })
 
+    test("should store and read raw task arguments field", () => {
+      const state: RalphLoopState = {
+        active: true,
+        iteration: 1,
+        max_iterations: 50,
+        completion_promise: "DONE",
+        started_at: "2025-12-30T01:00:00Z",
+        prompt: "Build a REST API",
+        raw_task_arguments: '"Build a REST API with \"quotes\"" --strategy=reset --max-iterations=50',
+      }
+
+      writeState(TEST_DIR, state)
+      const readResult = readState(TEST_DIR)
+
+      expect(readResult?.raw_task_arguments).toBe(state.raw_task_arguments)
+    })
+
+    test("should preserve literal backslash escape sequences in raw task arguments", () => {
+      const state: RalphLoopState = {
+        active: true,
+        iteration: 1,
+        max_iterations: 2,
+        completion_promise: "NEVER_MATCH",
+        started_at: "2025-12-30T01:00:00Z",
+        prompt: "fallback",
+        raw_task_arguments:
+          '"Path check: C:\\temp\\ralph\\test and json {\"n\":\"\\n\"}" --strategy=continue --max-iterations=2 --completion-promise=NEVER_MATCH',
+      }
+
+      writeState(TEST_DIR, state)
+      const readResult = readState(TEST_DIR)
+
+      expect(readResult?.raw_task_arguments).toContain("C:\\temp\\ralph\\test")
+      expect(readResult?.raw_task_arguments).toContain('{"n":"\\n"}')
+      expect(readResult?.raw_task_arguments?.includes("C:\temp")).toBe(false)
+    })
+
     test("should return null for non-existent state", () => {
       // given - no state file exists
       // when - read state
@@ -350,6 +387,26 @@ Line two "quoted"
       expect(parsedArguments.completionPromise).toBe("SINGLE_TASK_COMPLETE")
       expect(parsedArguments.maxIterations).toBe(50)
       expect(parsedArguments.strategy).toBe("reset")
+    })
+
+    test("should preserve full quoted task containing unescaped inner quotes before flags", () => {
+      const rawArguments = `"PRD file: @.sisyphus/prd.md
+Progress file: @.sisyphus/progress.md
+Special chars check:
+- double quotes: "alpha"
+- single quotes: 'beta'
+- backslashes: C:\\temp\\ralph\\test
+- json-like text: {"x":"y","n":"\\n"}
+If done, output: <promise>SINGLE_TASK_COMPLETE</promise>" --strategy=continue --max-iterations=2 --completion-promise=NEVER_MATCH`
+
+      const parsedArguments = parseRalphLoopArguments(rawArguments)
+
+      expect(parsedArguments.prompt).toContain('double quotes: "alpha"')
+      expect(parsedArguments.prompt).toContain('json-like text: {"x":"y","n":"\n"}')
+      expect(parsedArguments.prompt).toContain("If done, output: <promise>SINGLE_TASK_COMPLETE</promise>")
+      expect(parsedArguments.strategy).toBe("continue")
+      expect(parsedArguments.maxIterations).toBe(2)
+      expect(parsedArguments.completionPromise).toBe("NEVER_MATCH")
     })
   })
 
@@ -791,6 +848,48 @@ Line two "quoted"
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].text).toContain(multilinePrompt)
       expect(promptCalls[0].text.includes("\\n")).toBe(false)
+    })
+
+    test("should replay raw task arguments verbatim in reset iteration when available", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      const rawArguments = `"PRD file: @.sisyphus/prd.md\nSpecial chars: \"alpha\" and {\"x\":\"y\"}" --strategy=reset --max-iterations=2 --completion-promise=NEVER_MATCH`
+
+      hook.startLoop("session-123", "fallback prompt", {
+        strategy: "reset",
+        rawTaskArguments: rawArguments,
+      })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain(rawArguments)
+    })
+
+    test("should replay raw task arguments in continue prompt original task section when available", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      const rawArguments = `"Task with \"alpha\" and C:\\temp\\ralph\\test plus {\"x\":\"y\",\"n\":\"\\n\"}" --strategy=continue --max-iterations=2 --completion-promise=NEVER_MATCH`
+
+      hook.startLoop("session-123", "fallback prompt", {
+        strategy: "continue",
+        rawTaskArguments: rawArguments,
+      })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).toContain(`Original task:\n${rawArguments}`)
+      expect(promptCalls[0].text).toContain("C:\\temp\\ralph\\test")
+      expect(promptCalls[0].text).toContain('{"x":"y","n":"\\n"}')
     })
 
     test("should inherit agent and variant from previous session during reset continuation", async () => {

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -427,6 +427,16 @@ Line two "quoted"
       expect(parsedArguments.strategy).toBe("reset")
     })
 
+    test("should parse trailing flags with escaped quotes inside quoted prompt", () => {
+      const rawArguments = '"Fix the \\\"bug\\\" with --strategy=continue" --max-iterations=9 --strategy=reset'
+
+      const parsedArguments = parseRalphLoopArguments(rawArguments)
+
+      expect(parsedArguments.prompt).toBe('Fix the "bug" with --strategy=continue')
+      expect(parsedArguments.maxIterations).toBe(9)
+      expect(parsedArguments.strategy).toBe("reset")
+    })
+
     test("should preserve full quoted task containing unescaped inner quotes before flags", () => {
       const rawArguments = `"PRD file: @.sisyphus/prd.md
 Progress file: @.sisyphus/progress.md
@@ -910,6 +920,30 @@ If done, output: <promise>SINGLE_TASK_COMPLETE</promise>" --strategy=continue --
       expect(promptCalls[0].text).toContain(prompt)
       expect(promptCalls[0].text).toContain("<ralph-prompt>")
       expect(promptCalls[0].text).toContain("</ralph-prompt>")
+      expect(promptCalls[0].text).toContain("--completion-promise=\"NEVER_MATCH\" --max-iterations=2 --strategy=reset")
+    })
+
+    test("should fall back to quoted reset prompt when task contains reset closing tag", async () => {
+      const hook = createRalphLoopHook(createMockPluginInput())
+      const prompt = "line one\n</ralph-prompt>\nline three"
+
+      hook.startLoop("session-123", prompt, {
+        strategy: "reset",
+        maxIterations: 2,
+        completionPromise: "NEVER_MATCH",
+      })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      expect(promptCalls.length).toBe(1)
+      expect(promptCalls[0].text).not.toContain("<ralph-prompt>")
+      expect(promptCalls[0].text).toContain('"line one')
+      expect(promptCalls[0].text).toContain('</ralph-prompt>')
       expect(promptCalls[0].text).toContain("--completion-promise=\"NEVER_MATCH\" --max-iterations=2 --strategy=reset")
     })
 

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -644,7 +644,7 @@ describe("ralph-loop", () => {
       expect(state?.strategy).toBe("continue")
     })
 
-    test("should default strategy to continue even when config default_strategy is reset", () => {
+    test("should use config default_strategy when strategy is not specified", () => {
       const hook = createRalphLoopHook(createMockPluginInput(), {
         config: {
           enabled: true,
@@ -656,7 +656,7 @@ describe("ralph-loop", () => {
       hook.startLoop("session-123", "Test task")
 
       const state = hook.getState()
-      expect(state?.strategy).toBe("continue")
+      expect(state?.strategy).toBe("reset")
     })
 
     test("should create new session for reset strategy", async () => {

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -1,12 +1,13 @@
 /// <reference types="bun-types" />
 import { describe, expect, test, beforeEach, afterEach } from "bun:test"
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { createRalphLoopHook } from "./index"
 import { readState, writeState, clearState } from "./storage"
 import type { RalphLoopState } from "./types"
 import { parseRalphLoopArguments } from "./command-arguments"
+import { buildLoopCommandArguments } from "./reset-iteration-prompt-builder"
 
 describe("ralph-loop", () => {
   const TEST_DIR = join(tmpdir(), "ralph-loop-test-" + Date.now())
@@ -213,41 +214,57 @@ describe("ralph-loop", () => {
       expect(readResult?.strategy).toBe("reset")
     })
 
-    test("should store and read raw task arguments field", () => {
+    test("should preserve prompt body as canonical opaque text", () => {
       const state: RalphLoopState = {
         active: true,
         iteration: 1,
         max_iterations: 50,
         completion_promise: "DONE",
         started_at: "2025-12-30T01:00:00Z",
-        prompt: "Build a REST API",
-        raw_task_arguments: '"Build a REST API with \"quotes\"" --strategy=reset --max-iterations=50',
+        prompt: '"Build a REST API with \"quotes\"" --strategy=reset --max-iterations=50 --completion-promise=DONE',
       }
 
       writeState(TEST_DIR, state)
       const readResult = readState(TEST_DIR)
 
-      expect(readResult?.raw_task_arguments).toBe(state.raw_task_arguments)
+      expect(readResult?.prompt).toBe(
+        '"Build a REST API with \"quotes\"" --strategy=reset --max-iterations=50 --completion-promise=DONE',
+      )
     })
 
-    test("should preserve literal backslash escape sequences in raw task arguments", () => {
+    test("should keep prompt body canonical and store it only once", () => {
       const state: RalphLoopState = {
         active: true,
         iteration: 1,
         max_iterations: 2,
         completion_promise: "NEVER_MATCH",
         started_at: "2025-12-30T01:00:00Z",
-        prompt: "fallback",
-        raw_task_arguments:
-          '"Path check: C:\\temp\\ralph\\test and json {\"n\":\"\\n\"}" --strategy=continue --max-iterations=2 --completion-promise=NEVER_MATCH',
+        prompt: "PRD file: @prd.md\nProgress file: @progress.md",
+      }
+
+      writeState(TEST_DIR, state)
+      const rawFile = readFileSync(join(TEST_DIR, ".sisyphus/ralph-loop.local.md"), "utf-8")
+      const promptOccurrences = rawFile.split("PRD file: @prd.md").length - 1
+
+      expect(rawFile).toContain("---\nPRD file: @prd.md")
+      expect(promptOccurrences).toBe(1)
+    })
+
+    test("should preserve leading and trailing whitespace in canonical prompt body", () => {
+      const prompt = "\n  keep leading and trailing whitespace  \n"
+      const state: RalphLoopState = {
+        active: true,
+        iteration: 1,
+        max_iterations: 3,
+        completion_promise: "DONE",
+        started_at: "2025-12-30T01:00:00Z",
+        prompt,
       }
 
       writeState(TEST_DIR, state)
       const readResult = readState(TEST_DIR)
 
-      expect(readResult?.raw_task_arguments).toContain("C:\\temp\\ralph\\test")
-      expect(readResult?.raw_task_arguments).toContain('{"n":"\\n"}')
-      expect(readResult?.raw_task_arguments?.includes("C:\temp")).toBe(false)
+      expect(readResult?.prompt).toBe(prompt)
     })
 
     test("should return null for non-existent state", () => {
@@ -389,6 +406,27 @@ Line two "quoted"
       expect(parsedArguments.strategy).toBe("reset")
     })
 
+    test("should parse generated reset command arguments with strict prompt boundary", () => {
+      const state: RalphLoopState = {
+        active: true,
+        iteration: 2,
+        max_iterations: 2,
+        completion_promise: "NEVER_MATCH",
+        started_at: "2025-12-30T01:00:00Z",
+        prompt:
+          "PRD file: @prd.md\nProgress file: @progress.md\n1. Work ONLY one tiny task.\nSpecial chars: {\"x\":\"y\",\"n\":\"\\n\"}",
+        strategy: "reset",
+      }
+
+      const replayedArguments = buildLoopCommandArguments(state)
+      const parsedArguments = parseRalphLoopArguments(replayedArguments)
+
+      expect(parsedArguments.prompt).toBe(state.prompt)
+      expect(parsedArguments.completionPromise).toBe("NEVER_MATCH")
+      expect(parsedArguments.maxIterations).toBe(2)
+      expect(parsedArguments.strategy).toBe("reset")
+    })
+
     test("should preserve full quoted task containing unescaped inner quotes before flags", () => {
       const rawArguments = `"PRD file: @.sisyphus/prd.md
 Progress file: @.sisyphus/progress.md
@@ -402,7 +440,7 @@ If done, output: <promise>SINGLE_TASK_COMPLETE</promise>" --strategy=continue --
       const parsedArguments = parseRalphLoopArguments(rawArguments)
 
       expect(parsedArguments.prompt).toContain('double quotes: "alpha"')
-      expect(parsedArguments.prompt).toContain('json-like text: {"x":"y","n":"\n"}')
+      expect(parsedArguments.prompt).toContain('json-like text: {"x":"y","n":"\\n"}')
       expect(parsedArguments.prompt).toContain("If done, output: <promise>SINGLE_TASK_COMPLETE</promise>")
       expect(parsedArguments.strategy).toBe("continue")
       expect(parsedArguments.maxIterations).toBe(2)
@@ -828,7 +866,8 @@ If done, output: <promise>SINGLE_TASK_COMPLETE</promise>" --strategy=continue --
       expect(promptCalls.length).toBe(1)
       expect(promptCalls[0].text).toContain(multilinePrompt)
       expect(promptCalls[0].text.includes("\\n")).toBe(false)
-      expect(promptCalls[0].text).not.toContain("<ralph-prompt>")
+      expect(promptCalls[0].text).toContain("<ralph-prompt>")
+      expect(promptCalls[0].text).toContain("</ralph-prompt>")
       expect(promptCalls[0].text.includes('"PRD file:')).toBe(false)
     })
 
@@ -850,13 +889,14 @@ If done, output: <promise>SINGLE_TASK_COMPLETE</promise>" --strategy=continue --
       expect(promptCalls[0].text.includes("\\n")).toBe(false)
     })
 
-    test("should replay raw task arguments verbatim in reset iteration when available", async () => {
+    test("should include flags in reset iteration command body", async () => {
       const hook = createRalphLoopHook(createMockPluginInput())
-      const rawArguments = `"PRD file: @.sisyphus/prd.md\nSpecial chars: \"alpha\" and {\"x\":\"y\"}" --strategy=reset --max-iterations=2 --completion-promise=NEVER_MATCH`
+      const prompt = "PRD file: @.sisyphus/prd.md\nSpecial chars: \"alpha\" and {\"x\":\"y\"}"
 
-      hook.startLoop("session-123", "fallback prompt", {
+      hook.startLoop("session-123", prompt, {
         strategy: "reset",
-        rawTaskArguments: rawArguments,
+        maxIterations: 2,
+        completionPromise: "NEVER_MATCH",
       })
 
       await hook.event({
@@ -867,17 +907,21 @@ If done, output: <promise>SINGLE_TASK_COMPLETE</promise>" --strategy=continue --
       })
 
       expect(promptCalls.length).toBe(1)
-      expect(promptCalls[0].text).toContain(rawArguments)
+      expect(promptCalls[0].text).toContain(prompt)
+      expect(promptCalls[0].text).toContain("<ralph-prompt>")
+      expect(promptCalls[0].text).toContain("</ralph-prompt>")
+      expect(promptCalls[0].text).toContain("--completion-promise=\"NEVER_MATCH\" --max-iterations=2 --strategy=reset")
     })
 
-    test("should replay raw task arguments in continue prompt original task section when available", async () => {
+    test("should keep continue prompt original task section free of replay flags", async () => {
       const hook = createRalphLoopHook(createMockPluginInput())
       const backtickSubstitutionToken = "$`"
-      const rawArguments = `"Task with \"alpha\" and C:\\temp\\ralph\\test plus {\"x\":\"y\",\"n\":\"\\n\"} and dollar tokens $$ $& ${backtickSubstitutionToken}" --strategy=continue --max-iterations=2 --completion-promise=NEVER_MATCH`
+      const prompt = `Task with "alpha" and C:\\temp\\ralph\\test plus {"x":"y","n":"\\n"} and dollar tokens $$ $& ${backtickSubstitutionToken}`
 
-      hook.startLoop("session-123", "fallback prompt", {
+      hook.startLoop("session-123", prompt, {
         strategy: "continue",
-        rawTaskArguments: rawArguments,
+        maxIterations: 2,
+        completionPromise: "NEVER_MATCH",
       })
 
       await hook.event({
@@ -888,9 +932,10 @@ If done, output: <promise>SINGLE_TASK_COMPLETE</promise>" --strategy=continue --
       })
 
       expect(promptCalls.length).toBe(1)
-      expect(promptCalls[0].text).toContain(`Original task:\n${rawArguments}`)
-      expect(promptCalls[0].text).toContain("C:\\temp\\ralph\\test")
-      expect(promptCalls[0].text).toContain('{"x":"y","n":"\\n"}')
+      expect(promptCalls[0].text).toContain(`Original task:\n${prompt}`)
+      expect(promptCalls[0].text).not.toContain("--completion-promise=")
+      expect(promptCalls[0].text).not.toContain("--max-iterations=")
+      expect(promptCalls[0].text).not.toContain("--strategy=")
       expect(promptCalls[0].text).toContain("dollar tokens $$ $& $`")
     })
 

--- a/src/hooks/ralph-loop/iteration-continuation.ts
+++ b/src/hooks/ralph-loop/iteration-continuation.ts
@@ -3,6 +3,7 @@ import type { RalphLoopState } from "./types"
 import { log } from "../../shared/logger"
 import { HOOK_NAME } from "./constants"
 import { buildContinuationPrompt } from "./continuation-prompt-builder"
+import { buildResetIterationPrompt } from "./reset-iteration-prompt-builder"
 import { injectContinuationPrompt } from "./continuation-prompt-injector"
 import { createIterationSession, selectSessionInTui } from "./session-reset-strategy"
 
@@ -21,9 +22,9 @@ export async function continueIteration(
   options: ContinuationOptions,
 ): Promise<void> {
   const strategy = state.strategy ?? "continue"
-  const continuationPrompt = buildContinuationPrompt(state)
 
   if (strategy === "reset") {
+    const resetPrompt = buildResetIterationPrompt(state)
     const newSessionID = await createIterationSession(
       ctx,
       options.previousSessionID,
@@ -32,16 +33,6 @@ export async function continueIteration(
     if (!newSessionID) {
       return
     }
-
-    await injectContinuationPrompt(ctx, {
-      sessionID: newSessionID,
-      inheritFromSessionID: options.previousSessionID,
-      prompt: continuationPrompt,
-      directory: options.directory,
-      apiTimeoutMs: options.apiTimeoutMs,
-    })
-
-    await selectSessionInTui(ctx.client, newSessionID)
 
     const boundState = options.loopState.setSessionID(newSessionID)
     if (!boundState) {
@@ -52,8 +43,25 @@ export async function continueIteration(
       return
     }
 
+    try {
+      await injectContinuationPrompt(ctx, {
+        sessionID: newSessionID,
+        inheritFromSessionID: options.previousSessionID,
+        prompt: resetPrompt,
+        directory: options.directory,
+        apiTimeoutMs: options.apiTimeoutMs,
+      })
+    } catch (error) {
+      options.loopState.setSessionID(options.previousSessionID)
+      throw error
+    }
+
+    await selectSessionInTui(ctx.client, newSessionID)
+
     return
   }
+
+  const continuationPrompt = buildContinuationPrompt(state)
 
   await injectContinuationPrompt(ctx, {
     sessionID: options.previousSessionID,

--- a/src/hooks/ralph-loop/iteration-continuation.ts
+++ b/src/hooks/ralph-loop/iteration-continuation.ts
@@ -6,6 +6,7 @@ import { buildContinuationPrompt } from "./continuation-prompt-builder"
 import { buildResetIterationPrompt } from "./reset-iteration-prompt-builder"
 import { injectContinuationPrompt } from "./continuation-prompt-injector"
 import { createIterationSession, selectSessionInTui } from "./session-reset-strategy"
+import { updateIterationSessionTitle } from "./iteration-session-title"
 
 type ContinuationOptions = {
   directory: string
@@ -29,6 +30,8 @@ export async function continueIteration(
       ctx,
       options.previousSessionID,
       options.directory,
+      state.iteration,
+      state.max_iterations,
     )
     if (!newSessionID) {
       return
@@ -62,6 +65,14 @@ export async function continueIteration(
   }
 
   const continuationPrompt = buildContinuationPrompt(state)
+
+  await updateIterationSessionTitle(
+    ctx.client,
+    options.previousSessionID,
+    options.directory,
+    state.iteration,
+    state.max_iterations,
+  )
 
   await injectContinuationPrompt(ctx, {
     sessionID: options.previousSessionID,

--- a/src/hooks/ralph-loop/iteration-session-title.ts
+++ b/src/hooks/ralph-loop/iteration-session-title.ts
@@ -1,0 +1,56 @@
+import { isRecord } from "../../shared/record-type-guard"
+import { log } from "../../shared/logger"
+
+type SessionUpdateApi = (args: {
+  path: { id: string }
+  body: { title: string }
+  query: { directory: string }
+}) => Promise<unknown>
+
+export function buildIterationSessionTitle(iteration: number, maxIterations: number): string {
+  return `Ralph loop iteration ${iteration}/${maxIterations}`
+}
+
+export async function updateIterationSessionTitle(
+  client: unknown,
+  sessionID: string,
+  directory: string,
+  iteration: number,
+  maxIterations: number,
+): Promise<void> {
+  const updateSession = getSessionUpdateApi(client)
+  if (!updateSession) {
+    return
+  }
+
+  try {
+    await updateSession({
+      path: { id: sessionID },
+      body: { title: buildIterationSessionTitle(iteration, maxIterations) },
+      query: { directory },
+    })
+  } catch (error: unknown) {
+    log("[ralph-loop] Failed to update iteration session title", {
+      sessionID,
+      error: String(error),
+    })
+  }
+}
+
+function getSessionUpdateApi(client: unknown): SessionUpdateApi | null {
+  if (!isRecord(client)) {
+    return null
+  }
+
+  const sessionValue = client.session
+  if (!isRecord(sessionValue)) {
+    return null
+  }
+
+  const updateValue = sessionValue.update
+  if (typeof updateValue !== "function") {
+    return null
+  }
+
+  return (updateValue as Function).bind(sessionValue) as SessionUpdateApi
+}

--- a/src/hooks/ralph-loop/loop-state-controller.ts
+++ b/src/hooks/ralph-loop/loop-state-controller.ts
@@ -40,7 +40,7 @@ export function createLoopStateController(options: {
 					loopOptions?.completionPromise ??
 					DEFAULT_COMPLETION_PROMISE,
 				ultrawork: loopOptions?.ultrawork,
-				strategy: loopOptions?.strategy ?? "continue",
+				strategy: loopOptions?.strategy ?? config?.default_strategy ?? "continue",
 				started_at: new Date().toISOString(),
 				prompt,
 				session_id: sessionID,

--- a/src/hooks/ralph-loop/loop-state-controller.ts
+++ b/src/hooks/ralph-loop/loop-state-controller.ts
@@ -26,7 +26,6 @@ export function createLoopStateController(options: {
 				messageCountAtStart?: number
 				ultrawork?: boolean
 				strategy?: "reset" | "continue"
-				rawTaskArguments?: string
 			},
 		): boolean {
 			const state: RalphLoopState = {
@@ -44,7 +43,6 @@ export function createLoopStateController(options: {
 				strategy: loopOptions?.strategy ?? config?.default_strategy ?? "continue",
 				started_at: new Date().toISOString(),
 				prompt,
-				raw_task_arguments: loopOptions?.rawTaskArguments,
 				session_id: sessionID,
 			}
 

--- a/src/hooks/ralph-loop/loop-state-controller.ts
+++ b/src/hooks/ralph-loop/loop-state-controller.ts
@@ -40,7 +40,7 @@ export function createLoopStateController(options: {
 					loopOptions?.completionPromise ??
 					DEFAULT_COMPLETION_PROMISE,
 				ultrawork: loopOptions?.ultrawork,
-				strategy: loopOptions?.strategy ?? config?.default_strategy ?? "continue",
+				strategy: loopOptions?.strategy ?? "continue",
 				started_at: new Date().toISOString(),
 				prompt,
 				session_id: sessionID,

--- a/src/hooks/ralph-loop/loop-state-controller.ts
+++ b/src/hooks/ralph-loop/loop-state-controller.ts
@@ -26,6 +26,7 @@ export function createLoopStateController(options: {
 				messageCountAtStart?: number
 				ultrawork?: boolean
 				strategy?: "reset" | "continue"
+				rawTaskArguments?: string
 			},
 		): boolean {
 			const state: RalphLoopState = {
@@ -43,6 +44,7 @@ export function createLoopStateController(options: {
 				strategy: loopOptions?.strategy ?? config?.default_strategy ?? "continue",
 				started_at: new Date().toISOString(),
 				prompt,
+				raw_task_arguments: loopOptions?.rawTaskArguments,
 				session_id: sessionID,
 			}
 

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -25,6 +25,7 @@ type RalphLoopEventHandlerOptions = {
 	getTranscriptPath: (sessionID: string) => string | undefined
 	checkSessionExists?: RalphLoopOptions["checkSessionExists"]
 	onLoopCompleted?: (sessionID: string) => Promise<void> | void
+	shouldDeferIteration?: (sessionID: string) => Promise<boolean> | boolean
 	sessionRecovery: SessionRecovery
 	loopState: LoopStateController
 }
@@ -33,7 +34,8 @@ export function createRalphLoopEventHandler(
 	ctx: PluginInput,
 	options: RalphLoopEventHandlerOptions,
 ) {
-	const inFlightSessions = new Set<string>()
+	const inFlightIdleSessions = new Set<string>()
+	let continuationInFlight = false
 
 	return async ({ event }: { event: { type: string; properties?: unknown } }): Promise<void> => {
 		const props = event.properties as Record<string, unknown> | undefined
@@ -42,127 +44,137 @@ export function createRalphLoopEventHandler(
 			const sessionID = props?.sessionID as string | undefined
 			if (!sessionID) return
 
-			if (inFlightSessions.has(sessionID)) {
-				log(`[${HOOK_NAME}] Skipped: handler in flight`, { sessionID })
+			if (continuationInFlight) {
 				return
 			}
 
-			inFlightSessions.add(sessionID)
+			if (inFlightIdleSessions.has(sessionID)) {
+				return
+			}
 
+			continuationInFlight = true
+			inFlightIdleSessions.add(sessionID)
 			try {
-				if (options.sessionRecovery.isRecovering(sessionID)) {
-					log(`[${HOOK_NAME}] Skipped: in recovery`, { sessionID })
-					return
-				}
 
-				const state = options.loopState.getState()
-				if (!state || !state.active) {
-					return
-				}
+			if (options.sessionRecovery.isRecovering(sessionID)) {
+				log(`[${HOOK_NAME}] Skipped: in recovery`, { sessionID })
+				return
+			}
 
-				if (state.session_id && state.session_id !== sessionID) {
-					if (options.checkSessionExists) {
-						try {
-							const exists = await options.checkSessionExists(state.session_id)
-							if (!exists) {
-								options.loopState.clear()
-								log(`[${HOOK_NAME}] Cleared orphaned state from deleted session`, {
-									orphanedSessionId: state.session_id,
-									currentSessionId: sessionID,
-								})
-								return
-							}
-						} catch (err) {
-							log(`[${HOOK_NAME}] Failed to check session existence`, {
-								sessionId: state.session_id,
-								error: String(err),
+			const state = options.loopState.getState()
+			if (!state || !state.active) {
+				return
+			}
+
+			if (state.session_id && state.session_id !== sessionID) {
+				if (options.checkSessionExists) {
+					try {
+						const exists = await options.checkSessionExists(state.session_id)
+						if (!exists) {
+							options.loopState.clear()
+							log(`[${HOOK_NAME}] Cleared orphaned state from deleted session`, {
+								orphanedSessionId: state.session_id,
+								currentSessionId: sessionID,
 							})
+							return
 						}
+					} catch (err) {
+						log(`[${HOOK_NAME}] Failed to check session existence`, {
+							sessionId: state.session_id,
+							error: String(err),
+						})
 					}
-					return
-				}
-
-				const transcriptPath = options.getTranscriptPath(sessionID)
-				const completionViaTranscript = detectCompletionInTranscript(transcriptPath, state.completion_promise)
-				const completionViaApi = completionViaTranscript
-					? false
-					: await detectCompletionInSessionMessages(ctx, {
-						sessionID,
-						promise: state.completion_promise,
-						apiTimeoutMs: options.apiTimeoutMs,
-						directory: options.directory,
-						sinceMessageIndex: state.message_count_at_start,
-					})
-
-				if (completionViaTranscript || completionViaApi) {
-					log(`[${HOOK_NAME}] Completion detected!`, {
-						sessionID,
-						iteration: state.iteration,
-						promise: state.completion_promise,
-						detectedVia: completionViaTranscript
-							? "transcript_file"
-							: "session_messages_api",
-					})
-					options.loopState.clear()
-
-					const title = state.ultrawork ? "ULTRAWORK LOOP COMPLETE!" : "Ralph Loop Complete!"
-					const message = state.ultrawork ? `JUST ULW ULW! Task completed after ${state.iteration} iteration(s)` : `Task completed after ${state.iteration} iteration(s)`
-					await ctx.client.tui?.showToast?.({ body: { title, message, variant: "success", duration: 5000 } }).catch(() => {})
-					await options.onLoopCompleted?.(sessionID)
-					return
-				}
-
-				if (state.iteration >= state.max_iterations) {
-					log(`[${HOOK_NAME}] Max iterations reached`, {
-						sessionID,
-						iteration: state.iteration,
-						max: state.max_iterations,
-					})
-					options.loopState.clear()
-
-					await ctx.client.tui?.showToast?.({
-						body: { title: "Ralph Loop Stopped", message: `Max iterations (${state.max_iterations}) reached without completion`, variant: "warning", duration: 5000 },
-						}).catch(() => {})
-					return
-				}
-
-				const newState = options.loopState.incrementIteration()
-				if (!newState) {
-					log(`[${HOOK_NAME}] Failed to increment iteration`, { sessionID })
-					return
-				}
-
-				log(`[${HOOK_NAME}] Continuing loop`, {
-					sessionID,
-					iteration: newState.iteration,
-					max: newState.max_iterations,
-				})
-
-				await ctx.client.tui?.showToast?.({
-					body: {
-						title: "Ralph Loop",
-						message: `Iteration ${newState.iteration}/${newState.max_iterations}`,
-						variant: "info",
-						duration: 2000,
-					},
-					}).catch(() => {})
-
-				try {
-					await continueIteration(ctx, newState, {
-						previousSessionID: sessionID,
-						directory: options.directory,
-						apiTimeoutMs: options.apiTimeoutMs,
-						loopState: options.loopState,
-					})
-				} catch (err) {
-					log(`[${HOOK_NAME}] Failed to inject continuation`, {
-						sessionID,
-						error: String(err),
-					})
 				}
 				return
+			}
+
+			const transcriptPath = options.getTranscriptPath(sessionID)
+			const completionViaTranscript = detectCompletionInTranscript(transcriptPath, state.completion_promise)
+			const completionViaApi = completionViaTranscript
+				? false
+				: await detectCompletionInSessionMessages(ctx, {
+					sessionID,
+					promise: state.completion_promise,
+					apiTimeoutMs: options.apiTimeoutMs,
+					directory: options.directory,
+				})
+
+			if (completionViaTranscript || completionViaApi) {
+				log(`[${HOOK_NAME}] Completion detected!`, {
+					sessionID,
+					iteration: state.iteration,
+					promise: state.completion_promise,
+					detectedVia: completionViaTranscript
+						? "transcript_file"
+						: "session_messages_api",
+				})
+				options.loopState.clear()
+
+				const title = state.ultrawork ? "ULTRAWORK LOOP COMPLETE!" : "Ralph Loop Complete!"
+				const message = state.ultrawork ? `JUST ULW ULW! Task completed after ${state.iteration} iteration(s)` : `Task completed after ${state.iteration} iteration(s)`
+				await ctx.client.tui?.showToast?.({ body: { title, message, variant: "success", duration: 5000 } }).catch(() => {})
+				await options.onLoopCompleted?.(sessionID)
+				return
+			}
+
+			if (state.iteration >= state.max_iterations) {
+				log(`[${HOOK_NAME}] Max iterations reached`, {
+					sessionID,
+					iteration: state.iteration,
+					max: state.max_iterations,
+				})
+				options.loopState.clear()
+
+				await ctx.client.tui?.showToast?.({
+					body: { title: "Ralph Loop Stopped", message: `Max iterations (${state.max_iterations}) reached without completion`, variant: "warning", duration: 5000 },
+					}).catch(() => {})
+				return
+			}
+
+			const shouldDeferIteration = (await options.shouldDeferIteration?.(sessionID)) ?? false
+			if (shouldDeferIteration) {
+				log(`[${HOOK_NAME}] Skipped: waiting for background task/subagent`, { sessionID })
+				return
+			}
+
+			const newState = options.loopState.incrementIteration()
+			if (!newState) {
+				log(`[${HOOK_NAME}] Failed to increment iteration`, { sessionID })
+				return
+			}
+
+			log(`[${HOOK_NAME}] Continuing loop`, {
+				sessionID,
+				iteration: newState.iteration,
+				max: newState.max_iterations,
+			})
+
+			await ctx.client.tui?.showToast?.({
+				body: {
+					title: "Ralph Loop",
+					message: `Iteration ${newState.iteration}/${newState.max_iterations}`,
+					variant: "info",
+					duration: 2000,
+				},
+				}).catch(() => {})
+
+			try {
+				await continueIteration(ctx, newState, {
+					previousSessionID: sessionID,
+					directory: options.directory,
+					apiTimeoutMs: options.apiTimeoutMs,
+					loopState: options.loopState,
+				})
+			} catch (err) {
+				log(`[${HOOK_NAME}] Failed to inject continuation`, {
+					sessionID,
+					error: String(err),
+				})
+			}
+			return
 			} finally {
-				inFlightSessions.delete(sessionID)
+				inFlightIdleSessions.delete(sessionID)
+				continuationInFlight = false
 			}
 		}
 
@@ -227,7 +239,8 @@ function isAbortError(error: unknown): boolean {
 	if (typeof error === "object") {
 		const errObj = error as Record<string, unknown>
 		const name = errObj.name as string | undefined
-		const message = (errObj.message as string | undefined)?.toLowerCase() ?? ""
+		const dataObj = errObj.data as Record<string, unknown> | undefined
+		const message = ((errObj.message ?? dataObj?.message) as string | undefined)?.toLowerCase() ?? ""
 
 		if (name === "MessageAbortedError" || name === "AbortError") return true
 		if (name === "DOMException" && message.includes("abort")) return true

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -200,19 +200,6 @@ export function createRalphLoopEventHandler(
 			return
 		}
 
-		if (event.type === "session.stop") {
-			const sessionID = props?.sessionID as string | undefined
-			if (!sessionID) return
-
-			const state = options.loopState.getState()
-			if (state?.session_id === sessionID) {
-				options.loopState.clear()
-				log(`[${HOOK_NAME}] Session stopped, loop cleared`, { sessionID })
-			}
-			options.sessionRecovery.clear(sessionID)
-			return
-		}
-
 		if (event.type === "message.updated") {
 			const info = props?.info as Record<string, unknown> | undefined
 			const sessionID = info?.sessionID as string | undefined

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -19,7 +19,15 @@ type LoopStateController = {
 	incrementIteration: () => RalphLoopState | null
 	setSessionID: (sessionID: string) => RalphLoopState | null
 }
-type RalphLoopEventHandlerOptions = { directory: string; apiTimeoutMs: number; getTranscriptPath: (sessionID: string) => string | undefined; checkSessionExists?: RalphLoopOptions["checkSessionExists"]; sessionRecovery: SessionRecovery; loopState: LoopStateController }
+type RalphLoopEventHandlerOptions = {
+	directory: string
+	apiTimeoutMs: number
+	getTranscriptPath: (sessionID: string) => string | undefined
+	checkSessionExists?: RalphLoopOptions["checkSessionExists"]
+	onLoopCompleted?: (sessionID: string) => Promise<void> | void
+	sessionRecovery: SessionRecovery
+	loopState: LoopStateController
+}
 
 export function createRalphLoopEventHandler(
 	ctx: PluginInput,
@@ -42,7 +50,6 @@ export function createRalphLoopEventHandler(
 			inFlightSessions.add(sessionID)
 
 			try {
-
 				if (options.sessionRecovery.isRecovering(sessionID)) {
 					log(`[${HOOK_NAME}] Skipped: in recovery`, { sessionID })
 					return
@@ -101,6 +108,7 @@ export function createRalphLoopEventHandler(
 					const title = state.ultrawork ? "ULTRAWORK LOOP COMPLETE!" : "Ralph Loop Complete!"
 					const message = state.ultrawork ? `JUST ULW ULW! Task completed after ${state.iteration} iteration(s)` : `Task completed after ${state.iteration} iteration(s)`
 					await ctx.client.tui?.showToast?.({ body: { title, message, variant: "success", duration: 5000 } }).catch(() => {})
+					await options.onLoopCompleted?.(sessionID)
 					return
 				}
 
@@ -172,9 +180,9 @@ export function createRalphLoopEventHandler(
 
 		if (event.type === "session.error") {
 			const sessionID = props?.sessionID as string | undefined
-			const error = props?.error as { name?: string } | undefined
+			const error = props?.error
 
-			if (error?.name === "MessageAbortedError") {
+			if (isAbortError(error)) {
 				if (sessionID) {
 					const state = options.loopState.getState()
 					if (state?.session_id === sessionID) {
@@ -189,6 +197,60 @@ export function createRalphLoopEventHandler(
 			if (sessionID) {
 				options.sessionRecovery.markRecovering(sessionID)
 			}
+			return
+		}
+
+		if (event.type === "session.stop") {
+			const sessionID = props?.sessionID as string | undefined
+			if (!sessionID) return
+
+			const state = options.loopState.getState()
+			if (state?.session_id === sessionID) {
+				options.loopState.clear()
+				log(`[${HOOK_NAME}] Session stopped, loop cleared`, { sessionID })
+			}
+			options.sessionRecovery.clear(sessionID)
+			return
+		}
+
+		if (event.type === "message.updated") {
+			const info = props?.info as Record<string, unknown> | undefined
+			const sessionID = info?.sessionID as string | undefined
+			if (!sessionID) return
+
+			const state = options.loopState.getState()
+			if (!state || state.session_id !== sessionID) {
+				return
+			}
+
+			if (isAbortError(info?.error)) {
+				options.loopState.clear()
+				options.sessionRecovery.clear(sessionID)
+				log(`[${HOOK_NAME}] Abort detected via message.updated, loop cleared`, {
+					sessionID,
+				})
+			}
 		}
 	}
+}
+
+function isAbortError(error: unknown): boolean {
+	if (!error) return false
+
+	if (typeof error === "object") {
+		const errObj = error as Record<string, unknown>
+		const name = errObj.name as string | undefined
+		const message = (errObj.message as string | undefined)?.toLowerCase() ?? ""
+
+		if (name === "MessageAbortedError" || name === "AbortError") return true
+		if (name === "DOMException" && message.includes("abort")) return true
+		if (message.includes("aborted") || message.includes("cancelled") || message.includes("interrupted")) return true
+	}
+
+	if (typeof error === "string") {
+		const lower = error.toLowerCase()
+		return lower.includes("abort") || lower.includes("cancel") || lower.includes("interrupt")
+	}
+
+	return false
 }

--- a/src/hooks/ralph-loop/ralph-loop-hook.ts
+++ b/src/hooks/ralph-loop/ralph-loop-hook.ts
@@ -16,7 +16,6 @@ export interface RalphLoopHook {
       messageCountAtStart?: number
       ultrawork?: boolean
       strategy?: "reset" | "continue"
-      rawTaskArguments?: string
     }
   ) => boolean
   cancelLoop: (sessionID: string) => boolean

--- a/src/hooks/ralph-loop/ralph-loop-hook.ts
+++ b/src/hooks/ralph-loop/ralph-loop-hook.ts
@@ -20,6 +20,7 @@ export interface RalphLoopHook {
   ) => boolean
   cancelLoop: (sessionID: string) => boolean
   getState: () => RalphLoopState | null
+  setOnLoopCompleted: (callback: (sessionID: string) => Promise<void> | void) => void
 }
 
 const DEFAULT_API_TIMEOUT = 5000 as const
@@ -46,6 +47,7 @@ export function createRalphLoopHook(
   const getTranscriptPath = options?.getTranscriptPath ?? getDefaultTranscriptPath
   const apiTimeout = options?.apiTimeout ?? DEFAULT_API_TIMEOUT
   const checkSessionExists = options?.checkSessionExists
+  let onLoopCompleted = options?.onLoopCompleted
 
 	const loopState = createLoopStateController({
 		directory: ctx.directory,
@@ -59,6 +61,9 @@ export function createRalphLoopHook(
 		apiTimeoutMs: apiTimeout,
 		getTranscriptPath,
 		checkSessionExists,
+		onLoopCompleted: async (sessionID: string) => {
+			await onLoopCompleted?.(sessionID)
+		},
 		sessionRecovery,
 		loopState,
 	})
@@ -86,5 +91,8 @@ export function createRalphLoopHook(
 		},
 		cancelLoop: loopState.cancelLoop,
 		getState: loopState.getState as () => RalphLoopState | null,
+		setOnLoopCompleted: (callback) => {
+			onLoopCompleted = callback
+		},
 	}
 }

--- a/src/hooks/ralph-loop/ralph-loop-hook.ts
+++ b/src/hooks/ralph-loop/ralph-loop-hook.ts
@@ -21,6 +21,7 @@ export interface RalphLoopHook {
   cancelLoop: (sessionID: string) => boolean
   getState: () => RalphLoopState | null
   setOnLoopCompleted: (callback: (sessionID: string) => Promise<void> | void) => void
+  setShouldDeferIteration: (callback: (sessionID: string) => Promise<boolean> | boolean) => void
 }
 
 const DEFAULT_API_TIMEOUT = 5000 as const
@@ -48,6 +49,7 @@ export function createRalphLoopHook(
   const apiTimeout = options?.apiTimeout ?? DEFAULT_API_TIMEOUT
   const checkSessionExists = options?.checkSessionExists
   let onLoopCompleted = options?.onLoopCompleted
+  let shouldDeferIteration = options?.shouldDeferIteration
 
 	const loopState = createLoopStateController({
 		directory: ctx.directory,
@@ -63,6 +65,9 @@ export function createRalphLoopHook(
 		checkSessionExists,
 		onLoopCompleted: async (sessionID: string) => {
 			await onLoopCompleted?.(sessionID)
+		},
+		shouldDeferIteration: async (sessionID: string) => {
+			return (await shouldDeferIteration?.(sessionID)) ?? false
 		},
 		sessionRecovery,
 		loopState,
@@ -93,6 +98,9 @@ export function createRalphLoopHook(
 		getState: loopState.getState as () => RalphLoopState | null,
 		setOnLoopCompleted: (callback) => {
 			onLoopCompleted = callback
+		},
+		setShouldDeferIteration: (callback) => {
+			shouldDeferIteration = callback
 		},
 	}
 }

--- a/src/hooks/ralph-loop/ralph-loop-hook.ts
+++ b/src/hooks/ralph-loop/ralph-loop-hook.ts
@@ -16,6 +16,7 @@ export interface RalphLoopHook {
       messageCountAtStart?: number
       ultrawork?: boolean
       strategy?: "reset" | "continue"
+      rawTaskArguments?: string
     }
   ) => boolean
   cancelLoop: (sessionID: string) => boolean

--- a/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
+++ b/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
@@ -1,9 +1,6 @@
 import type { RalphLoopState } from "./types"
 import { RALPH_LOOP_TEMPLATE } from "../../features/builtin-commands/templates/ralph-loop"
 
-const RESET_PROMPT_BLOCK_START = "<ralph-prompt>"
-const RESET_PROMPT_BLOCK_END = "</ralph-prompt>"
-
 function quoteCommandValue(value: string): string {
   const escapedValue = value
     .replace(/\\/g, "\\\\")
@@ -19,9 +16,7 @@ function buildLoopCommandArguments(state: RalphLoopState): string {
     `--strategy=${state.strategy ?? "continue"}`,
   ]
 
-  return `${RESET_PROMPT_BLOCK_START}
-${state.prompt}
-${RESET_PROMPT_BLOCK_END}
+  return `${state.prompt}
 ${flags.join(" ")}`
 }
 

--- a/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
+++ b/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
@@ -10,6 +10,10 @@ function quoteCommandValue(value: string): string {
 }
 
 function buildLoopCommandArguments(state: RalphLoopState): string {
+  if (state.raw_task_arguments) {
+    return state.raw_task_arguments
+  }
+
   const flags = [
     `--completion-promise=${quoteCommandValue(state.completion_promise)}`,
     `--max-iterations=${state.max_iterations}`,

--- a/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
+++ b/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
@@ -9,18 +9,16 @@ function quoteCommandValue(value: string): string {
   return `"${escapedValue}"`
 }
 
-function buildLoopCommandArguments(state: RalphLoopState): string {
-  if (state.raw_task_arguments) {
-    return state.raw_task_arguments
-  }
-
+export function buildLoopCommandArguments(state: RalphLoopState): string {
   const flags = [
     `--completion-promise=${quoteCommandValue(state.completion_promise)}`,
     `--max-iterations=${state.max_iterations}`,
     `--strategy=${state.strategy ?? "continue"}`,
   ]
 
-  return `${state.prompt}
+  return `<ralph-prompt>
+${state.prompt}
+</ralph-prompt>
 ${flags.join(" ")}`
 }
 

--- a/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
+++ b/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
@@ -1,0 +1,27 @@
+import type { RalphLoopState } from "./types"
+import { RALPH_LOOP_TEMPLATE } from "../../features/builtin-commands/templates/ralph-loop"
+
+function buildLoopCommandArguments(state: RalphLoopState): string {
+  const quotedPrompt = JSON.stringify(state.prompt)
+  const flags = [
+    `--completion-promise=${JSON.stringify(state.completion_promise)}`,
+    `--max-iterations=${state.max_iterations}`,
+    `--strategy=${state.strategy ?? "continue"}`,
+  ]
+
+  return `${quotedPrompt} ${flags.join(" ")}`
+}
+
+export function buildResetIterationPrompt(state: RalphLoopState): string {
+  const commandBody = `[RALPH LOOP - Iteration ${state.iteration}/${state.max_iterations}]
+
+<command-instruction>
+${RALPH_LOOP_TEMPLATE}
+</command-instruction>
+
+<user-task>
+${buildLoopCommandArguments(state)}
+</user-task>`
+
+  return state.ultrawork ? `ultrawork ${commandBody}` : commandBody
+}

--- a/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
+++ b/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
@@ -9,6 +9,18 @@ function quoteCommandValue(value: string): string {
   return `"${escapedValue}"`
 }
 
+function buildPromptWithFlags(state: RalphLoopState, flagsText: string): string {
+  if (!state.prompt.includes("</ralph-prompt>")) {
+    return `<ralph-prompt>
+${state.prompt}
+</ralph-prompt>
+${flagsText}`
+  }
+
+  return `${quoteCommandValue(state.prompt)}
+${flagsText}`
+}
+
 export function buildLoopCommandArguments(state: RalphLoopState): string {
   const flags = [
     `--completion-promise=${quoteCommandValue(state.completion_promise)}`,
@@ -16,10 +28,7 @@ export function buildLoopCommandArguments(state: RalphLoopState): string {
     `--strategy=${state.strategy ?? "continue"}`,
   ]
 
-  return `<ralph-prompt>
-${state.prompt}
-</ralph-prompt>
-${flags.join(" ")}`
+  return buildPromptWithFlags(state, flags.join(" "))
 }
 
 export function buildResetIterationPrompt(state: RalphLoopState): string {

--- a/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
+++ b/src/hooks/ralph-loop/reset-iteration-prompt-builder.ts
@@ -1,15 +1,28 @@
 import type { RalphLoopState } from "./types"
 import { RALPH_LOOP_TEMPLATE } from "../../features/builtin-commands/templates/ralph-loop"
 
+const RESET_PROMPT_BLOCK_START = "<ralph-prompt>"
+const RESET_PROMPT_BLOCK_END = "</ralph-prompt>"
+
+function quoteCommandValue(value: string): string {
+  const escapedValue = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+
+  return `"${escapedValue}"`
+}
+
 function buildLoopCommandArguments(state: RalphLoopState): string {
-  const quotedPrompt = JSON.stringify(state.prompt)
   const flags = [
-    `--completion-promise=${JSON.stringify(state.completion_promise)}`,
+    `--completion-promise=${quoteCommandValue(state.completion_promise)}`,
     `--max-iterations=${state.max_iterations}`,
     `--strategy=${state.strategy ?? "continue"}`,
   ]
 
-  return `${quotedPrompt} ${flags.join(" ")}`
+  return `${RESET_PROMPT_BLOCK_START}
+${state.prompt}
+${RESET_PROMPT_BLOCK_END}
+${flags.join(" ")}`
 }
 
 export function buildResetIterationPrompt(state: RalphLoopState): string {

--- a/src/hooks/ralph-loop/reset-strategy-race-condition.test.ts
+++ b/src/hooks/ralph-loop/reset-strategy-race-condition.test.ts
@@ -36,7 +36,7 @@ async function waitUntil(condition: () => boolean): Promise<void> {
 }
 
 describe("ralph-loop reset strategy race condition", () => {
-  test("should skip duplicate idle while reset iteration handling is in flight", async () => {
+  test("should ignore old session idle once state is bound to reset session", async () => {
     // given - reset strategy loop with blocked TUI session switch
     const promptCalls: Array<{ sessionID: string; text: string }> = []
     const createSessionCalls: Array<{ parentID?: string }> = []
@@ -97,13 +97,16 @@ describe("ralph-loop reset strategy race condition", () => {
     await waitUntil(() => selectSessionCalls > 0)
 
     const secondIdleEvent = hook.event({
-      event: { type: "session.idle", properties: { sessionID: "session-old" } },
+      event: { type: "session.idle", properties: { sessionID: "new-session-1" } },
+    })
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 10)
     })
 
     selectSessionDeferred.resolve()
     await Promise.all([firstIdleEvent, secondIdleEvent])
 
-    // then - duplicate idle should be skipped to prevent concurrent continuation injection
     expect(createSessionCalls.length).toBe(1)
     expect(promptCalls.length).toBe(1)
     expect(hook.getState()?.iteration).toBe(2)

--- a/src/hooks/ralph-loop/session-reset-strategy.test.ts
+++ b/src/hooks/ralph-loop/session-reset-strategy.test.ts
@@ -141,7 +141,7 @@ describe("session-reset-strategy selectSessionInTui", () => {
 
     expect(sessionID).toBe("ses_new_iteration")
     expect(calls).toHaveLength(1)
-    expect(calls[0].body).toEqual({ title: "Ralph Loop Iteration" })
+    expect(calls[0].body).toEqual({})
     expect(calls[0].query).toEqual({ directory: "/tmp/project" })
   })
 })

--- a/src/hooks/ralph-loop/session-reset-strategy.test.ts
+++ b/src/hooks/ralph-loop/session-reset-strategy.test.ts
@@ -146,11 +146,13 @@ describe("session-reset-strategy selectSessionInTui", () => {
       ctx as never,
       "ses_previous_parent",
       "/tmp/project",
+      3,
+      50,
     )
 
     expect(sessionID).toBe("ses_new_iteration")
     expect(calls).toHaveLength(1)
-    expect(calls[0].body).toEqual({})
+    expect(calls[0].body).toEqual({ title: "Ralph loop iteration 3/50" })
     expect(calls[0].query).toEqual({ directory: "/tmp/project" })
   })
 })

--- a/src/hooks/ralph-loop/session-reset-strategy.test.ts
+++ b/src/hooks/ralph-loop/session-reset-strategy.test.ts
@@ -7,15 +7,24 @@ describe("session-reset-strategy selectSessionInTui", () => {
   const originalUsername = process.env.OPENCODE_SERVER_USERNAME
   const originalPassword = process.env.OPENCODE_SERVER_PASSWORD
 
+  const restoreEnv = (key: "OPENCODE_SERVER_USERNAME" | "OPENCODE_SERVER_PASSWORD", value: string | undefined) => {
+    if (value === undefined) {
+      delete process.env[key]
+      return
+    }
+
+    process.env[key] = value
+  }
+
   beforeEach(() => {
-    process.env.OPENCODE_SERVER_USERNAME = originalUsername
-    process.env.OPENCODE_SERVER_PASSWORD = originalPassword
+    restoreEnv("OPENCODE_SERVER_USERNAME", originalUsername)
+    restoreEnv("OPENCODE_SERVER_PASSWORD", originalPassword)
     globalThis.fetch = originalFetch
   })
 
   afterEach(() => {
-    process.env.OPENCODE_SERVER_USERNAME = originalUsername
-    process.env.OPENCODE_SERVER_PASSWORD = originalPassword
+    restoreEnv("OPENCODE_SERVER_USERNAME", originalUsername)
+    restoreEnv("OPENCODE_SERVER_PASSWORD", originalPassword)
     globalThis.fetch = originalFetch
   })
 

--- a/src/hooks/ralph-loop/session-reset-strategy.test.ts
+++ b/src/hooks/ralph-loop/session-reset-strategy.test.ts
@@ -1,0 +1,147 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { createIterationSession, selectSessionInTui } from "./session-reset-strategy"
+
+describe("session-reset-strategy selectSessionInTui", () => {
+  const originalFetch = globalThis.fetch
+  const originalUsername = process.env.OPENCODE_SERVER_USERNAME
+  const originalPassword = process.env.OPENCODE_SERVER_PASSWORD
+
+  beforeEach(() => {
+    process.env.OPENCODE_SERVER_USERNAME = originalUsername
+    process.env.OPENCODE_SERVER_PASSWORD = originalPassword
+    globalThis.fetch = originalFetch
+  })
+
+  afterEach(() => {
+    process.env.OPENCODE_SERVER_USERNAME = originalUsername
+    process.env.OPENCODE_SERVER_PASSWORD = originalPassword
+    globalThis.fetch = originalFetch
+  })
+
+  test("uses SDK TUI selectSession with v2 parameter shape when supported", async () => {
+    const calls: unknown[] = []
+    const client = {
+      tui: {
+        selectSession: async (args: unknown) => {
+          calls.push(args)
+          return {}
+        },
+      },
+    }
+
+    const result = await selectSessionInTui(client as never, "ses_v2")
+
+    expect(result).toBe(true)
+    expect(calls).toEqual([{ sessionID: "ses_v2" }])
+  })
+
+  test("falls back to legacy body-wrapped SDK shape when v2 call fails", async () => {
+    const calls: unknown[] = []
+    const client = {
+      tui: {
+        selectSession: async (args: unknown) => {
+          calls.push(args)
+          const record = args as { body?: { sessionID?: string }; sessionID?: string }
+          if (record.body?.sessionID) {
+            return {}
+          }
+          throw new Error("bad shape")
+        },
+      },
+    }
+
+    const result = await selectSessionInTui(client as never, "ses_v1")
+
+    expect(result).toBe(true)
+    expect(calls).toEqual([
+      { sessionID: "ses_v1" },
+      { body: { sessionID: "ses_v1" } },
+    ])
+  })
+
+  test("falls back to tui.publish session select event when selectSession is unavailable", async () => {
+    const publishCalls: unknown[] = []
+    const client = {
+      tui: {
+        publish: async (args: unknown) => {
+          publishCalls.push(args)
+          return {}
+        },
+      },
+    }
+
+    const result = await selectSessionInTui(client as never, "ses_publish")
+
+    expect(result).toBe(true)
+    expect(publishCalls).toEqual([
+      {
+        body: {
+          type: "tui.session.select",
+          properties: { sessionID: "ses_publish" },
+        },
+      },
+    ])
+  })
+
+  test("falls back to HTTP endpoint when SDK TUI methods are unavailable", async () => {
+    process.env.OPENCODE_SERVER_USERNAME = "opencode"
+    process.env.OPENCODE_SERVER_PASSWORD = "secret"
+
+    const fetchCalls: Array<{ url: string; body: unknown; method?: string; auth?: string | null }> = []
+    globalThis.fetch = (async (input: URL | RequestInfo, init?: RequestInit) => {
+      fetchCalls.push({
+        url: String(input),
+        body: init?.body,
+        method: init?.method,
+        auth: init?.headers instanceof Headers
+          ? init.headers.get("Authorization")
+          : Array.isArray(init?.headers)
+            ? null
+            : (init?.headers as Record<string, string> | undefined)?.Authorization ?? null,
+      })
+      return new Response(null, { status: 200 })
+    }) as typeof fetch
+
+    const client = {
+      _client: {
+        getConfig: () => ({ baseUrl: "http://127.0.0.1:4096" }),
+      },
+      tui: {},
+    }
+
+    const result = await selectSessionInTui(client as never, "ses_http")
+
+    expect(result).toBe(true)
+    expect(fetchCalls).toHaveLength(1)
+    expect(fetchCalls[0].url).toBe("http://127.0.0.1:4096/tui/select-session")
+    expect(fetchCalls[0].method).toBe("POST")
+    expect(fetchCalls[0].auth).toContain("Basic ")
+    expect(JSON.parse(String(fetchCalls[0].body))).toEqual({ sessionID: "ses_http" })
+  })
+
+  test("creates top-level iteration session without parentID", async () => {
+    const calls: Array<{ body?: unknown; query?: unknown }> = []
+    const ctx = {
+      client: {
+        session: {
+          create: async (args: { body?: unknown; query?: unknown }) => {
+            calls.push(args)
+            return { data: { id: "ses_new_iteration" } }
+          },
+        },
+      },
+    }
+
+    const sessionID = await createIterationSession(
+      ctx as never,
+      "ses_previous_parent",
+      "/tmp/project",
+    )
+
+    expect(sessionID).toBe("ses_new_iteration")
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body).toEqual({ title: "Ralph Loop Iteration" })
+    expect(calls[0].query).toEqual({ directory: "/tmp/project" })
+  })
+})

--- a/src/hooks/ralph-loop/session-reset-strategy.ts
+++ b/src/hooks/ralph-loop/session-reset-strategy.ts
@@ -3,16 +3,19 @@ import { getServerBaseUrl } from "../../shared/opencode-http-api"
 import { getServerBasicAuthHeader } from "../../shared/opencode-server-auth"
 import { isRecord } from "../../shared/record-type-guard"
 import { log } from "../../shared/logger"
+import { buildIterationSessionTitle } from "./iteration-session-title"
 
 export async function createIterationSession(
   ctx: PluginInput,
   parentSessionID: string,
   directory: string,
+  iteration: number,
+  maxIterations: number,
 ): Promise<string | null> {
   void parentSessionID
 
   const createResult = await ctx.client.session.create({
-    body: {},
+    body: { title: buildIterationSessionTitle(iteration, maxIterations) },
     query: { directory },
   })
 

--- a/src/hooks/ralph-loop/session-reset-strategy.ts
+++ b/src/hooks/ralph-loop/session-reset-strategy.ts
@@ -1,4 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
+import { getServerBaseUrl } from "../../shared/opencode-http-api"
+import { getServerBasicAuthHeader } from "../../shared/opencode-server-auth"
 import { isRecord } from "../../shared/record-type-guard"
 import { log } from "../../shared/logger"
 
@@ -9,7 +11,6 @@ export async function createIterationSession(
 ): Promise<string | null> {
   const createResult = await ctx.client.session.create({
     body: {
-      parentID: parentSessionID,
       title: "Ralph Loop Iteration",
     },
     query: { directory },
@@ -31,23 +32,28 @@ export async function selectSessionInTui(
   sessionID: string,
 ): Promise<boolean> {
   const selectSession = getSelectSessionApi(client)
-  if (!selectSession) {
-    return false
+  if (selectSession) {
+    const selectedViaApi = await trySelectSessionWithSdk(selectSession, sessionID)
+    if (selectedViaApi) {
+      return true
+    }
   }
 
-  try {
-    await selectSession({ body: { sessionID } })
-    return true
-  } catch (error: unknown) {
-    log("[ralph-loop] Failed to select session in TUI", {
-      sessionID,
-      error: String(error),
-    })
-    return false
+  const publish = getPublishTuiEventApi(client)
+  if (publish) {
+    const selectedViaPublish = await trySelectSessionWithPublish(publish, sessionID)
+    if (selectedViaPublish) {
+      return true
+    }
   }
+
+  return await trySelectSessionWithHttp(client, sessionID)
 }
 
 type SelectSessionApi = (args: { body: { sessionID: string } }) => Promise<unknown>
+type PublishTuiEventApi = (args: {
+  body: { type: "tui.session.select"; properties: { sessionID: string } }
+}) => Promise<unknown>
 
 function getSelectSessionApi(client: unknown): SelectSessionApi | null {
   if (!isRecord(client)) {
@@ -66,4 +72,114 @@ function getSelectSessionApi(client: unknown): SelectSessionApi | null {
   }
 
   return (selectSessionValue as Function).bind(tuiValue) as SelectSessionApi
+}
+
+function getPublishTuiEventApi(client: unknown): PublishTuiEventApi | null {
+  if (!isRecord(client)) {
+    return null
+  }
+
+  const clientRecord = client
+  const tuiValue = clientRecord.tui
+  if (!isRecord(tuiValue)) {
+    return null
+  }
+
+  const publishValue = tuiValue.publish
+  if (typeof publishValue !== "function") {
+    return null
+  }
+
+  return (publishValue as Function).bind(tuiValue) as PublishTuiEventApi
+}
+
+function hasError(result: unknown): boolean {
+  return isRecord(result) && result.error !== undefined && result.error !== null
+}
+
+async function trySelectSessionWithSdk(selectSession: SelectSessionApi, sessionID: string): Promise<boolean> {
+  try {
+    const v2Style = await selectSession({ sessionID } as never)
+    if (!hasError(v2Style)) {
+      return true
+    }
+  } catch (error: unknown) {
+    log("[ralph-loop] v2-style TUI select call failed, trying legacy shape", {
+      sessionID,
+      error: String(error),
+    })
+  }
+
+  try {
+    const v1Style = await selectSession({ body: { sessionID } })
+    if (!hasError(v1Style)) {
+      return true
+    }
+  } catch (error: unknown) {
+    log("[ralph-loop] Failed to select session in TUI via SDK", {
+      sessionID,
+      error: String(error),
+    })
+  }
+
+  return false
+}
+
+async function trySelectSessionWithPublish(publish: PublishTuiEventApi, sessionID: string): Promise<boolean> {
+  try {
+    const result = await publish({
+      body: {
+        type: "tui.session.select",
+        properties: { sessionID },
+      },
+    })
+
+    if (!hasError(result)) {
+      return true
+    }
+  } catch (error: unknown) {
+    log("[ralph-loop] Failed to select session via tui.publish", {
+      sessionID,
+      error: String(error),
+    })
+  }
+
+  return false
+}
+
+async function trySelectSessionWithHttp(client: unknown, sessionID: string): Promise<boolean> {
+  const baseUrl = getServerBaseUrl(client)
+  const authorization = getServerBasicAuthHeader()
+
+  if (!baseUrl || !authorization) {
+    return false
+  }
+
+  try {
+    const response = await fetch(`${baseUrl}/tui/select-session`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: authorization,
+      },
+      body: JSON.stringify({ sessionID }),
+      signal: AbortSignal.timeout(5000),
+    })
+
+    if (response.ok) {
+      return true
+    }
+
+    log("[ralph-loop] TUI session select request failed", {
+      sessionID,
+      status: response.status,
+    })
+  } catch (error: unknown) {
+    log("[ralph-loop] Failed to select session in TUI via HTTP fallback", {
+      sessionID,
+      error: String(error),
+    })
+  }
+
+  return false
 }

--- a/src/hooks/ralph-loop/session-reset-strategy.ts
+++ b/src/hooks/ralph-loop/session-reset-strategy.ts
@@ -9,10 +9,10 @@ export async function createIterationSession(
   parentSessionID: string,
   directory: string,
 ): Promise<string | null> {
+  void parentSessionID
+
   const createResult = await ctx.client.session.create({
-    body: {
-      title: "Ralph Loop Iteration",
-    },
+    body: {},
     query: { directory },
   })
 

--- a/src/hooks/ralph-loop/storage.ts
+++ b/src/hooks/ralph-loop/storage.ts
@@ -4,13 +4,6 @@ import { parseFrontmatter } from "../../shared/frontmatter"
 import type { RalphLoopState } from "./types"
 import { DEFAULT_STATE_FILE, DEFAULT_COMPLETION_PROMISE, DEFAULT_MAX_ITERATIONS } from "./constants"
 
-function toLiteralBlock(value: string): string {
-  return value
-    .split("\n")
-    .map((line) => `  ${line}`)
-    .join("\n")
-}
-
 export function getStateFilePath(directory: string, customPath?: string): string {
   return customPath
     ? join(directory, customPath)
@@ -62,10 +55,7 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
       max_iterations: Number(data.max_iterations) || DEFAULT_MAX_ITERATIONS,
       completion_promise: stripQuotes(data.completion_promise) || DEFAULT_COMPLETION_PROMISE,
       started_at: stripQuotes(data.started_at) || new Date().toISOString(),
-      prompt: body.trim(),
-      raw_task_arguments: typeof data.raw_task_arguments === "string"
-        ? data.raw_task_arguments
-        : undefined,
+      prompt: body,
       session_id: data.session_id ? stripQuotes(data.session_id) : undefined,
       ultrawork: data.ultrawork === true || data.ultrawork === "true" ? true : undefined,
       strategy: data.strategy === "reset" || data.strategy === "continue" ? data.strategy : undefined,
@@ -91,18 +81,16 @@ export function writeState(
     const sessionIdLine = state.session_id ? `session_id: "${state.session_id}"\n` : ""
     const ultraworkLine = state.ultrawork !== undefined ? `ultrawork: ${state.ultrawork}\n` : ""
     const strategyLine = state.strategy ? `strategy: "${state.strategy}"\n` : ""
-    const rawTaskArgumentsLine = state.raw_task_arguments
-      ? `raw_task_arguments: |-\n${toLiteralBlock(state.raw_task_arguments)}\n`
-      : ""
+    const promptBody = state.prompt
     const content = `---
+format_version: 2
 active: ${state.active}
 iteration: ${state.iteration}
 max_iterations: ${state.max_iterations}
 completion_promise: "${state.completion_promise}"
 started_at: "${state.started_at}"
-${sessionIdLine}${ultraworkLine}${strategyLine}${rawTaskArgumentsLine}---
-${state.prompt}
-`
+${sessionIdLine}${ultraworkLine}${strategyLine}---
+${promptBody}`
 
     writeFileSync(filePath, content, "utf-8")
     return true

--- a/src/hooks/ralph-loop/storage.ts
+++ b/src/hooks/ralph-loop/storage.ts
@@ -4,6 +4,13 @@ import { parseFrontmatter } from "../../shared/frontmatter"
 import type { RalphLoopState } from "./types"
 import { DEFAULT_STATE_FILE, DEFAULT_COMPLETION_PROMISE, DEFAULT_MAX_ITERATIONS } from "./constants"
 
+function toLiteralBlock(value: string): string {
+  return value
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n")
+}
+
 export function getStateFilePath(directory: string, customPath?: string): string {
   return customPath
     ? join(directory, customPath)
@@ -37,22 +44,28 @@ export function readState(directory: string, customPath?: string): RalphLoopStat
 
     const stripQuotes = (val: unknown): string => {
       const str = String(val ?? "")
-      return str.replace(/^["']|["']$/g, "")
+      const startsWithDouble = str.startsWith('"')
+      const endsWithDouble = str.endsWith('"')
+      const startsWithSingle = str.startsWith("'")
+      const endsWithSingle = str.endsWith("'")
+
+      if ((startsWithDouble && endsWithDouble) || (startsWithSingle && endsWithSingle)) {
+        return str.slice(1, -1)
+      }
+
+      return str
     }
 
     return {
       active: isActive,
       iteration: iterationNum,
       max_iterations: Number(data.max_iterations) || DEFAULT_MAX_ITERATIONS,
-      message_count_at_start:
-        typeof data.message_count_at_start === "number"
-          ? data.message_count_at_start
-          : typeof data.message_count_at_start === "string" && data.message_count_at_start.trim() !== ""
-            ? Number(data.message_count_at_start)
-            : undefined,
       completion_promise: stripQuotes(data.completion_promise) || DEFAULT_COMPLETION_PROMISE,
       started_at: stripQuotes(data.started_at) || new Date().toISOString(),
       prompt: body.trim(),
+      raw_task_arguments: typeof data.raw_task_arguments === "string"
+        ? data.raw_task_arguments
+        : undefined,
       session_id: data.session_id ? stripQuotes(data.session_id) : undefined,
       ultrawork: data.ultrawork === true || data.ultrawork === "true" ? true : undefined,
       strategy: data.strategy === "reset" || data.strategy === "continue" ? data.strategy : undefined,
@@ -78,17 +91,16 @@ export function writeState(
     const sessionIdLine = state.session_id ? `session_id: "${state.session_id}"\n` : ""
     const ultraworkLine = state.ultrawork !== undefined ? `ultrawork: ${state.ultrawork}\n` : ""
     const strategyLine = state.strategy ? `strategy: "${state.strategy}"\n` : ""
-    const messageCountAtStartLine =
-      typeof state.message_count_at_start === "number"
-        ? `message_count_at_start: ${state.message_count_at_start}\n`
-        : ""
+    const rawTaskArgumentsLine = state.raw_task_arguments
+      ? `raw_task_arguments: |-\n${toLiteralBlock(state.raw_task_arguments)}\n`
+      : ""
     const content = `---
 active: ${state.active}
 iteration: ${state.iteration}
 max_iterations: ${state.max_iterations}
 completion_promise: "${state.completion_promise}"
 started_at: "${state.started_at}"
-${sessionIdLine}${ultraworkLine}${strategyLine}${messageCountAtStartLine}---
+${sessionIdLine}${ultraworkLine}${strategyLine}${rawTaskArgumentsLine}---
 ${state.prompt}
 `
 

--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -18,4 +18,5 @@ export interface RalphLoopOptions {
   getTranscriptPath?: (sessionId: string) => string
   apiTimeout?: number
   checkSessionExists?: (sessionId: string) => Promise<boolean>
+  onLoopCompleted?: (sessionId: string) => Promise<void> | void
 }

--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -19,4 +19,5 @@ export interface RalphLoopOptions {
   apiTimeout?: number
   checkSessionExists?: (sessionId: string) => Promise<boolean>
   onLoopCompleted?: (sessionId: string) => Promise<void> | void
+  shouldDeferIteration?: (sessionId: string) => Promise<boolean> | boolean
 }

--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -8,7 +8,6 @@ export interface RalphLoopState {
   completion_promise: string
   started_at: string
   prompt: string
-  raw_task_arguments?: string
   session_id?: string
   ultrawork?: boolean
   strategy?: "reset" | "continue"

--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -8,6 +8,7 @@ export interface RalphLoopState {
   completion_promise: string
   started_at: string
   prompt: string
+  raw_task_arguments?: string
   session_id?: string
   ultrawork?: boolean
   strategy?: "reset" | "continue"

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -1,6 +1,7 @@
-import { describe, test, expect } from "bun:test"
+import { beforeEach, describe, test, expect } from "bun:test"
 
 import { createChatMessageHandler } from "./chat-message"
+import { clearSessionVariant, getSessionVariant, setSessionVariant } from "../shared/session-model-state"
 
 type ChatMessagePart = { type: string; text?: string; [key: string]: unknown }
 type ChatMessageHandlerOutput = { message: Record<string, unknown>; parts: ChatMessagePart[] }
@@ -47,6 +48,10 @@ function createMockOutput(variant?: string): ChatMessageHandlerOutput {
 }
 
 describe("createChatMessageHandler - TUI variant passthrough", () => {
+  beforeEach(() => {
+    clearSessionVariant("test-session")
+  })
+
   test("first message: does not override TUI variant when user has no selection", async () => {
     //#given - first message, no user-selected variant
     const args = createMockHandlerArgs({ shouldOverride: true })
@@ -101,6 +106,46 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
 
     //#then - should stay undefined, not auto-resolved from config
     expect(output.message["variant"]).toBeUndefined()
+  })
+
+  test("persists explicit variant and reuses it when next message omits variant", async () => {
+    //#given
+    const args = createMockHandlerArgs({ shouldOverride: false })
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+
+    const firstOutput = createMockOutput("medium")
+
+    //#when
+    await handler(input, firstOutput)
+    const secondOutput = createMockOutput()
+    await handler(input, secondOutput)
+
+    //#then
+    expect(firstOutput.message["variant"]).toBe("medium")
+    expect(secondOutput.message["variant"]).toBe("medium")
+  })
+
+  test("does not re-inject persisted variant when model fallback explicitly removes variant", async () => {
+    //#given
+    const args = createMockHandlerArgs({ shouldOverride: false })
+    args.hooks.modelFallback = {
+      "chat.message": async (_input: { sessionID: string }, output: ChatMessageHandlerOutput): Promise<void> => {
+        delete output.message["variant"]
+      },
+    }
+    setSessionVariant("test-session", "max")
+
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+    const output = createMockOutput()
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.message["variant"]).toBeUndefined()
+    expect(getSessionVariant("test-session")).toBeUndefined()
   })
 
   test("first message: marks gate as applied regardless of variant presence", async () => {

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, test, expect } from "bun:test"
 
 import { createChatMessageHandler } from "./chat-message"
 import { clearSessionVariant, getSessionVariant, setSessionVariant } from "../shared/session-model-state"
+import { buildResetIterationPrompt } from "../hooks/ralph-loop/reset-iteration-prompt-builder"
 
 type ChatMessagePart = { type: string; text?: string; [key: string]: unknown }
 type ChatMessageHandlerOutput = { message: Record<string, unknown>; parts: ChatMessagePart[] }
@@ -11,8 +12,20 @@ function createMockHandlerArgs(overrides?: {
   shouldOverride?: boolean
 }) {
   const appliedSessions: string[] = []
+  const sessionUpdateCalls: unknown[] = []
   return {
-    ctx: { client: { tui: { showToast: async () => {} } } } as any,
+    ctx: {
+      directory: "/tmp/test-project",
+      client: {
+        tui: { showToast: async () => {} },
+        session: {
+          update: async (params: unknown) => {
+            sessionUpdateCalls.push(params)
+            return {}
+          },
+        },
+      },
+    } as any,
     pluginConfig: (overrides?.pluginConfig ?? {}) as any,
     firstMessageVariantGate: {
       shouldOverride: () => overrides?.shouldOverride ?? false,
@@ -28,6 +41,7 @@ function createMockHandlerArgs(overrides?: {
       ralphLoop: null,
     } as any,
     _appliedSessions: appliedSessions,
+    _sessionUpdateCalls: sessionUpdateCalls,
   }
 }
 
@@ -187,4 +201,97 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
     expect(output.parts).toHaveLength(1)
     expect(output.parts[0].text).toContain("[BACKGROUND TASK COMPLETED]")
   })
+
+  test("does not restart active ralph loop when reset iteration prompt is injected into new session", async () => {
+    const startLoopCalls: Array<{ sessionID: string; prompt: string }> = []
+    const args = createMockHandlerArgs()
+    args.hooks.ralphLoop = {
+      getState: () => ({
+        active: true,
+        iteration: 2,
+        max_iterations: 2,
+        completion_promise: "DONE",
+        started_at: new Date().toISOString(),
+        prompt: "Say hi",
+        session_id: "test-session",
+        strategy: "reset",
+      }),
+      startLoop: (sessionID: string, prompt: string) => {
+        startLoopCalls.push({ sessionID, prompt })
+        return true
+      },
+      cancelLoop: () => false,
+      event: async () => {},
+      setOnLoopCompleted: () => {},
+    }
+
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+    const output = createMockOutput()
+    output.parts = [
+      {
+        type: "text",
+        text: buildResetIterationPrompt({
+          active: true,
+          iteration: 2,
+          max_iterations: 2,
+          completion_promise: "DONE",
+          started_at: new Date().toISOString(),
+          prompt: "Say hi",
+          session_id: "test-session",
+          strategy: "reset",
+        }),
+      },
+    ]
+
+    await handler(input, output)
+
+    expect(startLoopCalls).toHaveLength(0)
+  })
+
+  test("does not start a new ralph loop for reset iteration prompt even before state rebinding", async () => {
+    const startLoopCalls: Array<{ sessionID: string; prompt: string }> = []
+    const args = createMockHandlerArgs()
+    args.hooks.ralphLoop = {
+      getState: () => ({
+        active: true,
+        iteration: 2,
+        max_iterations: 10,
+        completion_promise: "DONE",
+        started_at: new Date().toISOString(),
+        prompt: "Say hi",
+        session_id: "old-session",
+        strategy: "reset",
+      }),
+      startLoop: (sessionID: string, prompt: string) => {
+        startLoopCalls.push({ sessionID, prompt })
+        return true
+      },
+      cancelLoop: () => false,
+      event: async () => {},
+      setOnLoopCompleted: () => {},
+    }
+
+    const handler = createChatMessageHandler(args)
+    const input = { ...createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" }), sessionID: "new-session" }
+    const output = createMockOutput()
+    output.parts = [{
+      type: "text",
+      text: buildResetIterationPrompt({
+        active: true,
+        iteration: 2,
+        max_iterations: 10,
+        completion_promise: "DONE",
+        started_at: new Date().toISOString(),
+        prompt: "Say hi",
+        session_id: "new-session",
+        strategy: "reset",
+      }),
+    }]
+
+    await handler(input, output)
+
+    expect(startLoopCalls).toHaveLength(0)
+  })
+
 })

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -202,6 +202,120 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
     expect(output.parts[0].text).toContain("[BACKGROUND TASK COMPLETED]")
   })
 
+  test("updates session title for first reset iteration", async () => {
+    const args = createMockHandlerArgs()
+    let loopState: {
+      active: boolean
+      iteration: number
+      max_iterations: number
+      completion_promise: string
+      started_at: string
+      prompt: string
+      session_id: string
+      strategy: "reset"
+    } | null = null
+
+    args.hooks.ralphLoop = {
+      getState: () => loopState,
+      startLoop: (
+        sessionID: string,
+        prompt: string,
+        options?: { maxIterations?: number; completionPromise?: string; strategy?: "reset" | "continue" },
+      ) => {
+        loopState = {
+          active: true,
+          iteration: 1,
+          max_iterations: options?.maxIterations ?? 100,
+          completion_promise: options?.completionPromise ?? "DONE",
+          started_at: new Date().toISOString(),
+          prompt,
+          session_id: sessionID,
+          strategy: "reset",
+        }
+        return true
+      },
+      cancelLoop: () => false,
+      event: async () => {},
+      setOnLoopCompleted: () => {},
+    }
+
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+    const output = createMockOutput()
+    output.parts = [
+      {
+        type: "text",
+        text: `You are starting a Ralph Loop\n<user-task>"Build title handling" --strategy=reset --max-iterations=50</user-task>`,
+      },
+    ]
+
+    await handler(input, output)
+
+    expect(args._sessionUpdateCalls).toHaveLength(1)
+    expect(args._sessionUpdateCalls[0]).toEqual({
+      path: { id: "test-session" },
+      body: { title: "Ralph loop iteration 1/50" },
+      query: { directory: "/tmp/test-project" },
+    })
+  })
+
+  test("updates session title for first continue iteration", async () => {
+    const args = createMockHandlerArgs()
+    let loopState: {
+      active: boolean
+      iteration: number
+      max_iterations: number
+      completion_promise: string
+      started_at: string
+      prompt: string
+      session_id: string
+      strategy: "continue"
+    } | null = null
+
+    args.hooks.ralphLoop = {
+      getState: () => loopState,
+      startLoop: (
+        sessionID: string,
+        prompt: string,
+        options?: { maxIterations?: number; completionPromise?: string; strategy?: "reset" | "continue" },
+      ) => {
+        loopState = {
+          active: true,
+          iteration: 1,
+          max_iterations: options?.maxIterations ?? 100,
+          completion_promise: options?.completionPromise ?? "DONE",
+          started_at: new Date().toISOString(),
+          prompt,
+          session_id: sessionID,
+          strategy: "continue",
+        }
+        return true
+      },
+      cancelLoop: () => false,
+      event: async () => {},
+      setOnLoopCompleted: () => {},
+    }
+
+    const handler = createChatMessageHandler(args)
+    const input = createMockInput("hephaestus", { providerID: "openai", modelID: "gpt-5.3-codex" })
+    const output = createMockOutput()
+    output.parts = [
+      {
+        type: "text",
+        text: `You are starting a Ralph Loop\n<user-task>"Build title handling" --strategy=continue --max-iterations=50</user-task>`,
+      },
+    ]
+
+    await handler(input, output)
+
+    expect(args._sessionUpdateCalls).toHaveLength(1)
+    expect(args._sessionUpdateCalls[0]).toEqual({
+      path: { id: "test-session" },
+      body: { title: "Ralph loop iteration 1/50" },
+      query: { directory: "/tmp/test-project" },
+    })
+  })
+
   test("does not restart active ralph loop when reset iteration prompt is injected into new session", async () => {
     const startLoopCalls: Array<{ sessionID: string; prompt: string }> = []
     const args = createMockHandlerArgs()

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -180,6 +180,7 @@ export function createChatMessageHandler(args: {
           maxIterations: parsedArguments.maxIterations,
           completionPromise: parsedArguments.completionPromise,
           strategy: parsedArguments.strategy,
+          rawTaskArguments: rawTask,
         })
 
         if (started) {

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -11,6 +11,7 @@ import {
 import { setSessionAgent } from "../features/claude-code-session-state"
 import { applyUltraworkModelOverrideOnMessage } from "./ultrawork-model-override"
 import { parseRalphLoopArguments } from "../hooks/ralph-loop/command-arguments"
+import { updateIterationSessionTitle } from "../hooks/ralph-loop/iteration-session-title"
 
 import type { CreatedHooks } from "../create-hooks"
 
@@ -175,11 +176,28 @@ export function createChatMessageHandler(args: {
         const rawTask = taskMatch?.[1]?.trim() || ""
         const parsedArguments = parseRalphLoopArguments(rawTask)
 
-        hooks.ralphLoop.startLoop(input.sessionID, parsedArguments.prompt, {
+        const started = hooks.ralphLoop.startLoop(input.sessionID, parsedArguments.prompt, {
           maxIterations: parsedArguments.maxIterations,
           completionPromise: parsedArguments.completionPromise,
           strategy: parsedArguments.strategy,
         })
+
+        if (started) {
+          const loopState = hooks.ralphLoop.getState()
+          if (
+            loopState?.active &&
+            loopState.session_id === input.sessionID &&
+            (loopState.strategy === "reset" || loopState.strategy === "continue")
+          ) {
+            await updateIterationSessionTitle(
+              ctx.client,
+              input.sessionID,
+              ctx.directory,
+              loopState.iteration,
+              loopState.max_iterations,
+            )
+          }
+        }
       } else if (isCancelRalphTemplate) {
         hooks.ralphLoop.cancelLoop(input.sessionID)
       }

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -159,11 +159,18 @@ export function createChatMessageHandler(args: {
       const isRalphLoopTemplate =
         promptText.includes("You are starting a Ralph Loop") &&
         promptText.includes("<user-task>")
+      const isRalphResetIterationPrompt =
+        promptText.includes("[RALPH LOOP - Iteration ") &&
+        promptText.includes("<command-instruction>") &&
+        promptText.includes("<user-task>")
       const isCancelRalphTemplate = promptText.includes(
         "Cancel the currently active Ralph Loop",
       )
+      const activeRalphLoopState = hooks.ralphLoop.getState()
+      const isActiveRalphLoopSession =
+        activeRalphLoopState?.active === true && activeRalphLoopState.session_id === input.sessionID
 
-      if (isRalphLoopTemplate) {
+      if (isRalphLoopTemplate && !isRalphResetIterationPrompt && !isActiveRalphLoopSession) {
         const taskMatch = promptText.match(/<user-task>\s*([\s\S]*?)\s*<\/user-task>/i)
         const rawTask = taskMatch?.[1]?.trim() || ""
         const parsedArguments = parseRalphLoopArguments(rawTask)

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -180,7 +180,6 @@ export function createChatMessageHandler(args: {
           maxIterations: parsedArguments.maxIterations,
           completionPromise: parsedArguments.completionPromise,
           strategy: parsedArguments.strategy,
-          rawTaskArguments: rawTask,
         })
 
         if (started) {

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -2,7 +2,12 @@ import type { OhMyOpenCodeConfig } from "../config"
 import type { PluginContext } from "./types"
 
 import { hasConnectedProvidersCache } from "../shared"
-import { setSessionModel } from "../shared/session-model-state"
+import {
+  clearSessionVariant,
+  getSessionVariant,
+  setSessionModel,
+  setSessionVariant,
+} from "../shared/session-model-state"
 import { setSessionAgent } from "../features/claude-code-session-state"
 import { applyUltraworkModelOverrideOnMessage } from "./ultrawork-model-override"
 import { parseRalphLoopArguments } from "../hooks/ralph-loop/command-arguments"
@@ -70,6 +75,8 @@ export function createChatMessageHandler(args: {
     input: ChatMessageInput,
     output: ChatMessageHandlerOutput
   ): Promise<void> => {
+    let injectedPersistedVariant = false
+
     if (input.agent) {
       setSessionAgent(input.sessionID, input.agent)
     }
@@ -78,9 +85,26 @@ export function createChatMessageHandler(args: {
       firstMessageVariantGate.markApplied(input.sessionID)
     }
 
+    const initialVariant = output.message["variant"]
+    if (!(typeof initialVariant === "string" && initialVariant.length > 0)) {
+      const persistedVariant = getSessionVariant(input.sessionID)
+      if (persistedVariant !== undefined) {
+        output.message["variant"] = persistedVariant
+        injectedPersistedVariant = true
+      }
+    }
+
     if (!isRuntimeFallbackEnabled) {
       await hooks.modelFallback?.["chat.message"]?.(input, output)
     }
+
+    const outputVariant = output.message["variant"]
+    if (typeof outputVariant === "string" && outputVariant.length > 0) {
+      setSessionVariant(input.sessionID, outputVariant)
+    } else if (injectedPersistedVariant) {
+      clearSessionVariant(input.sessionID)
+    }
+
     const modelOverride = output.message["model"]
     if (
       modelOverride &&

--- a/src/plugin/event.session-variant-cleanup.test.ts
+++ b/src/plugin/event.session-variant-cleanup.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+
+import { createEventHandler } from "./event"
+import { getSessionVariant, setSessionVariant } from "../shared/session-model-state"
+
+describe("createEventHandler session variant cleanup", () => {
+  test("clears persisted session variant on session.deleted", async () => {
+    const sessionID = "ses_cleanup_variant"
+    setSessionVariant(sessionID, "high")
+
+    const eventHandler = createEventHandler({
+      ctx: {} as never,
+      pluginConfig: {} as never,
+      firstMessageVariantGate: {
+        markSessionCreated: () => {},
+        clear: () => {},
+      },
+      managers: {
+        skillMcpManager: {
+          disconnectSession: async () => {},
+        },
+        tmuxSessionManager: {
+          onSessionCreated: async () => {},
+          onSessionDeleted: async () => {},
+        },
+      } as never,
+      hooks: {
+        writeExistingFileGuard: {
+          event: async () => {},
+        },
+      } as never,
+    })
+
+    await eventHandler({
+      event: {
+        type: "session.deleted",
+        properties: { info: { id: sessionID } },
+      },
+    } as never)
+
+    expect(getSessionVariant(sessionID)).toBeUndefined()
+  })
+})

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -18,7 +18,7 @@ import {
 import { resetMessageCursor } from "../shared";
 import { log } from "../shared/logger";
 import { shouldRetryError } from "../shared/model-error-classifier";
-import { clearSessionModel, setSessionModel } from "../shared/session-model-state";
+import { clearSessionModel, clearSessionVariant, setSessionModel } from "../shared/session-model-state";
 import { deleteSessionTools } from "../shared/session-tools-store";
 import { lspManager } from "../tools";
 
@@ -245,6 +245,7 @@ export function createEventHandler(args: {
         resetMessageCursor(sessionInfo.id);
         firstMessageVariantGate.clear(sessionInfo.id);
         clearSessionModel(sessionInfo.id);
+        clearSessionVariant(sessionInfo.id);
         syncSubagentSessions.delete(sessionInfo.id);
         deleteSessionTools(sessionInfo.id);
         await managers.skillMcpManager.disconnectSession(sessionInfo.id);

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -77,6 +77,7 @@ export function createToolExecuteBeforeHandler(args: {
           maxIterations: parsedArguments.maxIterations,
           completionPromise: parsedArguments.completionPromise,
           strategy: parsedArguments.strategy,
+          rawTaskArguments: rawArgs,
         })
       } else if (command === "cancel-ralph" && sessionID) {
         hooks.ralphLoop.cancelLoop(sessionID)
@@ -89,6 +90,7 @@ export function createToolExecuteBeforeHandler(args: {
           maxIterations: parsedArguments.maxIterations,
           completionPromise: parsedArguments.completionPromise,
           strategy: parsedArguments.strategy,
+          rawTaskArguments: rawArgs,
         })
       }
     }

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -77,7 +77,6 @@ export function createToolExecuteBeforeHandler(args: {
           maxIterations: parsedArguments.maxIterations,
           completionPromise: parsedArguments.completionPromise,
           strategy: parsedArguments.strategy,
-          rawTaskArguments: rawArgs,
         })
       } else if (command === "cancel-ralph" && sessionID) {
         hooks.ralphLoop.cancelLoop(sessionID)
@@ -90,7 +89,6 @@ export function createToolExecuteBeforeHandler(args: {
           maxIterations: parsedArguments.maxIterations,
           completionPromise: parsedArguments.completionPromise,
           strategy: parsedArguments.strategy,
-          rawTaskArguments: rawArgs,
         })
       }
     }

--- a/src/shared/session-model-state.test.ts
+++ b/src/shared/session-model-state.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { clearSessionModel, getSessionModel, setSessionModel } from "./session-model-state"
+import {
+  clearSessionModel,
+  clearSessionVariant,
+  getSessionModel,
+  getSessionVariant,
+  setSessionModel,
+  setSessionVariant,
+} from "./session-model-state"
 
 describe("session-model-state", () => {
   test("stores and retrieves a session model", () => {
@@ -26,5 +33,28 @@ describe("session-model-state", () => {
 
     //#then
     expect(getSessionModel(sessionID)).toBeUndefined()
+  })
+
+  test("stores and retrieves a session variant", () => {
+    //#given
+    const sessionID = "ses_variant"
+
+    //#when
+    setSessionVariant(sessionID, "medium")
+
+    //#then
+    expect(getSessionVariant(sessionID)).toBe("medium")
+  })
+
+  test("clears a session variant", () => {
+    //#given
+    const sessionID = "ses_variant_clear"
+    setSessionVariant(sessionID, "xhigh")
+
+    //#when
+    clearSessionVariant(sessionID)
+
+    //#then
+    expect(getSessionVariant(sessionID)).toBeUndefined()
   })
 })

--- a/src/shared/session-model-state.ts
+++ b/src/shared/session-model-state.ts
@@ -1,6 +1,7 @@
 export type SessionModel = { providerID: string; modelID: string }
 
 const sessionModels = new Map<string, SessionModel>()
+const sessionVariants = new Map<string, string>()
 
 export function setSessionModel(sessionID: string, model: SessionModel): void {
   sessionModels.set(sessionID, model)
@@ -12,4 +13,16 @@ export function getSessionModel(sessionID: string): SessionModel | undefined {
 
 export function clearSessionModel(sessionID: string): void {
   sessionModels.delete(sessionID)
+}
+
+export function setSessionVariant(sessionID: string, variant: string): void {
+  sessionVariants.set(sessionID, variant)
+}
+
+export function getSessionVariant(sessionID: string): string | undefined {
+  return sessionVariants.get(sessionID)
+}
+
+export function clearSessionVariant(sessionID: string): void {
+  sessionVariants.delete(sessionID)
 }


### PR DESCRIPTION
## Summary
- Finalized Ralph loop strategy behavior so omitted `--strategy` follows `ralph_loop.default_strategy` (with config fallback to `continue`).
- Stabilized reset-iteration flow (fresh top-level session per iteration with deterministic iteration titles) and preserved continue-mode session continuity.
- Documented the missing strategy surface in `docs/*`: `--strategy=continue|reset`, `default_strategy`, precedence rules, and practical guidance for when to use each loop style.

## Why this change
The Ralph loop strategy switch is not cosmetic: `continue` and `reset` represent opposing operating philosophies.
- `continue` = hot-context continuity in one thread (great for HITL and debugging continuity).
- `reset` = fresh-context iteration isolation (great for longer AFK runs and reducing context-rot pressure).

Given that these modes are meaningfully different, docs now explicitly call out behavioral and philosophical differences so users can intentionally choose the right loop style.

## What changed
### Runtime / hook behavior
- Follow-up fixes in this branch ensure strategy semantics stay coherent across reset/continue loop execution.
- Omitted `--strategy` now resolves via config (`ralph_loop.default_strategy`) rather than hardcoded behavior.
- Reset iterations keep deterministic iteration session titles and are handled as fresh top-level sessions.

### Documentation
Updated:
- `docs/reference/features.md`
  - Added full `/ralph-loop` flag docs including `--strategy`.
  - Added explicit `continue` vs `reset` comparison table and usage guidance.
  - Added config snippet including `default_strategy`.
- `docs/reference/configuration.md`
  - Added dedicated `ralph_loop` subsection including `default_strategy`.
  - Added precedence rules (`--strategy` flag > config > fallback).

## Validation and real-world testing
I validated this branch against real loop usage patterns and edge paths, including both strategies:
- Continue strategy behavior (same-session continuation and prompt injection flow)
- Reset strategy behavior (fresh-session iteration flow, title updates, TUI session switching)
- Loop-state handling and completion/continuation boundaries
- Hook interactions around continuation and reset timing/race conditions

Executed:
- `bun test src/hooks/ralph-loop/index.test.ts src/hooks/ralph-loop/session-reset-strategy.test.ts src/hooks/ralph-loop/reset-strategy-race-condition.test.ts src/plugin/chat-message.test.ts`
- `bun run typecheck`
- `bun run build`

## References
- Geoffrey Huntley — *everything is a ralph loop*: https://ghuntley.com/loop/
- Geoffrey Huntley — *Ralph Wiggum as a software engineer*: https://ghuntley.com/ralph/
- AI Hero — *11 Tips For AI Coding With Ralph Wiggum*: https://www.aihero.dev/tips-for-ai-coding-with-ralph-wiggum
- AI Hero — *Why the Anthropic Ralph plugin sucks (use a bash loop instead)*: https://www.aihero.dev/why-the-anthropic-ralph-plugin-sucks