### PR TITLE
fix(agents): add anti-duplication rules to Atlas agent prompts

### DIFF
--- a/src/agents/atlas/atlas-prompt.test.ts
+++ b/src/agents/atlas/atlas-prompt.test.ts
@@ -77,6 +77,21 @@ describe("Atlas prompts auto-continue policy", () => {
   })
 })
 
+describe("Atlas prompts anti-duplication coverage", () => {
+  test("all variants should include anti-duplication rules for delegated exploration", () => {
+    // given
+    const prompts = [ATLAS_SYSTEM_PROMPT, ATLAS_GPT_SYSTEM_PROMPT, ATLAS_GEMINI_SYSTEM_PROMPT]
+
+    // when / then
+    for (const prompt of prompts) {
+      expect(prompt).toContain("<Anti_Duplication>")
+      expect(prompt).toContain("Anti-Duplication Rule")
+      expect(prompt).toContain("DO NOT perform the same search yourself")
+      expect(prompt).toContain("non-overlapping work")
+    }
+  })
+})
+
 describe("Atlas prompts plan path consistency", () => {
   test("default variant should use .sisyphus/plans/{plan-name}.md path", () => {
     // given

--- a/src/agents/atlas/default.ts
+++ b/src/agents/atlas/default.ts
@@ -8,6 +8,8 @@
  * - Extended reasoning sections
  */
 
+import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder"
+
 export const ATLAS_SYSTEM_PROMPT = `
 <identity>
 You are Atlas - the Master Orchestrator from OhMyOpenCode.
@@ -23,6 +25,8 @@ Complete ALL tasks in a work plan via \`task()\` and pass the Final Verification
 Implementation tasks are the means. Final Wave approval is the goal.
 One task per delegation. Parallel when independent. Verify everything.
 </mission>
+
+${buildAntiDuplicationSection()}
 
 <delegation_system>
 ## How to Delegate

--- a/src/agents/atlas/gemini.ts
+++ b/src/agents/atlas/gemini.ts
@@ -8,6 +8,8 @@
  * - Consequence-driven framing (Gemini ignores soft warnings)
  */
 
+import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder"
+
 export const ATLAS_GEMINI_SYSTEM_PROMPT = `
 <identity>
 You are Atlas - Master Orchestrator from OhMyOpenCode.
@@ -50,6 +52,8 @@ Implementation tasks are the means. Final Wave approval is the goal.
 - Do NOT expand task boundaries beyond what's written.
 - **Your creativity should go into ORCHESTRATION QUALITY, not implementation decisions.**
 </scope_and_design_constraints>
+
+${buildAntiDuplicationSection()}
 
 <delegation_system>
 ## How to Delegate

--- a/src/agents/atlas/gpt.ts
+++ b/src/agents/atlas/gpt.ts
@@ -8,6 +8,8 @@
  * - Scope discipline (no extra features)
  */
 
+import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder"
+
 export const ATLAS_GPT_SYSTEM_PROMPT = `
 <identity>
 You are Atlas - Master Orchestrator from OhMyOpenCode.
@@ -60,6 +62,8 @@ Implementation tasks are the means. Final Wave approval is the goal.
   2. \`Bash\` for build/test commands
   3. \`Read\` for changed files
 </tool_usage_rules>
+
+${buildAntiDuplicationSection()}
 
 <delegation_system>
 ## Delegation API


### PR DESCRIPTION
## Summary
- Add `buildAntiDuplicationSection()` to all 3 Atlas agent variants (default, gemini, gpt)
- Atlas delegates to background agents and was missing anti-duplication rules that other agents already had
- Added test assertions verifying Atlas prompts contain anti-duplication content

Fixes regression from #2448

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add anti-duplication rules to all Atlas agent prompts to prevent redundant work during delegation. Fixes regression from #2448 and brings Atlas in line with other agents.

- **Bug Fixes**
  - Inject `buildAntiDuplicationSection()` into Atlas `default`, `gpt`, and `gemini` system prompts.
  - Add tests verifying anti-duplication guidance is present in all Atlas variants.
  - Prevents Atlas from repeating searches/tasks already delegated.

<sup>Written for commit 554392e639a9c4e704defbec2c2f2125c3348037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

