### PR TITLE
fix: remove config-context console.warn that leaks into TUI textbox

### DIFF
--- a/src/cli/config-manager/config-context.ts
+++ b/src/cli/config-manager/config-context.ts
@@ -19,9 +19,6 @@ export function initConfigContext(binary: OpenCodeBinaryType, version: string | 
 
 export function getConfigContext(): ConfigContext {
   if (!configContext) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[config-context] getConfigContext() called before initConfigContext(); defaulting to CLI paths.")
-    }
     const paths = getOpenCodeConfigPaths({ binary: "opencode", version: null })
     configContext = { binary: "opencode", version: null, paths }
   }


### PR DESCRIPTION
## Summary

- Removes `console.warn` in `getConfigContext()` that renders inside the TUI textbox during startup
- The fallback behavior (defaulting to standard CLI paths) is preserved — only the noisy warning is removed

## Problem

`initConfigContext()` runs async (spawns `opencode --version` subprocess), but modules calling `getConfigDir()` / `getConfigJson()` can resolve synchronously before it completes. The `console.warn` writes to stderr, which the TUI captures, causing the warning to appear in the user's input textbox.

Fixes #2183

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed console.warn in getConfigContext() that wrote to stderr and leaked into the TUI input box during startup. Behavior unchanged: if initConfigContext() hasn’t completed, we default to standard CLI paths.

<sup>Written for commit 83c024dd663635c004eb1aabeb1258a4af578690. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

