### PR TITLE
fix: preserve session provider context in fallback chain

### DIFF
--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -19,11 +19,12 @@ import {
 import { getFallbackModelsForSession } from "../hooks/runtime-fallback/fallback-models";
 import { resetMessageCursor } from "../shared";
 import { getAgentConfigKey } from "../shared/agent-display-names";
+import { readConnectedProvidersCache } from "../shared/connected-providers-cache";
 import { log } from "../shared/logger";
 import { shouldRetryError } from "../shared/model-error-classifier";
 import { buildFallbackChainFromModels } from "../shared/fallback-chain-from-models";
 import { extractRetryAttempt, normalizeRetryStatusMessage } from "../shared/retry-status-utils";
-import { clearSessionModel, setSessionModel } from "../shared/session-model-state";
+import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state";
 import { deleteSessionTools } from "../shared/session-tools-store";
 import { lspManager } from "../tools";
 
@@ -164,6 +165,30 @@ export function createEventHandler(args: {
   const lastHandledModelErrorMessageID = new Map<string, string>();
   const lastHandledRetryStatusKey = new Map<string, string>();
   const lastKnownModelBySession = new Map<string, { providerID: string; modelID: string }>();
+
+  const resolveFallbackProviderID = (sessionID: string, providerHint?: string): string => {
+    const sessionModel = getSessionModel(sessionID);
+    if (sessionModel?.providerID) {
+      return sessionModel.providerID;
+    }
+
+    const lastKnownModel = lastKnownModelBySession.get(sessionID);
+    if (lastKnownModel?.providerID) {
+      return lastKnownModel.providerID;
+    }
+
+    const connectedProvider = readConnectedProvidersCache()?.[0];
+    if (connectedProvider) {
+      return connectedProvider;
+    }
+
+    const normalizedProviderHint = providerHint?.trim();
+    if (normalizedProviderHint) {
+      return normalizedProviderHint;
+    }
+
+    return "opencode";
+  };
 
   const dispatchToHooks = async (input: EventInput): Promise<void> => {
     await Promise.resolve(hooks.autoUpdateChecker?.event?.(input));
@@ -360,7 +385,10 @@ export function createEventHandler(args: {
               }
 
               if (agentName) {
-                const currentProvider = (info?.providerID as string | undefined) ?? "opencode";
+                const currentProvider = resolveFallbackProviderID(
+                  sessionID,
+                  info?.providerID as string | undefined,
+                );
                 const rawModel = (info?.modelID as string | undefined) ?? "claude-opus-4-6";
                 const currentModel = normalizeFallbackModelID(rawModel);
                 applyUserConfiguredFallbackChain(sessionID, agentName, currentProvider, args.pluginConfig);
@@ -417,7 +445,7 @@ export function createEventHandler(args: {
             if (agentName) {
               const parsed = extractProviderModelFromErrorMessage(retryMessage);
               const lastKnown = lastKnownModelBySession.get(sessionID);
-              const currentProvider = parsed.providerID ?? lastKnown?.providerID ?? "opencode";
+              const currentProvider = resolveFallbackProviderID(sessionID, parsed.providerID);
               let currentModel = parsed.modelID ?? lastKnown?.modelID ?? "claude-opus-4-6";
               currentModel = normalizeFallbackModelID(currentModel);
               applyUserConfiguredFallbackChain(sessionID, agentName, currentProvider, args.pluginConfig);
@@ -489,7 +517,10 @@ export function createEventHandler(args: {
 
           if (agentName) {
             const parsed = extractProviderModelFromErrorMessage(errorMessage);
-            const currentProvider = (props?.providerID as string) || parsed.providerID || "opencode";
+            const currentProvider = resolveFallbackProviderID(
+              sessionID,
+              (props?.providerID as string | undefined) || parsed.providerID,
+            );
             let currentModel = (props?.modelID as string) || parsed.modelID || "claude-opus-4-6";
             currentModel = normalizeFallbackModelID(currentModel);
             applyUserConfiguredFallbackChain(sessionID, agentName, currentProvider, args.pluginConfig);

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -177,14 +177,14 @@ export function createEventHandler(args: {
       return lastKnownModel.providerID;
     }
 
-    const connectedProvider = readConnectedProvidersCache()?.[0];
-    if (connectedProvider) {
-      return connectedProvider;
-    }
-
     const normalizedProviderHint = providerHint?.trim();
     if (normalizedProviderHint) {
       return normalizedProviderHint;
+    }
+
+    const connectedProvider = readConnectedProvidersCache()?.[0];
+    if (connectedProvider) {
+      return connectedProvider;
     }
 
     return "opencode";

--- a/src/shared/fallback-chain-from-models.test.ts
+++ b/src/shared/fallback-chain-from-models.test.ts
@@ -1,4 +1,5 @@
-import { describe, test, expect } from "bun:test"
+declare const require: (name: string) => any
+const { describe, test, expect } = require("bun:test")
 import { buildFallbackChainFromModels, parseFallbackModelEntry } from "./fallback-chain-from-models"
 
 describe("fallback-chain-from-models", () => {
@@ -28,6 +29,21 @@ describe("fallback-chain-from-models", () => {
     expect(parsed).toEqual({
       providers: ["quotio"],
       model: "glm-5",
+      variant: undefined,
+    })
+  })
+
+  test("uses opencode as absolute fallback provider when context provider is missing", () => {
+    //#given
+    const fallbackModel = "gemini-3-flash"
+
+    //#when
+    const parsed = parseFallbackModelEntry(fallbackModel, undefined)
+
+    //#then
+    expect(parsed).toEqual({
+      providers: ["opencode"],
+      model: "gemini-3-flash",
       variant: undefined,
     })
   })

--- a/src/shared/fallback-chain-from-models.test.ts
+++ b/src/shared/fallback-chain-from-models.test.ts
@@ -1,5 +1,4 @@
-declare const require: (name: string) => any
-const { describe, test, expect } = require("bun:test")
+import { describe, test, expect } from "bun:test"
 import { buildFallbackChainFromModels, parseFallbackModelEntry } from "./fallback-chain-from-models"
 
 describe("fallback-chain-from-models", () => {

--- a/src/shared/fallback-chain-from-models.ts
+++ b/src/shared/fallback-chain-from-models.ts
@@ -39,13 +39,15 @@ function parseVariantFromModel(rawModel: string): { modelID: string; variant?: s
 
 export function parseFallbackModelEntry(
   model: string,
-  defaultProviderID: string,
+  contextProviderID: string | undefined,
+  defaultProviderID = "opencode",
 ): FallbackEntry | undefined {
   const trimmed = model.trim()
   if (!trimmed) return undefined
 
   const parts = trimmed.split("/")
-  const providerID = parts.length >= 2 ? parts[0].trim() : defaultProviderID
+  const providerID =
+    parts.length >= 2 ? parts[0].trim() : (contextProviderID?.trim() || defaultProviderID)
   const rawModelID = parts.length >= 2 ? parts.slice(1).join("/").trim() : trimmed
   if (!providerID || !rawModelID) return undefined
 
@@ -61,13 +63,14 @@ export function parseFallbackModelEntry(
 
 export function buildFallbackChainFromModels(
   fallbackModels: string | string[] | undefined,
-  defaultProviderID: string,
+  contextProviderID: string | undefined,
+  defaultProviderID = "opencode",
 ): FallbackEntry[] | undefined {
   const normalized = normalizeFallbackModels(fallbackModels)
   if (!normalized || normalized.length === 0) return undefined
 
   const parsed = normalized
-    .map((model) => parseFallbackModelEntry(model, defaultProviderID))
+    .map((model) => parseFallbackModelEntry(model, contextProviderID, defaultProviderID))
     .filter((entry): entry is FallbackEntry => entry !== undefined)
 
   if (parsed.length === 0) return undefined


### PR DESCRIPTION
Closes #2295

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the session’s provider context when building fallback chains so retries and agent changes don’t switch providers unexpectedly. Fixes #2295.

- **Bug Fixes**
  - Added `resolveFallbackProviderID` with priority: session model → last-known model → provider hint → connected-provider cache → `"opencode"`.
  - Updated all fallback chain call sites to pass the resolved provider to prevent provider switches on retries and errors.
  - `parseFallbackModelEntry` and `buildFallbackChainFromModels` now accept an optional context provider and default to `"opencode"` when missing.
  - Added a test for default provider behavior; reverted test imports to standard ESM.

<sup>Written for commit 2912b6598ca43d6eb31117cefe56d735ce0672d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

