### PR TITLE
fix(atlas): use worktree path for git verification when available (fixes #2229)

### DIFF
--- a/src/hooks/atlas/tool-execute-after.ts
+++ b/src/hooks/atlas/tool-execute-after.ts
@@ -65,11 +65,13 @@ export function createToolExecuteAfterHandler(input: {
     }
 
     if (toolOutput.output && typeof toolOutput.output === "string") {
-      const gitStats = collectGitDiffStats(ctx.directory)
+      const boulderState = readBoulderState(ctx.directory)
+      const worktreePath = boulderState?.worktree_path?.trim()
+      const verificationDirectory = worktreePath ? worktreePath : ctx.directory
+      const gitStats = collectGitDiffStats(verificationDirectory)
       const fileChanges = formatFileChanges(gitStats)
       const subagentSessionId = extractSessionIdFromOutput(toolOutput.output)
 
-      const boulderState = readBoulderState(ctx.directory)
       if (boulderState) {
         const progress = getPlanProgress(boulderState.active_plan)
         const sessionState = toolInput.sessionID ? getState(toolInput.sessionID) : undefined


### PR DESCRIPTION
## Summary
- Use worktree path instead of main repo path when Atlas verifies subagent work

## Problem
When subagents work in git worktrees, Atlas verifies their work using `ctx.directory` (main repo). Since changes exist only in the worktree directory, Atlas incorrectly reports fabricated results. This affects worktree-based Atlas verification flows.

## Fix
Read boulder state first and resolve a verification directory: use `boulderState.worktree_path` when it is non-empty, otherwise fall back to `ctx.directory`. Use that resolved directory for `collectGitDiffStats`.

## Changes
| File | Change |
|------|--------|
| `src/hooks/atlas/tool-execute-after.ts` | Use worktree-aware verification directory for git diff stats collection |

Fixes #2229

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Atlas now verifies subagent work against the active git worktree path, preventing false fabrication reports when changes live in a worktree. Falls back to the repo path when no worktree is set. Fixes #2229.

- **Bug Fixes**
  - Resolve the verification directory by reading Boulder state and using `worktree_path` when present; otherwise use `ctx.directory`.
  - Pass the resolved directory to `collectGitDiffStats` in `src/hooks/atlas/tool-execute-after.ts`.

<sup>Written for commit 4723319eef905512ca8b3d3e227e3e4fadb04b31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

