### PR TITLE
fix(todo-continuation-enforcer): prevent post-compaction agent fallback to General

### DIFF
--- a/src/hooks/prometheus-md-only/agent-resolution.ts
+++ b/src/hooks/prometheus-md-only/agent-resolution.ts
@@ -12,21 +12,30 @@ import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 
 type OpencodeClient = PluginInput["client"]
 
+function isCompactionAgent(agent: string): boolean {
+  return agent.toLowerCase() === "compaction"
+}
+
 async function getAgentFromMessageFiles(
   sessionID: string,
   client?: OpencodeClient
 ): Promise<string | undefined> {
   if (isSqliteBackend() && client) {
     const firstAgent = await findFirstMessageWithAgentFromSDK(client, sessionID)
-    if (firstAgent) return firstAgent
+    if (firstAgent && !isCompactionAgent(firstAgent)) return firstAgent
 
     const nearest = await findNearestMessageWithFieldsFromSDK(client, sessionID)
-    return nearest?.agent
+    if (nearest?.agent && !isCompactionAgent(nearest.agent)) return nearest.agent
+    return undefined
   }
 
   const messageDir = getMessageDir(sessionID)
   if (!messageDir) return undefined
-  return findFirstMessageWithAgent(messageDir) ?? findNearestMessageWithFields(messageDir)?.agent
+  const firstAgent = findFirstMessageWithAgent(messageDir)
+  if (firstAgent && !isCompactionAgent(firstAgent)) return firstAgent
+  const nearestAgent = findNearestMessageWithFields(messageDir)?.agent
+  if (nearestAgent && !isCompactionAgent(nearestAgent)) return nearestAgent
+  return undefined
 }
 
 /**

--- a/src/hooks/todo-continuation-enforcer/compaction-guard.ts
+++ b/src/hooks/todo-continuation-enforcer/compaction-guard.ts
@@ -1,0 +1,10 @@
+import { COMPACTION_GUARD_MS } from "./constants"
+import type { SessionState } from "./types"
+
+export function isCompactionGuardActive(state: SessionState, now: number): boolean {
+  if (!state.recentCompactionAt) {
+    return false
+  }
+
+  return now - state.recentCompactionAt < COMPACTION_GUARD_MS
+}

--- a/src/hooks/todo-continuation-enforcer/constants.ts
+++ b/src/hooks/todo-continuation-enforcer/constants.ts
@@ -17,6 +17,7 @@ export const TOAST_DURATION_MS = 900
 export const COUNTDOWN_GRACE_PERIOD_MS = 500
 
 export const ABORT_WINDOW_MS = 3000
+export const COMPACTION_GUARD_MS = 60_000
 export const CONTINUATION_COOLDOWN_MS = 5_000
 export const MAX_STAGNATION_COUNT = 3
 export const MAX_CONSECUTIVE_FAILURES = 5

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -120,6 +120,14 @@ export async function injectContinuation(args: {
     return
   }
 
+  if (!agentName) {
+    const compactionState = sessionStateStore.getExistingState(sessionID)
+    if (compactionState?.hasRecentCompaction) {
+      log(`[${HOOK_NAME}] Skipped: agent unknown after compaction`, { sessionID })
+      return
+    }
+  }
+
   if (!hasWritePermission(tools)) {
     log(`[${HOOK_NAME}] Skipped: agent lacks write permission`, { sessionID, agent: agentName })
     return

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -1,6 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 
 import type { BackgroundManager } from "../../features/background-agent"
+import { getSessionAgent } from "../../features/claude-code-session-state"
 import {
   createInternalAgentTextPart,
   normalizeSDKResponse,
@@ -20,6 +21,7 @@ import {
   DEFAULT_SKIP_AGENTS,
   HOOK_NAME,
 } from "./constants"
+import { isCompactionGuardActive } from "./compaction-guard"
 import { getMessageDir } from "./message-directory"
 import { getIncompleteCount } from "./todo"
 import type { ResolvedMessageInfo, Todo } from "./types"
@@ -88,7 +90,7 @@ export async function injectContinuation(args: {
     return
   }
 
-  let agentName = resolvedInfo?.agent
+  let agentName = resolvedInfo?.agent ?? getSessionAgent(sessionID)
   let model = resolvedInfo?.model
   let tools = resolvedInfo?.tools
 
@@ -122,7 +124,7 @@ export async function injectContinuation(args: {
 
   if (!agentName) {
     const compactionState = sessionStateStore.getExistingState(sessionID)
-    if (compactionState?.hasRecentCompaction) {
+    if (compactionState && isCompactionGuardActive(compactionState, Date.now())) {
       log(`[${HOOK_NAME}] Skipped: agent unknown after compaction`, { sessionID })
       return
     }

--- a/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.ts
@@ -63,6 +63,17 @@ export function createTodoContinuationHandler(args: {
       return
     }
 
+    if (event.type === "session.compacted") {
+      const sessionID = (props?.sessionID ?? (props?.info as { id?: string } | undefined)?.id) as string | undefined
+      if (sessionID) {
+        const state = sessionStateStore.getState(sessionID)
+        state.hasRecentCompaction = true
+        sessionStateStore.cancelCountdown(sessionID)
+        log(`[${HOOK_NAME}] Session compacted: marked hasRecentCompaction`, { sessionID })
+      }
+      return
+    }
+
     if (event.type === "session.deleted") {
       const sessionInfo = props?.info as { id?: string } | undefined
       if (sessionInfo?.id) {

--- a/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.ts
@@ -67,9 +67,9 @@ export function createTodoContinuationHandler(args: {
       const sessionID = (props?.sessionID ?? (props?.info as { id?: string } | undefined)?.id) as string | undefined
       if (sessionID) {
         const state = sessionStateStore.getState(sessionID)
-        state.hasRecentCompaction = true
+        state.recentCompactionAt = Date.now()
         sessionStateStore.cancelCountdown(sessionID)
-        log(`[${HOOK_NAME}] Session compacted: marked hasRecentCompaction`, { sessionID })
+        log(`[${HOOK_NAME}] Session compacted: marked recentCompactionAt`, { sessionID })
       }
       return
     }

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -146,7 +146,6 @@ export async function handleSessionIdle(args: {
   }
 
   let resolvedInfo: ResolvedMessageInfo | undefined
-  let hasCompactionMessage = false
   try {
     const messagesResp = await ctx.client.session.messages({
       path: { id: sessionID },
@@ -155,7 +154,6 @@ export async function handleSessionIdle(args: {
     for (let i = messages.length - 1; i >= 0; i--) {
       const info = messages[i].info
       if (info?.agent === "compaction") {
-        hasCompactionMessage = true
         continue
       }
       if (info?.agent || info?.model || (info?.modelID && info?.providerID)) {
@@ -171,14 +169,14 @@ export async function handleSessionIdle(args: {
     log(`[${HOOK_NAME}] Failed to fetch messages for agent check`, { sessionID, error: String(error) })
   }
 
-  log(`[${HOOK_NAME}] Agent check`, { sessionID, agentName: resolvedInfo?.agent, skipAgents, hasCompactionMessage })
+  log(`[${HOOK_NAME}] Agent check`, { sessionID, agentName: resolvedInfo?.agent, skipAgents, hasRecentCompaction: state.hasRecentCompaction })
 
   const resolvedAgentName = resolvedInfo?.agent
   if (resolvedAgentName && skipAgents.some(s => getAgentConfigKey(s) === getAgentConfigKey(resolvedAgentName))) {
     log(`[${HOOK_NAME}] Skipped: agent in skipAgents list`, { sessionID, agent: resolvedAgentName })
     return
   }
-  if (hasCompactionMessage && !resolvedInfo?.agent) {
+  if (state.hasRecentCompaction && !resolvedInfo?.agent) {
     log(`[${HOOK_NAME}] Skipped: compaction occurred but no agent info resolved`, { sessionID })
     return
   }

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -1,7 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-
 import type { BackgroundManager } from "../../features/background-agent"
-import type { ToolPermission } from "../../features/hook-message-injector"
+import { getSessionAgent } from "../../features/claude-code-session-state"
 import { normalizeSDKResponse } from "../../shared"
 import { log } from "../../shared/logger"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
@@ -19,6 +18,8 @@ import { hasUnansweredQuestion } from "./pending-question-detection"
 import { shouldStopForStagnation } from "./stagnation-detection"
 import { getIncompleteCount } from "./todo"
 import type { MessageInfo, ResolvedMessageInfo, Todo } from "./types"
+import { resolveLatestMessageInfo } from "./resolve-message-info"
+import { isCompactionGuardActive } from "./compaction-guard"
 import type { SessionStateStore } from "./session-state"
 import { startCountdown } from "./countdown"
 
@@ -119,10 +120,7 @@ export async function handleSessionIdle(args: {
     && Date.now() - state.lastInjectedAt >= FAILURE_RESET_WINDOW_MS
   ) {
     state.consecutiveFailures = 0
-    log(`[${HOOK_NAME}] Reset consecutive failures after recovery window`, {
-      sessionID,
-      failureResetWindowMs: FAILURE_RESET_WINDOW_MS,
-    })
+    log(`[${HOOK_NAME}] Reset consecutive failures after recovery window`, { sessionID, failureResetWindowMs: FAILURE_RESET_WINDOW_MS })
   }
 
   if (state.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
@@ -147,38 +145,31 @@ export async function handleSessionIdle(args: {
 
   let resolvedInfo: ResolvedMessageInfo | undefined
   try {
-    const messagesResp = await ctx.client.session.messages({
-      path: { id: sessionID },
-    })
-    const messages = normalizeSDKResponse(messagesResp, [] as Array<{ info?: MessageInfo }>)
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const info = messages[i].info
-      if (info?.agent === "compaction") {
-        continue
-      }
-      if (info?.agent || info?.model || (info?.modelID && info?.providerID)) {
-        resolvedInfo = {
-          agent: info.agent,
-          model: info.model ?? (info.providerID && info.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined),
-          tools: info.tools as Record<string, ToolPermission> | undefined,
-        }
-        break
-      }
-    }
+    resolvedInfo = await resolveLatestMessageInfo(ctx, sessionID)
   } catch (error) {
     log(`[${HOOK_NAME}] Failed to fetch messages for agent check`, { sessionID, error: String(error) })
   }
 
-  log(`[${HOOK_NAME}] Agent check`, { sessionID, agentName: resolvedInfo?.agent, skipAgents, hasRecentCompaction: state.hasRecentCompaction })
+  const sessionAgent = getSessionAgent(sessionID)
+  if (!resolvedInfo?.agent && sessionAgent) {
+    resolvedInfo = { ...resolvedInfo, agent: sessionAgent }
+  }
+
+  const compactionGuardActive = isCompactionGuardActive(state, Date.now())
+
+  log(`[${HOOK_NAME}] Agent check`, { sessionID, agentName: resolvedInfo?.agent, skipAgents, compactionGuardActive })
 
   const resolvedAgentName = resolvedInfo?.agent
   if (resolvedAgentName && skipAgents.some(s => getAgentConfigKey(s) === getAgentConfigKey(resolvedAgentName))) {
     log(`[${HOOK_NAME}] Skipped: agent in skipAgents list`, { sessionID, agent: resolvedAgentName })
     return
   }
-  if (state.hasRecentCompaction && !resolvedInfo?.agent) {
+  if (compactionGuardActive && !resolvedInfo?.agent) {
     log(`[${HOOK_NAME}] Skipped: compaction occurred but no agent info resolved`, { sessionID })
     return
+  }
+  if (state.recentCompactionAt && resolvedInfo?.agent) {
+    state.recentCompactionAt = undefined
   }
 
   if (isContinuationStopped?.(sessionID)) {
@@ -195,7 +186,6 @@ export async function handleSessionIdle(args: {
   if (shouldStopForStagnation({ sessionID, incompleteCount, progressUpdate })) {
     return
   }
-
   startCountdown({
     ctx,
     sessionID,

--- a/src/hooks/todo-continuation-enforcer/resolve-message-info.ts
+++ b/src/hooks/todo-continuation-enforcer/resolve-message-info.ts
@@ -1,0 +1,31 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+
+import { normalizeSDKResponse } from "../../shared"
+
+import type { MessageInfo, ResolvedMessageInfo } from "./types"
+
+export async function resolveLatestMessageInfo(
+  ctx: PluginInput,
+  sessionID: string
+): Promise<ResolvedMessageInfo | undefined> {
+  const messagesResp = await ctx.client.session.messages({
+    path: { id: sessionID },
+  })
+  const messages = normalizeSDKResponse(messagesResp, [] as Array<{ info?: MessageInfo }>)
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const info = messages[i].info
+    if (info?.agent === "compaction") {
+      continue
+    }
+    if (info?.agent || info?.model || (info?.modelID && info?.providerID)) {
+      return {
+        agent: info.agent,
+        model: info.model ?? (info.providerID && info.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined),
+        tools: info.tools,
+      }
+    }
+  }
+
+  return undefined
+}

--- a/src/hooks/todo-continuation-enforcer/types.ts
+++ b/src/hooks/todo-continuation-enforcer/types.ts
@@ -35,6 +35,7 @@ export interface SessionState {
   inFlight?: boolean
   stagnationCount: number
   consecutiveFailures: number
+  hasRecentCompaction?: boolean
 }
 
 export interface MessageInfo {

--- a/src/hooks/todo-continuation-enforcer/types.ts
+++ b/src/hooks/todo-continuation-enforcer/types.ts
@@ -35,7 +35,7 @@ export interface SessionState {
   inFlight?: boolean
   stagnationCount: number
   consecutiveFailures: number
-  hasRecentCompaction?: boolean
+  recentCompactionAt?: number
 }
 
 export interface MessageInfo {


### PR DESCRIPTION
## Summary

After compaction, message history is truncated and the original agent (e.g. Prometheus) can no longer be resolved from messages. The todo continuation enforcer would then inject a continuation prompt with `agent=undefined`, causing the host to default to General -- which has write permissions Prometheus should never have.

## Root Cause Chain

1. **`handler.ts` had no `session.compacted` handler** -- unlike Atlas (`atlas/event-handler.ts:246`), the enforcer was blind to compaction events
2. **`idle-event.ts` relied on finding a compaction marker in truncated message history** -- the marker disappears after real compaction, so `hasCompactionMessage` was always `false`
3. **`continuation-injection.ts:118`** -- the `skipAgents` check only matched truthy agent names, so `undefined` agent fell through
4. **`prometheus-md-only/agent-resolution.ts`** -- message history fallback did not filter compaction agent (unlike `atlas/session-last-agent.ts:53`)

## Fixes (5 files, +34/-7 lines)

| Priority | File | Change |
|----------|------|--------|
| P0 | `types.ts` | Add `hasRecentCompaction` field to `SessionState` |
| P0 | `handler.ts` | Add `session.compacted` event handler that sets `hasRecentCompaction` flag (follows Atlas pattern) |
| P0 | `idle-event.ts` | Replace fragile history-based compaction detection (`hasCompactionMessage`) with `state.hasRecentCompaction` flag |
| P0 | `continuation-injection.ts` | Block continuation injection when agent is unknown AND session was recently compacted |
| P1 | `agent-resolution.ts` | Filter compaction agent from message history fallback in Prometheus agent resolution |

## Testing

- `bun run typecheck` -- clean
- `bun test todo-continuation-enforcer.test.ts` -- 49/49 pass
- `bun test prometheus-md-only/index.test.ts` -- 35/35 pass

## Follow-up (not in this PR)

- `plugin/event.ts` -- `session.prompt("continue")` calls in model-fallback retry paths don't pass explicit `agent`. Separate concern from todo continuation.

Supersedes #2534 (closed due to branch delete during conflict resolution).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the todo continuation enforcer from falling back to `General` after session compaction by adding a short-lived compaction guard and preferring the session’s agent as a fallback. This keeps Prometheus flows on the right agent and blocks unsafe write prompts right after compaction.

- **Bug Fixes**
  - Added `recentCompactionAt` to `SessionState` and a 60s `COMPACTION_GUARD_MS`; set on `session.compacted` and cancel countdown.
  - Replaced history scanning with `resolveLatestMessageInfo` that skips the `compaction` agent; clear the guard once an agent is resolved.
  - Prefer `getSessionAgent(sessionID)` when message history has no agent (idle handling and injection).
  - In continuation injection, block when the agent is unknown and the compaction guard is active.
  - Filtered out the `compaction` agent in Prometheus agent resolution (SDK and filesystem paths).

<sup>Written for commit 088844474a27eb5d74fe964522789fbecf1877ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

