### PR TITLE
fix(todo-continuation-enforcer): skip continuation when only compaction messages exist

### DIFF
--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -144,8 +144,11 @@ export async function handleSessionIdle(args: {
   }
 
   let resolvedInfo: ResolvedMessageInfo | undefined
+  let encounteredCompaction = false
   try {
-    resolvedInfo = await resolveLatestMessageInfo(ctx, sessionID)
+    const messageInfoResult = await resolveLatestMessageInfo(ctx, sessionID)
+    resolvedInfo = messageInfoResult.resolvedInfo
+    encounteredCompaction = messageInfoResult.encounteredCompaction
   } catch (error) {
     log(`[${HOOK_NAME}] Failed to fetch messages for agent check`, { sessionID, error: String(error) })
   }
@@ -164,7 +167,7 @@ export async function handleSessionIdle(args: {
     log(`[${HOOK_NAME}] Skipped: agent in skipAgents list`, { sessionID, agent: resolvedAgentName })
     return
   }
-  if (compactionGuardActive && !resolvedInfo?.agent) {
+  if ((compactionGuardActive || encounteredCompaction) && !resolvedInfo?.agent) {
     log(`[${HOOK_NAME}] Skipped: compaction occurred but no agent info resolved`, { sessionID })
     return
   }

--- a/src/hooks/todo-continuation-enforcer/resolve-message-info.ts
+++ b/src/hooks/todo-continuation-enforcer/resolve-message-info.ts
@@ -2,30 +2,35 @@ import type { PluginInput } from "@opencode-ai/plugin"
 
 import { normalizeSDKResponse } from "../../shared"
 
-import type { MessageInfo, ResolvedMessageInfo } from "./types"
+import type { MessageInfo, ResolveLatestMessageInfoResult } from "./types"
 
 export async function resolveLatestMessageInfo(
   ctx: PluginInput,
   sessionID: string
-): Promise<ResolvedMessageInfo | undefined> {
+): Promise<ResolveLatestMessageInfoResult> {
   const messagesResp = await ctx.client.session.messages({
     path: { id: sessionID },
   })
   const messages = normalizeSDKResponse(messagesResp, [] as Array<{ info?: MessageInfo }>)
+  let encounteredCompaction = false
 
   for (let i = messages.length - 1; i >= 0; i--) {
     const info = messages[i].info
     if (info?.agent === "compaction") {
+      encounteredCompaction = true
       continue
     }
     if (info?.agent || info?.model || (info?.modelID && info?.providerID)) {
       return {
-        agent: info.agent,
-        model: info.model ?? (info.providerID && info.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined),
-        tools: info.tools,
+        resolvedInfo: {
+          agent: info.agent,
+          model: info.model ?? (info.providerID && info.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined),
+          tools: info.tools,
+        },
+        encounteredCompaction,
       }
     }
   }
 
-  return undefined
+  return { resolvedInfo: undefined, encounteredCompaction }
 }

--- a/src/hooks/todo-continuation-enforcer/types.ts
+++ b/src/hooks/todo-continuation-enforcer/types.ts
@@ -54,3 +54,8 @@ export interface ResolvedMessageInfo {
   model?: { providerID: string; modelID: string }
   tools?: Record<string, ToolPermission>
 }
+
+export interface ResolveLatestMessageInfoResult {
+  resolvedInfo?: ResolvedMessageInfo
+  encounteredCompaction: boolean
+}


### PR DESCRIPTION
## Summary
- Fixes a regression where idle continuation could still inject when message history contained only `compaction` entries and no resolvable agent.
- `resolveLatestMessageInfo` now returns both resolved agent/model info and whether compaction messages were encountered during scan.
- `handleSessionIdle` now treats compaction-only history as a skip condition even when the time-window compaction guard is not active.

## Why
- The previous guard depended on `recentCompactionAt` timing, which can miss compaction-only history scenarios and allow unintended continuation injection.

## Verification
- `bun test src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts`
- `bun test src/hooks/todo-continuation-enforcer`
- `bun run typecheck`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip idle continuation when the session history only has `compaction` messages. Fixes a regression that could inject continuation without a resolvable agent.

- **Bug Fixes**
  - `resolveLatestMessageInfo` now returns `{ resolvedInfo, encounteredCompaction }` and tracks `compaction` during the scan.
  - `handleSessionIdle` now skips when no agent is resolved and either the compaction guard is active or compaction-only history was detected.

<sup>Written for commit 9e7abe2deaf060558949fda1cb2e24e67acfb535. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

