### PR TITLE
test(hashline-edit): verify diff format compatibility with OpenCode UI

### DIFF
--- a/src/tools/hashline-edit/diff-utils.test.ts
+++ b/src/tools/hashline-edit/diff-utils.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="bun-types" />
 import { describe, expect, it } from "bun:test"
+import { parsePatch } from "diff"
 import { generateUnifiedDiff } from "./diff-utils"
 
 function createNumberedLines(totalLineCount: number): string {
@@ -7,6 +8,66 @@ function createNumberedLines(totalLineCount: number): string {
 }
 
 describe("generateUnifiedDiff", () => {
+  describe("#given OpenCode compatibility format", () => {
+    it("#then includes the Index header emitted by diff library", () => {
+      //#given
+      const oldContent = "a\n"
+      const newContent = "b\n"
+
+      //#when
+      const diff = generateUnifiedDiff(oldContent, newContent, "test.ts")
+
+      //#then
+      expect(diff).toContain("Index: test.ts")
+    })
+
+    it("#then includes unified --- and +++ file headers", () => {
+      //#given
+      const oldContent = "a\n"
+      const newContent = "b\n"
+
+      //#when
+      const diff = generateUnifiedDiff(oldContent, newContent, "test.ts")
+
+      //#then
+      expect(diff).toContain("--- test.ts")
+      expect(diff).toContain("+++ test.ts")
+    })
+
+    it("#then remains parseable by OpenCode parsePatch flow", () => {
+      //#given
+      const oldContent = "line1\nline2\n"
+      const newContent = "line1\nline2-updated\n"
+
+      //#when
+      const diff = generateUnifiedDiff(oldContent, newContent, "test.ts")
+      const patches = parsePatch(diff)
+
+      //#then
+      expect(patches).toHaveLength(1)
+      expect(patches[0]?.oldFileName).toBe("test.ts")
+      expect(patches[0]?.newFileName).toBe("test.ts")
+      expect(patches[0]?.hunks).toHaveLength(1)
+    })
+  })
+
+  describe("#given content without trailing newline", () => {
+    it("#then keeps no-newline markers parseable", () => {
+      //#given
+      const oldContent = "a"
+      const newContent = "b"
+
+      //#when
+      const diff = generateUnifiedDiff(oldContent, newContent, "test.ts")
+      const patches = parsePatch(diff)
+      const hunkLines = patches[0]?.hunks[0]?.lines ?? []
+
+      //#then
+      expect(diff).toContain("\\ No newline at end of file")
+      expect(hunkLines).toEqual(["-a", "\\ No newline at end of file", "+b", "\\ No newline at end of file"])
+    })
+  })
+
   it("creates separate hunks for distant changes", () => {
     //#given
     const oldContent = createNumberedLines(60)


### PR DESCRIPTION
## Summary
- Investigated OpenCode diff handling and verified it consumes `diff` library patches via `parsePatch` and existing tools keep the `Index:` header.
- Added hashline-edit compatibility tests to assert unified headers, `Index:` behavior, parseability via `parsePatch`, and handling of `\ No newline at end of file` markers.
- Kept `generateUnifiedDiff` implementation unchanged because investigation showed no format incompatibility.

## Verification
- `bun test src/tools/hashline-edit/` (pass)
- `bun run build` (pass)
- `bun test` (fails on existing unrelated test: `src/plugin/ultrawork-db-model-override.test.ts` expecting `thinking` to be `"max"` but got `null`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to confirm hashline-edit diffs match OpenCode UI’s expected format. Checks cover Index and unified headers, parsePatch parsing, and no-newline markers; generateUnifiedDiff remains unchanged.

<sup>Written for commit c8aa1bbce42c00dc329e0876ec655e62cc48b0ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

