### PR TITLE
fix(agents): include config agents and migrated plugin agents in customAgentSummaries

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -87,16 +87,28 @@ export async function applyAgentConfig(params: {
   const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
   const rawPluginAgents = params.pluginComponents.agents;
 
+  const pluginAgents = Object.fromEntries(
+    Object.entries(rawPluginAgents).map(([key, value]) => [
+      key,
+      value ? migrateAgentConfig(value as Record<string, unknown>) : value,
+    ]),
+  );
+
+  const configAgent = params.config.agent as AgentConfigRecord | undefined;
+
   const customAgentSummaries = [
+    ...Object.entries(configAgent ?? {}),
     ...Object.entries(userAgents),
     ...Object.entries(projectAgents),
-    ...Object.entries(rawPluginAgents).filter(([, config]) => config !== undefined),
-  ].map(([name, config]) => ({
-    name,
-    description: typeof (config as Record<string, unknown>)?.description === "string"
-      ? (config as Record<string, unknown>).description as string
-      : "",
-  }));
+    ...Object.entries(pluginAgents).filter(([, config]) => config !== undefined),
+  ]
+    .filter(([, config]) => config != null)
+    .map(([name, config]) => ({
+      name,
+      description: typeof (config as Record<string, unknown>)?.description === "string"
+        ? ((config as Record<string, unknown>).description as string)
+        : "",
+    }));
 
   const builtinAgents = await createBuiltinAgents(
     migratedDisabledAgents,
@@ -112,13 +124,6 @@ export async function applyAgentConfig(params: {
     disabledSkills,
     useTaskSystem,
     disableOmoEnv,
-  );
-
-  const pluginAgents = Object.fromEntries(
-    Object.entries(rawPluginAgents).map(([key, value]) => [
-      key,
-      value ? migrateAgentConfig(value as Record<string, unknown>) : value,
-    ]),
   );
 
   const disabledAgentNames = new Set(
@@ -137,8 +142,6 @@ export async function applyAgentConfig(params: {
   const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
   const shouldDemotePlan = plannerEnabled && replacePlan;
   const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
-
-  const configAgent = params.config.agent as AgentConfigRecord | undefined;
 
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
     if (configuredDefaultAgent) {


### PR DESCRIPTION
## Summary

Follow-up to #2424 which fixed the critical `customAgentSummaries` bug (passing client object instead of array). That fix covered user, project, and raw plugin agents but missed two sources:

- **OpenCode native config agents** (`params.config.agent`) — agents defined directly in OpenCode's config were not included in Sisyphus's summaries
- **Plugin agent migration** — `migrateAgentConfig` was not applied to plugin agents before summary extraction, so legacy field names could produce empty descriptions

## Changes

In `src/plugin-handlers/agent-config-handler.ts`:

1. Move `pluginAgents` (with `migrateAgentConfig`) and `configAgent` extraction **before** `customAgentSummaries` construction
2. Include all 4 agent sources in summaries: `configAgent`, `userAgents`, `projectAgents`, `pluginAgents`
3. Add null guard (`.filter(([, config]) => config != null)`) for safety
4. Remove duplicate declarations that were previously below `createBuiltinAgents`

## Context

Three PRs attempted to fix #2386:
- **#2424** (merged) — fixed the critical bug, covered 3/4 agent sources
- **#2392** (open, stale) — identified the missing `config.agent` source, but accumulated merge conflicts
- **#2478** (closed) — superseded by #2424

This PR cherry-picks the completeness improvement from #2392's analysis. Supersedes #2392.

## Related Issues

- Closes #2386 (completeness gap)
- Supersedes #2392

Co-authored-by: @davincilll

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include config-defined agents and migrated plugin agents in `customAgentSummaries` so Sisyphus sees all registered agents and descriptions. Fixes missing summaries from `params.config.agent` and legacy plugin plugin configs.

- Bug Fixes
  - Build summaries from four sources: `configAgent`, `userAgents`, `projectAgents`, `pluginAgents`.
  - Apply `migrateAgentConfig` before extracting summaries and add null guards.
  - Reorder extraction to run before `customAgentSummaries` and remove duplicates.

<sup>Written for commit e8a3e549bb0380385e554b060e8e7724babe067c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

