### PR TITLE
fix(config): support oh-my-openagent.jsonc as alternative config file name (fixes #2624)

### DIFF
--- a/src/cli/doctor/checks/config.ts
+++ b/src/cli/doctor/checks/config.ts
@@ -9,8 +9,11 @@ import { loadAvailableModelsFromCache } from "./model-resolution-cache"
 import { getModelResolutionInfoWithOverrides } from "./model-resolution"
 import type { OmoConfig } from "./model-resolution-types"
 
+const PACKAGE_NAME_ALT = "oh-my-openagent"
 const USER_CONFIG_BASE = join(getOpenCodeConfigDir({ binary: "opencode" }), PACKAGE_NAME)
+const USER_CONFIG_BASE_ALT = join(getOpenCodeConfigDir({ binary: "opencode" }), PACKAGE_NAME_ALT)
 const PROJECT_CONFIG_BASE = join(process.cwd(), ".opencode", PACKAGE_NAME)
+const PROJECT_CONFIG_BASE_ALT = join(process.cwd(), ".opencode", PACKAGE_NAME_ALT)
 
 interface ConfigValidationResult {
   exists: boolean
@@ -24,8 +27,14 @@ function findConfigPath(): string | null {
   const projectConfig = detectConfigFile(PROJECT_CONFIG_BASE)
   if (projectConfig.format !== "none") return projectConfig.path
 
+  const projectConfigAlt = detectConfigFile(PROJECT_CONFIG_BASE_ALT)
+  if (projectConfigAlt.format !== "none") return projectConfigAlt.path
+
   const userConfig = detectConfigFile(USER_CONFIG_BASE)
   if (userConfig.format !== "none") return userConfig.path
+
+  const userConfigAlt = detectConfigFile(USER_CONFIG_BASE_ALT)
+  if (userConfigAlt.format !== "none") return userConfigAlt.path
 
   return null
 }

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -160,18 +160,32 @@ export function loadPluginConfig(
   directory: string,
   ctx: unknown
 ): OhMyOpenCodeConfig {
-  // User-level config path - prefer .jsonc over .json
+  // User-level config path - prefer .jsonc over .json, try oh-my-openagent as fallback
   const configDir = getOpenCodeConfigDir({ binary: "opencode" });
   const userBasePath = path.join(configDir, "oh-my-opencode");
-  const userDetected = detectConfigFile(userBasePath);
+  let userDetected = detectConfigFile(userBasePath);
+  if (userDetected.format === "none") {
+    const altUserBasePath = path.join(configDir, "oh-my-openagent");
+    const altDetected = detectConfigFile(altUserBasePath);
+    if (altDetected.format !== "none") {
+      userDetected = altDetected;
+    }
+  }
   const userConfigPath =
     userDetected.format !== "none"
       ? userDetected.path
       : userBasePath + ".json";
 
-  // Project-level config path - prefer .jsonc over .json
+  // Project-level config path - prefer .jsonc over .json, try oh-my-openagent as fallback
   const projectBasePath = path.join(directory, ".opencode", "oh-my-opencode");
-  const projectDetected = detectConfigFile(projectBasePath);
+  let projectDetected = detectConfigFile(projectBasePath);
+  if (projectDetected.format === "none") {
+    const altProjectBasePath = path.join(directory, ".opencode", "oh-my-openagent");
+    const altDetected = detectConfigFile(altProjectBasePath);
+    if (altDetected.format !== "none") {
+      projectDetected = altDetected;
+    }
+  }
   const projectConfigPath =
     projectDetected.format !== "none"
       ? projectDetected.path

--- a/src/shared/opencode-config-dir-types.ts
+++ b/src/shared/opencode-config-dir-types.ts
@@ -12,4 +12,5 @@ export type OpenCodeConfigPaths = {
   configJsonc: string
   packageJson: string
   omoConfig: string
+  omoConfigAlt: string
 }

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -84,6 +84,7 @@ export function getOpenCodeConfigPaths(options: OpenCodeConfigDirOptions): OpenC
     configJsonc: join(configDir, "opencode.jsonc"),
     packageJson: join(configDir, "package.json"),
     omoConfig: join(configDir, "oh-my-opencode.json"),
+    omoConfigAlt: join(configDir, "oh-my-openagent.json"),
   }
 }
 

--- a/src/tools/lsp/server-config-loader.ts
+++ b/src/tools/lsp/server-config-loader.ts
@@ -37,9 +37,19 @@ export function loadJsonFile<T>(path: string): T | null {
 export function getConfigPaths(): { project: string; user: string; opencode: string } {
   const cwd = process.cwd()
   const configDir = getOpenCodeConfigDir({ binary: "opencode" })
+  const projectDetected = detectConfigFile(join(cwd, ".opencode", "oh-my-opencode"))
+  const projectPath = projectDetected.format !== "none"
+    ? projectDetected.path
+    : detectConfigFile(join(cwd, ".opencode", "oh-my-openagent")).path
+
+  const userDetected = detectConfigFile(join(configDir, "oh-my-opencode"))
+  const userPath = userDetected.format !== "none"
+    ? userDetected.path
+    : detectConfigFile(join(configDir, "oh-my-openagent")).path
+
   return {
-    project: detectConfigFile(join(cwd, ".opencode", "oh-my-opencode")).path,
-    user: detectConfigFile(join(configDir, "oh-my-opencode")).path,
+    project: projectPath,
+    user: userPath,
     opencode: detectConfigFile(join(configDir, "opencode")).path,
   }
 }


### PR DESCRIPTION
## Summary
- Add `oh-my-openagent.jsonc/json` as fallback config file names when `oh-my-opencode.jsonc/json` is not found
- Updated all config discovery paths: plugin-config, doctor check, LSP config loader, opencode-config-dir
- `oh-my-opencode` remains primary for backward compatibility

## Test plan
- [x] All 13 plugin-config tests pass
- [x] All 25 opencode-config-dir tests pass
- [x] Backward compatible - existing oh-my-opencode configs still work

Fixes #2624

🤖 Generated with assistance of [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `oh-my-openagent.jsonc/.json` as a fallback config filename across the app while keeping `oh-my-opencode` primary. Also introduces a `todo-description-override` hook that tightens the `todowrite` tool guidance for small, well-scoped todos.

- **Bug Fixes**
  - Config discovery now falls back to `oh-my-openagent.jsonc/.json` in project and user scopes (plugin config, doctor check, LSP loader, config-dir). Backward compatible; fixes #2624.

- **New Features**
  - Added `todo-description-override` hook to replace the `todowrite` description with stricter rules (WHERE/WHY/HOW/RESULT; 1–3 call granularity). Includes tests.

<sup>Written for commit f6ca8bc934b69a5a5f861e8120c907116e63f9a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

