### PR TITLE
fix(hashline-read-enhancer): add support for omp hashline format

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,13 +29,17 @@
         "typescript": "^5.7.3",
       },
       "optionalDependencies": {
-        "oh-my-opencode-darwin-arm64": "3.8.5",
-        "oh-my-opencode-darwin-x64": "3.8.5",
-        "oh-my-opencode-linux-arm64": "3.8.5",
-        "oh-my-opencode-linux-arm64-musl": "3.8.5",
-        "oh-my-opencode-linux-x64": "3.8.5",
-        "oh-my-opencode-linux-x64-musl": "3.8.5",
-        "oh-my-opencode-windows-x64": "3.8.5",
+        "oh-my-opencode-darwin-arm64": "3.9.0",
+        "oh-my-opencode-darwin-x64": "3.9.0",
+        "oh-my-opencode-darwin-x64-baseline": "3.9.0",
+        "oh-my-opencode-linux-arm64": "3.9.0",
+        "oh-my-opencode-linux-arm64-musl": "3.9.0",
+        "oh-my-opencode-linux-x64": "3.9.0",
+        "oh-my-opencode-linux-x64-baseline": "3.9.0",
+        "oh-my-opencode-linux-x64-musl": "3.9.0",
+        "oh-my-opencode-linux-x64-musl-baseline": "3.9.0",
+        "oh-my-opencode-windows-x64": "3.9.0",
+        "oh-my-opencode-windows-x64-baseline": "3.9.0",
       },
     },
   },
@@ -231,19 +235,27 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.8.5", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-bbLu1We9NNhYAVp9Q/FK8dYFlYLp2PKfvdBCr+O6QjNRixdjp8Ru4RK7i9mKg0ybYBUzzCcbbC2Cc1o8orkhBA=="],
+    "oh-my-opencode-darwin-arm64": ["oh-my-opencode-darwin-arm64@3.9.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-S+x8/rgWHTxjjnN/IMo1tmZCm9Ex5ODDU+Dnas51WR4ztdV2keYCtC97lQxz04iOeNaoV7flkV2/pA8516ah8Q=="],
 
-    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.8.5", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-N9GcmzYgL87UybSaMGiHc5lwT5Mxg1tyB502el5syouN39wfeUYoj37SonENrMUTiEfn75Lwv/5cSLCesSubpA=="],
+    "oh-my-opencode-darwin-x64": ["oh-my-opencode-darwin-x64@3.9.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-A3cv89/CgSdFJRgz2+/EvhgvK11i8BOOJgTJmG03ya0rcKltN3K7j02wXbH2sqwrr0+TqAQ5LLuRqURZO6GqBQ=="],
 
-    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.8.5", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-ki4a7s1DD5z5wEKmzcchqAKOIpw0LsBvyF8ieqNLS5Xl8PWE0gAZ7rqjlXC54NTubpexVH6lO2yenFJsk2Zk9A=="],
+    "oh-my-opencode-darwin-x64-baseline": ["oh-my-opencode-darwin-x64-baseline@3.9.0", "", { "os": "darwin", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-/8T7CSIMKu89yfAaHg/K/Me7+FkLg47TfK8ozf5SK8p7KBvjHE8iU4kCe9h0ck6F6g9kXcnuAHj4urIXzxsS6A=="],
 
-    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.8.5", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-9+6hU3z503fBzuV0VjxIkTKFElbKacHijFcdKAussG6gPFLWmCRWtdowzEDwUfAoIsoHHH7FBwvh5waGp/ZksA=="],
+    "oh-my-opencode-linux-arm64": ["oh-my-opencode-linux-arm64@3.9.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-XEC96voUOGErbjFJ2CEz7u/xz3mP2q3feNjHWXbFPVEMY4Xma1nayYt06bBzSSy1Q7cd21Ga/xbWEtNYsCofsA=="],
 
-    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.8.5", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-DmnMK/PgvdcCYL+OQE5iZWgi/vmjm0sIPQVQgSUbWn3izcUF7C5DtlxqaU2cKxNZwrhDTlJdLWxmJqgLmLqd9A=="],
+    "oh-my-opencode-linux-arm64-musl": ["oh-my-opencode-linux-arm64-musl@3.9.0", "", { "os": "linux", "cpu": "arm64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-Ln9mEvVb4A2jaIvxNQYk2I2hh6qCWLoXhODKyqD81tBmWAFpZ55d9zJkV499V3GsRbEV47C9GVpUtuYi/XXSYg=="],
 
-    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.8.5", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-jhCNStljsyapVq9X7PaHSOcWxxEA4BUcIibvoPs/xc7fVP8D47p651LzIRsM6STn6Bx684mlYbxxX1P/0QPKNg=="],
+    "oh-my-opencode-linux-x64": ["oh-my-opencode-linux-x64@3.9.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-1w0jnwuj9Db/QTEBtZxUgPx31S88zgS8AQaNl6GAAa3i+OVfLByKTmqf4LDtEDOfWcbl601RQBJ9yYI4ZkRvxQ=="],
 
