### PR TITLE
feat: upgrade oracle agent primary model to gpt-5.4

### DIFF
--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -176,7 +176,7 @@ See the [Orchestration System Guide](./orchestration.md) for how agents dispatch
     "explore":   { "model": "github-copilot/grok-code-fast-1" },
 
     // Architecture consultation: GPT or Claude Opus
-    "oracle": { "model": "openai/gpt-5.2", "variant": "high" },
+    "oracle": { "model": "openai/gpt-5.4", "variant": "high" },
 
     // Prometheus inherits sisyphus model; just add prompt guidance
     "prometheus": { "prompt_append": "Leverage deep & quick agents heavily, always in parallel." }

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -197,7 +197,7 @@ When GitHub Copilot is the best available provider, oh-my-opencode uses these mo
 | Agent         | Model                                                     |
 | ------------- | --------------------------------------------------------- |
 | **Sisyphus**  | `github-copilot/claude-opus-4-6`                          |
-| **Oracle**    | `github-copilot/gpt-5.2`                                  |
+| **Oracle**    | `github-copilot/gpt-5.4`                                  |
 | **Explore**   | `opencode/gpt-5-nano`                                     |
 | **Librarian** | `zai-coding-plan/glm-4.7` (if Z.ai available) or fallback |
 
@@ -225,7 +225,7 @@ When OpenCode Zen is the best available provider (no native or Copilot), these m
 | Agent         | Model                      |
 | ------------- | -------------------------- |
 | **Sisyphus**  | `opencode/claude-opus-4-6` |
-| **Oracle**    | `opencode/gpt-5.2`         |
+| **Oracle**    | `opencode/gpt-5.4`         |
 | **Explore**   | `opencode/gpt-5-nano`      |
 | **Librarian** | `opencode/glm-4.7-free`    |
 

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -181,7 +181,7 @@ You can override specific agents or categories in your config:
     "explore": { "model": "github-copilot/grok-code-fast-1" },
 
     // Architecture consultation: GPT or Claude Opus
