### PR TITLE
fix: make Edit tool lines schema compatible with Vertex AI strict validation

### DIFF
--- a/src/plugin/normalize-tool-arg-schemas.test.ts
+++ b/src/plugin/normalize-tool-arg-schemas.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { pathToFileURL } from "node:url"
 import { tool } from "@opencode-ai/plugin"
+import { createHashlineEditTool } from "../tools/hashline-edit"
 import { normalizeToolArgSchemas } from "./normalize-tool-arg-schemas"
 
 const tempDirectories: string[] = []
@@ -17,6 +18,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function getNestedRecord(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
   const value = record[key]
   return isRecord(value) ? value : undefined
+}
+
+function getRecordAtPath(record: Record<string, unknown>, path: string[]): Record<string, unknown> | undefined {
+  return path.reduce<Record<string, unknown> | undefined>(
+    (currentRecord, key) => (currentRecord ? getNestedRecord(currentRecord, key) : undefined),
+    record,
+  )
 }
 
 async function loadSeparateHostZodModule(): Promise<typeof import("zod")> {
@@ -93,5 +101,30 @@ describe("normalizeToolArgSchemas", () => {
     expect(afterQuery?.description).toBe("Free-text search query")
     expect(afterQuery?.title).toBe("Query")
     expect(afterQuery?.examples).toEqual(["issue 2314"])
+  })
+
+  it("collapses hashline lines union into a Vertex-compatible array schema", async () => {
+    // given
+    const hostZod = await loadSeparateHostZodModule()
+    const toolDefinition = createHashlineEditTool()
+
+    // when
+    const beforeSchema = serializeWithHostZod(hostZod, toolDefinition.args)
+    const beforeLines = getRecordAtPath(beforeSchema, ["properties", "edits", "items", "properties", "lines"])
+
+    normalizeToolArgSchemas(toolDefinition)
+
+    const afterSchema = serializeWithHostZod(hostZod, toolDefinition.args)
+    const afterLines = getRecordAtPath(afterSchema, ["properties", "edits", "items", "properties", "lines"])
+    const afterItems = afterLines ? getNestedRecord(afterLines, "items") : undefined
+
+    // then
+    expect(beforeLines?.type).toBeUndefined()
+    expect(Array.isArray(beforeLines?.anyOf)).toBe(true)
+    expect(afterLines?.type).toBe("array")
+    expect(afterLines?.nullable).toBe(true)
+    expect(afterLines?.anyOf).toBeUndefined()
+    expect(afterItems?.type).toBe("string")
+    expect(afterLines?.description).toBe("Replacement or inserted lines. null/[] deletes with replace")
   })
 })

