### PR TITLE
fix(background-task): clarify timeout unit is milliseconds in description

### DIFF
--- a/src/tools/background-task/constants.ts
+++ b/src/tools/background-task/constants.ts
@@ -2,6 +2,6 @@ export const BACKGROUND_TASK_DESCRIPTION = `Run agent task in background. Return
 
 Use \`background_output\` to get results. Prompts MUST be in English.`
 
-export const BACKGROUND_OUTPUT_DESCRIPTION = `Get output from background task. Use full_session=true to fetch session messages with filters. System notifies on completion, so block=true rarely needed.`
+export const BACKGROUND_OUTPUT_DESCRIPTION = `Get output from background task. Use full_session=true to fetch session messages with filters. System notifies on completion, so block=true rarely needed. All timeouts are in milliseconds (ms), NOT seconds.`
 
 export const BACKGROUND_CANCEL_DESCRIPTION = `Cancel running background task(s). Use all=true to cancel ALL before final answer.`

--- a/src/tools/background-task/constants.ts
+++ b/src/tools/background-task/constants.ts
@@ -2,6 +2,6 @@ export const BACKGROUND_TASK_DESCRIPTION = `Run agent task in background. Return
 
 Use \`background_output\` to get results. Prompts MUST be in English.`
 
-export const BACKGROUND_OUTPUT_DESCRIPTION = `Get output from background task. Use full_session=true to fetch session messages with filters. System notifies on completion, so block=true rarely needed. All timeouts are in milliseconds (ms), NOT seconds.`
+export const BACKGROUND_OUTPUT_DESCRIPTION = `Get output from background task. Use full_session=true to fetch session messages with filters. System notifies on completion, so block=true rarely needed. - Timeout values are in milliseconds (ms), NOT seconds.`
 
 export const BACKGROUND_CANCEL_DESCRIPTION = `Cancel running background task(s). Use all=true to cancel ALL before final answer.`


### PR DESCRIPTION
## Summary

- Append "All timeouts are in milliseconds (ms), NOT seconds." to `BACKGROUND_OUTPUT_DESCRIPTION` to prevent agents from misinterpreting timeout values as seconds.

## Changes

- Updated `BACKGROUND_OUTPUT_DESCRIPTION` in `src/tools/background-task/constants.ts` to explicitly state that timeouts are in milliseconds.

## Testing

```bash
bun run typecheck
bun test
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified BACKGROUND_OUTPUT_DESCRIPTION to state timeout values are in milliseconds (ms), not seconds. This prevents misread timeouts and unnecessary blocking.

<sup>Written for commit 389625cb20142bf66cccefffa038343e09397ccd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

