### PR TITLE
fix: rename OMX_OPENCLAW env vars to OMO_OPENCLAW

### DIFF
--- a/src/openclaw/__tests__/client.test.ts
+++ b/src/openclaw/__tests__/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "bun:test";
-import { resolveGateway } from "../client";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { resolveGateway, wakeOpenClaw } from "../client";
 import { type OpenClawConfig } from "../types";
 
 describe("OpenClaw Client", () => {
@@ -36,6 +36,63 @@ describe("OpenClaw Client", () => {
     it("returns null for unmapped event", () => {
       const result = resolveGateway(config, "ask-user-question");
       expect(result).toBeNull();
+    });
+  });
+
+  describe("wakeOpenClaw env gate", () => {
+    let oldEnv: string | undefined;
+
+    beforeEach(() => {
+      oldEnv = process.env.OMO_OPENCLAW;
+    });
+
+    afterEach(() => {
+      if (oldEnv === undefined) {
+        delete process.env.OMO_OPENCLAW;
+      } else {
+        process.env.OMO_OPENCLAW = oldEnv;
+      }
+    });
+
+    it("returns null when OMO_OPENCLAW is not set", async () => {
+      delete process.env.OMO_OPENCLAW;
+      const config: OpenClawConfig = {
+        enabled: true,
+        gateways: { gw: { type: "command", command: "echo test" } },
+        hooks: {
+          "session-start": { gateway: "gw", instruction: "hi", enabled: true },
+        },
+      };
+      const result = await wakeOpenClaw("session-start", { projectPath: "/tmp" }, config);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when OMO_OPENCLAW is not '1'", async () => {
+      process.env.OMO_OPENCLAW = "0";
+      const config: OpenClawConfig = {
+        enabled: true,
+        gateways: { gw: { type: "command", command: "echo test" } },
+        hooks: {
+          "session-start": { gateway: "gw", instruction: "hi", enabled: true },
+        },
+      };
+      const result = await wakeOpenClaw("session-start", { projectPath: "/tmp" }, config);
+      expect(result).toBeNull();
+    });
+
+    it("does not use OMX_OPENCLAW (old env var)", async () => {
+      delete process.env.OMO_OPENCLAW;
+      process.env.OMX_OPENCLAW = "1";
+      const config: OpenClawConfig = {
+        enabled: true,
+        gateways: { gw: { type: "command", command: "echo test" } },
+        hooks: {
+          "session-start": { gateway: "gw", instruction: "hi", enabled: true },
+        },
+      };
+      const result = await wakeOpenClaw("session-start", { projectPath: "/tmp" }, config);
+      expect(result).toBeNull();
+      delete process.env.OMX_OPENCLAW;
     });
   });
 });

