### PR TITLE
fix(doctor): fall back to loadedVersion when pluginVersion is null

### DIFF
--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -36,7 +36,7 @@ export async function gatherSystemInfo(): Promise<SystemInfo> {
   const loadedInfo = getLoadedPluginVersion()
 
   const opencodeVersion = binaryInfo ? await getOpenCodeVersion(binaryInfo.path) : null
-  const pluginVersion = pluginInfo.pinnedVersion ?? loadedInfo.expectedVersion
+  const pluginVersion = pluginInfo.pinnedVersion ?? loadedInfo.expectedVersion ?? loadedInfo.loadedVersion
 
   return {
     opencodeVersion,


### PR DESCRIPTION
## Summary

- Doctor displays `oh-my-opencode unknown` because `pluginVersion` has no fallback to `loadedVersion`
- Add `loadedVersion` as third fallback in nullish coalescing chain

Closes #2595

## Change

`src/cli/doctor/checks/system.ts` — 1 line:

```diff
- const pluginVersion = pluginInfo.pinnedVersion ?? loadedInfo.expectedVersion
+ const pluginVersion = pluginInfo.pinnedVersion ?? loadedInfo.expectedVersion ?? loadedInfo.loadedVersion
```

## Why

When `opencode.json` registers the plugin without a version (`"oh-my-opencode"`) and the auto-updater syncs the cache `package.json` to use `"latest"` tag, `normalizeVersion("latest")` returns `null` because it only matches semver patterns. Meanwhile `loadedVersion` correctly reads `"3.11.2"` from `node_modules/oh-my-opencode/package.json` but is never used for display.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Doctor showing `oh-my-opencode unknown` by falling back to the loaded plugin version when pinned/expected versions are missing. Ensures the real installed version shows even when `opencode.json` uses `latest`.

- **Bug Fixes**
  - In `src/cli/doctor/checks/system.ts`, compute `pluginVersion` as `pinnedVersion ?? expectedVersion ?? loadedVersion` (Closes #2595).

<sup>Written for commit 5b7ca99b9605728b1d80eb579c4b88d6eb5de102. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

