### PR TITLE
fix: suppress analyze/search keyword injection for planner agents

### DIFF
--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -51,7 +51,9 @@ export function createKeywordDetectorHook(ctx: PluginInput, _collector?: Context
       let detectedKeywords = detectKeywordsWithType(cleanText, currentAgent, modelID)
 
       if (isPlannerAgent(currentAgent)) {
-        detectedKeywords = detectedKeywords.filter((k) => k.type !== "ultrawork")
+        detectedKeywords = detectedKeywords.filter(
+          (k) => k.type !== "ultrawork" && k.type !== "analyze" && k.type !== "search"
+        )
       }
 
       if (detectedKeywords.length === 0) {

--- a/src/hooks/keyword-detector/index.test.ts
+++ b/src/hooks/keyword-detector/index.test.ts
@@ -557,6 +557,71 @@ describe("keyword-detector agent-specific ultrawork messages", () => {
     } as any
   }
 
+  test("should skip analyze-mode injection when agent is prometheus", async () => {
+    // given - prometheus agent with analyze keyword in message
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "prometheus-analyze-session"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "왜 로그인이 안되는지 파악해서 계획해줘" }],
+    }
+
+    // when - analyze keyword detected with prometheus agent
+    await hook["chat.message"]({ sessionID, agent: "prometheus" }, output)
+
+    // then - analyze-mode should be skipped for planner agents, text unchanged
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toBe("왜 로그인이 안되는지 파악해서 계획해줘")
+    expect(textPart!.text).not.toContain("[analyze-mode]")
+  })
+
+  test("should skip search-mode injection when agent is prometheus", async () => {
+    // given - prometheus agent with search keyword in message
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+    const sessionID = "prometheus-search-session"
+    const output = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "찾아봐서 계획 세워줘" }],
+    }
+
+    // when - search keyword detected with prometheus agent
+    await hook["chat.message"]({ sessionID, agent: "prometheus" }, output)
+
+    // then - search-mode should be skipped for planner agents, text unchanged
+    const textPart = output.parts.find(p => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toBe("찾아봐서 계획 세워줘")
+    expect(textPart!.text).not.toContain("[search-mode]")
+  })
+
+  test("should skip all keyword injections for planner agents but allow for non-planner", async () => {
+    // given - same message tested with prometheus vs sisyphus
+    const collector = new ContextCollector()
+    const hook = createKeywordDetectorHook(createMockPluginInput(), collector)
+
+    // prometheus agent - should skip
+    const prometheusOutput = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "분석해서 계획해줘" }],
+    }
+    await hook["chat.message"]({ sessionID: "prom-sess", agent: "prometheus" }, prometheusOutput)
+
+    // sisyphus agent - should inject
+    setMainSession("sis-sess")
+    const sisyphusOutput = {
+      message: {} as Record<string, unknown>,
+      parts: [{ type: "text", text: "분석해서 계획해줘" }],
+    }
+    await hook["chat.message"]({ sessionID: "sis-sess", agent: "sisyphus" }, sisyphusOutput)
+
+    // then - prometheus: unchanged, sisyphus: analyze-mode injected
+    expect(prometheusOutput.parts[0].text).toBe("분석해서 계획해줘")
+    expect(sisyphusOutput.parts[0].text).toContain("[analyze-mode]")
+  })
+
   test("should skip ultrawork injection when agent is prometheus", async () => {
     // given - collector and prometheus agent
     const collector = new ContextCollector()


### PR DESCRIPTION
## Problem

When using `@plan` (Prometheus) directly, messages containing common Korean words like 왜/어떻게/이해/파악/분석 (or English equivalents: analyze/search/investigate) trigger the `[analyze-mode]` or `[search-mode]` injection via the `keyword-detector` hook.

This overrides Prometheus's interview mode — Prometheus sees the injected mode instructions first and immediately gathers context + generates a plan, **skipping the interview phase entirely**.

## Root Cause

`src/hooks/keyword-detector/hook.ts` only filters `ultrawork` keywords for planner agents, but not `analyze` or `search` types:

```typescript
// Before (bug)
if (isPlannerAgent(currentAgent)) {
  detectedKeywords = detectedKeywords.filter((k) => k.type !== "ultrawork")
  // analyze and search still leak through → overrides interview behavior
}
```

## Fix

Extended the filter to also suppress `analyze` and `search` for planner agents:

```typescript
// After (fix)
if (isPlannerAgent(currentAgent)) {
  detectedKeywords = detectedKeywords.filter(
    (k) => k.type !== "ultrawork" && k.type !== "analyze" && k.type !== "search"
  )
}
```

## Tests Added

- `should skip analyze-mode injection when agent is prometheus`
- `should skip search-mode injection when agent is prometheus`
- `should skip all keyword injections for planner agents but allow for non-planner`

All 28 tests pass. Build succeeds.

## Impact

- Prometheus interview mode now works correctly when user messages contain common analysis/search keywords
- analyze/search behavior is preserved for all non-planner agents (Sisyphus, Hephaestus, Atlas, etc.)
- No changes to non-planner agent behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress analyze/search keyword injection for planner agents so Prometheus keeps its interview flow instead of jumping to planning when messages include common analysis/search words. Non-planner agents keep existing analyze/search behavior.

- **Bug Fixes**
  - Filter out `ultrawork`, `analyze`, and `search` keywords for planner agents in the `keyword-detector` hook.
  - Added tests to confirm analyze/search suppression for Prometheus and normal injection for non-planner agents.

<sup>Written for commit 8555eda8c28a820c49b4b5bd173b4c46a02d1200. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

