### PR TITLE
fix(tool-config): respect question permission from OPENCODE_CONFIG_CONTENT

### DIFF
--- a/src/plugin-handlers/tool-config-handler.test.ts
+++ b/src/plugin-handlers/tool-config-handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
 import { applyToolConfig } from "./tool-config-handler"
 import type { OhMyOpenCodeConfig } from "../config"
 
@@ -53,6 +53,109 @@ describe("applyToolConfig", () => {
         expect(agent.permission.todowrite).toBe("deny")
         expect(agent.permission.todoread).toBe("deny")
       })
+    })
+  })
+
+  describe("#given OPENCODE_CONFIG_CONTENT has question set to deny", () => {
+    let originalConfigContent: string | undefined
+    let originalCliRunMode: string | undefined
+
+    beforeEach(() => {
+      originalConfigContent = process.env.OPENCODE_CONFIG_CONTENT
+      originalCliRunMode = process.env.OPENCODE_CLI_RUN_MODE
+    })
+
+    afterEach(() => {
+      if (originalConfigContent === undefined) {
+        delete process.env.OPENCODE_CONFIG_CONTENT
+      } else {
+        process.env.OPENCODE_CONFIG_CONTENT = originalConfigContent
+      }
+      if (originalCliRunMode === undefined) {
+        delete process.env.OPENCODE_CLI_RUN_MODE
+      } else {
+        process.env.OPENCODE_CLI_RUN_MODE = originalCliRunMode
+      }
+    })
+
+    describe("#when config explicitly denies question permission", () => {
+      it.each(["sisyphus", "hephaestus", "prometheus"])(
+        "#then should deny question for %s even without CLI_RUN_MODE",
+        (agentName) => {
+          process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+            permission: { question: "deny" },
+          })
+          delete process.env.OPENCODE_CLI_RUN_MODE
+          const params = createParams({ agents: [agentName] })
+
+          applyToolConfig(params)
+
+          const agent = params.agentResult[agentName] as {
+            permission: Record<string, unknown>
+          }
+          expect(agent.permission.question).toBe("deny")
+        },
+      )
+    })
+
+    describe("#when config does not deny question permission", () => {
+      it.each(["sisyphus", "hephaestus", "prometheus"])(
+        "#then should allow question for %s in interactive mode",
+        (agentName) => {
+          process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+            permission: { question: "allow" },
+          })
+          delete process.env.OPENCODE_CLI_RUN_MODE
+          const params = createParams({ agents: [agentName] })
+
+          applyToolConfig(params)
+
+          const agent = params.agentResult[agentName] as {
+            permission: Record<string, unknown>
+          }
+          expect(agent.permission.question).toBe("allow")
+        },
+      )
+    })
+
+    describe("#when CLI_RUN_MODE is true and config does not deny", () => {
+      it.each(["sisyphus", "hephaestus", "prometheus"])(
+        "#then should deny question for %s via CLI_RUN_MODE",
+        (agentName) => {
+          process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+            permission: {},
+          })
+          process.env.OPENCODE_CLI_RUN_MODE = "true"
+          const params = createParams({ agents: [agentName] })
+
+          applyToolConfig(params)
+
+          const agent = params.agentResult[agentName] as {
+            permission: Record<string, unknown>
+          }
+          expect(agent.permission.question).toBe("deny")
+        },
+      )
+    })
+
+    describe("#when config deny overrides CLI_RUN_MODE allow", () => {
+      it.each(["sisyphus", "hephaestus", "prometheus"])(
+        "#then should deny question for %s when config says deny regardless of CLI_RUN_MODE",
+        (agentName) => {
+          process.env.OPENCODE_CONFIG_CONTENT = JSON.stringify({
+            permission: { question: "deny" },
+          })
+          process.env.OPENCODE_CLI_RUN_MODE = "false"
+          const params = createParams({ agents: [agentName] })
+
+          applyToolConfig(params)
+
+          const agent = params.agentResult[agentName] as {
+            permission: Record<string, unknown>
+          }
+          expect(agent.permission.question).toBe("deny")
+        },
+      )
     })
   })
 

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -3,6 +3,17 @@ import { getAgentDisplayName } from "../shared/agent-display-names";
 
 type AgentWithPermission = { permission?: Record<string, unknown> };
 
