### PR TITLE
fix(runtime-fallback): preserve agent variant and reasoningEffort on model fallback (fixes #2621)

### DIFF
--- a/src/hooks/runtime-fallback/auto-retry.ts
+++ b/src/hooks/runtime-fallback/auto-retry.ts
@@ -101,7 +101,13 @@ export function createAutoRetryHelpers(deps: HookDeps) {
       return
     }
 
-    const retryModelPayload = buildRetryModelPayload(newModel)
+    const agentSettings = resolvedAgent
+      ? pluginConfig?.agents?.[resolvedAgent as keyof typeof pluginConfig.agents]
+      : undefined
+    const retryModelPayload = buildRetryModelPayload(newModel, agentSettings ? {
+      variant: agentSettings.variant,
+      reasoningEffort: agentSettings.reasoningEffort,
+    } : undefined)
     if (!retryModelPayload) {
       log(`[${HOOK_NAME}] Invalid model format (missing provider prefix): ${newModel}`)
       const state = sessionStates.get(sessionID)

--- a/src/hooks/runtime-fallback/retry-model-payload.test.ts
+++ b/src/hooks/runtime-fallback/retry-model-payload.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect } from "bun:test"
+import { buildRetryModelPayload } from "./retry-model-payload"
+
+describe("buildRetryModelPayload", () => {
+  test("should return undefined for empty model string", () => {
+    // given
+    const model = ""
+
+    // when
+    const result = buildRetryModelPayload(model)
+
+    // then
+    expect(result).toBeUndefined()
+  })
+
+  test("should return undefined for model without provider prefix", () => {
+    // given
+    const model = "kimi-k2.5"
+
+    // when
+    const result = buildRetryModelPayload(model)
+
+    // then
+    expect(result).toBeUndefined()
+  })
+
+  test("should parse provider and model ID", () => {
+    // given
+    const model = "chutes/kimi-k2.5"
+
+    // when
+    const result = buildRetryModelPayload(model)
+
+    // then
+    expect(result).toEqual({
+      model: { providerID: "chutes", modelID: "kimi-k2.5" },
+    })
+  })
+
+  test("should include variant from model string", () => {
+    // given
+    const model = "anthropic/claude-sonnet-4-5 high"
+
+    // when
+    const result = buildRetryModelPayload(model)
+
+    // then
+    expect(result).toEqual({
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+      variant: "high",
+    })
+  })
+
+  test("should use agent variant when model string has no variant", () => {
+    // given
+    const model = "chutes/kimi-k2.5"
+    const agentSettings = { variant: "max" }
+
+    // when
+    const result = buildRetryModelPayload(model, agentSettings)
+
+    // then
+    expect(result).toEqual({
+      model: { providerID: "chutes", modelID: "kimi-k2.5" },
+      variant: "max",
+    })
+  })
+
+  test("should prefer model string variant over agent variant", () => {
+    // given
+    const model = "anthropic/claude-sonnet-4-5 high"
+    const agentSettings = { variant: "max" }
+
+    // when
+    const result = buildRetryModelPayload(model, agentSettings)
+
+    // then
+    expect(result).toEqual({
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+      variant: "high",
+    })
+  })
+
+  test("should include reasoningEffort from agent settings", () => {
+    // given
+    const model = "openai/gpt-5.4"
+    const agentSettings = { variant: "high", reasoningEffort: "xhigh" }
+
+    // when
+    const result = buildRetryModelPayload(model, agentSettings)
+
+    // then
+    expect(result).toEqual({
+      model: { providerID: "openai", modelID: "gpt-5.4" },
+      variant: "high",
+      reasoningEffort: "xhigh",
+    })
+  })
+
+  test("should not include reasoningEffort when agent settings has none", () => {
+    // given
+    const model = "chutes/kimi-k2.5"
+    const agentSettings = { variant: "medium" }
+
+    // when
+    const result = buildRetryModelPayload(model, agentSettings)
+
+    // then
+    expect(result).toEqual({
+      model: { providerID: "chutes", modelID: "kimi-k2.5" },
+      variant: "medium",
+    })
+  })
+})

--- a/src/hooks/runtime-fallback/retry-model-payload.ts
+++ b/src/hooks/runtime-fallback/retry-model-payload.ts
@@ -2,24 +2,29 @@ import { parseModelString } from "../../tools/delegate-task/model-string-parser"
 
 export function buildRetryModelPayload(
   model: string,
-): { model: { providerID: string; modelID: string }; variant?: string } | undefined {
+  agentSettings?: { variant?: string; reasoningEffort?: string },
+): { model: { providerID: string; modelID: string }; variant?: string; reasoningEffort?: string } | undefined {
   const parsedModel = parseModelString(model)
   if (!parsedModel) {
     return undefined
   }
 
-  return parsedModel.variant
-    ? {
-        model: {
-          providerID: parsedModel.providerID,
-          modelID: parsedModel.modelID,
-        },
-        variant: parsedModel.variant,
-      }
-    : {
-        model: {
-          providerID: parsedModel.providerID,
-          modelID: parsedModel.modelID,
-        },
-      }
+  const variant = parsedModel.variant ?? agentSettings?.variant
+  const reasoningEffort = agentSettings?.reasoningEffort
+
+  const payload: { model: { providerID: string; modelID: string }; variant?: string; reasoningEffort?: string } = {
+    model: {
+      providerID: parsedModel.providerID,
+      modelID: parsedModel.modelID,
+    },
+  }
+
+  if (variant) {
+    payload.variant = variant
+  }
+  if (reasoningEffort) {
+    payload.reasoningEffort = reasoningEffort
+  }
+
+  return payload
 }


### PR DESCRIPTION
## Summary
- Fix `buildRetryModelPayload` to accept optional agent settings (variant, reasoningEffort)
- When a fallback model string doesn't include a variant (e.g., `chutes/kimi-k2.5`), the agent's configured variant is now used as fallback
- `reasoningEffort` from agent config is now passed through to the retry request
- Model string variant still takes precedence over agent config variant

## Test plan
- [x] Added 8 new test cases for `buildRetryModelPayload` covering all combinations
- [x] All 96 runtime-fallback tests pass
- [x] No regressions

Fixes #2621

🤖 Generated with assistance of [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the agent’s variant and reasoningEffort when runtime fallback switches models. Also adds a `todo-description-override` hook that rewrites the `todowrite` description to enforce atomic, well‑scoped todos (fixes #2621).

- **Bug Fixes**
  - `buildRetryModelPayload` now accepts optional agent settings and uses the agent’s variant when the model string has none; passes through `reasoningEffort`.
  - Auto-retry supplies agent `variant`/`reasoningEffort` to the retry payload; a model-string variant still takes precedence.
  - Added 8 unit tests for `buildRetryModelPayload`; runtime-fallback tests pass.

- **New Features**
  - Added `todo-description-override` hook on `tool.definition` to override `todowrite` description with rules: WHERE/WHY/HOW/RESULT and 1–3 tool-call granularity.
  - Registered the hook in configuration and wired it into the plugin interface and tool-guard setup.
  - Added tests for the description override behavior.

<sup>Written for commit 9ca259dcdc837ac5706aaaa49ca4cf55dbfc8d69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

