### PR TITLE
fix(hooks): use terminal-notifier for macOS notification click-to-focus

### DIFF
--- a/src/hooks/session-notification-sender.ts
+++ b/src/hooks/session-notification-sender.ts
@@ -7,6 +7,7 @@ import {
   getAfplayPath,
   getPaplayPath,
   getAplayPath,
+  getTerminalNotifierPath,
 } from "./session-notification-utils"
 import { buildWindowsToastScript, escapeAppleScriptText, escapePowerShellSingleQuotedText } from "./session-notification-formatting"
 
@@ -39,6 +40,19 @@ export async function sendSessionNotification(
 ): Promise<void> {
   switch (platform) {
     case "darwin": {
+      // Try terminal-notifier first — deterministic click-to-focus
+      const terminalNotifierPath = await getTerminalNotifierPath()
+      if (terminalNotifierPath) {
+        const bundleId = process.env.__CFBundleIdentifier
+        const args = [terminalNotifierPath, "-title", title, "-message", message]
+        if (bundleId) {
+          args.push("-activate", bundleId)
+        }
+        await ctx.$`${args}`.catch(() => {})
+        break
+      }
+
+      // Fallback: osascript (click may open Finder instead of terminal)
       const osascriptPath = await getOsascriptPath()
       if (!osascriptPath) return
 

--- a/src/hooks/session-notification-utils.ts
+++ b/src/hooks/session-notification-utils.ts
@@ -32,11 +32,13 @@ export const getPowershellPath = createCommandFinder("powershell")
 export const getAfplayPath = createCommandFinder("afplay")
 export const getPaplayPath = createCommandFinder("paplay")
 export const getAplayPath = createCommandFinder("aplay")
+export const getTerminalNotifierPath = createCommandFinder("terminal-notifier")
 
 export function startBackgroundCheck(platform: Platform): void {
   if (platform === "darwin") {
     getOsascriptPath().catch(() => {})
     getAfplayPath().catch(() => {})
+    getTerminalNotifierPath().catch(() => {})
   } else if (platform === "linux") {
     getNotifySendPath().catch(() => {})
     getPaplayPath().catch(() => {})

--- a/src/hooks/session-notification.test.ts
+++ b/src/hooks/session-notification.test.ts
@@ -366,9 +366,7 @@ describe("session-notification", () => {
     expect(notificationCalls).toHaveLength(1)
   })
 
-  test("should use terminal-notifier with -activate when available on darwin", async () => {
-    // given - terminal-notifier is available and __CFBundleIdentifier is set
-    spyOn(sender, "sendSessionNotification").mockRestore()
+  function createSenderMockCtx() {
     const notifyCalls: string[] = []
     const mockCtx = {
       $: async (cmd: TemplateStringsArray | string, ...values: any[]) => {
@@ -379,41 +377,40 @@ describe("session-notification", () => {
         return { stdout: "", stderr: "", exitCode: 0 }
       },
     } as any
+    return { mockCtx, notifyCalls }
+  }
+
+  test("should use terminal-notifier with -activate when available on darwin", async () => {
+    // given - terminal-notifier is available and __CFBundleIdentifier is set
+    spyOn(sender, "sendSessionNotification").mockRestore()
+    const { mockCtx, notifyCalls } = createSenderMockCtx()
     spyOn(utils, "getTerminalNotifierPath").mockResolvedValue("/usr/local/bin/terminal-notifier")
     const originalEnv = process.env.__CFBundleIdentifier
     process.env.__CFBundleIdentifier = "com.mitchellh.ghostty"
 
-    // when - sendSessionNotification is called directly on darwin
-    await sender.sendSessionNotification(mockCtx, "darwin", "Test Title", "Test Message")
+    try {
+      // when - sendSessionNotification is called directly on darwin
+      await sender.sendSessionNotification(mockCtx, "darwin", "Test Title", "Test Message")
 
-    // then - notification uses terminal-notifier with -activate flag
-    expect(notifyCalls.length).toBeGreaterThanOrEqual(1)
-    const tnCall = notifyCalls.find(c => c.includes("terminal-notifier"))
-    expect(tnCall).toBeDefined()
-    expect(tnCall).toContain("-activate")
-    expect(tnCall).toContain("com.mitchellh.ghostty")
-
-    // cleanup
-    if (originalEnv !== undefined) {
-      process.env.__CFBundleIdentifier = originalEnv
-    } else {
-      delete process.env.__CFBundleIdentifier
+      // then - notification uses terminal-notifier with -activate flag
+      expect(notifyCalls.length).toBeGreaterThanOrEqual(1)
+      const tnCall = notifyCalls.find(c => c.includes("terminal-notifier"))
+      expect(tnCall).toBeDefined()
+      expect(tnCall).toContain("-activate")
+      expect(tnCall).toContain("com.mitchellh.ghostty")
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env.__CFBundleIdentifier = originalEnv
+      } else {
+        delete process.env.__CFBundleIdentifier
+      }
     }
   })
 
   test("should fall back to osascript when terminal-notifier is not available", async () => {
     // given - terminal-notifier is NOT available
     spyOn(sender, "sendSessionNotification").mockRestore()
-    const notifyCalls: string[] = []
-    const mockCtx = {
-      $: async (cmd: TemplateStringsArray | string, ...values: any[]) => {
-        const cmdStr = typeof cmd === "string"
-          ? cmd
-          : cmd.reduce((acc, part, i) => acc + part + (values[i] ?? ""), "")
-        notifyCalls.push(cmdStr)
-        return { stdout: "", stderr: "", exitCode: 0 }
-      },
-    } as any
+    const { mockCtx, notifyCalls } = createSenderMockCtx()
     spyOn(utils, "getTerminalNotifierPath").mockResolvedValue(null)
     spyOn(utils, "getOsascriptPath").mockResolvedValue("/usr/bin/osascript")
 
@@ -431,33 +428,24 @@ describe("session-notification", () => {
   test("should use terminal-notifier without -activate when __CFBundleIdentifier is not set", async () => {
     // given - terminal-notifier available but no bundle ID
     spyOn(sender, "sendSessionNotification").mockRestore()
-    const notifyCalls: string[] = []
-    const mockCtx = {
-      $: async (cmd: TemplateStringsArray | string, ...values: any[]) => {
-        const cmdStr = typeof cmd === "string"
-          ? cmd
-          : cmd.reduce((acc, part, i) => acc + part + (values[i] ?? ""), "")
-        notifyCalls.push(cmdStr)
-        return { stdout: "", stderr: "", exitCode: 0 }
-      },
-    } as any
+    const { mockCtx, notifyCalls } = createSenderMockCtx()
     spyOn(utils, "getTerminalNotifierPath").mockResolvedValue("/usr/local/bin/terminal-notifier")
     const originalEnv = process.env.__CFBundleIdentifier
     delete process.env.__CFBundleIdentifier
 
-    // when - sendSessionNotification is called directly on darwin
-    await sender.sendSessionNotification(mockCtx, "darwin", "Test Title", "Test Message")
+    try {
+      // when - sendSessionNotification is called directly on darwin
+      await sender.sendSessionNotification(mockCtx, "darwin", "Test Title", "Test Message")
 
-    // then - terminal-notifier used but without -activate flag
-    expect(notifyCalls.length).toBeGreaterThanOrEqual(1)
-    const tnCall = notifyCalls.find(c => c.includes("terminal-notifier"))
-    expect(tnCall).toBeDefined()
-    expect(tnCall).not.toContain("-activate")
-
-    // cleanup
-    if (originalEnv !== undefined) {
-      process.env.__CFBundleIdentifier = originalEnv
+      // then - terminal-notifier used but without -activate flag
+      expect(notifyCalls.length).toBeGreaterThanOrEqual(1)
+      const tnCall = notifyCalls.find(c => c.includes("terminal-notifier"))
+      expect(tnCall).toBeDefined()
+      expect(tnCall).not.toContain("-activate")
+    } finally {
+      if (originalEnv !== undefined) {
+        process.env.__CFBundleIdentifier = originalEnv
+      }
     }
   })
-
 })

--- a/src/hooks/session-notification.test.ts
+++ b/src/hooks/session-notification.test.ts
@@ -365,4 +365,99 @@ describe("session-notification", () => {
     // then - only one notification should be sent
     expect(notificationCalls).toHaveLength(1)
   })
+
+  test("should use terminal-notifier with -activate when available on darwin", async () => {
+    // given - terminal-notifier is available and __CFBundleIdentifier is set
+    spyOn(sender, "sendSessionNotification").mockRestore()
+    const notifyCalls: string[] = []
+    const mockCtx = {
+      $: async (cmd: TemplateStringsArray | string, ...values: any[]) => {
+        const cmdStr = typeof cmd === "string"
+          ? cmd
+          : cmd.reduce((acc, part, i) => acc + part + (values[i] ?? ""), "")
+        notifyCalls.push(cmdStr)
+        return { stdout: "", stderr: "", exitCode: 0 }
+      },
+    } as any
+    spyOn(utils, "getTerminalNotifierPath").mockResolvedValue("/usr/local/bin/terminal-notifier")
+    const originalEnv = process.env.__CFBundleIdentifier
+    process.env.__CFBundleIdentifier = "com.mitchellh.ghostty"
+
+    // when - sendSessionNotification is called directly on darwin
+    await sender.sendSessionNotification(mockCtx, "darwin", "Test Title", "Test Message")
+
+    // then - notification uses terminal-notifier with -activate flag
+    expect(notifyCalls.length).toBeGreaterThanOrEqual(1)
+    const tnCall = notifyCalls.find(c => c.includes("terminal-notifier"))
+    expect(tnCall).toBeDefined()
+    expect(tnCall).toContain("-activate")
+    expect(tnCall).toContain("com.mitchellh.ghostty")
+
+    // cleanup
+    if (originalEnv !== undefined) {
+      process.env.__CFBundleIdentifier = originalEnv
+    } else {
+      delete process.env.__CFBundleIdentifier
+    }
+  })
+
+  test("should fall back to osascript when terminal-notifier is not available", async () => {
+    // given - terminal-notifier is NOT available
+    spyOn(sender, "sendSessionNotification").mockRestore()
+    const notifyCalls: string[] = []
+    const mockCtx = {
+      $: async (cmd: TemplateStringsArray | string, ...values: any[]) => {
+        const cmdStr = typeof cmd === "string"
+          ? cmd
+          : cmd.reduce((acc, part, i) => acc + part + (values[i] ?? ""), "")
+        notifyCalls.push(cmdStr)
+        return { stdout: "", stderr: "", exitCode: 0 }
+      },
+    } as any
+    spyOn(utils, "getTerminalNotifierPath").mockResolvedValue(null)
+    spyOn(utils, "getOsascriptPath").mockResolvedValue("/usr/bin/osascript")
+
+    // when - sendSessionNotification is called directly on darwin
+    await sender.sendSessionNotification(mockCtx, "darwin", "Test Title", "Test Message")
+
+    // then - notification uses osascript (fallback)
+    expect(notifyCalls.length).toBeGreaterThanOrEqual(1)
+    const osascriptCall = notifyCalls.find(c => c.includes("osascript"))
+    expect(osascriptCall).toBeDefined()
+    const tnCall = notifyCalls.find(c => c.includes("terminal-notifier"))
+    expect(tnCall).toBeUndefined()
+  })
+
+  test("should use terminal-notifier without -activate when __CFBundleIdentifier is not set", async () => {
+    // given - terminal-notifier available but no bundle ID
+    spyOn(sender, "sendSessionNotification").mockRestore()
+    const notifyCalls: string[] = []
+    const mockCtx = {
+      $: async (cmd: TemplateStringsArray | string, ...values: any[]) => {
+        const cmdStr = typeof cmd === "string"
+          ? cmd
+          : cmd.reduce((acc, part, i) => acc + part + (values[i] ?? ""), "")
+        notifyCalls.push(cmdStr)
+        return { stdout: "", stderr: "", exitCode: 0 }
+      },
+    } as any
+    spyOn(utils, "getTerminalNotifierPath").mockResolvedValue("/usr/local/bin/terminal-notifier")
+    const originalEnv = process.env.__CFBundleIdentifier
+    delete process.env.__CFBundleIdentifier
+
+    // when - sendSessionNotification is called directly on darwin
+    await sender.sendSessionNotification(mockCtx, "darwin", "Test Title", "Test Message")
+
+    // then - terminal-notifier used but without -activate flag
+    expect(notifyCalls.length).toBeGreaterThanOrEqual(1)
+    const tnCall = notifyCalls.find(c => c.includes("terminal-notifier"))
+    expect(tnCall).toBeDefined()
+    expect(tnCall).not.toContain("-activate")
+
+    // cleanup
+    if (originalEnv !== undefined) {
+      process.env.__CFBundleIdentifier = originalEnv
+    }
+  })
+
 })


### PR DESCRIPTION
## Summary

- Fix macOS notification click behavior where clicking an OpenCode session notification opens Finder instead of focusing the terminal
- Replace `osascript display notification` with `terminal-notifier -activate $__CFBundleIdentifier` as the primary macOS notification backend
- Gracefully fall back to `osascript` when `terminal-notifier` is not installed

## Changes

- `src/hooks/session-notification-utils.ts`: Added `getTerminalNotifierPath` export using the existing `createCommandFinder` factory; added eager pre-resolution in `startBackgroundCheck` darwin case
- `src/hooks/session-notification-sender.ts`: Modified darwin case in `sendSessionNotification` to try `terminal-notifier` first with `-activate $__CFBundleIdentifier` for deterministic click-to-focus, falling back to `osascript` when `terminal-notifier` is not available
- `src/hooks/session-notification.test.ts`: Added 3 new tests for darwin notification backend selection logic

## Screenshots

<!-- Not applicable — CLI/notification behavior change -->

## Testing

```bash
bun run typecheck
bun run build
bun test src/hooks/session-notification.test.ts
```

Expected: typecheck exits 0, build exits 0, 14 tests pass (11 existing + 3 new)

**Root cause**: `osascript -e 'display notification...'` attributes notification ownership to Script Editor (`com.apple.ScriptEditor2`). When clicked, macOS tries to activate Script Editor; when it isn't running, Finder activates as fallback.

**Fix**: `terminal-notifier -activate $__CFBundleIdentifier` deterministically activates the terminal that launched OpenCode (e.g., `com.mitchellh.ghostty` for Ghostty, `com.googlecode.iterm2` for iTerm2). The `__CFBundleIdentifier` env var is set by macOS and identifies the running app, working correctly even inside tmux sessions.

## Related Issues

<!-- No existing issues found for this bug -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS notification clicks opening Finder instead of the terminal. Notifications now use terminal-notifier so clicks focus the terminal that launched OpenCode.

- **Bug Fixes**
  - Use terminal-notifier on macOS, adding -activate $__CFBundleIdentifier when available for deterministic click-to-focus.
  - Fall back to osascript when terminal-notifier is not available.
  - Pre-resolve notifier paths on darwin; add backend selection tests with a shared mock helper and try-finally env cleanup.

<sup>Written for commit fbe3b5423db3336fcfe0dd3d4ee6dece5e2f75c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

