### PR TITLE
fix(look-at): preserve variant metadata and block non-vision models

### DIFF
--- a/src/tools/look-at/multimodal-agent-metadata.test.ts
+++ b/src/tools/look-at/multimodal-agent-metadata.test.ts
@@ -65,6 +65,35 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
     })
   })
 
+  test("preserves hardcoded fallback variant when the registered model matches a cache-derived entry", async () => {
+    // given
+    setVisionCapableModelsCache(new Map([
+      [
+        "openai/gpt-5.4",
+        { providerID: "openai", modelID: "gpt-5.4" },
+      ],
+    ]))
+    spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(
+      new Set(["openai/gpt-5.4"]),
+    )
+    spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+    const ctx = createPluginInput([
+      {
+        name: "multimodal-looker",
+        model: { providerID: "openai", modelID: "gpt-5.4" },
+      },
+    ])
+
+    // when
+    const result = await resolveMultimodalLookerAgentMetadata(ctx)
+
+    // then
+    expect(result).toEqual({
+      agentModel: { providerID: "openai", modelID: "gpt-5.4" },
+      agentVariant: "medium",
+    })
+  })
+
   test("prefers connected vision-capable provider models before the hardcoded fallback chain", async () => {
     // given
     setVisionCapableModelsCache(new Map([
@@ -97,6 +126,12 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
 
   test("falls back to the hardcoded multimodal chain when no dynamic vision model exists", async () => {
     // given
+    setVisionCapableModelsCache(new Map([
+      [
+        "google/gemini-3-flash",
+        { providerID: "google", modelID: "gemini-3-flash" },
+      ],
+    ]))
     spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(
       new Set(["google/gemini-3-flash"]),
     )
@@ -111,5 +146,25 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
       agentModel: { providerID: "google", modelID: "gemini-3-flash" },
       agentVariant: undefined,
     })
+  })
+
+  test("does not return a registered model when no vision-capable model is available", async () => {
+    // given
+    spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(
+      new Set(["openai/gpt-5.4"]),
+    )
+    spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+    const ctx = createPluginInput([
+      {
+        name: "multimodal-looker",
+        model: { providerID: "openai", modelID: "gpt-5.4" },
+      },
+    ])
+
+    // when
+    const result = await resolveMultimodalLookerAgentMetadata(ctx)
+
+    // then
+    expect(result).toEqual({})
   })
 })

--- a/src/tools/look-at/multimodal-agent-metadata.ts
+++ b/src/tools/look-at/multimodal-agent-metadata.ts
@@ -28,6 +28,19 @@ function getFullModelKey(model: AgentModel): string {
   return `${model.providerID}/${model.modelID}`
 }
 
+function isVisionCapableAgentModel(
+  agentModel: AgentModel | undefined,
+  visionCapableModels: Array<AgentModel>,
+): agentModel is AgentModel {
+  if (!agentModel) {
+    return false
+  }
+
+  return visionCapableModels.some((visionCapableModel) =>
+    getFullModelKey(visionCapableModel) === getFullModelKey(agentModel),
+  )
+}
+
 function parseAgentModel(model: string): AgentModel | undefined {
   const [providerID, ...modelIDParts] = model.split("/")
   const modelID = modelIDParts.join("/")
@@ -90,6 +103,10 @@ async function resolveDynamicAgentMetadata(
   })
 
   const agentModel = resolution ? parseAgentModel(resolution.model) : undefined
+  if (!isVisionCapableAgentModel(agentModel, visionCapableModels)) {
+    return {}
+  }
+
   return {
     agentModel,
     agentVariant: resolution?.variant,
@@ -113,22 +130,32 @@ export async function resolveMultimodalLookerAgentMetadata(
   try {
     const registeredMetadata = await resolveRegisteredAgentMetadata(ctx)
     const visionCapableModels = readVisionCapableModelsCache()
-
-    if (registeredMetadata.agentModel && visionCapableModels.length === 0) {
-      return registeredMetadata
-    }
+    const registeredModelIsVisionCapable = isVisionCapableAgentModel(
+      registeredMetadata.agentModel,
+      visionCapableModels,
+    )
 
     const dynamicMetadata = await resolveDynamicAgentMetadata(ctx, visionCapableModels)
 
-    if (isConfiguredVisionModel(registeredMetadata.agentModel, dynamicMetadata.agentModel)) {
-      return registeredMetadata
+    if (
+      registeredModelIsVisionCapable &&
+      isConfiguredVisionModel(registeredMetadata.agentModel, dynamicMetadata.agentModel)
+    ) {
+      return {
+        agentModel: registeredMetadata.agentModel,
+        agentVariant: registeredMetadata.agentVariant ?? dynamicMetadata.agentVariant,
+      }
     }
 
     if (dynamicMetadata.agentModel) {
       return dynamicMetadata
     }
 
-    return registeredMetadata
+    if (registeredModelIsVisionCapable) {
+      return registeredMetadata
+    }
+
+    return {}
   } catch (error) {
     log("[look_at] Failed to resolve multimodal-looker model info", error)
     return {}

--- a/src/tools/look-at/multimodal-fallback-chain.test.ts
+++ b/src/tools/look-at/multimodal-fallback-chain.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "bun:test"
+
 describe("buildMultimodalLookerFallbackChain", () => {
   it("builds fallback chain from vision-capable models", async () => {
     // given
@@ -27,5 +29,21 @@ describe("buildMultimodalLookerFallbackChain", () => {
     expect(result.length).toBeGreaterThan(0)
     expect(result[0].model).toBe("gpt-5.4")
     expect(result[0].providers).toContain("openai")
+  })
+
+  it("preserves hardcoded variant metadata for cache-derived entries", async () => {
+    // given
+    const { buildMultimodalLookerFallbackChain } = await import("./multimodal-fallback-chain")
+    const visionCapableModels = [{ providerID: "openai", modelID: "gpt-5.4" }]
+
+    // when
+    const result = buildMultimodalLookerFallbackChain(visionCapableModels)
+
+    // then
+    expect(result[0]).toEqual({
+      providers: ["openai"],
+      model: "gpt-5.4",
+      variant: "medium",
+    })
   })
 })

--- a/src/tools/look-at/multimodal-fallback-chain.ts
+++ b/src/tools/look-at/multimodal-fallback-chain.ts
@@ -8,6 +8,15 @@ function getFullModelKey(providerID: string, modelID: string): string {
   return `${providerID}/${modelID}`
 }
 
+function findHardcodedFallbackEntry(
+  providerID: string,
+  modelID: string,
+): FallbackEntry | undefined {
+  return MULTIMODAL_LOOKER_REQUIREMENT.fallbackChain.find((entry) =>
+    entry.model === modelID && entry.providers.includes(providerID),
+  )
+}
+
 export function isHardcodedMultimodalFallbackModel(model: VisionCapableModel): boolean {
   return MULTIMODAL_LOOKER_REQUIREMENT.fallbackChain.some((entry) =>
     entry.providers.some((providerID) =>
@@ -26,10 +35,16 @@ export function buildMultimodalLookerFallbackChain(
     const key = getFullModelKey(visionCapableModel.providerID, visionCapableModel.modelID)
     if (seen.has(key)) continue
 
+    const hardcodedEntry = findHardcodedFallbackEntry(
+      visionCapableModel.providerID,
+      visionCapableModel.modelID,
+    )
+
     seen.add(key)
     fallbackChain.push({
       providers: [visionCapableModel.providerID],
       model: visionCapableModel.modelID,
+      ...(hardcodedEntry?.variant ? { variant: hardcodedEntry.variant } : {}),
     })
   }
 
@@ -41,7 +56,9 @@ export function buildMultimodalLookerFallbackChain(
       continue
     }
 
-    providerModelKeys.forEach((key) => seen.add(key))
+    providerModelKeys.forEach((key) => {
+      seen.add(key)
+    })
     fallbackChain.push(entry)
   }
 

--- a/src/tools/look-at/tools.test.ts
+++ b/src/tools/look-at/tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, mock } from "bun:test"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
+import { setVisionCapableModelsCache } from "../../shared/vision-capable-models-cache"
 import { normalizeArgs, validateArgs, createLookAt } from "./tools"
 
 describe("look-at tool", () => {
@@ -255,6 +256,8 @@ describe("look-at tool", () => {
     // when LookAt tool executed
     // then model info should be passed to sync prompt
     test("passes multimodal-looker model to sync prompt when available", async () => {
+      setVisionCapableModelsCache(new Map([["google/gemini-3-flash", { providerID: "google", modelID: "gemini-3-flash" }]]))
+
       let promptBody: any
 
       const mockClient = {

--- a/src/tools/look-at/tools.ts
+++ b/src/tools/look-at/tools.ts
@@ -4,6 +4,7 @@ import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin
 import { LOOK_AT_DESCRIPTION, MULTIMODAL_LOOKER_AGENT } from "./constants"
 import type { LookAtArgs } from "./types"
 import { log, promptSyncWithModelSuggestionRetry } from "../../shared"
+import { readVisionCapableModelsCache } from "../../shared/vision-capable-models-cache"
 import { extractLatestAssistantText } from "./assistant-message-extractor"
 import type { LookAtArgsWithAlias } from "./look-at-arguments"
 import { normalizeArgs, validateArgs } from "./look-at-arguments"
@@ -36,6 +37,16 @@ function getTemporaryConversionPath(error: unknown): string | null {
   }
 
   return null
+}
+
+function isVisionCapableResolvedModel(model: {
+  providerID: string
+  modelID: string
+}): boolean {
+  return readVisionCapableModelsCache().some((visionCapableModel) =>
+    visionCapableModel.providerID === model.providerID &&
+    visionCapableModel.modelID === model.modelID,
+  )
 }
 
 export { normalizeArgs, validateArgs } from "./look-at-arguments"
@@ -136,6 +147,14 @@ Provide ONLY the extracted information that matches the goal.
 Be thorough on what was requested, concise on everything else.
 If the requested information is not found, clearly state what is missing.`
 
+      const { agentModel, agentVariant } = await resolveMultimodalLookerAgentMetadata(ctx)
+      if (!agentModel || !isVisionCapableResolvedModel(agentModel)) {
+        log("[look_at] No vision-capable multimodal-looker model resolved", {
+          resolvedModel: agentModel,
+        })
+        return "Error: No vision-capable multimodal-looker model available"
+      }
+
       log(`[look_at] Creating session with parent: ${toolContext.sessionID}`)
       const parentSession = await ctx.client.session.get({
         path: { id: toolContext.sessionID },
@@ -169,8 +188,6 @@ Original error: ${createResult.error}`
       const sessionID = createResult.data.id
       log(`[look_at] Created session: ${sessionID}`)
 
-      const { agentModel, agentVariant } = await resolveMultimodalLookerAgentMetadata(ctx)
-
       log(`[look_at] Sending prompt with ${isBase64Input ? "base64 image" : "file"} to session ${sessionID}`)
       try {
         await promptSyncWithModelSuggestionRetry(ctx.client, {
@@ -187,7 +204,7 @@ Original error: ${createResult.error}`
               { type: "text", text: prompt },
               filePart,
             ],
-            ...(agentModel ? { model: { providerID: agentModel.providerID, modelID: agentModel.modelID } } : {}),
+            model: { providerID: agentModel.providerID, modelID: agentModel.modelID },
             ...(agentVariant ? { variant: agentVariant } : {}),
           },
         })

--- a/src/tools/look-at/tools.ts
+++ b/src/tools/look-at/tools.ts
@@ -148,11 +148,11 @@ Be thorough on what was requested, concise on everything else.
 If the requested information is not found, clearly state what is missing.`
 
       const { agentModel, agentVariant } = await resolveMultimodalLookerAgentMetadata(ctx)
-      if (!agentModel || !isVisionCapableResolvedModel(agentModel)) {
-        log("[look_at] No vision-capable multimodal-looker model resolved", {
+      if (agentModel && !isVisionCapableResolvedModel(agentModel)) {
+        log("[look_at] Resolved model is not vision-capable, blocking", {
           resolvedModel: agentModel,
         })
-        return "Error: No vision-capable multimodal-looker model available"
+        return "Error: Resolved multimodal-looker model is not vision-capable"
       }
 
       log(`[look_at] Creating session with parent: ${toolContext.sessionID}`)
@@ -204,7 +204,7 @@ Original error: ${createResult.error}`
               { type: "text", text: prompt },
               filePart,
             ],
-            model: { providerID: agentModel.providerID, modelID: agentModel.modelID },
+            ...(agentModel ? { model: { providerID: agentModel.providerID, modelID: agentModel.modelID } } : {}),
             ...(agentVariant ? { variant: agentVariant } : {}),
           },
         })


### PR DESCRIPTION
## Summary
- `fallback-chain.ts`: cache-derived entries inherit `variant` from matching hardcoded entries
- `agent-metadata.ts`: new `isVisionCapableAgentModel()` guard blocks non-vision registered models
- `tools.ts`: early vision-capability check before session creation, fail-fast with error message
- Regression tests for variant preservation and non-vision model rejection

## Context
Oracle regression check on PR #2371 found variant metadata was lost in fallback chain and non-vision models could be returned as vision-capable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves variant metadata in the multimodal fallback chain and ensures the `look-at` tool only uses vision-capable models. Adds a safe early check that blocks only when a resolved model is explicitly non-vision.

- **Bug Fixes**
  - Preserve hardcoded variant for cache-derived fallback entries, including when the registered model matches a cache entry.
  - Block non-vision registered models via `isVisionCapableAgentModel`; return empty metadata when none.
  - In `look-at`, fail fast only if a resolved model is not vision-capable; do not block when no model is resolved.

<sup>Written for commit a668860b8690899b8ada141bc7f87be0f7fb9f87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

