### PR TITLE
fix(delegate-task): build categoryModel with variant for categories without fallback chain

### DIFF
--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -98,6 +98,11 @@ Available categories: ${allCategoryNames}`,
       modelInfo = explicitCategoryModel || overrideModel
         ? { model: actualModel, type: "user-defined", source: "override" }
         : { model: actualModel, type: "system-default", source: "system-default" }
+      const parsedModel = parseModelString(actualModel)
+      const variantToUse = userCategories?.[args.category!]?.variant ?? resolved.config.variant
+      categoryModel = parsedModel
+        ? (variantToUse ? { ...parsedModel, variant: variantToUse } : parsedModel)
+        : undefined
     }
   } else {
     const resolution = resolveModelForDelegateTask({


### PR DESCRIPTION
## Summary
- Fix variant being silently dropped for categories without `CATEGORY_MODEL_REQUIREMENTS` entry (e.g. user-defined categories like `solana-re`, `solana-develop`)
- Mirror the `requirement` branch logic in the `!requirement` branch to build `categoryModel` with variant from user config

## Bug Fix
In `category-resolver.ts`, when a category has no `CATEGORY_MODEL_REQUIREMENTS` entry, the `!requirement` branch set `actualModel` but never built `categoryModel`. The bottom fallback (`if (!categoryModel && actualModel)`) then created `categoryModel` via `parseModelString()` alone, which only extracts `providerID` and `modelID` — silently dropping the `variant` configured in `oh-my-opencode.json`.

**Before:** `categoryModel = { providerID: "codex", modelID: "gpt-5.2-codex" }` (no variant)
**After:** `categoryModel = { providerID: "codex", modelID: "gpt-5.2-codex", variant: "xhigh" }`

## Verification
Patched `dist/index.js` locally and confirmed via instrumented logging:
- Before patch: `HTTP_prompt_async | variant=undefined` → LLM uses default reasoning effort
- After patch: `HTTP_prompt_async | variant=xhigh` → `LLM.stream | resolved={"reasoningEffort":"xhigh"}`

Fixes #2538

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent dropping of the model variant for categories without `CATEGORY_MODEL_REQUIREMENTS`, ensuring the user-configured variant is preserved in `categoryModel`. This restores correct reasoning effort selection in LLM calls.

- **Bug Fixes**
  - In `category-resolver.ts`, when no requirement exists, parse `actualModel` and build `categoryModel` with `variant` from `userCategories` or `resolved.config`.
  - Covers user-defined categories (e.g., `solana-re`, `solana-develop`).
  - Before: variant lost; After: variant included (e.g., `xhigh`).

<sup>Written for commit 11e92764983d92ab5819fac952f9f364948caa15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

