### PR TITLE
fix(test): update agent-variant test model to gpt-5.4

### DIFF
--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -179,7 +179,7 @@ describe("resolveVariantForModel", () => {
         "custom-agent": { category: "ultrabrain" },
       },
     } as OhMyOpenCodeConfig
-    const model = { providerID: "openai", modelID: "gpt-5.3-codex" }
+    const model = { providerID: "openai", modelID: "gpt-5.4" }
 
     // when
     const variant = resolveVariantForModel(config, "custom-agent", model)


### PR DESCRIPTION
Updates the agent-variant test to use gpt-5.4 model, matching the ultrabrain category configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the agent-variant test to use `gpt-5.4`, matching the ultrabrain category config. Fixes the fallback selection test regression.

<sup>Written for commit 9832f7b52e2e36c715b79066f6ef26b61f6bf34d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

