### PR TITLE
fix(tools): resolve relative paths in glob/grep against project directory

### DIFF
--- a/src/tools/glob/tools.ts
+++ b/src/tools/glob/tools.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { runRgFiles } from "./cli"
@@ -22,10 +23,12 @@ export function createGlobTools(ctx: PluginInput): Record<string, ToolDefinition
             "simply omit it for the default behavior. Must be a valid directory path if provided."
         ),
     },
-    execute: async (args) => {
+    execute: async (args, context) => {
       try {
         const cli = await resolveGrepCliWithAutoInstall()
-        const searchPath = args.path ?? ctx.directory
+        const runtimeCtx = context as Record<string, unknown>
+        const dir = typeof runtimeCtx.directory === "string" ? runtimeCtx.directory : ctx.directory
+        const searchPath = args.path ? resolve(dir, args.path) : dir
         const paths = [searchPath]
 
         const result = await runRgFiles(

--- a/src/tools/grep/tools.ts
+++ b/src/tools/grep/tools.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool"
 import { runRg, runRgCount } from "./cli"
@@ -32,10 +33,12 @@ export function createGrepTools(ctx: PluginInput): Record<string, ToolDefinition
         .optional()
         .describe("Limit output to first N entries. 0 or omitted means no limit."),
     },
-    execute: async (args) => {
+    execute: async (args, context) => {
       try {
         const globs = args.include ? [args.include] : undefined
-        const searchPath = args.path ?? ctx.directory
+        const runtimeCtx = context as Record<string, unknown>
+        const dir = typeof runtimeCtx.directory === "string" ? runtimeCtx.directory : ctx.directory
+        const searchPath = args.path ? resolve(dir, args.path) : dir
         const paths = [searchPath]
         const outputMode = args.output_mode ?? "files_with_matches"
         const headLimit = args.head_limit ?? 0


### PR DESCRIPTION
## Summary

- Fix glob and grep tools to use the per-session `context.directory` from the tool execution callback instead of the closure-captured `ctx.directory` from plugin init
- Also resolve relative paths against the project directory, preventing "No such file or directory" errors
- Falls back to `ctx.directory` for backwards compatibility when `context.directory` is unavailable

## Changes

- `src/tools/glob/tools.ts`: Use `context.directory` (per-session, live) with fallback to `ctx.directory` (plugin init, stale); resolve relative paths via `path.resolve()`
- `src/tools/grep/tools.ts`: Same change

## Root Cause

**Two layered bugs:**

### Bug 1: Relative paths not resolved

Both tools used:
```ts
const searchPath = args.path ?? ctx.directory
```

When a model provides a **relative** path (e.g. `src/components`), it's forwarded to ripgrep as-is. Ripgrep resolves it against `process.cwd()`, which differs by environment:
- **CLI/Terminal**: `process.cwd()` = project directory → works by accident
- **OpenCode Desktop**: `process.cwd()` = `/` → fails

### Bug 2: `ctx.directory` captured once at plugin init, not per-session

`ctx` comes from `PluginInput`, which is constructed once when the plugin loads:

```ts
// opencode/packages/opencode/src/plugin/index.ts
const input: PluginInput = {
  directory: Instance.directory,  // captured ONCE at plugin load time
  // ...
}
```

In OpenCode Desktop (Electron), `Instance.directory` at plugin load time can be `/` (the Electron process CWD). However, OpenCode's tool registry passes the **correct per-session directory** via the `execute` callback's second argument:

```ts
// opencode/packages/opencode/src/tool/registry.ts (fromPlugin)
execute: async (input) => {
  const pluginCtx: ToolContext = {
    directory: Instance.directory,  // LIVE per-session value
    // ...
  }
  return tool.execute(input, pluginCtx)
}
```

The `ToolContext` type in newer OpenCode versions explicitly documents this:
```ts
export type ToolContext = {
  /** Current project directory for this session.
   *  Prefer this over process.cwd() when resolving relative paths. */
  directory: string
  // ...
}
```

**Our plugin tools were ignoring this second argument entirely**, using the stale closure-captured `ctx.directory` instead.

## Fix

```ts
// Before:
execute: async (args) => {
  const searchPath = args.path ?? ctx.directory

// After:
execute: async (args, context) => {
  const runtimeCtx = context as Record<string, unknown>
  const dir = typeof runtimeCtx.directory === "string" ? runtimeCtx.directory : ctx.directory
  const searchPath = args.path ? resolve(dir, args.path) : dir
```

This fixes both bugs:
1. **Relative paths** are resolved against the project directory via `resolve()`
2. **Per-session directory** is used via `context.directory`, with `ctx.directory` as fallback

## Note on Types

The `directory` field exists on `ToolContext` in `@opencode-ai/plugin@1.2.15+`, but the project currently depends on `@1.1.19` where `ToolContext` lacks it. We access it via a runtime type check (`context as Record<string, unknown>`) to avoid bumping the SDK in this PR.

Once `@opencode-ai/plugin` is bumped to `>=1.2.15`, this can be simplified to `context.directory ?? ctx.directory`.

## Evidence

Queried the OpenCode session database across explore subagent sessions on a real project:

```sql
-- Glob failures with relative paths
SELECT p.session_id, s.title, substr(p.data, 1, 400)
FROM part p JOIN session s ON p.session_id = s.id
WHERE p.data LIKE '%No such file or directory%' AND p.data LIKE '%glob%';
```

Dozens of failures:
```json
{"tool":"glob","input":{"path":"apps/ios/MyApp","pattern":"**/*.swift"},
  "output":"Error: rg: apps/ios/MyApp: IO error ... No such file or directory (os error 2)"}
```

Same sessions succeed with absolute paths:
```json
{"tool":"glob","input":{"path":"/Users/user/Projects/myproject/apps/ios/MyApp","pattern":"**/*.swift"},
  "output":"Found 98 file(s)..."}
```

Additionally, glob calls with **no path parameter at all** also failed — returning "No files found" because `ctx.directory` was `/`:
```json
{"tool":"glob","input":{"pattern":"apps/backend/**/*.ts"},
  "output":"No files found matching pattern"}
```

Confirmed no sessions have `/` as their directory — the session directory is always correct:
```sql
SELECT id, directory FROM session WHERE directory = '/';
-- (empty)
```

## Testing

```bash
bun test src/tools/glob/ src/tools/grep/
# 29 pass, 0 fail
```

`path.resolve()` with an already-absolute second argument returns it unchanged, so existing behavior for absolute paths is preserved.