### PR TITLE
fix: pin bun to stable to resolve Windows ThreadLock panic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: stable
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: stable
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: stable
 
       - name: Install dependencies
         run: bun install
@@ -108,7 +108,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: stable
 
       - name: Install dependencies
         run: bun install
@@ -134,7 +134,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: stable
 
       - uses: actions/setup-node@v4
         with:
@@ -255,7 +255,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: stable
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/sisyphus-agent.yml
+++ b/.github/workflows/sisyphus-agent.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: stable
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
Confirmed that Bun v1.3.10-canary causes ThreadLock panic during .env loading on Windows. Switching to stable resolves this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Bun to stable in all GitHub Actions workflows to stop a ThreadLock panic on Windows during .env loading caused by v1.3.10-canary. This stabilizes CI and publish pipelines.

<sup>Written for commit f19b6bbe4172c42dbda95f9632a342d5d39be5ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

