### PR TITLE
test

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,22 @@
+{
+  "mcpServers": {
+    "context-engine": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@context-engine-bridge/context-engine-mcp-bridge",
+        "mcp-serve",
+        "--workspace",
+        "/Users/mirlok/Desktop/Context-Engine",
+        "--indexer-url",
+        "http://localhost:8003/mcp",
+        "--memory-url",
+        "http://localhost:8002/mcp"
+      ],
+      "env": {
+        "COLLECTION_NAME": "Context-Engine-41e67959"
+      }
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,22 +1,12 @@
 {
   "mcpServers": {
-    "context-engine": {
-      "type": "stdio",
-      "command": "npx",
-      "args": [
-        "-y",
-        "@context-engine-bridge/context-engine-mcp-bridge",
-        "mcp-serve",
-        "--workspace",
-        "/Users/mirlok/Desktop/Context-Engine",
-        "--indexer-url",
-        "http://localhost:8003/mcp",
-        "--memory-url",
-        "http://localhost:8002/mcp"
-      ],
-      "env": {
-        "COLLECTION_NAME": "Context-Engine-41e67959"
-      }
+    "context-engine-indexer": {
+      "type": "remote",
+      "url": "http://localhost:8003/mcp"
+    },
+    "context-engine-memory": {
+      "type": "remote",
+      "url": "http://localhost:8002/mcp"
     }
   }
 }

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -40,7 +40,8 @@
         "enum": [
           "playwright",
           "frontend-ui-ux",
-          "git-master"
+          "git-master",
+          "context-engine"
         ]
       }
     },

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -33,6 +33,7 @@ export const BuiltinSkillNameSchema = z.enum([
   "playwright",
   "frontend-ui-ux",
   "git-master",
+  "context-engine",
 ])
 
 export const OverridableAgentNameSchema = z.enum([

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -92,6 +92,76 @@ Match implementation complexity to aesthetic vision:
 Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. You are capable of extraordinary creative work—don't hold back.`,
 }
 
+const contextEngineSkill: BuiltinSkill = {
+  name: "context-engine",
+  description:
+    "MCP Tool Selection Rules for Context-Engine. Use MCP tools for semantic code search, symbol graphs, memory, and codebase exploration. Favor context-engine tools over grep/literal search.",
+  template: `# Context-Engine MCP Tool Selection
+
+**Core principle:** Context-Engine MCP tools are PRIMARY for exploring code and history. Start with MCP for exploration, debugging, or "where/why" questions; use literal search only for exact-literal lookups.
+
+## When to Use MCP Tools
+
+- Exploring code without knowing exact strings/symbols
+- Need semantic or cross-file understanding (relationships, patterns, architecture)
+- Want ranked results with surrounding context, not just line hits
+- Asking conceptual/architectural or "where/why" behavior questions
+- Need rich context/snippets around matches
+
+## When to Use Literal Search (grep)
+
+- Know exact string/function/variable or error message
+- Only need to confirm existence or file/line quickly (not to understand behavior)
+
+## Tool Quick Reference
+
+| Tool | Use Case |
+|------|----------|
+| \`repo_search\` | General code search - "where is X implemented?" |
+| \`context_answer\` | NL explanations with citations - "What does module X do?" |
+| \`info_request\` | Quick discovery with summaries - broad architecture overviews |
+| \`symbol_graph\` | Call/import/definition graphs - "who calls this function?" |
+| \`neo4j_graph_query\` | Advanced traversals - impact analysis, transitive callers, cycles |
+| \`memory_store\` / \`memory_find\` | Store and retrieve knowledge/notes |
+| \`search_tests_for\` | Find test files for a query |
+| \`search_config_for\` | Find configuration files |
+| \`change_history_for_path\` | File change summary |
+| \`search_commits_for\` | Search git commit history |
+
+## Query Style
+
+Write queries as short natural-language fragments:
+- "database connection handling"
+- "error reporting patterns"
+- "authentication mechanisms"
+
+Do NOT use boolean operators (OR, AND), regex, or code patterns in semantic queries.
+
+## Performance Tips
+
+- Start with \`limit=3\`, \`compact=true\` for discovery
+- Increase to \`limit=5\`, \`include_snippet=true\` for details
+- Use \`output_format="toon"\` for 60-80% token reduction
+- Apply \`language\` and \`under\` filters to narrow scope
+
+## Grep Anti-Patterns (DON'T)
+
+\`\`\`bash
+grep -r "auth" .        # → Use MCP: "authentication mechanisms"
+grep -r "cache" .       # → Use MCP: "caching strategies"
+grep -r "error" .       # → Use MCP: "error handling patterns"
+\`\`\`
+
+## Grep Patterns (DO)
+
+\`\`\`bash
+grep -rn "UserAlreadyExists" .    # Specific error class
+grep -rn "REDIS_HOST" .           # Exact environment variable
+\`\`\`
+
+**If in doubt → start with MCP**`,
+}
+
 const gitMasterSkill: BuiltinSkill = {
   name: "git-master",
   description:
@@ -1199,5 +1269,5 @@ POTENTIAL ACTIONS:
 }
 
 export function createBuiltinSkills(): BuiltinSkill[] {
-  return [playwrightSkill, frontendUiUxSkill, gitMasterSkill]
+  return [playwrightSkill, frontendUiUxSkill, gitMasterSkill, contextEngineSkill]
 }

--- a/src/mcp/context-engine-mcp.ts
+++ b/src/mcp/context-engine-mcp.ts
@@ -1,19 +1,31 @@
 /**
- * Context-Engine MCP configuration for desktop usage.
+ * Context-Engine MCP configurations for semantic code search and memory.
  * 
- * This provides a fallback HTTP remote MCP config for context-engine.
- * If users have context-engine configured in their opencode.json with
- * a local command (bridge), that takes precedence.
+ * Two separate MCPs:
+ * - Indexer (8003): Code indexing, symbol graphs, semantic search
+ * - Memory (8002): Persistent memory, context storage
+ * 
+ * ENABLED BY DEFAULT: Assumes context-engine services are running.
+ * Disable via environment variable if not using context-engine.
  * 
  * Environment variables:
- * - CONTEXT_ENGINE_URL: Override the default URL (default: http://127.0.0.1:30810/mcp)
- * - CONTEXT_ENGINE_ENABLED: Set to "false" to disable (default: true)
+ * - CONTEXT_ENGINE_INDEXER_URL: Override indexer URL (default: http://localhost:8003/mcp)
+ * - CONTEXT_ENGINE_MEMORY_URL: Override memory URL (default: http://localhost:8002/mcp)
+ * - CONTEXT_ENGINE_DISABLED: Set to "true" to disable (default: false)
  */
-export const context_engine_mcp = {
+export const context_engine_indexer_mcp = {
   type: "remote" as const,
-  url: process.env.CONTEXT_ENGINE_URL ?? "http://127.0.0.1:30810/mcp",
-  enabled: process.env.CONTEXT_ENGINE_ENABLED !== "false",
+  url: process.env.CONTEXT_ENGINE_INDEXER_URL ?? "http://localhost:8003/mcp",
+  enabled: process.env.CONTEXT_ENGINE_DISABLED !== "true",
   oauth: false as const,
 }
 
-export const MCP_NAME = "context-engine"
+export const context_engine_memory_mcp = {
+  type: "remote" as const,
+  url: process.env.CONTEXT_ENGINE_MEMORY_URL ?? "http://localhost:8002/mcp",
+  enabled: process.env.CONTEXT_ENGINE_DISABLED !== "true",
+  oauth: false as const,
+}
+
+export const MCP_NAME_INDEXER = "context-engine-indexer"
+export const MCP_NAME_MEMORY = "context-engine-memory"

--- a/src/mcp/context-engine-mcp.ts
+++ b/src/mcp/context-engine-mcp.ts
@@ -1,0 +1,19 @@
+/**
+ * Context-Engine MCP configuration for desktop usage.
+ * 
+ * This provides a fallback HTTP remote MCP config for context-engine.
+ * If users have context-engine configured in their opencode.json with
+ * a local command (bridge), that takes precedence.
+ * 
+ * Environment variables:
+ * - CONTEXT_ENGINE_URL: Override the default URL (default: http://127.0.0.1:30810/mcp)
+ * - CONTEXT_ENGINE_ENABLED: Set to "false" to disable (default: true)
+ */
+export const context_engine_mcp = {
+  type: "remote" as const,
+  url: process.env.CONTEXT_ENGINE_URL ?? "http://127.0.0.1:30810/mcp",
+  enabled: process.env.CONTEXT_ENGINE_ENABLED !== "false",
+  oauth: false as const,
+}
+
+export const MCP_NAME = "context-engine"

--- a/src/mcp/index.test.ts
+++ b/src/mcp/index.test.ts
@@ -13,8 +13,11 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(result).toHaveProperty("context-engine")
-    expect(Object.keys(result)).toHaveLength(4)
+    expect(result).toHaveProperty("context-engine-indexer")
+    expect(result).toHaveProperty("context-engine-memory")
+    expect(result["context-engine-indexer"].enabled).toBe(true)
+    expect(result["context-engine-memory"].enabled).toBe(true)
+    expect(Object.keys(result)).toHaveLength(5)
   })
 
   test("should filter out disabled built-in MCPs", () => {
@@ -28,13 +31,14 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).not.toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(result).toHaveProperty("context-engine")
-    expect(Object.keys(result)).toHaveLength(3)
+    expect(result).toHaveProperty("context-engine-indexer")
+    expect(result).toHaveProperty("context-engine-memory")
+    expect(Object.keys(result)).toHaveLength(4)
   })
 
   test("should filter out all built-in MCPs when all disabled", () => {
     //#given
-    const disabledMcps = ["websearch", "context7", "grep_app", "context-engine"]
+    const disabledMcps = ["websearch", "context7", "grep_app", "context-engine-indexer", "context-engine-memory"]
 
     //#when
     const result = createBuiltinMcps(disabledMcps)
@@ -43,7 +47,8 @@ describe("createBuiltinMcps", () => {
     expect(result).not.toHaveProperty("websearch")
     expect(result).not.toHaveProperty("context7")
     expect(result).not.toHaveProperty("grep_app")
-    expect(result).not.toHaveProperty("context-engine")
+    expect(result).not.toHaveProperty("context-engine-indexer")
+    expect(result).not.toHaveProperty("context-engine-memory")
     expect(Object.keys(result)).toHaveLength(0)
   })
 
@@ -58,8 +63,9 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).not.toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(result).toHaveProperty("context-engine")
-    expect(Object.keys(result)).toHaveLength(3)
+    expect(result).toHaveProperty("context-engine-indexer")
+    expect(result).toHaveProperty("context-engine-memory")
+    expect(Object.keys(result)).toHaveLength(4)
   })
 
   test("should handle empty disabled_mcps by default", () => {
@@ -71,8 +77,9 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(result).toHaveProperty("context-engine")
-    expect(Object.keys(result)).toHaveLength(4)
+    expect(result).toHaveProperty("context-engine-indexer")
+    expect(result).toHaveProperty("context-engine-memory")
+    expect(Object.keys(result)).toHaveLength(5)
   })
 
   test("should only filter built-in MCPs, ignoring unknown names", () => {
@@ -86,7 +93,8 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(result).toHaveProperty("context-engine")
-    expect(Object.keys(result)).toHaveLength(4)
+    expect(result).toHaveProperty("context-engine-indexer")
+    expect(result).toHaveProperty("context-engine-memory")
+    expect(Object.keys(result)).toHaveLength(5)
   })
 })

