### PR TITLE
fix(no-sisyphus-gpt): honor effective Sisyphus model for GPT-5.4

### DIFF
--- a/src/hooks/no-sisyphus-gpt/hook.ts
+++ b/src/hooks/no-sisyphus-gpt/hook.ts
@@ -52,7 +52,7 @@ export function createNoSisyphusGptHook(
     }): Promise<void> => {
       const rawAgent = input.agent ?? getSessionAgent(input.sessionID) ?? ""
       const agentKey = getAgentConfigKey(rawAgent)
-      const modelID = normalizeModelID(options?.configuredModelID) ?? normalizeModelID(input.model?.modelID)
+      const modelID = normalizeModelID(input.model?.modelID) ?? normalizeModelID(options?.configuredModelID)
 
       if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGpt5_4Model(modelID)) {
         showToast(ctx, input.sessionID)

--- a/src/hooks/no-sisyphus-gpt/hook.ts
+++ b/src/hooks/no-sisyphus-gpt/hook.ts
@@ -12,6 +12,16 @@ const TOAST_MESSAGE = [
 ].join("\n")
 const HEPHAESTUS_DISPLAY = getAgentDisplayName("hephaestus")
 
+type NoSisyphusGptHookOptions = {
+  configuredModelID?: string
+}
+
+function normalizeModelID(modelID?: string): string | undefined {
+  if (typeof modelID !== "string") return undefined
+  const trimmed = modelID.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
 function showToast(ctx: PluginInput, sessionID: string): void {
   ctx.client.tui.showToast({
     body: {
@@ -28,7 +38,10 @@ function showToast(ctx: PluginInput, sessionID: string): void {
   })
 }
 
-export function createNoSisyphusGptHook(ctx: PluginInput) {
+export function createNoSisyphusGptHook(
+  ctx: PluginInput,
+  options?: NoSisyphusGptHookOptions,
+) {
   return {
     "chat.message": async (input: {
       sessionID: string
@@ -39,7 +52,7 @@ export function createNoSisyphusGptHook(ctx: PluginInput) {
     }): Promise<void> => {
       const rawAgent = input.agent ?? getSessionAgent(input.sessionID) ?? ""
       const agentKey = getAgentConfigKey(rawAgent)
-      const modelID = input.model?.modelID
+      const modelID = normalizeModelID(options?.configuredModelID) ?? normalizeModelID(input.model?.modelID)
 
       if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGpt5_4Model(modelID)) {
         showToast(ctx, input.sessionID)

--- a/src/hooks/no-sisyphus-gpt/index.test.ts
+++ b/src/hooks/no-sisyphus-gpt/index.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, spyOn, test } from "bun:test"
 import { _resetForTesting, updateSessionAgent } from "../../features/claude-code-session-state"
 import { getAgentDisplayName } from "../../shared/agent-display-names"
@@ -6,7 +8,7 @@ import { createNoSisyphusGptHook } from "./index"
 const SISYPHUS_DISPLAY = getAgentDisplayName("sisyphus")
 const HEPHAESTUS_DISPLAY = getAgentDisplayName("hephaestus")
 
-function createOutput() {
+function createOutput(): { message: { agent?: string }; parts: unknown[] } {
   return {
     message: {},
     parts: [],
@@ -40,13 +42,15 @@ describe("no-sisyphus-gpt hook", () => {
     expect(showToast).toHaveBeenCalledTimes(2)
     expect(output1.message.agent).toBe(HEPHAESTUS_DISPLAY)
     expect(output2.message.agent).toBe(HEPHAESTUS_DISPLAY)
-    expect(showToast.mock.calls[0]?.[0]).toMatchObject({
-      body: {
-        title: "NEVER Use Sisyphus with GPT",
-        message: expect.stringContaining("For GPT models (other than 5.4), always use Hephaestus."),
-        variant: "error",
-      },
-    })
+    expect(showToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          title: "NEVER Use Sisyphus with GPT",
+          message: expect.stringContaining("For GPT models (other than 5.4), always use Hephaestus."),
+          variant: "error",
+        }),
+      }),
+    )
   })
 
   test("does not show toast for gpt-5.4 model (Sisyphus has specialized support)", async () => {
@@ -68,6 +72,46 @@ describe("no-sisyphus-gpt hook", () => {
     // then - no toast, agent NOT switched to Hephaestus
     expect(showToast).toHaveBeenCalledTimes(0)
     expect(output.message.agent).toBeUndefined()
+  })
+
+  test("does not switch when sisyphus configured model is gpt-5.4", async () => {
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook({
+      client: { tui: { showToast } },
+    } as any, {
+      configuredModelID: "openai/gpt-5.4",
+    })
+
+    const output = createOutput()
+
+    await hook["chat.message"]?.({
+      sessionID: "ses_cfg_gpt54",
+      agent: SISYPHUS_DISPLAY,
+      model: { providerID: "openai", modelID: "gpt-5.3-codex" },
+    }, output)
+
+    expect(showToast).toHaveBeenCalledTimes(0)
+    expect(output.message.agent).toBeUndefined()
+  })
+
+  test("falls back to input model when configured model is empty", async () => {
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook({
+      client: { tui: { showToast } },
+    } as any, {
+      configuredModelID: "   ",
+    })
+
+    const output = createOutput()
+
+    await hook["chat.message"]?.({
+      sessionID: "ses_empty_cfg",
+      agent: SISYPHUS_DISPLAY,
+      model: { providerID: "openai", modelID: "gpt-5.3-codex" },
+    }, output)
+
+    expect(showToast).toHaveBeenCalledTimes(1)
+    expect(output.message.agent).toBe(HEPHAESTUS_DISPLAY)
   })
 
   test("does not show toast for non-gpt model", async () => {

--- a/src/hooks/no-sisyphus-gpt/index.test.ts
+++ b/src/hooks/no-sisyphus-gpt/index.test.ts
@@ -74,7 +74,7 @@ describe("no-sisyphus-gpt hook", () => {
     expect(output.message.agent).toBeUndefined()
   })
 
-  test("does not switch when sisyphus configured model is gpt-5.4", async () => {
+  test("prioritizes input model over configured model when input model is present", async () => {
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
     const hook = createNoSisyphusGptHook({
       client: { tui: { showToast } },
@@ -88,6 +88,25 @@ describe("no-sisyphus-gpt hook", () => {
       sessionID: "ses_cfg_gpt54",
       agent: SISYPHUS_DISPLAY,
       model: { providerID: "openai", modelID: "gpt-5.3-codex" },
+    }, output)
+
+    expect(showToast).toHaveBeenCalledTimes(1)
+    expect(output.message.agent).toBe(HEPHAESTUS_DISPLAY)
+  })
+
+  test("uses configured model when input model is missing", async () => {
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook({
+      client: { tui: { showToast } },
+    } as any, {
+      configuredModelID: "openai/gpt-5.4",
+    })
+
+    const output = createOutput()
+
+    await hook["chat.message"]?.({
+      sessionID: "ses_cfg_no_input_model",
+      agent: SISYPHUS_DISPLAY,
     }, output)
 
     expect(showToast).toHaveBeenCalledTimes(0)

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -73,11 +73,11 @@ function resolveSisyphusConfiguredModelID(pluginConfig: OhMyOpenCodeConfig): str
   const directModel = normalizeConfiguredModelID(pluginConfig.agents?.sisyphus?.model)
   if (directModel) return directModel
 
-  const categoryName = pluginConfig.agents?.sisyphus?.category?.trim()
-  if (!categoryName) return undefined
+  const rawCategoryName = pluginConfig.agents?.sisyphus?.category
+  if (!rawCategoryName || rawCategoryName.trim().length === 0) return undefined
 
   const mergedCategories = mergeCategories(pluginConfig.categories)
-  return normalizeConfiguredModelID(mergedCategories[categoryName]?.model)
+  return normalizeConfiguredModelID(mergedCategories[rawCategoryName]?.model)
 }
 
 export function createSessionHooks(args: {

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -33,6 +33,7 @@ import {
   log,
   normalizeSDKResponse,
 } from "../../shared"
+import { mergeCategories } from "../../shared/merge-categories"
 import { safeCreateHook } from "../../shared/safe-create-hook"
 import { sessionExists } from "../../tools"
 
@@ -62,6 +63,23 @@ export type SessionHooks = {
   runtimeFallback: ReturnType<typeof createRuntimeFallbackHook> | null
 }
 
+function normalizeConfiguredModelID(model?: string): string | undefined {
+  if (typeof model !== "string") return undefined
+  const trimmed = model.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function resolveSisyphusConfiguredModelID(pluginConfig: OhMyOpenCodeConfig): string | undefined {
+  const directModel = normalizeConfiguredModelID(pluginConfig.agents?.sisyphus?.model)
+  if (directModel) return directModel
+
+  const categoryName = pluginConfig.agents?.sisyphus?.category?.trim()
+  if (!categoryName) return undefined
+
+  const mergedCategories = mergeCategories(pluginConfig.categories)
+  return normalizeConfiguredModelID(mergedCategories[categoryName]?.model)
+}
+
 export function createSessionHooks(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
@@ -70,6 +88,7 @@ export function createSessionHooks(args: {
   safeHookEnabled: boolean
 }): SessionHooks {
   const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } = args
+  const configuredSisyphusModelID = resolveSisyphusConfiguredModelID(pluginConfig)
   const safeHook = <T>(hookName: HookName, factory: () => T): T | null =>
     safeCreateHook(hookName, factory, { enabled: safeHookEnabled })
 
@@ -228,7 +247,10 @@ export function createSessionHooks(args: {
     : null
 
   const noSisyphusGpt = isHookEnabled("no-sisyphus-gpt")
-    ? safeHook("no-sisyphus-gpt", () => createNoSisyphusGptHook(ctx))
+    ? safeHook("no-sisyphus-gpt", () =>
+      createNoSisyphusGptHook(ctx, {
+        configuredModelID: configuredSisyphusModelID,
+      }))
     : null
 
   const noHephaestusNonGpt = isHookEnabled("no-hephaestus-non-gpt")


### PR DESCRIPTION
## Summary
- 7fe44024 added a GPT-5.4 exemption to `no-sisyphus-gpt`, but the guard still evaluated only `input.model.modelID`.
- In real sessions where Sisyphus is configured via override/category to GPT-5.4, `input.model` can remain a stale non-5.4 GPT model and still trigger an unintended switch to Hephaestus.
- This patch keeps the original intent of `7fe44024` and applies it to the effective configured Sisyphus model with minimal scope.

## Changes
- `src/hooks/no-sisyphus-gpt/hook.ts`
  - Add optional `configuredModelID` support.
  - Normalize model IDs and evaluate guard model as `configuredModelID -> input.model.modelID`.
- `src/plugin/hooks/create-session-hooks.ts`
  - Resolve effective Sisyphus configured model from direct agent model override or category model (`mergeCategories`) and pass it into the hook.
- `src/hooks/no-sisyphus-gpt/index.test.ts`
  - Add regression: configured GPT-5.4 with stale GPT-5.3 input does not switch.
  - Add regression: empty configured model falls back to input model.

## Why previous behavior did not fully apply
- The GPT-5.4 exception introduced in `7fe44024` was correct for direct model input, but it did not account for the runtime path where Sisyphus model is sourced from configuration (agent override/category) while `input.model` does not reflect that effective model.

## Testing
- `bun test src/hooks/no-sisyphus-gpt/index.test.ts src/hooks/no-hephaestus-non-gpt/index.test.ts src/plugin/chat-message.test.ts`
- `bun run typecheck`
- `bun run build`

## Related Issues
- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the no-sisyphus-gpt guard to honor the effective Sisyphus model and prefer the runtime input model, so GPT-5.4 sessions aren’t wrongly switched to Hephaestus when the input or config is stale.

- **Bug Fixes**
  - Guard checks input.model.modelID first, then configuredModelID, with ID trimming/normalization.
  - Resolves Sisyphus model from agent override or category (mergeCategories) using the raw category key and ignoring whitespace-only values, then passes it to the hook.
  - Adds tests for input-over-config precedence, configured-only fallback, and empty-config fallback; updates toast expectation.

<sup>Written for commit 76d0ec8c89f0d16b7474a8c6a79f7470f097149e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

