### PR TITLE
docs: add guide for speeding up fallback with proxy APIs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -558,6 +558,23 @@ Auto-switches to backup models on API errors.
 | `timeout_seconds` | `30` | Seconds before forcing next fallback. **Set to `0` to disable timeout-based escalation and provider retry message detection.** |
 | `notify_on_fallback` | `true` | Toast notification on model switch |
 
+#### Speeding Up Fallback (Proxy APIs)
+
+If you are using a proxy API provider, they may return different error codes (e.g., `401`, `403`, `404`) for quota exhaustion or model unavailability. To make fallback trigger instantly without waiting for long timeouts:
+
+```jsonc
+{
+  "runtime_fallback": {
+    "enabled": true,
+    // Add your proxy's specific error codes to retry_on_errors
+    "retry_on_errors": [400, 401, 403, 404, 429, 500, 502, 503, 504],
+    "max_fallback_attempts": 3,
+    "cooldown_seconds": 15, // Shorter cooldown
+    "timeout_seconds": 10   // Detect hung proxy requests faster
+  }
+}
+```
+
 Define `fallback_models` per agent or category:
 
 ```json


### PR DESCRIPTION
## Description

Adds a section in the runtime-fallback documentation explaining how to speed up fallback times when using API proxy providers. It covers adding additional status codes (`401`, `403`, `404`) to `retry_on_errors` and reducing `timeout_seconds` and `cooldown_seconds`.

This directly helps users dealing with exhausted provider quotas or missing proxy models by ensuring they don't wait for default timeouts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a short guide to speed up runtime fallback when using proxy API providers. It recommends adding 401/403/404 to retry_on_errors and lowering timeout_seconds and cooldown_seconds so users don’t wait on exhausted quotas or missing models.

<sup>Written for commit b8c4f44c1f3a59e1a66e401838ac9675f6905e5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

