### PR TITLE
Fix disabled_tools config merge semantics

### DIFF
--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -115,6 +115,23 @@ describe("mergeConfigs", () => {
       expect(result.disabled_hooks).toContain("session-recovery");
       expect(result.disabled_hooks?.length).toBe(3);
     });
+
+    it("should merge disabled_tools without duplicates", () => {
+      const base: OhMyOpenCodeConfig = {
+        disabled_tools: ["delegate_task", "web_search"],
+      };
+
+      const override: OhMyOpenCodeConfig = {
+        disabled_tools: ["web_search", "call_omo_agent"],
+      };
+
+      const result = mergeConfigs(base, override);
+
+      expect(result.disabled_tools).toContain("delegate_task");
+      expect(result.disabled_tools).toContain("web_search");
+      expect(result.disabled_tools).toContain("call_omo_agent");
+      expect(result.disabled_tools?.length).toBe(3);
+    });
   });
 });
 

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -140,6 +140,12 @@ export function mergeConfigs(
         ...(override.disabled_commands ?? []),
       ]),
     ],
+    disabled_tools: [
+      ...new Set([
+        ...(base.disabled_tools ?? []),
+        ...(override.disabled_tools ?? []),
+      ]),
+    ],
     disabled_skills: [
       ...new Set([
         ...(base.disabled_skills ?? []),


### PR DESCRIPTION
## Summary
- union `disabled_tools` during config merge, matching the other `disabled_*` arrays
- add a regression test proving base + override tool disables are preserved and deduplicated

## Testing
- `bun test src/plugin-config.test.ts`
- `bun run typecheck`

## Issue
- Closes #2555


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes config merge to union and dedupe `disabled_tools`, aligning it with other `disabled_*` arrays. Prevents losing tool disables from either base or override and adds a regression test to lock behavior.

<sup>Written for commit 148a5019f4a811d42ded449d411330df20e3730e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

