### PR TITLE
fix: correct librarian agent tool name from websearch_exa_web_search_exa to websearch_web_search_exa

### DIFF
--- a/src/agents/librarian.ts
+++ b/src/agents/librarian.ts
@@ -242,10 +242,10 @@ https://github.com/tanstack/query/blob/abc123def/packages/react-query/src/useQue
 ### Primary Tools by Purpose
 
 - **Official Docs**: Use context7 — \`context7_resolve-library-id\` → \`context7_query-docs\`
-- **Find Docs URL**: Use websearch_exa — \`websearch_exa_web_search_exa("library official documentation")\`
+- **Find Docs URL**: Use websearch_exa — \`websearch_web_search_exa("library official documentation")\`
 - **Sitemap Discovery**: Use webfetch — \`webfetch(docs_url + "/sitemap.xml")\` to understand doc structure
 - **Read Doc Page**: Use webfetch — \`webfetch(specific_doc_page)\` for targeted documentation
-- **Latest Info**: Use websearch_exa — \`websearch_exa_web_search_exa("query ${new Date().getFullYear()}")\`
+- **Latest Info**: Use websearch_exa — \`websearch_web_search_exa("query ${new Date().getFullYear()}")\`
 - **Fast Code Search**: Use grep_app — \`grep_app_searchGitHub(query, language, useRegexp)\`
 - **Deep Code Search**: Use gh CLI — \`gh search code "query" --repo owner/repo\`
 - **Clone Repo**: Use gh CLI — \`gh repo clone owner/repo \${TMPDIR:-/tmp}/name -- --depth 1\`


### PR DESCRIPTION
## Summary

- Fixes incorrect tool name in librarian agent's system prompt
- Changes `websearch_exa_web_search_exa` to `websearch_web_search_exa` in two locations (lines 245 and 248)

## Problem

The librarian agent's system prompt contained incorrect example function names for the Exa web search tool, causing the agent to call a non-existent tool `websearch_exa_web_search_exa` instead of the correct `websearch_web_search_exa`.

## Error Observed

```
invalid [tool=web_search_exa, error=Model tried to call unavailable tool 'web_search_exa'. Available tools: ... websearch_web_search_exa, ...]
Tool execution aborted
```

## Verification

- Typecheck passes
- Tool name now matches the actual MCP tool name used throughout the codebase

Fixes #2242

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the Exa web search tool name in the librarian agent prompt from websearch_exa_web_search_exa to websearch_web_search_exa. This prevents invalid tool calls and aligns the prompt with the available MCP tool.

<sup>Written for commit c69344686c03bd2991403d0bc49b1e6fccaa3bc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