--- a/src/mcp/index.test.ts
+++ b/src/mcp/index.test.ts
@@ -13,7 +13,8 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(Object.keys(result)).toHaveLength(3)
+    expect(result).toHaveProperty("context-engine")
+    expect(Object.keys(result)).toHaveLength(4)
   })
 
   test("should filter out disabled built-in MCPs", () => {
@@ -27,12 +28,13 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).not.toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(Object.keys(result)).toHaveLength(2)
+    expect(result).toHaveProperty("context-engine")
+    expect(Object.keys(result)).toHaveLength(3)
   })
 
   test("should filter out all built-in MCPs when all disabled", () => {
     //#given
-    const disabledMcps = ["websearch", "context7", "grep_app"]
+    const disabledMcps = ["websearch", "context7", "grep_app", "context-engine"]
 
     //#when
     const result = createBuiltinMcps(disabledMcps)
@@ -41,6 +43,7 @@ describe("createBuiltinMcps", () => {
     expect(result).not.toHaveProperty("websearch")
     expect(result).not.toHaveProperty("context7")
     expect(result).not.toHaveProperty("grep_app")
+    expect(result).not.toHaveProperty("context-engine")
     expect(Object.keys(result)).toHaveLength(0)
   })
 
@@ -55,7 +58,8 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).not.toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(Object.keys(result)).toHaveLength(2)
+    expect(result).toHaveProperty("context-engine")
+    expect(Object.keys(result)).toHaveLength(3)
   })
 
   test("should handle empty disabled_mcps by default", () => {
@@ -67,7 +71,8 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(Object.keys(result)).toHaveLength(3)
+    expect(result).toHaveProperty("context-engine")
+    expect(Object.keys(result)).toHaveLength(4)
   })
 
   test("should only filter built-in MCPs, ignoring unknown names", () => {
@@ -81,6 +86,7 @@ describe("createBuiltinMcps", () => {
     expect(result).toHaveProperty("websearch")
     expect(result).toHaveProperty("context7")
     expect(result).toHaveProperty("grep_app")
-    expect(Object.keys(result)).toHaveLength(3)
+    expect(result).toHaveProperty("context-engine")
+    expect(Object.keys(result)).toHaveLength(4)
   })
 })

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,6 +1,7 @@
 import { websearch } from "./websearch"
 import { context7 } from "./context7"
 import { grep_app } from "./grep-app"
