### PR TITLE
fix(momus): make keyTrigger specify file-path-only invocation requirement

### DIFF
--- a/src/agents/momus.ts
+++ b/src/agents/momus.ts
@@ -342,5 +342,6 @@ export const momusPromptMetadata: AgentPromptMetadata = {
     "When user explicitly wants to skip review",
     "For trivial plans that don't need formal review",
   ],
-  keyTrigger: "Work plan created → invoke Momus for review before execution",
+  keyTrigger:
+    "Work plan saved to `.sisyphus/plans/*.md` → invoke Momus with the file path as the sole prompt (e.g. `prompt=\".sisyphus/plans/my-plan.md\"`). Do NOT invoke Momus for inline plans or todo lists.",
 };


### PR DESCRIPTION
## Summary

- Fix Momus REJECT errors caused by Sisyphus invoking Momus with inline plan text instead of a `.sisyphus/plans/*.md` file path

## Changes

- Updated `momusPromptMetadata.keyTrigger` in `src/agents/momus.ts` to explicitly require:
  - A `.sisyphus/plans/*.md` file must exist on disk before invoking Momus
  - The file path must be the **sole prompt content** (with an example)
  - Inline plans and todo lists must NOT trigger Momus invocation

### Before
```
Work plan created → invoke Momus for review before execution
```

### After
```
Work plan saved to `.sisyphus/plans/*.md` → invoke Momus with the file path as the sole prompt
(e.g. `prompt=".sisyphus/plans/my-plan.md"`). Do NOT invoke Momus for inline plans or todo lists.
```

## Context

The previous `keyTrigger` was injected into Sisyphus's Phase 0 "Key Triggers" section via `buildKeyTriggersSection()`. It told Sisyphus to "invoke Momus" whenever a "work plan" was created, but gave no guidance on **how** to invoke it.

Meanwhile, Momus's `<input_extraction>` rule strictly requires exactly one `.sisyphus/plans/*.md` file path as input — rejecting anything else. The detailed invocation rules (file-path-only) were only documented in the Prometheus/Atlas high-accuracy-mode sections, not in the key trigger that Sisyphus sees.

This mismatch caused Sisyphus to pass inline plan text or conversational prompts to Momus, triggering a REJECT every time.

## Testing

Existing tests in `src/agents/momus.test.ts` only validate `MOMUS_SYSTEM_PROMPT` content — not `momusPromptMetadata`. This change is type-safe (`keyTrigger` is `string`) and doesn't affect the Momus agent prompt itself.

```bash
bun run typecheck
bun test
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified Momus invocation so Sisyphus only calls it with a plan file path, preventing REJECTs from inline plan inputs. Updated `momusPromptMetadata.keyTrigger` to require a `.sisyphus/plans/*.md` path as the sole prompt (e.g., `".sisyphus/plans/my-plan.md"`), and to ignore inline plans and todo lists.

<sup>Written for commit d62a586be4df5d97363c8e6a9b7ca3158fd2dbef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