-    "oracle": { "model": "openai/gpt-5.2", "variant": "high" }
+    "oracle": { "model": "openai/gpt-5.4", "variant": "high" }
   },
 
   "categories": {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -81,7 +81,7 @@ Here's a practical starting configuration:
     "explore":   { "model": "github-copilot/grok-code-fast-1" },
 
     // Architecture consultation: GPT or Claude Opus
-    "oracle": { "model": "openai/gpt-5.2", "variant": "high" },
+    "oracle": { "model": "openai/gpt-5.4", "variant": "high" },
 
     // Prometheus inherits sisyphus model; just add prompt guidance
     "prometheus": { "prompt_append": "Leverage deep & quick agents heavily, always in parallel." }
@@ -253,7 +253,7 @@ Disable categories: `{ "disabled_categories": ["ultrabrain"] }`
 |-------|---------------|-------------------|
 | **Sisyphus** | `claude-opus-4-6` | anthropic → github-copilot → opencode → kimi-for-coding → zai-coding-plan |
 | **Hephaestus** | `gpt-5.3-codex` | openai → github-copilot → opencode |
-| **oracle** | `gpt-5.2` | openai → google → anthropic (via github-copilot/opencode) |
+| **oracle** | `gpt-5.4` | openai → google → anthropic (via github-copilot/opencode) |
 | **librarian** | `glm-4.7` | zai-coding-plan → opencode → anthropic |
 | **explore** | `grok-code-fast-1` | github-copilot → anthropic/opencode → opencode |
 | **multimodal-looker** | `gemini-3-flash` | google → openai → zai-coding-plan → kimi-for-coding → opencode → anthropic |

--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -12,7 +12,7 @@ Agent factories following `createXXXAgent(model) → AgentConfig` pattern. Each 
 |-------|-------|------|------|----------------|---------|
 | **Sisyphus** | claude-opus-4-6 | 0.1 | all | kimi-k2.5 → glm-5 → big-pickle | Main orchestrator, plans + delegates |
 | **Hephaestus** | gpt-5.3-codex | 0.1 | all | gpt-5.2 (copilot) | Autonomous deep worker |
-| **Oracle** | gpt-5.2 | 0.1 | subagent | gemini-3.1-pro → claude-opus-4-6 | Read-only consultation |
+| **Oracle** | gpt-5.4 | 0.1 | subagent | gemini-3.1-pro → claude-opus-4-6 | Read-only consultation |
 | **Librarian** | kimi-k2.5 | 0.1 | subagent | gemini-3-flash → gpt-5.2 → glm-4.6v | External docs/code search |
 | **Explore** | grok-code-fast-1 | 0.1 | subagent | minimax-m2.5 → claude-haiku-4-5 → gpt-5-nano | Contextual grep |
 | **Multimodal-Looker** | gemini-3-flash | 0.1 | subagent | minimax-m2.5 → big-pickle | PDF/image analysis |

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -169,15 +169,14 @@ describe("createBuiltinAgents with model overrides", () => {
    test("Oracle uses connected provider fallback when availableModels is empty and cache exists", async () => {
      // #given - connected providers cache has "openai", which matches oracle's first fallback entry
      const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
-
+     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set())
      // #when
      const agents = await createBuiltinAgents([], {}, undefined, TEST_DEFAULT_MODEL, undefined, undefined, [], undefined, undefined)
-
-     // #then - oracle resolves via connected cache fallback to openai/gpt-5.2 (not system default)
-     expect(agents.oracle.model).toBe("openai/gpt-5.2")
+     expect(agents.oracle.model).toBe("openai/gpt-5.4")
      expect(agents.oracle.reasoningEffort).toBe("medium")
      expect(agents.oracle.thinking).toBeUndefined()
      cacheSpy.mockRestore?.()
+     fetchSpy.mockRestore?.()
    })
 
    test("Oracle created without model field when no cache exists (first run scenario)", async () => {
@@ -473,14 +472,13 @@ describe("createBuiltinAgents without systemDefaultModel", () => {
    test("agents created via connected cache fallback even without systemDefaultModel", async () => {
      // #given - connected cache has "openai", which matches oracle's fallback chain
      const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
-
+     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set())
      // #when
      const agents = await createBuiltinAgents([], {}, undefined, undefined)
-
-     // #then - connected cache enables model resolution despite no systemDefaultModel
      expect(agents.oracle).toBeDefined()
-     expect(agents.oracle.model).toBe("openai/gpt-5.2")
+     expect(agents.oracle.model).toBe("openai/gpt-5.4")
      cacheSpy.mockRestore?.()
+     fetchSpy.mockRestore?.()
    })
 
    test("agents NOT created when no cache and no systemDefaultModel (first run without defaults)", async () => {

--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -216,7 +216,7 @@ exports[`generateModelConfig single native provider uses OpenAI models when only
       "variant": "medium",
     },
     "oracle": {
-      "model": "openai/gpt-5.2",
+      "model": "openai/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -284,7 +284,7 @@ exports[`generateModelConfig single native provider uses OpenAI models with isMa
       "variant": "medium",
     },
     "oracle": {
-      "model": "openai/gpt-5.2",
+      "model": "openai/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -474,7 +474,7 @@ exports[`generateModelConfig all native providers uses preferred models from fal
       "variant": "medium",
     },
     "oracle": {
-      "model": "openai/gpt-5.2",
+      "model": "openai/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -549,7 +549,7 @@ exports[`generateModelConfig all native providers uses preferred models with isM
       "variant": "medium",
     },
     "oracle": {
-      "model": "openai/gpt-5.2",
+      "model": "openai/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -625,7 +625,7 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models when on
       "variant": "medium",
     },
     "oracle": {
-      "model": "opencode/gpt-5.2",
+      "model": "opencode/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -700,7 +700,7 @@ exports[`generateModelConfig fallback providers uses OpenCode Zen models with is
       "variant": "medium",
     },
     "oracle": {
-      "model": "opencode/gpt-5.2",
+      "model": "opencode/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -771,7 +771,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
       "model": "github-copilot/gemini-3-flash-preview",
     },
     "oracle": {
-      "model": "github-copilot/gpt-5.2",
+      "model": "github-copilot/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -837,7 +837,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
       "model": "github-copilot/gemini-3-flash-preview",
     },
     "oracle": {
-      "model": "github-copilot/gpt-5.2",
+      "model": "github-copilot/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -1019,7 +1019,7 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + OpenCode Zen
       "variant": "medium",
     },
     "oracle": {
-      "model": "opencode/gpt-5.2",
+      "model": "opencode/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -1094,7 +1094,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
       "variant": "medium",
     },
     "oracle": {
-      "model": "openai/gpt-5.2",
+      "model": "openai/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -1296,7 +1296,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
       "variant": "medium",
     },
     "oracle": {
-      "model": "github-copilot/gpt-5.2",
+      "model": "github-copilot/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -1371,7 +1371,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "variant": "medium",
     },
     "oracle": {
-      "model": "openai/gpt-5.2",
+      "model": "openai/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {
@@ -1446,7 +1446,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "variant": "medium",
     },
     "oracle": {
-      "model": "openai/gpt-5.2",
+      "model": "openai/gpt-5.4",
       "variant": "high",
     },
     "prometheus": {

--- a/src/cli/config-manager.test.ts
+++ b/src/cli/config-manager.test.ts
@@ -322,7 +322,7 @@ describe("generateOmoConfig - model fallback system", () => {
     // #then Sisyphus is omitted (requires all fallback providers)
     expect((result.agents as Record<string, { model: string }>).sisyphus).toBeUndefined()
     // #then Oracle should use native OpenAI (first fallback entry)
-    expect((result.agents as Record<string, { model: string }>).oracle.model).toBe("openai/gpt-5.2")
+    expect((result.agents as Record<string, { model: string }>).oracle.model).toBe("openai/gpt-5.4")
     // #then multimodal-looker should use native OpenAI (first fallback entry is gpt-5.3-codex)
     expect((result.agents as Record<string, { model: string }>)["multimodal-looker"].model).toBe("openai/gpt-5.3-codex")
   })

--- a/src/cli/model-fallback-requirements.ts
+++ b/src/cli/model-fallback-requirements.ts
@@ -22,7 +22,7 @@ export const CLI_AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   oracle: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.4", variant: "high" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3.1-pro", variant: "high" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
     ],

--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -191,7 +191,7 @@ describe("resolveVariantForModel", () => {
   test("returns correct variant for oracle agent with openai", () => {
     // given
     const config = {} as OhMyOpenCodeConfig
-    const model = { providerID: "openai", modelID: "gpt-5.2" }
+    const model = { providerID: "openai", modelID: "gpt-5.4" }
 
     // when
     const variant = resolveVariantForModel(config, "oracle", model)

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -7,19 +7,19 @@ import {
 } from "./model-requirements"
 
 describe("AGENT_MODEL_REQUIREMENTS", () => {
-  test("oracle has valid fallbackChain with gpt-5.2 as primary", () => {
+  test("oracle has valid fallbackChain with gpt-5.4 as primary", () => {
     // given - oracle agent requirement
     const oracle = AGENT_MODEL_REQUIREMENTS["oracle"]
 
     // when - accessing oracle requirement
-    // then - fallbackChain exists with gpt-5.2 as first entry
+    // then - fallbackChain exists with gpt-5.4 as first entry
     expect(oracle).toBeDefined()
     expect(oracle.fallbackChain).toBeArray()
     expect(oracle.fallbackChain.length).toBeGreaterThan(0)
 
     const primary = oracle.fallbackChain[0]
     expect(primary.providers).toContain("openai")
-    expect(primary.model).toBe("gpt-5.2")
+    expect(primary.model).toBe("gpt-5.4")
     expect(primary.variant).toBe("high")
   })
 

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -30,7 +30,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   oracle: {
     fallbackChain: [
-      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.2", variant: "high" },
+      { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.4", variant: "high" },
       { providers: ["google", "github-copilot", "opencode"], model: "gemini-3.1-pro", variant: "high" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-6", variant: "max" },
     ],

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -20,6 +20,7 @@ const TEST_AVAILABLE_MODELS = new Set([
   "google/gemini-3.1-pro",
   "google/gemini-3-flash",
   "openai/gpt-5.2",
+  "openai/gpt-5.4",
   "openai/gpt-5.3-codex",
 ])
 
@@ -53,7 +54,7 @@ describe("sisyphus-task", () => {
       models: {
         anthropic: ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
         google: ["gemini-3.1-pro", "gemini-3-flash"],
-        openai: ["gpt-5.2", "gpt-5.3-codex"],
+        openai: ["gpt-5.2", "gpt-5.4", "gpt-5.3-codex"],
       },
       connected: ["anthropic", "google", "openai"],
       updatedAt: "2026-01-01T00:00:00.000Z",
@@ -3375,7 +3376,7 @@ describe("sisyphus-task", () => {
          app: {
            agents: async () => ({
              data: [
-               { name: "oracle", mode: "subagent", model: { providerID: "openai", modelID: "gpt-5.2" } },
+                { name: "oracle", mode: "subagent", model: { providerID: "openai", modelID: "gpt-5.4" } },
              ],
            }),
          },
@@ -3442,7 +3443,7 @@ describe("sisyphus-task", () => {
          app: {
            agents: async () => ({
              data: [
-               { name: "oracle", mode: "subagent", model: { providerID: "openai", modelID: "gpt-5.2" } },
+                { name: "oracle", mode: "subagent", model: { providerID: "openai", modelID: "gpt-5.4" } },
              ],
            }),
          },
@@ -3551,11 +3552,11 @@ describe("sisyphus-task", () => {
       )
 
       // then - should resolve via AGENT_MODEL_REQUIREMENTS fallback chain for oracle
-      // oracle fallback chain: gpt-5.2 (openai) > gemini-3.1-pro (google) > claude-opus-4-6 (anthropic)
-      // Since openai is in connectedProviders, should resolve to openai/gpt-5.2
+      // oracle fallback chain: gpt-5.4 (openai) > gemini-3.1-pro (google) > claude-opus-4-6 (anthropic)
+      // Since openai is in connectedProviders, should resolve to openai/gpt-5.4
       expect(promptBody.model).toBeDefined()
       expect(promptBody.model.providerID).toBe("openai")
-      expect(promptBody.model.modelID).toContain("gpt-5.2")
+      expect(promptBody.model.modelID).toContain("gpt-5.4")
     }, { timeout: 20000 })
   })
 


### PR DESCRIPTION
## Summary

- Upgrade oracle agent's primary fallback chain model from `gpt-5.2` to `gpt-5.4` across source, tests, snapshots, and documentation
- Fix 2 pre-existing test fragility issues in `utils.test.ts` where tests labeled "when availableModels is empty" were not actually mocking `fetchAvailableModels`, causing them to depend on local `models.json` cache contents

## Changes

### Source
- `src/shared/model-requirements.ts` — oracle fallbackChain[0] model: `gpt-5.2` → `gpt-5.4`
- `src/cli/model-fallback-requirements.ts` — CLI oracle fallbackChain[0] model: `gpt-5.2` → `gpt-5.4`

### Tests
- `src/shared/model-requirements.test.ts` — oracle primary model assertion updated
- `src/shared/agent-variant.test.ts` — oracle variant test now uses `gpt-5.4` modelID
- `src/cli/config-manager.test.ts` — generateOmoConfig oracle model assertion updated
- `src/agents/utils.test.ts` — oracle resolution assertions updated + added missing `fetchAvailableModels` mock to 2 tests that claimed "availableModels is empty" but weren't actually enforcing it
- `src/tools/delegate-task/tools.test.ts` — added `gpt-5.4` to TEST_AVAILABLE_MODELS and mock cache
- `src/cli/__snapshots__/model-fallback.test.ts.snap` — 22 snapshots regenerated

### Documentation
- `src/agents/AGENTS.md`, `docs/reference/configuration.md`, `docs/guide/installation.md`, `docs/guide/overview.md`, `docs/guide/agent-model-matching.md` — oracle model references updated

## Verification

Full test suite: **3531 pass, 0 fail**, 22 snapshots updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the Oracle agent’s primary fallback model to gpt-5.4 across code, tests, and docs to improve default resolution across providers. Also fixed two fragile tests by properly mocking available models.

- **New Features**
  - Switched oracle fallbackChain primary from gpt-5.2 to gpt-5.4 in shared and CLI requirements; updated related tests, snapshots, and docs.

- **Bug Fixes**
  - Added missing fetchAvailableModels mocks in two utils tests to actually simulate an empty set and remove reliance on local cache.

<sup>Written for commit e98132d6b2484a4cf69ff76021367615630b4b41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

