### PR TITLE
feat(start-work): add auto_commit config option

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -3837,6 +3837,19 @@
       },
       "additionalProperties": false
     },
+    "start_work": {
+      "type": "object",
+      "properties": {
+        "auto_commit": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "auto_commit"
+      ],
+      "additionalProperties": false
+    },
     "_migrations": {
       "type": "array",
       "items": {

--- a/src/config/AGENTS.md
+++ b/src/config/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## OVERVIEW
 
-7ZB|22 schema files composing `OhMyOpenCodeConfigSchema`. Zod v4 validation with `safeParse()`. All fields optional — omitted fields use plugin defaults.
+22 schema files composing `OhMyOpenCodeConfigSchema`. Zod v4 validation with `safeParse()`. All fields optional — omitted fields use plugin defaults.
 
 ## SCHEMA TREE
 
@@ -33,8 +33,7 @@ config/schema/
 ├── dynamic-context-pruning.ts  # Context pruning settings
 ├── start-work.ts              # StartWorkConfigSchema (auto_commit)
 └── internal/permission.ts      # AgentPermissionSchema
-├── start-work.ts               # StartWorkConfigSchema (auto_commit)
-└── internal/permission.ts      # AgentPermissionSchema
+
 ```
 
 ## ROOT SCHEMA FIELDS (28)

--- a/src/config/AGENTS.md
+++ b/src/config/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## OVERVIEW
 
-22 schema files composing `OhMyOpenCodeConfigSchema`. Zod v4 validation with `safeParse()`. All fields optional — omitted fields use plugin defaults.
+7ZB|22 schema files composing `OhMyOpenCodeConfigSchema`. Zod v4 validation with `safeParse()`. All fields optional — omitted fields use plugin defaults.
 
 ## SCHEMA TREE
 
@@ -31,12 +31,15 @@ config/schema/
 ├── background-task.ts          # Concurrency limits per model/provider
 ├── babysitting.ts              # Unstable agent monitoring
 ├── dynamic-context-pruning.ts  # Context pruning settings
+├── start-work.ts              # StartWorkConfigSchema (auto_commit)
+└── internal/permission.ts      # AgentPermissionSchema
+├── start-work.ts               # StartWorkConfigSchema (auto_commit)
 └── internal/permission.ts      # AgentPermissionSchema
 ```
 
-## ROOT SCHEMA FIELDS (27)
+## ROOT SCHEMA FIELDS (28)
 
-`$schema`, `new_task_system_enabled`, `default_run_agent`, `disabled_mcps`, `disabled_agents`, `disabled_skills`, `disabled_hooks`, `disabled_commands`, `disabled_tools`, `hashline_edit`, `agents`, `categories`, `claude_code`, `sisyphus_agent`, `comment_checker`, `experimental`, `auto_update`, `skills`, `ralph_loop`, `background_task`, `notification`, `babysitting`, `git_master`, `browser_automation_engine`, `websearch`, `tmux`, `sisyphus`, `_migrations`
+`$schema`, `new_task_system_enabled`, `default_run_agent`, `disabled_mcps`, `disabled_agents`, `disabled_skills`, `disabled_hooks`, `disabled_commands`, `disabled_tools`, `hashline_edit`, `agents`, `categories`, `claude_code`, `sisyphus_agent`, `comment_checker`, `experimental`, `auto_update`, `skills`, `ralph_loop`, `background_task`, `notification`, `babysitting`, `git_master`, `browser_automation_engine`, `websearch`, `tmux`, `sisyphus`, `start_work`, `_migrations`
 
 ## AGENT OVERRIDE FIELDS (21)
 

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -18,6 +18,7 @@ import { SkillsConfigSchema } from "./skills"
 import { SisyphusConfigSchema } from "./sisyphus"
 import { SisyphusAgentConfigSchema } from "./sisyphus-agent"
 import { TmuxConfigSchema } from "./tmux"
+import { StartWorkConfigSchema } from "./start-work"
 import { WebsearchConfigSchema } from "./websearch"
 
 export const OhMyOpenCodeConfigSchema = z.object({
@@ -60,6 +61,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
   websearch: WebsearchConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),
   sisyphus: SisyphusConfigSchema.optional(),
+  start_work: StartWorkConfigSchema.optional(),
   /** Migration history to prevent re-applying migrations (e.g., model version upgrades) */
   _migrations: z.array(z.string()).optional(),
 })

--- a/src/config/schema/start-work.ts
+++ b/src/config/schema/start-work.ts
@@ -1,0 +1,8 @@
+import { z } from "zod"
+
+export const StartWorkConfigSchema = z.object({
+  /** Enable auto-commit after each atomic task completion (default: true) */
+  auto_commit: z.boolean().default(true),
+})
+
+export type StartWorkConfig = z.infer<typeof StartWorkConfigSchema>

--- a/src/hooks/atlas/atlas-hook.ts
+++ b/src/hooks/atlas/atlas-hook.ts
@@ -7,6 +7,7 @@ import type { AtlasHookOptions, SessionState } from "./types"
 export function createAtlasHook(ctx: PluginInput, options?: AtlasHookOptions) {
   const sessions = new Map<string, SessionState>()
   const pendingFilePaths = new Map<string, string>()
+  const autoCommit = options?.autoCommit ?? true
 
   function getState(sessionID: string): SessionState {
     let state = sessions.get(sessionID)
@@ -20,6 +21,6 @@ export function createAtlasHook(ctx: PluginInput, options?: AtlasHookOptions) {
   return {
     handler: createAtlasEventHandler({ ctx, options, sessions, getState }),
     "tool.execute.before": createToolExecuteBeforeHandler({ ctx, pendingFilePaths }),
-    "tool.execute.after": createToolExecuteAfterHandler({ ctx, pendingFilePaths }),
+    "tool.execute.after": createToolExecuteAfterHandler({ ctx, pendingFilePaths, autoCommit }),
   }
 }

--- a/src/hooks/atlas/tool-execute-after.ts
+++ b/src/hooks/atlas/tool-execute-after.ts
@@ -14,9 +14,9 @@ import type { ToolExecuteAfterInput, ToolExecuteAfterOutput } from "./types"
 export function createToolExecuteAfterHandler(input: {
   ctx: PluginInput
   pendingFilePaths: Map<string, string>
-}): (toolInput: ToolExecuteAfterInput, toolOutput: ToolExecuteAfterOutput) => Promise<void> {
-  const { ctx, pendingFilePaths } = input
-
+  autoCommit: boolean
+  }): (toolInput: ToolExecuteAfterInput, toolOutput: ToolExecuteAfterOutput) => Promise<void> {
+  const { ctx, pendingFilePaths, autoCommit } = input
   return async (toolInput, toolOutput): Promise<void> => {
     // Guard against undefined output (e.g., from /review command - see issue #1035)
     if (!toolOutput) {
@@ -76,7 +76,7 @@ export function createToolExecuteAfterHandler(input: {
         // Preserve original subagent response - critical for debugging failed tasks
         const originalResponse = toolOutput.output
 
-        toolOutput.output = `
+toolOutput.output = `
 ## SUBAGENT WORK COMPLETED
 
 ${fileChanges}
@@ -88,9 +88,8 @@ ${fileChanges}
 ${originalResponse}
 
 <system-reminder>
-${buildOrchestratorReminder(boulderState.plan_name, progress, subagentSessionId)}
+${buildOrchestratorReminder(boulderState.plan_name, progress, subagentSessionId, autoCommit)}
 </system-reminder>`
-
         log(`[${HOOK_NAME}] Output transformed for orchestrator mode (boulder)`, {
           plan: boulderState.plan_name,
           progress: `${progress.completed}/${progress.total}`,

--- a/src/hooks/atlas/types.ts
+++ b/src/hooks/atlas/types.ts
@@ -8,6 +8,8 @@ export interface AtlasHookOptions {
   backgroundManager?: BackgroundManager
   isContinuationStopped?: (sessionID: string) => boolean
   agentOverrides?: AgentOverrides
+  /** Enable auto-commit after each atomic task completion (default: true) */
+  autoCommit?: boolean
 }
 
 export interface ToolExecuteAfterInput {

--- a/src/hooks/atlas/verification-reminders.ts
+++ b/src/hooks/atlas/verification-reminders.ts
@@ -14,9 +14,22 @@ task(session_id="${sessionId}", prompt="fix: [describe the specific failure]")
 export function buildOrchestratorReminder(
   planName: string,
   progress: { total: number; completed: number },
-  sessionId: string
+  sessionId: string,
+  autoCommit: boolean = true
 ): string {
   const remaining = progress.total - progress.completed
+  
+  const commitStep = autoCommit
+    ? `
+**STEP 8: COMMIT ATOMIC UNIT**
+
+- Stage ONLY the verified changes
+- Commit with clear message describing what was done
+`
+    : ""
+
+  const nextStepNumber = autoCommit ? 9 : 8
+
   return `
 ---
 
@@ -60,13 +73,8 @@ Update the plan file \`.sisyphus/plans/${planName}.md\`:
 - Use \`Edit\` tool to modify the checkbox
 
 **DO THIS BEFORE ANYTHING ELSE. Unmarked = Untracked = Lost progress.**
-
-**STEP 8: COMMIT ATOMIC UNIT**
-
-- Stage ONLY the verified changes
-- Commit with clear message describing what was done
-
-**STEP 9: PROCEED TO NEXT TASK**
+${commitStep}
+**STEP ${nextStepNumber}: PROCEED TO NEXT TASK**
 
 - Read the plan file AGAIN to identify the next \`- [ ]\` task
 - Start immediately - DO NOT STOP

--- a/src/plugin/hooks/create-continuation-hooks.ts
+++ b/src/plugin/hooks/create-continuation-hooks.ts
@@ -111,6 +111,7 @@ export function createContinuationHooks(args: {
           isContinuationStopped: (sessionID: string) =>
             stopContinuationGuard?.isStopped(sessionID) ?? false,
           agentOverrides: pluginConfig.agents,
+          autoCommit: pluginConfig.start_work?.auto_commit,
         }))
     : null
 


### PR DESCRIPTION
## Summary

- Adds `start_work.auto_commit` configuration option to allow users to disable the automatic commit step in the `/start-work` workflow
- When `auto_commit` is `false`, "STEP 8: COMMIT ATOMIC UNIT" is removed from the orchestrator reminder and step numbering is adjusted accordingly

## Usage

Users can now disable auto-commit in their configuration file:

```jsonc
{
  "start_work": {
    "auto_commit": false
  }
}
```

## Changes

| File | Change |
|------|--------|
| `src/config/schema/start-work.ts` | NEW - Zod schema for `start_work` config with `auto_commit: boolean` (default: `true`) |
| `src/config/schema/oh-my-opencode-config.ts` | Added `start_work` to root schema |
| `src/hooks/atlas/types.ts` | Added `autoCommit` to `AtlasHookOptions` |
| `src/hooks/atlas/atlas-hook.ts` | Forward `autoCommit` option to tool handlers |
| `src/hooks/atlas/tool-execute-after.ts` | Pass `autoCommit` to `buildOrchestratorReminder` |
| `src/hooks/atlas/verification-reminders.ts` | Conditionally render commit step with renumbering |
| `src/plugin/hooks/create-continuation-hooks.ts` | Pass config to `createAtlasHook` |

## Verification

- ✅ Typecheck passes
- ✅ Build passes  
- ✅ 41 Atlas hook tests pass
- ✅ JSON schema generated with new `start_work` option

Resolves #2197

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a start_work.auto_commit config to let users turn off automatic commits in the /start-work workflow. When disabled, the orchestrator reminder hides the commit step and renumbers the next step.

- **New Features**
  - Added start_work.auto_commit (default true) to the root config and JSON schema.
  - Wired autoCommit through Atlas hook and tool-execute-after to verification reminders.
  - Commit step renders only when enabled; next step number adjusts.
  - Updated AGENTS.md to include start_work.

- **Bug Fixes**
  - Cleaned AGENTS.md by removing an accidental keystroke and duplicate schema entries.

<sup>Written for commit 5e726a2af2ff3f62999fe26bbb645c7148940858. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

