### PR TITLE
fix: prevent infinite loop in todo-continuation-enforcer when model makes no progress

### DIFF
--- a/src/hooks/todo-continuation-enforcer/constants.ts
+++ b/src/hooks/todo-continuation-enforcer/constants.ts
@@ -20,3 +20,4 @@ export const ABORT_WINDOW_MS = 3000
 export const CONTINUATION_COOLDOWN_MS = 5_000
 export const MAX_CONSECUTIVE_FAILURES = 5
 export const FAILURE_RESET_WINDOW_MS = 5 * 60 * 1000
+export const MAX_NO_PROGRESS = 3

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -13,10 +13,11 @@ import {
   FAILURE_RESET_WINDOW_MS,
   HOOK_NAME,
   MAX_CONSECUTIVE_FAILURES,
+  MAX_NO_PROGRESS,
 } from "./constants"
 import { isLastAssistantMessageAborted } from "./abort-detection"
 import { hasUnansweredQuestion } from "./pending-question-detection"
-import { getIncompleteCount } from "./todo"
+import { computeIncompleteFingerprint, getIncompleteCount } from "./todo"
 import type { MessageInfo, ResolvedMessageInfo, Todo } from "./types"
 import type { SessionStateStore } from "./session-state"
 import { startCountdown } from "./countdown"
