### PR TITLE
fix(agents): add anti-duplication rules to Prometheus and Metis

### DIFF
--- a/src/agents/anti-duplication.test.ts
+++ b/src/agents/anti-duplication.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from "bun:test"
 import { buildAntiDuplicationSection } from "./dynamic-agent-prompt-builder"
+import { METIS_SYSTEM_PROMPT } from "./metis"
 
 describe("buildAntiDuplicationSection", () => {
   it("#given no arguments #when building anti-duplication section #then returns comprehensive rule section", () => {
@@ -88,5 +89,18 @@ describe("buildAntiDuplicationSection", () => {
     //#then: should be wrapped in Anti_Duplication tag
     expect(result).toContain("<Anti_Duplication>")
     expect(result).toContain("</Anti_Duplication>")
+  })
+})
+
+describe("METIS_SYSTEM_PROMPT anti-duplication coverage", () => {
+  it("#given the system prompt #when reading delegated exploration rules #then includes anti-duplication guidance", () => {
+    // given
+    const prompt = METIS_SYSTEM_PROMPT
+
+    // when / then
+    expect(prompt).toContain("<Anti_Duplication>")
+    expect(prompt).toContain("Anti-Duplication Rule")
+    expect(prompt).toContain("DO NOT perform the same search yourself")
+    expect(prompt).toContain("non-overlapping work")
   })
 })

--- a/src/agents/metis.ts
+++ b/src/agents/metis.ts
@@ -1,5 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode, AgentPromptMetadata } from "./types"
+import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
 const MODE: AgentMode = "subagent"
@@ -24,6 +25,8 @@ export const METIS_SYSTEM_PROMPT = `# Metis - Pre-Planning Consultant
 
 - **READ-ONLY**: You analyze, question, advise. You do NOT implement or modify files.
 - **OUTPUT**: Your analysis feeds into Prometheus (planner). Be actionable.
+
+${buildAntiDuplicationSection()}
 
 ---
 

--- a/src/agents/metis.ts
+++ b/src/agents/metis.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode, AgentPromptMetadata } from "./types"
-import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder"
+import { buildAntiDuplicationSection } from "./dynamic-agent-prompt-builder"
 import { createAgentToolRestrictions } from "../shared/permission-compat"
 
 const MODE: AgentMode = "subagent"

--- a/src/agents/prometheus-prompt.test.ts
+++ b/src/agents/prometheus-prompt.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from "bun:test"
 import { PROMETHEUS_SYSTEM_PROMPT } from "./prometheus"
+import { PROMETHEUS_GPT_SYSTEM_PROMPT } from "./prometheus/gpt"
+import { PROMETHEUS_GEMINI_SYSTEM_PROMPT } from "./prometheus/gemini"
 
 describe("PROMETHEUS_SYSTEM_PROMPT Momus invocation policy", () => {
   test("should direct providing ONLY the file path string when invoking Momus", () => {
@@ -80,5 +82,24 @@ describe("PROMETHEUS_SYSTEM_PROMPT zero human intervention", () => {
     expect(lowerPrompt).toMatch(/every task has agent-executed qa scenarios/)
     expect(lowerPrompt).toMatch(/happy-path and negative/)
     expect(lowerPrompt).toMatch(/zero acceptance criteria require human/)
+  })
+})
+
+describe("Prometheus prompts anti-duplication coverage", () => {
+  test("all variants should include anti-duplication rules for delegated exploration", () => {
+    // given
+    const prompts = [
+      PROMETHEUS_SYSTEM_PROMPT,
+      PROMETHEUS_GPT_SYSTEM_PROMPT,
+      PROMETHEUS_GEMINI_SYSTEM_PROMPT,
+    ]
+
+    // when / then
+    for (const prompt of prompts) {
+      expect(prompt).toContain("<Anti_Duplication>")
+      expect(prompt).toContain("Anti-Duplication Rule")
+      expect(prompt).toContain("DO NOT perform the same search yourself")
+      expect(prompt).toContain("non-overlapping work")
+    }
   })
 })

--- a/src/agents/prometheus/gemini.ts
+++ b/src/agents/prometheus/gemini.ts
@@ -9,6 +9,8 @@
  * - Tool-call mandate for every phase transition
  */
 
+import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder"
+
 export const PROMETHEUS_GEMINI_SYSTEM_PROMPT = `
 <identity>
 You are Prometheus - Strategic Planning Consultant from OhMyOpenCode.
@@ -42,6 +44,8 @@ Produce **decision-complete** work plans for agent execution.
 A plan is "decision complete" when the implementer needs ZERO judgment calls — every decision is made, every ambiguity resolved, every pattern reference provided.
 This is your north star quality metric.
 </mission>
+
+${buildAntiDuplicationSection()}
 
 <core_principles>
 ## Three Principles

--- a/src/agents/prometheus/gpt.ts
+++ b/src/agents/prometheus/gpt.ts
@@ -8,6 +8,8 @@
  * - Principle-driven: Decision Complete, Explore Before Asking, Two Kinds of Unknowns
  */
 
+import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder";
+
 export const PROMETHEUS_GPT_SYSTEM_PROMPT = `
 <identity>
 You are Prometheus - Strategic Planning Consultant from OhMyOpenCode.
@@ -24,6 +26,8 @@ Produce **decision-complete** work plans for agent execution.
 A plan is "decision complete" when the implementer needs ZERO judgment calls — every decision is made, every ambiguity resolved, every pattern reference provided.
 This is your north star quality metric.
 </mission>
+
+${buildAntiDuplicationSection()}
 
 <core_principles>
 ## Three Principles (Read First)

--- a/src/agents/prometheus/interview-mode.ts
+++ b/src/agents/prometheus/interview-mode.ts
@@ -5,6 +5,8 @@
  * Includes intent classification, research patterns, and anti-patterns.
  */
 
+import { buildAntiDuplicationSection } from "../dynamic-agent-prompt-builder"
+
 export const PROMETHEUS_INTERVIEW_MODE = `# PHASE 1: INTERVIEW MODE (DEFAULT)
 
 ## Step 0: Intent Classification (EVERY request)
@@ -28,6 +30,8 @@ Before diving into consultation, classify the work intent. This determines your 
 - **Trivial** (single file, <10 lines change, obvious fix) — **Skip heavy interview**. Quick confirm → suggest action.
 - **Simple** (1-2 files, clear scope, <30 min work) — **Lightweight**: 1-2 targeted questions → propose approach.
 - **Complex** (3+ files, multiple components, architectural impact) — **Full consultation**: Intent-specific deep interview.
+
+${buildAntiDuplicationSection()}
 
 ---
 


### PR DESCRIPTION
## Summary
- Import and inject `buildAntiDuplicationSection()` in all 3 Prometheus variants (interview-mode, gpt, gemini) and Metis
- Tests verify anti-dup section presence in all prompt variants
- Completes anti-duplication coverage for ALL delegating agents

## Context
Oracle regression check on PR #2448/#2461 found Prometheus and Metis were the only remaining delegating agents without anti-duplication rules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds anti-duplication rules to all Prometheus variants (interview-mode, GPT, Gemini) and Metis to prevent duplicated exploration by delegated agents. Adds tests and fixes a Metis import path so the rules load correctly.

- **Bug Fixes**
  - Injected `buildAntiDuplicationSection()` into Prometheus variants and `METIS_SYSTEM_PROMPT`.
  - Fixed `buildAntiDuplicationSection()` import path in `metis.ts`.
  - Added tests verifying the anti-dup section appears in all prompts.
  - Ensures delegating agents follow non-overlapping exploration guidance.

<sup>Written for commit ccfb5702ac751020283febcb520616185e73359c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

