### PR TITLE
fix: tighten Anthropic provider matching and fix look-at test isolation

### DIFF
--- a/src/shared/context-limit-resolver.ts
+++ b/src/shared/context-limit-resolver.ts
@@ -8,7 +8,8 @@ export type ContextLimitModelCacheState = {
 }
 
 function isAnthropicProvider(providerID: string): boolean {
-  return providerID.toLowerCase().includes("anthropic")
+  const normalized = providerID.toLowerCase()
+  return normalized === "anthropic" || normalized === "google-vertex-anthropic" || normalized === "aws-bedrock-anthropic"
 }
 
 function getAnthropicActualLimit(modelCacheState?: ContextLimitModelCacheState): number {

--- a/src/tools/look-at/tools.test.ts
+++ b/src/tools/look-at/tools.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test, mock } from "bun:test"
+import { afterEach, describe, expect, test, mock } from "bun:test"
 import type { ToolContext } from "@opencode-ai/plugin/tool"
-import { setVisionCapableModelsCache } from "../../shared/vision-capable-models-cache"
+import { clearVisionCapableModelsCache, setVisionCapableModelsCache } from "../../shared/vision-capable-models-cache"
 import { normalizeArgs, validateArgs, createLookAt } from "./tools"
 
 describe("look-at tool", () => {
+  afterEach(() => {
+    clearVisionCapableModelsCache()
+  })
+
   describe("normalizeArgs", () => {
     // given LLM might use `path` instead of `file_path`
     // when called with path parameter


### PR DESCRIPTION
## Summary

- **context-limit-resolver.ts**: Replace `providerID.toLowerCase().includes("anthropic")` with exact matching against known Anthropic provider IDs (`anthropic`, `google-vertex-anthropic`, `aws-bedrock-anthropic`). Prevents hypothetical false positives from providers containing "anthropic" substring. Follows existing pattern from `preemptive-compaction.ts` and `anthropic-effort/hook.ts`.
- **tools.test.ts**: Add `afterEach` cleanup calling `clearVisionCapableModelsCache()` to prevent vision model cache state from leaking between tests.

## What was NOT fixed (and why)

The ultrabrain regression check also flagged 2 other items:
- **subagent-spawn-limits.test.ts mock return type**: False positive — the `createMockClient()` helper already uses `as OpencodeClient` cast, and TypeScript compiles clean. The mock structure correctly exercises the runtime error paths.
- **event-compaction-agent.test.ts mock event shape**: False positive — `providerID`/`modelID` fields on the event `info` object match the runtime access pattern in `event.ts` (lines 324-325). TypeScript compiles clean.

Both "false positive" files have 0 type errors and all tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened Anthropic provider detection with exact ID matching and added test cleanup to keep look-at tool tests isolated.

- **Bug Fixes**
  - Use exact matches for Anthropic provider IDs (`anthropic`, `google-vertex-anthropic`, `aws-bedrock-anthropic`) in `context-limit-resolver.ts` to avoid substring false positives.
  - Add `afterEach` to clear the vision-capable models cache in `src/tools/look-at/tools.test.ts` to prevent cross-test state leakage.

<sup>Written for commit f1b5b1023f2b22de6a0b75a66abe0b6def25ca07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

