### PR TITLE
fix(runtime-fallback): extract status code from nested AI SDK errors

### DIFF
--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { classifyErrorType, extractAutoRetrySignal, isRetryableError } from "./error-classifier"
+import { classifyErrorType, extractAutoRetrySignal, extractStatusCode, isRetryableError } from "./error-classifier"
 
 describe("runtime-fallback error classifier", () => {
   test("detects cooling-down auto-retry status signals", () => {
@@ -95,5 +95,74 @@ describe("runtime-fallback error classifier", () => {
 
     //#then
     expect(signal).toBeUndefined()
+  })
+})
+
+describe("extractStatusCode", () => {
+  test("extracts numeric statusCode from top-level", () => {
+    expect(extractStatusCode({ statusCode: 429 })).toBe(429)
+  })
+
+  test("extracts numeric status from top-level", () => {
+    expect(extractStatusCode({ status: 503 })).toBe(503)
+  })
+
+  test("extracts statusCode from nested data", () => {
+    expect(extractStatusCode({ data: { statusCode: 500 } })).toBe(500)
+  })
+
+  test("extracts statusCode from nested error", () => {
+    expect(extractStatusCode({ error: { statusCode: 502 } })).toBe(502)
+  })
+
+  test("extracts statusCode from nested cause", () => {
+    expect(extractStatusCode({ cause: { statusCode: 504 } })).toBe(504)
+  })
+
+  test("skips non-numeric status and finds deeper numeric statusCode", () => {
+    //#given — status is a string, but error.statusCode is numeric
+    const error = {
+      status: "error",
+      error: { statusCode: 429 },
+    }
+
+    //#when
+    const code = extractStatusCode(error)
+
+    //#then
+    expect(code).toBe(429)
+  })
+
+  test("skips non-numeric statusCode string and finds numeric in cause", () => {
+    const error = {
+      statusCode: "UNKNOWN",
+      status: "failed",
+      cause: { statusCode: 503 },
+    }
+
+    expect(extractStatusCode(error)).toBe(503)
+  })
+
+  test("returns undefined when no numeric status exists", () => {
+    expect(extractStatusCode({ status: "error", message: "something broke" })).toBeUndefined()
+  })
+
+  test("returns undefined for null/undefined error", () => {
+    expect(extractStatusCode(null)).toBeUndefined()
+    expect(extractStatusCode(undefined)).toBeUndefined()
+  })
+
+  test("falls back to regex match in error message", () => {
+    const error = { message: "Request failed with status code 429" }
+    expect(extractStatusCode(error, [429, 503])).toBe(429)
+  })
+
+  test("prefers top-level numeric over nested numeric", () => {
+    const error = {
+      statusCode: 400,
+      error: { statusCode: 429 },
+      cause: { statusCode: 503 },
+    }
+    expect(extractStatusCode(error)).toBe(400)
   })
 })

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -33,7 +33,7 @@ export function extractStatusCode(error: unknown, retryOnErrors?: number[]): num
 
   const errorObj = error as Record<string, unknown>
 
-  const statusCode = errorObj.statusCode ?? errorObj.status ?? (errorObj.data as Record<string, unknown>)?.statusCode
+  const statusCode = errorObj.statusCode ?? errorObj.status ?? (errorObj.data as Record<string, unknown>)?.statusCode ?? (errorObj.error as Record<string, unknown>)?.statusCode ?? (errorObj.cause as Record<string, unknown>)?.statusCode
   if (typeof statusCode === "number") {
     return statusCode
   }

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -33,8 +33,15 @@ export function extractStatusCode(error: unknown, retryOnErrors?: number[]): num
 
   const errorObj = error as Record<string, unknown>
 
-  const statusCode = errorObj.statusCode ?? errorObj.status ?? (errorObj.data as Record<string, unknown>)?.statusCode ?? (errorObj.error as Record<string, unknown>)?.statusCode ?? (errorObj.cause as Record<string, unknown>)?.statusCode
-  if (typeof statusCode === "number") {
+  const statusCode = [
+    errorObj.statusCode,
+    errorObj.status,
+    (errorObj.data as Record<string, unknown>)?.statusCode,
+    (errorObj.error as Record<string, unknown>)?.statusCode,
+    (errorObj.cause as Record<string, unknown>)?.statusCode,
+  ].find((code): code is number => typeof code === "number")
+
+  if (statusCode !== undefined) {
     return statusCode
   }
 


### PR DESCRIPTION
## What's broken

When a model call fails, `extractStatusCode()` tries to find the HTTP status code in the error object so it can decide whether to retry with a fallback model.

The problem: the AI SDK (`@ai-sdk/provider-utils`) wraps errors in a nested structure. The status code ends up at `error.error.statusCode`, but `extractStatusCode()` only looks at the top level (`error.statusCode`, `error.status`, `error.data.statusCode`).

So when Claude returns a 400 or OpenAI returns a 500, the fallback system can't see the status code and treats the error as non-retryable. The user gets an error with no fallback attempt, even though their `retry_on_errors` config covers those codes.

## What this fixes

Adds two more places to look for the status code:

```typescript
// before
const statusCode = errorObj.statusCode ?? errorObj.status ?? errorObj.data?.statusCode

// after
const statusCode = errorObj.statusCode ?? errorObj.status ?? errorObj.data?.statusCode
  ?? errorObj.error?.statusCode    // AI SDK puts it here
  ?? errorObj.cause?.statusCode    // error chains sometimes use this
```

## Which errors were affected

| Status | Before | After |
|--------|--------|-------|
| 429 (rate limit) | Worked (text matching catches "rate limit") | Still works |
| 502/503 | Worked (text matching) | Still works |
| **400 (bad request)** | Silently skipped | Now detected |
| **500 (server error)** | Silently skipped | Now detected |
| **402, 403, 404, 504** | Silently skipped | Now detected |

## How I found this

I was debugging why runtime-fallback never fired for a 400 error. Real session log showed Atlas getting a 400 from Claude through CLIProxyAPI:

```json
{"error":{"name":"AI_APICallError","statusCode":400,"url":"http://127.0.0.1:8317/v1/messages"}}
```

The `statusCode: 400` was right there — just one level deeper than where the code was looking. The text fallback (regex matching "400" in the error message) also missed it because the message was just "Bad Request" without the number.

After patching this locally, all 11 configured `retry_on_errors` codes are properly detected.

Closes #2617

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runtime fallback by extracting HTTP status codes from nested SDK errors and ignoring non‑numeric fields. Ensures `retry_on_errors` reliably triggers on 4xx/5xx (including 400/500/504); closes #2617.

- **Bug Fixes**
  - Extend `extractStatusCode()` to check nested fields used by `@ai-sdk/provider-utils` (e.g., `AI_APICallError`) and select the first numeric code (skips strings like `status: "error"`).
  - Add tests covering top-level, nested (`data`/`error`/`cause`), non-numeric skip, regex message fallback, and precedence.

<sup>Written for commit de66f1f397b85d60f59a6854185045fc368228d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

