### PR TITLE
Revert "fix(test): update package name to oh-my-openagent in install test"

### DIFF
--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -108,7 +108,7 @@ describe("install CLI - binary check behavior", () => {
     // then opencode.json should have plugin entry
     const config = JSON.parse(readFileSync(configPath, "utf-8"))
     expect(config.plugin).toBeDefined()
-    expect(config.plugin.some((p: string) => p.includes("oh-my-openagent"))).toBe(true)
+    expect(config.plugin.some((p: string) => p.includes("oh-my-opencode"))).toBe(true)
 
     // then exit code should be 0 (success)
     expect(exitCode).toBe(0)


### PR DESCRIPTION
Reverts code-yeongyu/oh-my-openagent#2582. Upstream reverted package identity back to oh-my-opencode, so the installer test should assert the restored plugin entry rather than the oh-my-openagent name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update install CLI test to assert `oh-my-opencode` instead of `oh-my-openagent`, matching the upstream package rename revert. Fixes the test by checking the restored plugin entry in `opencode.json`.

<sup>Written for commit a7800a8bf691b0fd1502effda9546e0ebfb68cb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

