### PR TITLE
fix: custom agent is invisible

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -84,8 +84,6 @@ export async function applyAgentConfig(params: {
       name,
       description: (config as { description?: string }).description ?? "",
     }));
-      })
-  );
 
   const builtinAgents = await createBuiltinAgents(
     migratedDisabledAgents,

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -78,10 +78,12 @@ export async function applyAgentConfig(params: {
   const useTaskSystem = params.pluginConfig.experimental?.task_system ?? false;
   const disableOmoEnv = params.pluginConfig.experimental?.disable_omo_env ?? false;
 
-  const customAgentSummaries = Object.entries(params.config.agent ?? {}).map(
-      ([name, config]) => ({
-        name,
-        description: (config as { description?: string }).description ?? "",
+  const customAgentSummaries = Object.entries(params.config.agent ?? {})
+    .filter(([, config]) => config != null)
+    .map(([name, config]) => ({
+      name,
+      description: (config as { description?: string }).description ?? "",
+    }));
       })
   );
 

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -78,13 +78,31 @@ export async function applyAgentConfig(params: {
   const useTaskSystem = params.pluginConfig.experimental?.task_system ?? false;
   const disableOmoEnv = params.pluginConfig.experimental?.disable_omo_env ?? false;
 
-  const customAgentSummaries = Object.entries(params.config.agent ?? {})
+  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
+  const userAgents = includeClaudeAgents ? loadUserAgents() : {};
+  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
+
+  const rawPluginAgents = params.pluginComponents.agents;
+  const pluginAgents = Object.fromEntries(
+    Object.entries(rawPluginAgents).map(([key, value]) => [
+      key,
+      value ? migrateAgentConfig(value as Record<string, unknown>) : value,
+    ]),
+  );
+
+  const configAgent = params.config.agent as AgentConfigRecord | undefined;
+  const allAgentsForSummary = {
+    ...configAgent,
+    ...userAgents,
+    ...projectAgents,
+    ...pluginAgents,
+  };
+  const customAgentSummaries = Object.entries(allAgentsForSummary)
     .filter(([, config]) => config != null)
     .map(([name, config]) => ({
       name,
       description: (config as { description?: string }).description ?? "",
     }));
-
   const builtinAgents = await createBuiltinAgents(
     migratedDisabledAgents,
     params.pluginConfig.agents,
@@ -99,18 +117,6 @@ export async function applyAgentConfig(params: {
     disabledSkills,
     useTaskSystem,
     disableOmoEnv,
-  );
-
-  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
-  const userAgents = includeClaudeAgents ? loadUserAgents() : {};
-  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
-
-  const rawPluginAgents = params.pluginComponents.agents;
-  const pluginAgents = Object.fromEntries(
-    Object.entries(rawPluginAgents).map(([key, value]) => [
-      key,
-      value ? migrateAgentConfig(value as Record<string, unknown>) : value,
-    ]),
   );
 
   const disabledAgentNames = new Set(
@@ -129,8 +135,6 @@ export async function applyAgentConfig(params: {
   const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
   const shouldDemotePlan = plannerEnabled && replacePlan;
   const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
-
-  const configAgent = params.config.agent as AgentConfigRecord | undefined;
 
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
     if (configuredDefaultAgent) {

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -78,6 +78,13 @@ export async function applyAgentConfig(params: {
   const useTaskSystem = params.pluginConfig.experimental?.task_system ?? false;
   const disableOmoEnv = params.pluginConfig.experimental?.disable_omo_env ?? false;
 
+  const customAgentSummaries = Object.entries(params.config.agent ?? {}).map(
+      ([name, config]) => ({
+        name,
+        description: (config as { description?: string }).description ?? "",
+      })
+  );
+
   const builtinAgents = await createBuiltinAgents(
     migratedDisabledAgents,
     params.pluginConfig.agents,
@@ -86,7 +93,7 @@ export async function applyAgentConfig(params: {
     params.pluginConfig.categories,
     params.pluginConfig.git_master,
     allDiscoveredSkills,
-    params.ctx.client,
+    customAgentSummaries,
     browserProvider,
     currentModel,
     disabledSkills,


### PR DESCRIPTION
## Summary

- Fixes the 8th parameter of `createBuiltinAgents` which was incorrectly passing `ctx.client` (client object) instead of the custom agent summaries (array format)
- This bug caused custom agents registered in OpenCode to be invisible to orchestrator agents (Sisyphus/Atlas/Hephaestus)

## Changes

In `src/plugin-handlers/agent-config-handler.ts`:

- Convert `params.config.agent` to the correct `customAgentSummaries` array format before passing to `createBuiltinAgents`
- The 8th parameter expects `{ name: string, description: string }[]` but was receiving a client object

```typescript
// Before (broken):
createBuiltinAgents(
  ...
  params.ctx.client,  // ❌ client object
  ...
)

// After (fixed):
const customAgentSummaries = Object.entries(params.pluginConfig.agents ?? {}).map(
  ([name, config]) => ({
    name,
    description: (config as { description?: string }).description ?? "",
  })
);
createBuiltinAgents(
  ...
  customAgentSummaries,  // ✅ array format
  ...
)
```

## Testing
Define a custom agent in opencode.json or .opencode/agents/
Start OpenCode with oh-my-opencode plugin
Ask "What subagents do you support?" - custom agent should now appear in the response
The custom agent should now be visible in the orchestrator's delegation table

## Related Issues
https://github.com/code-yeongyu/oh-my-openagent/issues/1623
## Related PR
https://github.com/code-yeongyu/oh-my-openagent/pull/1652