### PR TITLE
fix(config): preserve formatter config from opencode settings

### DIFF
--- a/src/plugin-handlers/config-handler-formatter.test.ts
+++ b/src/plugin-handlers/config-handler-formatter.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
+
+import type { OhMyOpenCodeConfig } from "../config"
+import { createConfigHandler } from "./config-handler"
+import * as agentConfigHandler from "./agent-config-handler"
+import * as commandConfigHandler from "./command-config-handler"
+import * as mcpConfigHandler from "./mcp-config-handler"
+import * as pluginComponentsLoader from "./plugin-components-loader"
+import * as providerConfigHandler from "./provider-config-handler"
+import * as shared from "../shared"
+import * as toolConfigHandler from "./tool-config-handler"
+
+let logSpy: ReturnType<typeof spyOn>
+let loadPluginComponentsSpy: ReturnType<typeof spyOn>
+let applyAgentConfigSpy: ReturnType<typeof spyOn>
+let applyToolConfigSpy: ReturnType<typeof spyOn>
+let applyMcpConfigSpy: ReturnType<typeof spyOn>
+let applyCommandConfigSpy: ReturnType<typeof spyOn>
+let applyProviderConfigSpy: ReturnType<typeof spyOn>
+
+beforeEach(() => {
+  logSpy = spyOn(shared, "log").mockImplementation(() => {})
+  loadPluginComponentsSpy = spyOn(
+    pluginComponentsLoader,
+    "loadPluginComponents",
+  ).mockResolvedValue({
+    commands: {},
+    skills: {},
+    agents: {},
+    mcpServers: {},
+    hooksConfigs: [],
+    plugins: [],
+    errors: [],
+  })
+  applyAgentConfigSpy = spyOn(agentConfigHandler, "applyAgentConfig").mockResolvedValue(
+    {},
+  )
+  applyToolConfigSpy = spyOn(toolConfigHandler, "applyToolConfig").mockImplementation(
+    () => {},
+  )
+  applyMcpConfigSpy = spyOn(mcpConfigHandler, "applyMcpConfig").mockResolvedValue()
+  applyCommandConfigSpy = spyOn(
+    commandConfigHandler,
+    "applyCommandConfig",
+  ).mockResolvedValue()
+  applyProviderConfigSpy = spyOn(
+    providerConfigHandler,
+    "applyProviderConfig",
+  ).mockImplementation(() => {})
+})
+
+afterEach(() => {
+  logSpy.mockRestore()
+  loadPluginComponentsSpy.mockRestore()
+  applyAgentConfigSpy.mockRestore()
+  applyToolConfigSpy.mockRestore()
+  applyMcpConfigSpy.mockRestore()
+  applyCommandConfigSpy.mockRestore()
+  applyProviderConfigSpy.mockRestore()
+})
+
+describe("createConfigHandler formatter pass-through", () => {
+  test("preserves formatter object configured in opencode config", async () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const formatterConfig = {
+      prettier: {
+        command: ["prettier", "--write"],
+        extensions: [".ts", ".tsx"],
+        environment: {
+          PRETTIERD_DEFAULT_CONFIG: ".prettierrc",
+        },
+      },
+      eslint: {
+        disabled: false,
+        command: ["eslint", "--fix"],
+        extensions: [".js", ".ts"],
+      },
+    }
+    const config: Record<string, unknown> = {
+      formatter: formatterConfig,
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // when
+    await handler(config)
+
+    // then
+    expect(config.formatter).toEqual(formatterConfig)
+  })
+
+  test("preserves formatter=false configured in opencode config", async () => {
+    // given
+    const pluginConfig: OhMyOpenCodeConfig = {}
+    const config: Record<string, unknown> = {
+      formatter: false,
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    // when
+    await handler(config)
+
+    // then
+    expect(config.formatter).toBe(false)
+  })
+})

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -20,6 +20,8 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
   const { ctx, pluginConfig, modelCacheState } = deps;
 
   return async (config: Record<string, unknown>) => {
+    const formatterConfig = config.formatter;
+
     applyProviderConfig({ config, modelCacheState });
 
     const pluginComponents = await loadPluginComponents({ pluginConfig });
@@ -34,6 +36,8 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     applyToolConfig({ config, pluginConfig, agentResult });
     await applyMcpConfig({ config, pluginConfig, pluginComponents });
     await applyCommandConfig({ config, pluginConfig, ctx, pluginComponents });
+
+    config.formatter = formatterConfig;
 
     log("[config-handler] config handler applied", {
       agentCount: Object.keys(agentResult).length,


### PR DESCRIPTION
## Problem

Formatters defined in opencode's configuration don't work because the oh-my-opencode plugin drops the `formatter` field during config processing.

## Root Cause

`config-handler.ts` doesn't preserve the `formatter` field when processing OpenCode configuration.

## Fix

Preserve the formatter configuration in the config handler pipeline.

## Test

- Added `src/plugin-handlers/config-handler-formatter.test.ts` to verify both object and `false` formatter values are preserved.

Closes #2117


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the formatter setting from OpenCode config in the oh-my-opencode config handler so configured formatters are respected. Closes #2117.

- **Bug Fixes**
  - Save formatter before the handler pipeline and restore it after to prevent it being dropped.
  - Added tests to verify passthrough for object configs and formatter=false.

<sup>Written for commit 7ff8352a0aa27456a840f1fce7b9355468a529ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

