### PR TITLE
fix(delegate-task): add subagent turn limit and model routing transparency

### DIFF
--- a/src/tools/delegate-task/sync-session-poller.ts
+++ b/src/tools/delegate-task/sync-session-poller.ts
@@ -39,6 +39,8 @@ export function isSessionComplete(messages: SessionMessage[]): boolean {
   return lastUser.info.id < lastAssistant.info.id
 }
 
+const DEFAULT_MAX_ASSISTANT_TURNS = 300
+
 export async function pollSyncSession(
   ctx: ToolContextWithMetadata,
   client: OpencodeClient,
@@ -48,16 +50,20 @@ export async function pollSyncSession(
     toastManager: { removeTask: (id: string) => void } | null | undefined
     taskId: string | undefined
     anchorMessageCount?: number
+    maxAssistantTurns?: number
   },
   timeoutMs?: number
 ): Promise<string | null> {
   const syncTiming = getTimingConfig()
   const maxPollTimeMs = Math.max(timeoutMs ?? getDefaultSyncPollTimeoutMs(), 50)
+  const maxTurns = input.maxAssistantTurns ?? DEFAULT_MAX_ASSISTANT_TURNS
   const pollStart = Date.now()
   let pollCount = 0
   let timedOut = false
+  let assistantTurnCount = 0
+  let lastSeenAssistantId: string | undefined
 
-  log("[task] Starting poll loop", { sessionID: input.sessionID, agentToUse: input.agentToUse })
+  log("[task] Starting poll loop", { sessionID: input.sessionID, agentToUse: input.agentToUse, maxTurns })
 
   while (Date.now() - pollStart < maxPollTimeMs) {
     if (ctx.abort?.aborted) {
@@ -112,7 +118,23 @@ export async function pollSyncSession(
       break
     }
 
+    // 计数新出现的 assistant 轮次，用于熔断无限循环
     const lastAssistant = [...msgs].reverse().find((m) => m.info?.role === "assistant")
+    if (lastAssistant?.info?.id && lastAssistant.info.id !== lastSeenAssistantId) {
+      lastSeenAssistantId = lastAssistant.info.id
+      assistantTurnCount++
+      if (assistantTurnCount >= maxTurns) {
+        log("[task] Max assistant turns reached, aborting to prevent infinite loop", {
+          sessionID: input.sessionID,
+          assistantTurnCount,
+          maxTurns,
+        })
+        abortSyncSession(client, input.sessionID, "max_turns_exceeded")
+        if (input.toastManager && input.taskId) input.toastManager.removeTask(input.taskId)
+        return `Task aborted: subagent exceeded ${maxTurns} assistant turns without completing. This usually indicates an infinite tool-call loop. Session ID: ${input.sessionID}`
+      }
+    }
+
     const hasAssistantText = msgs.some((m) => {
       if (m.info?.role !== "assistant") return false
       const parts = m.parts ?? []

--- a/src/tools/delegate-task/sync-task.ts
+++ b/src/tools/delegate-task/sync-task.ts
@@ -149,9 +149,23 @@ export async function executeSyncTask(
 
       const duration = formatDuration(startTime)
 
+      // 检测模型路由是否与父 session 不同，给用户可见的提示
+      const actualModelStr = categoryModel
+        ? `${categoryModel.providerID}/${categoryModel.modelID}`
+        : undefined
+      const parentModelStr = parentContext.model
+        ? `${parentContext.model.providerID}/${parentContext.model.modelID}`
+        : undefined
+      const modelRoutingNote =
+        actualModelStr && parentModelStr && actualModelStr !== parentModelStr
+          ? `\n⚠️  Model routing: parent used ${parentModelStr}, this subagent used ${actualModelStr} (via category: ${args.category ?? "unknown"})`
+          : actualModelStr
+            ? `\nModel: ${actualModelStr}${args.category ? ` (category: ${args.category})` : ""}`
+            : ""
+
       return `Task completed in ${duration}.
 
-Agent: ${agentToUse}${args.category ? ` (category: ${args.category})` : ""}
+Agent: ${agentToUse}${args.category ? ` (category: ${args.category})` : ""}${modelRoutingNote}
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #2571 — a subagent infinite tool-call loop burned $350+ in one afternoon due to two missing safeguards.

## Changes

### Bug 1: Subagent infinite loop — no circuit breaker
**File:** `src/tools/delegate-task/sync-session-poller.ts`

Added a `maxAssistantTurns` parameter (default: **300**) to `pollSyncSession`. Each time a new assistant message is detected, a counter increments. When the limit is reached, the session is aborted and a clear error message is returned to the parent.

```
Task aborted: subagent exceeded 300 assistant turns without completing.
This usually indicates an infinite tool-call loop. Session ID: ...
```

The default of 300 is well above any normal task's requirements while still preventing runaway loops. The parameter is optional and backward-compatible.

### Bug 2: Silent model routing — no user visibility
**File:** `src/tools/delegate-task/sync-task.ts`

When a task completes, the return string now includes the actual model used. If the subagent was routed to a **different model** than the parent session (via category resolution), a ⚠️ warning is shown:

```
⚠️  Model routing: parent used openai/gpt-5.4, this subagent used google/gemini-3.1-pro-preview (via category: visual-engineering)
```

## Root Cause (from issue)

A Sisyphus-Junior subagent was silently routed to `google/gemini-3.1-pro-preview` via the `visual-engineering` category, despite the parent session using GPT-5.4. The subagent then entered an infinite `tool-calls` loop (809 turns, 3.5 hours) with no safeguard to stop it. Gemini 3.1 Pro has zero prompt caching, so each of the 809 turns sent ~880K input tokens at full price (~$1.76/turn displayed, ~$3.52/turn actual due to >200K context tier).

## Testing

```
bun test src/tools/delegate-task/
# 199 pass, 0 fail
```

All existing delegate-task tests pass. No breaking changes — `maxAssistantTurns` is an optional parameter with a safe default.

## Related

- Closes #2571
- Related: #2527 (repeating text loop — similar symptom)
- Related: #2538 (category variant routing bugs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a turn-limit circuit breaker for subagents and makes model routing visible in task results to prevent infinite loops and surprise model costs. Addresses #2571.

- **Bug Fixes**
  - Added maxAssistantTurns (default 300) to subagent polling; aborts the session and returns a clear error when the limit is hit.
  - Task output now includes the actual model used; shows a warning if it differs from the parent session’s model, with the routing category.

- **Migration**
  - Backward compatible. No changes required; maxAssistantTurns is optional and defaults to 300.

<sup>Written for commit f2b26e5346656843c1404f46e8f06129a924ecdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

