### PR TITLE
fix: github copilot model version for Sisyphus agent

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -199,7 +199,7 @@ When GitHub Copilot is the best available provider, oh-my-opencode uses these mo
 
 | Agent         | Model                             |
 | ------------- | --------------------------------- |
-| **Sisyphus**  | `github-copilot/claude-opus-4-6`  |
+| **Sisyphus**  | `github-copilot/claude-opus-4.6`  |
 | **Oracle**    | `github-copilot/gpt-5.4`          |
 | **Explore**   | `github-copilot/grok-code-fast-1` |
 | **Librarian** | `github-copilot/gemini-3-flash`   |


### PR DESCRIPTION
## Summary

This pull request makes a minor correction to the documentation, updating the model name for the Sisyphus agent to use the correct version format.

- Corrected the Sisyphus agent's github copilot model name from `claude-opus-4-6` to `claude-opus-4.6` in the `docs/guide/installation.md` file.

## Changes

<!-- What was changed and how. List specific modifications. -->

- Corrected the Sisyphus agent's github copilot  model name from `claude-opus-4-6` to `claude-opus-4.6` in the `docs/guide/installation.md` file.

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Sisyphus agent model in the installation guide from `github-copilot/claude-opus-4-6` to `github-copilot/claude-opus-4.6` so users copy the right version.

<sup>Written for commit 6d8bc95fa67e0eb627c6664ab8091ced90429e23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

