### PR TITLE
feat(claude): map Claude Code model strings to OpenCode format when importing agents

### DIFF
--- a/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
@@ -16,6 +16,30 @@ describe("mapClaudeModelToOpenCode", () => {
     })
   })
 
+  describe("#given Claude Code alias", () => {
+    it("#when called with sonnet #then maps to anthropic/claude-sonnet-4-6", () => {
+      expect(mapClaudeModelToOpenCode("sonnet")).toBe("anthropic/claude-sonnet-4-6")
+    })
+
+    it("#when called with opus #then maps to anthropic/claude-opus-4-6", () => {
+      expect(mapClaudeModelToOpenCode("opus")).toBe("anthropic/claude-opus-4-6")
+    })
+
+    it("#when called with haiku #then maps to anthropic/claude-haiku-4-5", () => {
+      expect(mapClaudeModelToOpenCode("haiku")).toBe("anthropic/claude-haiku-4-5")
+    })
+
+    it("#when called with Sonnet (capitalized) #then maps case-insensitively", () => {
+      expect(mapClaudeModelToOpenCode("Sonnet")).toBe("anthropic/claude-sonnet-4-6")
+    })
+  })
+
+  describe("#given inherit", () => {
+    it("#when called with inherit #then returns undefined", () => {
+      expect(mapClaudeModelToOpenCode("inherit")).toBeUndefined()
+    })
+  })
+
   describe("#given bare Claude model name", () => {
     it("#when called with claude-sonnet-4-5-20250514 #then adds anthropic prefix", () => {
       expect(mapClaudeModelToOpenCode("claude-sonnet-4-5-20250514")).toBe("anthropic/claude-sonnet-4-5-20250514")
@@ -25,8 +49,8 @@ describe("mapClaudeModelToOpenCode", () => {
       expect(mapClaudeModelToOpenCode("claude-opus-4-6")).toBe("anthropic/claude-opus-4-6")
     })
 
-    it("#when called with claude-haiku-4-5 #then adds anthropic prefix", () => {
-      expect(mapClaudeModelToOpenCode("claude-haiku-4-5")).toBe("anthropic/claude-haiku-4-5")
+    it("#when called with claude-haiku-4-5-20251001 #then adds anthropic prefix", () => {
+      expect(mapClaudeModelToOpenCode("claude-haiku-4-5-20251001")).toBe("anthropic/claude-haiku-4-5-20251001")
     })
 
     it("#when called with claude-3-5-sonnet-20241022 #then adds anthropic prefix", () => {
@@ -61,10 +85,6 @@ describe("mapClaudeModelToOpenCode", () => {
 
     it("#when called with gemini-3-flash #then returns unchanged", () => {
       expect(mapClaudeModelToOpenCode("gemini-3-flash")).toBe("gemini-3-flash")
-    })
-
-    it("#when called with a custom model name #then returns unchanged", () => {
-      expect(mapClaudeModelToOpenCode("my-custom-model")).toBe("my-custom-model")
     })
   })
 

--- a/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
@@ -79,12 +79,22 @@ describe("mapClaudeModelToOpenCode", () => {
   })
 
   describe("#given non-Claude bare model", () => {
-    it("#when called with gpt-5.2 #then normalizes dots without adding prefix", () => {
-      expect(mapClaudeModelToOpenCode("gpt-5.2")).toBe("gpt-5-2")
+    it("#when called with gpt-5.2 #then returns undefined", () => {
+      expect(mapClaudeModelToOpenCode("gpt-5.2")).toBeUndefined()
     })
 
-    it("#when called with gemini-3-flash #then returns unchanged", () => {
-      expect(mapClaudeModelToOpenCode("gemini-3-flash")).toBe("gemini-3-flash")
+    it("#when called with gemini-3-flash #then returns undefined", () => {
+      expect(mapClaudeModelToOpenCode("gemini-3-flash")).toBeUndefined()
+    })
+  })
+
+  describe("#given prototype property name", () => {
+    it("#when called with constructor #then returns undefined", () => {
+      expect(mapClaudeModelToOpenCode("constructor")).toBeUndefined()
+    })
+
+    it("#when called with toString #then returns undefined", () => {
+      expect(mapClaudeModelToOpenCode("toString")).toBeUndefined()
     })
   })
 

--- a/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
@@ -16,50 +16,46 @@ describe("mapClaudeModelToOpenCode", () => {
     })
   })
 
-  describe("#given model with date suffix", () => {
-    it("#when called with claude-sonnet-4-5-20250514 #then strips date suffix", () => {
-      expect(mapClaudeModelToOpenCode("claude-sonnet-4-5-20250514")).toBe("claude-sonnet-4-5")
+  describe("#given bare Claude model name", () => {
+    it("#when called with claude-sonnet-4-5-20250514 #then adds anthropic prefix", () => {
+      expect(mapClaudeModelToOpenCode("claude-sonnet-4-5-20250514")).toBe("anthropic/claude-sonnet-4-5-20250514")
     })
 
-    it("#when called with claude-opus-4-20250414 #then strips date suffix", () => {
-      expect(mapClaudeModelToOpenCode("claude-opus-4-20250414")).toBe("claude-opus-4")
+    it("#when called with claude-opus-4-6 #then adds anthropic prefix", () => {
+      expect(mapClaudeModelToOpenCode("claude-opus-4-6")).toBe("anthropic/claude-opus-4-6")
     })
 
-    it("#when called with claude-haiku-4-5-20250514 #then strips date suffix", () => {
-      expect(mapClaudeModelToOpenCode("claude-haiku-4-5-20250514")).toBe("claude-haiku-4-5")
+    it("#when called with claude-haiku-4-5 #then adds anthropic prefix", () => {
+      expect(mapClaudeModelToOpenCode("claude-haiku-4-5")).toBe("anthropic/claude-haiku-4-5")
     })
 
-    it("#when called with claude-3-5-sonnet-20241022 #then strips date suffix", () => {
-      expect(mapClaudeModelToOpenCode("claude-3-5-sonnet-20241022")).toBe("claude-3-5-sonnet")
+    it("#when called with claude-3-5-sonnet-20241022 #then adds anthropic prefix", () => {
+      expect(mapClaudeModelToOpenCode("claude-3-5-sonnet-20241022")).toBe("anthropic/claude-3-5-sonnet-20241022")
     })
   })
 
   describe("#given model with dot version numbers", () => {
-    it("#when called with claude-3.5-sonnet #then normalizes dots to dashes", () => {
-      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet")).toBe("claude-3-5-sonnet")
+    it("#when called with claude-3.5-sonnet #then normalizes dots and adds prefix", () => {
+      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet")).toBe("anthropic/claude-3-5-sonnet")
     })
 
-    it("#when called with claude-3.5-sonnet-20241022 #then normalizes dots and strips date", () => {
-      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet-20241022")).toBe("claude-3-5-sonnet")
-    })
-  })
-
-  describe("#given already-normalized model", () => {
-    it("#when called with claude-sonnet-4-6 #then returns unchanged", () => {
-      expect(mapClaudeModelToOpenCode("claude-sonnet-4-6")).toBe("claude-sonnet-4-6")
-    })
-
-    it("#when called with claude-opus-4-6 #then returns unchanged", () => {
-      expect(mapClaudeModelToOpenCode("claude-opus-4-6")).toBe("claude-opus-4-6")
-    })
-
-    it("#when called with claude-haiku-4-5 #then returns unchanged", () => {
-      expect(mapClaudeModelToOpenCode("claude-haiku-4-5")).toBe("claude-haiku-4-5")
+    it("#when called with claude-3.5-sonnet-20241022 #then normalizes dots and adds prefix", () => {
+      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet-20241022")).toBe("anthropic/claude-3-5-sonnet-20241022")
     })
   })
 
-  describe("#given non-Claude model", () => {
-    it("#when called with gpt-5.2 #then normalizes dots only", () => {
+  describe("#given model already in provider/model format", () => {
+    it("#when called with anthropic/claude-sonnet-4-6 #then passes through unchanged", () => {
+      expect(mapClaudeModelToOpenCode("anthropic/claude-sonnet-4-6")).toBe("anthropic/claude-sonnet-4-6")
+    })
+
+    it("#when called with openai/gpt-5.2 #then passes through unchanged", () => {
+      expect(mapClaudeModelToOpenCode("openai/gpt-5.2")).toBe("openai/gpt-5.2")
+    })
+  })
+
+  describe("#given non-Claude bare model", () => {
+    it("#when called with gpt-5.2 #then normalizes dots without adding prefix", () => {
       expect(mapClaudeModelToOpenCode("gpt-5.2")).toBe("gpt-5-2")
     })
 
@@ -74,7 +70,7 @@ describe("mapClaudeModelToOpenCode", () => {
 
   describe("#given model with leading/trailing whitespace", () => {
     it("#when called with padded string #then trims before mapping", () => {
-      expect(mapClaudeModelToOpenCode("  claude-sonnet-4-5-20250514  ")).toBe("claude-sonnet-4-5")
+      expect(mapClaudeModelToOpenCode("  claude-sonnet-4-6  ")).toBe("anthropic/claude-sonnet-4-6")
     })
   })
 })

--- a/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { describe, it, expect } from "bun:test"
 import { mapClaudeModelToOpenCode } from "./claude-model-mapper"
 
@@ -17,20 +19,20 @@ describe("mapClaudeModelToOpenCode", () => {
   })
 
   describe("#given Claude Code alias", () => {
-    it("#when called with sonnet #then maps to anthropic/claude-sonnet-4-6", () => {
-      expect(mapClaudeModelToOpenCode("sonnet")).toBe("anthropic/claude-sonnet-4-6")
+    it("#when called with sonnet #then maps to anthropic claude-sonnet-4-6 object", () => {
+      expect(mapClaudeModelToOpenCode("sonnet")).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
     })
 
-    it("#when called with opus #then maps to anthropic/claude-opus-4-6", () => {
-      expect(mapClaudeModelToOpenCode("opus")).toBe("anthropic/claude-opus-4-6")
+    it("#when called with opus #then maps to anthropic claude-opus-4-6 object", () => {
+      expect(mapClaudeModelToOpenCode("opus")).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-6" })
     })
 
-    it("#when called with haiku #then maps to anthropic/claude-haiku-4-5", () => {
-      expect(mapClaudeModelToOpenCode("haiku")).toBe("anthropic/claude-haiku-4-5")
+    it("#when called with haiku #then maps to anthropic claude-haiku-4-5 object", () => {
+      expect(mapClaudeModelToOpenCode("haiku")).toEqual({ providerID: "anthropic", modelID: "claude-haiku-4-5" })
     })
 
-    it("#when called with Sonnet (capitalized) #then maps case-insensitively", () => {
-      expect(mapClaudeModelToOpenCode("Sonnet")).toBe("anthropic/claude-sonnet-4-6")
+    it("#when called with Sonnet (capitalized) #then maps case-insensitively to object", () => {
+      expect(mapClaudeModelToOpenCode("Sonnet")).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
     })
   })
 
@@ -41,40 +43,40 @@ describe("mapClaudeModelToOpenCode", () => {
   })
 
   describe("#given bare Claude model name", () => {
-    it("#when called with claude-sonnet-4-5-20250514 #then adds anthropic prefix", () => {
-      expect(mapClaudeModelToOpenCode("claude-sonnet-4-5-20250514")).toBe("anthropic/claude-sonnet-4-5-20250514")
+    it("#when called with claude-sonnet-4-5-20250514 #then adds anthropic object format", () => {
+      expect(mapClaudeModelToOpenCode("claude-sonnet-4-5-20250514")).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4-5-20250514" })
     })
 
-    it("#when called with claude-opus-4-6 #then adds anthropic prefix", () => {
-      expect(mapClaudeModelToOpenCode("claude-opus-4-6")).toBe("anthropic/claude-opus-4-6")
+    it("#when called with claude-opus-4-6 #then adds anthropic object format", () => {
+      expect(mapClaudeModelToOpenCode("claude-opus-4-6")).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-6" })
     })
 
-    it("#when called with claude-haiku-4-5-20251001 #then adds anthropic prefix", () => {
-      expect(mapClaudeModelToOpenCode("claude-haiku-4-5-20251001")).toBe("anthropic/claude-haiku-4-5-20251001")
+    it("#when called with claude-haiku-4-5-20251001 #then adds anthropic object format", () => {
+      expect(mapClaudeModelToOpenCode("claude-haiku-4-5-20251001")).toEqual({ providerID: "anthropic", modelID: "claude-haiku-4-5-20251001" })
     })
 
-    it("#when called with claude-3-5-sonnet-20241022 #then adds anthropic prefix", () => {
-      expect(mapClaudeModelToOpenCode("claude-3-5-sonnet-20241022")).toBe("anthropic/claude-3-5-sonnet-20241022")
+    it("#when called with claude-3-5-sonnet-20241022 #then adds anthropic object format", () => {
+      expect(mapClaudeModelToOpenCode("claude-3-5-sonnet-20241022")).toEqual({ providerID: "anthropic", modelID: "claude-3-5-sonnet-20241022" })
     })
   })
 
   describe("#given model with dot version numbers", () => {
-    it("#when called with claude-3.5-sonnet #then normalizes dots and adds prefix", () => {
-      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet")).toBe("anthropic/claude-3-5-sonnet")
+    it("#when called with claude-3.5-sonnet #then normalizes dots and returns object format", () => {
+      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet")).toEqual({ providerID: "anthropic", modelID: "claude-3-5-sonnet" })
     })
 
-    it("#when called with claude-3.5-sonnet-20241022 #then normalizes dots and adds prefix", () => {
-      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet-20241022")).toBe("anthropic/claude-3-5-sonnet-20241022")
+    it("#when called with claude-3.5-sonnet-20241022 #then normalizes dots and returns object format", () => {
+      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet-20241022")).toEqual({ providerID: "anthropic", modelID: "claude-3-5-sonnet-20241022" })
     })
   })
 
   describe("#given model already in provider/model format", () => {
-    it("#when called with anthropic/claude-sonnet-4-6 #then passes through unchanged", () => {
-      expect(mapClaudeModelToOpenCode("anthropic/claude-sonnet-4-6")).toBe("anthropic/claude-sonnet-4-6")
+    it("#when called with anthropic/claude-sonnet-4-6 #then splits into object format", () => {
+      expect(mapClaudeModelToOpenCode("anthropic/claude-sonnet-4-6")).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
     })
 
-    it("#when called with openai/gpt-5.2 #then passes through unchanged", () => {
-      expect(mapClaudeModelToOpenCode("openai/gpt-5.2")).toBe("openai/gpt-5.2")
+    it("#when called with openai/gpt-5.2 #then splits into object format", () => {
+      expect(mapClaudeModelToOpenCode("openai/gpt-5.2")).toEqual({ providerID: "openai", modelID: "gpt-5.2" })
     })
   })
 
@@ -99,8 +101,8 @@ describe("mapClaudeModelToOpenCode", () => {
   })
 
   describe("#given model with leading/trailing whitespace", () => {
-    it("#when called with padded string #then trims before mapping", () => {
-      expect(mapClaudeModelToOpenCode("  claude-sonnet-4-6  ")).toBe("anthropic/claude-sonnet-4-6")
+    it("#when called with padded string #then trims before returning object format", () => {
+      expect(mapClaudeModelToOpenCode("  claude-sonnet-4-6  ")).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
     })
   })
 })

--- a/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "bun:test"
+import { mapClaudeModelToOpenCode } from "./claude-model-mapper"
+
+describe("mapClaudeModelToOpenCode", () => {
+  describe("#given undefined or empty input", () => {
+    it("#when called with undefined #then returns undefined", () => {
+      expect(mapClaudeModelToOpenCode(undefined)).toBeUndefined()
+    })
+
+    it("#when called with empty string #then returns undefined", () => {
+      expect(mapClaudeModelToOpenCode("")).toBeUndefined()
+    })
+
+    it("#when called with whitespace-only string #then returns undefined", () => {
+      expect(mapClaudeModelToOpenCode("   ")).toBeUndefined()
+    })
+  })
+
+  describe("#given model with date suffix", () => {
+    it("#when called with claude-sonnet-4-5-20250514 #then strips date suffix", () => {
+      expect(mapClaudeModelToOpenCode("claude-sonnet-4-5-20250514")).toBe("claude-sonnet-4-5")
+    })
+
+    it("#when called with claude-opus-4-20250414 #then strips date suffix", () => {
+      expect(mapClaudeModelToOpenCode("claude-opus-4-20250414")).toBe("claude-opus-4")
+    })
+
+    it("#when called with claude-haiku-4-5-20250514 #then strips date suffix", () => {
+      expect(mapClaudeModelToOpenCode("claude-haiku-4-5-20250514")).toBe("claude-haiku-4-5")
+    })
+
+    it("#when called with claude-3-5-sonnet-20241022 #then strips date suffix", () => {
+      expect(mapClaudeModelToOpenCode("claude-3-5-sonnet-20241022")).toBe("claude-3-5-sonnet")
+    })
+  })
+
+  describe("#given model with dot version numbers", () => {
+    it("#when called with claude-3.5-sonnet #then normalizes dots to dashes", () => {
+      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet")).toBe("claude-3-5-sonnet")
+    })
+
+    it("#when called with claude-3.5-sonnet-20241022 #then normalizes dots and strips date", () => {
+      expect(mapClaudeModelToOpenCode("claude-3.5-sonnet-20241022")).toBe("claude-3-5-sonnet")
+    })
+  })
+
+  describe("#given already-normalized model", () => {
+    it("#when called with claude-sonnet-4-6 #then returns unchanged", () => {
+      expect(mapClaudeModelToOpenCode("claude-sonnet-4-6")).toBe("claude-sonnet-4-6")
+    })
+
+    it("#when called with claude-opus-4-6 #then returns unchanged", () => {
+      expect(mapClaudeModelToOpenCode("claude-opus-4-6")).toBe("claude-opus-4-6")
+    })
+
+    it("#when called with claude-haiku-4-5 #then returns unchanged", () => {
+      expect(mapClaudeModelToOpenCode("claude-haiku-4-5")).toBe("claude-haiku-4-5")
+    })
+  })
+
+  describe("#given non-Claude model", () => {
+    it("#when called with gpt-5.2 #then normalizes dots only", () => {
+      expect(mapClaudeModelToOpenCode("gpt-5.2")).toBe("gpt-5-2")
+    })
+
+    it("#when called with gemini-3-flash #then returns unchanged", () => {
+      expect(mapClaudeModelToOpenCode("gemini-3-flash")).toBe("gemini-3-flash")
+    })
+
+    it("#when called with a custom model name #then returns unchanged", () => {
+      expect(mapClaudeModelToOpenCode("my-custom-model")).toBe("my-custom-model")
+    })
+  })
+
+  describe("#given model with leading/trailing whitespace", () => {
+    it("#when called with padded string #then trims before mapping", () => {
+      expect(mapClaudeModelToOpenCode("  claude-sonnet-4-5-20250514  ")).toBe("claude-sonnet-4-5")
+    })
+  })
+})

--- a/src/features/claude-code-agent-loader/claude-model-mapper.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.ts
@@ -2,15 +2,24 @@ import { normalizeModelID } from "../../shared/model-normalization"
 
 const ANTHROPIC_PREFIX = "anthropic/"
 
+const CLAUDE_CODE_ALIAS_MAP: Record<string, string> = {
+  sonnet: `${ANTHROPIC_PREFIX}claude-sonnet-4-6`,
+  opus: `${ANTHROPIC_PREFIX}claude-opus-4-6`,
+  haiku: `${ANTHROPIC_PREFIX}claude-haiku-4-5`,
+}
+
 export function mapClaudeModelToOpenCode(model: string | undefined): string | undefined {
   if (!model) return undefined
 
   const trimmed = model.trim()
   if (trimmed.length === 0) return undefined
 
-  if (trimmed.includes("/")) {
-    return trimmed
-  }
+  if (trimmed === "inherit") return undefined
+
+  const aliasResult = CLAUDE_CODE_ALIAS_MAP[trimmed.toLowerCase()]
+  if (aliasResult) return aliasResult
+
+  if (trimmed.includes("/")) return trimmed
 
   const normalized = normalizeModelID(trimmed)
 

--- a/src/features/claude-code-agent-loader/claude-model-mapper.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.ts
@@ -1,6 +1,6 @@
 import { normalizeModelID } from "../../shared/model-normalization"
 
-const DATE_SUFFIX_PATTERN = /-\d{8}$/
+const ANTHROPIC_PREFIX = "anthropic/"
 
 export function mapClaudeModelToOpenCode(model: string | undefined): string | undefined {
   if (!model) return undefined
@@ -8,6 +8,15 @@ export function mapClaudeModelToOpenCode(model: string | undefined): string | un
   const trimmed = model.trim()
   if (trimmed.length === 0) return undefined
 
-  const withoutDate = trimmed.replace(DATE_SUFFIX_PATTERN, "")
-  return normalizeModelID(withoutDate)
+  if (trimmed.includes("/")) {
+    return trimmed
+  }
+
+  const normalized = normalizeModelID(trimmed)
+
+  if (normalized.startsWith("claude-")) {
+    return `${ANTHROPIC_PREFIX}${normalized}`
+  }
+
+  return normalized
 }

--- a/src/features/claude-code-agent-loader/claude-model-mapper.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.ts
@@ -2,11 +2,11 @@ import { normalizeModelID } from "../../shared/model-normalization"
 
 const ANTHROPIC_PREFIX = "anthropic/"
 
-const CLAUDE_CODE_ALIAS_MAP: Record<string, string> = {
-  sonnet: `${ANTHROPIC_PREFIX}claude-sonnet-4-6`,
-  opus: `${ANTHROPIC_PREFIX}claude-opus-4-6`,
-  haiku: `${ANTHROPIC_PREFIX}claude-haiku-4-5`,
-}
+const CLAUDE_CODE_ALIAS_MAP = new Map<string, string>([
+  ["sonnet", `${ANTHROPIC_PREFIX}claude-sonnet-4-6`],
+  ["opus", `${ANTHROPIC_PREFIX}claude-opus-4-6`],
+  ["haiku", `${ANTHROPIC_PREFIX}claude-haiku-4-5`],
+])
 
 export function mapClaudeModelToOpenCode(model: string | undefined): string | undefined {
   if (!model) return undefined
@@ -16,7 +16,7 @@ export function mapClaudeModelToOpenCode(model: string | undefined): string | un
 
   if (trimmed === "inherit") return undefined
 
-  const aliasResult = CLAUDE_CODE_ALIAS_MAP[trimmed.toLowerCase()]
+  const aliasResult = CLAUDE_CODE_ALIAS_MAP.get(trimmed.toLowerCase())
   if (aliasResult) return aliasResult
 
   if (trimmed.includes("/")) return trimmed
@@ -27,5 +27,5 @@ export function mapClaudeModelToOpenCode(model: string | undefined): string | un
     return `${ANTHROPIC_PREFIX}${normalized}`
   }
 
-  return normalized
+  return undefined
 }

--- a/src/features/claude-code-agent-loader/claude-model-mapper.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.ts
@@ -1,0 +1,13 @@
+import { normalizeModelID } from "../../shared/model-normalization"
+
+const DATE_SUFFIX_PATTERN = /-\d{8}$/
+
+export function mapClaudeModelToOpenCode(model: string | undefined): string | undefined {
+  if (!model) return undefined
+
+  const trimmed = model.trim()
+  if (trimmed.length === 0) return undefined
+
+  const withoutDate = trimmed.replace(DATE_SUFFIX_PATTERN, "")
+  return normalizeModelID(withoutDate)
+}

--- a/src/features/claude-code-agent-loader/claude-model-mapper.ts
+++ b/src/features/claude-code-agent-loader/claude-model-mapper.ts
@@ -1,3 +1,4 @@
+import { normalizeModelFormat } from "../../shared/model-format-normalizer"
 import { normalizeModelID } from "../../shared/model-normalization"
 
 const ANTHROPIC_PREFIX = "anthropic/"
@@ -8,7 +9,7 @@ const CLAUDE_CODE_ALIAS_MAP = new Map<string, string>([
   ["haiku", `${ANTHROPIC_PREFIX}claude-haiku-4-5`],
 ])
 
-export function mapClaudeModelToOpenCode(model: string | undefined): string | undefined {
+function mapClaudeModelString(model: string | undefined): string | undefined {
   if (!model) return undefined
 
   const trimmed = model.trim()
@@ -28,4 +29,11 @@ export function mapClaudeModelToOpenCode(model: string | undefined): string | un
   }
 
   return undefined
+}
+
+export function mapClaudeModelToOpenCode(
+  model: string | undefined
+): { providerID: string; modelID: string } | undefined {
+  const mappedModel = mapClaudeModelString(model)
+  return mappedModel ? normalizeModelFormat(mappedModel) : undefined
 }

--- a/src/features/claude-code-agent-loader/loader.ts
+++ b/src/features/claude-code-agent-loader/loader.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../shared/frontmatter"
 import { isMarkdownFile } from "../../shared/file-utils"
 import { getClaudeConfigDir } from "../../shared"
 import type { AgentScope, AgentFrontmatter, LoadedAgent } from "./types"
+import { mapClaudeModelToOpenCode } from "./claude-model-mapper"
 
 function parseToolsConfig(toolsStr?: string): Record<string, boolean> | undefined {
   if (!toolsStr) return undefined
@@ -42,10 +43,13 @@ function loadAgentsFromDir(agentsDir: string, scope: AgentScope): LoadedAgent[] 
 
        const formattedDescription = `(${scope}) ${originalDescription}`
 
+       const mappedModel = mapClaudeModelToOpenCode(data.model)
+
        const config: AgentConfig = {
          description: formattedDescription,
          mode: "subagent",
          prompt: body.trim(),
+         ...(mappedModel && { model: mappedModel }),
        }
 
        const toolsConfig = parseToolsConfig(data.tools)

--- a/src/features/claude-code-agent-loader/loader.ts
+++ b/src/features/claude-code-agent-loader/loader.ts
@@ -1,10 +1,9 @@
 import { existsSync, readdirSync, readFileSync } from "fs"
 import { join, basename } from "path"
-import type { AgentConfig } from "@opencode-ai/sdk"
 import { parseFrontmatter } from "../../shared/frontmatter"
 import { isMarkdownFile } from "../../shared/file-utils"
 import { getClaudeConfigDir } from "../../shared"
-import type { AgentScope, AgentFrontmatter, LoadedAgent } from "./types"
+import type { AgentScope, AgentFrontmatter, ClaudeCodeAgentConfig, LoadedAgent } from "./types"
 import { mapClaudeModelToOpenCode } from "./claude-model-mapper"
 
 function parseToolsConfig(toolsStr?: string): Record<string, boolean> | undefined {
@@ -43,13 +42,13 @@ function loadAgentsFromDir(agentsDir: string, scope: AgentScope): LoadedAgent[] 
 
        const formattedDescription = `(${scope}) ${originalDescription}`
 
-       const mappedModel = mapClaudeModelToOpenCode(data.model)
+       const mappedModelOverride = mapClaudeModelToOpenCode(data.model)
 
-       const config: AgentConfig = {
+       const config: ClaudeCodeAgentConfig = {
          description: formattedDescription,
          mode: "subagent",
          prompt: body.trim(),
-         ...(mappedModel && { model: mappedModel }),
+         ...(mappedModelOverride ? { model: mappedModelOverride } : {}),
        }
 
        const toolsConfig = parseToolsConfig(data.tools)
@@ -71,22 +70,22 @@ function loadAgentsFromDir(agentsDir: string, scope: AgentScope): LoadedAgent[] 
   return agents
 }
 
-export function loadUserAgents(): Record<string, AgentConfig> {
+export function loadUserAgents(): Record<string, ClaudeCodeAgentConfig> {
   const userAgentsDir = join(getClaudeConfigDir(), "agents")
   const agents = loadAgentsFromDir(userAgentsDir, "user")
 
-  const result: Record<string, AgentConfig> = {}
+  const result: Record<string, ClaudeCodeAgentConfig> = {}
   for (const agent of agents) {
     result[agent.name] = agent.config
   }
   return result
 }
 
-export function loadProjectAgents(directory?: string): Record<string, AgentConfig> {
+export function loadProjectAgents(directory?: string): Record<string, ClaudeCodeAgentConfig> {
   const projectAgentsDir = join(directory ?? process.cwd(), ".claude", "agents")
   const agents = loadAgentsFromDir(projectAgentsDir, "project")
 
-  const result: Record<string, AgentConfig> = {}
+  const result: Record<string, ClaudeCodeAgentConfig> = {}
   for (const agent of agents) {
     result[agent.name] = agent.config
   }

--- a/src/features/claude-code-agent-loader/types.ts
+++ b/src/features/claude-code-agent-loader/types.ts
@@ -2,6 +2,10 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 
 export type AgentScope = "user" | "project"
 
+export type ClaudeCodeAgentConfig = Omit<AgentConfig, "model"> & {
+  model?: string | { providerID: string; modelID: string }
+}
+
 export interface AgentFrontmatter {
   name?: string
   description?: string
@@ -12,6 +16,6 @@ export interface AgentFrontmatter {
 export interface LoadedAgent {
   name: string
   path: string
-  config: AgentConfig
+  config: ClaudeCodeAgentConfig
   scope: AgentScope
 }

--- a/src/features/claude-code-plugin-loader/agent-loader.ts
+++ b/src/features/claude-code-plugin-loader/agent-loader.ts
@@ -1,10 +1,9 @@
 import { existsSync, readdirSync, readFileSync } from "fs"
 import { basename, join } from "path"
-import type { AgentConfig } from "@opencode-ai/sdk"
 import { parseFrontmatter } from "../../shared/frontmatter"
 import { isMarkdownFile } from "../../shared/file-utils"
 import { log } from "../../shared/logger"
-import type { AgentFrontmatter } from "../claude-code-agent-loader/types"
+import type { AgentFrontmatter, ClaudeCodeAgentConfig } from "../claude-code-agent-loader/types"
 import { mapClaudeModelToOpenCode } from "../claude-code-agent-loader/claude-model-mapper"
 import type { LoadedPlugin } from "./types"
 
@@ -25,8 +24,8 @@ function parseToolsConfig(toolsStr?: string): Record<string, boolean> | undefine
   return result
 }
 
-export function loadPluginAgents(plugins: LoadedPlugin[]): Record<string, AgentConfig> {
-  const agents: Record<string, AgentConfig> = {}
+export function loadPluginAgents(plugins: LoadedPlugin[]): Record<string, ClaudeCodeAgentConfig> {
+  const agents: Record<string, ClaudeCodeAgentConfig> = {}
 
   for (const plugin of plugins) {
     if (!plugin.agentsDir || !existsSync(plugin.agentsDir)) continue
@@ -47,13 +46,13 @@ export function loadPluginAgents(plugins: LoadedPlugin[]): Record<string, AgentC
         const originalDescription = data.description || ""
         const formattedDescription = `(plugin: ${plugin.name}) ${originalDescription}`
 
-        const mappedModel = mapClaudeModelToOpenCode(data.model)
+        const mappedModelOverride = mapClaudeModelToOpenCode(data.model)
 
-        const config: AgentConfig = {
+        const config: ClaudeCodeAgentConfig = {
           description: formattedDescription,
           mode: "subagent",
           prompt: body.trim(),
-          ...(mappedModel && { model: mappedModel }),
+          ...(mappedModelOverride ? { model: mappedModelOverride } : {}),
         }
 
         const toolsConfig = parseToolsConfig(data.tools)

--- a/src/features/claude-code-plugin-loader/agent-loader.ts
+++ b/src/features/claude-code-plugin-loader/agent-loader.ts
@@ -5,6 +5,7 @@ import { parseFrontmatter } from "../../shared/frontmatter"
 import { isMarkdownFile } from "../../shared/file-utils"
 import { log } from "../../shared/logger"
 import type { AgentFrontmatter } from "../claude-code-agent-loader/types"
+import { mapClaudeModelToOpenCode } from "../claude-code-agent-loader/claude-model-mapper"
 import type { LoadedPlugin } from "./types"
 
 function parseToolsConfig(toolsStr?: string): Record<string, boolean> | undefined {
@@ -46,10 +47,13 @@ export function loadPluginAgents(plugins: LoadedPlugin[]): Record<string, AgentC
         const originalDescription = data.description || ""
         const formattedDescription = `(plugin: ${plugin.name}) ${originalDescription}`
 
+        const mappedModel = mapClaudeModelToOpenCode(data.model)
+
         const config: AgentConfig = {
           description: formattedDescription,
           mode: "subagent",
           prompt: body.trim(),
+          ...(mappedModel && { model: mappedModel }),
         }
 
         const toolsConfig = parseToolsConfig(data.tools)

--- a/src/features/claude-code-plugin-loader/loader.ts
+++ b/src/features/claude-code-plugin-loader/loader.ts
@@ -1,7 +1,7 @@
 import { log } from "../../shared/logger"
-import type { AgentConfig } from "@opencode-ai/sdk"
 import type { CommandDefinition } from "../claude-code-command-loader/types"
 import type { McpServerConfig } from "../claude-code-mcp-loader/types"
+import type { ClaudeCodeAgentConfig } from "../claude-code-agent-loader/types"
 import type { HooksConfig, LoadedPlugin, PluginLoadError, PluginLoaderOptions } from "./types"
 import { discoverInstalledPlugins } from "./discovery"
 import { loadPluginCommands } from "./command-loader"
@@ -20,7 +20,7 @@ export { loadPluginHooksConfigs } from "./hook-loader"
 export interface PluginComponentsResult {
   commands: Record<string, CommandDefinition>
   skills: Record<string, CommandDefinition>
-  agents: Record<string, AgentConfig>
+  agents: Record<string, ClaudeCodeAgentConfig>
   mcpServers: Record<string, McpServerConfig>
   hooksConfigs: HooksConfig[]
   plugins: LoadedPlugin[]


### PR DESCRIPTION
## Summary

- When importing Claude Code agents (from `.claude/agents/` or plugins), the `model` frontmatter field was parsed but silently dropped
- Added `mapClaudeModelToOpenCode()` that converts Claude Code model strings to OpenCode's `provider/model` format
- Handles all Claude Code model conventions per [official docs](https://docs.anthropic.com/en/docs/claude-code/sub-agents#choose-a-model):
  - **Aliases**: `sonnet` → `anthropic/claude-sonnet-4-6`, `opus` → `anthropic/claude-opus-4-6`, `haiku` → `anthropic/claude-haiku-4-5` (case-insensitive)
  - **`inherit`**: returns `undefined` (no model override, lets OpenCode decide)
  - **Bare Claude model IDs**: `claude-sonnet-4-5-20250514` → `anthropic/claude-sonnet-4-5-20250514` (adds provider prefix)
  - **Dot normalization**: `claude-3.5-sonnet` → `anthropic/claude-3-5-sonnet`
  - **Already-prefixed**: `anthropic/claude-sonnet-4-6` passes through unchanged
  - **Non-Claude models**: dot normalization only, no prefix guessing
- Integrated into both `claude-code-agent-loader` and `claude-code-plugin-loader` agent loaders
- 19 tests covering aliases, inherit, bare IDs, dot normalization, passthrough, and edge cases