### PR TITLE
fix(tmux): handle serverUrl throw getter from upstream opencode refactor

### DIFF
--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -71,7 +71,11 @@ export class TmuxSessionManager {
     this.tmuxConfig = tmuxConfig
     this.deps = deps
     const defaultPort = process.env.OPENCODE_PORT ?? "4096"
-    this.serverUrl = ctx.serverUrl?.toString() ?? `http://localhost:${defaultPort}`
+    try {
+      this.serverUrl = ctx.serverUrl?.toString() ?? `http://localhost:${defaultPort}`
+    } catch {
+      this.serverUrl = `http://localhost:${defaultPort}`
+    }
     this.sourcePaneId = deps.getCurrentPaneId()
     this.pollingManager = new TmuxPollingManager(
       this.client,


### PR DESCRIPTION
## Summary

OpenCode upstream commit `89d6f60d` (`refactor(server): extract createApp function`) changed `PluginInput.serverUrl` from `Server.url()` to a throw getter:

```typescript
// opencode/src/plugin/index.ts
get serverUrl(): URL {
  throw new Error("Server URL is no longer supported in plugins")
}
```

This causes the entire oh-my-opencode plugin to crash during initialization because `TmuxSessionManager` constructor accesses `ctx.serverUrl`:

```typescript
this.serverUrl = ctx.serverUrl?.toString() ?? `http://localhost:${defaultPort}`
```

Optional chaining (`?.`) does **not** prevent the throw — the getter executes on property access before the nullish check.

**Impact**: All agents, hooks, and tools fail to register. The plugin appears to load but silently crashes.

## Fix

Wrap the `serverUrl` access in a try-catch, falling back to `http://localhost:{port}`:

```typescript
try {
  this.serverUrl = ctx.serverUrl?.toString() ?? `http://localhost:${defaultPort}`
} catch {
  this.serverUrl = `http://localhost:${defaultPort}`
}
```

## Notes

- The OpenCode change (`89d6f60d`) is not yet released (current npm is v1.2.17), but affects anyone running from source.
- This is a defensive fix — it preserves existing behavior when `serverUrl` is available, and gracefully degrades when it's not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent tmux subagent crash after upstream `opencode` made `PluginInput.serverUrl` a throwing getter. Guard `ctx.serverUrl` with try/catch and default to `http://localhost:${OPENCODE_PORT || 4096}` so agents, hooks, and tools register.

<sup>Written for commit 309a3e48ec28ddd0638bd81e90b04ce757b1fb3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

