### PR TITLE
fix: optimize chat.message hooks to reduce TUI display delay

### DIFF
--- a/src/hooks/claude-code-hooks/config-loader.ts
+++ b/src/hooks/claude-code-hooks/config-loader.ts
@@ -53,6 +53,11 @@ function mergeDisabledHooks(
 }
 
 export async function loadPluginExtendedConfig(): Promise<PluginExtendedConfig> {
+  const now = Date.now()
+  if (cachedExtendedConfig !== undefined && now - extendedConfigLastLoaded < EXTENDED_CONFIG_CACHE_TTL_MS) {
+    return cachedExtendedConfig
+  }
+
   const userConfig = await loadConfigFromPath(USER_CONFIG_PATH)
   const projectConfig = await loadConfigFromPath(getProjectConfigPath())
 
@@ -71,8 +76,14 @@ export async function loadPluginExtendedConfig(): Promise<PluginExtendedConfig> 
     })
   }
 
+  cachedExtendedConfig = merged
+  extendedConfigLastLoaded = Date.now()
   return merged
 }
+
+let cachedExtendedConfig: PluginExtendedConfig | undefined = undefined
+let extendedConfigLastLoaded = 0
+const EXTENDED_CONFIG_CACHE_TTL_MS = 30000
 
 const regexCache = new Map<string, RegExp>()
 

--- a/src/hooks/claude-code-hooks/config.ts
+++ b/src/hooks/claude-code-hooks/config.ts
@@ -3,6 +3,10 @@ import { existsSync } from "fs"
 import { getClaudeConfigDir } from "../../shared"
 import type { ClaudeHooksConfig, HookMatcher, HookAction } from "./types"
 
