### PR TITLE
fix: initialize config context in plugin runtime to prevent warnings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { initConfigContext } from "./cli/config-manager/config-context"
 import type { Plugin } from "@opencode-ai/plugin"
 
 import type { HookName } from "./config"
@@ -14,6 +15,8 @@ import { injectServerAuthIntoClient, log } from "./shared"
 import { startTmuxCheck } from "./tools"
 
 const OhMyOpenCodePlugin: Plugin = async (ctx) => {
+  // Initialize config context for plugin runtime (prevents warnings from hooks)
+  initConfigContext("opencode", null)
   log("[OhMyOpenCodePlugin] ENTRY - plugin loading", {
     directory: ctx.directory,
   })


### PR DESCRIPTION
## Problem

When using OpenCode TUI, users see a spurious warning message:

```
bun install v1.3.9 (cf6cdbbb) text) called before initConfigContext); defaulting to CLI paths.
```

This occurs when opening folders containing `.mulch` or `.beads` directories (or any folder that triggers lifecycle plugins).

## Root Cause

The `auto-update-checker` hook runs `bun install` to check for updates, which internally calls `getConfigDir()`. This function requires the config context to be initialized via `initConfigContext()`.

When running in the OpenCode TUI plugin runtime (vs the CLI), this initialization never happens because:
- The CLI entry point (`src/cli/install.ts`) calls `initConfigContext()` 
- The plugin entry point (`src/index.ts`) did NOT call it

The warning appears in the TUI because the auto-update checker triggers when lifecycle plugins activate.

## Solution

Add `initConfigContext("opencode", null)` at the start of the plugin initialization to ensure the config context is properly initialized for all hooks and utilities.

### Changes
- Import `initConfigContext` from `./cli/config-manager/config-context`
- Call `initConfigContext("opencode", null)` at plugin startup

This is a minimal, safe change that:
- ✅ Fixes the warning for all TUI users
- ✅ Ensures config-dependent features work correctly in plugin context
- ✅ Aligns with the intended design pattern (context should be initialized)
- ✅ No breaking changes - uses same defaults as the fallback behavior

## Testing

Before this fix:
- Opening folders with `.mulch` or `.beads` directories showed the warning
- The warning was confusing and appeared to be an error

After this fix:
- No warning appears
- Plugin initialization is clean
- All hooks work correctly with proper config context

## Related Code

The warning originates in:
- `src/cli/config-manager/config-context.ts:23`

Triggered by:
- `src/hooks/auto-update-checker/hook/background-update-check.ts` → calls `runBunInstall()` → calls `getConfigDir()`

Fixed in:
- `src/index.ts` (this PR)

## Checklist

- [x] Fix addresses root cause, not just symptom
- [x] Minimal change with no side effects  
- [x] Follows existing code patterns
- [x] No breaking changes
- [x] Tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize the config context at plugin startup to prevent the “getConfigContext() called before initConfigContext()” warning in the TUI. Hooks now run with the correct config paths.

- **Bug Fixes**
  - Import and call initConfigContext("opencode", null) in src/index.ts for the plugin runtime.
  - Removes bun install warning when lifecycle plugins (e.g., auto-update checker) run.

<sup>Written for commit 09fd131f24328a746737909f3fd7d841ce46a77a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

