### PR TITLE
fix(chat-headers): skip x-initiator override for @ai-sdk/github-copilot models

### DIFF
--- a/src/plugin/chat-headers.test.ts
+++ b/src/plugin/chat-headers.test.ts
@@ -106,4 +106,41 @@ describe("createChatHeadersHandler", () => {
 
     expect(output.headers["x-initiator"]).toBeUndefined()
   })
+
+  test("skips x-initiator override when model uses @ai-sdk/github-copilot", async () => {
+    const handler = createChatHeadersHandler({
+      ctx: {
+        client: {
+          session: {
+            message: async () => ({
+              data: {
+                parts: [
+                  {
+                    type: "text",
+                    text: `notification\n${OMO_INTERNAL_INITIATOR_MARKER}`,
+                  },
+                ],
+              },
+            }),
+          },
+        },
+      } as never,
+    })
+    const output: { headers: Record<string, string> } = { headers: {} }
+
+    await handler(
+      {
+        sessionID: "ses_4",
+        provider: { id: "github-copilot" },
+        model: { api: { npm: "@ai-sdk/github-copilot" } },
+        message: {
+          id: "msg_4",
+          role: "user",
+        },
+      },
+      output,
+    )
+
+    expect(output.headers["x-initiator"]).toBeUndefined()
+  })
 })

--- a/src/plugin/chat-headers.ts
+++ b/src/plugin/chat-headers.ts
@@ -123,6 +123,17 @@ export function createChatHeadersHandler(args: { ctx: PluginContext }): (input: 
     if (!isChatHeadersOutput(output)) return
 
     if (!isCopilotProvider(normalizedInput.provider.id)) return
+
+    // Do not override x-initiator when @ai-sdk/github-copilot is active.
+    // OpenCode's copilot fetch wrapper already sets x-initiator based on
+    // the actual request body content. Overriding it here causes a mismatch
+    // that the Copilot API rejects with "invalid initiator".
+    const model = isRecord(input) && isRecord((input as Record<string, unknown>).model)
+      ? (input as Record<string, unknown>).model as Record<string, unknown>
+      : undefined
+    const api = model && isRecord(model.api) ? model.api as Record<string, unknown> : undefined
+    if (api?.npm === "@ai-sdk/github-copilot") return
+
     if (!(await isOmoInternalMessage(normalizedInput, ctx.client))) return
 
     output.headers["x-initiator"] = "agent"


### PR DESCRIPTION
## Summary

Fixes the `Bad Request: bad request: error: invalid initiator` error that occurs when subagents are scheduled via oh-my-opencode on GitHub Copilot providers.

## Root Cause

OpenCode recently switched all Copilot models to use `@ai-sdk/github-copilot` ([copilot.ts:56](https://github.com/code-yeongyu/oh-my-opencode/blob/dev/src/plugin/chat-headers.ts)). This SDK package has its own fetch wrapper that sets `x-initiator` based on the actual HTTP request body — if the last message is `role: "user"`, it sets `x-initiator: user`.

oh-my-opencode's `chat.headers` hook was overriding this with `x-initiator: agent` (because it detected the `<!-- OMO_INTERNAL_INITIATOR -->` marker). The Copilot API then saw a mismatch between the header (`agent`) and the request body content (`role: "user"`) and rejected the request.

**OpenCode's own `chat.headers` handler already handles this correctly** — it explicitly skips `@ai-sdk/github-copilot` models because the fetch wrapper handles `x-initiator` on its own:
PR: https://github.com/anomalyco/opencode/pull/13485
```typescript
// opencode/packages/opencode/src/plugin/copilot.ts:311-314
// Skip x-initiator override when using @ai-sdk/github-copilot - it has its own
// fetch wrapper that sets x-initiator based on message content, and overriding
// it here causes "invalid initiator" validation errors from Copilot API
if (incoming.model.api.npm === "@ai-sdk/github-copilot") return
```

## Fix

Skip the `x-initiator` override when `model.api.npm === "@ai-sdk/github-copilot"`, matching OpenCode's approach.

## Changes

- `src/plugin/chat-headers.ts` — Check `model.api.npm` and skip override for `@ai-sdk/github-copilot`
- `src/plugin/chat-headers.test.ts` — Added test for the skip behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip x-initiator override for @ai-sdk/github-copilot models to prevent “invalid initiator” errors on Copilot requests. This matches OpenCode’s behavior and restores successful subagent scheduling.

- **Bug Fixes**
  - Do not set x-initiator when model.api.npm === "@ai-sdk/github-copilot".
  - Added a test to verify the skip behavior.

<sup>Written for commit 890a737d1e8493238a26f52fa95eb9cd030d7a71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

