### PR TITLE
fix(background-agent): handle SDK error response in spawn lineage lookup

### DIFF
--- a/src/features/background-agent/subagent-spawn-limits.test.ts
+++ b/src/features/background-agent/subagent-spawn-limits.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import type { OpencodeClient } from "./constants"
+import { resolveSubagentSpawnContext } from "./subagent-spawn-limits"
+
+function createMockClient(sessionGet: OpencodeClient["session"]["get"]): OpencodeClient {
+  return {
+    session: {
+      get: sessionGet,
+    },
+  } as OpencodeClient
+}
+
+describe("resolveSubagentSpawnContext", () => {
+  describe("#given session.get returns an SDK error response", () => {
+    test("throws a fail-closed spawn blocked error", async () => {
+      // given
+      const client = createMockClient(async () => ({
+        error: "lookup failed",
+        data: undefined,
+      }))
+
+      // when
+      const result = resolveSubagentSpawnContext(client, "parent-session")
+
+      // then
+      await expect(result).rejects.toThrow(/background_task\.maxDescendants cannot be enforced safely.*lookup failed/)
+    })
+  })
+
+  describe("#given session.get returns no session data", () => {
+    test("throws a fail-closed spawn blocked error", async () => {
+      // given
+      const client = createMockClient(async () => ({
+        data: undefined,
+      }))
+
+      // when
+      const result = resolveSubagentSpawnContext(client, "parent-session")
+
+      // then
+      await expect(result).rejects.toThrow(/background_task\.maxDescendants cannot be enforced safely.*No session data returned/)
+    })
+  })
+})

--- a/src/features/background-agent/subagent-spawn-limits.ts
+++ b/src/features/background-agent/subagent-spawn-limits.ts
@@ -36,10 +36,18 @@ export async function resolveSubagentSpawnContext(
 
     let nextParentSessionID: string | undefined
     try {
-      const session = await client.session.get({
+      const response = await client.session.get({
         path: { id: currentSessionID },
       })
-      nextParentSessionID = session.data?.parentID
+      if (response.error) {
+        throw new Error(String(response.error))
+      }
+
+      if (!response.data) {
+        throw new Error("No session data returned")
+      }
+
+      nextParentSessionID = response.data.parentID
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error)
       throw new Error(


### PR DESCRIPTION
## Summary
- Check `response.error` and `!response.data` after `session.get()` to fail closed
- Prevents unlimited spawning when SDK returns non-throwing error responses
- Regression tests for SDK error and missing data scenarios

## Context
Oracle regression check on PR #2449 found that `client.session.get()` can return `{ error: "..." }` without throwing, causing fail-open behavior in spawn limits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed in subagent spawn lineage lookup when the SDK returns an error or no data from `client.session.get()`. Prevents unlimited spawning and enforces `background_task.maxDescendants` safely.

- **Bug Fixes**
  - Check `response.error` and missing `response.data` after `session.get()`; throw with reason to block spawn.
  - Added regression tests for SDK error responses and no session data.

<sup>Written for commit cc1c23032fc9a288c367eda8c0a3cf48071ee3ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

