### PR TITLE
fix: preserve Atlas handoff metadata on /start-work

### DIFF
--- a/src/hooks/start-work/index.test.ts
+++ b/src/hooks/start-work/index.test.ts
@@ -404,6 +404,24 @@ describe("start-work hook", () => {
       expect(updateSpy).toHaveBeenCalledWith("ses-prometheus-to-sisyphus", "atlas")
       updateSpy.mockRestore()
     })
+
+    test("should stamp the outgoing message with Atlas so follow-up events keep the handoff", async () => {
+      // given
+      const hook = createStartWorkHook(createMockPluginInput())
+      const output = {
+        message: {},
+        parts: [{ type: "text", text: "<session-context></session-context>" }],
+      }
+
+      // when
+      await hook["chat.message"](
+        { sessionID: "ses-prometheus-to-atlas" },
+        output
+      )
+
+      // then
+      expect(output.message.agent).toBe("Atlas (Plan Executor)")
+    })
   })
 
   describe("worktree support", () => {

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -11,6 +11,7 @@ import {
   clearBoulderState,
 } from "../../features/boulder-state"
 import { log } from "../../shared/logger"
+import { getAgentDisplayName } from "../../shared/agent-display-names"
 import { updateSessionAgent } from "../../features/claude-code-session-state"
 import { detectWorktreePath } from "./worktree-detector"
 import { parseUserRequest } from "./parse-user-request"
@@ -23,6 +24,7 @@ interface StartWorkHookInput {
 }
 
 interface StartWorkHookOutput {
+  message?: Record<string, unknown>
   parts: Array<{ type: string; text?: string }>
 }
 
@@ -79,6 +81,9 @@ export function createStartWorkHook(ctx: PluginInput) {
 
       log(`[${HOOK_NAME}] Processing start-work command`, { sessionID: input.sessionID })
       updateSessionAgent(input.sessionID, "atlas")
+      if (output.message) {
+        output.message["agent"] = getAgentDisplayName("atlas")
+      }
 
       const existingState = readBoulderState(ctx.directory)
       const sessionId = input.sessionID


### PR DESCRIPTION
## Summary
- stamp `/start-work` messages with `Atlas (Plan Executor)` after the session agent is switched
- keep downstream event/UI readers from reverting the active session back to Prometheus
- add a regression test for the Atlas message stamp

## Problem
`/start-work` already updated the internal session agent to `atlas`, but it did not update the outgoing message metadata. Downstream readers that rely on message agent data could still see `Prometheus (Plan Builder)` and later treat the session as Prometheus again.

## Fix
Set `output.message.agent` to `Atlas (Plan Executor)` in the `start-work` hook immediately after `updateSessionAgent(input.sessionID, "atlas")`.

## Companion issue
- #2584
- https://github.com/code-yeongyu/oh-my-openagent/issues/2584

## Verification
- `bun test src/hooks/start-work/index.test.ts`
- `bun test src/plugin/event.test.ts`
