### PR TITLE
[Bug]: agent-usage-reminder hook sends circular reminders to explore/librarian subagents

### DIFF
--- a/src/hooks/agent-usage-reminder/hook.ts
+++ b/src/hooks/agent-usage-reminder/hook.ts
@@ -6,6 +6,8 @@ import {
 } from "./storage";
 import { TARGET_TOOLS, AGENT_TOOLS, REMINDER_MESSAGE } from "./constants";
 import type { AgentUsageState } from "./types";
+import { getSessionAgent } from "../../features/claude-code-session-state";
+import { getAgentConfigKey } from "../../shared/agent-display-names";
 
 interface ToolExecuteInput {
   tool: string;
@@ -24,6 +26,23 @@ interface EventInput {
     type: string;
     properties?: unknown;
   };
+}
+
+/**
+ * Only orchestrator agents should receive usage reminders.
+ * Subagents (explore, librarian, oracle, etc.) are the targets of delegation,
+ * so reminding them to delegate to themselves is counterproductive.
+ */
+const ORCHESTRATOR_AGENTS = new Set([
+  "sisyphus",
+  "sisyphus-junior",
+  "atlas",
+  "hephaestus",
+  "prometheus",
+]);
+
+function isOrchestratorAgent(agentName: string): boolean {
+  return ORCHESTRATOR_AGENTS.has(getAgentConfigKey(agentName));
 }
 
 export function createAgentUsageReminderHook(_ctx: PluginInput) {
@@ -60,6 +79,12 @@ export function createAgentUsageReminderHook(_ctx: PluginInput) {
     output: ToolExecuteOutput,
   ) => {
     const { tool, sessionID } = input;
+
+    const agent = getSessionAgent(sessionID);
+    if (agent && !isOrchestratorAgent(agent)) {
+      return;
+    }
+
     const toolLower = tool.toLowerCase();
 
     if (AGENT_TOOLS.has(toolLower)) {


### PR DESCRIPTION
## Summary

- Fix `agent-usage-reminder` hook sending reminders to subagents (explore, librarian, oracle, etc.) that cannot act on them
- Subagents are denied `task`/`call_omo_agent` tools, so they can never dismiss the reminder — every search tool call gets the reminder appended

## Changes

- Added `ORCHESTRATOR_AGENTS` allowlist (`sisyphus`, `sisyphus-junior`, `atlas`) matching the pattern used by `category-skill-reminder`
- Added `isOrchestratorAgent()` helper using `getAgentConfigKey()` for display-name normalization
- Early-return when session agent is known and is not an orchestrator
- If no agent is set yet (fresh session before `setSessionAgent` is called), the reminder still fires — safe default for the main session

## Testing

```bash
bun run typecheck
bun test
```

Manual verification: explore/librarian agents no longer receive `[Agent Usage Reminder]` appended to grep/glob/webfetch tool output.

## Related Issues

This is a bug where:
1. `agent-usage-reminder` applies to **all** sessions with no agent filtering
2. Explore/librarian are denied `task`/`call_omo_agent` tools, so `agentUsed` can never become `true`
3. Every target tool call (grep, glob, webfetch, etc.) appends a reminder telling search agents to delegate to... search agents
4. The sister hook `category-skill-reminder` correctly handles this by targeting only orchestrator agents via `TARGET_AGENTS`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent-usage-reminder sending circular prompts to subagents by targeting only orchestrator agents. This stops reminders in explore/librarian/oracle sessions and keeps them in main orchestration.

- **Bug Fixes**
  - Allowlist orchestrators via normalized config keys: sisyphus, sisyphus-junior, atlas, hephaestus, prometheus.
  - Skip reminders when a non-orchestrator is active; if no agent is set yet, reminders still fire as a safe default.

<sup>Written for commit 35edcecd8f1ef214d2528de37565926b3eeb9003. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

