### PR TITLE
fix(install): build dist for git-based plugin installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build:binaries": "bun run script/build-binaries.ts",
     "build:schema": "bun run script/build-schema.ts",
     "clean": "rm -rf dist",
+    "prepare": "bun run build",
     "postinstall": "node postinstall.mjs",
     "prepublishOnly": "bun run clean && bun run build",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- add a  script so git-based installs build the plugin runtime before OpenCode Desktop tries to load it
- unblock dev-branch plugin installs that currently fail because  is missing in git checkouts

## Verification
- committed the packaging fix in this branch
- simulated a git install from the local repository and confirmed the installed package now contains 

## Context
OpenCode Desktop can load published plugins reliably, but a git plugin spec like  fails when the checkout has no built  output. Running  on git installs fixes that packaging gap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a prepare script that runs the build during git-based installs so dist is generated before OpenCode Desktop loads the plugin. This fixes install failures from branches/checkouts that don’t include dist.

<sup>Written for commit f6d8d44aba5131d98778005291d9efca75f9e420. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

