### PR TITLE
feat(background-agent): add tab indicator index to task descriptions

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -151,14 +151,18 @@ export class BackgroundManager {
       throw new Error("Agent parameter is required")
     }
 
-    // Create task immediately with status="pending"
+    const siblingTasks = input.parentSessionID
+      ? this.getTasksByParentSession(input.parentSessionID)
+          .filter(t => t.status === "pending" || t.status === "running")
+      : []
+    const taskIndex = siblingTasks.length + 1
+    const descriptionWithIndicator = `[${taskIndex}] ${input.description}`
+
     const task: BackgroundTask = {
       id: `bg_${crypto.randomUUID().slice(0, 8)}`,
       status: "pending",
       queuedAt: new Date(),
-      // Do NOT set startedAt - will be set when running
-      // Do NOT set sessionID - will be set when running
-      description: input.description,
+      description: descriptionWithIndicator,
       prompt: input.prompt,
       agent: input.agent,
       parentSessionID: input.parentSessionID,
@@ -173,7 +177,7 @@ export class BackgroundManager {
     }
 
     this.tasks.set(task.id, task)
-    this.taskHistory.record(input.parentSessionID, { id: task.id, agent: input.agent, description: input.description, status: "pending", category: input.category })
+    this.taskHistory.record(input.parentSessionID, { id: task.id, agent: input.agent, description: descriptionWithIndicator, status: "pending", category: input.category })
 
     // Track for batched notifications immediately (pending state)
     if (input.parentSessionID) {
@@ -194,7 +198,7 @@ export class BackgroundManager {
     if (toastManager) {
       toastManager.addTask({
         id: task.id,
-        description: input.description,
+        description: descriptionWithIndicator,
         agent: input.agent,
         isBackground: true,
         status: "queued",

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -151,11 +151,14 @@ export class BackgroundManager {
       throw new Error("Agent parameter is required")
     }
 
-    const siblingTasks = input.parentSessionID
+    const allSiblingTasks = input.parentSessionID
       ? this.getTasksByParentSession(input.parentSessionID)
-          .filter(t => t.status === "pending" || t.status === "running")
       : []
-    const taskIndex = siblingTasks.length + 1
+    const maxIndex = allSiblingTasks.reduce((max, t) => {
+      const match = t.description.match(/^\[(\d+)\]/)
+      return match ? Math.max(max, parseInt(match[1], 10)) : max
+    }, 0)
+    const taskIndex = maxIndex + 1
     const descriptionWithIndicator = `[${taskIndex}] ${input.description}`
 
     const task: BackgroundTask = {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -186,10 +186,12 @@ export class BackgroundManager {
       this.pendingByParent.set(input.parentSessionID, pending)
     }
 
+    const modifiedInput = { ...input, description: descriptionWithIndicator }
+
     // Add to queue
-    const key = this.getConcurrencyKeyFromInput(input)
+    const key = this.getConcurrencyKeyFromInput(modifiedInput)
     const queue = this.queuesByKey.get(key) ?? []
-    queue.push({ task, input })
+    queue.push({ task, input: modifiedInput })
     this.queuesByKey.set(key, queue)
 
     log("[background-agent] Task queued:", { taskId: task.id, key, queueLength: queue.length })

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -61,6 +61,7 @@ export async function startTask(
   const createResult = await client.session.create({
     body: {
       parentID: input.parentSessionID,
+      title: input.description,
     } as Record<string, unknown>,
     query: {
       directory: parentDirectory,

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -6,6 +6,7 @@ import { subagentSessions } from "../claude-code-session-state"
 import { getTaskToastManager } from "../task-toast-manager"
 import { isInsideTmux } from "../../shared/tmux"
 import type { ConcurrencyManager } from "./concurrency"
+import { createSystemDirective } from "../../shared/system-directive"
 
 export interface SpawnerContext {
   client: OpencodeClient
@@ -132,6 +133,19 @@ export async function startTask(
     : undefined
   const launchVariant = input.model?.variant
 
+  const indexMatch = input.description.match(/^\[(\d+)\]/)
+  const index = indexMatch ? indexMatch[1] : "?"
+
+  const bannerText = `${createSystemDirective("SUBAGENT TAB INDICATOR")}
+
+┌─────────────────────────────────────────┐
+│  📋 Sub-Agent [${index}]                               │
+│  🤖 Agent: ${input.agent}                      │
+└─────────────────────────────────────────┘
+
+---
+`
+
   promptWithModelSuggestionRetry(client, {
     path: { id: sessionID },
     body: {
@@ -145,7 +159,7 @@ export async function startTask(
         question: false,
         ...getAgentToolRestrictions(input.agent),
       },
-      parts: [createInternalAgentTextPart(input.prompt)],
+      parts: [createInternalAgentTextPart(bannerText), createInternalAgentTextPart(input.prompt)],
     },
   }).catch((error) => {
     log("[background-agent] promptAsync error:", error)


### PR DESCRIPTION
## Summary

Adds sequential index prefix to background task descriptions to help users identify tasks when switching between sub-agents in the OpenCode TUI (Ctrl+X down).

## Problem

When using `/ulw-loop` or creating multiple sub-agents, users can press Ctrl+X then down arrow to see a list of running background tasks. However, there is no clear indicator of which task is which when navigating with left/right arrows.

## Solution

Each task now shows its index in the description:
- `[1] Explore agent`
- `[2] Librarian agent`
- `[3] Oracle consultation`

The index is calculated based on the number of existing active tasks (pending/running) for the same parent session.

## Changes

Modified `src/features/background-agent/manager.ts`:
- Calculate task index before creating the task
- Prefix description with `[index] `
- Update `taskHistory.record()` and `toastManager.addTask()` to use the modified description

## Testing

1. Run `ultrawork` and create multiple sub-agents
2. Press Ctrl+X then down arrow to open task list
3. Observe task descriptions now show `[1]`, `[2]`, etc.
4. Use left/right arrows to switch between tasks

## Related

Replaces #2318 which was based on a misunderstanding (tmux pane titles instead of OpenCode TUI task list).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sequential index (e.g., [1], [2]) to background task descriptions and sub-agent session titles, and shows a banner at session start to make sub-agent tabs easy to identify in the TUI.

- **New Features**
  - Prefixes each new task’s description and session title with a monotonic index per parent session (max existing + 1). Used in the queue, task history, and toasts. Indices remain unique even if tasks complete out of order.
  - Injects a banner as the first message in each sub-agent session showing the index and agent type (system directive + visual box) before the user prompt.

<sup>Written for commit 594102aebe6b2740be8174a81bc7f94435184650. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

