### PR TITLE
fix(tool-config): stop overriding external_directory permission

### DIFF
--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -100,7 +100,6 @@ export function applyToolConfig(params: {
 
   params.config.permission = {
     webfetch: "allow",
-    external_directory: "allow",
     ...(params.config.permission as Record<string, unknown>),
     task: "deny",
   };


### PR DESCRIPTION
## Summary

Remove the hardcoded `external_directory: "allow"` from `applyToolConfig()`. This line silently overrides both OpenCode's built-in default (`"ask"`) and any user-configured `external_directory` permission.

## Problem

In `src/plugin-handlers/tool-config-handler.ts`, the permission merge includes:

```typescript
params.config.permission = {
  webfetch: "allow",
  external_directory: "allow",   // ← forces allow, user config cannot override
  ...(params.config.permission as Record<string, unknown>),
  task: "deny",
};
```

Even after PR #1984 reordered the spread (defaults first, user config last), **the fundamental issue remains**: OMO is making an opinionated decision to weaken a security-sensitive permission that OpenCode intentionally defaults to `"ask"`.

Users who explicitly configure `external_directory: { "*": "ask" }` or `external_directory: "deny"` in their `opencode.json` expect that setting to be respected. With the current code, it works only because the spread happens to come after — but OMO should not be setting this value at all.

## Principle: Least Privilege

OMO is a plugin — it should **not** implicitly override the host's security permissions. The `external_directory` permission exists to protect users from unintended file operations outside their workspace. This is a security boundary that belongs to OpenCode and the user, not to the plugin.

Specifically:
- **OpenCode's default is `"ask"` for a reason** — it's a conscious security decision by the OpenCode team
- **Plugins should not weaken security defaults** — a plugin overriding `external_directory` to `"allow"` violates the principle of least privilege
- **User intent must be respected** — if a user configures `"ask"` or `"deny"`, no plugin should silently discard that

The correct approach is to simply not touch `external_directory` at all. If OMO agents need external directory access, they should trigger the ask prompt like any other tool — or document that users should explicitly allow it.

## Fix

Delete the `external_directory: "allow"` line entirely. Let OpenCode's default (`"ask"`) and user configuration control this permission without plugin interference.

## Related Issues

Fixes #1973
Fixes #2194
Supersedes #1996

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop forcing external_directory permission to "allow" in applyToolConfig so OpenCode’s default "ask" and any user setting are respected. This restores least-privilege behavior and avoids weakening a security-sensitive permission.

<sup>Written for commit a1ca658d768bb216eff23121bf69464a3fdc98ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

