### PR TITLE
fix(test): update package name to oh-my-openagent in install test

### DIFF
--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -108,7 +108,7 @@ describe("install CLI - binary check behavior", () => {
     // then opencode.json should have plugin entry
     const config = JSON.parse(readFileSync(configPath, "utf-8"))
     expect(config.plugin).toBeDefined()
-    expect(config.plugin.some((p: string) => p.includes("oh-my-opencode"))).toBe(true)
+    expect(config.plugin.some((p: string) => p.includes("oh-my-openagent"))).toBe(true)
 
     // then exit code should be 0 (success)
     expect(exitCode).toBe(0)


### PR DESCRIPTION
## Summary
- Fixes failing CI test in `src/cli/install.test.ts`
- Updates assertion to check for `oh-my-openagent` instead of legacy `oh-my-opencode`

## Root Cause
The package name was renamed from `oh-my-opencode` to `oh-my-openagent` in `add-plugin-to-opencode-config.ts`, but the test assertion was not updated.

## Test
- `bun test src/cli/install.test.ts` → 3 pass
- Related CLI tests → 58 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing install CLI test by updating the assertion to expect `oh-my-openagent` instead of `oh-my-opencode`. Aligns with current plugin registration and restores CI to green.

<sup>Written for commit 0f0e4c649b689249adad592bcae1350d0c93649b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

