### PR TITLE
fix: add FreeUsageLimitError to RETRYABLE_ERROR_NAMES set

### DIFF
--- a/src/shared/model-error-classifier.test.ts
+++ b/src/shared/model-error-classifier.test.ts
@@ -82,4 +82,26 @@ describe("model-error-classifier", () => {
     //#then
     expect(provider).toBe("provider-x")
   })
+
+  test("treats FreeUsageLimitError (lowercase) as retryable by name", () => {
+    //#given
+    const error = { name: "FreeUsageLimitError" }
+
+    //#when
+    const result = shouldRetryError(error)
+
+    //#then
+    expect(result).toBe(true)
+  })
+
+  test("treats freeusagelimiterror (lowercase name) as retryable by name", () => {
+    //#given
+    const error = { name: "freeusagelimiterror" }
+
+    //#when
+    const result = shouldRetryError(error)
+
+    //#then
+    expect(result).toBe(true)
+  })
 })

--- a/src/shared/model-error-classifier.test.ts
+++ b/src/shared/model-error-classifier.test.ts
@@ -83,7 +83,7 @@ describe("model-error-classifier", () => {
     expect(provider).toBe("provider-x")
   })
 
-  test("treats FreeUsageLimitError (lowercase) as retryable by name", () => {
+  test("treats FreeUsageLimitError (PascalCase name) as retryable by name", () => {
     //#given
     const error = { name: "FreeUsageLimitError" }
 

--- a/src/shared/model-error-classifier.ts
+++ b/src/shared/model-error-classifier.ts
@@ -13,6 +13,7 @@ const RETRYABLE_ERROR_NAMES = new Set([
   "ModelUnavailableError",
   "ProviderConnectionError",
   "AuthenticationError",
+  "freeusagelimiterror",
 ])
 
 /**
@@ -97,12 +98,13 @@ export interface ErrorInfo {
 export function isRetryableModelError(error: ErrorInfo): boolean {
   // If we have an error name, check against known lists
   if (error.name) {
+    const errorNameLower = error.name.toLowerCase()
     // Explicit non-retryable takes precedence
-    if (NON_RETRYABLE_ERROR_NAMES.has(error.name)) {
+    if (NON_RETRYABLE_ERROR_NAMES.has(errorNameLower)) {
       return false
     }
     // Check if it's a known retryable error
-    if (RETRYABLE_ERROR_NAMES.has(error.name)) {
+    if (RETRYABLE_ERROR_NAMES.has(errorNameLower)) {
       return true
     }
   }

--- a/src/shared/model-error-classifier.ts
+++ b/src/shared/model-error-classifier.ts
@@ -6,13 +6,13 @@ import { readConnectedProvidersCache } from "./connected-providers-cache"
  * These errors completely halt the action loop and should trigger fallback retry.
  */
 const RETRYABLE_ERROR_NAMES = new Set([
-  "ProviderModelNotFoundError",
-  "RateLimitError",
-  "QuotaExceededError",
-  "InsufficientCreditsError",
-  "ModelUnavailableError",
-  "ProviderConnectionError",
-  "AuthenticationError",
+  "providermodelnotfounderror",
+  "ratelimiterror",
+  "quotaexceedederror",
+  "insufficientcreditserror",
+  "modelunavailableerror",
+  "providerconnectionerror",
+  "authenticationerror",
   "freeusagelimiterror",
 ])
 
@@ -21,13 +21,13 @@ const RETRYABLE_ERROR_NAMES = new Set([
  * These errors are typically user-induced or fixable without switching models.
  */
 const NON_RETRYABLE_ERROR_NAMES = new Set([
-  "MessageAbortedError",
-  "PermissionDeniedError",
-  "ContextLengthError",
-  "TimeoutError",
-  "ValidationError",
-  "SyntaxError",
-  "UserError",
+  "messageabortederror",
+  "permissiondeniederror",
+  "contextlengtherror",
+  "timeouterror",
+  "validationerror",
+  "syntaxerror",
+  "usererror",
 ])
 
 /**

--- a/src/tools/background-task/create-background-task.ts
+++ b/src/tools/background-task/create-background-task.ts
@@ -98,7 +98,7 @@ export function createBackgroundTask(
             ...(sessionId ? { sessionId } : {}),
           },
         }
-        await ctx.metadata?.(bgMeta)
+        ctx.metadata?.(bgMeta)
 
         if (ctx.callID) {
           storeToolMetadata(ctx.sessionID, ctx.callID, bgMeta)

--- a/src/tools/background-task/create-background-task.ts
+++ b/src/tools/background-task/create-background-task.ts
@@ -98,7 +98,7 @@ export function createBackgroundTask(
             ...(sessionId ? { sessionId } : {}),
           },
         }
-        ctx.metadata?.(bgMeta)
+        await ctx.metadata?.(bgMeta)
 
         if (ctx.callID) {
           storeToolMetadata(ctx.sessionID, ctx.callID, bgMeta)


### PR DESCRIPTION
Follow-up to #2422. Adds FreeUsageLimitError to structured error name set as identified by cubic code reviewer — aligns with OpenCode SDK error classification model.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats FreeUsageLimitError as retryable and makes error name checks case-insensitive, resolving Linear issue 2393 (Cubic error name not retried).

- **Bug Fixes**
  - Normalize error names to lowercase for both retryable and non-retryable checks, add "freeusagelimiterror" to the retryable set, and add tests for PascalCase/lowercase variants.

<sup>Written for commit 755efe226eeb28da44952b414621d895efc5e30e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

