### PR TITLE
fix(agents): prevent user/project .md agents from overriding builtin agent modes

### DIFF
--- a/src/features/claude-code-agent-loader/loader.ts
+++ b/src/features/claude-code-agent-loader/loader.ts
@@ -44,7 +44,7 @@ function loadAgentsFromDir(agentsDir: string, scope: AgentScope): LoadedAgent[] 
 
        const config: AgentConfig = {
          description: formattedDescription,
-         mode: "subagent",
+         mode: data.mode || "subagent",
          prompt: body.trim(),
        }
 

--- a/src/features/claude-code-agent-loader/types.ts
+++ b/src/features/claude-code-agent-loader/types.ts
@@ -7,6 +7,7 @@ export interface AgentFrontmatter {
   description?: string
   model?: string
   tools?: string
+  mode?: "subagent" | "primary" | "all"
 }
 
 export interface LoadedAgent {

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -198,23 +198,47 @@ export async function applyAgentConfig(params: {
         )
       : undefined;
 
+    // Collect all builtin agent names to prevent user/project .md files from overriding them
+    const builtinAgentNames = new Set([
+      ...Object.keys(agentConfig),
+      ...Object.keys(builtinAgents),
+    ]);
+
+    // Filter user/project agents that duplicate builtin agents (they have mode: "subagent" hardcoded
+    // in loadAgentsFromDir which would incorrectly override the builtin mode: "primary")
+    const filteredUserAgents = Object.fromEntries(
+      Object.entries(userAgents).filter(([key]) => !builtinAgentNames.has(key)),
+    );
+    const filteredProjectAgents = Object.fromEntries(
+      Object.entries(projectAgents).filter(([key]) => !builtinAgentNames.has(key)),
+    );
+
     params.config.agent = {
       ...agentConfig,
       ...Object.fromEntries(
         Object.entries(builtinAgents).filter(([key]) => key !== "sisyphus"),
       ),
-      ...filterDisabledAgents(userAgents),
-      ...filterDisabledAgents(projectAgents),
+      ...filterDisabledAgents(filteredUserAgents),
+      ...filterDisabledAgents(filteredProjectAgents),
       ...filterDisabledAgents(pluginAgents),
       ...filteredConfigAgents,
       build: { ...migratedBuild, mode: "subagent", hidden: true },
       ...(planDemoteConfig ? { plan: planDemoteConfig } : {}),
     };
   } else {
+    // Filter user/project agents that duplicate builtin agents
+    const builtinAgentNames = new Set(Object.keys(builtinAgents));
+    const filteredUserAgents = Object.fromEntries(
+      Object.entries(userAgents).filter(([key]) => !builtinAgentNames.has(key)),
+    );
+    const filteredProjectAgents = Object.fromEntries(
+      Object.entries(projectAgents).filter(([key]) => !builtinAgentNames.has(key)),
+    );
+
     params.config.agent = {
       ...builtinAgents,
-      ...filterDisabledAgents(userAgents),
-      ...filterDisabledAgents(projectAgents),
+      ...filterDisabledAgents(filteredUserAgents),
+      ...filterDisabledAgents(filteredProjectAgents),
       ...filterDisabledAgents(pluginAgents),
       ...configAgent,
     };


### PR DESCRIPTION
## Summary

- Fix builtin agents (Sisyphus, Hephaestus, Atlas, Prometheus) being invisible in the opencode TUI agent selector when users have identically-named `.md` files in `~/.claude/agents/`
- Root cause: `loadAgentsFromDir()` hardcodes `mode: "subagent"` for every `.md`-loaded agent, and the config assembly spread order allows these to override builtin agents' `mode: "primary"` — the TUI then filters them all out as subagents
- Secondary fix: the loader now respects the frontmatter `mode` field instead of ignoring it

## Root Cause

`loadAgentsFromDir()` in `src/features/claude-code-agent-loader/loader.ts` creates agent configs from `.md` files with `mode: "subagent"` hardcoded, regardless of file contents:

```ts
const config: AgentConfig = {
  description: formattedDescription,
  mode: "subagent",  // ← always subagent, even for agents that should be primary
  prompt: body.trim(),
}
```

When a user has `.md` agent files in `~/.claude/agents/` that share names with builtin agents (e.g. `sisyphus.md`, `hephaestus.md`, `atlas.md`), the config assembly in `applyAgentConfig()` spreads `userAgents` **after** `builtinAgents`:

```ts
params.config.agent = {
  ...builtinAgents,   // sisyphus: { mode: "primary", model: "...", ... }
  ...userAgents,      // sisyphus: { mode: "subagent", prompt: "..." } ← JS spread overrides entirely
  ...projectAgents,
  ...
}
```

Because JS object spread replaces the entire value for duplicate keys, the builtin config (with `mode: "primary"`, `model`, `color`, `maxTokens`, `thinking`, etc.) is completely replaced by the `.md` loader's minimal config (only `description`, `mode: "subagent"`, `prompt`).

The opencode TUI filters agents with `agent.filter(x => x.mode !== "subagent" && !x.hidden)`, so all primary agents disappear from the selector — only `docs` (a file-based agent with default `mode: "all"`) survives.

## Changes

- **`src/plugin-handlers/agent-config-handler.ts`**:
  - Collect all builtin agent names (from `agentConfig` + `builtinAgents`) into a `Set`
  - Filter out user/project `.md` agents whose names collide with builtin agents before spreading into `config.agent`
  - Applied to both the sisyphus-enabled branch and the fallback `else` branch
  - User/project agents with **unique** names (not matching any builtin) continue to load normally

- **`src/features/claude-code-agent-loader/loader.ts`**:
  - Changed `mode: "subagent"` → `mode: data.mode || "subagent"`
  - `.md` files can now specify `mode` via frontmatter (e.g. `mode: primary`); defaults to `"subagent"` if omitted

- **`src/features/claude-code-agent-loader/types.ts`**:
  - Added `mode?: "subagent" | "primary" | "all"` to the `AgentFrontmatter` interface to support the new field

## Testing

```bash
bun run typecheck
bun test
```

Manual reproduction:
1. Have `.md` agent files in `~/.claude/agents/` with builtin agent names (e.g. `sisyphus.md`, `hephaestus.md`, `atlas.md`)
2. Launch opencode TUI → **Before fix:** only "docs" visible in the agent selector
3. **After fix:** Sisyphus, Hephaestus, Atlas, Prometheus all appear with correct `mode: "primary"`

Verified via `GET /agent` endpoint:
```
Before: Sisyphus (Ultraworker): mode=subagent, no-model  ← broken
After:  Sisyphus (Ultraworker): mode=primary, model=opencode/big-pickle  ← correct
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes builtin agents disappearing from the opencode TUI when users have same-named .md agents by preventing overrides and honoring frontmatter mode. Sisyphus, Hephaestus, Atlas, and Prometheus now show as primary again.

- **Bug Fixes**
  - Filter out user/project .md agents that collide with builtin names before merging (both code paths).
  - Loader now reads mode from frontmatter (primary | subagent | all), defaulting to subagent.
  - Added mode to AgentFrontmatter type.

<sup>Written for commit 7f2188bd076d02b4476fa6a391142671025ddd3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

