### PR TITLE
fix(ci): restore version commit step for correct CLI version embedding

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -82,6 +82,15 @@ jobs:
           cd packages/${{ matrix.platform }}
           jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
 
+      - name: Update version in root package.json
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          VERSION="${{ inputs.version }}"
+          # Update root package.json version (CLI reads from here at compile time)
+          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+          # Update optionalDependencies versions to match
+          jq --arg v "$VERSION" '.optionalDependencies = (.optionalDependencies | to_entries | map(.value = $v) | from_entries)' package.json > tmp.json && mv tmp.json package.json
+
       - name: Pre-download baseline compile target
         if: steps.check.outputs.skip != 'true' && endsWith(matrix.platform, '-baseline')
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -247,8 +247,36 @@ jobs:
       - name: Restore package.json
         if: steps.check.outputs.skip != 'true'
         run: |
+          VERSION="${{ steps.version.outputs.version }}"
           # Restore original package name
           jq '.name = "oh-my-opencode"' package.json > tmp.json && mv tmp.json package.json
+          # Restore optionalDependencies to oh-my-opencode naming
+          jq --arg v "$VERSION" '.optionalDependencies = {
+            "oh-my-opencode-darwin-arm64": $v,
+            "oh-my-opencode-darwin-x64": $v,
+            "oh-my-opencode-darwin-x64-baseline": $v,
+            "oh-my-opencode-linux-arm64": $v,
+            "oh-my-opencode-linux-arm64-musl": $v,
+            "oh-my-opencode-linux-x64": $v,
+            "oh-my-opencode-linux-x64-baseline": $v,
+            "oh-my-opencode-linux-x64-musl": $v,
+            "oh-my-opencode-linux-x64-musl-baseline": $v,
+            "oh-my-opencode-windows-x64": $v,
+            "oh-my-opencode-windows-x64-baseline": $v
+          }' package.json > tmp.json && mv tmp.json package.json
+
+      - name: Git commit and tag
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add package.json packages/*/package.json
+          git diff --cached --quiet || git commit -m "release: v${{ steps.version.outputs.version }}"
+          git tag -f "v${{ steps.version.outputs.version }}"
+          git push origin --tags --force
+          git push origin HEAD
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   trigger-platform:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes #2407

The "Git commit and tag" step was accidentally removed from `publish.yml` when adding oh-my-openagent dual-publish support. This caused version bumps to not be committed to git, so `publish-platform.yml` always checked out stale `package.json` with the old version.

Since `bun build --compile` embeds the version from `package.json` at compile time, the published platform binaries had stale version strings (e.g., `3.11.0` instead of `3.11.2`).

## Changes

| File | Change |
|------|--------|
| `publish.yml` | Restored "Git commit and tag" step to commit version bumps after publishing |
| `publish-platform.yml` | Added defensive root `package.json` update before building binaries |

## Test Plan

After the next release (e.g., `3.11.3`):
```bash
bunx oh-my-opencode@3.11.3 -v  # Should output 3.11.3
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the version commit/tag step and ensures the root package.json and `optionalDependencies` are updated during platform builds so compiled binaries embed the correct CLI version. Fixes stale version strings in published platform artifacts.

- **Bug Fixes**
  - publish.yml: Restore package name and `optionalDependencies` to `oh-my-opencode-*` with the new version, then commit the bump, tag, and push.
  - publish-platform.yml: Update root package.json version and align `optionalDependencies` before compile so `bun build --compile` embeds the correct version.

<sup>Written for commit b6b9bdbf6ce5b932d5c05d4d426fa1bed8f6ade3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