--- a/src/plugin/normalize-tool-arg-schemas.ts
+++ b/src/plugin/normalize-tool-arg-schemas.ts
@@ -9,9 +9,104 @@ type SchemaWithJsonSchemaOverride = ToolArgSchema & {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
 function stripRootJsonSchemaFields(jsonSchema: Record<string, unknown>): Record<string, unknown> {
   const { $schema: _schema, ...rest } = jsonSchema
   return rest
+}
+
+function isNullSchema(jsonSchema: Record<string, unknown>): boolean {
+  return jsonSchema.type === "null"
+}
+
+function isStringSchema(jsonSchema: Record<string, unknown>): boolean {
+  return jsonSchema.type === "string"
+}
+
+function isStringArraySchema(jsonSchema: Record<string, unknown>): boolean {
+  if (jsonSchema.type !== "array") {
+    return false
+  }
+
+  const items = jsonSchema.items
+  return isRecord(items) && items.type === "string"
+}
+
+function collapseNullableUnion(
+  jsonSchema: Record<string, unknown>,
+  variants: Record<string, unknown>[],
+): Record<string, unknown> | null {
+  const nonNullVariants = variants.filter((variant) => !isNullSchema(variant))
+
+  if (nonNullVariants.length !== 1 || variants.length !== nonNullVariants.length + 1) {
+    return null
+  }
+
+  const { anyOf: _anyOf, ...schemaWithoutAnyOf } = jsonSchema
+  return {
+    ...nonNullVariants[0],
+    ...schemaWithoutAnyOf,
+    nullable: true,
+  }
+}
+
+function collapseStringOrStringArrayUnion(
+  jsonSchema: Record<string, unknown>,
+  variants: Record<string, unknown>[],
+): Record<string, unknown> | null {
+  const nonNullVariants = variants.filter((variant) => !isNullSchema(variant))
+  const stringVariant = nonNullVariants.find(isStringSchema)
+  const stringArrayVariant = nonNullVariants.find(isStringArraySchema)
+
+  if (!stringVariant || !stringArrayVariant || nonNullVariants.length !== 2) {
+    return null
+  }
+
+  const { anyOf: _anyOf, ...schemaWithoutAnyOf } = jsonSchema
+
+  return {
+    ...stringArrayVariant,
+    ...schemaWithoutAnyOf,
+    nullable: variants.length !== nonNullVariants.length,
+  }
+}
+
+function normalizeAnyOfUnion(jsonSchema: Record<string, unknown>): Record<string, unknown> {
+  const anyOf = jsonSchema.anyOf
+  if (!Array.isArray(anyOf) || jsonSchema.type !== undefined) {
+    return jsonSchema
+  }
+
+  const variants = anyOf.filter(isRecord)
+  if (variants.length !== anyOf.length) {
+    return jsonSchema
+  }
+
+  return collapseNullableUnion(jsonSchema, variants) ?? collapseStringOrStringArrayUnion(jsonSchema, variants) ?? jsonSchema
+}
+
+function normalizeJsonSchemaValue(jsonSchema: unknown): unknown {
+  if (Array.isArray(jsonSchema)) {
+    return jsonSchema.map((item) => normalizeJsonSchemaValue(item))
+  }
+
+  if (!isRecord(jsonSchema)) {
+    return jsonSchema
+  }
+
+  return normalizeJsonSchema(jsonSchema)
+}
+
+function normalizeJsonSchema(jsonSchema: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(jsonSchema)) {
+    normalized[key] = normalizeJsonSchemaValue(value)
+  }
+
+  return normalizeAnyOfUnion(normalized)
 }
 
 function attachJsonSchemaOverride(schema: SchemaWithJsonSchemaOverride): void {
@@ -24,7 +119,7 @@ function attachJsonSchemaOverride(schema: SchemaWithJsonSchemaOverride): void {
     delete schema._zod.toJSONSchema
 
     try {
-      return stripRootJsonSchemaFields(tool.schema.toJSONSchema(schema))
+      return normalizeJsonSchema(stripRootJsonSchemaFields(tool.schema.toJSONSchema(schema)))
     } finally {
       schema._zod.toJSONSchema = originalOverride
     }

--- a/src/tools/hashline-edit/tools.test.ts
+++ b/src/tools/hashline-edit/tools.test.ts
@@ -192,6 +192,25 @@ describe("createHashlineEditTool", () => {
     expect(result).toContain("non-empty")
   })
 
+  it("treats replace with null lines as deletion", async () => {
+    //#given
+    const filePath = path.join(tempDir, "delete-line.txt")
+    fs.writeFileSync(filePath, "line1\nline2\nline3")
+    const line2Hash = computeLineHash(2, "line2")
+
+    //#when
+    await tool.execute(
+      {
+        filePath,
+        edits: [{ op: "replace", pos: `2#${line2Hash}`, lines: null }],
+      },
+      createMockContext(),
+    )
+
+    //#then
+    expect(fs.readFileSync(filePath, "utf-8")).toBe("line1\nline3")
+  })
+
   it("supports file rename with edits", async () => {
     //#given
     const filePath = path.join(tempDir, "source.txt")


### PR DESCRIPTION
Closes #2408

## Summary
- Normalize Edit tool lines schema to include a Vertex-compatible top-level type
- Preserve existing Edit tool behavior for string, string[], and null inputs
- Add regression coverage for schema serialization and null delete behavior


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the Edit tool `lines` schema for Vertex AI strict validation. Collapses string|string[]|null into a nullable string array without changing behavior (string/string[] still accepted; null deletes on replace). Fixes #2408.

- **Bug Fixes**
  - Add JSON Schema normalization that collapses `anyOf` unions into a single top-level type when possible (nullable and string|string[] cases).
  - Emit Vertex‑compatible schema for `edits[].lines`: `{ type: "array", items: { type: "string" }, nullable: true }` with the existing description.
  - Preserve runtime behavior: string and string[] inputs continue to work; `lines: null` with `op: "replace"` deletes content.
  - Add regression tests for schema serialization and null‑delete behavior.

<sup>Written for commit 5073cc6b156d7ffd94a11ad9122a1b2136e5cfd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

