### PR TITLE
fix: invalidate opencode plugin cache on global install

### DIFF
--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -28,26 +28,13 @@ function getLibcFamily() {
 }
 
 /**
- * Resolve the platform-appropriate opencode cache directory.
+ * Resolve the opencode cache directory.
  *
- * opencode (a Go binary) uses os.UserCacheDir() which maps to:
- *   - Linux:   $XDG_CACHE_HOME/opencode  or  ~/.cache/opencode
- *   - macOS:   ~/Library/Caches/opencode
- *   - Windows: %LOCALAPPDATA%/opencode
+ * opencode uses xdg-basedir on all platforms, so the cache path is always
+ * $XDG_CACHE_HOME/opencode (defaults to ~/.cache/opencode).
  */
 function getOpenCodeCacheDir() {
-  const home = homedir();
-
-  if (process.platform === "darwin") {
-    return join(home, "Library", "Caches", "opencode");
-  }
-
-  if (process.platform === "win32") {
-    return join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), "opencode");
-  }
-
-  // Linux and other Unix-like: respect XDG_CACHE_HOME
-  return join(process.env.XDG_CACHE_HOME || join(home, ".cache"), "opencode");
+  return join(process.env.XDG_CACHE_HOME || join(homedir(), ".cache"), "opencode");
 }
 
 /**
@@ -55,7 +42,7 @@ function getOpenCodeCacheDir() {
  *
  * opencode installs plugins into its cache with a separate bun.lock.
  * When a user runs `bun install -g oh-my-opencode`, only the global copy is updated
- * while the cached copy remains stale. Removing the cached module and lockfile forces
+ * while the cached copy remains stale. Removing the cached module forces
  * opencode to re-resolve "oh-my-opencode@latest" on next startup.
  */
 async function invalidateOpenCodePluginCache() {
@@ -65,20 +52,14 @@ async function invalidateOpenCodePluginCache() {
     return;
   }
 
-  const targets = [
-    join(cacheBase, "node_modules", "oh-my-opencode"),
-    join(cacheBase, "bun.lock"),
-    join(cacheBase, "bun.lockb"),
-  ];
+  const target = join(cacheBase, "node_modules", "oh-my-opencode");
 
-  for (const target of targets) {
-    try {
-      await rm(target, { recursive: true, force: true });
-    } catch (error) {
-      // force: true already handles ENOENT (missing files).
-      // Real errors (EPERM, EBUSY) indicate the cache could not be cleared.
-      console.warn(`⚠ oh-my-opencode: failed to clear cache at ${target}: ${error.message}`);
-    }
+  try {
+    await rm(target, { recursive: true, force: true });
+  } catch (error) {
+    // force: true already handles ENOENT (missing files).
+    // Real errors (EPERM, EBUSY) indicate the cache could not be cleared.
+    console.warn(`⚠ oh-my-opencode: failed to clear cache at ${target}: ${error.message}`);
   }
 }
 

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -1,0 +1,92 @@
+// postinstall.mjs
+// Runs after npm install to verify platform binary is available
+// and invalidate opencode's plugin cache so the new version is picked up on next launch.
+
+import { createRequire } from "node:module";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { getPlatformPackageCandidates, getBinaryPath } from "./bin/platform.js";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Detect libc family on Linux
+ */
+function getLibcFamily() {
+  if (process.platform !== "linux") {
+    return undefined;
+  }
+  
+  try {
+    const detectLibc = require("detect-libc");
+    return detectLibc.familySync();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Invalidate opencode's plugin cache so the updated version is resolved on next launch.
+ *
+ * opencode installs plugins into ~/.cache/opencode/node_modules/ with its own bun.lock.
+ * When a user runs `bun install -g oh-my-opencode`, only the global copy is updated
+ * while the cached copy remains stale. Removing the cached module and lockfile forces
+ * opencode to re-resolve "oh-my-opencode@latest" on next startup.
+ */
+async function invalidateOpenCodePluginCache() {
+  const cacheBase = join(homedir(), ".cache", "opencode");
+  const targets = [
+    join(cacheBase, "node_modules", "oh-my-opencode"),
+    join(cacheBase, "bun.lock"),
+  ];
+
+  for (const target of targets) {
+    try {
+      await rm(target, { recursive: true, force: true });
+    } catch {
+      // Cache may not exist yet (fresh install) - safe to ignore
+    }
+  }
+}
+
+function verifyPlatformBinary() {
+  const { platform, arch } = process;
+  const libcFamily = getLibcFamily();
+  
+  try {
+    const packageCandidates = getPlatformPackageCandidates({
+      platform,
+      arch,
+      libcFamily,
+    });
+
+    const resolvedPackage = packageCandidates.find((pkg) => {
+      try {
+        require.resolve(getBinaryPath(pkg, platform));
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    if (!resolvedPackage) {
+      throw new Error(
+        `No platform binary package installed. Tried: ${packageCandidates.join(", ")}`
+      );
+    }
+
+    console.log(`✓ oh-my-opencode binary installed for ${platform}-${arch} (${resolvedPackage})`);
+  } catch (error) {
+    console.warn(`⚠ oh-my-opencode: ${error.message}`);
+    console.warn(`  The CLI may not work on this platform.`);
+    // Don't fail installation - let user try anyway
+  }
+}
+
+async function main() {
+  verifyPlatformBinary();
+  await invalidateOpenCodePluginCache();
+}
+
+main();

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -42,8 +42,11 @@ function getOpenCodeCacheDir() {
  *
  * opencode installs plugins into its cache with a separate bun.lock.
  * When a user runs `bun install -g oh-my-opencode`, only the global copy is updated
- * while the cached copy remains stale. Removing the cached module forces
- * opencode to re-resolve "oh-my-opencode@latest" on next startup.
+ * while the cached copy remains stale. Removing the cached module and lockfiles
+ * forces opencode to re-resolve "oh-my-opencode@latest" on next startup.
+ *
+ * The lockfiles must also be deleted because bun would otherwise reinstall the
+ * exact pinned (stale) version from the lock entry instead of resolving latest.
  */
 async function invalidateOpenCodePluginCache() {
   const cacheBase = getOpenCodeCacheDir();
@@ -52,14 +55,20 @@ async function invalidateOpenCodePluginCache() {
     return;
   }
 
-  const target = join(cacheBase, "node_modules", "oh-my-opencode");
+  const targets = [
+    join(cacheBase, "node_modules", "oh-my-opencode"),
+    join(cacheBase, "bun.lock"),
+    join(cacheBase, "bun.lockb"),
+  ];
 
-  try {
-    await rm(target, { recursive: true, force: true });
-  } catch (error) {
-    // force: true already handles ENOENT (missing files).
-    // Real errors (EPERM, EBUSY) indicate the cache could not be cleared.
-    console.warn(`⚠ oh-my-opencode: failed to clear cache at ${target}: ${error.message}`);
+  for (const target of targets) {
+    try {
+      await rm(target, { recursive: true, force: true });
+    } catch (error) {
+      // force: true already handles ENOENT (missing files).
+      // Real errors (EPERM, EBUSY) indicate the cache could not be cleared.
+      console.warn(`⚠ oh-my-opencode: failed to clear cache at ${target}: ${error.message}`);
+    }
   }
 }
 

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -3,6 +3,7 @@
 // and invalidate opencode's plugin cache so the new version is picked up on next launch.
 
 import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
@@ -27,15 +28,43 @@ function getLibcFamily() {
 }
 
 /**
+ * Resolve the platform-appropriate opencode cache directory.
+ *
+ * opencode (a Go binary) uses os.UserCacheDir() which maps to:
+ *   - Linux:   $XDG_CACHE_HOME/opencode  or  ~/.cache/opencode
+ *   - macOS:   ~/Library/Caches/opencode
+ *   - Windows: %LOCALAPPDATA%/opencode
+ */
+function getOpenCodeCacheDir() {
+  const home = homedir();
+
+  if (process.platform === "darwin") {
+    return join(home, "Library", "Caches", "opencode");
+  }
+
+  if (process.platform === "win32") {
+    return join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), "opencode");
+  }
+
+  // Linux and other Unix-like: respect XDG_CACHE_HOME
+  return join(process.env.XDG_CACHE_HOME || join(home, ".cache"), "opencode");
+}
+
+/**
  * Invalidate opencode's plugin cache so the updated version is resolved on next launch.
  *
- * opencode installs plugins into ~/.cache/opencode/node_modules/ with its own bun.lock.
+ * opencode installs plugins into its cache with a separate bun.lock.
  * When a user runs `bun install -g oh-my-opencode`, only the global copy is updated
  * while the cached copy remains stale. Removing the cached module and lockfile forces
  * opencode to re-resolve "oh-my-opencode@latest" on next startup.
  */
 async function invalidateOpenCodePluginCache() {
-  const cacheBase = join(homedir(), ".cache", "opencode");
+  const cacheBase = getOpenCodeCacheDir();
+
+  if (!existsSync(cacheBase)) {
+    return;
+  }
+
   const targets = [
     join(cacheBase, "node_modules", "oh-my-opencode"),
     join(cacheBase, "bun.lock"),
@@ -92,4 +121,6 @@ async function main() {
   await invalidateOpenCodePluginCache();
 }
 
-main();
+main().catch(() => {
+  // Postinstall must never fail the install process.
+});

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -39,13 +39,16 @@ async function invalidateOpenCodePluginCache() {
   const targets = [
     join(cacheBase, "node_modules", "oh-my-opencode"),
     join(cacheBase, "bun.lock"),
+    join(cacheBase, "bun.lockb"),
   ];
 
   for (const target of targets) {
     try {
       await rm(target, { recursive: true, force: true });
-    } catch {
-      // Cache may not exist yet (fresh install) - safe to ignore
+    } catch (error) {
+      // force: true already handles ENOENT (missing files).
+      // Real errors (EPERM, EBUSY) indicate the cache could not be cleared.
+      console.warn(`⚠ oh-my-opencode: failed to clear cache at ${target}: ${error.message}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fixes stale plugin version after `bun install -g oh-my-opencode` by invalidating opencode's plugin cache in the postinstall script.

## Problem

When users run `bun install -g oh-my-opencode`, only the global npm package at `~/.bun/install/global/node_modules/` is updated. However, opencode resolves plugins from its own separate cache at `~/.cache/opencode/node_modules/` with its own `bun.lock`. The stale cached version continues to be loaded on subsequent launches, causing version mismatch.

## Solution

The `postinstall.mjs` script now removes:
- `~/.cache/opencode/node_modules/oh-my-opencode` (cached plugin module)
- `~/.cache/opencode/bun.lock` (lockfile pinning the old version)

This forces opencode to re-resolve `oh-my-opencode@latest` on next startup, ensuring the newly installed version is picked up immediately.

## Changes

- `postinstall.mjs`: Added `invalidateOpenCodePluginCache()` that clears stale cache entries after a global install. Extracted existing platform verification into `verifyPlatformBinary()` for clarity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidate `opencode`'s plugin cache on global installs so the latest `oh-my-opencode` loads on next launch. Keeps a non-blocking platform binary check in postinstall.

- **Bug Fixes**
  - Postinstall deletes the cached `oh-my-opencode` directory and `bun.lock`/`bun.lockb` in the XDG cache (`$XDG_CACHE_HOME` or `~/.cache/opencode`) to force resolving `oh-my-opencode@latest` after `bun install -g oh-my-opencode`.
  - Adds an `existsSync` guard and safe `main().catch()`; logs warnings on real errors only and never blocks install.

<sup>Written for commit c6c907680f60b4a2eace996e7066a7be323e1b7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

