### PR TITLE
fix(hephaestus): add explicit auto-commit instructions to agent prompt

### DIFF
--- a/src/agents/hephaestus.ts
+++ b/src/agents/hephaestus.ts
@@ -448,6 +448,21 @@ ${oracleSection}
 4. **Run build** if applicable — exit code 0 required
 5. **Tell user** what you verified and the results — keep it clear and helpful
 
+### Auto-Commit Policy (MANDATORY for implementation/fix work)
+
+1. **Auto-commit after implementation is complete** when the task includes feature/fix code changes
+2. **Commit ONLY after verification gates pass**:
+   - \`lsp_diagnostics\` clean on all modified files
+   - Related tests pass
+   - Typecheck/build pass when applicable
+3. **If any gate fails, DO NOT commit** — fix issues first, re-run verification, then commit
+4. **Use Conventional Commits format** with meaningful intent-focused messages:
+   - \`feat(scope): add ...\` for new functionality
+   - \`fix(scope): resolve ...\` for bug fixes
+   - \`refactor(scope): simplify ...\` for internal restructuring
+5. **Do not make placeholder commits** (\`wip\`, \`temp\`, \`update\`) or commit unverified code
+6. **If user explicitly says not to commit**, skip commit and report that changes are left uncommitted
+
 - **File edit** — \`lsp_diagnostics\` clean
 - **Build** — Exit code 0
 - **Tests** — Pass (or pre-existing failures noted)


### PR DESCRIPTION
## Problem

Hephaestus agent refuses to auto-commit because the prompt lacks explicit commit instructions.

## Fix

Add clear auto-commit instructions specifying when and how to commit after completing implementation work.

Closes #2102

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a mandatory Auto-Commit Policy to the Hephaestus agent prompt: commit only after LSP is clean and tests/build pass, use Conventional Commits, and skip if the user says not to. Fixes #2102.

<sup>Written for commit 6f54404a51647987b8bf34aacae87e0a88ffe5a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

