### PR TITLE
fix(ultrawork-db): write $.thinking alongside $.variant in deferred model override

### DIFF
--- a/src/plugin/ultrawork-db-model-override.ts
+++ b/src/plugin/ultrawork-db-model-override.ts
@@ -23,8 +23,8 @@ function tryUpdateMessageModel(
   if (result.changes === 0) return false
   if (variant) {
     db.prepare(
-      `UPDATE message SET data = json_set(data, '$.variant', ?) WHERE id = ?`,
-    ).run(variant, messageId)
+      `UPDATE message SET data = json_set(data, '$.variant', ?, '$.thinking', ?) WHERE id = ?`,
+    ).run(variant, variant, messageId)
   }
   return true
 }


### PR DESCRIPTION
## Summary
- write deferred variant update to also persist `$.thinking` in `tryUpdateMessageModel`
- keep behavior unchanged for non-variant paths and leave tests untouched

## Validation
- `bun test src/plugin/ultrawork-db-model-override.test.ts` (6/6 passing)
- `bun test` (full suite passing)
- LSP diagnostics clean for `src/plugin/ultrawork-db-model-override.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist $.thinking alongside $.variant when applying deferred model overrides, so the message’s thinking state is saved with the variant. Non-variant paths remain unchanged.

- **Bug Fixes**
  - Update tryUpdateMessageModel to set both $.variant and $.thinking in a single UPDATE using json_set.
  - No change for messages without a variant.

<sup>Written for commit 2ffa803b05e28a8563ee46f87ab814cc6e3526b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

