### PR TITLE
fix(glob): use cwd-relative search for ripgrep to fix directory prefix patterns

### DIFF
--- a/src/tools/glob/cli.ts
+++ b/src/tools/glob/cli.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path"
 import { spawn } from "bun"
 import {
   resolveGrepCli,
@@ -119,10 +120,9 @@ async function runRgFilesInternal(
 
   if (isRg) {
     const args = buildRgArgs(options)
-    const paths = options.paths?.length ? options.paths : ["."]
-    args.push(...paths)
+    cwd = options.paths?.[0] || "."
+    args.push(".")
     command = [cli.path, ...args]
-    cwd = undefined
   } else if (isWindows) {
     command = buildPowerShellCommand(options)
     cwd = undefined
@@ -177,7 +177,7 @@ async function runRgFilesInternal(
 
       let filePath: string
       if (isRg) {
-        filePath = line
+        filePath = cwd ? resolve(cwd, line) : line
       } else if (isWindows) {
         filePath = line.trim()
       } else {

--- a/src/tools/glob/tools.ts
+++ b/src/tools/glob/tools.ts
@@ -29,12 +29,11 @@ export function createGlobTools(ctx: PluginInput): Record<string, ToolDefinition
         const runtimeCtx = context as Record<string, unknown>
         const dir = typeof runtimeCtx.directory === "string" ? runtimeCtx.directory : ctx.directory
         const searchPath = args.path ? resolve(dir, args.path) : dir
-        const paths = [searchPath]
 
         const result = await runRgFiles(
           {
             pattern: args.pattern,
-            paths,
+            paths: [searchPath],
           },
           cli
         )


### PR DESCRIPTION
## Summary

- Fix glob tool silently returning "No files found" when patterns contain directory prefixes like `apps/backend/**/*.ts`
- Run ripgrep with `cwd` set to the search path and `.` as the target, matching how the `find` backend already operates

## Root Cause

Ripgrep's `--glob` flag doesn't match patterns that contain directory prefixes when the search target is an absolute path. When a model writes:

```json
{ "pattern": "apps/backend/**/*.{ts,js}", "path": "/project/root" }
```

The tool constructs:
```
rg --files --glob='apps/backend/**/*.{ts,js}' /project/root
```

This silently returns zero results, even though files exist under `/project/root/apps/backend/`. Models naturally write patterns this way when exploring unfamiliar codebases — they combine the subdirectory and file filter into a single glob.

**Verified with direct testing:**

| Command | Result |
|---|---|
| `rg --files --glob 'apps/backend/**/*.ts' /project` | No results |
| `rg --files --glob 'apps/backend/**/*.ts' .` (cwd=/project) | Works |
| `rg --files --glob '**/*.ts' /project/apps/backend` | Works |

## Fix

Instead of passing the absolute search path as a ripgrep argument, set it as the working directory and search `.`:

```diff
  if (isRg) {
    const args = buildRgArgs(options)
-   const paths = options.paths?.length ? options.paths : ["."]
-   args.push(...paths)
-   command = [cli.path, ...args]
-   cwd = undefined
+   cwd = options.paths?.[0] || "."
+   args.push(".")
+   command = [cli.path, ...args]
  }
```

Ripgrep then sees relative paths internally, so directory-prefixed globs match correctly. Output paths are resolved back to absolute via `resolve(cwd, line)`.

This matches how the `find` backend already operates — it sets `cwd = paths[0]` and searches `.`.

**Safe because:**
- No pattern mangling — the full user-provided glob is passed to ripgrep unchanged
- Output paths are resolved back to absolute, so consumers see no difference
- Consistent with the existing `find` backend behavior

## Testing

```bash
bun test src/tools/glob/
# 18 pass, 0 fail
bun run typecheck
# Clean
```