### PR TITLE
fix(think-mode): remove modelID modification, only set variant

### DIFF
--- a/src/hooks/think-mode/detector.ts
+++ b/src/hooks/think-mode/detector.ts
@@ -1,7 +1,7 @@
 const ENGLISH_PATTERNS = [/\bultrathink\b/i, /\bthink\b/i]
 
 const MULTILINGUAL_KEYWORDS = [
-  "생각", "고민", "검토", "제대로",
+  "생각", "검토", "제대로",
   "思考", "考虑", "考慮",
   "思考", "考え", "熟考",
   "सोच", "विचार",

--- a/src/hooks/think-mode/hook.ts
+++ b/src/hooks/think-mode/hook.ts
@@ -1,5 +1,5 @@
 import { detectThinkKeyword, extractPromptText } from "./detector"
-import { getHighVariant, isAlreadyHighVariant } from "./switcher"
+import { isAlreadyHighVariant } from "./switcher"
 import type { ThinkModeState } from "./types"
 import { log } from "../../shared"
 
@@ -56,22 +56,10 @@ export function createThinkModeHook() {
         return
       }
 
-      const highVariant = getHighVariant(currentModel.modelID)
-
-      if (highVariant) {
-        output.message.model = {
-          providerID: currentModel.providerID,
-          modelID: highVariant,
-        }
-        output.message.variant = "high"
-        state.modelSwitched = true
-        state.variantSet = true
-        log("Think mode: model switched to high variant", {
-          sessionID,
-          from: currentModel.modelID,
-          to: highVariant,
-        })
-      }
+      output.message.variant = "high"
+      state.modelSwitched = false
+      state.variantSet = true
+      log("Think mode: variant set to high", { sessionID })
 
       thinkModeState.set(sessionID, state)
     },

--- a/src/hooks/think-mode/index.test.ts
+++ b/src/hooks/think-mode/index.test.ts
@@ -43,7 +43,7 @@ describe("createThinkModeHook", () => {
     clearThinkModeState(sessionID)
   })
 
-  it("sets high variant and switches model when think keyword is present", async () => {
+  it("sets high variant when think keyword is present", async () => {
     // given
     const hook = createThinkModeHook()
     const input = createHookInput({
@@ -58,13 +58,10 @@ describe("createThinkModeHook", () => {
 
     // then
     expect(output.message.variant).toBe("high")
-    expect(output.message.model).toEqual({
-      providerID: "github-copilot",
-      modelID: "claude-opus-4-6-high",
-    })
+    expect(output.message.model).toBeUndefined()
   })
 
-  it("supports dotted model IDs by switching to normalized high variant", async () => {
+  it("sets high variant for dotted model IDs", async () => {
     // given
     const hook = createThinkModeHook()
     const input = createHookInput({
@@ -79,10 +76,7 @@ describe("createThinkModeHook", () => {
 
     // then
     expect(output.message.variant).toBe("high")
-    expect(output.message.model).toEqual({
-      providerID: "github-copilot",
-      modelID: "gpt-5-4-high",
-    })
+    expect(output.message.model).toBeUndefined()
   })
 
   it("skips when message variant is already set", async () => {

--- a/src/hooks/think-mode/switcher.test.ts
+++ b/src/hooks/think-mode/switcher.test.ts
@@ -4,6 +4,20 @@ import {
   isAlreadyHighVariant,
 } from "./switcher"
 
+/**
+ * DEPRECATION NOTICE:
+ *
+ * getHighVariant() is no longer used by the think-mode hook.
+ * The hook now only sets output.message.variant = "high" and lets
+ * OpenCode's native variant system handle the transformation.
+ *
+ * This function is kept for:
+ * - Potential future validation use
+ * - Backward compatibility for external consumers
+ *
+ * Tests verify the function still works correctly.
+ */
+
 describe("think-mode switcher", () => {
   describe("Model ID normalization", () => {
     describe("getHighVariant with dots vs hyphens", () => {


### PR DESCRIPTION
## Summary

- Fix the think-mode hook that causes `ProviderModelNotFoundError` by removing incorrect modelID modification
- The hook now only sets `output.message.variant = "high"` and lets OpenCode's native variant system handle the rest
- Remove overly broad Korean keyword "고민" that caused false positives
- Document deprecation of `getHighVariant()` function (kept for backward compatibility)

## Root Cause

The hook was incorrectly setting `output.message.model.modelID` to non-existent variants like "gpt-5-nano-high", causing `ProviderModelNotFoundError`. OpenCode's native variant system only needs the `output.message.variant` field - it handles the transformation automatically.

## Changes

| File | Change |
|------|--------|
| `src/hooks/think-mode/hook.ts` | Removed modelID modification, only sets variant |
| `src/hooks/think-mode/detector.ts` | Removed "고민" keyword |
| `src/hooks/think-mode/index.test.ts` | Updated tests for variant-only behavior |
| `src/hooks/think-mode/switcher.test.ts` | Added deprecation notice |

## Testing

- All 27 tests pass: `bun test src/hooks/think-mode/`
- No TypeScript errors

Fixes #2382, superseeds #2383

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Think-mode now sets `output.message.variant = "high"` without changing model IDs, letting the native variant system prevent ProviderModelNotFoundError. Also removes the Korean keyword "고민" to reduce false activations and documents `getHighVariant()` deprecation; tests updated.

<sup>Written for commit 05a5c010ab088e5e775099e35d1fba519252d37d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

