### PR TITLE
fix: model format normalization and explicit config cache bypass

### DIFF
--- a/src/shared/model-resolution-pipeline.test.ts
+++ b/src/shared/model-resolution-pipeline.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { resolveModelPipeline } from "./model-resolution-pipeline"
+
+describe("resolveModelPipeline", () => {
+  test("does not return unused explicit user config metadata in override result", () => {
+    // given
+    const result = resolveModelPipeline({
+      intent: {
+        userModel: "openai/gpt-5.3-codex",
+      },
+      constraints: {
+        availableModels: new Set<string>(),
+      },
+    })
+
+    // when
+    const hasExplicitUserConfigField = result
+      ? Object.prototype.hasOwnProperty.call(result, "explicitUserConfig")
+      : false
+
+    // then
+    expect(result).toEqual({ model: "openai/gpt-5.3-codex", provenance: "override" })
+    expect(hasExplicitUserConfigField).toBe(false)
+  })
+})

--- a/src/shared/model-resolution-pipeline.ts
+++ b/src/shared/model-resolution-pipeline.ts
@@ -34,7 +34,6 @@ export type ModelResolutionResult = {
   variant?: string
   attempted?: string[]
   reason?: string
-  explicitUserConfig?: boolean
 }
 
 
@@ -56,7 +55,7 @@ export function resolveModelPipeline(
   const normalizedUserModel = normalizeModel(intent?.userModel)
   if (normalizedUserModel) {
     log("Model resolved via config override", { model: normalizedUserModel })
-    return { model: normalizedUserModel, provenance: "override", explicitUserConfig: true }
+    return { model: normalizedUserModel, provenance: "override" }
   }
 
   const normalizedCategoryDefault = normalizeModel(intent?.categoryDefaultModel)

--- a/src/tools/delegate-task/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/subagent-resolver.test.ts
@@ -4,6 +4,7 @@ import { resolveSubagentExecution } from "./subagent-resolver"
 import type { DelegateTaskArgs } from "./types"
 import type { ExecutorContext } from "./executor-types"
 import * as logger from "../../shared/logger"
+import * as connectedProvidersCache from "../../shared/connected-providers-cache"
 
 function createBaseArgs(overrides?: Partial<DelegateTaskArgs>): DelegateTaskArgs {
   return {
@@ -78,5 +79,26 @@ describe("resolveSubagentExecution", () => {
       parentAgent: "sisyphus",
       error: "network timeout",
     })
+  })
+
+  test("normalizes matched agent model string before returning categoryModel", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: { openai: ["grok-3"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const args = createBaseArgs({ subagent_type: "oracle" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "oracle", mode: "subagent", model: "openai/gpt-5.3-codex" },
+    ]))
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({ providerID: "openai", modelID: "gpt-5.3-codex" })
+    cacheSpy.mockRestore()
   })
 })

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -51,7 +51,11 @@ Create the work plan directly - that's your job as the planning agent.`,
 
   try {
     const agentsResult = await client.app.agents()
-    type AgentInfo = { name: string; mode?: "subagent" | "primary" | "all"; model?: { providerID: string; modelID: string } }
+    type AgentInfo = {
+      name: string
+      mode?: "subagent" | "primary" | "all"
+      model?: string | { providerID: string; modelID: string }
+    }
     const agents = normalizeSDKResponse(agentsResult, [] as AgentInfo[], {
       preferResponseOnMissingData: true,
     })
@@ -99,7 +103,9 @@ Create the work plan directly - that's your job as the planning agent.`,
     if (agentOverride?.model || agentRequirement || matchedAgent.model) {
       const availableModels = await getAvailableModelsForDelegateTask(client)
 
-      const normalizedMatchedModel = normalizeModelFormat(matchedAgent.model as Parameters<typeof normalizeModelFormat>[0])
+      const normalizedMatchedModel = matchedAgent.model
+        ? normalizeModelFormat(matchedAgent.model)
+        : undefined
       const matchedAgentModelStr = normalizedMatchedModel
         ? `${normalizedMatchedModel.providerID}/${normalizedMatchedModel.modelID}`
         : undefined
@@ -122,7 +128,10 @@ Create the work plan directly - that's your job as the planning agent.`,
     }
 
     if (!categoryModel && matchedAgent.model) {
-      categoryModel = matchedAgent.model
+      const normalizedMatchedModel = normalizeModelFormat(matchedAgent.model)
+      if (normalizedMatchedModel) {
+        categoryModel = normalizedMatchedModel
+      }
     }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
## Summary
- Normalize subagent model values before handing them to sync/background execution, so raw string models never produce `{ providerID: undefined, modelID: undefined }`.
- Remove the unused `explicitUserConfig` field from the model resolution pipeline result to eliminate dead metadata.
- Add regression tests for both issues (`subagent-resolver` normalization path and `model-resolution-pipeline` override shape).

## Testing
- `bun test src/tools/delegate-task/subagent-resolver.test.ts`
- `bun test src/shared/model-resolution-pipeline.test.ts src/shared/model-resolver.test.ts`
- `bun run typecheck`
- `bun test` *(fails in this branch on existing unrelated tests in `src/hooks/model-fallback/hook.test.ts`)*

## Related
- Fixes #2080

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes subagent agent model values to {providerID, modelID} and removes the unused explicitUserConfig flag from model resolution overrides. This prevents undefined provider/model in categoryModel and keeps override results clean (fixes #2080).

- **Bug Fixes**
  - Accepts string or object agent model; normalizes before checking availability and setting categoryModel.
  - Model resolution override no longer returns explicitUserConfig; result includes only model and provenance.

<sup>Written for commit c80a74c5f4c6ec18404e24ff0c6b1698d9f9b27f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