+import { context_engine_mcp, MCP_NAME as CONTEXT_ENGINE_MCP_NAME } from "./context-engine-mcp"
 import type { McpName } from "./types"
 
 export { McpNameSchema, type McpName } from "./types"
@@ -17,6 +18,7 @@ const allBuiltinMcps: Record<McpName, RemoteMcpConfig> = {
   websearch,
   context7,
   grep_app,
+  [CONTEXT_ENGINE_MCP_NAME]: context_engine_mcp,
 }
 
 export function createBuiltinMcps(disabledMcps: string[] = []) {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,7 +1,12 @@
 import { websearch } from "./websearch"
 import { context7 } from "./context7"
 import { grep_app } from "./grep-app"
-import { context_engine_mcp, MCP_NAME as CONTEXT_ENGINE_MCP_NAME } from "./context-engine-mcp"
+import { 
+  context_engine_indexer_mcp, 
+  context_engine_memory_mcp, 
+  MCP_NAME_INDEXER, 
+  MCP_NAME_MEMORY 
+} from "./context-engine-mcp"
 import type { McpName } from "./types"
 
 export { McpNameSchema, type McpName } from "./types"
@@ -18,7 +23,8 @@ const allBuiltinMcps: Record<McpName, RemoteMcpConfig> = {
   websearch,
   context7,
   grep_app,
-  [CONTEXT_ENGINE_MCP_NAME]: context_engine_mcp,
+  [MCP_NAME_INDEXER]: context_engine_indexer_mcp,
+  [MCP_NAME_MEMORY]: context_engine_memory_mcp,
 }
 
 export function createBuiltinMcps(disabledMcps: string[] = []) {

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-export const McpNameSchema = z.enum(["websearch", "context7", "grep_app", "context-engine"])
+export const McpNameSchema = z.enum(["websearch", "context7", "grep_app", "context-engine-indexer", "context-engine-memory"])
 
 export type McpName = z.infer<typeof McpNameSchema>
 

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-export const McpNameSchema = z.enum(["websearch", "context7", "grep_app"])
+export const McpNameSchema = z.enum(["websearch", "context7", "grep_app", "context-engine"])
 
 export type McpName = z.infer<typeof McpNameSchema>
 

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -329,11 +329,17 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
       ? await loadMcpConfigs()
       : { servers: {} };
 
+    const systemMcpConfig = config.mcp as Record<string, unknown> | undefined;
+    const disabledMcpsWithSystemOverrides = [
+      ...(pluginConfig.disabled_mcps ?? []),
+      ...Object.keys(systemMcpConfig ?? {}),
+    ];
+
     config.mcp = {
-      ...(config.mcp as Record<string, unknown>),
-      ...createBuiltinMcps(pluginConfig.disabled_mcps),
+      ...createBuiltinMcps(disabledMcpsWithSystemOverrides),
       ...mcpResult.servers,
       ...pluginComponents.mcpServers,
+      ...systemMcpConfig,
     };
 
     const builtinCommands = loadBuiltinCommands(pluginConfig.disabled_commands);

--- a/src/shared/agent-tool-restrictions.ts
+++ b/src/shared/agent-tool-restrictions.ts
@@ -2,7 +2,17 @@
  * Agent tool restrictions for session.prompt calls.
  * OpenCode SDK's session.prompt `tools` parameter expects boolean values.
  * true = tool allowed, false = tool denied.
+ *
+ * MCP tools use wildcards: "mcp-server-name_*": true enables all tools from that MCP.
  */
+
+/**
+ * Context-Engine MCP tools - enabled for agents that benefit from semantic code search.
+ * Uses wildcard to enable all context-engine tools (repo_search, symbol_graph, etc.)
+ */
+const CONTEXT_ENGINE_MCP_TOOLS: Record<string, boolean> = {
+  "context-engine_*": true,
+};
 
 const EXPLORATION_AGENT_DENYLIST: Record<string, boolean> = {
   write: false,
@@ -10,18 +20,25 @@ const EXPLORATION_AGENT_DENYLIST: Record<string, boolean> = {
   task: false,
   delegate_task: false,
   call_omo_agent: false,
-}
+};
 
 const AGENT_RESTRICTIONS: Record<string, Record<string, boolean>> = {
-  explore: EXPLORATION_AGENT_DENYLIST,
+  explore: {
+    ...EXPLORATION_AGENT_DENYLIST,
+    ...CONTEXT_ENGINE_MCP_TOOLS,
+  },
 
-  librarian: EXPLORATION_AGENT_DENYLIST,
+  librarian: {
+    ...EXPLORATION_AGENT_DENYLIST,
+    ...CONTEXT_ENGINE_MCP_TOOLS,
+  },
 
   oracle: {
     write: false,
     edit: false,
     task: false,
     delegate_task: false,
+    ...CONTEXT_ENGINE_MCP_TOOLS,
   },
 
   "multimodal-looker": {
@@ -32,25 +49,48 @@ const AGENT_RESTRICTIONS: Record<string, Record<string, boolean>> = {
     task: false,
     delegate_task: false,
     call_omo_agent: false,
+    ...CONTEXT_ENGINE_MCP_TOOLS,
   },
 
   "frontend-ui-ux-engineer": {
     task: false,
     delegate_task: false,
     call_omo_agent: false,
+    ...CONTEXT_ENGINE_MCP_TOOLS,
   },
 
   "Sisyphus-Junior": {
     task: false,
     delegate_task: false,
+    ...CONTEXT_ENGINE_MCP_TOOLS,
   },
+
+  "sisyphus-junior": {
+    task: false,
+    delegate_task: false,
+    ...CONTEXT_ENGINE_MCP_TOOLS,
+  },
+
+  general: {
+    ...CONTEXT_ENGINE_MCP_TOOLS,
+  },
+};
+
+export function getAgentToolRestrictions(
+  agentName: string,
+): Record<string, boolean> {
+  return AGENT_RESTRICTIONS[agentName] ?? {};
 }
 
-export function getAgentToolRestrictions(agentName: string): Record<string, boolean> {
-  return AGENT_RESTRICTIONS[agentName] ?? {}
+/**
+ * Get context-engine MCP tool restrictions.
+ * Can be used to add context-engine tools to custom agent configurations.
+ */
+export function getContextEngineMcpTools(): Record<string, boolean> {
+  return { ...CONTEXT_ENGINE_MCP_TOOLS };
 }
 
 export function hasAgentToolRestrictions(agentName: string): boolean {
-  const restrictions = AGENT_RESTRICTIONS[agentName]
-  return restrictions !== undefined && Object.keys(restrictions).length > 0
+  const restrictions = AGENT_RESTRICTIONS[agentName];
+  return restrictions !== undefined && Object.keys(restrictions).length > 0;
 }

--- a/src/shared/agent-tool-restrictions.ts
+++ b/src/shared/agent-tool-restrictions.ts
@@ -12,6 +12,8 @@
  */
 const CONTEXT_ENGINE_MCP_TOOLS: Record<string, boolean> = {
   "context-engine_*": true,
+  "context-engine-indexer_*": true,
+  "context-engine-memory_*": true,
 };
 
 const EXPLORATION_AGENT_DENYLIST: Record<string, boolean> = {

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -599,6 +599,7 @@ System notifies on completion. Use \`background_output\` with task_id="${task.id
               agent: agentToUse,
               system: systemContent,
               tools: {
+                ...getAgentToolRestrictions(agentToUse),
                 task: false,
                 delegate_task: false,
                 call_omo_agent: true,


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates Context-Engine as built-in MCP servers for semantic code search and persistent memory (split into indexer and memory). Enables these tools across key agents and adds a skill to prefer MCP over grep for exploration.

- **New Features**
  - Added built-in MCPs: context-engine-indexer and context-engine-memory (remote, default-enabled).
  - Added “context-engine” built-in skill with clear MCP tool selection rules.
  - Enabled wildcard MCP tools (context-engine_*, context-engine-indexer_*, context-engine-memory_*) for explore, librarian, oracle, multimodal-looker, frontend-ui-ux-engineer, sisyphus-junior, and general agents; passed through in delegate calls.
  - Included .mcp.json defaults for local dev; updated schemas, types, and tests.
  - Config handler now merges system MCP overrides and auto-disables overlapping built-ins to prevent conflicts.

- **Migration**
  - Run services at http://localhost:8003/mcp (indexer) and http://localhost:8002/mcp (memory), or set CONTEXT_ENGINE_INDEXER_URL / CONTEXT_ENGINE_MEMORY_URL.
  - Set CONTEXT_ENGINE_DISABLED=true to turn off globally, or use plugin disabled_mcps to filter per server.
  - You can override built-ins via user config; overrides take precedence and built-ins are excluded automatically.

<sup>Written for commit 0954013b29f93f08209630a587d3915ab5e4c9c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

