### PR TITLE
fix(task): align background delegate-task output with OpenCode TUI session metadata contract

### DIFF
--- a/src/tools/delegate-task/background-task.test.ts
+++ b/src/tools/delegate-task/background-task.test.ts
@@ -102,7 +102,55 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
     //#then - output and metadata should include canonical session linkage
     expectFn(result).toContain("<task_metadata>")
     expectFn(result).toContain("session_id: ses_sub_123")
+    expectFn(result).toContain("task_id: ses_sub_123")
+    expectFn(result).toContain("Background Task ID: bg_resolved")
     expectFn(metadataCalls).toHaveLength(1)
     expectFn(metadataCalls[0].metadata.sessionId).toBe("ses_sub_123")
+  })
+
+  testFn("captures late-resolved session id and emits synced metadata", async () => {
+    //#given - background task session id appears after launch via manager polling
+    const metadataCalls: any[] = []
+    let reads = 0
+    const manager = {
+      launch: async () => ({
+        id: "bg_late",
+        sessionID: undefined,
+        description: "Late session",
+        agent: "explore",
+        status: "running",
+      }),
+      getTask: () => {
+        reads += 1
+        return reads >= 2 ? { sessionID: "ses_late_123" } : undefined
+      },
+    }
+
+    const result = await executeBackgroundTask(
+      {
+        description: "Late session",
+        prompt: "check",
+        run_in_background: true,
+        load_skills: [],
+      },
+      {
+        sessionID: "ses_parent",
+        callID: "call_3",
+        metadata: async (value: any) => metadataCalls.push(value),
+        abort: new AbortController().signal,
+      },
+      { manager },
+      { sessionID: "ses_parent", messageID: "msg_3" },
+      "explore",
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    //#then - late session id still propagates to task metadata contract
+    expectFn(result).toContain("session_id: ses_late_123")
+    expectFn(result).toContain("task_id: ses_late_123")
+    expectFn(metadataCalls).toHaveLength(1)
+    expectFn(metadataCalls[0].metadata.sessionId).toBe("ses_late_123")
   })
 })

