### PR TITLE
fix(thinking-block-validator): preserve original signature by reusing the thinking Part verbatim

### DIFF
--- a/src/hooks/thinking-block-validator/hook.ts
+++ b/src/hooks/thinking-block-validator/hook.ts
@@ -21,11 +21,6 @@ interface MessageWithParts {
   parts: Part[]
 }
 
-interface ThinkingPart {
-  thinking?: string
-  text?: string
-}
-
 interface MessageInfoExtended {
   id: string
   role: string
@@ -87,53 +82,52 @@ function startsWithThinkingBlock(parts: Part[]): boolean {
 }
 
 /**
- * Find the most recent thinking content from previous assistant messages
+ * Find the most recent real thinking part from previous assistant messages.
+ *
+ * Returns the original Part object (including its `signature` field) so it can
+ * be reused verbatim in another message.  Synthetic parts — those that were
+ * injected by a previous run of this hook — are intentionally skipped because
+ * they lack a valid `signature` and would be rejected by the Anthropic API with
+ * "Invalid `signature` in `thinking` block".
  */
-function findPreviousThinkingContent(
+function findPreviousThinkingPart(
   messages: MessageWithParts[],
   currentIndex: number
-): string {
+): Part | null {
   // Search backwards from current message
   for (let i = currentIndex - 1; i >= 0; i--) {
     const msg = messages[i]
     if (msg.info.role !== "assistant") continue
-
-    // Look for thinking parts
     if (!msg.parts) continue
+
     for (const part of msg.parts) {
       const type = part.type as string
-      if (type === "thinking" || type === "reasoning") {
-        const thinking = (part as unknown as ThinkingPart).thinking || (part as unknown as ThinkingPart).text
-        if (thinking && typeof thinking === "string" && thinking.trim().length > 0) {
-          return thinking
-        }
-      }
+      if (type !== "thinking" && type !== "reasoning") continue
+
+      // Skip synthetic parts — they have no valid signature
+      if ((part as unknown as { synthetic?: boolean }).synthetic) continue
+
+      return part
     }
   }
 
-  return ""
+  return null
 }
 
 /**
- * Prepend a thinking block to a message's parts array
+ * Prepend an existing thinking block (with its original signature) to a
+ * message's parts array.
+ *
+ * We reuse the original Part verbatim instead of creating a new one, because
+ * the Anthropic API validates the `signature` field against the thinking
+ * content.  Any synthetic block we create ourselves would fail that check.
  */
-function prependThinkingBlock(message: MessageWithParts, thinkingContent: string): void {
+function prependThinkingBlock(message: MessageWithParts, thinkingPart: Part): void {
   if (!message.parts) {
     message.parts = []
   }
 
-  // Create synthetic thinking part
-  const thinkingPart = {
-    type: "thinking" as const,
-    id: `prt_0000000000_synthetic_thinking`,
-    sessionID: (message.info as unknown as MessageInfoExtended).sessionID || "",
-    messageID: message.info.id,
-    thinking: thinkingContent,
-    synthetic: true,
-  }
-
-  // Prepend to parts array
-  message.parts.unshift(thinkingPart as unknown as Part)
+  message.parts.unshift(thinkingPart)
 }
 
 /**
@@ -166,13 +160,18 @@ export function createThinkingBlockValidatorHook(): MessagesTransformHook {
 
         // Check if message has content parts but doesn't start with thinking
         if (hasContentParts(msg.parts) && !startsWithThinkingBlock(msg.parts)) {
-          // Find thinking content from previous turns
-          const previousThinking = findPreviousThinkingContent(messages, i)
+          // Find the most recent real thinking part (with valid signature) from
+          // previous turns.  If none exists we cannot safely inject a thinking
+          // block — a synthetic block without a signature would cause the API
+          // to reject the request with "Invalid `signature` in `thinking` block".
+          const previousThinkingPart = findPreviousThinkingPart(messages, i)
 
-          // Prepend thinking block with content from previous turn or placeholder
-          const thinkingContent = previousThinking || "[Continuing from previous reasoning]"
-
-          prependThinkingBlock(msg, thinkingContent)
+          if (previousThinkingPart) {
+            prependThinkingBlock(msg, previousThinkingPart)
+          }
+          // If no real thinking part is available, skip injection entirely.
+          // The downstream error (if any) is preferable to a guaranteed API
+          // rejection caused by a signature-less synthetic thinking block.
         }
       }
     },

--- a/src/hooks/thinking-block-validator/hook.ts
+++ b/src/hooks/thinking-block-validator/hook.ts
@@ -28,7 +28,7 @@ type MessagesTransformHook = {
   ) => Promise<void>
 }
 
-interface ThinkingPart extends Part {
+type ThinkingPart = Part & {
   thinking: string
   signature: string
   synthetic?: boolean

--- a/src/hooks/thinking-block-validator/hook.ts
+++ b/src/hooks/thinking-block-validator/hook.ts
@@ -28,19 +28,35 @@ type MessagesTransformHook = {
   ) => Promise<void>
 }
 
+interface ThinkingPart extends Part {
+  thinking: string
+  signature: string
+  synthetic?: boolean
+}
+
+function isAnthropicThinkingPart(part: Part): part is ThinkingPart {
+  return (
+    (part.type as string) === "thinking" &&
+    typeof (part as ThinkingPart).thinking === "string" &&
+    typeof (part as ThinkingPart).signature === "string"
+  )
+}
+
 /**
- * Check if there are any real thinking/reasoning blocks in the message history.
+ * Check if there are any Anthropic-signed thinking blocks in the message history.
+ *
+ * Only returns true for real `type: "thinking"` blocks with a valid `signature`.
+ * GPT reasoning blocks (`type: "reasoning"`) are intentionally excluded — they
+ * have no Anthropic signature and must never be forwarded to the Anthropic API.
+ *
  * Model-name checks are unreliable (miss GPT+thinking, custom model IDs, etc.)
  * so we inspect the messages themselves.
  */
-function hasThinkingBlocksInHistory(messages: MessageWithParts[]): boolean {
+function hasAnthropicThinkingBlocksInHistory(messages: MessageWithParts[]): boolean {
   return messages.some(
     m =>
       m.info.role === "assistant" &&
-      m.parts?.some((p: Part) => {
-        const type = p.type as string
-        return type === "thinking" || type === "reasoning"
-      }),
+      m.parts?.some((p: Part) => isAnthropicThinkingPart(p)),
   )
 }
 
@@ -69,18 +85,19 @@ function startsWithThinkingBlock(parts: Part[]): boolean {
 }
 
 /**
- * Find the most recent real thinking part from previous assistant messages.
+ * Find the most recent Anthropic-signed thinking part from previous assistant messages.
  *
  * Returns the original Part object (including its `signature` field) so it can
- * be reused verbatim in another message.  Synthetic parts — those that were
- * injected by a previous run of this hook — are intentionally skipped because
- * they lack a valid `signature` and would be rejected by the Anthropic API with
- * "Invalid `signature` in `thinking` block".
+ * be reused verbatim in another message.  Only `type: "thinking"` blocks with
+ * both a `signature` and `thinking` field are returned — GPT `type: "reasoning"`
+ * blocks are excluded because they lack an Anthropic signature and would be
+ * rejected by the API with "Invalid `signature` in `thinking` block".
+ * Synthetic parts injected by a previous run of this hook are also skipped.
  */
 function findPreviousThinkingPart(
   messages: MessageWithParts[],
   currentIndex: number
-): Part | null {
+): ThinkingPart | null {
   // Search backwards from current message
   for (let i = currentIndex - 1; i >= 0; i--) {
     const msg = messages[i]
@@ -88,11 +105,11 @@ function findPreviousThinkingPart(
     if (!msg.parts) continue
 
     for (const part of msg.parts) {
-      const type = part.type as string
-      if (type !== "thinking" && type !== "reasoning") continue
+      // Only Anthropic thinking blocks — type must be "thinking", not "reasoning"
+      if (!isAnthropicThinkingPart(part)) continue
 
       // Skip synthetic parts — they have no valid signature
-      if ((part as unknown as { synthetic?: boolean }).synthetic) continue
+      if (part.synthetic) continue
 
       return part
     }
@@ -109,7 +126,7 @@ function findPreviousThinkingPart(
  * the Anthropic API validates the `signature` field against the thinking
  * content.  Any synthetic block we create ourselves would fail that check.
  */
-function prependThinkingBlock(message: MessageWithParts, thinkingPart: Part): void {
+function prependThinkingBlock(message: MessageWithParts, thinkingPart: ThinkingPart): void {
   if (!message.parts) {
     message.parts = []
   }
@@ -129,10 +146,12 @@ export function createThinkingBlockValidatorHook(): MessagesTransformHook {
         return
       }
 
-      // Skip if there are no thinking blocks in history at all.
+      // Skip if there are no Anthropic-signed thinking blocks in history.
       // This is more reliable than checking model names — works for Claude,
-      // GPT with thinking variants, or any future model.
-      if (!hasThinkingBlocksInHistory(messages)) {
+      // GPT with thinking variants, or any future model.  Crucially, GPT
+      // reasoning blocks (type="reasoning", no signature) do NOT trigger this
+      // hook — only real Anthropic thinking blocks do.
+      if (!hasAnthropicThinkingBlocksInHistory(messages)) {
         return
       }
 

--- a/src/hooks/thinking-block-validator/hook.ts
+++ b/src/hooks/thinking-block-validator/hook.ts
@@ -21,13 +21,6 @@ interface MessageWithParts {
   parts: Part[]
 }
 
-interface MessageInfoExtended {
-  id: string
-  role: string
-  sessionID?: string
-  modelID?: string
-}
-
 type MessagesTransformHook = {
   "experimental.chat.messages.transform"?: (
     input: Record<string, never>,
@@ -36,24 +29,18 @@ type MessagesTransformHook = {
 }
 
 /**
- * Check if a model has extended thinking enabled
- * Uses patterns from think-mode/switcher.ts for consistency
+ * Check if there are any real thinking/reasoning blocks in the message history.
+ * Model-name checks are unreliable (miss GPT+thinking, custom model IDs, etc.)
+ * so we inspect the messages themselves.
  */
-function isExtendedThinkingModel(modelID: string): boolean {
-  if (!modelID) return false
-  const lower = modelID.toLowerCase()
-
-  // Check for explicit thinking/high variants (always enabled)
-  if (lower.includes("thinking") || lower.endsWith("-high")) {
-    return true
-  }
-
-  // Check for thinking-capable models (claude-4 family, claude-3)
-  // Aligns with THINKING_CAPABLE_MODELS in think-mode/switcher.ts
-  return (
-    lower.includes("claude-sonnet-4") ||
-    lower.includes("claude-opus-4") ||
-    lower.includes("claude-3")
+function hasThinkingBlocksInHistory(messages: MessageWithParts[]): boolean {
+  return messages.some(
+    m =>
+      m.info.role === "assistant" &&
+      m.parts?.some((p: Part) => {
+        const type = p.type as string
+        return type === "thinking" || type === "reasoning"
+      }),
   )
 }
 
@@ -142,12 +129,10 @@ export function createThinkingBlockValidatorHook(): MessagesTransformHook {
         return
       }
 
-      // Get the model info from the last user message
-      const lastUserMessage = messages.findLast(m => m.info.role === "user")
-      const modelID = (lastUserMessage?.info as unknown as MessageInfoExtended)?.modelID || ""
-
-      // Only process if extended thinking might be enabled
-      if (!isExtendedThinkingModel(modelID)) {
+      // Skip if there are no thinking blocks in history at all.
+      // This is more reliable than checking model names — works for Claude,
+      // GPT with thinking variants, or any future model.
+      if (!hasThinkingBlocksInHistory(messages)) {
         return
       }
 


### PR DESCRIPTION
## Problem

The `thinking-block-validator` hook crashes sessions that use extended thinking models with:

```
messages.N.content.M: Invalid `signature` in `thinking` block
```

### Root cause

`prependThinkingBlock` constructed a brand-new object from the thinking *text* alone:

```ts
const thinkingPart = {
  type: "thinking" as const,
  id: `prt_0000000000_synthetic_thinking`,
  thinking: thinkingContent,
  synthetic: true,
  // ❌ no 'signature' field
}
```

The Anthropic API requires every `thinking` block in conversation history to carry the **original `signature`** that was returned when the block was first generated.  A synthetic block without a valid signature is rejected unconditionally — making the hook cause exactly the kind of API error it was designed to prevent.

## Fix

1. **`findPreviousThinkingContent` → `findPreviousThinkingPart`** — returns the original `Part` object (including its `signature`) rather than a plain string.  Previously-injected synthetic parts are skipped because they have no valid signature.

2. **`prependThinkingBlock`** — now accepts a `Part` and `unshift`s it verbatim, so the `signature` is preserved unchanged.

3. **No-op when no real part exists** — if no previous assistant turn contains a real (non-synthetic) thinking block, injection is skipped entirely.  The downstream error — if any — is preferable to a *guaranteed* API rejection caused by a signature-less block.

## Impact

- Fixes the `Invalid `signature` in `thinking` block` error for all extended-thinking models
- No behavioural change for sessions where a real thinking part is available in history
- Removes the `[Continuing from previous reasoning]` placeholder that was never valid

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session crashes in `thinking-block-validator` by reusing the original Anthropic-signed `thinking` part and only injecting when such parts exist. Prevents Anthropic “Invalid `signature` in `thinking` block” errors and ignores GPT `reasoning` blocks.

- **Bug Fixes**
  - Renamed `findPreviousThinkingContent` → `findPreviousThinkingPart`; returns the original Anthropic `thinking` `Part` and skips synthetic entries.
  - `prependThinkingBlock` now unshifts the original `Part` verbatim to preserve `signature`.
  - Replaced model-name heuristic with a content-based check that only matches signed Anthropic `thinking` blocks; excludes GPT `reasoning`.
  - Added `ThinkingPart` and `isAnthropicThinkingPart`; lookup requires both `thinking` and `signature`, and we skip injection if none is found.

<sup>Written for commit 98fb17e801c73dd52b0a46986a10f08310d54f03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

