### PR TITLE
fix: isUnstableAgent checks default model instead of resolved model, crashing visual-engineering and writing categories

### DIFF
--- a/src/tools/delegate-task/category-resolver.test.ts
+++ b/src/tools/delegate-task/category-resolver.test.ts
@@ -75,4 +75,159 @@ describe("resolveCategoryExecution", () => {
 		expect(result.error).toContain("Unknown category")
 		expect(result.error).toContain("definitely-not-a-real-category-xyz123")
 	})
+
+	describe("#given isUnstableAgent detection", () => {
+		test("visual-engineering with user override to stable model sets isUnstableAgent=false", async () => {
+			//#given - user overrides visual-engineering model to a stable (non-gemini) model
+			const args = {
+				category: "visual-engineering",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enableSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			executorCtx.userCategories = {
+				"visual-engineering": { model: "anthropic/claude-sonnet-4-6" },
+			}
+			const inheritedModel = undefined
+			const systemDefaultModel = "anthropic/claude-sonnet-4-6"
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - actualModel is the stable override, isUnstableAgent must be false
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toBe("anthropic/claude-sonnet-4-6")
+			expect(result.isUnstableAgent).toBe(false)
+		})
+
+		test("visual-engineering with default gemini model sets isUnstableAgent=true", async () => {
+			//#given - no user override, default gemini model resolves
+			const args = {
+				category: "visual-engineering",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enableSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			const inheritedModel = undefined
+			const systemDefaultModel = undefined
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - default model contains "gemini", so isUnstableAgent should be true
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toContain("gemini")
+			expect(result.isUnstableAgent).toBe(true)
+		})
+
+		test("writing with user override to stable model sets isUnstableAgent=false", async () => {
+			//#given - user overrides writing model to a stable (non-kimi) model
+			const args = {
+				category: "writing",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enableSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			executorCtx.userCategories = {
+				writing: { model: "anthropic/claude-sonnet-4-6" },
+			}
+			const inheritedModel = undefined
+			const systemDefaultModel = "anthropic/claude-sonnet-4-6"
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - actualModel is the stable override, isUnstableAgent must be false
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toBe("anthropic/claude-sonnet-4-6")
+			expect(result.isUnstableAgent).toBe(false)
+		})
+
+		test("writing with default kimi model sets isUnstableAgent=true", async () => {
+			//#given - no user override, default kimi model resolves
+			const args = {
+				category: "writing",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enableSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			const inheritedModel = undefined
+			const systemDefaultModel = undefined
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - default model contains "kimi", so isUnstableAgent should be true
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toContain("kimi")
+			expect(result.isUnstableAgent).toBe(true)
+		})
+
+		test("is_unstable_agent=true in config forces isUnstableAgent=true regardless of model", async () => {
+			//#given - user sets is_unstable_agent=true with a stable model
+			const args = {
+				category: "quick",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enableSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			executorCtx.userCategories = {
+				quick: { model: "anthropic/claude-sonnet-4-6", is_unstable_agent: true },
+			}
+			const inheritedModel = undefined
+			const systemDefaultModel = "anthropic/claude-sonnet-4-6"
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - is_unstable_agent=true overrides model-based detection
+			expect(result.error).toBeUndefined()
+			expect(result.isUnstableAgent).toBe(true)
+		})
+
+		test("sisyphusJuniorModel override to stable model sets isUnstableAgent=false for visual-engineering", async () => {
+			//#given - global sisyphus-junior model overrides to stable model
+			const args = {
+				category: "visual-engineering",
+				prompt: "test prompt",
+				description: "Test task",
+				run_in_background: false,
+				load_skills: [],
+				blockedBy: undefined,
+				enableSkillTools: false,
+			}
+			const executorCtx = createMockExecutorContext()
+			executorCtx.sisyphusJuniorModel = "anthropic/claude-sonnet-4-6"
+			const inheritedModel = undefined
+			const systemDefaultModel = "anthropic/claude-sonnet-4-6"
+
+			//#when
+			const result = await resolveCategoryExecution(args, executorCtx, inheritedModel, systemDefaultModel)
+
+			//#then - actualModel is the stable override via sisyphusJuniorModel
+			expect(result.error).toBeUndefined()
+			expect(result.actualModel).toBe("anthropic/claude-sonnet-4-6")
+			expect(result.isUnstableAgent).toBe(false)
+		})
+	})
 })

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -175,8 +175,7 @@ Available categories: ${categoryNames.join(", ")}`,
   }
 
   const unstableModel = actualModel?.toLowerCase()
-  const categoryConfigModel = resolved.config.model?.toLowerCase()
-  const isUnstableAgent = resolved.config.is_unstable_agent === true || [unstableModel, categoryConfigModel].some(m => m ? m.includes("gemini") || m.includes("minimax") || m.includes("kimi") : false)
+  const isUnstableAgent = resolved.config.is_unstable_agent === true || (unstableModel != null && (unstableModel.includes("gemini") || unstableModel.includes("minimax") || unstableModel.includes("kimi")))
 
   return {
     agentToUse: SISYPHUS_JUNIOR_AGENT,

--- a/src/tools/delegate-task/unstable-agent-task.test.ts
+++ b/src/tools/delegate-task/unstable-agent-task.test.ts
@@ -221,4 +221,78 @@ describe("executeUnstableAgentTask - interrupt detection", () => {
     expect(result.toLowerCase()).toContain("stale timeout")
     expect(elapsed).toBeLessThan(400)
   })
+
+  test("should complete gracefully when getTask returns undefined (race condition)", async () => {
+    //#given - a background task where getTask returns undefined (task cleaned up before poll)
+    let pollCount = 0
+    const launchState = {
+      id: "bg_test_race",
+      sessionID: "ses_test_race",
+      status: "running" as string,
+      description: "test race condition",
+      prompt: "test prompt",
+      agent: "sisyphus-junior",
+      error: undefined as string | undefined,
+    }
+
+    const mockManager = {
+      launch: async () => launchState,
+      getTask: () => {
+        pollCount++
+        if (pollCount >= 2) return undefined
+        return launchState
+      },
+    }
+
+    const mockClient = {
+      session: {
+        status: async () => ({ data: { [launchState.sessionID!]: { type: "idle" } } }),
+        messages: async () => ({
+          data: [{
+            info: { role: "assistant", time: { created: Date.now() } },
+            parts: [{ type: "text", text: "Task result" }],
+          }],
+        }),
+      },
+    }
+
+    const { executeUnstableAgentTask } = require("./unstable-agent-task")
+
+    const args = {
+      prompt: "test prompt",
+      description: "test task",
+      category: "test",
+      load_skills: [],
+      run_in_background: false,
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-123",
+      metadata: () => {},
+    }
+
+    const mockExecutorCtx = {
+      manager: mockManager,
+      client: mockClient,
+      directory: "/tmp",
+    }
+
+    const parentContext = {
+      sessionID: "parent-session",
+      messageID: "msg-123",
+    }
+
+    //#when - getTask returns undefined during polling (race condition)
+    const startTime = Date.now()
+    const result = await executeUnstableAgentTask(
+      args, mockCtx, mockExecutorCtx, parentContext,
+      "test-agent", undefined, undefined, "test-model"
+    )
+    const elapsed = Date.now() - startTime
+
+    //#then - should complete successfully, not crash or timeout
+    expect(result).toContain("COMPLETED SUCCESSFULLY")
+    expect(elapsed).toBeLessThan(400)
+  })
 })

--- a/src/tools/delegate-task/unstable-agent-task.ts
+++ b/src/tools/delegate-task/unstable-agent-task.ts
@@ -90,7 +90,11 @@ export async function executeUnstableAgentTask(
       await new Promise(resolve => setTimeout(resolve, timingCfg.POLL_INTERVAL_MS))
 
       const currentTask = manager.getTask(task.id)
-      if (currentTask && (currentTask.status === "interrupt" || currentTask.status === "error" || currentTask.status === "cancelled")) {
+      if (!currentTask) {
+        completedDuringMonitoring = true
+        break
+      }
+      if (currentTask.status === "interrupt" || currentTask.status === "error" || currentTask.status === "cancelled") {
         terminalStatus = { status: currentTask.status, error: currentTask.error }
         break
       }


### PR DESCRIPTION
## Summary

Fixes #2287 — `visual-engineering` and `writing` task categories always crash with "Task not found" regardless of user model configuration.

## Root Cause

Two bugs in `src/tools/delegate-task/`:

**1. `category-resolver.ts` — `isUnstableAgent` checks hardcoded default model instead of resolved model**

```typescript
// Before: checks BOTH actualModel AND default config model
const categoryConfigModel = resolved.config.model?.toLowerCase()
const isUnstableAgent = ... || [unstableModel, categoryConfigModel].some(m => ...)
```

- `visual-engineering` defaults to `google/gemini-3.1-pro` → contains "gemini" → always unstable
- `writing` defaults to `kimi-for-coding/k2p5` → contains "kimi" → always unstable
- Even user overrides to `anthropic/claude-sonnet-4-6` don't help because `categoryConfigModel` still checks the default

**2. `unstable-agent-task.ts` — race condition in polling loop**

`manager.getTask(task.id)` returns `undefined` when task completes and gets cleaned up before the polling loop catches it. The code falls through and keeps polling until timeout → "Task not found".

## Fix

**Bug 1:** Only check `actualModel` (the resolved, post-override model) for unstable model names. Remove `categoryConfigModel` from the check entirely.

```typescript
// After: only checks the resolved actualModel
const isUnstableAgent = resolved.config.is_unstable_agent === true 
  || (unstableModel != null && (unstableModel.includes("gemini") || unstableModel.includes("minimax") || unstableModel.includes("kimi")))
```

**Bug 2:** Add null guard — when `getTask()` returns `undefined`, treat as task-completed instead of continuing to poll.

## Behavior Matrix

| Scenario | `isUnstableAgent` |
|----------|-------------------|
| Default `google/gemini-3.1-pro` (no override) | `true` ✅ |
| User overrides to `anthropic/claude-sonnet-4-6` | `false` ✅ (was `true` ❌) |
| Default `kimi-for-coding/k2p5` (no override) | `true` ✅ |
| `is_unstable_agent: true` explicit config | `true` ✅ |
| Stable model like `anthropic/claude-haiku-4-5` | `false` ✅ |

## Tests

- 6 new tests in `category-resolver.test.ts` covering all override scenarios
- 1 new test in `unstable-agent-task.test.ts` for the race condition
- All existing tests pass, build and typecheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2287 by stopping crashes in visual-engineering and writing tasks. Detection now uses the resolved model only, the polling loop treats cleaned-up tasks as completed, and tests cover overrides and the race condition.

- **Bug Fixes**
  - Detect unstable agents from the resolved actualModel instead of the category default, so user model overrides work as expected.
  - Treat getTask(...) === undefined as task completed in the polling loop to avoid "Task not found" timeouts.

<sup>Written for commit acb257a4139c4cf1663f626b5084daa00d0f1a5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

