### PR TITLE
fix(config): respect user model selection in web mode instead of reverting to plugin defaults (fixes #2351)

### DIFF
--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -278,4 +278,48 @@ describe("applyAgentConfig builtin override protection", () => {
     // then
     expect(createSisyphusJuniorAgentSpy).toHaveBeenCalledWith(undefined, "openai/gpt-5.4", false)
   })
+
+  test("keeps runtime-selected model for managed builtin agent display names", async () => {
+    // given
+    const config = createBaseConfig()
+    config.agent = {
+      [BUILTIN_SISYPHUS_DISPLAY_NAME]: {
+        model: "openai/gpt-5.4",
+        variant: "high",
+      },
+    }
+
+    // when
+    const result = await applyAgentConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    expect((result[BUILTIN_SISYPHUS_DISPLAY_NAME] as AgentConfig | undefined)?.model).toBe("openai/gpt-5.4")
+    expect((result[BUILTIN_SISYPHUS_DISPLAY_NAME] as AgentConfig | undefined)?.variant).toBe("high")
+  })
+
+  test("keeps runtime-selected model for managed builtin config-key aliases", async () => {
+    // given
+    const config = createBaseConfig()
+    config.agent = {
+      sisyphus: {
+        model: "openai/gpt-5.4",
+      },
+    }
+
+    // when
+    const result = await applyAgentConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    expect((result[BUILTIN_SISYPHUS_DISPLAY_NAME] as AgentConfig | undefined)?.model).toBe("openai/gpt-5.4")
+  })
 })

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -3,7 +3,7 @@ import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junio
 import type { OhMyOpenCodeConfig } from "../config";
 import { log, migrateAgentConfig } from "../shared";
 import { AGENT_NAME_MAP } from "../shared/migration";
-import { getAgentDisplayName } from "../shared/agent-display-names";
+import { getAgentConfigKey, getAgentDisplayName } from "../shared/agent-display-names";
 import {
   discoverConfigSourceSkills,
   discoverOpencodeGlobalSkills,
@@ -26,6 +26,51 @@ type AgentConfigRecord = Record<string, Record<string, unknown> | undefined> & {
   build?: Record<string, unknown>;
   plan?: Record<string, unknown>;
 };
+
+function applyRuntimeSelectedModels(params: {
+  generatedAgents: Record<string, unknown>;
+  configAgent: AgentConfigRecord | undefined;
+}): Record<string, unknown> {
+  const { generatedAgents, configAgent } = params;
+  if (!configAgent) return generatedAgents;
+
+  const generatedByConfigKey = new Map<string, string>();
+  for (const generatedKey of Object.keys(generatedAgents)) {
+    generatedByConfigKey.set(getAgentConfigKey(generatedKey), generatedKey);
+  }
+
+  const result = { ...generatedAgents };
+
+  for (const [incomingKey, incomingConfig] of Object.entries(configAgent)) {
+    if (!incomingConfig) continue;
+
+    const targetGeneratedKey = generatedByConfigKey.get(getAgentConfigKey(incomingKey));
+    if (!targetGeneratedKey) continue;
+
+    const runtimeModel = incomingConfig.model;
+    if (typeof runtimeModel !== "string" || runtimeModel.trim() === "") continue;
+
+    const generatedConfig = result[targetGeneratedKey];
+    if (typeof generatedConfig !== "object" || generatedConfig === null) continue;
+
+    const generatedRecord = generatedConfig as Record<string, unknown>;
+    const generatedModel =
+      typeof generatedRecord.model === "string" ? generatedRecord.model : undefined;
+
+    if (generatedModel === runtimeModel) continue;
+
+    result[targetGeneratedKey] = {
+      ...generatedRecord,
+      model: runtimeModel,
+      ...(typeof incomingConfig.variant === "string" ? { variant: incomingConfig.variant } : {}),
+      ...(typeof incomingConfig.thinking === "string"
+        ? { thinking: incomingConfig.thinking }
+        : {}),
+    };
+  }
+
+  return result;
+}
 
 function getConfiguredDefaultAgent(config: Record<string, unknown>): string | undefined {
   const defaultAgent = config.default_agent;
@@ -233,11 +278,18 @@ export async function applyAgentConfig(params: {
       protectedBuiltinAgentNames,
     );
 
+    const generatedAgentConfig = applyRuntimeSelectedModels({
+      generatedAgents: {
+        ...agentConfig,
+        ...Object.fromEntries(
+          Object.entries(builtinAgents).filter(([key]) => key !== "sisyphus"),
+        ),
+      },
+      configAgent,
+    });
+
     params.config.agent = {
-      ...agentConfig,
-      ...Object.fromEntries(
-        Object.entries(builtinAgents).filter(([key]) => key !== "sisyphus"),
-      ),
+      ...generatedAgentConfig,
       ...filterDisabledAgents(filteredUserAgents),
       ...filterDisabledAgents(filteredProjectAgents),
       ...filterDisabledAgents(filteredPluginAgents),


### PR DESCRIPTION
## Summary
- Respect user's manual model selection in web mode instead of reverting to plugin defaults

## Problem
When oh-my-opencode is enabled with agent-specific models, the web UI model selection reverts to the plugin-configured default after each message. The config merge flow dropped managed builtin agent entries from the incoming runtime config, so rebuilt agent configs overwrote a user-selected model.

## Fix
Updated managed agent config merging to preserve runtime-selected model overrides for builtin agents when the incoming runtime model differs from the plugin-generated default. This keeps explicit user model choices in web mode while still allowing normal plugin-managed agent generation.

## Changes
| File | Change |
|------|--------|
| `src/plugin-handlers/agent-config-handler.ts` | Preserve runtime-selected `model`/`variant`/`thinking` values for managed builtin agents during agent config rebuild |
| `src/plugin-handlers/agent-config-handler.test.ts` | Add regression tests for display-name and config-key aliases preserving user-selected models |

Fixes #2351

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the user's chosen model in web mode for builtin agents instead of reverting to plugin defaults after each message. Fixes #2351 by preserving runtime overrides for `model`, `variant`, and `thinking` during agent config rebuild.

- **Bug Fixes**
  - Map incoming agent keys (display names and aliases) to generated keys and apply runtime-selected overrides when they differ from defaults.
  - Add regression tests for display-name and config-key alias cases to ensure selections persist.

<sup>Written for commit 9737b6c2b02d4251ef0453e3510a4ab13bafcd4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

