### PR TITLE
feat: add default_model config for all agents

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -73,6 +73,9 @@
     "model_fallback": {
       "type": "boolean"
     },
+    "default_model": {
+      "type": "string"
+    },
     "agents": {
       "type": "object",
       "properties": {

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -38,6 +38,8 @@ export const OhMyOpenCodeConfigSchema = z.object({
   hashline_edit: z.boolean().optional(),
   /** Enable model fallback on API errors (default: false). Set to true to enable automatic model switching when model errors occur. */
   model_fallback: z.boolean().optional(),
+  /** Default model for all agents and categories when no specific model is configured */
+  default_model: z.string().optional(),
   agents: AgentOverridesSchema.optional(),
   categories: CategoriesConfigSchema.optional(),
   claude_code: ClaudeCodeConfigSchema.optional(),

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -68,6 +68,7 @@ export function createToolRegistry(args: {
     availableCategories,
     availableSkills: skillContext.availableSkills,
     syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
+    defaultModel: pluginConfig.default_model,
     onSyncSessionCreated: async (event) => {
       log("[index] onSyncSessionCreated callback", {
         sessionID: event.sessionID,

--- a/src/tools/delegate-task/categories.ts
+++ b/src/tools/delegate-task/categories.ts
@@ -10,6 +10,7 @@ export interface ResolveCategoryConfigOptions {
   inheritedModel?: string
   systemDefaultModel?: string
   availableModels?: Set<string>
+  defaultModel?: string
 }
 
 export interface ResolveCategoryConfigResult {
@@ -26,7 +27,7 @@ export function resolveCategoryConfig(
   categoryName: string,
   options: ResolveCategoryConfigOptions
 ): ResolveCategoryConfigResult | null {
-  const { userCategories, inheritedModel: _inheritedModel, systemDefaultModel, availableModels } = options
+  const { userCategories, inheritedModel: _inheritedModel, systemDefaultModel, availableModels, defaultModel } = options
 
   const defaultConfig = DEFAULT_CATEGORIES[categoryName]
   const userConfig = userCategories?.[categoryName]
@@ -49,12 +50,11 @@ export function resolveCategoryConfig(
     return null
   }
 
-  // Model priority for categories: user override > category default > system default
-  // Categories have explicit models - no inheritance from parent session
+  // Model priority for categories: user override > category default > default_model > system default
   const model = resolveModel({
     userModel: userConfig?.model,
-    inheritedModel: defaultConfig?.model, // Category's built-in model takes precedence over system default
-    systemDefault: systemDefaultModel,
+    inheritedModel: defaultConfig?.model, // Category's built-in model takes precedence over default_model
+    systemDefault: defaultModel ?? systemDefaultModel, // default_model takes precedence over system default
   })
   const config: CategoryConfig = {
     ...defaultConfig,

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -26,7 +26,8 @@ export async function resolveCategoryExecution(
   args: DelegateTaskArgs,
   executorCtx: ExecutorContext,
   inheritedModel: string | undefined,
-  systemDefaultModel: string | undefined
+  systemDefaultModel: string | undefined,
+  defaultModel?: string
 ): Promise<CategoryResolutionResult> {
   const { client, userCategories, sisyphusJuniorModel } = executorCtx
 
@@ -41,6 +42,7 @@ export async function resolveCategoryExecution(
     inheritedModel,
     systemDefaultModel,
     availableModels,
+    defaultModel,
   })
 
   if (!resolved) {

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -15,7 +15,8 @@ export async function resolveSubagentExecution(
   args: DelegateTaskArgs,
   executorCtx: ExecutorContext,
   parentAgent: string | undefined,
-  categoryExamples: string
+  categoryExamples: string,
+  defaultModel?: string,
 ): Promise<{ agentToUse: string; categoryModel: { providerID: string; modelID: string; variant?: string } | undefined; fallbackChain?: FallbackEntry[]; error?: string }> {
   const { client, agentOverrides } = executorCtx
 
@@ -115,7 +116,7 @@ Create the work plan directly - that's your job as the planning agent.`,
         categoryDefaultModel: matchedAgentModelStr,
         fallbackChain: agentRequirement?.fallbackChain,
         availableModels,
-        systemDefaultModel: undefined,
+        systemDefaultModel: defaultModel,
       })
 
       if (resolution) {

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -187,7 +187,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
       let maxPromptTokens: number | undefined
 
       if (args.category) {
-        const resolution = await resolveCategoryExecution(args, options, inheritedModel, systemDefaultModel)
+        const resolution = await resolveCategoryExecution(args, options, inheritedModel, systemDefaultModel, options.defaultModel)
         if (resolution.error) {
           return resolution.error
         }

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -226,7 +226,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
           return executeUnstableAgentTask(args, ctx, options, parentContext, agentToUse, categoryModel, systemContent, actualModel)
         }
       } else {
-        const resolution = await resolveSubagentExecution(args, options, parentContext.agent, categoryExamples)
+        const resolution = await resolveSubagentExecution(args, options, parentContext.agent, categoryExamples, options.defaultModel)
         if (resolution.error) {
           return resolution.error
         }

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -69,6 +69,8 @@ export interface DelegateTaskToolOptions {
   agentOverrides?: AgentOverrides
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>
   syncPollTimeoutMs?: number
+  /** Default model for all agents and categories when no specific model is configured */
+  defaultModel?: string
 }
 
 export interface BuildSystemContentInput {


### PR DESCRIPTION
Add global default model configuration for all agents and categories

- default_model field in config schema
- Categories inherit default_model when no specific model is configured
- Agent-specific model settings override default_model

Fixes #2205

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global default_model used when no agent or category model is set, reducing config duplication and making fallbacks consistent. Fixes #2205.

- **New Features**
  - Added default_model to the config schema and plumbed it through tool registry and delegate-task.
  - Enforced precedence: agent override > category default > default_model > system default.

- **Bug Fixes**
  - Passed default_model into subagent resolution so agents correctly fallback when no model is set.

<sup>Written for commit 06d59ece6759ebe9a8f7a75c80da684c6619e4b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

