### PR TITLE
test: update ultrabrain model expectations to gpt-5.4

### DIFF
--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -1116,7 +1116,7 @@ describe("buildAgent with category and skills", () => {
     const agent = buildAgent(source["test-agent"], TEST_MODEL)
 
     // #then - category's built-in model and skills are applied
-    expect(agent.model).toBe("openai/gpt-5.3-codex")
+    expect(agent.model).toBe("openai/gpt-5.4")
     expect(agent.variant).toBe("xhigh")
     expect(agent.prompt).toContain("Role: Designer-Turned-Developer")
     expect(agent.prompt).toContain("Task description")
@@ -1229,9 +1229,9 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - ultrabrain category: model=openai/gpt-5.3-codex, variant=xhigh
+    // #then - ultrabrain category: model=openai/gpt-5.4, variant=xhigh
     expect(agents.oracle).toBeDefined()
-    expect(agents.oracle.model).toBe("openai/gpt-5.3-codex")
+    expect(agents.oracle.model).toBe("openai/gpt-5.4")
     expect(agents.oracle.variant).toBe("xhigh")
   })
 
@@ -1298,9 +1298,9 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - ultrabrain category: model=openai/gpt-5.3-codex, variant=xhigh
+    // #then - ultrabrain category: model=openai/gpt-5.4, variant=xhigh
     expect(agents.sisyphus).toBeDefined()
-    expect(agents.sisyphus.model).toBe("openai/gpt-5.3-codex")
+    expect(agents.sisyphus.model).toBe("openai/gpt-5.4")
     expect(agents.sisyphus.variant).toBe("xhigh")
   })
 
@@ -1313,9 +1313,9 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - ultrabrain category: model=openai/gpt-5.3-codex, variant=xhigh
+    // #then - ultrabrain category: model=openai/gpt-5.4, variant=xhigh
     expect(agents.atlas).toBeDefined()
-    expect(agents.atlas.model).toBe("openai/gpt-5.3-codex")
+    expect(agents.atlas.model).toBe("openai/gpt-5.4")
     expect(agents.atlas.variant).toBe("xhigh")
   })
 

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -557,7 +557,7 @@ describe("Prometheus category config resolution", () => {
 
     // then
     expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.3-codex")
+    expect(config?.model).toBe("openai/gpt-5.4")
     expect(config?.variant).toBe("xhigh")
   })
 
@@ -617,7 +617,7 @@ describe("Prometheus category config resolution", () => {
 
     // then - falls back to DEFAULT_CATEGORIES
     expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.3-codex")
+    expect(config?.model).toBe("openai/gpt-5.4")
     expect(config?.variant).toBe("xhigh")
   })
 


### PR DESCRIPTION
## Summary

Fixes test regressions caused by the `ultrabrain` category model update from `openai/gpt-5.3-codex` to `openai/gpt-5.4` in commit `7c2996201`.

The `DEFAULT_CATEGORIES` was intentionally updated but test expectations were not updated to match.

## Changes

Updated test expectations in:
- `src/plugin-handlers/config-handler.test.ts` (lines 560, 620)
- `src/agents/utils.test.ts` (lines 1119, 1232, 1234, 1301, 1303, 1316, 1318)

## Test Results

- ✅ `bun test src/plugin-handlers/config-handler.test.ts` - 39/39 pass
- ✅ `bun test src/agents/utils.test.ts` - 66/66 pass
- ✅ Total: 105/105 tests pass for changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates tests to expect `openai/gpt-5.4` for the `ultrabrain` category, matching `DEFAULT_CATEGORIES` and fixing CI regressions. This aligns `buildAgent` and category config resolution across suites.

- **Bug Fixes**
  - Updated expectations to `openai/gpt-5.4` in `src/plugin-handlers/config-handler.test.ts` and `src/agents/utils.test.ts`.
  - All affected tests now pass (105/105).

<sup>Written for commit 2d6be11fa06d18f0edb2d90d4e512c81e85b5db6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

