### PR TITLE
fix(hashline): use strict whitespace hashing (trimEnd only, preserve leading indentation)

### DIFF
--- a/src/tools/hashline-edit/hash-computation.test.ts
+++ b/src/tools/hashline-edit/hash-computation.test.ts
@@ -45,10 +45,36 @@ describe("computeLineHash", () => {
     expect(hash1).not.toBe(hash2)
   })
 
-  it("ignores whitespace differences", () => {
+  it("produces different hashes for different leading indentation", () => {
     //#given
     const content1 = "function hello() {"
-    const content2 = "  function hello() {  "
+    const content2 = "  function hello() {"
+
+    //#when
+    const hash1 = computeLineHash(1, content1)
+    const hash2 = computeLineHash(1, content2)
+
+    //#then
+    expect(hash1).not.toBe(hash2)
+  })
+
+  it("ignores trailing whitespace differences", () => {
+    //#given
+    const content1 = "function hello() {"
+    const content2 = "function hello() {  "
+
+    //#when
+    const hash1 = computeLineHash(1, content1)
+    const hash2 = computeLineHash(1, content2)
+
+    //#then
+    expect(hash1).toBe(hash2)
+  })
+
+  it("produces same hash for CRLF and LF line endings", () => {
+    //#given
+    const content1 = "function hello() {"
+    const content2 = "function hello() {\r"
 
     //#when
     const hash1 = computeLineHash(1, content1)

--- a/src/tools/hashline-edit/hash-computation.ts
+++ b/src/tools/hashline-edit/hash-computation.ts
@@ -4,7 +4,7 @@ import { createHashlineChunkFormatter } from "./hashline-chunk-formatter"
 const RE_SIGNIFICANT = /[\p{L}\p{N}]/u
 
 export function computeLineHash(lineNumber: number, content: string): string {
-  const stripped = content.endsWith("\r") ? content.slice(0, -1).replace(/\s+/g, "") : content.replace(/\s+/g, "")
+  const stripped = content.replace(/\r/g, "").trimEnd()
   const seed = RE_SIGNIFICANT.test(stripped) ? 0 : lineNumber
   const hash = Bun.hash.xxHash32(stripped, seed)
   const index = hash % 256


### PR DESCRIPTION
## Summary

- Changed `computeLineHash()` to use `.replace(/\r/g, "").trimEnd()` instead of `.replace(/\s+/g, "")`, matching [oh-my-pi upstream behavior](https://github.com/can1357/oh-my-pi/blob/main/packages/coding-agent/src/patch/hashline.ts#L42)
- Leading indentation is now preserved in the hash, so indentation-only changes correctly trigger hash mismatches
- Trailing whitespace and carriage returns are still normalized (stripped before hashing)

## Why

The previous implementation stripped **all whitespace** before hashing, which meant `"    foo"` and `"foo"` produced the same hash. This weakened the stale-line detection guarantee:

- Indentation changes between read and edit were invisible to hash validation
- Especially problematic for indentation-sensitive files (Python, YAML, Makefiles)
- oh-my-pi [explicitly reverted](https://github.com/can1357/oh-my-pi) from strip-all to trimEnd-only after finding integrity more valuable than LLM tolerance at this boundary

LLM whitespace tolerance is already handled by separate layers (`autocorrect-replacement-lines.ts`, `edit-text-normalization.ts`), so the hash should be strict.

## Changes

| File | Change |
|------|--------|
| `hash-computation.ts` | 1-line change: `content.replace(/\s+/g, "")` -> `content.replace(/\r/g, "").trimEnd()` |
| `hash-computation.test.ts` | Updated whitespace test + added 3 new test cases (leading indent, trailing whitespace, CRLF) |

## Test Results

- `bun test src/tools/hashline-edit/` -> 89 pass, 0 fail
- Full suite: 5 pre-existing failures unrelated to this change (tmux-utils, background-update-check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make line hashing stricter by preserving leading indentation and only trimming trailing spaces and carriage returns. This restores reliable stale-line detection, especially for indentation‑sensitive files.

- **Bug Fixes**
  - Updated `computeLineHash()` to use `content.replace(/\r/g, "").trimEnd()` so indentation-only changes produce different hashes.
  - Added tests for leading indent differences (different hashes), trailing whitespace (same hash), and CRLF vs LF (same hash).

<sup>Written for commit 0cbc15da9649e43cef78e79b0fb84e89e028d109. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

