### PR TITLE
fix(release): set version when publishing oh-my-openagent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -233,11 +233,10 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           
-          # Update package name to oh-my-openagent
-          jq '.name = "oh-my-openagent"' package.json > tmp.json && mv tmp.json package.json
-          
-          # Update optionalDependencies to use oh-my-openagent naming
+          # Update package name, version, and optionalDependencies for oh-my-openagent
           jq --arg v "$VERSION" '
+            .name = "oh-my-openagent" |
+            .version = $v |
             .optionalDependencies = (
               .optionalDependencies | to_entries |
               map(.key = (.key | sub("^oh-my-opencode-"; "oh-my-openagent-")) | .value = $v) |


### PR DESCRIPTION
Fixes the publish workflow not setting version for oh-my-openagent package. Was trying to publish with base package.json version (3.11.0) instead of the release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the publish workflow to set the release version when publishing `oh-my-openagent`, so npm publishes the correct version and avoids version conflict errors.

- **Bug Fixes**
  - In `.github/workflows/publish.yml`, set `package.json` `.version` to `${{ steps.version.outputs.version }}` and `.name` to `oh-my-openagent`.
  - Align `optionalDependencies` names to `oh-my-openagent-*` and set their versions to the same release version.

<sup>Written for commit 9b8aca45f9d7c6eb85bfe9bdaa4c30fc6eadcd9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

