### PR TITLE
fix: restore await on metadata call in create-background-task

### DIFF
--- a/src/tools/background-task/create-background-task.ts
+++ b/src/tools/background-task/create-background-task.ts
@@ -98,7 +98,7 @@ export function createBackgroundTask(
             ...(sessionId ? { sessionId } : {}),
           },
         }
-        ctx.metadata?.(bgMeta)
+        await ctx.metadata?.(bgMeta)
 
         if (ctx.callID) {
           storeToolMetadata(ctx.sessionID, ctx.callID, bgMeta)


### PR DESCRIPTION
Follow-up to #2476. Restores await on ctx.metadata() call as identified by cubic code reviewer — prevents race condition where tool execution completes before metadata is written.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore awaiting the `ctx.metadata(bgMeta)` call in `create-background-task` so metadata is written before the task completes, preventing a race condition that could miss or delay metadata.

<sup>Written for commit 9eefbfe3103e8651807a6b008e4c27ee8c57398d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

