### PR TITLE
fix(config): preserve existing user config when writing new defaults

### DIFF
--- a/src/cli/config-manager/write-omo-config.test.ts
+++ b/src/cli/config-manager/write-omo-config.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { parseJsonc } from "../../shared/jsonc-parser"
+import type { InstallConfig } from "../types"
+import { resetConfigContext } from "./config-context"
+import { generateOmoConfig } from "./generate-omo-config"
+import { writeOmoConfig } from "./write-omo-config"
+
+const installConfig: InstallConfig = {
+  hasClaude: true,
+  isMax20: true,
+  hasOpenAI: true,
+  hasGemini: true,
+  hasCopilot: false,
+  hasOpencodeZen: false,
+  hasZaiCodingPlan: false,
+  hasKimiForCoding: false,
+}
+
+function getRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+
+  return {}
+}
+
+describe("writeOmoConfig", () => {
+  let testConfigDir = ""
+  let testConfigPath = ""
+
+  beforeEach(() => {
+    testConfigDir = join(tmpdir(), `omo-write-config-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    testConfigPath = join(testConfigDir, "oh-my-opencode.json")
+
+    mkdirSync(testConfigDir, { recursive: true })
+    process.env.OPENCODE_CONFIG_DIR = testConfigDir
+    resetConfigContext()
+  })
+
+  afterEach(() => {
+    rmSync(testConfigDir, { recursive: true, force: true })
+    resetConfigContext()
+    delete process.env.OPENCODE_CONFIG_DIR
+  })
+
+  it("preserves existing user values while adding new defaults", () => {
+    // given
+    const existingConfig = {
+      agents: {
+        sisyphus: {
+          model: "custom/provider-model",
+        },
+      },
+      disabled_hooks: ["comment-checker"],
+    }
+    writeFileSync(testConfigPath, JSON.stringify(existingConfig, null, 2) + "\n", "utf-8")
+
+    const generatedDefaults = generateOmoConfig(installConfig)
+
+    // when
+    const result = writeOmoConfig(installConfig)
+
+    // then
+    expect(result.success).toBe(true)
+
+    const savedConfig = parseJsonc<Record<string, unknown>>(readFileSync(testConfigPath, "utf-8"))
+    const savedAgents = getRecord(savedConfig.agents)
+    const savedSisyphus = getRecord(savedAgents.sisyphus)
+    expect(savedSisyphus.model).toBe("custom/provider-model")
+    expect(savedConfig.disabled_hooks).toEqual(["comment-checker"])
+
+    for (const defaultKey of Object.keys(generatedDefaults)) {
+      expect(savedConfig).toHaveProperty(defaultKey)
+    }
+  })
+})

--- a/src/cli/config-manager/write-omo-config.ts
+++ b/src/cli/config-manager/write-omo-config.ts
@@ -43,7 +43,7 @@ export function writeOmoConfig(installConfig: InstallConfig): ConfigMergeResult 
           return { success: true, configPath: omoConfigPath }
         }
 
-        const merged = deepMergeRecord(existing, newConfig)
+        const merged = deepMergeRecord(newConfig, existing)
         writeFileSync(omoConfigPath, JSON.stringify(merged, null, 2) + "\n")
       } catch (parseErr) {
         if (parseErr instanceof SyntaxError) {


### PR DESCRIPTION
## Problem

oh-my-opencode overwrites user's config file instead of preserving existing settings.

## Root Cause

In `write-omo-config.ts`, the deepMergeRecord parameter order causes new defaults to override existing user settings instead of the other way around.

## Fix

Swap parameter order so existing user config values take precedence.

## Validation

- `bun test src/cli/ --timeout 30000`
- Added regression test: `src/cli/config-manager/write-omo-config.test.ts`

Closes #2064

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves existing user config when writing new defaults so user settings aren’t overwritten; closes #2064. Reverses deepMergeRecord argument order to give existing values priority and adds a regression test.

<sup>Written for commit 52658ac1c401788c1bb5cd927f0017389f4e64d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

