### PR TITLE
chore(security): pin MCP transitive vulnerability fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@ast-grep/napi": "^0.40.0",
         "@clack/prompts": "^0.11.0",
         "@code-yeongyu/comment-checker": "^0.7.0",
-        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "@opencode-ai/plugin": "^1.2.16",
         "@opencode-ai/sdk": "^1.2.17",
         "commander": "^14.0.2",
@@ -49,7 +49,12 @@
     "@code-yeongyu/comment-checker",
   ],
   "overrides": {
+    "@hono/node-server": "^1.19.10",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@opencode-ai/sdk": "^1.2.17",
+    "ajv": "^8.18.0",
+    "hono": "^4.12.5",
+    "qs": "^6.15.0",
   },
   "packages": {
     "@ast-grep/cli": ["@ast-grep/cli@0.40.5", "", { "dependencies": { "detect-libc": "2.1.2" }, "optionalDependencies": { "@ast-grep/cli-darwin-arm64": "0.40.5", "@ast-grep/cli-darwin-x64": "0.40.5", "@ast-grep/cli-linux-arm64-gnu": "0.40.5", "@ast-grep/cli-linux-x64-gnu": "0.40.5", "@ast-grep/cli-win32-arm64-msvc": "0.40.5", "@ast-grep/cli-win32-ia32-msvc": "0.40.5", "@ast-grep/cli-win32-x64-msvc": "0.40.5" }, "bin": { "sg": "sg", "ast-grep": "ast-grep" } }, "sha512-yVXL7Gz0WIHerQLf+MVaVSkhIhidtWReG5akNVr/JS9OVCVkSdz7gWm7H8jVv2M9OO1tauuG76K3UaRGBPu5lQ=="],

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@ast-grep/napi": "^0.40.0",
     "@clack/prompts": "^0.11.0",
     "@code-yeongyu/comment-checker": "^0.7.0",
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@opencode-ai/plugin": "^1.2.16",
     "@opencode-ai/sdk": "^1.2.17",
     "commander": "^14.0.2",
@@ -88,7 +88,12 @@
     "oh-my-opencode-windows-x64-baseline": "3.10.0"
   },
   "overrides": {
-    "@opencode-ai/sdk": "^1.2.17"
+    "@opencode-ai/sdk": "^1.2.17",
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@hono/node-server": "^1.19.10",
+    "hono": "^4.12.5",
+    "ajv": "^8.18.0",
+    "qs": "^6.15.0"
   },
   "trustedDependencies": [
     "@ast-grep/cli",


### PR DESCRIPTION
## Summary

- Hardens transitive dependency resolution for vulnerabilities pulled through `@modelcontextprotocol/sdk`.
- Bumps the MCP SDK floor to `^1.27.1` and enforces patched transitive versions via `overrides`.
- Regenerates `bun.lock` so installs deterministically resolve the patched dependency set.

## Changes

- Updated `package.json`:
  - `@modelcontextprotocol/sdk` from `^1.25.2` to `^1.27.1`
  - Added/updated `overrides` for:
    - `@modelcontextprotocol/sdk: ^1.27.1`
    - `@hono/node-server: ^1.19.10`
    - `hono: ^4.12.5`
    - `ajv: ^8.18.0`
    - `qs: ^6.15.0`
- Updated `bun.lock` to reflect override-enforced resolutions.

## Screenshots

N/A (dependency/config-only changes).

## Testing

```bash
bun run typecheck
bun run build
bun audit
bun test src/features/skill-mcp-manager
bun test src/tools/skill
```

- `bun run typecheck`: pass
- `bun run build`: pass
- `bun audit`: no vulnerabilities found
- Targeted MCP-related tests: pass

## Related Issues

<!-- Closes # -->

## Checklist

- [x] Code follows project conventions
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] Tested locally with OpenCode
- [x] Updated documentation if needed (N/A for dependency-only security update)
- [x] No package release version bump in `package.json` (`version` unchanged; dependency ranges updated intentionally for security)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins @modelcontextprotocol/sdk to ^1.27.1 and enforces patched transitive versions to fix vulnerabilities. Regenerates bun.lock to ensure secure, deterministic installs.

- **Dependencies**
  - @modelcontextprotocol/sdk → ^1.27.1 (dep + override)
  - @hono/node-server → ^1.19.10
  - hono → ^4.12.5
  - ajv → ^8.18.0
  - qs → ^6.15.0

<sup>Written for commit fade192399cf26834fb573d84b16a01fc4faf2b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

