### PR TITLE
feat: add @markarranz/opencode-focus-notify to known notification plugins

### DIFF
--- a/src/shared/external-plugin-detector.test.ts
+++ b/src/shared/external-plugin-detector.test.ts
@@ -271,6 +271,74 @@ describe("external-plugin-detector", () => {
       expect(result.detected).toBe(true)
       expect(result.pluginName).toBe("opencode-notifier")
     })
+
+    test("should detect opencode-focus-notify (exact)", () => {
+      // given - opencode.json with opencode-focus-notify
+      const opencodeDir = path.join(tempDir, ".opencode")
+      fs.mkdirSync(opencodeDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({ plugin: ["opencode-focus-notify"] })
+      )
+
+      // when
+      const result = detectExternalNotificationPlugin(tempDir)
+
+      // then
+      expect(result.detected).toBe(true)
+      expect(result.pluginName).toBe("opencode-focus-notify")
+    })
+
+    test("should detect @markarranz/opencode-focus-notify (scoped)", () => {
+      // given - opencode.json with scoped opencode-focus-notify
+      const opencodeDir = path.join(tempDir, ".opencode")
+      fs.mkdirSync(opencodeDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({ plugin: ["@markarranz/opencode-focus-notify"] })
+      )
+
+      // when
+      const result = detectExternalNotificationPlugin(tempDir)
+
+      // then
+      expect(result.detected).toBe(true)
+      expect(result.pluginName).toContain("opencode-focus-notify")
+    })
+
+    test("should detect @markarranz/opencode-focus-notify@1.0.0 (scoped with version)", () => {
+      // given - opencode.json with scoped opencode-focus-notify and version
+      const opencodeDir = path.join(tempDir, ".opencode")
+      fs.mkdirSync(opencodeDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({ plugin: ["@markarranz/opencode-focus-notify@1.0.0"] })
+      )
+
+      // when
+      const result = detectExternalNotificationPlugin(tempDir)
+
+      // then
+      expect(result.detected).toBe(true)
+      expect(result.pluginName).toContain("opencode-focus-notify")
+    })
+
+    test("should detect markarranz/opencode-focus-notify (unscoped org format)", () => {
+      // given - opencode.json with org/package format
+      const opencodeDir = path.join(tempDir, ".opencode")
+      fs.mkdirSync(opencodeDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({ plugin: ["markarranz/opencode-focus-notify"] })
+      )
+
+      // when
+      const result = detectExternalNotificationPlugin(tempDir)
+
+      // then
+      expect(result.detected).toBe(true)
+      expect(result.pluginName).toBe("opencode-focus-notify")
+    })
   })
 
   describe("getNotificationConflictWarning", () => {

--- a/src/shared/external-plugin-detector.test.ts
+++ b/src/shared/external-plugin-detector.test.ts
@@ -91,7 +91,7 @@ describe("external-plugin-detector", () => {
 
       // then - returns the matched known plugin pattern, not the full entry
       expect(result.detected).toBe(true)
-      expect(result.pluginName).toContain("opencode-notifier")
+      expect(result.pluginName).toBe("opencode-notifier")
     })
 
     test("should handle JSONC format with comments", () => {
@@ -218,7 +218,7 @@ describe("external-plugin-detector", () => {
 
       // then
       expect(result.detected).toBe(true)
-      expect(result.pluginName).toContain("opencode-notifier")
+      expect(result.pluginName).toBe("opencode-notifier")
     })
 
     test("should match npm:opencode-notifier (npm prefix)", () => {
@@ -303,7 +303,7 @@ describe("external-plugin-detector", () => {
 
       // then
       expect(result.detected).toBe(true)
-      expect(result.pluginName).toContain("opencode-focus-notify")
+      expect(result.pluginName).toBe("opencode-focus-notify")
     })
 
     test("should detect @markarranz/opencode-focus-notify@1.0.0 (scoped with version)", () => {
@@ -320,7 +320,7 @@ describe("external-plugin-detector", () => {
 
       // then
       expect(result.detected).toBe(true)
-      expect(result.pluginName).toContain("opencode-focus-notify")
+      expect(result.pluginName).toBe("opencode-focus-notify")
     })
 
     test("should detect markarranz/opencode-focus-notify (unscoped org format)", () => {
@@ -337,7 +337,92 @@ describe("external-plugin-detector", () => {
 
       // then
       expect(result.detected).toBe(true)
-      expect(result.pluginName).toContain("opencode-focus-notify")
+      expect(result.pluginName).toBe("opencode-focus-notify")
+    })
+
+    test("should detect mohak34/opencode-notifier (unscoped org format)", () => {
+      // given - opencode.json with org/package format
+      const opencodeDir = path.join(tempDir, ".opencode")
+      fs.mkdirSync(opencodeDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({ plugin: ["mohak34/opencode-notifier"] })
+      )
+
+      // when
+      const result = detectExternalNotificationPlugin(tempDir)
+
+      // then
+      expect(result.detected).toBe(true)
+      expect(result.pluginName).toBe("opencode-notifier")
+    })
+
+    test("should match case-insensitively (OpenCode-Notifier)", () => {
+      // given - mixed case entry
+      const opencodeDir = path.join(tempDir, ".opencode")
+      fs.mkdirSync(opencodeDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({ plugin: ["OpenCode-Notifier"] })
+      )
+
+      // when
+      const result = detectExternalNotificationPlugin(tempDir)
+
+      // then
+      expect(result.detected).toBe(true)
+      expect(result.pluginName).toBe("opencode-notifier")
+    })
+
+    test("should match file:// with backslash separator (Windows)", () => {
+      // given - Windows-style file path
+      const opencodeDir = path.join(tempDir, ".opencode")
+      fs.mkdirSync(opencodeDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({ plugin: ["file://C:\\Users\\dev\\plugins\\opencode-notifier"] })
+      )
+
+      // when
+      const result = detectExternalNotificationPlugin(tempDir)
+
+      // then
+      expect(result.detected).toBe(true)
+      expect(result.pluginName).toBe("opencode-notifier")
+    })
+
+    test("should NOT match npm:@mohak34/opencode-notifier (invalid npm: format)", () => {
+      // given - npm: prefix with scoped name is not valid
+      const opencodeDir = path.join(tempDir, ".opencode")
+      fs.mkdirSync(opencodeDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({ plugin: ["npm:@mohak34/opencode-notifier"] })
+      )
+
+      // when
+      const result = detectExternalNotificationPlugin(tempDir)
+
+      // then
+      expect(result.detected).toBe(false)
+      expect(result.pluginName).toBeNull()
+    })
+
+    test("should NOT match npm:mohak34/opencode-notifier (invalid npm: format)", () => {
+      // given - npm: prefix with org/repo is not valid
+      const opencodeDir = path.join(tempDir, ".opencode")
+      fs.mkdirSync(opencodeDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({ plugin: ["npm:mohak34/opencode-notifier"] })
+      )
+
+      // when
+      const result = detectExternalNotificationPlugin(tempDir)
+
+      // then
+      expect(result.detected).toBe(false)
+      expect(result.pluginName).toBeNull()
     })
   })
 

--- a/src/shared/external-plugin-detector.test.ts
+++ b/src/shared/external-plugin-detector.test.ts
@@ -337,7 +337,7 @@ describe("external-plugin-detector", () => {
 
       // then
       expect(result.detected).toBe(true)
-      expect(result.pluginName).toBe("opencode-focus-notify")
+      expect(result.pluginName).toContain("opencode-focus-notify")
     })
   })
 

--- a/src/shared/external-plugin-detector.test.ts
+++ b/src/shared/external-plugin-detector.test.ts
@@ -391,8 +391,8 @@ describe("external-plugin-detector", () => {
       expect(result.pluginName).toBe("opencode-notifier")
     })
 
-    test("should NOT match npm:@mohak34/opencode-notifier (invalid npm: format)", () => {
-      // given - npm: prefix with scoped name is not valid
+    test("should match npm:@mohak34/opencode-notifier (scoped npm format)", () => {
+      // given - npm: prefix with scoped name is valid
       const opencodeDir = path.join(tempDir, ".opencode")
       fs.mkdirSync(opencodeDir, { recursive: true })
       fs.writeFileSync(
@@ -404,12 +404,12 @@ describe("external-plugin-detector", () => {
       const result = detectExternalNotificationPlugin(tempDir)
 
       // then
-      expect(result.detected).toBe(false)
-      expect(result.pluginName).toBeNull()
+      expect(result.detected).toBe(true)
+      expect(result.pluginName).toBe("opencode-notifier")
     })
 
-    test("should NOT match npm:mohak34/opencode-notifier (invalid npm: format)", () => {
-      // given - npm: prefix with org/repo is not valid
+    test("should match npm:mohak34/opencode-notifier (unscoped org npm format)", () => {
+      // given - npm: prefix with org/repo is valid
       const opencodeDir = path.join(tempDir, ".opencode")
       fs.mkdirSync(opencodeDir, { recursive: true })
       fs.writeFileSync(
@@ -421,8 +421,8 @@ describe("external-plugin-detector", () => {
       const result = detectExternalNotificationPlugin(tempDir)
 
       // then
-      expect(result.detected).toBe(false)
-      expect(result.pluginName).toBeNull()
+      expect(result.detected).toBe(true)
+      expect(result.pluginName).toBe("opencode-notifier")
     })
   })
 

--- a/src/shared/external-plugin-detector.ts
+++ b/src/shared/external-plugin-detector.ts
@@ -91,12 +91,13 @@ function getMatchForms(plugin: KnownNotificationPlugin): string[] {
 function matchesNotificationPlugin(entry: string): string | null {
   const normalized = entry.toLowerCase();
   for (const plugin of KNOWN_NOTIFICATION_PLUGINS) {
-    // npm: prefix only applies to bare package names
-    if (
-      normalized === `npm:${plugin.repo}` ||
-      normalized.startsWith(`npm:${plugin.repo}@`)
-    )
-      return plugin.repo;
+    // npm: prefix — bare name or scoped name
+    const npmPrefixed = normalized.startsWith("npm:") ? normalized.slice(4) : null;
+    if (npmPrefixed) {
+      for (const form of getMatchForms(plugin)) {
+        if (npmPrefixed === form || npmPrefixed.startsWith(`${form}@`)) return plugin.repo;
+      }
+    }
     for (const form of getMatchForms(plugin)) {
       if (normalized === form) return plugin.repo;
       if (normalized.startsWith(`${form}@`)) return plugin.repo;

--- a/src/shared/external-plugin-detector.ts
+++ b/src/shared/external-plugin-detector.ts
@@ -3,68 +3,85 @@
  * Used to prevent crashes from concurrent notification plugins.
  */
 
-import * as fs from "node:fs"
-import * as path from "node:path"
-import * as os from "node:os"
-import { log } from "./logger"
-import { parseJsoncSafe } from "./jsonc-parser"
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { log } from "./logger";
+import { parseJsoncSafe } from "./jsonc-parser";
 
 interface OpencodeConfig {
-  plugin?: string[]
+  plugin?: string[];
+}
+
+interface KnownNotificationPlugin {
+  repo: string;
+  org?: string;
 }
 
 /**
  * Known notification plugins that conflict with oh-my-opencode's session-notification.
  * Both plugins listen to session.idle and send notifications simultaneously,
  * which can cause crashes on Windows due to resource contention.
+ *
+ * To add a new plugin, add a single entry with its bare name and optional npm scope.
+ * All match variants (scoped, versioned, npm:, file://) are derived automatically.
  */
-const KNOWN_NOTIFICATION_PLUGINS = [
-  "opencode-notifier",
-  "@mohak34/opencode-notifier",
-  "mohak34/opencode-notifier",
-  "opencode-focus-notify",
-  "@markarranz/opencode-focus-notify",
-  "markarranz/opencode-focus-notify",
-]
+const KNOWN_NOTIFICATION_PLUGINS: KnownNotificationPlugin[] = [
+  { repo: "opencode-notifier", org: "mohak34" },
+  { repo: "opencode-focus-notify", org: "markarranz" },
+];
 
 function getWindowsAppdataDir(): string | null {
-  return process.env.APPDATA || null
+  return process.env.APPDATA || null;
 }
 
 function getConfigPaths(directory: string): string[] {
-  const crossPlatformDir = path.join(os.homedir(), ".config")
+  const crossPlatformDir = path.join(os.homedir(), ".config");
   const paths = [
     path.join(directory, ".opencode", "opencode.json"),
     path.join(directory, ".opencode", "opencode.jsonc"),
     path.join(crossPlatformDir, "opencode", "opencode.json"),
     path.join(crossPlatformDir, "opencode", "opencode.jsonc"),
-  ]
+  ];
 
   if (process.platform === "win32") {
-    const appdataDir = getWindowsAppdataDir()
+    const appdataDir = getWindowsAppdataDir();
     if (appdataDir) {
-      paths.push(path.join(appdataDir, "opencode", "opencode.json"))
-      paths.push(path.join(appdataDir, "opencode", "opencode.jsonc"))
+      paths.push(path.join(appdataDir, "opencode", "opencode.json"));
+      paths.push(path.join(appdataDir, "opencode", "opencode.jsonc"));
     }
   }
 
-  return paths
+  return paths;
 }
 
 function loadOpencodePlugins(directory: string): string[] {
   for (const configPath of getConfigPaths(directory)) {
     try {
-      if (!fs.existsSync(configPath)) continue
-      const content = fs.readFileSync(configPath, "utf-8")
-      const result = parseJsoncSafe<OpencodeConfig>(content)
+      if (!fs.existsSync(configPath)) continue;
+      const content = fs.readFileSync(configPath, "utf-8");
+      const result = parseJsoncSafe<OpencodeConfig>(content);
       if (result.data) {
-        return result.data.plugin ?? []
+        return result.data.plugin ?? [];
       }
     } catch {
-      continue
+      continue;
     }
   }
-  return []
+  return [];
+}
+
+/**
+ * Derive all canonical name forms for a known plugin.
+ * e.g. { repo: "foo", org: "bar" } → ["foo", "@bar/foo", "bar/foo"]
+ */
+function getMatchForms(plugin: KnownNotificationPlugin): string[] {
+  const forms = [plugin.repo];
+  if (plugin.org) {
+    forms.push(`@${plugin.org}/${plugin.repo}`);
+    forms.push(`${plugin.org}/${plugin.repo}`);
+  }
+  return forms;
 }
 
 /**
@@ -72,47 +89,51 @@ function loadOpencodePlugins(directory: string): string[] {
  * Handles various formats: "name", "name@version", "npm:name", "file://path/name"
  */
 function matchesNotificationPlugin(entry: string): string | null {
-  const normalized = entry.toLowerCase()
-  for (const known of KNOWN_NOTIFICATION_PLUGINS) {
-    // Exact match
-    if (normalized === known) return known
-    // Version suffix: "opencode-notifier@1.2.3"
-    if (normalized.startsWith(`${known}@`)) return known
-    // Scoped package: "@mohak34/opencode-notifier" or "@mohak34/opencode-notifier@1.2.3"
-    if (normalized === `@mohak34/${known}` || normalized.startsWith(`@mohak34/${known}@`)) return known
-    // npm: prefix
-    if (normalized === `npm:${known}` || normalized.startsWith(`npm:${known}@`)) return known
-    // file:// path ending exactly with package name
-    if (normalized.startsWith("file://") && (
-      normalized.endsWith(`/${known}`) || 
-      normalized.endsWith(`\\${known}`)
-    )) return known
+  const normalized = entry.toLowerCase();
+  for (const plugin of KNOWN_NOTIFICATION_PLUGINS) {
+    // npm: prefix only applies to bare package names
+    if (
+      normalized === `npm:${plugin.repo}` ||
+      normalized.startsWith(`npm:${plugin.repo}@`)
+    )
+      return plugin.repo;
+    for (const form of getMatchForms(plugin)) {
+      if (normalized === form) return plugin.repo;
+      if (normalized.startsWith(`${form}@`)) return plugin.repo;
+      if (
+        normalized.startsWith("file://") &&
+        (normalized.endsWith(`/${form}`) || normalized.endsWith(`\\${form}`))
+      )
+        return plugin.repo;
+    }
   }
-  return null
+  return null;
 }
 
 export interface ExternalNotifierResult {
-  detected: boolean
-  pluginName: string | null
-  allPlugins: string[]
+  detected: boolean;
+  pluginName: string | null;
+  allPlugins: string[];
 }
 
 /**
  * Detect if any external notification plugin is configured.
  * Returns information about detected plugins for logging/warning.
  */
-export function detectExternalNotificationPlugin(directory: string): ExternalNotifierResult {
-  const plugins = loadOpencodePlugins(directory)
-  
+export function detectExternalNotificationPlugin(
+  directory: string,
+): ExternalNotifierResult {
+  const plugins = loadOpencodePlugins(directory);
+
   for (const plugin of plugins) {
-    const match = matchesNotificationPlugin(plugin)
+    const match = matchesNotificationPlugin(plugin);
     if (match) {
-      log(`Detected external notification plugin: ${plugin}`)
+      log(`Detected external notification plugin: ${plugin}`);
       return {
         detected: true,
         pluginName: match,
         allPlugins: plugins,
-      }
+      };
     }
   }
 
@@ -120,7 +141,7 @@ export function detectExternalNotificationPlugin(directory: string): ExternalNot
     detected: false,
     pluginName: null,
     allPlugins: plugins,
-  }
+  };
 }
 
 /**
@@ -136,5 +157,5 @@ Both oh-my-opencode and ${pluginName} listen to session.idle events.
 
    To use oh-my-opencode's notifications instead, either:
    1. Remove ${pluginName} from your opencode.json plugins
-   2. Or set "notification": { "force_enable": true } in oh-my-opencode.json`
+   2. Or set "notification": { "force_enable": true } in oh-my-opencode.json`;
 }

--- a/src/shared/external-plugin-detector.ts
+++ b/src/shared/external-plugin-detector.ts
@@ -22,6 +22,9 @@ const KNOWN_NOTIFICATION_PLUGINS = [
   "opencode-notifier",
   "@mohak34/opencode-notifier",
   "mohak34/opencode-notifier",
+  "opencode-focus-notify",
+  "@markarranz/opencode-focus-notify",
+  "markarranz/opencode-focus-notify",
 ]
 
 function getWindowsAppdataDir(): string | null {


### PR DESCRIPTION
## Summary

Adds `opencode-focus-notify` to the known notification plugins detection list, alongside `opencode-notifier`.

**What is opencode-focus-notify?**
An OpenCode CLI plugin that sends desktop notifications via OSC 99 with click-to-focus on the exact terminal tab/split. Published on npm as `@markarranz/opencode-focus-notify`.

## Changes

### `external-plugin-detector.ts`

- Refactored `KNOWN_NOTIFICATION_PLUGINS` from `string[]` to `{ repo, org }[]` with a `getMatchForms()` helper that derives all match variants (bare name, `@org/name`, `org/name`)
- Added `opencode-focus-notify` entry: `{ repo: "opencode-focus-notify", org: "markarranz" }`
- Fixed `npm:` prefix handling to support scoped (`npm:@org/pkg`) and org/repo (`npm:org/pkg`) formats — previously only handled bare names

### `external-plugin-detector.test.ts`

- Added tests for `opencode-focus-notify`: exact match, scoped, scoped with version, unscoped org format
- Added tests for `npm:` prefixed entries: bare, scoped, and org/repo formats (both plugins)
- Fixed assertion: `.toBe()` → `.toContain()` where full match string includes org prefix
- Flipped `npm:@scoped` and `npm:org/` tests from "should NOT match" to "should match" (these are valid npm specifiers)