### PR TITLE
fix: invalidate opencode plugin cache on global install

### DIFF
--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -1,0 +1,116 @@
+// postinstall.mjs
+// Runs after npm install to verify platform binary is available
+// and invalidate opencode's plugin cache so the new version is picked up on next launch.
+
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { getPlatformPackageCandidates, getBinaryPath } from "./bin/platform.js";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Detect libc family on Linux
+ */
+function getLibcFamily() {
+  if (process.platform !== "linux") {
+    return undefined;
+  }
+  
+  try {
+    const detectLibc = require("detect-libc");
+    return detectLibc.familySync();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the opencode cache directory.
+ *
+ * opencode uses xdg-basedir on all platforms, so the cache path is always
+ * $XDG_CACHE_HOME/opencode (defaults to ~/.cache/opencode).
+ */
+function getOpenCodeCacheDir() {
+  return join(process.env.XDG_CACHE_HOME || join(homedir(), ".cache"), "opencode");
+}
+
+/**
+ * Invalidate opencode's plugin cache so the updated version is resolved on next launch.
+ *
+ * opencode installs plugins into its cache with a separate bun.lock.
+ * When a user runs `bun install -g oh-my-opencode`, only the global copy is updated
+ * while the cached copy remains stale. Removing the cached module and lockfiles
+ * forces opencode to re-resolve "oh-my-opencode@latest" on next startup.
+ *
+ * The lockfiles must also be deleted because bun would otherwise reinstall the
+ * exact pinned (stale) version from the lock entry instead of resolving latest.
+ */
+async function invalidateOpenCodePluginCache() {
+  const cacheBase = getOpenCodeCacheDir();
+
+  if (!existsSync(cacheBase)) {
+    return;
+  }
+
+  const targets = [
+    join(cacheBase, "node_modules", "oh-my-opencode"),
+    join(cacheBase, "bun.lock"),
+    join(cacheBase, "bun.lockb"),
+  ];
+
+  for (const target of targets) {
+    try {
+      await rm(target, { recursive: true, force: true });
+    } catch (error) {
+      // force: true already handles ENOENT (missing files).
+      // Real errors (EPERM, EBUSY) indicate the cache could not be cleared.
+      console.warn(`⚠ oh-my-opencode: failed to clear cache at ${target}: ${error.message}`);
+    }
+  }
+}
+
+function verifyPlatformBinary() {
+  const { platform, arch } = process;
+  const libcFamily = getLibcFamily();
+  
+  try {
+    const packageCandidates = getPlatformPackageCandidates({
+      platform,
+      arch,
+      libcFamily,
+    });
+
+    const resolvedPackage = packageCandidates.find((pkg) => {
+      try {
+        require.resolve(getBinaryPath(pkg, platform));
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    if (!resolvedPackage) {
+      throw new Error(
+        `No platform binary package installed. Tried: ${packageCandidates.join(", ")}`
+      );
+    }
+
+    console.log(`✓ oh-my-opencode binary installed for ${platform}-${arch} (${resolvedPackage})`);
+  } catch (error) {
+    console.warn(`⚠ oh-my-opencode: ${error.message}`);
+    console.warn(`  The CLI may not work on this platform.`);
+    // Don't fail installation - let user try anyway
+  }
+}
+
+async function main() {
+  verifyPlatformBinary();
+  await invalidateOpenCodePluginCache();
+}
+
+main().catch(() => {
+  // Postinstall must never fail the install process.
+});


### PR DESCRIPTION
## Summary

- Fixes stale plugin version after `bun install -g oh-my-opencode` by invalidating opencode's plugin cache in the postinstall script.

## Problem

When users run `bun install -g oh-my-opencode`, only the global npm package at `~/.bun/install/global/node_modules/` is updated. However, opencode resolves plugins from its own separate cache at `$XDG_CACHE_HOME/opencode/node_modules/` with its own `bun.lock`. The stale cached version continues to be loaded on subsequent launches, causing version mismatch.

## Solution

The `postinstall.mjs` script now:
1. Detects the opencode cache directory using xdg-basedir (same as opencode on all platforms)
2. Removes `node_modules/oh-my-opencode` (stale cached module)
3. Removes `bun.lock` and `bun.lockb` (required because bun reinstalls the exact pinned version from the lock entry)
4. Guards with `existsSync` to skip if cache doesn't exist (fresh install)
5. Wraps `main()` with `.catch()` to never fail the install process
6. Warns on real deletion errors (EPERM/EBUSY) instead of silently swallowing them

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale plugin versions after global installs by clearing the opencode plugin cache during postinstall. Also verifies the platform binary is present and warns if missing, without failing installs.

- **Bug Fixes**
  - Adds `postinstall.mjs` to delete cached `oh-my-opencode` and `bun.lock*` in `$XDG_CACHE_HOME/opencode/`, ensuring the latest version loads on next launch.
  - Uses xdg-basedir paths, skips when cache is absent, logs warnings on real deletion errors, and never breaks install.
  - Verifies the platform binary package at install time and prints a warning if none is found.

<sup>Written for commit 7ddf9bb3c3b0c5a66b79708fd94204c3091a10ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

