### PR TITLE
feat(background-task): add global maxSessions and per-parent maxTasksPerParent caps

### DIFF
--- a/src/config/schema/background-task.ts
+++ b/src/config/schema/background-task.ts
@@ -6,6 +6,10 @@ export const BackgroundTaskConfigSchema = z.object({
   modelConcurrency: z.record(z.string(), z.number().min(0)).optional(),
   maxDepth: z.number().int().min(1).optional(),
   maxDescendants: z.number().int().min(1).optional(),
+  /** Global cap on total active background sessions across all models/providers. Opt-in: no limit unless set. */
+  maxSessions: z.number().int().min(1).optional(),
+  /** Cap on outstanding background tasks per parent session. Opt-in: no limit unless set. */
+  maxTasksPerParent: z.number().int().min(1).optional(),
   /** Stale timeout in milliseconds - interrupt tasks with no activity for this duration (default: 180000 = 3 minutes, minimum: 60000 = 1 minute) */
   staleTimeoutMs: z.number().min(60000).optional(),
   /** Timeout for tasks that never received any progress update, falling back to startedAt (default: 1800000 = 30 minutes, minimum: 60000 = 1 minute) */

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -242,6 +242,26 @@ export class BackgroundManager {
     this.unregisterRootDescendant(task.rootSessionID)
   }
 
+  private getActiveTaskCount(): number {
+    let count = 0
+    for (const task of this.tasks.values()) {
+      if (task.status === "running" || task.status === "pending") {
+        count += 1
+      }
+    }
+    return count
+  }
+
+  private getActiveTaskCountForParent(parentSessionID: string): number {
+    let count = 0
+    for (const task of this.tasks.values()) {
+      if (task.parentSessionID === parentSessionID && (task.status === "running" || task.status === "pending")) {
+        count += 1
+      }
+    }
+    return count
+  }
+
   async launch(input: LaunchInput): Promise<BackgroundTask> {
     log("[background-agent] launch() called with:", {
       agent: input.agent,
@@ -252,6 +272,26 @@ export class BackgroundManager {
 
     if (!input.agent || input.agent.trim() === "") {
       throw new Error("Agent parameter is required")
+    }
+
+    const maxSessions = this.config?.maxSessions
+    if (maxSessions !== undefined) {
+      const activeCount = this.getActiveTaskCount()
+      if (activeCount >= maxSessions) {
+        throw new Error(
+          `Background task spawn blocked: ${activeCount} active sessions meets background_task.maxSessions=${maxSessions}. Wait for existing tasks to complete before spawning new ones.`
+        )
+      }
+    }
+
+    const maxTasksPerParent = this.config?.maxTasksPerParent
+    if (maxTasksPerParent !== undefined) {
+      const parentCount = this.getActiveTaskCountForParent(input.parentSessionID)
+      if (parentCount >= maxTasksPerParent) {
+        throw new Error(
+          `Background task spawn blocked: parent session ${input.parentSessionID} already has ${parentCount} active tasks, which meets background_task.maxTasksPerParent=${maxTasksPerParent}. Wait for existing tasks to complete or reuse a session.`
+        )
+      }
     }
 
     const spawnReservation = await this.reserveSubagentSpawn(input.parentSessionID)

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -274,29 +274,31 @@ export class BackgroundManager {
       throw new Error("Agent parameter is required")
     }
 
-    const maxSessions = this.config?.maxSessions
-    if (maxSessions !== undefined) {
-      const activeCount = this.getActiveTaskCount()
-      if (activeCount >= maxSessions) {
-        throw new Error(
-          `Background task spawn blocked: ${activeCount} active sessions meets background_task.maxSessions=${maxSessions}. Wait for existing tasks to complete before spawning new ones.`
-        )
-      }
-    }
-
-    const maxTasksPerParent = this.config?.maxTasksPerParent
-    if (maxTasksPerParent !== undefined) {
-      const parentCount = this.getActiveTaskCountForParent(input.parentSessionID)
-      if (parentCount >= maxTasksPerParent) {
-        throw new Error(
-          `Background task spawn blocked: parent session ${input.parentSessionID} already has ${parentCount} active tasks, which meets background_task.maxTasksPerParent=${maxTasksPerParent}. Wait for existing tasks to complete or reuse a session.`
-        )
-      }
-    }
-
     const spawnReservation = await this.reserveSubagentSpawn(input.parentSessionID)
 
     try {
+      const maxSessions = this.config?.maxSessions
+      if (maxSessions !== undefined) {
+        const activeCount = this.getActiveTaskCount()
+        if (activeCount >= maxSessions) {
+          spawnReservation.rollback()
+          throw new Error(
+            `Background task spawn blocked: ${activeCount} active sessions meets background_task.maxSessions=${maxSessions}. Wait for existing tasks to complete before spawning new ones.`
+          )
+        }
+      }
+
+      const maxTasksPerParent = this.config?.maxTasksPerParent
+      if (maxTasksPerParent !== undefined) {
+        const parentCount = this.getActiveTaskCountForParent(input.parentSessionID)
+        if (parentCount >= maxTasksPerParent) {
+          spawnReservation.rollback()
+          throw new Error(
+            `Background task spawn blocked: parent session ${input.parentSessionID} already has ${parentCount} active tasks, which meets background_task.maxTasksPerParent=${maxTasksPerParent}. Wait for existing tasks to complete or reuse a session.`
+          )
+        }
+      }
+
       log("[background-agent] spawn guard passed", {
         parentSessionID: input.parentSessionID,
         rootSessionID: spawnReservation.spawnContext.rootSessionID,


### PR DESCRIPTION
## Summary

Closes #2349 — Adds opt-in global and per-parent caps for background task spawning to prevent runaway session creation.

## Changes

### Config: `src/config/schema/background-task.ts`
- Added `maxSessions` (integer, min 1, optional) — global cap on total active background sessions across all models/providers
- Added `maxTasksPerParent` (integer, min 1, optional) — cap on outstanding tasks per parent session

### Enforcement: `src/features/background-agent/manager.ts`
- Added `getActiveTaskCount()` — counts all running + pending tasks globally
- Added `getActiveTaskCountForParent()` — counts running + pending tasks for a specific parent session
- Both caps enforced in `launch()` before spawn reservation, following the same pattern as existing `maxDepth`/`maxDescendants` guards

## Configuration

```jsonc
// .opencode/oh-my-opencode.jsonc
{
  "background_task": {
    "maxSessions": 3,       // Global: max 3 active background sessions total
    "maxTasksPerParent": 5  // Per-parent: max 5 active tasks per parent session
  }
}
```

## Design decisions

- **Opt-in only**: No behavior change unless config keys are set (both default to undefined = unlimited)
- **Consistent error messages**: Follow the same pattern as existing spawn limit errors (`Subagent spawn blocked: ...`)
- **Checked before spawn reservation**: Prevents wasting a descendant budget slot when the global/parent cap would reject anyway

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in caps for background task spawning: `maxSessions` (global) and `maxTasksPerParent` (per parent) to prevent runaway sessions. Checks run atomically after `reserveSubagentSpawn()` to fix a TOCTOU race. Closes #2349.

- **New Features**
  - Config: add `maxSessions` and `maxTasksPerParent` in `src/config/schema/background-task.ts`.
  - Enforcement in `BackgroundManager.launch()`: counts running + pending tasks; on limit, rolls back the reservation and throws consistent errors.

- **Migration**
  - To enable, set `background_task.maxSessions` and/or `background_task.maxTasksPerParent`.

<sup>Written for commit bfb909015dcea4a7accfe69adfa3c2b68a1e9ff1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

