### PR TITLE
fix(stop-continuation): wire backgroundManager to cancel running tasks on stop

### DIFF
--- a/src/hooks/stop-continuation-guard/hook.ts
+++ b/src/hooks/stop-continuation-guard/hook.ts
@@ -1,4 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
+import type { BackgroundManager } from "../../features/background-agent"
 
 import {
   clearContinuationMarker,
@@ -7,6 +8,11 @@ import {
 import { log } from "../../shared/logger"
 
 const HOOK_NAME = "stop-continuation-guard"
+
+type StopContinuationBackgroundManager = Pick<
+  BackgroundManager,
+  "getAllDescendantTasks" | "cancelTask"
+>
 
 export interface StopContinuationGuard {
   event: (input: { event: { type: string; properties?: unknown } }) => Promise<void>
@@ -17,7 +23,10 @@ export interface StopContinuationGuard {
 }
 
 export function createStopContinuationGuardHook(
-  ctx: PluginInput
+  ctx: PluginInput,
+  options?: {
+    backgroundManager?: StopContinuationBackgroundManager
+  }
 ): StopContinuationGuard {
   const stoppedSessions = new Set<string>()
 
@@ -25,6 +34,38 @@ export function createStopContinuationGuardHook(
     stoppedSessions.add(sessionID)
     setContinuationMarkerSource(ctx.directory, sessionID, "stop", "stopped", "continuation stopped")
     log(`[${HOOK_NAME}] Continuation stopped for session`, { sessionID })
+
+    const backgroundManager = options?.backgroundManager
+    if (!backgroundManager) {
+      return
+    }
+
+    const cancellableTasks = backgroundManager
+      .getAllDescendantTasks(sessionID)
+      .filter((task) => task.status === "running" || task.status === "pending")
+
+    if (cancellableTasks.length === 0) {
+      return
+    }
+
+    void Promise.allSettled(
+      cancellableTasks.map(async (task) => {
+        await backgroundManager.cancelTask(task.id, {
+          source: "stop-continuation",
+          reason: "Continuation stopped via /stop-continuation",
+          abortSession: task.status === "running",
+          skipNotification: true,
+        })
+      })
+    ).then((results) => {
+      const cancelledCount = results.filter((result) => result.status === "fulfilled").length
+      const failedCount = results.length - cancelledCount
+      log(`[${HOOK_NAME}] Cancelled background tasks for stopped session`, {
+        sessionID,
+        cancelledCount,
+        failedCount,
+      })
+    })
   }
 
   const isStopped = (sessionID: string): boolean => {

--- a/src/hooks/stop-continuation-guard/index.test.ts
+++ b/src/hooks/stop-continuation-guard/index.test.ts
@@ -2,8 +2,14 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import type { BackgroundManager, BackgroundTask } from "../../features/background-agent"
 import { readContinuationMarker } from "../../features/run-continuation-state"
 import { createStopContinuationGuardHook } from "./index"
+
+type CancelCall = {
+  taskId: string
+  options?: Parameters<BackgroundManager["cancelTask"]>[1]
+}
 
 describe("stop-continuation-guard", () => {
   const tempDirs: string[] = []
@@ -32,6 +38,33 @@ describe("stop-continuation-guard", () => {
       },
       directory: createTempDir(),
     } as any
+  }
+
+  function createBackgroundTask(status: BackgroundTask["status"], id: string): BackgroundTask {
+    return {
+      id,
+      status,
+      description: `${id} description`,
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-message",
+      prompt: "prompt",
+      agent: "sisyphus-junior",
+    }
+  }
+
+  function createMockBackgroundManager(tasks: BackgroundTask[], cancelCalls: CancelCall[]): Pick<BackgroundManager, "getAllDescendantTasks" | "cancelTask"> {
+    return {
+      getAllDescendantTasks: () => tasks,
+      cancelTask: async (taskId: string, options?: Parameters<BackgroundManager["cancelTask"]>[1]) => {
+        cancelCalls.push({ taskId, options })
+        return true
+      },
+    }
+  }
+
+  async function flushMicrotasks(): Promise<void> {
+    await Promise.resolve()
+    await Promise.resolve()
   }
 
   test("should mark session as stopped", () => {
@@ -165,5 +198,32 @@ describe("stop-continuation-guard", () => {
 
     // then - should not throw and stopped session remains stopped
     expect(guard.isStopped("some-session")).toBe(true)
+  })
+
+  test("should cancel only running and pending background tasks on stop", async () => {
+    // given - a background manager with mixed task statuses
+    const cancelCalls: CancelCall[] = []
+    const backgroundManager = createMockBackgroundManager(
+      [
+        createBackgroundTask("running", "task-running"),
+        createBackgroundTask("pending", "task-pending"),
+        createBackgroundTask("completed", "task-completed"),
+      ],
+      cancelCalls,
+    )
+    const guard = createStopContinuationGuardHook(createMockPluginInput(), {
+      backgroundManager,
+    })
+
+    // when - stop continuation is triggered
+    guard.stop("test-session-bg")
+    await flushMicrotasks()
+
+    // then - only running and pending tasks are cancelled
+    expect(cancelCalls).toHaveLength(2)
+    expect(cancelCalls[0]?.taskId).toBe("task-running")
+    expect(cancelCalls[0]?.options?.abortSession).toBe(true)
+    expect(cancelCalls[1]?.taskId).toBe("task-pending")
+    expect(cancelCalls[1]?.options?.abortSession).toBe(false)
   })
 })

--- a/src/plugin/hooks/create-continuation-hooks.ts
+++ b/src/plugin/hooks/create-continuation-hooks.ts
@@ -49,7 +49,10 @@ export function createContinuationHooks(args: {
     safeCreateHook(hookName, factory, { enabled: safeHookEnabled })
 
   const stopContinuationGuard = isHookEnabled("stop-continuation-guard")
-    ? safeHook("stop-continuation-guard", () => createStopContinuationGuardHook(ctx))
+    ? safeHook("stop-continuation-guard", () =>
+        createStopContinuationGuardHook(ctx, {
+          backgroundManager,
+        }))
     : null
 
   const compactionContextInjector = isHookEnabled("compaction-context-injector")


### PR DESCRIPTION
## Problem

`/stop-continuation` sets a stop flag but does not cancel active background tasks, so child sessions keep running.

## Root Cause

The `stop-continuation-guard` hook had no access to `backgroundManager`, so it could not call task cancellation APIs.

## Fix

- Wire `backgroundManager` into `createStopContinuationGuardHook` via continuation hook registration.
- On `stop(sessionID)`, cancel all descendant tasks in that session subtree that are `running` or `pending`.
- Keep cancellation session-scoped by using `getAllDescendantTasks(sessionID)`.
- Add test coverage to verify only `running`/`pending` tasks are cancelled.

Closes #2017


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stopping a continuation now cancels running and pending background tasks for that session, so child sessions don’t keep working after /stop-continuation. Fixes #2017.

- **Bug Fixes**
  - Wired backgroundManager into stop-continuation-guard during hook registration.
  - On stop(sessionID), cancels descendant tasks with status running or pending; running tasks use abortSession=true and notifications are skipped.
  - Scope is limited to the session subtree; added tests to verify only running/pending tasks are cancelled.

<sup>Written for commit ccb789e5dfec18997d865e2b8b9e86bb79ee3fb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

