### PR TITLE
fix(test): fix flaky late-session-id background task test

### DIFF
--- a/src/tools/delegate-task/background-task.test.ts
+++ b/src/tools/delegate-task/background-task.test.ts
@@ -13,7 +13,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
     //#given - reduce waiting to keep tests fast
     __setTimingConfig({
       WAIT_FOR_SESSION_INTERVAL_MS: 1,
-      WAIT_FOR_SESSION_TIMEOUT_MS: 2,
+      WAIT_FOR_SESSION_TIMEOUT_MS: 50,
     })
   })
 


### PR DESCRIPTION
## Summary

- Fix flaky `captures late-resolved session id and emits synced metadata` test in `background-task.test.ts`.
- The 2ms poll timeout was too tight for 2 iterations at 1ms intervals — setTimeout precision caused the budget to expire before the 2nd `getTask` call.

## Changes

- Increase `WAIT_FOR_SESSION_TIMEOUT_MS` from 2 to 50 in the `beforeEach` timing config. This gives sufficient headroom for poll iterations while still keeping the test fast.

## Testing

```bash
bun test src/tools/delegate-task/background-task.test.ts
```

Verified 10/10 consecutive passes after fix.

## Related Issues

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky "captures late-resolved session id and emits synced metadata" test in background-task.test.ts. Increase WAIT_FOR_SESSION_TIMEOUT_MS from 2ms to 50ms to allow two 1ms polls despite setTimeout precision.

<sup>Written for commit 1429ae1505c89dc4bf332cb9ff53691767b6f5b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

