### PR TITLE
fix(doctor): improve version detection and show config path in verbose

### DIFF
--- a/src/cli/doctor/checks/system-loaded-version.ts
+++ b/src/cli/doctor/checks/system-loaded-version.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { getLatestVersion } from "../../../hooks/auto-update-checker/checker"
 import { extractChannel } from "../../../hooks/auto-update-checker"
 import { PACKAGE_NAME } from "../constants"
-import { getOpenCodeCacheDir, getOpenCodeConfigPaths, parseJsonc } from "../../../shared"
+import { getOpenCodeCacheDir, getOpenCodeConfigPaths, parseJsonc, getOpenCodeConfigDir } from "../../../shared"
 
 interface PackageJsonShape {
   version?: string
@@ -54,39 +54,45 @@ function normalizeVersion(value: string | undefined): string | null {
 }
 
 export function getLoadedPluginVersion(): LoadedVersionInfo {
-  const configPaths = getOpenCodeConfigPaths({ binary: "opencode" })
-  const cacheDir = resolveOpenCodeCacheDir()
-  const candidates = [
-    {
-      cacheDir: configPaths.configDir,
-      cachePackagePath: configPaths.packageJson,
-      installedPackagePath: join(configPaths.configDir, "node_modules", PACKAGE_NAME, "package.json"),
-    },
-    {
-      cacheDir,
-      cachePackagePath: join(cacheDir, "package.json"),
-      installedPackagePath: join(cacheDir, "node_modules", PACKAGE_NAME, "package.json"),
-    },
-  ]
+   const configPaths = getOpenCodeConfigPaths({ binary: "opencode" })
+   const cacheDir = resolveOpenCodeCacheDir()
+   const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+   const candidates = [
+     {
+       cacheDir: configPaths.configDir,
+       cachePackagePath: configPaths.packageJson,
+       installedPackagePath: join(configPaths.configDir, "node_modules", PACKAGE_NAME, "package.json"),
+     },
+     {
+       cacheDir,
+       cachePackagePath: join(cacheDir, "package.json"),
+       installedPackagePath: join(cacheDir, "node_modules", PACKAGE_NAME, "package.json"),
+     },
+     {
+       cacheDir: configDir,
+       cachePackagePath: join(configDir, "package.json"),
+       installedPackagePath: join(configDir, "node_modules", PACKAGE_NAME, "package.json"),
+     },
+   ]
 
-  const selectedCandidate = candidates.find((candidate) => existsSync(candidate.installedPackagePath)) ?? candidates[0]
+   const selectedCandidate = candidates.find((candidate) => existsSync(candidate.installedPackagePath)) ?? candidates[0]
 
-  const { cacheDir: selectedDir, cachePackagePath, installedPackagePath } = selectedCandidate
+   const { cacheDir: selectedDir, cachePackagePath, installedPackagePath } = selectedCandidate
 
-  const cachePackage = readPackageJson(cachePackagePath)
-  const installedPackage = readPackageJson(installedPackagePath)
+   const cachePackage = readPackageJson(cachePackagePath)
+   const installedPackage = readPackageJson(installedPackagePath)
 
-  const expectedVersion = normalizeVersion(cachePackage?.dependencies?.[PACKAGE_NAME])
-  const loadedVersion = normalizeVersion(installedPackage?.version)
+   const expectedVersion = normalizeVersion(cachePackage?.dependencies?.[PACKAGE_NAME])
+   const loadedVersion = normalizeVersion(installedPackage?.version)
 
-  return {
-    cacheDir: selectedDir,
-    cachePackagePath,
-    installedPackagePath,
-    expectedVersion,
-    loadedVersion,
-  }
-}
+   return {
+     cacheDir: selectedDir,
+     cachePackagePath,
+     installedPackagePath,
+     expectedVersion,
+     loadedVersion,
+   }
+ }
 
 export async function getLatestPluginVersion(currentVersion: string | null): Promise<string | null> {
   const channel = extractChannel(currentVersion)

--- a/src/cli/doctor/format-verbose.ts
+++ b/src/cli/doctor/format-verbose.ts
@@ -20,6 +20,9 @@ export function formatVerbose(result: DoctorResult): string {
     lines.push(`  ${formatStatusSymbol("pass")} bun         ${systemInfo.bunVersion}`)
   }
   lines.push(`  ${formatStatusSymbol("pass")} path        ${systemInfo.opencodePath ?? "unknown"}`)
+  if (systemInfo.configPath) {
+    lines.push(`  ${formatStatusSymbol("pass")} config      ${systemInfo.configPath}`)
+  }
   if (systemInfo.isLocalDev) {
     lines.push(`  ${color.yellow("*")} ${color.dim("(local development mode)")}`)
   }


### PR DESCRIPTION
## Summary

Closes #2240, Closes #2239

### Fix #2240: Doctor shows 'unknown' when plugin installed in config directory

The `getLoadedPluginVersion()` function only searched the standard cache directory for the installed plugin. When the plugin is installed in the OpenCode config directory instead, it couldn't find the `package.json` and returned `null`, displaying as "unknown".

Now falls back to searching the OpenCode config directory (`~/.config/opencode/node_modules/oh-my-opencode/package.json`) when the cache directory lookup fails.

### Fix #2239: Doctor --verbose should show config path

Added the `oh-my-opencode.jsonc` config file path to the System Information section in verbose output, making it easier to verify which config file is being used.

## Changes

- **`src/cli/doctor/checks/system-loaded-version.ts`** — Added config directory fallback for version detection
- **`src/cli/doctor/format-verbose.ts`** — Added config path display in System Information section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Doctor now detects the loaded `oh-my-opencode` version when the plugin is installed in the OpenCode config directory and shows the active config file path in --verbose output. Fixes #2240 and #2239 to improve troubleshooting clarity.

- **Bug Fixes**
  - Fallback to the OpenCode config directory for version detection when the cache directory check fails.
  - Show the `oh-my-opencode.jsonc` path in the System Information section of `doctor --verbose`.

<sup>Written for commit 335c0320ecc4716c39fd6b094967607c31f956bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

