### PR TITLE
fix(background-agent): add TTL for terminal task retention

### DIFF
--- a/src/features/background-agent/task-poller.test.ts
+++ b/src/features/background-agent/task-poller.test.ts
@@ -420,6 +420,21 @@ describe("checkAndInterruptStaleTasks", () => {
 })
 
 describe("pruneStaleTasksAndNotifications", () => {
+  function createTerminalTask(overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+    return {
+      id: "terminal-task",
+      parentSessionID: "parent",
+      parentMessageID: "msg",
+      description: "terminal",
+      prompt: "terminal",
+      agent: "explore",
+      status: "completed",
+      startedAt: new Date(Date.now() - 40 * 60 * 1000),
+      completedAt: new Date(Date.now() - 31 * 60 * 1000),
+      ...overrides,
+    }
+  }
+
   it("should prune tasks that exceeded TTL", () => {
     //#given
     const tasks = new Map<string, BackgroundTask>()
@@ -449,24 +464,18 @@ describe("pruneStaleTasksAndNotifications", () => {
     expect(pruned).toContain("old-task")
   })
 
-  it("should skip terminal tasks even when they exceeded TTL", () => {
+  it("should prune terminal tasks when completion time exceeds terminal TTL", () => {
     //#given
     const tasks = new Map<string, BackgroundTask>()
-    const oldStartedAt = new Date(Date.now() - 31 * 60 * 1000)
     const terminalStatuses: BackgroundTask["status"][] = ["completed", "error", "cancelled", "interrupt"]
 
     for (const status of terminalStatuses) {
-      tasks.set(status, {
+      tasks.set(status, createTerminalTask({
         id: status,
-        parentSessionID: "parent",
-        parentMessageID: "msg",
         description: status,
         prompt: status,
-        agent: "explore",
         status,
-        startedAt: oldStartedAt,
-        completedAt: new Date(),
-      })
+      }))
     }
 
     const pruned: string[] = []
@@ -480,6 +489,26 @@ describe("pruneStaleTasksAndNotifications", () => {
 
     //#then
     expect(pruned).toEqual([])
-    expect(Array.from(tasks.keys())).toEqual(terminalStatuses)
+    expect(Array.from(tasks.keys())).toEqual([])
+  })
+
+  it("should keep terminal tasks with pending notifications until notification cleanup", () => {
+    //#given
+    const task = createTerminalTask()
+    const tasks = new Map<string, BackgroundTask>([[task.id, task]])
+    const notifications = new Map<string, BackgroundTask[]>([[task.parentSessionID, [task]]])
+    const pruned: string[] = []
+
+    //#when
+    pruneStaleTasksAndNotifications({
+      tasks,
+      notifications,
+      onTaskPruned: (taskId) => pruned.push(taskId),
+    })
+
+    //#then
+    expect(pruned).toEqual([])
+    expect(tasks.has(task.id)).toBe(true)
+    expect(notifications.has(task.parentSessionID)).toBe(false)
   })
 })

--- a/src/features/background-agent/task-poller.ts
+++ b/src/features/background-agent/task-poller.ts
@@ -13,6 +13,8 @@ import {
 } from "./constants"
 import { removeTaskToastTracking } from "./remove-task-toast-tracking"
 
+const TERMINAL_TASK_TTL_MS = 30 * 60 * 1000
+
 const TERMINAL_TASK_STATUSES = new Set<BackgroundTask["status"]>([
   "completed",
   "error",
@@ -27,9 +29,28 @@ export function pruneStaleTasksAndNotifications(args: {
 }): void {
   const { tasks, notifications, onTaskPruned } = args
   const now = Date.now()
+  const tasksWithPendingNotifications = new Set<string>()
+
+  for (const queued of notifications.values()) {
+    for (const task of queued) {
+      tasksWithPendingNotifications.add(task.id)
+    }
+  }
 
   for (const [taskId, task] of tasks.entries()) {
-    if (TERMINAL_TASK_STATUSES.has(task.status)) continue
+    if (TERMINAL_TASK_STATUSES.has(task.status)) {
+      if (tasksWithPendingNotifications.has(taskId)) continue
+
+      const completedAt = task.completedAt?.getTime()
+      if (!completedAt) continue
+
+      const age = now - completedAt
+      if (age <= TERMINAL_TASK_TTL_MS) continue
+
+      removeTaskToastTracking(taskId)
+      tasks.delete(taskId)
+      continue
+    }
 
     const timestamp = task.status === "pending"
       ? task.queuedAt?.getTime()


### PR DESCRIPTION
## Summary
- add `TERMINAL_TASK_TTL_MS` to hard-prune terminal background tasks once their `completedAt` age exceeds 30 minutes
- keep terminal tasks alive while they still have pending notifications, then let notification cleanup clear the queue
- add regression coverage for terminal TTL pruning and pending-notification preservation

## Testing
- bun test src/features/background-agent/
- bun run build


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 30-minute TTL for terminal background tasks and prune them after completion unless they still have pending notifications. This prevents unbounded task growth in the background agent.

- **Bug Fixes**
  - Prune terminal tasks after 30 minutes from completedAt (`TERMINAL_TASK_TTL_MS`).
  - Keep terminal tasks with pending notifications; let notification cleanup run first.
  - Add regression tests for TTL pruning and notification preservation.

<sup>Written for commit 0d9f001c115c02d57daface95a51fe16f184f266. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