--- a/src/openclaw/__tests__/dispatcher.test.ts
+++ b/src/openclaw/__tests__/dispatcher.test.ts
@@ -63,8 +63,8 @@ describe("OpenClaw Dispatcher", () => {
 
   describe("wakeCommandGateway", () => {
     it("rejects if disabled via env", async () => {
-      const oldEnv = process.env.OMX_OPENCLAW_COMMAND;
-      process.env.OMX_OPENCLAW_COMMAND = "0";
+      const oldEnv = process.env.OMO_OPENCLAW_COMMAND;
+      process.env.OMO_OPENCLAW_COMMAND = "0";
       const config: OpenClawCommandGatewayConfig = {
         type: "command",
         command: "echo hi",
@@ -72,7 +72,7 @@ describe("OpenClaw Dispatcher", () => {
       const result = await wakeCommandGateway("test", config, {});
       expect(result.success).toBe(false);
       expect(result.error).toContain("disabled");
-      process.env.OMX_OPENCLAW_COMMAND = oldEnv;
+      process.env.OMO_OPENCLAW_COMMAND = oldEnv;
     });
   });
 });

--- a/src/openclaw/client.ts
+++ b/src/openclaw/client.ts
@@ -6,7 +6,7 @@
  * Usage:
  *   wakeOpenClaw("session-start", { sessionId, projectPath: directory }, config);
  *
- * Activation requires OMX_OPENCLAW=1 env var and config in pluginConfig.openclaw.
+ * Activation requires OMO_OPENCLAW=1 env var and config in pluginConfig.openclaw.
  */
 
 import {
@@ -29,7 +29,7 @@ import { execSync } from "child_process";
 import { basename } from "path";
 
 /** Whether debug logging is enabled */
-const DEBUG = process.env.OMX_OPENCLAW_DEBUG === "1";
+const DEBUG = process.env.OMO_OPENCLAW_DEBUG === "1";
 
 // Helper for tmux session
 function getCurrentTmuxSession(): string | undefined {
@@ -138,8 +138,8 @@ export async function wakeOpenClaw(
   config?: OpenClawConfig
 ): Promise<OpenClawResult | null> {
   try {
-    // Activation gate: only active when OMX_OPENCLAW=1
-    if (process.env.OMX_OPENCLAW !== "1") {
+    // Activation gate: only active when OMO_OPENCLAW=1
+    if (process.env.OMO_OPENCLAW !== "1") {
       return null;
     }
 

--- a/src/openclaw/dispatcher.ts
+++ b/src/openclaw/dispatcher.ts
@@ -5,7 +5,7 @@
  * All calls are non-blocking with timeouts. Failures are swallowed
  * to avoid blocking hooks.
  *
- * SECURITY: Command gateway requires OMX_OPENCLAW_COMMAND=1 opt-in.
+ * SECURITY: Command gateway requires OMO_OPENCLAW_COMMAND=1 opt-in.
  * Command timeout is configurable with safe bounds.
  * Prefers execFile for simple commands; falls back to sh -c only for shell metacharacters.
  */
@@ -105,11 +105,11 @@ export function shellEscapeArg(value: string): string {
 
 /**
  * Resolve command gateway timeout with precedence:
- * gateway timeout > OMX_OPENCLAW_COMMAND_TIMEOUT_MS > default.
+ * gateway timeout > OMO_OPENCLAW_COMMAND_TIMEOUT_MS > default.
  */
 export function resolveCommandTimeoutMs(
   gatewayTimeout?: number,
-  envTimeoutRaw = process.env.OMX_OPENCLAW_COMMAND_TIMEOUT_MS
+  envTimeoutRaw = process.env.OMO_OPENCLAW_COMMAND_TIMEOUT_MS
 ): number {
   const parseFinite = (value: unknown): number | undefined => {
     if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
@@ -189,8 +189,8 @@ export async function wakeGateway(
  * Wake a command-type OpenClaw gateway by executing a shell command.
  *
  * SECURITY REQUIREMENTS:
- * - Requires OMX_OPENCLAW_COMMAND=1 opt-in (separate gate from OMX_OPENCLAW)
- * - Timeout is configurable via gateway.timeout or OMX_OPENCLAW_COMMAND_TIMEOUT_MS
+ * - Requires OMO_OPENCLAW_COMMAND=1 opt-in (separate gate from OMO_OPENCLAW)
+ * - Timeout is configurable via gateway.timeout or OMO_OPENCLAW_COMMAND_TIMEOUT_MS
  *   with safe clamping bounds and backward-compatible default 5000ms
  * - Prefers execFile for simple commands (no metacharacters)
  * - Falls back to sh -c only when metacharacters detected
@@ -206,11 +206,11 @@ export async function wakeCommandGateway(
   variables: Record<string, string | undefined>
 ): Promise<OpenClawResult> {
   // Separate command gateway opt-in gate
-  if (process.env.OMX_OPENCLAW_COMMAND !== "1") {
+  if (process.env.OMO_OPENCLAW_COMMAND !== "1") {
     return {
       gateway: gatewayName,
       success: false,
-      error: "Command gateway disabled (set OMX_OPENCLAW_COMMAND=1 to enable)",
+      error: "Command gateway disabled (set OMO_OPENCLAW_COMMAND=1 to enable)",
     };
   }
 

--- a/src/openclaw/types.ts
+++ b/src/openclaw/types.ts
@@ -36,7 +36,7 @@ export interface OpenClawCommandGatewayConfig {
   command: string;
   /**
    * Per-command timeout in ms.
-   * Precedence: gateway timeout > OMX_OPENCLAW_COMMAND_TIMEOUT_MS > default (5000ms).
+   * Precedence: gateway timeout > OMO_OPENCLAW_COMMAND_TIMEOUT_MS > default (5000ms).
    * Runtime clamps to safe bounds.
    */
   timeout?: number;


### PR DESCRIPTION
Renames all environment variable gates from the old oh-my-codex (OMX) prefix to the correct oh-my-openagent (OMO) prefix.

### Changes
- `OMX_OPENCLAW` -> `OMO_OPENCLAW`
- `OMX_OPENCLAW_COMMAND` -> `OMO_OPENCLAW_COMMAND`
- `OMX_OPENCLAW_DEBUG` -> `OMO_OPENCLAW_DEBUG`
- `OMX_OPENCLAW_COMMAND_TIMEOUT_MS` -> `OMO_OPENCLAW_COMMAND_TIMEOUT_MS`

### TDD
- Added env gate tests verifying OMO_OPENCLAW=1 is required
- Added negative test confirming old OMX_OPENCLAW is rejected
- 19 tests pass, 0 fail

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames OpenClaw env gates from `OMX_*` to `OMO_*` and enforces the new names. Old `OMX_*` vars are ignored; `OMO_OPENCLAW=1` is required to activate.

- **Migration**
  - Replace: `OMX_OPENCLAW` -> `OMO_OPENCLAW`, `OMX_OPENCLAW_COMMAND` -> `OMO_OPENCLAW_COMMAND`, `OMX_OPENCLAW_DEBUG` -> `OMO_OPENCLAW_DEBUG`, `OMX_OPENCLAW_COMMAND_TIMEOUT_MS` -> `OMO_OPENCLAW_COMMAND_TIMEOUT_MS`.
  - Ensure `OMO_OPENCLAW=1` to enable OpenClaw, and `OMO_OPENCLAW_COMMAND=1` for command gateways.

<sup>Written for commit 2c8813e95d2faa31e05068d456389351a6d387db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

