### PR TITLE
fix(agents): retain original agent keys in remapAgentKeysToDisplayNames to prevent crash

### DIFF
--- a/src/plugin-handlers/agent-key-remapper.test.ts
+++ b/src/plugin-handlers/agent-key-remapper.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test"
 import { remapAgentKeysToDisplayNames } from "./agent-key-remapper"
 
 describe("remapAgentKeysToDisplayNames", () => {
-  it("remaps known agent keys to display names", () => {
+  it("remaps known agent keys to display names while preserving original keys", () => {
     // given agents with lowercase keys
     const agents = {
       sisyphus: { prompt: "test", mode: "primary" },
@@ -12,10 +12,11 @@ describe("remapAgentKeysToDisplayNames", () => {
     // when remapping
     const result = remapAgentKeysToDisplayNames(agents)
 
-    // then known agents get display name keys
+    // then known agents get display name keys and original keys remain accessible
     expect(result["Sisyphus (Ultraworker)"]).toBeDefined()
     expect(result["oracle"]).toBeDefined()
-    expect(result["sisyphus"]).toBeUndefined()
+    expect(result["sisyphus"]).toBeDefined()
+    expect(result["Sisyphus (Ultraworker)"]).toBe(result["sisyphus"])
   })
 
   it("preserves unknown agent keys unchanged", () => {
@@ -31,7 +32,7 @@ describe("remapAgentKeysToDisplayNames", () => {
     expect(result["custom-agent"]).toBeDefined()
   })
 
-  it("remaps all core agents", () => {
+  it("remaps all core agents while preserving original keys", () => {
     // given all core agents
     const agents = {
       sisyphus: {},
@@ -46,15 +47,20 @@ describe("remapAgentKeysToDisplayNames", () => {
     // when remapping
     const result = remapAgentKeysToDisplayNames(agents)
 
-    // then all get display name keys
-    expect(Object.keys(result)).toEqual([
-      "Sisyphus (Ultraworker)",
-      "Hephaestus (Deep Agent)",
-      "Prometheus (Plan Builder)",
-      "Atlas (Plan Executor)",
-      "Metis (Plan Consultant)",
-      "Momus (Plan Critic)",
-      "Sisyphus-Junior",
-    ])
+    // then all get display name keys while original keys still work
+    expect(result["Sisyphus (Ultraworker)"]).toBeDefined()
+    expect(result["sisyphus"]).toBeDefined()
+    expect(result["Hephaestus (Deep Agent)"]).toBeDefined()
+    expect(result["hephaestus"]).toBeDefined()
+    expect(result["Prometheus (Plan Builder)"]).toBeDefined()
+    expect(result["prometheus"]).toBeDefined()
+    expect(result["Atlas (Plan Executor)"]).toBeDefined()
+    expect(result["atlas"]).toBeDefined()
+    expect(result["Metis (Plan Consultant)"]).toBeDefined()
+    expect(result["metis"]).toBeDefined()
+    expect(result["Momus (Plan Critic)"]).toBeDefined()
+    expect(result["momus"]).toBeDefined()
+    expect(result["Sisyphus-Junior"]).toBeDefined()
+    expect(result["sisyphus-junior"]).toBeDefined()
   })
 })

--- a/src/plugin-handlers/agent-key-remapper.ts
+++ b/src/plugin-handlers/agent-key-remapper.ts
@@ -9,6 +9,7 @@ export function remapAgentKeysToDisplayNames(
     const displayName = AGENT_DISPLAY_NAMES[key]
     if (displayName && displayName !== key) {
       result[displayName] = value
+      result[key] = value
     } else {
       result[key] = value
     }


### PR DESCRIPTION
## Problem

`remapAgentKeysToDisplayNames` drops original agent keys, causing crashes when agents are accessed by original keys.

## Root Cause

The function replaces original keys with display names but doesn't retain the original key mappings.

## Fix

Keep both original key and display name key in the agents map.

## Validation

- `bun test src/shared/ --timeout 30000`
- `bun run typecheck`
- `bun run build`

Closes #1922


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retain original agent keys when remapping to display names to prevent crashes when agents are accessed by their original keys. Resolves Linear #1922.

- **Bug Fixes**
  - Keep both original and display name keys in the agents map.
  - Update tests to confirm original keys remain and reference the same agent as the display name.

<sup>Written for commit df02c73a547b4cea22e49ab0428474e832f5297f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

