### PR TITLE
fix(boulder-state): treat plans without checkboxes as incomplete (fixes #2648)

### DIFF
--- a/src/features/boulder-state/storage.test.ts
+++ b/src/features/boulder-state/storage.test.ts
@@ -351,7 +351,7 @@ describe("boulder-state", () => {
       expect(progress.isComplete).toBe(true)
     })
 
-    test("should return isComplete true for empty plan", () => {
+    test("should return isComplete false for plan with content but no checkboxes", () => {
       // given - plan with no checkboxes
       const planPath = join(TEST_DIR, "empty-plan.md")
       writeFileSync(planPath, "# Plan\nNo tasks here")
@@ -361,7 +361,7 @@ describe("boulder-state", () => {
 
       // then
       expect(progress.total).toBe(0)
-      expect(progress.isComplete).toBe(true)
+      expect(progress.isComplete).toBe(false)
     })
 
     test("should handle non-existent file", () => {

--- a/src/features/boulder-state/storage.ts
+++ b/src/features/boulder-state/storage.ts
@@ -133,7 +133,7 @@ export function getPlanProgress(planPath: string): PlanProgress {
     return {
       total,
       completed,
-      isComplete: total === 0 || completed === total,
+      isComplete: total > 0 && completed === total,
     }
   } catch {
     return { total: 0, completed: 0, isComplete: true }


### PR DESCRIPTION
## Summary
- Fix `getPlanProgress()` to return `isComplete: false` when a plan file exists but contains no markdown checkboxes
- Previously, plans with 0 total checkboxes were treated as complete (`0/0 = true`), causing `/start-work` to skip Atlas execution
- GPT/Gemini Prometheus plans sometimes generate plans without `- [ ]` task checkboxes, triggering this bug

## Test plan
- [x] Updated `storage.test.ts` to expect `isComplete: false` for plans with content but no checkboxes
- [x] All 26 storage tests pass
- [x] Non-existent file case still correctly returns `isComplete: true`

Fixes #2648

🤖 Generated with assistance of [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat plans without markdown checkboxes as incomplete to stop /start-work from skipping Atlas, and add a new hook to enforce clear, atomic TodoWrite items.

- **Bug Fixes**
  - Change isComplete to require total > 0 and completed === total.
  - Update tests to expect isComplete=false for plans with content but no checkboxes.
  - Non-existent file behavior unchanged (still returns complete).

- **New Features**
  - Add `todo-description-override` hook to replace the TodoWrite tool description with rules for WHERE/WHY/HOW/RESULT and 1–3-call granularity.
  - Wire the hook into the plugin interface and tool-guard creation; only runs when enabled.
  - Include tests for overriding behavior.

<sup>Written for commit ef8f22caba516585e7d8d741f0369a51e3286afd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

