### PR TITLE
fix(background-agent): clean pendingNotifications on session.deleted

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -2987,6 +2987,28 @@ describe("BackgroundManager.handleEvent - session.deleted cascade", () => {
     manager.shutdown()
     resetToastManager()
   })
+
+  test("should clean pending notifications for deleted sessions", () => {
+    //#given
+    const manager = createBackgroundManager()
+    const sessionID = "session-pending-notifications"
+
+    manager.queuePendingNotification(sessionID, "<system-reminder>queued</system-reminder>")
+    expect(getPendingNotifications(manager).get(sessionID)).toEqual([
+      "<system-reminder>queued</system-reminder>",
+    ])
+
+    //#when
+    manager.handleEvent({
+      type: "session.deleted",
+      properties: { info: { id: sessionID } },
+    })
+
+    //#then
+    expect(getPendingNotifications(manager).has(sessionID)).toBe(false)
+
+    manager.shutdown()
+  })
 })
 
 describe("BackgroundManager.handleEvent - session.error", () => {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -830,6 +830,8 @@ export class BackgroundManager {
         tasksToCancel.set(descendant.id, descendant)
       }
 
+      this.pendingNotifications.delete(sessionID)
+
       if (tasksToCancel.size === 0) return
 
       for (const task of tasksToCancel.values()) {
@@ -866,6 +868,13 @@ export class BackgroundManager {
           subagentSessions.delete(task.sessionID)
         }
       }
+
+      for (const task of tasksToCancel.values()) {
+        if (task.parentSessionID) {
+          this.pendingNotifications.delete(task.parentSessionID)
+        }
+      }
+
       SessionCategoryRegistry.remove(sessionID)
     }
 


### PR DESCRIPTION
## Summary
- Add a regression test that verifies `pendingNotifications` entries are removed when `session.deleted` is handled.
- Clean `pendingNotifications` for the deleted session and for parent sessions of cancelled descendant tasks in `BackgroundManager.handleEvent`.

## Testing
- `bun test src/features/background-agent/manager.test.ts -t "should clean pending notifications for deleted sessions"`
- `bun test src/features/background-agent/`
- `bun test` *(fails on existing unrelated test: `src/plugin/ultrawork-db-model-override.test.ts` expecting `thinking` to be `"max"` but received `null`)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale notifications by clearing pendingNotifications when a session is deleted, and for parent sessions of cancelled descendant tasks. Adds a regression test to prevent the leak from coming back.

- **Bug Fixes**
  - Delete pendingNotifications for the deleted session in BackgroundManager.handleEvent.
  - Clear pendingNotifications for parent sessions of cancelled descendant tasks.
  - Add a regression test to verify cleanup on session.deleted.

<sup>Written for commit 050b93bebb303abb415abf3d8413c290a1409d00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

