### PR TITLE
fix: use combined npm downloads badge (oh-my-opencode + oh-my-openagent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 <div align="center">
 
 [![GitHub Release](https://img.shields.io/github/v/release/code-yeongyu/oh-my-openagent?color=369eff&labelColor=black&logo=github&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/releases)
-[![npm downloads](https://img.shields.io/npm/dt/oh-my-opencode?color=ff6b35&labelColor=black&style=flat-square)](https://www.npmjs.com/package/oh-my-opencode)
+[![npm downloads](https://img.shields.io/endpoint?url=https%3A%2F%2Fohmyopenagent.com%2Fapi%2Fnpm-downloads&style=flat-square)](https://www.npmjs.com/package/oh-my-openagent)
 [![GitHub Contributors](https://img.shields.io/github/contributors/code-yeongyu/oh-my-openagent?color=c4f042&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/graphs/contributors)
 [![GitHub Forks](https://img.shields.io/github/forks/code-yeongyu/oh-my-openagent?color=8ae8ff&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/network/members)
 [![GitHub Stars](https://img.shields.io/github/stars/code-yeongyu/oh-my-openagent?color=ffcb47&labelColor=black&style=flat-square)](https://github.com/code-yeongyu/oh-my-openagent/stargazers)


### PR DESCRIPTION
Replace the single-package `npm/dt/oh-my-opencode` shields.io badge with a custom endpoint badge that combines downloads from both `oh-my-opencode` and `oh-my-openagent` NPM packages.

## Why
As we transition from `oh-my-opencode` to `oh-my-openagent`, the download count should reflect the sum of both packages to accurately represent total adoption.

## How
Uses a shields.io endpoint badge pointing to `https://ohmyopenagent.com/api/npm-downloads`, which fetches and sums downloads from both NPM packages.

The endpoint is served from the oh-my-opencode-web project (merged in code-yeongyu/oh-my-opencode-web#1).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the README npm downloads badge to use a shields.io endpoint that combines downloads from `oh-my-opencode` and `oh-my-openagent`. The badge now shows total adoption via https://ohmyopenagent.com/api/npm-downloads.

<sup>Written for commit e1ff18ca128f98ad034469f21da357028fcf9d54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