+function getConfigQuestionPermission(): string | null {
+  const configContent = process.env.OPENCODE_CONFIG_CONTENT;
+  if (!configContent) return null;
+  try {
+    const parsed = JSON.parse(configContent);
+    return parsed?.permission?.question ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function agentByKey(agentResult: Record<string, unknown>, key: string): AgentWithPermission | undefined {
   return (agentResult[key] ?? agentResult[getAgentDisplayName(key)]) as
     | AgentWithPermission
@@ -32,7 +43,11 @@ export function applyToolConfig(params: {
   };
 
   const isCliRunMode = process.env.OPENCODE_CLI_RUN_MODE === "true";
-  const questionPermission = isCliRunMode ? "deny" : "allow";
+  const configQuestionPermission = getConfigQuestionPermission();
+  const questionPermission =
+    configQuestionPermission === "deny" ? "deny" :
+    isCliRunMode ? "deny" :
+    "allow";
 
   const librarian = agentByKey(params.agentResult, "librarian");
   if (librarian) {


### PR DESCRIPTION
## Summary

`applyToolConfig()` ignores the `question: "deny"` permission already set via `OPENCODE_CONFIG_CONTENT` and unconditionally overrides it based solely on the plugin-internal `OPENCODE_CLI_RUN_MODE` variable. This causes agents to hang indefinitely in headless environments (e.g., [Maestro](https://github.com/RunMaestro/Maestro) Auto Run) where the host correctly sets `question: "deny"` but has no knowledge of the plugin-internal env var.

## Root Cause

The current logic in `tool-config-handler.ts`:

```typescript
const isCliRunMode = process.env.OPENCODE_CLI_RUN_MODE === "true";
const questionPermission = isCliRunMode ? "deny" : "allow";
```

This only checks `OPENCODE_CLI_RUN_MODE` (set exclusively by oh-my-opencode's own `run()` function in `src/cli/run/runner.ts`). Any external caller that sets `question: "deny"` via the standard `OPENCODE_CONFIG_CONTENT` env var gets silently overridden to `"allow"`, causing the question tool to block on stdin in headless mode.

### Causal chain:

1. Host (e.g. Maestro) spawns OpenCode with `OPENCODE_CONFIG_CONTENT='{"permission":{"question":"deny"}}'`
2. OpenCode reads config → `question: "deny"` ✅
3. oh-my-opencode plugin's `applyToolConfig()` runs
4. `OPENCODE_CLI_RUN_MODE` is not set (host doesn't know about it) → `questionPermission = "allow"`
5. Sisyphus, Hephaestus, Prometheus get `question: "allow"` → **overrides the host's deny**
6. Question tool activates → waits for stdin → **hang**

## Fix

Read `permission.question` from `OPENCODE_CONFIG_CONTENT` and give it highest priority:

```
config explicit deny  →  deny   (respects host/caller intent)
CLI run mode          →  deny   (existing behavior preserved)
default               →  allow  (interactive mode, unchanged)
```

## Changes

- **`src/plugin-handlers/tool-config-handler.ts`**: Added `getConfigQuestionPermission()` helper that reads `OPENCODE_CONFIG_CONTENT` env var. Updated `questionPermission` to check config deny first.
- **`src/plugin-handlers/tool-config-handler.test.ts`**: Added 12 tests covering 4 scenarios × 3 agents (sisyphus, hephaestus, prometheus), with proper env var save/restore.

## Test Results

```
bun test v1.3.6
 23 pass
 0 fail
 34 expect() calls
Ran 23 tests across 1 file. [21.00ms]
```

## Context

- Related: #730 (question tool fix that introduced the hard-coded `"allow"`)
- Related: #934 (duplicate of #730)
- External: [RunMaestro/Maestro#338](https://github.com/RunMaestro/Maestro/issues/338) — the downstream issue this fixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect OPENCODE_CONFIG_CONTENT.permission.question in applyToolConfig to avoid overriding host settings. This prevents headless hangs (e.g., Maestro Auto Run) by not forcing question: allow.

- **Bug Fixes**
  - Priority: config deny → deny; CLI run mode (true) → deny; default → allow.
  - Added getConfigQuestionPermission and tests covering agents and env var scenarios.

<sup>Written for commit 65bc742881b8808ec9a0341f23623975494dc1e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

