### PR TITLE
feat(hephaestus): support custom OpenAI-compatible providers

### DIFF
--- a/src/hooks/no-hephaestus-non-gpt/index.test.ts
+++ b/src/hooks/no-hephaestus-non-gpt/index.test.ts
@@ -52,7 +52,7 @@ describe("no-hephaestus-non-gpt hook", () => {
   })
 
   test("shows warning and does not switch agent when allow_non_gpt_model is enabled", async () => {
-    // given - hephaestus with claude model and opt-out enabled
+    // given - hephaestus with claude model and allow_non_gpt_model enabled
     const showToast = spyOn({ fn: async (_input: unknown) => ({}) }, "fn")
     const hook = createNoHephaestusNonGptHook({
       client: { tui: { showToast } },
@@ -69,7 +69,7 @@ describe("no-hephaestus-non-gpt hook", () => {
       model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
     }, output)
 
-    // then - warning toast is shown but agent is not switched
+    // then - warning toast shown but agent is not switched
     expect(showToast).toHaveBeenCalledTimes(1)
     expect(output.message.agent).toBeUndefined()
     expect(showToast.mock.calls[0]?.[0]).toMatchObject({

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -168,14 +168,14 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(primary.providers[0]).toBe("opencode")
   })
 
-  test("hephaestus requires openai/opencode provider (not github-copilot since gpt-5.3-codex unavailable there)", () => {
+  test("hephaestus has no provider restriction (supports custom OpenAI-compatible providers)", () => {
     // #given - hephaestus agent requirement
     const hephaestus = AGENT_MODEL_REQUIREMENTS["hephaestus"]
 
     // #when - accessing hephaestus requirement
-    // #then - requiresProvider is set to openai and opencode only (github-copilot removed)
+    // #then - requiresProvider is undefined to allow custom providers via user config
     expect(hephaestus).toBeDefined()
-    expect(hephaestus.requiresProvider).toEqual(["openai", "opencode"])
+    expect(hephaestus.requiresProvider).toBeUndefined()
     expect(hephaestus.requiresModel).toBeUndefined()
   })
 

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -26,7 +26,8 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       { providers: ["openai", "opencode"], model: "gpt-5.3-codex", variant: "medium" },
     ],
-    requiresProvider: ["openai", "opencode"],
+    // Provider restriction removed to support custom OpenAI-compatible providers
+    // Users can configure any model via oh-my-opencode.json
   },
   oracle: {
     fallbackChain: [


### PR DESCRIPTION
## Summary

- Remove `requiresProvider` restriction from Hephaestus to support custom OpenAI-compatible providers
- Allow users to configure Hephaestus with any model via `oh-my-opencode.json`
- When `allow_non_gpt_model: true` is set, a warning toast is shown but the agent is not blocked

## Changes

### 1. Remove Provider Restriction (`src/shared/model-requirements.ts`)
- Removed `requiresProvider: ["openai", "opencode"]` from Hephaestus
- Users can now configure any OpenAI-compatible provider (OpenRouter, LiteLLM, custom proxies)
- GPT remains the default via existing `fallbackChain`

### 2. Hook Behavior (`src/hooks/no-hephaestus-non-gpt/hook.ts`)
- **Default behavior**: Block non-GPT models with error toast, switch to Sisyphus
- **With `allow_non_gpt_model: true`**: Show warning toast but allow the model to proceed

## Usage Example

Users can now configure Hephaestus with custom thinking-capable models:

```json
{
  "agents": {
    "hephaestus": {
      "model": "custom-provider/thinking-model-id",
      "reasoningEffort": "high",
      "allow_non_gpt_model": true
    }
  }
}
```

## Testing

- All existing tests pass
- Tests verify warning toast is shown when `allow_non_gpt_model: true`

## Related Issues

- #1071 - Support for custom provider in default categories
- #1637 - Native OpenRouter provider support

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)