### PR TITLE
fix(hooks): ensure notification fallback on terminal-notifier failure

### DIFF
--- a/src/hooks/session-notification-sender.ts
+++ b/src/hooks/session-notification-sender.ts
@@ -44,12 +44,15 @@ export async function sendSessionNotification(
       const terminalNotifierPath = await getTerminalNotifierPath()
       if (terminalNotifierPath) {
         const bundleId = process.env.__CFBundleIdentifier
-        const args = [terminalNotifierPath, "-title", title, "-message", message]
-        if (bundleId) {
-          args.push("-activate", bundleId)
+        try {
+          if (bundleId) {
+            await ctx.$`${terminalNotifierPath} -title ${title} -message ${message} -activate ${bundleId}`
+          } else {
+            await ctx.$`${terminalNotifierPath} -title ${title} -message ${message}`
+          }
+          break
+        } catch {
         }
-        await ctx.$`${args}`.catch(() => {})
-        break
       }
 
       // Fallback: osascript (click may open Finder instead of terminal)

--- a/src/hooks/session-notification.test.ts
+++ b/src/hooks/session-notification.test.ts
@@ -425,6 +425,67 @@ describe("session-notification", () => {
     expect(tnCall).toBeUndefined()
   })
 
+  test("should fall back to osascript when terminal-notifier execution fails", async () => {
+    // given - terminal-notifier exists but invocation fails
+    spyOn(sender, "sendSessionNotification").mockRestore()
+    const notifyCalls: string[] = []
+    const mockCtx = {
+      $: async (cmd: TemplateStringsArray | string, ...values: unknown[]) => {
+        const cmdStr = typeof cmd === "string"
+          ? cmd
+          : cmd.reduce((acc, part, index) => `${acc}${part}${String(values[index] ?? "")}`, "")
+        notifyCalls.push(cmdStr)
+
+        if (cmdStr.includes("terminal-notifier")) {
+          throw new Error("terminal-notifier failed")
+        }
+
+        return { stdout: "", stderr: "", exitCode: 0 }
+      },
+    } as any
+    spyOn(utils, "getTerminalNotifierPath").mockResolvedValue("/usr/local/bin/terminal-notifier")
+    spyOn(utils, "getOsascriptPath").mockResolvedValue("/usr/bin/osascript")
+
+    // when - sendSessionNotification is called directly on darwin
+    await sender.sendSessionNotification(mockCtx, "darwin", "Test Title", "Test Message")
+
+    // then - osascript fallback should be attempted after terminal-notifier failure
+    const tnCall = notifyCalls.find(c => c.includes("terminal-notifier"))
+    const osascriptCall = notifyCalls.find(c => c.includes("osascript"))
+    expect(tnCall).toBeDefined()
+    expect(osascriptCall).toBeDefined()
+  })
+
+  test("should invoke terminal-notifier without array interpolation", async () => {
+    // given - shell interpolation rejects array values
+    spyOn(sender, "sendSessionNotification").mockRestore()
+    const notifyCalls: string[] = []
+    const mockCtx = {
+      $: async (cmd: TemplateStringsArray | string, ...values: unknown[]) => {
+        if (values.some(Array.isArray)) {
+          throw new Error("array interpolation unsupported")
+        }
+
+        const commandString = typeof cmd === "string"
+          ? cmd
+          : cmd.reduce((acc, part, index) => `${acc}${part}${String(values[index] ?? "")}`, "")
+        notifyCalls.push(commandString)
+        return { stdout: "", stderr: "", exitCode: 0 }
+      },
+    } as any
+    spyOn(utils, "getTerminalNotifierPath").mockResolvedValue("/usr/local/bin/terminal-notifier")
+    spyOn(utils, "getOsascriptPath").mockResolvedValue("/usr/bin/osascript")
+
+    // when - terminal-notifier command is executed
+    await sender.sendSessionNotification(mockCtx, "darwin", "Test Title", "Test Message")
+
+    // then - terminal-notifier succeeds directly and fallback is not used
+    const tnCall = notifyCalls.find(c => c.includes("terminal-notifier"))
+    const osascriptCall = notifyCalls.find(c => c.includes("osascript"))
+    expect(tnCall).toBeDefined()
+    expect(osascriptCall).toBeUndefined()
+  })
+
   test("should use terminal-notifier without -activate when __CFBundleIdentifier is not set", async () => {
     // given - terminal-notifier available but no bundle ID
     spyOn(sender, "sendSessionNotification").mockRestore()


### PR DESCRIPTION
## Summary
- add TDD coverage for darwin notification flow when `terminal-notifier` fails at runtime, verifying fallback to `osascript`
- add TDD coverage ensuring terminal-notifier invocation does not rely on array interpolation semantics
- update `sendSessionNotification` to only break on successful terminal-notifier execution and to invoke notifier with explicit templated arguments

## Validation
- `bun test src/hooks/session-notification.test.ts`
- `bun run typecheck`
- `bun test` *(fails on pre-existing unrelated failures in `src/hooks/model-fallback/hook.test.ts`)*

Fixes #2166

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make macOS session notifications reliable by falling back to osascript when terminal-notifier fails. Invoke terminal-notifier with explicit template arguments to avoid array interpolation issues.

- **Bug Fixes**
  - Break only after a successful terminal-notifier run; on error, fall back to osascript.
  - Pass -activate only when __CFBundleIdentifier is set.
  - Add tests for failure fallback and non-array invocation.
  - Fixes #2166.

<sup>Written for commit cf40ca5553be93a2ac6e3520814737ea9679651f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

