### PR TITLE
fix: pass agent summaries array instead of client object to createBuiltinAgents (#2386)

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -38,7 +38,7 @@ export async function applyAgentConfig(params: {
   pluginComponents: PluginComponents;
 }): Promise<Record<string, unknown>> {
   const migratedDisabledAgents = (params.pluginConfig.disabled_agents ?? []).map(
-    (agent) => {
+    (agent: string) => {
       return AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent;
     },
   ) as typeof params.pluginConfig.disabled_agents;
@@ -77,6 +77,31 @@ export async function applyAgentConfig(params: {
   const disabledSkills = new Set<string>(params.pluginConfig.disabled_skills ?? []);
   const useTaskSystem = params.pluginConfig.experimental?.task_system ?? false;
   const disableOmoEnv = params.pluginConfig.experimental?.disable_omo_env ?? false;
+  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
+  const userAgents = includeClaudeAgents ? loadUserAgents() : {};
+  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
+  const rawPluginAgents = params.pluginComponents.agents;
+  const pluginAgents = Object.fromEntries(
+    Object.entries(rawPluginAgents).map(([key, value]) => [
+      key,
+      value ? migrateAgentConfig(value as Record<string, unknown>) : value,
+    ]),
+  );
+  const configAgent = params.config.agent as AgentConfigRecord | undefined;
+  const registeredAgentSummaries = Object.entries({
+    ...userAgents,
+    ...projectAgents,
+    ...pluginAgents,
+    ...configAgent,
+  })
+    .filter((entry): entry is [string, Record<string, unknown>] => {
+      const registeredAgent = entry[1];
+      return typeof registeredAgent === "object" && registeredAgent !== null;
+    })
+    .map(([name, registeredAgent]) => ({
+      name,
+      ...registeredAgent,
+    }));
 
   const builtinAgents = await createBuiltinAgents(
     migratedDisabledAgents,
@@ -86,7 +111,7 @@ export async function applyAgentConfig(params: {
     params.pluginConfig.categories,
     params.pluginConfig.git_master,
     allDiscoveredSkills,
-    params.ctx.client,
+    registeredAgentSummaries,
     browserProvider,
     currentModel,
     disabledSkills,
@@ -94,20 +119,8 @@ export async function applyAgentConfig(params: {
     disableOmoEnv,
   );
 
-  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
-  const userAgents = includeClaudeAgents ? loadUserAgents() : {};
-  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
-
-  const rawPluginAgents = params.pluginComponents.agents;
-  const pluginAgents = Object.fromEntries(
-    Object.entries(rawPluginAgents).map(([key, value]) => [
-      key,
-      value ? migrateAgentConfig(value as Record<string, unknown>) : value,
-    ]),
-  );
-
   const disabledAgentNames = new Set(
-    (migratedDisabledAgents ?? []).map(a => a.toLowerCase())
+    (migratedDisabledAgents ?? []).map((agentName: string) => agentName.toLowerCase())
   );
 
   const filterDisabledAgents = (agents: Record<string, unknown>) =>
@@ -122,8 +135,6 @@ export async function applyAgentConfig(params: {
   const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
   const shouldDemotePlan = plannerEnabled && replacePlan;
   const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
-
-  const configAgent = params.config.agent as AgentConfigRecord | undefined;
 
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
     if (configuredDefaultAgent) {


### PR DESCRIPTION
## Summary
- Load registered Claude Code, plugin, and config agents before builtin agent creation.
- Pass merged registered agent summaries to `createBuiltinAgents()` so custom agents are injected into builtin orchestrator prompts.
- Keep `createBuiltinAgents()` and `parseRegisteredAgentSummaries()` behavior unchanged.

## Validation
- `bun run typecheck`
- `bun test` *(fails in existing `src/plugin-config.test.ts` assertions unrelated to this change in this worktree)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass registered agent summaries to `createBuiltinAgents` and load them before builtin creation, so custom agents are correctly injected into builtin orchestrator prompts. Fixes missing Claude Code, plugin, and config agents when `claude_code.agents` is enabled.

- **Bug Fixes**
  - Build `registeredAgentSummaries` from user, project, plugin, and config agents, and pass it to `createBuiltinAgents` (replaces `params.ctx.client`).
  - Load registered agents before builtin agent creation.
  - Normalize disabled agent names and migrate plugin agent configs where present.

<sup>Written for commit 943dd365208c4e4f1eabdaebee74ab8f671310b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

