### PR TITLE
fix(anthropic-recovery): break compaction retry loop after successful summarization (fixes #2225)

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.test.ts
@@ -119,4 +119,41 @@ describe("runSummarizeRetryStrategy", () => {
     expect(timeoutCalls[0]!.delay).toBeGreaterThan(0)
     expect(timeoutCalls[0]!.delay).toBeLessThanOrEqual(500)
   })
+
+  test("clears session state after successful summarize", async () => {
+    //#given
+    autoCompactState.pendingCompact.add(sessionID)
+    autoCompactState.errorDataBySession.set(sessionID, {
+      currentTokens: 250000,
+      maxTokens: 200000,
+      errorType: "token_limit_exceeded",
+    })
+    autoCompactState.retryStateBySession.set(sessionID, {
+      attempt: 1,
+      lastAttemptTime: Date.now(),
+      firstAttemptTime: Date.now() - 1000,
+    })
+    autoCompactState.truncateStateBySession.set(sessionID, { truncateAttempt: 1 })
+    autoCompactState.emptyContentAttemptBySession.set(sessionID, 1)
+    autoCompactState.compactionInProgress.add(sessionID)
+
+    //#when
+    await runSummarizeRetryStrategy({
+      sessionID,
+      msg: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      autoCompactState,
+      client: client as never,
+      directory,
+      pluginConfig: {} as OhMyOpenCodeConfig,
+    })
+
+    //#then
+    expect(summarizeMock).toHaveBeenCalledTimes(1)
+    expect(autoCompactState.pendingCompact.has(sessionID)).toBe(false)
+    expect(autoCompactState.errorDataBySession.has(sessionID)).toBe(false)
+    expect(autoCompactState.retryStateBySession.has(sessionID)).toBe(false)
+    expect(autoCompactState.truncateStateBySession.has(sessionID)).toBe(false)
+    expect(autoCompactState.emptyContentAttemptBySession.has(sessionID)).toBe(false)
+    expect(autoCompactState.compactionInProgress.has(sessionID)).toBe(false)
+  })
 })

--- a/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.ts
@@ -114,6 +114,7 @@ export async function runSummarizeRetryStrategy(params: {
           body: summarizeBody as never,
           query: { directory: params.directory },
         })
+        clearSessionState(params.autoCompactState, params.sessionID)
         return
       } catch {
         const remainingTimeMs = SUMMARIZE_RETRY_TOTAL_TIMEOUT_MS - (Date.now() - retryState.firstAttemptTime)


### PR DESCRIPTION
## Summary
- Break the compaction retry loop after successful summarization to prevent infinite compaction cycles

## Problem
When Claude models hit context limits, the `anthropic-context-window-limit-recovery` hook triggers compaction via `summarize-retry-strategy.ts`. After compaction succeeds, the retry loop fails to exit, causing repeated compaction attempts in an infinite loop. This makes sessions with Claude models unusable.

## Fix
Added proper retry-state cleanup after successful compaction in `summarize-retry-strategy.ts`, so summarize success exits recovery flow and stops further retries.

## Changes
| File | Change |
|------|--------|
| `src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.ts` | Clear session retry/compaction state immediately after successful summarize call |
| `src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.test.ts` | Add regression test asserting session state is cleared on summarize success |

Fixes #2225

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops infinite compaction retries in Anthropic context-window recovery by clearing session retry state after a successful summarize. Restores normal sessions with Claude models. Fixes #2225.

- **Bug Fixes**
  - Clear session compaction/retry state on summarize success to exit recovery flow.
  - Add regression test verifying all related session state is cleared.

<sup>Written for commit ad50eb1a75653e1b5527c3713eeb07bbd6c6c24e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

