### PR TITLE
fix(doctor): count intelephense in LSP detection

### DIFF
--- a/src/cli/doctor/checks/tools-lsp.ts
+++ b/src/cli/doctor/checks/tools-lsp.ts
@@ -6,6 +6,7 @@ const DEFAULT_LSP_SERVERS: Array<{ id: string; binary: string; extensions: strin
   { id: "pyright", binary: "pyright-langserver", extensions: [".py"] },
   { id: "rust-analyzer", binary: "rust-analyzer", extensions: [".rs"] },
   { id: "gopls", binary: "gopls", extensions: [".go"] },
+  { id: "php", binary: "intelephense", extensions: [".php"] },
 ]
 
 export function getLspServersInfo(): LspServerInfo[] {


### PR DESCRIPTION
## Bug
`oh-my-opencode doctor` reports `No LSP servers detected` in PHP/Laravel environments even when `intelephense` is installed and PHP LSP support is available elsewhere in the package.

## Current behavior
`doctor` only counts these LSP binaries in `src/cli/doctor/checks/tools-lsp.ts`:
- `typescript-language-server`
- `pyright-langserver`
- `rust-analyzer`
- `gopls`

That means a PHP-only setup can show `LSP 0/4 installed` and emit this warning:
> No LSP servers detected  
> LSP-dependent tools will be limited until at least one server is installed.

## Why this is misleading
PHP support already exists via `intelephense`, so the doctor output does not match actual supported runtime behavior. In practice, PHP/Laravel users can have working LSP tooling while `doctor` still says no LSP servers are installed.

## Proposed fix
Add PHP to the doctor detection list:
```ts
{ id: "php", binary: "intelephense", extensions: [".php"] },
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach `oh-my-opencode doctor` to detect PHP by counting `intelephense` as an LSP server. Fixes false "No LSP servers detected" warnings in PHP/Laravel environments and aligns the LSP summary with existing PHP support.

<sup>Written for commit c162ebb827ec8b752cc18dc53a9b909824bf6bb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

