### PR TITLE
fix: remove misleading hint from replace pos only description

### DIFF
--- a/src/tools/hashline-edit/tool-description.ts
+++ b/src/tools/hashline-edit/tool-description.ts
@@ -34,7 +34,7 @@ FILE CREATION:
   CRITICAL: only unanchored append/prepend can create a missing file.
 
 OPERATION CHOICE:
-  replace with pos only -> replace one line at pos (MOST COMMON for single-line edits)
+  replace with pos only -> replace one line at pos
   replace with pos+end -> replace ENTIRE range pos..end as a block (ranges MUST NOT overlap across edits)
   append with pos/end anchor -> insert after that anchor
   prepend with pos/end anchor -> insert before that anchor


### PR DESCRIPTION
## Problem

When an agent uses the `replace` operation with `pos` only (without `end`) but provides multi-line content in `lines`, the tool only replaces a single line. This causes subsequent lines from the original file to be retained, resulting in duplicate code.

### Root Cause

The tool description contains a misleading hint: "(MOST COMMON for single-line edits)". This misleads agents into thinking that pos-only replace is the default/recommended approach, even when they need to replace multiple lines.

### Concrete Example

Original file (3 lines):
```typescript
export function cn(...inputs: string[]) {  // line 1
  return inputs.join(' ');                  // line 2
}                                          // line 3
```

Agent intends to replace with (4 lines):
```typescript
export function cn(...inputs: string[]) {
  // test comment
  return inputs.join(' ');
}
```

Agent constructs:
```json
{
  "op": "replace",
  "pos": "1#ZV",
  "lines": "export function cn(...inputs: string[]) {\n  // test comment\n  return inputs.join(' ');\n}"
}
```

**What happens:**
- Tool checks: no `end` specified → uses `applySetLine()` (single-line replacement)
- Tool executes: `splice(line - 1, 1, ...replacement)` — deletes 1 line, inserts 4 lines
- Result: **Original lines 2-3 are retained!**

**Actual output (6 lines):**
```typescript
export function cn(...inputs: string[]) {  // new line 1
  // test comment                        // new line 2
  return inputs.join(' ');                // new line 3
}                                         // new line 4
  return inputs.join(' ');                // old line 2 (retained!)
}                                         // old line 3 (retained!)
```

## Solution

Remove the misleading hint from the tool description. Agents should understand that:
- `pos` only → replaces exactly one line
- `pos` + `end` → replaces the entire range

## Reproduction Steps

1. Create a file with 3 lines
2. Use the edit tool with `pos-only` replace, passing 4 lines in the `lines` parameter
3. Result: Lines 2-3 from the original file are retained, causing 6 lines of output
