### PR TITLE
fix: skip preemptive compaction when model context limit is unknown

### DIFF
--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -92,12 +92,25 @@ export function createPreemptiveCompactionHook(
     const cached = tokenCache.get(sessionID)
     if (!cached) return
 
-    const modelSpecificLimit = !isAnthropicProvider(cached.providerID)
+    const isAnthropic = isAnthropicProvider(cached.providerID)
+    const modelSpecificLimit = !isAnthropic
       ? modelCacheState?.modelContextLimitsCache?.get(`${cached.providerID}/${cached.modelID}`)
       : undefined
-    const actualLimit = isAnthropicProvider(cached.providerID)
-      ? getAnthropicActualLimit(modelCacheState)
-      : modelSpecificLimit ?? DEFAULT_ACTUAL_LIMIT
+
+    let actualLimit: number
+    if (isAnthropic) {
+      actualLimit = getAnthropicActualLimit(modelCacheState)
+    } else {
+      if (modelSpecificLimit === undefined) {
+        log("[preemptive-compaction] Skipping preemptive compaction: unknown context limit for model", {
+          providerID: cached.providerID,
+          modelID: cached.modelID,
+        })
+        return
+      }
+
+      actualLimit = modelSpecificLimit
+    }
 
     const lastTokens = cached.tokens
     const totalInputTokens = (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0)


### PR DESCRIPTION
## Summary
- Skip preemptive compaction when a non-Anthropic model has no cached context limit instead of falling back to 200K.
- Log the skipped compaction with provider and model IDs so cache misses are visible during debugging.
- Keep `DEFAULT_ACTUAL_LIMIT` for existing Anthropic behavior without using it as the cache-miss fallback.

## Testing
- `bun run typecheck`
- `bun test` *(currently fails in `src/plugin-config.test.ts` with two existing `parseConfigPartially` assertions unrelated to this change)*

## Related
- Fixes #2356
- Related to #2300


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip preemptive compaction for non-Anthropic models when their context limit isn’t cached, instead of assuming 200K, and log when this happens for visibility. Anthropic behavior is unchanged. Fixes #2356.

- **Bug Fixes**
  - Avoid fallback to `DEFAULT_ACTUAL_LIMIT` for non-Anthropic cache misses; return early instead.
  - Log skipped compaction with `providerID` and `modelID` to surface cache misses.

<sup>Written for commit 26091b2f48e20cd3db9dec7d3dec28e8b5acd695. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

