### PR TITLE
fix(cli): render verbose doctor check details

### DIFF
--- a/src/cli/doctor/format-verbose.ts
+++ b/src/cli/doctor/format-verbose.ts
@@ -57,6 +57,19 @@ export function formatVerbose(result: DoctorResult): string {
   }
   lines.push("")
 
+  for (const check of results) {
+    if (!check.details || check.details.length === 0) {
+      continue
+    }
+
+    lines.push(`${color.bold(check.name)}`)
+    lines.push(`${color.dim("\u2500".repeat(40))}`)
+    for (const detail of check.details) {
+      lines.push(detail)
+    }
+    lines.push("")
+  }
+
   const allIssues = results.flatMap((r) => r.issues)
   if (allIssues.length > 0) {
     lines.push(`${color.bold("Issues")}`)

--- a/src/cli/doctor/formatter.test.ts
+++ b/src/cli/doctor/formatter.test.ts
@@ -51,6 +51,23 @@ function createDoctorResultWithIssues(): DoctorResult {
   return base
 }
 
+function createDoctorResultWithDetails(): DoctorResult {
+  const base = createDoctorResult()
+  base.results = [
+    ...base.results,
+    {
+      name: "Models",
+      status: "pass",
+      message: "2 agents, 1 category, 0 overrides",
+      details: ["Available models: openai/gpt-5.4", "Agent sisyphus -> openai/gpt-5.4"],
+      issues: [],
+    },
+  ]
+  base.summary.total = 3
+  base.summary.passed = 2
+  return base
+}
+
 describe("formatDoctorOutput", () => {
   describe("#given default mode", () => {
     it("shows System OK when no issues", async () => {
@@ -136,6 +153,20 @@ describe("formatDoctorOutput", () => {
       expect(output).toContain("1 passed")
       expect(output).toContain("0 failed")
       expect(output).toContain("1 warnings")
+    })
+
+    it("renders check details sections such as Models", async () => {
+      //#given
+      const result = createDoctorResultWithDetails()
+      const { formatDoctorOutput } = await import(`./formatter?verbose-details-${Date.now()}`)
+
+      //#when
+      const output = stripAnsi(formatDoctorOutput(result, "verbose"))
+
+      //#then
+      expect(output).toContain("Models")
+      expect(output).toContain("Available models: openai/gpt-5.4")
+      expect(output).toContain("Agent sisyphus -> openai/gpt-5.4")
     })
   })
 


### PR DESCRIPTION
## Summary
- render verbose doctor `details` for each check so the `Models` section appears again in `doctor --verbose`
- add a formatter regression test that verifies `Models` details are included in verbose output
- keep the fix generic at the formatter layer instead of hardcoding model-specific rendering

## Verification
- `bun test src/cli/doctor/formatter.test.ts`
- `bun run dist/cli/index.js doctor --verbose`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `doctor --verbose` output to show per-check details, so the Models section and other details appear again. Keeps the rendering generic in the formatter.

- **Bug Fixes**
  - Render check `details` blocks in verbose output (e.g., Models).
  - Add regression test ensuring Models details appear.
  - Implemented at the formatter layer (`format-verbose.ts`), no model-specific logic.

<sup>Written for commit 63ac37cd291af97c5308e8fedd9c0a477a27995e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

