### PR TITLE
fix: register preemptive-compaction event handler in dispatchToHooks

### DIFF
--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -174,6 +174,7 @@ export function createEventHandler(args: {
     await Promise.resolve(hooks.todoContinuationEnforcer?.handler?.(input));
     await Promise.resolve(hooks.unstableAgentBabysitter?.event?.(input));
     await Promise.resolve(hooks.contextWindowMonitor?.event?.(input));
+    await Promise.resolve(hooks.preemptiveCompaction?.event?.(input));
     await Promise.resolve(hooks.directoryAgentsInjector?.event?.(input));
     await Promise.resolve(hooks.directoryReadmeInjector?.event?.(input));
     await Promise.resolve(hooks.rulesInjector?.event?.(input));


### PR DESCRIPTION
Closes #2300

## Summary
- Register preemptiveCompaction.event in dispatchToHooks so tokenCache is populated
- One-line fix: adds dispatch call matching existing hook patterns


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers `preemptiveCompaction.event` in `dispatchToHooks` so preemptive-compaction events are dispatched and the token cache is populated as expected. Aligns with existing hook dispatch pattern to fix the missing handler invocation.

<sup>Written for commit 4a67044cd637301c819dbb7a8406b70d0844f0e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

