### PR TITLE
fix(todo-sync): provide default priority to prevent SQLite NOT NULL violation

### DIFF
--- a/src/tools/task/todo-sync.ts
+++ b/src/tools/task/todo-sync.ts
@@ -65,7 +65,7 @@ export function syncTaskToTodo(task: Task): TodoInfo | null {
     id: task.id,
     content: task.subject,
     status: todoStatus,
-    priority: extractPriority(task.metadata),
+    priority: extractPriority(task.metadata) ?? "medium",
   };
 }
 


### PR DESCRIPTION
## Problem

`syncTaskToTodo()` calls `extractPriority(task.metadata)` which returns `undefined` when task metadata has no `priority` field (the common case — almost no one manually passes `metadata.priority`).

However, OpenCode's `TodoTable` schema defines `priority` as `NOT NULL`:

```sql
CREATE TABLE `todo` (
  `priority` text NOT NULL,
  ...
);
```

This causes a `SQLiteError: NOT NULL constraint failed: todo.priority` on every `Todo.update()` call. The error is silently caught by the `try/catch` in `syncTaskTodoUpdate`, making Task→Todo sync **completely non-functional** by default.

## Root Cause

```typescript
// todo-sync.ts — syncTaskToTodo()
return {
  id: task.id,
  content: task.subject,
  status: todoStatus,
  priority: extractPriority(task.metadata), // ← returns undefined when no metadata.priority
};
```

## Fix

```diff
- priority: extractPriority(task.metadata),
+ priority: extractPriority(task.metadata) ?? "medium",
```

One-line change: provide `"medium"` as default when no priority is specified. This matches the semantic middle ground and doesn't alter behavior for users who explicitly set priority via metadata.

## Impact

Without this fix, **no tasks created via `task_create` or `task_update` appear in the OpenCode TUI Todo panel** unless the user manually passes `metadata: { priority: "medium" }` — which virtually no one does.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provide a default "medium" priority in Task→Todo sync to satisfy the TodoTable NOT NULL constraint and restore syncing for tasks without metadata.priority.

- **Bug Fixes**
  - Use extractPriority(task.metadata) ?? "medium" to avoid NULL writes.
  - Stops SQLite NOT NULL errors and makes new/updated tasks show in the Todo panel by default.

<sup>Written for commit 229c6b0cdb9ae1e51baa18cd8387378a43feaffd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

