### PR TITLE
fix(comment-checker): bump dependency to ^0.7.0 for --prompt support

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@ast-grep/cli": "^0.40.0",
     "@ast-grep/napi": "^0.40.0",
     "@clack/prompts": "^0.11.0",
-    "@code-yeongyu/comment-checker": "^0.6.1",
+    "@code-yeongyu/comment-checker": "^0.7.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@opencode-ai/plugin": "^1.1.19",
     "@opencode-ai/sdk": "^1.1.19",


### PR DESCRIPTION
## Problem

I always felt like comment-checker wasn't doing anything when I had `custom_prompt` configured. After digging into it, turns out it's been silently failing every time.

`465c9e51` added `--prompt` flag support, but `package.json` still has `^0.6.1`. Since this is a 0.x package, caret semantics mean `>=0.6.1 <0.7.0` — so v0.7.0 (which actually has the `--prompt` flag) never gets installed.

When v0.6.x receives an unknown flag, cobra exits with code 0. The hook treats exit 0 as "no comments detected", so the entire check is silently skipped with no error or warning.

## Fix

Bump `@code-yeongyu/comment-checker` from `^0.6.1` to `^0.7.0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped @code-yeongyu/comment-checker to ^0.7.0 to add --prompt support. This fixes silent skips where v0.6.x treated the unknown flag as “no comments” when custom_prompt is set.

<sup>Written for commit acb51d1702493ccca41e9b2b08e21670a9933b99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

