### PR TITLE
fix: also invalidate plugin from CACHE_DIR in invalidatePackage

### DIFF
--- a/src/hooks/auto-update-checker/cache.ts
+++ b/src/hooks/auto-update-checker/cache.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
-import { PACKAGE_NAME, USER_CONFIG_DIR } from "./constants"
+import { CACHE_DIR, PACKAGE_NAME, USER_CONFIG_DIR } from "./constants"
 import { log } from "../../shared/logger"
 
 interface BunLockfile {
@@ -48,17 +48,22 @@ function removeFromBunLock(packageName: string): boolean {
 
 export function invalidatePackage(packageName: string = PACKAGE_NAME): boolean {
   try {
-    const pkgDir = path.join(USER_CONFIG_DIR, "node_modules", packageName)
+    const pkgDirs = [
+      path.join(USER_CONFIG_DIR, "node_modules", packageName),
+      path.join(CACHE_DIR, "node_modules", packageName),
+    ]
     const pkgJsonPath = path.join(USER_CONFIG_DIR, "package.json")
 
     let packageRemoved = false
     let dependencyRemoved = false
     let lockRemoved = false
 
-    if (fs.existsSync(pkgDir)) {
-      fs.rmSync(pkgDir, { recursive: true, force: true })
-      log(`[auto-update-checker] Package removed: ${pkgDir}`)
-      packageRemoved = true
+    for (const pkgDir of pkgDirs) {
+      if (fs.existsSync(pkgDir)) {
+        fs.rmSync(pkgDir, { recursive: true, force: true })
+        log(`[auto-update-checker] Package removed: ${pkgDir}`)
+        packageRemoved = true
+      }
     }
 
     if (fs.existsSync(pkgJsonPath)) {


### PR DESCRIPTION
## Summary

Fixes #2289

`invalidatePackage()` only removed the stale plugin from `USER_CONFIG_DIR/node_modules/`, but on some systems bun installs the plugin into `CACHE_DIR/node_modules/` instead. This left the old version untouched, so `getCachedVersion()` would keep reading the stale copy via `import.meta.url` traversal, causing the startup toast to show the old version even after the auto-updater ran successfully.

## Root Cause

`constants.ts` defines two separate directories:
- `USER_CONFIG_DIR` = `~/.config/opencode/` (where config lives)
- `CACHE_DIR` = `~/.cache/opencode/` on Linux/macOS, `%LOCALAPPDATA%\opencode` on Windows

`invalidatePackage()` was only checking `USER_CONFIG_DIR/node_modules/oh-my-opencode/`. If bun placed the plugin in `CACHE_DIR/node_modules/`, the stale directory was never removed.

## Change

**`src/hooks/auto-update-checker/cache.ts`** — check and remove the plugin from both candidate directories:

```ts
// Before
const pkgDir = path.join(USER_CONFIG_DIR, "node_modules", packageName)
if (fs.existsSync(pkgDir)) {
  fs.rmSync(pkgDir, { recursive: true, force: true })
  packageRemoved = true
}

// After
const pkgDirs = [
  path.join(USER_CONFIG_DIR, "node_modules", packageName),
  path.join(CACHE_DIR, "node_modules", packageName),
]
for (const pkgDir of pkgDirs) {
  if (fs.existsSync(pkgDir)) {
    fs.rmSync(pkgDir, { recursive: true, force: true })
    packageRemoved = true
  }
}
```

## PR Checklist

- [x] Code follows project conventions
- [x] No version changes in `package.json`
- [x] Minimal change — only the affected function is modified

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures auto-updated plugins load correctly by removing stale installs from both USER_CONFIG_DIR and CACHE_DIR. Fixes the startup toast showing the old version after an update.

- **Bug Fixes**
  - invalidatePackage now removes oh-my-opencode from USER_CONFIG_DIR/node_modules and CACHE_DIR/node_modules.
  - Prevents getCachedVersion from reading a stale plugin via import.meta.url traversal.

<sup>Written for commit f67b605f7a7a6e3e3d09cf51f3c94ca109298d19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

