### PR TITLE
fix(think-mode): skip gpt-5-nano high upgrade on unsupported Zen model

### DIFF
--- a/src/hooks/think-mode/detector.ts
+++ b/src/hooks/think-mode/detector.ts
@@ -1,7 +1,11 @@
 const ENGLISH_PATTERNS = [/\bultrathink\b/i, /\bthink\b/i]
 
 const MULTILINGUAL_KEYWORDS = [
-  "생각", "고민", "검토", "제대로",
+  // Korean: intentionally use only explicit reasoning-request forms.
+  // "고민" (“to worry/ponder”) is excluded — it is a common conversational word
+  // that fires think mode on everyday sentences like "어떻게 할지 고민하고 있었는데".
+  // Only "생각해줘" / "깊이 생각" style explicit directives should trigger think mode.
+  "생각해줘", "깊이 생각", "신중하게 검토", "제대로",
   "思考", "考虑", "考慮",
   "思考", "考え", "熟考",
   "सोच", "विचार",

--- a/src/hooks/think-mode/detector.ts
+++ b/src/hooks/think-mode/detector.ts
@@ -1,11 +1,7 @@
 const ENGLISH_PATTERNS = [/\bultrathink\b/i, /\bthink\b/i]
 
 const MULTILINGUAL_KEYWORDS = [
-  // Korean: intentionally use only explicit reasoning-request forms.
-  // "고민" (“to worry/ponder”) is excluded — it is a common conversational word
-  // that fires think mode on everyday sentences like "어떻게 할지 고민하고 있었는데".
-  // Only "생각해줘" / "깊이 생각" style explicit directives should trigger think mode.
-  "생각해줘", "깊이 생각", "신중하게 검토", "제대로",
+  "생각", "고민", "검토", "제대로",
   "思考", "考虑", "考慮",
   "思考", "考え", "熟考",
   "सोच", "विचार",

--- a/src/hooks/think-mode/index.test.ts
+++ b/src/hooks/think-mode/index.test.ts
@@ -153,3 +153,70 @@ describe("createThinkModeHook", () => {
     expect(output.message.model).toBeUndefined()
   })
 })
+
+describe("think-mode: regression tests for issue #2382", () => {
+  const sessionID = "regression-2382"
+
+  beforeEach(() => {
+    clearThinkModeState(sessionID)
+  })
+
+  it("does NOT activate think mode for conversational Korean '고민' (to worry/ponder)", async () => {
+    // given — a real user sentence that triggered the bug:
+    // "너와 인공지능 엔진에게 이미지와 참조 자료를 어떻게 전달할지 고민하고 있었는데"
+    const hook = createThinkModeHook()
+    const input = createHookInput({
+      sessionID,
+      providerID: "opencode",
+      modelID: "gpt-5-nano",
+    })
+    const output = createHookOutput(
+      "너와 인공지능 엔진에게 이미지와 참조 자료를 어떻게 전달할지 고민하고 있었는데"
+    )
+
+    // when
+    await hook["chat.message"](input, output)
+
+    // then — model must NOT be upgraded; '고민' is conversational, not a reasoning directive
+    expect(output.message.variant).toBeUndefined()
+    expect(output.message.model).toBeUndefined()
+  })
+
+  it("does NOT upgrade gpt-5-nano even when think keyword IS present", async () => {
+    // given — gpt-5-nano has no -high variant on Zen; upgrading it causes Model not found
+    const hook = createThinkModeHook()
+    const input = createHookInput({
+      sessionID,
+      providerID: "opencode",
+      modelID: "gpt-5-nano",
+    })
+    const output = createHookOutput("신중하게 검토해줘")
+
+    // when
+    await hook["chat.message"](input, output)
+
+    // then — no high variant exists for gpt-5-nano, so model stays unchanged
+    expect(output.message.model).toBeUndefined()
+  })
+
+  it("still activates think mode for explicit Korean reasoning directive '생각해줘'", async () => {
+    // given — explicit reasoning request should still trigger think mode on capable models
+    const hook = createThinkModeHook()
+    const input = createHookInput({
+      sessionID,
+      providerID: "anthropic",
+      modelID: "claude-opus-4-6",
+    })
+    const output = createHookOutput("이 문제 깊이 생각해줘")
+
+    // when
+    await hook["chat.message"](input, output)
+
+    // then — explicit directive on a capable model should still upgrade
+    expect(output.message.variant).toBe("high")
+    expect(output.message.model).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-opus-4-6-high",
+    })
+  })
+})

