### PR TITLE
fix: sync root package.json version before binary compile

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -82,6 +82,11 @@ jobs:
           cd packages/${{ matrix.platform }}
           jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
 
+      - name: Set root package version
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          jq --arg v "${{ inputs.version }}" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+
       - name: Pre-download baseline compile target
         if: steps.check.outputs.skip != 'true' && endsWith(matrix.platform, '-baseline')
         shell: bash


### PR DESCRIPTION
Closes #2407

## Summary
- Add step in publish-platform.yml to update root package.json version before bun build --compile
- Ensures compiled binary reports correct version via --version flag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the root package.json to the release version before compiling so the binary reports the correct version with --version. Fixes #2407.

- **Bug Fixes**
  - In `.github/workflows/publish-platform.yml`, add a step to set the root `package.json` version from `inputs.version` (only when not skipped) before `bun build --compile`.

<sup>Written for commit 88568398ac8115b88cda5991e8d3391eb1c70e29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

