### PR TITLE
chore(oh-my-opencode): add generated metadata files to .gitignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Auto-generated .gitattributes for cross-platform line ending consistency
+# Default: LF for all text files
+* text=auto eol=lf
+
+# Binary files
+*.jpg binary
+*.png binary
+


### PR DESCRIPTION
Adds _open_prs.json, _open_issues.json and other generated metadata files to .gitignore - produced by tooling, change frequently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add .gitattributes to enforce LF line endings across platforms and avoid EOL churn. Also mark JPG/PNG as binary to prevent unintended diffs and conversions.

<sup>Written for commit 9af2b56bd9ed6117c136bf60a37875a0906dd016. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