@@ -100,6 +101,23 @@ export async function handleSessionIdle(args: {
   const incompleteCount = getIncompleteCount(todos)
   if (incompleteCount === 0) {
     log(`[${HOOK_NAME}] All todos complete`, { sessionID, total: todos.length })
+    return
+  }
+
+  const currentFingerprint = computeIncompleteFingerprint(todos)
+  if (state.lastIncompleteFingerprint === currentFingerprint) {
+    state.noProgressCount = (state.noProgressCount ?? 0) + 1
+  } else {
+    state.noProgressCount = 0
+    state.lastIncompleteFingerprint = currentFingerprint
+  }
+
+  if (state.noProgressCount >= MAX_NO_PROGRESS) {
+    log(`[${HOOK_NAME}] Skipped: no progress after ${state.noProgressCount} attempts`, {
+      sessionID,
+      noProgressCount: state.noProgressCount,
+      maxNoProgress: MAX_NO_PROGRESS,
+    })
     return
   }
 

--- a/src/hooks/todo-continuation-enforcer/non-idle-events.ts
+++ b/src/hooks/todo-continuation-enforcer/non-idle-events.ts
@@ -25,7 +25,11 @@ export function handleNonIdleEvent(args: {
           return
         }
       }
-      if (state) state.abortDetectedAt = undefined
+      if (state) {
+        state.abortDetectedAt = undefined
+        state.noProgressCount = 0
+        state.lastIncompleteFingerprint = null
+      }
       sessionStateStore.cancelCountdown(sessionID)
       return
     }

--- a/src/hooks/todo-continuation-enforcer/session-state.ts
+++ b/src/hooks/todo-continuation-enforcer/session-state.ts
@@ -47,6 +47,8 @@ export function createSessionStateStore(): SessionStateStore {
 
     const state: SessionState = {
       consecutiveFailures: 0,
+      noProgressCount: 0,
+      lastIncompleteFingerprint: null,
     }
     sessions.set(sessionID, { state, lastAccessedAt: Date.now() })
     return state

--- a/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -8,6 +8,7 @@ import {
   CONTINUATION_COOLDOWN_MS,
   FAILURE_RESET_WINDOW_MS,
   MAX_CONSECUTIVE_FAILURES,
+  MAX_NO_PROGRESS,
 } from "./constants"
 
 type TimerCallback = (...args: any[]) => void
@@ -626,6 +627,13 @@ describe("todo-continuation-enforcer", () => {
     const sessionID = "main-max-consecutive-failures"
     setMainSession(sessionID)
     const mockInput = createMockPluginInput()
+    let todoCallCount = 0
+    mockInput.client.session.todo = async () => {
+      todoCallCount++
+      return { data: [
+        { id: "1", content: `Task ${todoCallCount}`, status: "pending", priority: "high" },
+      ]}
+    }
     mockInput.client.session.promptAsync = async (opts: PromptRequestOptions) => {
       promptCalls.push({
         sessionID: opts.path.id,
@@ -657,6 +665,13 @@ describe("todo-continuation-enforcer", () => {
     const sessionID = "main-recovery-after-max-failures"
     setMainSession(sessionID)
     const mockInput = createMockPluginInput()
+    let todoCallCount = 0
+    mockInput.client.session.todo = async () => {
+      todoCallCount++
+      return { data: [
+        { id: "1", content: `Task ${todoCallCount}`, status: "pending", priority: "high" },
+      ]}
+    }
     mockInput.client.session.promptAsync = async (opts: PromptRequestOptions) => {
       promptCalls.push({
         sessionID: opts.path.id,
@@ -753,9 +768,9 @@ describe("todo-continuation-enforcer", () => {
     expect(promptCalls).toHaveLength(3)
   }, { timeout: 30000 })
 
-  test("should keep injecting even when todos remain unchanged across cycles", async () => {
+  test("should stop injecting after MAX_NO_PROGRESS with unchanged todos", async () => {
     //#given
-    const sessionID = "main-no-stagnation-cap"
+    const sessionID = "main-no-progress-detection"
     setMainSession(sessionID)
     const mockInput = createMockPluginInput()
     mockInput.client.session.todo = async () => ({ data: [
@@ -764,28 +779,79 @@ describe("todo-continuation-enforcer", () => {
     ]})
     const hook = createTodoContinuationEnforcer(mockInput, {})
 
-    //#when — 5 consecutive idle cycles with unchanged todos
-    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
-    await fakeTimers.advanceBy(2500, true)
+    //#when — MAX_NO_PROGRESS + 2 idle cycles with unchanged todos
+    for (let index = 0; index < MAX_NO_PROGRESS + 2; index++) {
+      await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+      await fakeTimers.advanceBy(2500, true)
+      await fakeTimers.advanceClockBy(CONTINUATION_COOLDOWN_MS)
+    }
+
+    //#then — only MAX_NO_PROGRESS injections should fire, then stop
+    expect(promptCalls).toHaveLength(MAX_NO_PROGRESS)
+  }, { timeout: 60000 })
+
+  test("should reset no-progress counter when user sends a message", async () => {
+    //#given
+    const sessionID = "main-no-progress-user-reset"
+    setMainSession(sessionID)
+    const mockInput = createMockPluginInput()
+    mockInput.client.session.todo = async () => ({ data: [
+      { id: "1", content: "Task 1", status: "pending", priority: "high" },
+    ]})
+    const hook = createTodoContinuationEnforcer(mockInput, {})
+
+    //#when — exhaust no-progress limit
+    for (let index = 0; index < MAX_NO_PROGRESS + 1; index++) {
+      await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+      await fakeTimers.advanceBy(2500, true)
+      await fakeTimers.advanceClockBy(CONTINUATION_COOLDOWN_MS)
+    }
+    expect(promptCalls).toHaveLength(MAX_NO_PROGRESS)
+
+    //#when — user sends a message (resets no-progress)
+    await hook.handler({
+      event: {
+        type: "message.updated",
+        properties: { info: { sessionID, role: "user" } },
+      },
+    })
     await fakeTimers.advanceClockBy(CONTINUATION_COOLDOWN_MS)
 
+    //#when — idle again
     await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
     await fakeTimers.advanceBy(2500, true)
+
+    //#then — injection resumes after user message reset
+    expect(promptCalls).toHaveLength(MAX_NO_PROGRESS + 1)
+  }, { timeout: 60000 })
+
+  test("should reset no-progress counter when todo fingerprint changes", async () => {
+    //#given
+    const sessionID = "main-no-progress-fingerprint-change"
+    setMainSession(sessionID)
+    const mockInput = createMockPluginInput()
+    let todoVersion = 1
+    mockInput.client.session.todo = async () => ({ data: [
+      { id: "1", content: `Task v${todoVersion}`, status: "pending", priority: "high" },
+    ]})
+    const hook = createTodoContinuationEnforcer(mockInput, {})
+
+    //#when — exhaust no-progress limit
+    for (let index = 0; index < MAX_NO_PROGRESS + 1; index++) {
+      await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
+      await fakeTimers.advanceBy(2500, true)
+      await fakeTimers.advanceClockBy(CONTINUATION_COOLDOWN_MS)
+    }
+    expect(promptCalls).toHaveLength(MAX_NO_PROGRESS)
+
+    //#when — todo content changes (simulating actual progress)
+    todoVersion = 2
     await fakeTimers.advanceClockBy(CONTINUATION_COOLDOWN_MS)
-
-    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
-    await fakeTimers.advanceBy(2500, true)
-    await fakeTimers.advanceClockBy(CONTINUATION_COOLDOWN_MS)
-
-    await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
-    await fakeTimers.advanceBy(2500, true)
-    await fakeTimers.advanceClockBy(CONTINUATION_COOLDOWN_MS)
-
     await hook.handler({ event: { type: "session.idle", properties: { sessionID } } })
     await fakeTimers.advanceBy(2500, true)
 
-    //#then — all 5 injections should fire (no stagnation cap)
-    expect(promptCalls).toHaveLength(5)
+    //#then — injection resumes because fingerprint changed
+    expect(promptCalls).toHaveLength(MAX_NO_PROGRESS + 1)
   }, { timeout: 60000 })
 
   test("should skip idle handling while injection is in flight", async () => {

--- a/src/hooks/todo-continuation-enforcer/todo.ts
+++ b/src/hooks/todo-continuation-enforcer/todo.ts
@@ -1,11 +1,22 @@
 import type { Todo } from "./types"
 
-export function getIncompleteCount(todos: Todo[]): number {
+export function getIncompleteTodos(todos: Todo[]): Todo[] {
   return todos.filter(
     (todo) =>
       todo.status !== "completed"
       && todo.status !== "cancelled"
       && todo.status !== "blocked"
       && todo.status !== "deleted",
-  ).length
+  )
+}
+
+export function getIncompleteCount(todos: Todo[]): number {
+  return getIncompleteTodos(todos).length
+}
+
+export function computeIncompleteFingerprint(todos: Todo[]): string {
+  return getIncompleteTodos(todos)
+    .map((t) => t.content)
+    .sort()
+    .join("|")
 }

--- a/src/hooks/todo-continuation-enforcer/types.ts
+++ b/src/hooks/todo-continuation-enforcer/types.ts
@@ -30,6 +30,8 @@ export interface SessionState {
   lastInjectedAt?: number
   inFlight?: boolean
   consecutiveFailures: number
+  noProgressCount: number
+  lastIncompleteFingerprint: string | null
 }
 
 export interface MessageInfo {


### PR DESCRIPTION
## Summary

Fixes #2216 — the `todo-continuation-enforcer` hook enters an infinite loop when the model fails to make progress on incomplete todos (e.g., when `todowrite` tool is unavailable).

## Root Cause

`consecutiveFailures` in `SessionState` only tracks API call failures (`promptAsync()` throwing). Since the API call always succeeds (it just sends a message), the counter resets to 0 every time, and the `MAX_CONSECUTIVE_FAILURES = 5` safeguard never triggers.

## Fix

Added a **"no progress" detector** that compares the fingerprint (sorted content joined by `|`) of incomplete todos between injections:

- After `MAX_NO_PROGRESS` (3) consecutive injections with the same set of incomplete todos, the hook stops firing
- Counter resets when:
  - User sends a new message
  - Todo fingerprint changes (actual progress was made)

## Changes

| File | Change |
|------|--------|
| `types.ts` | Added `noProgressCount` + `lastIncompleteFingerprint` to `SessionState` |
| `constants.ts` | Added `MAX_NO_PROGRESS = 3` |
| `session-state.ts` | Initialize new fields in `getState()` |
| `idle-event.ts` | Fingerprint-based no-progress detection before `startCountdown()` |
| `non-idle-events.ts` | Reset no-progress state on user message |
| `todo.ts` | Added `getIncompleteTodos()` + `computeIncompleteFingerprint()` helpers |
| `*.test.ts` | Updated existing tests + added 3 new tests for no-progress detection |

## Test Results

```
61 pass
0 fail
75 expect() calls
```

### New Tests

1. **should stop injecting after MAX_NO_PROGRESS with unchanged todos** — verifies injection stops after 3 identical attempts
2. **should reset no-progress counter when user sends a message** — verifies user message resets the counter
3. **should reset no-progress counter when todo fingerprint changes** — verifies actual progress resets the counter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent infinite loops in todo-continuation-enforcer when todos don’t change across injections. Fixes #2216 by detecting “no progress” and stopping after 3 identical cycles.

- **Bug Fixes**
  - Compare a fingerprint of incomplete todos between injections; stop after MAX_NO_PROGRESS=3 unchanged cycles.
  - Reset the counter when a user sends a message or when the todo fingerprint changes.
  - Added state fields (noProgressCount, lastIncompleteFingerprint), fingerprint helpers, and updates to idle/non-idle handlers; tests added for new behavior.

<sup>Written for commit 62279051e4cf33f808c39b3b7228aa6761d46eab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

