### PR TITLE
fix(thinking-block-validator): inject missing tool_result blocks before API submission

### DIFF
--- a/src/hooks/thinking-block-validator/hook.ts
+++ b/src/hooks/thinking-block-validator/hook.ts
@@ -31,6 +31,7 @@ interface MessageInfoExtended {
   id: string
   role: string
   sessionID?: string
+  modelID?: string
   model?: {
     modelID?: string
   }
@@ -153,7 +154,8 @@ export function createThinkingBlockValidatorHook(): MessagesTransformHook {
 
       // Get model info before synthetic injection (synthetic messages lack modelID)
       const lastUserMessage = messages.findLast(m => m.info.role === "user")
-      const modelID = (lastUserMessage?.info as unknown as MessageInfoExtended)?.model?.modelID || ""
+      const infoExt = lastUserMessage?.info as unknown as MessageInfoExtended
+      const modelID = (infoExt?.model?.modelID ?? infoExt?.modelID) || ""
 
       validateToolResults(messages)
 

--- a/src/hooks/thinking-block-validator/hook.ts
+++ b/src/hooks/thinking-block-validator/hook.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Message, Part } from "@opencode-ai/sdk"
+import { validateToolResults } from "./validate-tool-results"
 
 interface MessageWithParts {
   info: Message
@@ -147,6 +148,8 @@ export function createThinkingBlockValidatorHook(): MessagesTransformHook {
       if (!messages || messages.length === 0) {
         return
       }
+
+      validateToolResults(messages)
 
       // Get the model info from the last user message
       const lastUserMessage = messages.findLast(m => m.info.role === "user")

--- a/src/hooks/thinking-block-validator/hook.ts
+++ b/src/hooks/thinking-block-validator/hook.ts
@@ -31,7 +31,9 @@ interface MessageInfoExtended {
   id: string
   role: string
   sessionID?: string
-  modelID?: string
+  model?: {
+    modelID?: string
+  }
 }
 
 type MessagesTransformHook = {
@@ -151,7 +153,7 @@ export function createThinkingBlockValidatorHook(): MessagesTransformHook {
 
       // Get model info before synthetic injection (synthetic messages lack modelID)
       const lastUserMessage = messages.findLast(m => m.info.role === "user")
-      const modelID = (lastUserMessage?.info as unknown as MessageInfoExtended)?.modelID || ""
+      const modelID = (lastUserMessage?.info as unknown as MessageInfoExtended)?.model?.modelID || ""
 
       validateToolResults(messages)
 

--- a/src/hooks/thinking-block-validator/hook.ts
+++ b/src/hooks/thinking-block-validator/hook.ts
@@ -149,11 +149,11 @@ export function createThinkingBlockValidatorHook(): MessagesTransformHook {
         return
       }
 
-      validateToolResults(messages)
-
-      // Get the model info from the last user message
+      // Get model info before synthetic injection (synthetic messages lack modelID)
       const lastUserMessage = messages.findLast(m => m.info.role === "user")
       const modelID = (lastUserMessage?.info as unknown as MessageInfoExtended)?.modelID || ""
+
+      validateToolResults(messages)
 
       // Only process if extended thinking might be enabled
       if (!isExtendedThinkingModel(modelID)) {

--- a/src/hooks/thinking-block-validator/validate-tool-results.ts
+++ b/src/hooks/thinking-block-validator/validate-tool-results.ts
@@ -115,11 +115,13 @@ function appendMissingToolResults(
   if (missingIds.length === 0) return
 
   const sessionID = (assistantInfo as unknown as ExtendedInfo).sessionID || ""
+  const messageID = (userMessage.info as unknown as ExtendedInfo).id || `msg_synthetic_${Date.now()}`
+  const timestamp = Date.now()
   const syntheticParts = missingIds.map((toolUseId) => ({
     type: "tool_result" as const,
-    id: `prt_synthetic_${Date.now()}_${toolUseId.slice(-8)}`,
+    id: `prt_synthetic_${timestamp}_${toolUseId.slice(-8)}`,
     sessionID,
-    messageID: (userMessage.info as unknown as ExtendedInfo).id || `msg_synthetic_${Date.now()}`,
+    messageID,
     tool_use_id: toolUseId,
     content: "Tool execution was interrupted before completion.",
     is_error: true,

--- a/src/hooks/thinking-block-validator/validate-tool-results.ts
+++ b/src/hooks/thinking-block-validator/validate-tool-results.ts
@@ -73,11 +73,12 @@ function createSyntheticToolResultMessage(
   sessionID: string,
   index: number
 ): MessageWithParts {
-  const messageID = `msg_synthetic_${Date.now()}_${index}`
+  const timestamp = Date.now()
+  const messageID = `msg_synthetic_${timestamp}_${index}`
 
   const parts = toolUseIds.map((toolUseId) => ({
     type: "tool_result" as const,
-    id: `prt_synthetic_${Date.now()}_${toolUseId.slice(-8)}`,
+    id: `prt_synthetic_${timestamp}_${toolUseId.slice(-8)}`,
     sessionID,
     messageID,
     tool_use_id: toolUseId,

--- a/src/hooks/thinking-block-validator/validate-tool-results.ts
+++ b/src/hooks/thinking-block-validator/validate-tool-results.ts
@@ -1,0 +1,130 @@
+// Pre-flight tool_result validation — runs for ALL models before API submission.
+// Handles: consecutive assistant messages + missing tool_result in user messages.
+
+import type { Message, Part } from "@opencode-ai/sdk"
+
+interface MessageWithParts {
+  info: Message
+  parts: Part[]
+}
+
+interface ExtendedPart {
+  callID?: string
+  id?: string
+  type: string
+  tool_use_id?: string
+}
+
+interface ExtendedInfo {
+  id?: string
+  sessionID?: string
+}
+
+// Prefers callID (toolu_*) over id (prt_*) for API compatibility
+function getToolCallId(part: Part): string | undefined {
+  const p = part as unknown as ExtendedPart
+  return p.callID || p.id
+}
+
+function extractToolUseIds(parts: Part[]): string[] {
+  if (!parts) return []
+  return parts
+    .filter((p) => {
+      const type = p.type as string
+      return (type === "tool_use" || type === "tool") && getToolCallId(p)
+    })
+    .map((p) => getToolCallId(p)!)
+}
+
+// Must run before thinking block validation (may insert synthetic messages)
+export function validateToolResults(messages: MessageWithParts[]): void {
+  const insertions: { index: number; message: MessageWithParts }[] = []
+
+  for (let i = 0; i < messages.length - 1; i++) {
+    const current = messages[i]
+    const next = messages[i + 1]
+
+    if (current?.info?.role === "assistant" && next?.info?.role === "assistant") {
+      const toolUseIds = extractToolUseIds(current.parts)
+      if (toolUseIds.length > 0) {
+        const sessionID = (current.info as unknown as ExtendedInfo).sessionID || ""
+        insertions.push({
+          index: i + 1,
+          message: createSyntheticToolResultMessage(toolUseIds, sessionID, i),
+        })
+      }
+    }
+
+    if (current?.info?.role === "assistant" && next?.info?.role === "user") {
+      const toolUseIds = extractToolUseIds(current.parts)
+      if (toolUseIds.length > 0) {
+        appendMissingToolResults(toolUseIds, next, current.info)
+      }
+    }
+  }
+
+  for (let j = insertions.length - 1; j >= 0; j--) {
+    messages.splice(insertions[j].index, 0, insertions[j].message)
+  }
+}
+
+function createSyntheticToolResultMessage(
+  toolUseIds: string[],
+  sessionID: string,
+  index: number
+): MessageWithParts {
+  const messageID = `msg_synthetic_${Date.now()}_${index}`
+
+  const parts = toolUseIds.map((toolUseId) => ({
+    type: "tool_result" as const,
+    id: `prt_synthetic_${Date.now()}_${toolUseId.slice(-8)}`,
+    sessionID,
+    messageID,
+    tool_use_id: toolUseId,
+    content: "Tool execution was interrupted before completion.",
+    is_error: true,
+    synthetic: true,
+  }))
+
+  return {
+    info: {
+      id: messageID,
+      sessionID,
+      role: "user",
+      synthetic: true,
+    } as unknown as Message,
+    parts: parts as unknown as Part[],
+  }
+}
+
+function appendMissingToolResults(
+  toolUseIds: string[],
+  userMessage: MessageWithParts,
+  assistantInfo: Message
+): void {
+  const existingResultIds = new Set(
+    (userMessage.parts || [])
+      .filter((p) => {
+        const part = p as unknown as ExtendedPart
+        return (p.type as string) === "tool_result" && part.tool_use_id
+      })
+      .map((p) => (p as unknown as ExtendedPart).tool_use_id!)
+  )
+
+  const missingIds = toolUseIds.filter((id) => !existingResultIds.has(id))
+  if (missingIds.length === 0) return
+
+  const sessionID = (assistantInfo as unknown as ExtendedInfo).sessionID || ""
+  const syntheticParts = missingIds.map((toolUseId) => ({
+    type: "tool_result" as const,
+    id: `prt_synthetic_${Date.now()}_${toolUseId.slice(-8)}`,
+    sessionID,
+    messageID: (userMessage.info as unknown as ExtendedInfo).id || `msg_synthetic_${Date.now()}`,
+    tool_use_id: toolUseId,
+    content: "Tool execution was interrupted before completion.",
+    is_error: true,
+    synthetic: true,
+  }))
+
+  userMessage.parts = [...(userMessage.parts || []), ...(syntheticParts as unknown as Part[])]
+}


### PR DESCRIPTION
## Summary

- Add pre-flight `tool_result` validation in `messages.transform` hook to prevent `tool_use ids were found without tool_result blocks` errors
- Runs for **all models** (not just thinking models) since tool_result validation is an API-wide constraint
- Complements existing reactive recovery in `session-recovery/recover-tool-result-missing.ts`

## Root Cause

OpenCode can produce message arrays where `tool_use` blocks lack matching `tool_result` blocks. Two patterns cause this:

**Pattern A — Consecutive assistant messages:**
When OpenCode stores multiple assistant responses for a single user turn, the first assistant's `tool_use` has no `tool_result` because no user message exists between them.

```
[assistant: tool_use A] → [assistant: ...] → API ERROR
```

**Pattern B — Missing tool_result in user message:**
When the user interrupts (ESC) during tool execution, the following user message may be missing `tool_result` for some `tool_use` IDs.

```
[assistant: tool_use A, B] → [user: tool_result A only] → API ERROR
```

Both patterns trigger the Prometheus → Momus workflow failure described in #2070.

## Fix

New file `validate-tool-results.ts` with a single exported function `validateToolResults()`:

- **Pattern A**: Inserts a synthetic `user(tool_result)` message between consecutive assistants
- **Pattern B**: Appends missing `tool_result` parts to the existing user message (preserves existing parts)

Called from `hook.ts` **before** the `isExtendedThinkingModel` check so it runs for all models.

**Changes to `hook.ts`**: 2 lines (1 import + 1 function call).

**Safe because:**
- Only activates when tool_use IDs have no matching tool_result — normal conversations are untouched
- Uses `callID || id` priority matching OmO's existing pattern (line 44 of `recover-tool-result-missing.ts`)
- Runs before thinking block validation, so array mutations don't interfere with downstream logic
- Proactive (prevents error) rather than reactive (fixes after error), so session-recovery is not triggered

## Testing

```bash
$ bun run typecheck
# Clean — no errors

$ bun run build
# Bundled 1107 modules in 52ms
# index.js  2.78 MB
```

Tested locally with OpenCode — Prometheus → Momus workflow completes without `tool_result` errors.

## Related Issues

Fixes #2070

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures every tool_use has a matching tool_result before API submission. Prevents API errors across all models and stabilizes the Prometheus → Momus workflow.

- **Bug Fixes**
  - Added validateToolResults() pre-flight to pair tool_use/tool_result across all models.
  - Injects a synthetic user(tool_result) between consecutive assistant messages or appends missing parts to the next user message.
  - Reads modelID from the last user message before injection; uses dual-path extraction (info.model?.modelID ?? info.modelID).
  - Hoists Date.now() and messageID to keep synthetic IDs consistent.
  - Only modifies messages with missing results; normal conversations are untouched. Fixes #2070.

<sup>Written for commit f60853e1978e71e829c09c0f91710b7eab044df6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