--- a/src/tools/delegate-task/background-task.test.ts
+++ b/src/tools/delegate-task/background-task.test.ts
@@ -1,0 +1,108 @@
+const bunTest = require("bun:test")
+const describeFn = bunTest.describe
+const testFn = bunTest.test
+const expectFn = bunTest.expect
+const beforeEachFn = bunTest.beforeEach
+const afterEachFn = bunTest.afterEach
+
+const { executeBackgroundTask } = require("./background-task")
+const { __setTimingConfig, __resetTimingConfig } = require("./timing")
+
+describeFn("executeBackgroundTask output/session metadata compatibility", () => {
+  beforeEachFn(() => {
+    //#given - reduce waiting to keep tests fast
+    __setTimingConfig({
+      WAIT_FOR_SESSION_INTERVAL_MS: 1,
+      WAIT_FOR_SESSION_TIMEOUT_MS: 2,
+    })
+  })
+
+  afterEachFn(() => {
+    __resetTimingConfig()
+  })
+
+  testFn("does not emit synthetic pending session metadata when session id is unresolved", async () => {
+    //#given - launched task without resolved subagent session id
+    const metadataCalls: any[] = []
+    const manager = {
+      launch: async () => ({
+        id: "bg_unresolved",
+        sessionID: undefined,
+        description: "Unresolved session",
+        agent: "explore",
+        status: "running",
+      }),
+      getTask: () => undefined,
+    }
+
+    const result = await executeBackgroundTask(
+      {
+        description: "Unresolved session",
+        prompt: "check",
+        run_in_background: true,
+        load_skills: [],
+      },
+      {
+        sessionID: "ses_parent",
+        callID: "call_1",
+        metadata: async (value: any) => metadataCalls.push(value),
+        abort: new AbortController().signal,
+      },
+      { manager },
+      { sessionID: "ses_parent", messageID: "msg_1" },
+      "explore",
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    //#then - output and metadata should avoid fake session markers
+    expectFn(result).not.toContain("<task_metadata>")
+    expectFn(result).not.toContain("session_id: undefined")
+    expectFn(result).not.toContain("session_id: pending")
+    expectFn(metadataCalls).toHaveLength(1)
+    expectFn("sessionId" in metadataCalls[0].metadata).toBe(false)
+  })
+
+  testFn("emits task metadata session_id when real session id is available", async () => {
+    //#given - launched task with resolved subagent session id
+    const metadataCalls: any[] = []
+    const manager = {
+      launch: async () => ({
+        id: "bg_resolved",
+        sessionID: "ses_sub_123",
+        description: "Resolved session",
+        agent: "explore",
+        status: "running",
+      }),
+      getTask: () => ({ sessionID: "ses_sub_123" }),
+    }
+
+    const result = await executeBackgroundTask(
+      {
+        description: "Resolved session",
+        prompt: "check",
+        run_in_background: true,
+        load_skills: [],
+      },
+      {
+        sessionID: "ses_parent",
+        callID: "call_2",
+        metadata: async (value: any) => metadataCalls.push(value),
+        abort: new AbortController().signal,
+      },
+      { manager },
+      { sessionID: "ses_parent", messageID: "msg_2" },
+      "explore",
+      undefined,
+      undefined,
+      undefined,
+    )
+
+    //#then - output and metadata should include canonical session linkage
+    expectFn(result).toContain("<task_metadata>")
+    expectFn(result).toContain("session_id: ses_sub_123")
+    expectFn(metadataCalls).toHaveLength(1)
+    expectFn(metadataCalls[0].metadata.sessionId).toBe("ses_sub_123")
+  })
+})

--- a/src/tools/delegate-task/background-task.test.ts
+++ b/src/tools/delegate-task/background-task.test.ts
@@ -103,6 +103,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
     expectFn(result).toContain("<task_metadata>")
     expectFn(result).toContain("session_id: ses_sub_123")
     expectFn(result).toContain("task_id: ses_sub_123")
+    expectFn(result).toContain("background_task_id: bg_resolved")
     expectFn(result).toContain("Background Task ID: bg_resolved")
     expectFn(metadataCalls).toHaveLength(1)
     expectFn(metadataCalls[0].metadata.sessionId).toBe("ses_sub_123")
@@ -150,6 +151,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
     //#then - late session id still propagates to task metadata contract
     expectFn(result).toContain("session_id: ses_late_123")
     expectFn(result).toContain("task_id: ses_late_123")
+    expectFn(result).toContain("background_task_id: bg_late")
     expectFn(metadataCalls).toHaveLength(1)
     expectFn(metadataCalls[0].metadata.sessionId).toBe("ses_late_123")
   })

--- a/src/tools/delegate-task/background-task.ts
+++ b/src/tools/delegate-task/background-task.ts
@@ -56,24 +56,30 @@ export async function executeBackgroundTask(
       SessionCategoryRegistry.register(sessionId, args.category)
     }
 
+    const metadata = {
+      prompt: args.prompt,
+      agent: task.agent,
+      category: args.category,
+      load_skills: args.load_skills,
+      description: args.description,
+      run_in_background: args.run_in_background,
+      command: args.command,
+      ...(sessionId ? { sessionId } : {}),
+      ...(categoryModel ? { model: { providerID: categoryModel.providerID, modelID: categoryModel.modelID } } : {}),
+    }
+
     const unstableMeta = {
       title: args.description,
-      metadata: {
-        prompt: args.prompt,
-        agent: task.agent,
-        category: args.category,
-        load_skills: args.load_skills,
-        description: args.description,
-        run_in_background: args.run_in_background,
-        sessionId: sessionId ?? "pending",
-        command: args.command,
-        model: categoryModel ? { providerID: categoryModel.providerID, modelID: categoryModel.modelID } : undefined,
-      },
+      metadata,
     }
     await ctx.metadata?.(unstableMeta)
     if (ctx.callID) {
       storeToolMetadata(ctx.sessionID, ctx.callID, unstableMeta)
     }
