### PR TITLE
fix: generalize isAnthropicProvider to match custom provider variants

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -3,7 +3,7 @@ import { log, normalizeModelID } from "../../shared"
 const OPUS_4_6_PATTERN = /claude-opus-4[-.]6/i
 
 function isClaudeProvider(providerID: string, modelID: string): boolean {
-  if (["anthropic", "google-vertex-anthropic", "opencode"].includes(providerID)) return true
+  if (providerID === "anthropic" || providerID.startsWith("google-vertex-anthropic") || providerID === "opencode") return true
   if (providerID === "github-copilot" && modelID.toLowerCase().includes("claude")) return true
   return false
 }

--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -36,7 +36,7 @@ interface CachedTokenState {
 }
 
 function isAnthropicProvider(providerID: string): boolean {
-  return providerID === "anthropic" || providerID === "google-vertex-anthropic"
+  return providerID === "anthropic" || providerID.startsWith("google-vertex-anthropic")
 }
 
 export function createContextWindowMonitorHook(

--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -54,7 +54,7 @@ function withTimeout<TValue>(
 }
 
 function isAnthropicProvider(providerID: string): boolean {
-  return providerID === "anthropic" || providerID === "google-vertex-anthropic"
+  return providerID === "anthropic" || providerID.startsWith("google-vertex-anthropic")
 }
 
 type PluginInput = {


### PR DESCRIPTION
## Problem

`isAnthropicProvider()` uses exact string matching (`providerID === "google-vertex-anthropic"`), which means custom provider variants like `google-vertex-anthropic-standard` are not recognized as Anthropic providers.

This breaks users who split Vertex AI Anthropic into multiple provider entries with different configurations — for example, one provider with the `anthropic-beta: context-1m` header (for 1M-capable models like Opus/Sonnet 4.6) and one without (for models like Haiku 4.5 that reject the header with a 400 error).

## Fix

Use `providerID.startsWith("google-vertex-anthropic")` instead of exact match in all 3 occurrences:

- `src/hooks/context-window-monitor.ts` — context window tracking
- `src/hooks/preemptive-compaction.ts` — preemptive compaction threshold
- `src/hooks/anthropic-effort/hook.ts` — effort level adjustment

## Impact

- Any provider ID starting with `google-vertex-anthropic` (e.g., `google-vertex-anthropic-standard`, `google-vertex-anthropic-eu`) will be correctly recognized
- The existing `google-vertex-anthropic` exact match still works (startsWith matches it)
- No breaking changes

## Testing

The existing test cases use `"google-vertex-anthropic"` which still matches with `startsWith`. The fix is backwards-compatible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalized Anthropic provider detection to recognize all `google-vertex-anthropic*` variants, restoring correct context tracking, compaction, and effort tuning for split Vertex Anthropic configurations.

- **Bug Fixes**
  - Replaced exact match with `providerID.startsWith("google-vertex-anthropic")` (keeping `"anthropic"` support) in:
    - `src/hooks/context-window-monitor.ts`
    - `src/hooks/preemptive-compaction.ts`
    - `src/hooks/anthropic-effort/hook.ts`
  - Ensures variants like `google-vertex-anthropic-standard` and `google-vertex-anthropic-eu` are handled without breaking existing IDs.

<sup>Written for commit 73d463bf2fe27135e484bc611de850ab8a74eb78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

