### PR TITLE
fix(agents): add termination criteria to Sisyphus-Junior default

### DIFF
--- a/src/agents/sisyphus-junior/default.ts
+++ b/src/agents/sisyphus-junior/default.ts
@@ -35,6 +35,11 @@ Task NOT complete without:
 - ${verificationText}
 </Verification>
 
+<Termination>
+STOP after first successful verification. Do NOT re-verify.
+Maximum status checks: 2. Then stop regardless.
+</Termination>
+
 <Style>
 - Start immediately. No acknowledgments.
 - Match user's communication style.


### PR DESCRIPTION
## Summary

Fixes status-checking loops in the quick category agent by adding explicit termination criteria to `default.ts`.

## Problem

The quick agent (used by Nemotron, GLM 4.7 Flash, and other non-GPT models) exhibited "completion anxiety" loops:
- Repeatedly reading todo lists without modifications
- Running "final test verification" over and over despite tests passing
- Creating verification todo chains: "Verify X" → "Final verification" → "Double-check"

## Root Cause

The Sisyphus-Junior `default.ts` prompt tells the agent *what* to verify, but not *when to stop*:

```xml
<Verification>
Task NOT complete without:
- lsp_diagnostics clean on changed files
- Build passes (if applicable)
- All todos marked completed
</Verification>
```

**Missing**: Termination criteria. The agent keeps verifying because no one told it to stop after first success.

**Model routing context**:
- GPT models → `gpt.ts` (has some termination guidance)
- Gemini models → `gemini.ts`
- Nemotron, GLM 4.7 Flash, Claude, others → `default.ts` (this fix)

## Solution

Added `<Termination>` section to `src/agents/sisyphus-junior/default.ts`:

```xml
<Termination>
STOP after first successful verification. Do NOT re-verify.
Maximum status checks: 2. Then stop regardless.
</Termination>
```

## Changes

- **File**: `src/agents/sisyphus-junior/default.ts`
- **Lines**: +5 (Termination section after Verification)
- **Scope**: Affects Nemotron, GLM 4.7 Flash, Claude, and other non-GPT/non-Gemini models

## Testing

- ✅ 40/40 tests pass
- ✅ Build succeeds
- ✅ Termination section verified in bundled output