+
+    const taskMetadataBlock = sessionId
+      ? `\n\n<task_metadata>\nsession_id: ${sessionId}\n</task_metadata>`
+      : ""
 
     return `Background task launched.
 
@@ -82,11 +88,7 @@ Description: ${task.description}
 Agent: ${task.agent}${args.category ? ` (category: ${args.category})` : ""}
 Status: ${task.status}
 
-System notifies on completion. Use \`background_output\` with task_id="${task.id}" to check.
-
-<task_metadata>
-session_id: ${sessionId}
-</task_metadata>`
+System notifies on completion. Use \`background_output\` with task_id="${task.id}" to check.${taskMetadataBlock}`
   } catch (error) {
     return formatDetailedError(error, {
       operation: "Launch background task",

--- a/src/tools/delegate-task/background-task.ts
+++ b/src/tools/delegate-task/background-task.ts
@@ -78,12 +78,12 @@ export async function executeBackgroundTask(
     }
 
     const taskMetadataBlock = sessionId
-      ? `\n\n<task_metadata>\nsession_id: ${sessionId}\n</task_metadata>`
+      ? `\n\n<task_metadata>\nsession_id: ${sessionId}\ntask_id: ${sessionId}\n</task_metadata>`
       : ""
 
     return `Background task launched.
 
-Task ID: ${task.id}
+Background Task ID: ${task.id}
 Description: ${task.description}
 Agent: ${task.agent}${args.category ? ` (category: ${args.category})` : ""}
 Status: ${task.status}

--- a/src/tools/delegate-task/background-task.ts
+++ b/src/tools/delegate-task/background-task.ts
@@ -78,7 +78,7 @@ export async function executeBackgroundTask(
     }
 
     const taskMetadataBlock = sessionId
-      ? `\n\n<task_metadata>\nsession_id: ${sessionId}\ntask_id: ${sessionId}\n</task_metadata>`
+      ? `\n\n<task_metadata>\nsession_id: ${sessionId}\ntask_id: ${sessionId}\nbackground_task_id: ${task.id}\n</task_metadata>`
       : ""
 
     return `Background task launched.


### PR DESCRIPTION
## Summary

Fix 3 contract mismatches between `delegate-task` background output metadata and OpenCode TUI's `Task` component expectations, preventing broken session syncing and ambiguous task ID semantics.

## Problem

When `delegate-task` launches a background task, the output metadata sent to OpenCode's TUI had several issues:

1. **Fake `sessionId: "pending"`** — When the background manager hasn't resolved the subagent session yet, we emitted `metadata.sessionId = "pending"`, causing TUI to call `sync.session.sync("pending")` on a non-existent session.
2. **Missing `task_id` field** — OpenCode's built-in `task` tool emits `task_id: <sessionId>` in its output, but our background path omitted it entirely.
3. **Ambiguous `task_id` semantics** — Our background flow has *two* distinct IDs (background manager task ID vs session ID), but the output conflated them.

## Root Cause Analysis (with OpenCode source references)

### TUI Contract: `metadata.sessionId`

OpenCode's TUI `Task` component uses `props.metadata.sessionId` to sync the child session and count toolcalls:

- **Sync trigger** ([`index.tsx:1952-1955`](https://github.com/anomalyco/opencode/blob/324230806e99d4e5c9cc14fd66ddad0ba0c2b6e6/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx#L1952-L1955)):
  ```tsx
  onMount(() => {
    if (props.metadata.sessionId && !sync.data.message[props.metadata.sessionId]?.length)
      sync.session.sync(props.metadata.sessionId)
  })
  ```

- **Toolcall counting** ([`index.tsx:1957-1965`](https://github.com/anomalyco/opencode/blob/324230806e99d4e5c9cc14fd66ddad0ba0c2b6e6/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx#L1957-L1965)):
  ```tsx
  const messages = createMemo(() => sync.data.message[props.metadata.sessionId ?? ""] ?? [])
  const tools = createMemo(() => {
    return messages().flatMap((msg) =>
      (sync.data.part[msg.id] ?? [])
        .filter((part): part is ToolPart => part.type === "tool")
        .map((part) => ({ tool: part.tool, state: part.state })),
    )
  })
  ```

### TUI Contract: `task_id` output

OpenCode's built-in `task` tool emits `task_id: <sessionId>` as a session resumption key ([`task.ts:147-153`](https://github.com/anomalyco/opencode/blob/324230806e99d4e5c9cc14fd66ddad0ba0c2b6e6/packages/opencode/src/tool/task.ts#L147-L153)):

```ts
`task_id: ${session.id} (for resuming to continue this task if needed)`,
"",
"<task_result>",
result,
"</task_result>",
```

### TUI Permission rendering

TUI permission dialog reads `data.subagent_type` for task display ([`permission.tsx:300-313`](https://github.com/anomalyco/opencode/blob/324230806e99d4e5c9cc14fd66ddad0ba0c2b6e6/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx#L300-L313)).

## Changes

### Commit 1: `fix(task): avoid pending sessionId metadata in background delegate output`

- **Problem**: `metadata.sessionId` was set to `"pending"` when session wasn't yet created, causing TUI sync failures.
- **Fix**: Only include `sessionId` in metadata when a real session ID is available. Conditionally emit `<task_metadata>` block.
- **Files**: `src/tools/delegate-task/background-task.ts`, `src/tools/delegate-task/background-task.test.ts` (new)

### Commit 2: `fix(task): align background output task_id with opencode contract`

- **Problem**: Output lacked `task_id` field that OpenCode's TUI and agents expect for session resumption.
- **Fix**: Add `task_id: <sessionId>` to `<task_metadata>` block (matching upstream contract). Rename human-readable label to `Background Task ID` to distinguish from session-based `task_id`.
- **Files**: same as above

### Commit 3: `fix(task): disambiguate background task_id metadata`

- **Problem**: `task_id` (session ID) vs background manager task ID were ambiguous in output.
- **Fix**: Add `background_task_id: <bg_task_id>` to `<task_metadata>` block alongside `task_id: <sessionId>`, making both IDs explicit.
- **Files**: same as above

## Test Coverage

New test file `src/tools/delegate-task/background-task.test.ts` with 3 test cases:

| Test | What it verifies |
|------|-----------------|
| `does not emit synthetic pending session metadata when session id is unresolved` | No fake `sessionId`, no `<task_metadata>` block when session unavailable |
| `emits task metadata session_id when real session id is available` | `session_id`, `task_id`, `background_task_id` all present with correct values |
| `captures late-resolved session id and emits synced metadata` | Session ID that appears mid-polling still propagates to metadata correctly |

## Verification

- `bun test src/tools/delegate-task/background-task.test.ts src/tools/delegate-task/tools.test.ts` — 112 pass, 0 fail
- `bun run typecheck` — clean
- `bun run build` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns delegate-task background output with OpenCode TUI’s Task contract to fix session syncing and clarify task ID semantics. Background output now emits session metadata only when a real or late-resolved session is available and distinguishes between session and background task IDs.

- **Bug Fixes**
  - Stop emitting metadata.sessionId="pending"; only include sessionId when resolved (including late-resolved via polling).
  - Emit <task_metadata> only when sessionId is present; add task_id: <sessionId> to match TUI’s resume contract.
  - Add background_task_id: <bg_task_id> and rename visible label to “Background Task ID” to avoid confusion.

<sup>Written for commit 39d94a4af67b7f00e8a82afcdf642b57b746abcc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

