### PR TITLE
fix(installer): always use .config/opencode for CLI on Windows (#2502)

### DIFF
--- a/src/shared/opencode-config-dir.test.ts
+++ b/src/shared/opencode-config-dir.test.ts
@@ -183,6 +183,7 @@ describe("opencode-config-dir", () => {
         // given opencode CLI binary detected, platform is Windows
         Object.defineProperty(process, "platform", { value: "win32" })
         delete process.env.APPDATA
+        delete process.env.XDG_CONFIG_HOME
         delete process.env.OPENCODE_CONFIG_DIR
 
         // when getOpenCodeConfigDir is called with binary="opencode"
@@ -197,6 +198,7 @@ describe("opencode-config-dir", () => {
         // (regression test: previously would check AppData for existing config)
         Object.defineProperty(process, "platform", { value: "win32" })
         process.env.APPDATA = "C:\\Users\\TestUser\\AppData\\Roaming"
+        delete process.env.XDG_CONFIG_HOME
         delete process.env.OPENCODE_CONFIG_DIR
 
         // when getOpenCodeConfigDir is called with binary="opencode"

--- a/src/shared/opencode-config-dir.test.ts
+++ b/src/shared/opencode-config-dir.test.ts
@@ -191,6 +191,20 @@ describe("opencode-config-dir", () => {
         // then returns ~/.config/opencode (cross-platform default)
         expect(result).toBe(join(homedir(), ".config", "opencode"))
       })
+
+      test("returns ~/.config/opencode on Windows even when APPDATA is set (#2502)", () => {
+        // given opencode CLI binary detected, platform is Windows with APPDATA set
+        // (regression test: previously would check AppData for existing config)
+        Object.defineProperty(process, "platform", { value: "win32" })
+        process.env.APPDATA = "C:\\Users\\TestUser\\AppData\\Roaming"
+        delete process.env.OPENCODE_CONFIG_DIR
+
+        // when getOpenCodeConfigDir is called with binary="opencode"
+        const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200", checkExisting: false })
+
+        // then returns ~/.config/opencode (ignores APPDATA entirely for CLI)
+        expect(result).toBe(join(homedir(), ".config", "opencode"))
+      })
     })
 
     describe("for opencode-desktop Tauri binary", () => {

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -48,10 +48,6 @@ function getCliConfigDir(): string {
     return resolve(envConfigDir)
   }
 
-  if (process.platform === "win32") {
-    return join(homedir(), ".config", "opencode")
-  }
-
   const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
   return join(xdgConfig, "opencode")
 }

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -49,22 +49,7 @@ function getCliConfigDir(): string {
   }
 
   if (process.platform === "win32") {
-    const crossPlatformDir = join(homedir(), ".config", "opencode")
-    const crossPlatformConfig = join(crossPlatformDir, "opencode.json")
-
-    if (existsSync(crossPlatformConfig)) {
-      return crossPlatformDir
-    }
-
-    const appData = process.env.APPDATA || join(homedir(), "AppData", "Roaming")
-    const appdataDir = join(appData, "opencode")
-    const appdataConfig = join(appdataDir, "opencode.json")
-
-    if (existsSync(appdataConfig)) {
-      return appdataDir
-    }
-
-    return crossPlatformDir
+    return join(homedir(), ".config", "opencode")
   }
 
   const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")


### PR DESCRIPTION
## Summary

Fixes #2502 - On Windows, the oh-my-opencode installer was incorrectly checking for existing configs in AppData and potentially targeting that directory. OpenCode CLI always reads from `~/.config/opencode`, so the installer should always write there.

## Changes

- **`src/shared/opencode-config-dir.ts`**: Simplified `getCliConfigDir()` Windows block to always return `~/.config/opencode`, removing the AppData fallback logic
- **`src/shared/opencode-config-dir.test.ts`**: Added regression test verifying Windows CLI ignores APPDATA env var

## Test Plan

```bash
bun test src/shared/opencode-config-dir.test.ts  # 25 tests pass
bun run typecheck                                # 0 errors
```