### PR TITLE
fix(agents): remove duplicate remapped agent keys

### DIFF
--- a/src/plugin-handlers/agent-key-remapper.test.ts
+++ b/src/plugin-handlers/agent-key-remapper.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test"
 import { remapAgentKeysToDisplayNames } from "./agent-key-remapper"
 
 describe("remapAgentKeysToDisplayNames", () => {
-  it("remaps known agent keys to display names while preserving original keys", () => {
+  it("remaps known agent keys to display names", () => {
     // given agents with lowercase keys
     const agents = {
       sisyphus: { prompt: "test", mode: "primary" },
@@ -12,11 +12,10 @@ describe("remapAgentKeysToDisplayNames", () => {
     // when remapping
     const result = remapAgentKeysToDisplayNames(agents)
 
-    // then known agents get display name keys and original keys remain accessible
+    // then known agents get display name keys only
     expect(result["Sisyphus (Ultraworker)"]).toBeDefined()
     expect(result["oracle"]).toBeDefined()
-    expect(result["sisyphus"]).toBeDefined()
-    expect(result["Sisyphus (Ultraworker)"]).toBe(result["sisyphus"])
+    expect(result["sisyphus"]).toBeUndefined()
   })
 
   it("preserves unknown agent keys unchanged", () => {
@@ -32,7 +31,7 @@ describe("remapAgentKeysToDisplayNames", () => {
     expect(result["custom-agent"]).toBeDefined()
   })
 
-  it("remaps all core agents while preserving original keys", () => {
+  it("remaps all core agents to display names", () => {
     // given all core agents
     const agents = {
       sisyphus: {},
@@ -47,20 +46,20 @@ describe("remapAgentKeysToDisplayNames", () => {
     // when remapping
     const result = remapAgentKeysToDisplayNames(agents)
 
-    // then all get display name keys while original keys still work
+    // then all get display name keys without lowercase duplicates
     expect(result["Sisyphus (Ultraworker)"]).toBeDefined()
-    expect(result["sisyphus"]).toBeDefined()
+    expect(result["sisyphus"]).toBeUndefined()
     expect(result["Hephaestus (Deep Agent)"]).toBeDefined()
-    expect(result["hephaestus"]).toBeDefined()
+    expect(result["hephaestus"]).toBeUndefined()
     expect(result["Prometheus (Plan Builder)"]).toBeDefined()
-    expect(result["prometheus"]).toBeDefined()
+    expect(result["prometheus"]).toBeUndefined()
     expect(result["Atlas (Plan Executor)"]).toBeDefined()
-    expect(result["atlas"]).toBeDefined()
+    expect(result["atlas"]).toBeUndefined()
     expect(result["Metis (Plan Consultant)"]).toBeDefined()
-    expect(result["metis"]).toBeDefined()
+    expect(result["metis"]).toBeUndefined()
     expect(result["Momus (Plan Critic)"]).toBeDefined()
-    expect(result["momus"]).toBeDefined()
+    expect(result["momus"]).toBeUndefined()
     expect(result["Sisyphus-Junior"]).toBeDefined()
-    expect(result["sisyphus-junior"]).toBeDefined()
+    expect(result["sisyphus-junior"]).toBeUndefined()
   })
 })

--- a/src/plugin-handlers/agent-key-remapper.ts
+++ b/src/plugin-handlers/agent-key-remapper.ts
@@ -9,7 +9,6 @@ export function remapAgentKeysToDisplayNames(
     const displayName = AGENT_DISPLAY_NAMES[key]
     if (displayName && displayName !== key) {
       result[displayName] = value
-      result[key] = value
     } else {
       result[key] = value
     }


### PR DESCRIPTION
## Summary
- Remove duplicate agent entries by emitting only display-name keys from the agent key remapper.
- Update remapper tests to assert lowercase built-in keys are not duplicated alongside display names.
- Preserve behavior for unknown/custom agent keys.

## Verification
- bun test src/plugin-handlers/agent-key-remapper.test.ts
- bun run typecheck
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes duplicate agent entries by emitting only display-name keys for known agents. This makes each core agent map to a single canonical key and prevents lowercase duplicates.

- **Bug Fixes**
  - Emit display-name keys only for core agents; drop lowercase duplicates.
  - Preserve unknown/custom agent keys unchanged.
  - Update tests to assert no lowercase duplicates.

<sup>Written for commit d6dd54867a60bf6aa95643f9d4d658eb6f3006b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