-    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.8.5", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-lcPBp9NCNQ6TnqzsN9p/K+xKwOzBoIPw7HncxmrXSberZ3uHy0K9uNraQ7fqnXIKWqQiK4kSwWfSHpmhbaHiNg=="],
+    "oh-my-opencode-linux-x64-baseline": ["oh-my-opencode-linux-x64-baseline@3.9.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-DDMfV/l9iz3tFJqesg2XxP2rDR+yzfTOTqXOlVOmyFgO43tAMOrNl50pq5WS3y8mfLgLsDSPCf22PImWx1GM2A=="],
+
+    "oh-my-opencode-linux-x64-musl": ["oh-my-opencode-linux-x64-musl@3.9.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-gZvSUQXmhrsP3yF7U0PSZF6SixSLLRTKJfNPrOJdUhX/DspULQxnBpzc2AUhDv+ncmqT1gHdqE3Mg8A4T/qhlw=="],
+
+    "oh-my-opencode-linux-x64-musl-baseline": ["oh-my-opencode-linux-x64-musl-baseline@3.9.0", "", { "os": "linux", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode" } }, "sha512-EuX2k2JudJsALvo2KV6nwd7iTD0QJgh27jt7joIlm5awAssyd9VKFW79ri/2jVcxMHfLlCxDz/0nAa2tsrc9Ag=="],
+
+    "oh-my-opencode-windows-x64": ["oh-my-opencode-windows-x64@3.9.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-xohpzwmIo2x675nL8KLGdrANGsHSdXLmj1QpMfnWJE8gTxROBjS85uWCsqdLtjNapJ+q1oESStW3y+SNgPjDOA=="],
+
+    "oh-my-opencode-windows-x64-baseline": ["oh-my-opencode-windows-x64-baseline@3.9.0", "", { "os": "win32", "cpu": "x64", "bin": { "oh-my-opencode": "bin/oh-my-opencode.exe" } }, "sha512-JTkBkXV9m2/HVcOoean5Eun6Rvma/n5Eu2/EaIKbqEtkXVB9Bf9KXMMI8tf51V9CxlG2QEw7+HmPDWAeFN3LWA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 

--- a/src/hooks/hashline-read-enhancer/hook.ts
+++ b/src/hooks/hashline-read-enhancer/hook.ts
@@ -1,193 +1,226 @@
-import type { PluginInput } from "@opencode-ai/plugin"
-import { computeLineHash } from "../../tools/hashline-edit/hash-computation"
+import type { PluginInput } from "@opencode-ai/plugin";
+import { computeLineHash } from "../../tools/hashline-edit/hash-computation";
 
-const WRITE_SUCCESS_MARKER = "File written successfully."
+const WRITE_SUCCESS_MARKER = "File written successfully.";
 
 interface HashlineReadEnhancerConfig {
-  hashline_edit?: { enabled: boolean }
+  hashline_edit?: { enabled: boolean };
 }
 
-const COLON_READ_LINE_PATTERN = /^\s*(\d+): ?(.*)$/
-const PIPE_READ_LINE_PATTERN = /^\s*(\d+)\| ?(.*)$/
-const CONTENT_OPEN_TAG = "<content>"
-const CONTENT_CLOSE_TAG = "</content>"
-const FILE_OPEN_TAG = "<file>"
-const FILE_CLOSE_TAG = "</file>"
-const OPENCODE_LINE_TRUNCATION_SUFFIX = "... (line truncated to 2000 chars)"
+const COLON_READ_LINE_PATTERN = /^\s*(\d+): ?(.*)$/;
+const PIPE_READ_LINE_PATTERN = /^\s*(\d+)\| ?(.*)$/;
+const HASHLINE_READ_LINE_PATTERN = /^\s*(\d+)#([ZPMQVRWSNKTXJBYH]{2}): ?(.*)$/;
+const CONTENT_OPEN_TAG = "<content>";
+const CONTENT_CLOSE_TAG = "</content>";
+const FILE_OPEN_TAG = "<file>";
+const FILE_CLOSE_TAG = "</file>";
+const OPENCODE_LINE_TRUNCATION_SUFFIX = "... (line truncated to 2000 chars)";
 
 function isReadTool(toolName: string): boolean {
-  return toolName.toLowerCase() === "read"
+  return toolName.toLowerCase() === "read";
 }
 
 function isWriteTool(toolName: string): boolean {
-  return toolName.toLowerCase() === "write"
+  return toolName.toLowerCase() === "write";
 }
 
 function shouldProcess(config: HashlineReadEnhancerConfig): boolean {
-  return config.hashline_edit?.enabled ?? false
+  return config.hashline_edit?.enabled ?? false;
 }
 
 function isTextFile(output: string): boolean {
-  const firstLine = output.split("\n")[0] ?? ""
-  return COLON_READ_LINE_PATTERN.test(firstLine) || PIPE_READ_LINE_PATTERN.test(firstLine)
+  const firstLine = output.split("\n")[0] ?? "";
+  return (
+    COLON_READ_LINE_PATTERN.test(firstLine) ||
+    PIPE_READ_LINE_PATTERN.test(firstLine) ||
+    HASHLINE_READ_LINE_PATTERN.test(firstLine)
+  );
 }
 
-function parseReadLine(line: string): { lineNumber: number; content: string } | null {
-  const colonMatch = COLON_READ_LINE_PATTERN.exec(line)
+function parseReadLine(
+  line: string,
+): { lineNumber: number; content: string } | null {
+  // Check for omp hashline format first: "1#HH:content"
+  const hashlineMatch = HASHLINE_READ_LINE_PATTERN.exec(line);
+  if (hashlineMatch) {
+    return {
+      lineNumber: Number.parseInt(hashlineMatch[1], 10),
+      content: hashlineMatch[3],
+    };
+  }
+
+  const colonMatch = COLON_READ_LINE_PATTERN.exec(line);
   if (colonMatch) {
     return {
       lineNumber: Number.parseInt(colonMatch[1], 10),
       content: colonMatch[2],
-    }
+    };
   }
 
-  const pipeMatch = PIPE_READ_LINE_PATTERN.exec(line)
+  const pipeMatch = PIPE_READ_LINE_PATTERN.exec(line);
   if (pipeMatch) {
     return {
       lineNumber: Number.parseInt(pipeMatch[1], 10),
       content: pipeMatch[2],
-    }
+    };
   }
 
-  return null
+  return null;
 }
 
 function transformLine(line: string): string {
-  const parsed = parseReadLine(line)
+  const parsed = parseReadLine(line);
   if (!parsed) {
-    return line
+    return line;
   }
   if (parsed.content.endsWith(OPENCODE_LINE_TRUNCATION_SUFFIX)) {
-    return line
+    return line;
   }
-  const hash = computeLineHash(parsed.lineNumber, parsed.content)
-  return `${parsed.lineNumber}#${hash}|${parsed.content}`
+  const hash = computeLineHash(parsed.lineNumber, parsed.content);
+  return `${parsed.lineNumber}#${hash}|${parsed.content}`;
 }
 
 function transformOutput(output: string): string {
   if (!output) {
-    return output
+    return output;
   }
 
-  const lines = output.split("\n")
+  const lines = output.split("\n");
   const contentStart = lines.findIndex(
-    (line) => line === CONTENT_OPEN_TAG || line.startsWith(CONTENT_OPEN_TAG)
-  )
-  const contentEnd = lines.indexOf(CONTENT_CLOSE_TAG)
-  const fileStart = lines.findIndex((line) => line === FILE_OPEN_TAG || line.startsWith(FILE_OPEN_TAG))
-  const fileEnd = lines.indexOf(FILE_CLOSE_TAG)
+    (line) => line === CONTENT_OPEN_TAG || line.startsWith(CONTENT_OPEN_TAG),
+  );
+  const contentEnd = lines.indexOf(CONTENT_CLOSE_TAG);
+  const fileStart = lines.findIndex(
+    (line) => line === FILE_OPEN_TAG || line.startsWith(FILE_OPEN_TAG),
+  );
+  const fileEnd = lines.indexOf(FILE_CLOSE_TAG);
 
-  const blockStart = contentStart !== -1 ? contentStart : fileStart
-  const blockEnd = contentStart !== -1 ? contentEnd : fileEnd
-  const openTag = contentStart !== -1 ? CONTENT_OPEN_TAG : FILE_OPEN_TAG
+  const blockStart = contentStart !== -1 ? contentStart : fileStart;
+  const blockEnd = contentStart !== -1 ? contentEnd : fileEnd;
+  const openTag = contentStart !== -1 ? CONTENT_OPEN_TAG : FILE_OPEN_TAG;
 
   if (blockStart !== -1 && blockEnd !== -1 && blockEnd > blockStart) {
-    const openLine = lines[blockStart] ?? ""
-    const inlineFirst = openLine.startsWith(openTag) && openLine !== openTag
-      ? openLine.slice(openTag.length)
-      : null
-    const fileLines = inlineFirst !== null
-      ? [inlineFirst, ...lines.slice(blockStart + 1, blockEnd)]
-      : lines.slice(blockStart + 1, blockEnd)
+    const openLine = lines[blockStart] ?? "";
+    const inlineFirst =
+      openLine.startsWith(openTag) && openLine !== openTag
+        ? openLine.slice(openTag.length)
+        : null;
+    const fileLines =
+      inlineFirst !== null
+        ? [inlineFirst, ...lines.slice(blockStart + 1, blockEnd)]
+        : lines.slice(blockStart + 1, blockEnd);
     if (!isTextFile(fileLines[0] ?? "")) {
-      return output
+      return output;
     }
 
-    const result: string[] = []
+    const result: string[] = [];
     for (const line of fileLines) {
       if (!parseReadLine(line)) {
-        result.push(...fileLines.slice(result.length))
-        break
+        result.push(...fileLines.slice(result.length));
+        break;
       }
-      result.push(transformLine(line))
+      result.push(transformLine(line));
     }
 
-    const prefixLines = inlineFirst !== null
-      ? [...lines.slice(0, blockStart), openTag]
-      : lines.slice(0, blockStart + 1)
+    const prefixLines =
+      inlineFirst !== null
+        ? [...lines.slice(0, blockStart), openTag]
+        : lines.slice(0, blockStart + 1);
 
-    return [...prefixLines, ...result, ...lines.slice(blockEnd)].join("\n")
+    return [...prefixLines, ...result, ...lines.slice(blockEnd)].join("\n");
   }
 
   if (!isTextFile(lines[0] ?? "")) {
-    return output
+    return output;
   }
 
-  const result: string[] = []
+  const result: string[] = [];
   for (const line of lines) {
     if (!parseReadLine(line)) {
-      result.push(...lines.slice(result.length))
-      break
+      result.push(...lines.slice(result.length));
+      break;
     }
-    result.push(transformLine(line))
+    result.push(transformLine(line));
   }
 
-  return result.join("\n")
+  return result.join("\n");
 }
 
 function extractFilePath(metadata: unknown): string | undefined {
   if (!metadata || typeof metadata !== "object") {
-    return undefined
+    return undefined;
   }
 
-  const objectMeta = metadata as Record<string, unknown>
-  const candidates = [objectMeta.filepath, objectMeta.filePath, objectMeta.path, objectMeta.file]
+  const objectMeta = metadata as Record<string, unknown>;
+  const candidates = [
+    objectMeta.filepath,
+    objectMeta.filePath,
+    objectMeta.path,
+    objectMeta.file,
+  ];
   for (const candidate of candidates) {
     if (typeof candidate === "string" && candidate.length > 0) {
-      return candidate
+      return candidate;
     }
   }
 
-  return undefined
+  return undefined;
 }
 
-async function appendWriteHashlineOutput(output: { output: string; metadata: unknown }): Promise<void> {
+async function appendWriteHashlineOutput(output: {
+  output: string;
+  metadata: unknown;
+}): Promise<void> {
   if (output.output.startsWith(WRITE_SUCCESS_MARKER)) {
-    return
+    return;
   }
 
-  const outputLower = output.output.toLowerCase()
+  const outputLower = output.output.toLowerCase();
   if (outputLower.startsWith("error") || outputLower.includes("failed")) {
-    return
+    return;
   }
 
-  const filePath = extractFilePath(output.metadata)
+  const filePath = extractFilePath(output.metadata);
   if (!filePath) {
-    return
+    return;
   }
 
-  const file = Bun.file(filePath)
+  const file = Bun.file(filePath);
   if (!(await file.exists())) {
-    return
+    return;
   }
 
-  const content = await file.text()
-  const lineCount = content === "" ? 0 : content.split("\n").length
-  output.output = `${WRITE_SUCCESS_MARKER} ${lineCount} lines written.`
+  const content = await file.text();
+  const lineCount = content === "" ? 0 : content.split("\n").length;
+  output.output = `${WRITE_SUCCESS_MARKER} ${lineCount} lines written.`;
 }
 
 export function createHashlineReadEnhancerHook(
   _ctx: PluginInput,
-  config: HashlineReadEnhancerConfig
+  config: HashlineReadEnhancerConfig,
 ) {
   return {
     "tool.execute.after": async (
       input: { tool: string; sessionID: string; callID: string },
-      output: { title: string; output: string; metadata: unknown }
+      output: { title: string; output: string; metadata: unknown },
     ) => {
       if (!isReadTool(input.tool)) {
-        if (isWriteTool(input.tool) && typeof output.output === "string" && shouldProcess(config)) {
-          await appendWriteHashlineOutput(output)
+        if (
+          isWriteTool(input.tool) &&
+          typeof output.output === "string" &&
+          shouldProcess(config)
+        ) {
+          await appendWriteHashlineOutput(output);
         }
-        return
+        return;
       }
       if (typeof output.output !== "string") {
-        return
+        return;
       }
       if (!shouldProcess(config)) {
-        return
+        return;
       }
-      output.output = transformOutput(output.output)
+      output.output = transformOutput(output.output);
     },
-  }
+  };
 }


### PR DESCRIPTION
## Summary

The `hashline-read-enhancer` hook was designed to parse read tool output in formats like `123: content` or `123| content`, but failed to recognize the **omp hashline format** `123#HH:content` used by oh-my-pi's ReadTool.

This caused hash anchors to be lost when using omo with omp's read tool, leading to:
- Edit failures due to missing LINE#ID anchors
- Duplicate code segments (as reported in issue #2172)

## Changes

- Added `HASHLINE_READ_LINE_PATTERN` regex for `1#HH:content` format
- Updated `isTextFile()` to recognize omp hashline format
- Updated `parseReadLine()` to check hashline format first before falling back to other formats

## Testing

- All existing tests pass
- Manual testing confirms omp format is now correctly parsed

Fixes #2172

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for the omp hashline format (123#HH:content) in hashline-read-enhancer so anchors are preserved when reading from oh-my-pi’s ReadTool. Fixes edit failures and duplicate code segments when using omp (fixes #2172).

- **Bug Fixes**
  - Recognize and prioritize the omp pattern via HASHLINE_READ_LINE_PATTERN in parseReadLine.
  - isTextFile now detects omp lines, ensuring anchors are computed and retained.

- **Dependencies**
  - Bump oh-my-opencode optional binaries to 3.9.0 and add baseline variants in bun.lock.

<sup>Written for commit 14a4f429375a8aebed7ab61625f2359e7c77f20e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

