### PR TITLE
fix(atlas): allow task and call_omo_agent tools for subagent dispatch

### DIFF
--- a/src/agents/atlas/agent.ts
+++ b/src/agents/atlas/agent.ts
@@ -17,7 +17,6 @@ import type { AvailableAgent, AvailableSkill, AvailableCategory } from "../dynam
 import { buildCategorySkillsDelegationGuide } from "../dynamic-agent-prompt-builder"
 import type { CategoryConfig } from "../../config/schema"
 import { mergeCategories } from "../../shared/merge-categories"
-import { createAgentToolRestrictions } from "../../shared/permission-compat"
 
 import { getDefaultAtlasPrompt } from "./default"
 import { getGptAtlasPrompt } from "./gpt"
@@ -100,11 +99,6 @@ function buildDynamicOrchestratorPrompt(ctx?: OrchestratorContext): string {
 }
 
 export function createAtlasAgent(ctx: OrchestratorContext): AgentConfig {
-  const restrictions = createAgentToolRestrictions([
-    "task",
-    "call_omo_agent",
-  ])
-
   const baseConfig = {
     description:
       "Orchestrates work via task() to complete ALL tasks in a todo list until fully done. (Atlas - OhMyOpenCode)",
@@ -113,7 +107,6 @@ export function createAtlasAgent(ctx: OrchestratorContext): AgentConfig {
     temperature: 0.1,
     prompt: buildDynamicOrchestratorPrompt(ctx),
     color: "#10B981",
-    ...restrictions,
   }
 
   return baseConfig as AgentConfig

--- a/src/agents/tool-restrictions.test.ts
+++ b/src/agents/tool-restrictions.test.ts
@@ -4,6 +4,7 @@ import { createLibrarianAgent } from "./librarian"
 import { createExploreAgent } from "./explore"
 import { createMomusAgent } from "./momus"
 import { createMetisAgent } from "./metis"
+import { createAtlasAgent } from "./atlas"
 
 const TEST_MODEL = "anthropic/claude-sonnet-4-5"
 
@@ -94,6 +95,20 @@ describe("read-only agent tool restrictions", () => {
       for (const tool of FILE_WRITE_TOOLS) {
         expect(permission[tool]).toBe("deny")
       }
+    })
+  })
+
+  describe("Atlas", () => {
+    test("allows delegation tools for orchestration", () => {
+      // given
+      const agent = createAtlasAgent({ model: TEST_MODEL })
+
+      // when
+      const permission = (agent.permission ?? {}) as Record<string, string>
+
+      // then
+      expect(permission["task"]).toBeUndefined()
+      expect(permission["call_omo_agent"]).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## Problem

Atlas agent cannot dispatch subagents because the `task` and `call_omo_agent` tools are blocked by tool restriction configuration.

## Root Cause

In `atlas/agent.ts`, tool restrictions incorrectly deny access to delegation tools.

## Fix

Update tool permission configuration to allow Atlas to use task and call_omo_agent tools.

## Validation

- `bun test src/agents/ --timeout 30000`
- `bun run typecheck`
- `bun run build`

Closes #2044


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows the Atlas agent to dispatch subagents by removing tool restrictions on task and call_omo_agent. Fixes orchestration failures and closes #2044.

- **Bug Fixes**
  - Removed Atlas permission config that blocked task and call_omo_agent.
  - Added tests to ensure delegation tools are allowed for Atlas.

<sup>Written for commit 0639ce8df7bd0421a4a295c84c703c8b817e1697. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