+let cachedConfig: ClaudeHooksConfig | null | undefined = undefined
+let configLastLoaded = 0
+const CONFIG_CACHE_TTL_MS = 30000
+
 interface RawHookMatcher {
   matcher?: string
   pattern?: string
@@ -83,6 +87,11 @@ function mergeHooksConfig(
 export async function loadClaudeHooksConfig(
   customSettingsPath?: string
 ): Promise<ClaudeHooksConfig | null> {
+  const now = Date.now()
+  if (cachedConfig !== undefined && now - configLastLoaded < CONFIG_CACHE_TTL_MS) {
+    return cachedConfig
+  }
+
   const paths = getClaudeSettingsPaths(customSettingsPath)
   let mergedConfig: ClaudeHooksConfig = {}
 
@@ -101,5 +110,7 @@ export async function loadClaudeHooksConfig(
     }
   }
 
-  return Object.keys(mergedConfig).length > 0 ? mergedConfig : null
+  cachedConfig = Object.keys(mergedConfig).length > 0 ? mergedConfig : null
+  configLastLoaded = Date.now()
+  return cachedConfig
 }

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -96,18 +96,27 @@ export function createChatMessageHandler(args: {
     } else if (input.model) {
       setSessionModel(input.sessionID, input.model)
     }
-    await hooks.stopContinuationGuard?.["chat.message"]?.(input)
-    await hooks.backgroundNotificationHook?.["chat.message"]?.(input, output)
-    await hooks.runtimeFallback?.["chat.message"]?.(input, output)
-    await hooks.keywordDetector?.["chat.message"]?.(input, output)
-    await hooks.thinkMode?.["chat.message"]?.(input, output)
-    await hooks.claudeCodeHooks?.["chat.message"]?.(input, output)
+
+    await Promise.all([
+      hooks.stopContinuationGuard?.["chat.message"]?.(input),
+      hooks.backgroundNotificationHook?.["chat.message"]?.(input, output),
+      hooks.runtimeFallback?.["chat.message"]?.(input, output),
+      hooks.keywordDetector?.["chat.message"]?.(input, output),
+      hooks.thinkMode?.["chat.message"]?.(input, output),
+      hooks.noSisyphusGpt?.["chat.message"]?.(input, output),
+      hooks.noHephaestusNonGpt?.["chat.message"]?.(input, output),
+    ])
+
     await hooks.autoSlashCommand?.["chat.message"]?.(input, output)
-    await hooks.noSisyphusGpt?.["chat.message"]?.(input, output)
-    await hooks.noHephaestusNonGpt?.["chat.message"]?.(input, output)
-    if (hooks.startWork && isStartWorkHookOutput(output)) {
-      await hooks.startWork["chat.message"]?.(input, output)
-    }
+
+    const nonBlockingHooks: Promise<void>[] = [
+      hooks.claudeCodeHooks?.["chat.message"]?.(input, output),
+      hooks.startWork && isStartWorkHookOutput(output)
+        ? hooks.startWork["chat.message"]?.(input, output)
+        : undefined,
+    ].filter((p): p is Promise<void> => p !== undefined)
+
+    void Promise.all(nonBlockingHooks).catch(() => {})
 
     if (!hasConnectedProvidersCache()) {
       pluginContext.client.tui

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -109,11 +109,12 @@ export function createChatMessageHandler(args: {
 
     await hooks.autoSlashCommand?.["chat.message"]?.(input, output)
 
+    if (hooks.startWork && isStartWorkHookOutput(output)) {
+      await hooks.startWork["chat.message"]?.(input, output)
+    }
+
     const nonBlockingHooks: Promise<void>[] = [
       hooks.claudeCodeHooks?.["chat.message"]?.(input, output),
-      hooks.startWork && isStartWorkHookOutput(output)
-        ? hooks.startWork["chat.message"]?.(input, output)
-        : undefined,
     ].filter((p): p is Promise<void> => p !== undefined)
 
     void Promise.all(nonBlockingHooks).catch(() => {})

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -105,6 +105,7 @@ export function createChatMessageHandler(args: {
       hooks.thinkMode?.["chat.message"]?.(input, output),
       hooks.noSisyphusGpt?.["chat.message"]?.(input, output),
       hooks.noHephaestusNonGpt?.["chat.message"]?.(input, output),
+      hooks.claudeCodeHooks?.["chat.message"]?.(input, output),
     ])
 
     await hooks.autoSlashCommand?.["chat.message"]?.(input, output)
@@ -112,12 +113,6 @@ export function createChatMessageHandler(args: {
     if (hooks.startWork && isStartWorkHookOutput(output)) {
       await hooks.startWork["chat.message"]?.(input, output)
     }
-
-    const nonBlockingHooks: Promise<void>[] = [
-      hooks.claudeCodeHooks?.["chat.message"]?.(input, output),
-    ].filter((p): p is Promise<void> => p !== undefined)
-
-    void Promise.all(nonBlockingHooks).catch(() => {})
 
     if (!hasConnectedProvidersCache()) {
       pluginContext.client.tui


### PR DESCRIPTION
## Summary
This PR fixes the issue where user input messages don't display promptly in the TUI due to sequential execution of chat.message hooks.

### Changes
- Run independent hooks in parallel using Promise.all()
- Make I/O-heavy hooks (claudeCodeHooks) non-blocking
- Ensure hooks that modify output.parts execute sequentially:
  - keywordDetector → autoSlashCommand → startWork
- Fix incorrect classification of startWork as non-blocking

### Test Plan
- [x] Verify TUI displays user messages immediately
- [x] Test with claude-code-hooks enabled
- [x] Test slash commands (/start-work)
- [x] Test keyword detection (ultrawork, search, analyze)

### Type Safety
- [x] bun run typecheck passes
- [x] No TypeScript errors"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce TUI message display delay by parallelizing independent `chat.message` hooks and caching Claude Code configs. Output-mutating steps stay ordered, and errors from `claudeCodeHooks` still surface.

- **Bug Fixes**
  - Run independent hooks in parallel with Promise.all (stopContinuationGuard, backgroundNotificationHook, runtimeFallback, keywordDetector, thinkMode, noSisyphusGpt, noHephaestusNonGpt, `claudeCodeHooks`).
  - Move `claudeCodeHooks` back into Promise.all to preserve error propagation.
  - Keep mutating hooks sequential: autoSlashCommand → startWork.
  - Treat `startWork` as blocking only when triggered.

- **Performance**
  - Add 30s cache for `claude-code-hooks` config and extended config loading to reduce I/O and latency.

<sup>Written for commit 48703456f31d076459bf8de53abff4f67f08593a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

