### PR TITLE
fix(tmux): strict integer parsing and isActive validation

### DIFF
--- a/src/features/tmux-subagent/pane-state-parser.test.ts
+++ b/src/features/tmux-subagent/pane-state-parser.test.ts
@@ -1,0 +1,72 @@
+/// <reference path="../../../bun-test.d.ts" />
+
+import { describe, expect, it } from "bun:test"
+import { parsePaneStateOutput } from "./pane-state-parser"
+
+describe("parsePaneStateOutput", () => {
+  it("rejects malformed integer fields", () => {
+    // given
+    const stdout = "%0\t120oops\t40\t0\t0\t1\t120\t40\n"
+
+    // when
+    const result = parsePaneStateOutput(stdout)
+
+    // then
+    expect(result).toBe(null)
+  })
+
+  it("rejects negative integer fields", () => {
+    // given
+    const stdout = "%0\t-1\t40\t0\t0\t1\t120\t40\n"
+
+    // when
+    const result = parsePaneStateOutput(stdout)
+
+    // then
+    expect(result).toBe(null)
+  })
+
+  it("rejects empty integer fields", () => {
+    // given
+    const stdout = "%0\t\t40\t0\t0\t1\t120\t40\n"
+
+    // when
+    const result = parsePaneStateOutput(stdout)
+
+    // then
+    expect(result).toBe(null)
+  })
+
+  it("rejects non-binary active flags", () => {
+    // given
+    const stdout = "%0\t120\t40\t0\t0\tx\t120\t40\n"
+
+    // when
+    const result = parsePaneStateOutput(stdout)
+
+    // then
+    expect(result).toBe(null)
+  })
+
+  it("rejects numeric active flags other than zero or one", () => {
+    // given
+    const stdout = "%0\t120\t40\t0\t0\t2\t120\t40\n"
+
+    // when
+    const result = parsePaneStateOutput(stdout)
+
+    // then
+    expect(result).toBe(null)
+  })
+
+  it("rejects empty active flags", () => {
+    // given
+    const stdout = "%0\t120\t40\t0\t0\t\t120\t40\n"
+
+    // when
+    const result = parsePaneStateOutput(stdout)
+
+    // then
+    expect(result).toBe(null)
+  })
+})

--- a/src/features/tmux-subagent/pane-state-parser.ts
+++ b/src/features/tmux-subagent/pane-state-parser.ts
@@ -60,6 +60,7 @@ function parsePaneLine(line: string): ParsedPaneLine | null {
   const height = parseInteger(heightString)
   const left = parseInteger(leftString)
   const top = parseInteger(topString)
+  const isActive = parseActiveValue(activeString)
   const windowWidth = parseInteger(windowWidthString)
   const windowHeight = parseInteger(windowHeightString)
 
@@ -68,6 +69,7 @@ function parsePaneLine(line: string): ParsedPaneLine | null {
     height === null ||
     left === null ||
     top === null ||
+    isActive === null ||
     windowWidth === null ||
     windowHeight === null
   ) {
@@ -82,7 +84,7 @@ function parsePaneLine(line: string): ParsedPaneLine | null {
       left,
       top,
       title: fields.slice(MANDATORY_PANE_FIELD_COUNT).join("\t"),
-      isActive: activeString === "1",
+      isActive,
     },
     windowWidth,
     windowHeight,
@@ -120,6 +122,14 @@ function getMandatoryPaneFields(fields: string[]): MandatoryPaneFields | null {
 }
 
 function parseInteger(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null
+
   const parsedValue = Number.parseInt(value, 10)
   return Number.isNaN(parsedValue) ? null : parsedValue
+}
+
+function parseActiveValue(value: string): boolean | null {
+  if (value === "1") return true
+  if (value === "0") return false
+  return null
 }


### PR DESCRIPTION
## Summary
- `parseInteger()` now rejects malformed input (e.g. "120oops") using `/^\d+$/` regex validation
- New `parseActiveValue()` validates active flag is exactly "0" or "1", returns null otherwise
- Regression tests for malformed integers, negative values, empty fields, non-binary active flags

## Context
Oracle regression check on PR #2453 found that `Number.parseInt()` silently accepted trailing garbage and `isActive` had no validation for invalid values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened tmux pane state parsing to reject malformed integers and invalid active flags, preventing bad data from `parsePaneStateOutput`. This fixes the regression where `Number.parseInt()` accepted trailing garbage and unvalidated `isActive` values.

- **Bug Fixes**
  - `parseInteger` now uses `/^\d+$/` to accept only non-negative integers; rejects empty, negative, and malformed values.
  - Added `parseActiveValue` to allow only "0" or "1" and return null otherwise.
  - `parsePaneLine` now returns null if any field is invalid.
  - Added tests covering malformed integers, negatives, empty fields, and non-binary active flags.

<sup>Written for commit 599ce0c283d86b27e2e8aca8f9cc4bc144c88a6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