--- a/src/hooks/think-mode/index.test.ts
+++ b/src/hooks/think-mode/index.test.ts
@@ -161,9 +161,7 @@ describe("think-mode: regression tests for issue #2382", () => {
     clearThinkModeState(sessionID)
   })
 
-  it("does NOT activate think mode for conversational Korean '고민' (to worry/ponder)", async () => {
-    // given — a real user sentence that triggered the bug:
-    // "너와 인공지능 엔진에게 이미지와 참조 자료를 어떻게 전달할지 고민하고 있었는데"
+  it("does NOT upgrade gpt-5-nano on Korean think-mode trigger text", async () => {
     const hook = createThinkModeHook()
     const input = createHookInput({
       sessionID,
@@ -177,46 +175,28 @@ describe("think-mode: regression tests for issue #2382", () => {
     // when
     await hook["chat.message"](input, output)
 
-    // then — model must NOT be upgraded; '고민' is conversational, not a reasoning directive
     expect(output.message.variant).toBeUndefined()
     expect(output.message.model).toBeUndefined()
   })
 
-  it("does NOT upgrade gpt-5-nano even when think keyword IS present", async () => {
-    // given — gpt-5-nano has no -high variant on Zen; upgrading it causes Model not found
-    const hook = createThinkModeHook()
-    const input = createHookInput({
-      sessionID,
-      providerID: "opencode",
-      modelID: "gpt-5-nano",
-    })
-    const output = createHookOutput("신중하게 검토해줘")
-
-    // when
-    await hook["chat.message"](input, output)
-
-    // then — no high variant exists for gpt-5-nano, so model stays unchanged
-    expect(output.message.model).toBeUndefined()
-  })
-
-  it("still activates think mode for explicit Korean reasoning directive '생각해줘'", async () => {
-    // given — explicit reasoning request should still trigger think mode on capable models
+  it("still upgrades claude-sonnet-4-6 on the same Korean think-mode trigger text", async () => {
     const hook = createThinkModeHook()
     const input = createHookInput({
       sessionID,
       providerID: "anthropic",
-      modelID: "claude-opus-4-6",
+      modelID: "claude-sonnet-4-6",
     })
-    const output = createHookOutput("이 문제 깊이 생각해줘")
+    const output = createHookOutput(
+      "너와 인공지능 엔진에게 이미지와 참조 자료를 어떻게 전달할지 고민하고 있었는데"
+    )
 
     // when
     await hook["chat.message"](input, output)
 
-    // then — explicit directive on a capable model should still upgrade
     expect(output.message.variant).toBe("high")
     expect(output.message.model).toEqual({
       providerID: "anthropic",
-      modelID: "claude-opus-4-6-high",
+      modelID: "claude-sonnet-4-6-high",
     })
   })
 })

--- a/src/hooks/think-mode/switcher.test.ts
+++ b/src/hooks/think-mode/switcher.test.ts
@@ -69,6 +69,13 @@ describe("think-mode switcher", () => {
         expect(getHighVariant("llama-3-70b")).toBeNull()
         expect(getHighVariant("mistral-large")).toBeNull()
       })
+
+      it("should return null for gpt-5-nano (no reasoning variant on Zen)", () => {
+        // given gpt-5-nano — a lightweight model with no high variant on OpenCode Zen
+        // see: https://github.com/code-yeongyu/oh-my-openagent/issues/2382
+        expect(getHighVariant("gpt-5-nano")).toBeNull()
+        expect(getHighVariant("opencode/gpt-5-nano")).toBeNull()
+      })
     })
   })
 

--- a/src/hooks/think-mode/switcher.ts
+++ b/src/hooks/think-mode/switcher.ts
@@ -50,9 +50,11 @@ const HIGH_VARIANT_MAP: Record<string, string> = {
    "gemini-3-1-pro-low": "gemini-3-1-pro-high",
    "gemini-3-flash": "gemini-3-flash-high",
   // GPT-5
+  // NOTE: gpt-5-nano is intentionally excluded — it is a lightweight nano model
+  // that does not have a reasoning/high-effort variant on the OpenCode Zen provider.
+  // Mapping it to gpt-5-nano-high causes a "Model not found" error.
   "gpt-5": "gpt-5-high",
   "gpt-5-mini": "gpt-5-mini-high",
-  "gpt-5-nano": "gpt-5-nano-high",
   "gpt-5-pro": "gpt-5-pro-high",
   "gpt-5-chat-latest": "gpt-5-chat-latest-high",
   // GPT-5.1


### PR DESCRIPTION
## Summary

Fixes `Model not found: opencode/gpt-5-nano-high` with the minimum production change needed.

Closes #2382

## Why this is the smallest safe fix

The failure is not in multilingual think-mode detection itself. The actual incompatibility is narrower:

- think-mode intentionally upgrades supported models to their `-high` variant
- `gpt-5-nano` was included in `HIGH_VARIANT_MAP`
- OpenCode Zen does **not** provide `opencode/gpt-5-nano-high`
- the request therefore fails at model lookup with `Model not found`

Because of that, this PR leaves `detector.ts` unchanged and only removes the unsupported upgrade path.

## Production change

**File:** `src/hooks/think-mode/switcher.ts`

Removed the single unsupported mapping:

```ts
"gpt-5-nano": "gpt-5-nano-high",
```

That means:
- capable models such as Claude Sonnet / Opus still upgrade to `-high`
- `gpt-5-nano` no longer upgrades to a model ID that Zen cannot resolve
- existing multilingual trigger behavior is preserved

## Stability / risk profile

This is intentionally a minimal-scope fix:

- **1 production file changed**: `src/hooks/think-mode/switcher.ts`
- **No detector behavior change**: `src/hooks/think-mode/detector.ts` is untouched in the final PR
- **No hook contract change**: `createThinkModeHook()` API stays the same
- **No fallback/routing change**: model-fallback behavior is unchanged
- **Failure mode removed, not redirected**: unsupported upgrade is skipped instead of introducing a new code path

## Tests

Regression coverage was added to prove both safety and behavior preservation:

### `src/hooks/think-mode/switcher.test.ts`
- `getHighVariant("gpt-5-nano")` returns `null`
- `getHighVariant("opencode/gpt-5-nano")` returns `null`

### `src/hooks/think-mode/index.test.ts`
Using the **same Korean trigger sentence** that surfaced the bug:

> "너와 인공지능 엔진에게 이미지와 참조 자료를 어떻게 전달할지 고민하고 있었는데"

- `gpt-5-nano` does **not** upgrade
- `claude-sonnet-4-6` **still does** upgrade to `claude-sonnet-4-6-high`

This directly verifies that the fix is narrow:
- unsupported Nano upgrade is removed
- existing Sonnet think-mode behavior is preserved on identical trigger text

## Verification

```bash
bun test src/hooks/think-mode/
```

Result:
- **30 pass**
- **0 fail**

## Review note

cubic identified a valid test weakness in the first draft: the original regression test used `gpt-5-nano` alone, which was not sufficient to prove keyword-trigger behavior on a model that can actually upgrade. This PR now includes a paired Sonnet regression on the same Korean sentence to preserve that coverage while keeping the production fix minimal.