### PR TITLE
fix(skill-context): gate discovered browser skills by provider

### DIFF
--- a/src/plugin/skill-context.test.ts
+++ b/src/plugin/skill-context.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { OhMyOpenCodeConfigSchema } from "../config"
+import * as mcpLoader from "../features/claude-code-mcp-loader"
+import * as skillLoader from "../features/opencode-skill-loader"
+import { createSkillContext } from "./skill-context"
+
+describe("createSkillContext", () => {
+  const testDirectory = join(tmpdir(), `skill-context-test-${Date.now()}`)
+
+  beforeEach(() => {
+    mkdirSync(testDirectory, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(testDirectory, { recursive: true, force: true })
+  })
+
+  it("excludes discovered playwright skill when browser provider is agent-browser", async () => {
+    // given
+    const discoveredPlaywrightDir = join(testDirectory, ".claude", "skills", "playwright")
+    mkdirSync(discoveredPlaywrightDir, { recursive: true })
+    writeFileSync(
+      join(discoveredPlaywrightDir, "SKILL.md"),
+      [
+        "---",
+        "name: playwright",
+        "description: Discovered playwright skill",
+        "---",
+        "Discovered playwright body.",
+        "",
+      ].join("\n"),
+    )
+
+    const discoverConfigSourceSkillsSpy = spyOn(
+      skillLoader,
+      "discoverConfigSourceSkills",
+    ).mockResolvedValue([])
+    const discoverUserClaudeSkillsSpy = spyOn(
+      skillLoader,
+      "discoverUserClaudeSkills",
+    ).mockResolvedValue([])
+    const discoverOpencodeGlobalSkillsSpy = spyOn(
+      skillLoader,
+      "discoverOpencodeGlobalSkills",
+    ).mockResolvedValue([])
+    const discoverProjectAgentsSkillsSpy = spyOn(
+      skillLoader,
+      "discoverProjectAgentsSkills",
+    ).mockResolvedValue([])
+    const discoverGlobalAgentsSkillsSpy = spyOn(
+      skillLoader,
+      "discoverGlobalAgentsSkills",
+    ).mockResolvedValue([])
+    const getSystemMcpServerNamesSpy = spyOn(
+      mcpLoader,
+      "getSystemMcpServerNames",
+    ).mockReturnValue(new Set<string>())
+
+    const pluginConfig = OhMyOpenCodeConfigSchema.parse({
+      browser_automation_engine: { provider: "agent-browser" },
+    })
+
+    try {
+      // when
+      const result = await createSkillContext({
+        directory: testDirectory,
+        pluginConfig,
+      })
+
+      // then
+      expect(result.browserProvider).toBe("agent-browser")
+      expect(result.mergedSkills.some((skill) => skill.name === "agent-browser")).toBe(true)
+      expect(result.mergedSkills.some((skill) => skill.name === "playwright")).toBe(false)
+      expect(result.availableSkills.some((skill) => skill.name === "playwright")).toBe(false)
+    } finally {
+      discoverConfigSourceSkillsSpy.mockRestore()
+      discoverUserClaudeSkillsSpy.mockRestore()
+      discoverOpencodeGlobalSkillsSpy.mockRestore()
+      discoverProjectAgentsSkillsSpy.mockRestore()
+      discoverGlobalAgentsSkillsSpy.mockRestore()
+      getSystemMcpServerNamesSpy.mockRestore()
+    }
+  })
+})

--- a/src/plugin/skill-context.ts
+++ b/src/plugin/skill-context.ts
@@ -26,10 +26,25 @@ export type SkillContext = {
   disabledSkills: Set<string>
 }
 
+const PROVIDER_GATED_SKILL_NAMES = new Set(["agent-browser", "playwright"])
+
 function mapScopeToLocation(scope: SkillScope): AvailableSkill["location"] {
   if (scope === "user" || scope === "opencode") return "user"
   if (scope === "project" || scope === "opencode-project") return "project"
   return "plugin"
+}
+
+function filterProviderGatedSkills(
+  skills: LoadedSkill[],
+  browserProvider: BrowserAutomationProvider,
+): LoadedSkill[] {
+  return skills.filter((skill) => {
+    if (!PROVIDER_GATED_SKILL_NAMES.has(skill.name)) {
+      return true
+    }
+
+    return skill.name === browserProvider
+  })
 }
 
 export async function createSkillContext(args: {
@@ -71,14 +86,34 @@ export async function createSkillContext(args: {
       discoverGlobalAgentsSkills(),
     ])
 
+  const filteredConfigSourceSkills = filterProviderGatedSkills(
+    configSourceSkills,
+    browserProvider,
+  )
+  const filteredUserSkills = filterProviderGatedSkills(userSkills, browserProvider)
+  const filteredGlobalSkills = filterProviderGatedSkills(globalSkills, browserProvider)
+  const filteredProjectSkills = filterProviderGatedSkills(projectSkills, browserProvider)
+  const filteredOpencodeProjectSkills = filterProviderGatedSkills(
+    opencodeProjectSkills,
+    browserProvider,
+  )
+  const filteredAgentsProjectSkills = filterProviderGatedSkills(
+    agentsProjectSkills,
+    browserProvider,
+  )
+  const filteredAgentsGlobalSkills = filterProviderGatedSkills(
+    agentsGlobalSkills,
+    browserProvider,
+  )
+
   const mergedSkills = mergeSkills(
     builtinSkills,
     pluginConfig.skills,
-    configSourceSkills,
-    [...userSkills, ...agentsGlobalSkills],
-    globalSkills,
-    [...projectSkills, ...agentsProjectSkills],
-    opencodeProjectSkills,
+    filteredConfigSourceSkills,
+    [...filteredUserSkills, ...filteredAgentsGlobalSkills],
+    filteredGlobalSkills,
+    [...filteredProjectSkills, ...filteredAgentsProjectSkills],
+    filteredOpencodeProjectSkills,
     { configDir: directory },
   )
 


### PR DESCRIPTION
## Summary
- prevent discovered provider-gated browser skills from overriding the selected builtin browser provider in `createSkillContext`
- add a regression test proving `agent-browser` no longer reintroduces a discovered `playwright` skill

## Verification
- `bun test src/plugin/skill-context.test.ts src/features/opencode-skill-loader/skill-content.test.ts src/features/builtin-skills/skills.test.ts`
- `bun run typecheck`
- `bun run build`
- manual QA: loaded `createSkillContext` with `browser_automation_engine.provider = "agent-browser"` and a discovered `.claude/skills/playwright`; confirmed `hasPlaywright: false` and `hasAgentBrowser: true`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where discovered browser skills could override the configured provider in `createSkillContext`. Only the skill matching `browser_automation_engine.provider` is included, preventing `playwright` from superseding `agent-browser`.

- **Bug Fixes**
  - Gate provider-specific browser skills to the selected provider (`agent-browser`, `playwright`).
  - Filter discovered skills across all sources before merging to honor the configured provider.
  - Add a regression test verifying `browser_automation_engine.provider = "agent-browser"` ignores a discovered `playwright` skill.

<sup>Written for commit 1528e46faa77f49ae5be1ae114676d739c7e9157. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

