### PR TITLE
refactor: deduplicate DelegatedModelConfig into shared module

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -309,6 +309,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -590,6 +592,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -871,6 +875,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -1152,6 +1158,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -1436,6 +1444,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -1717,6 +1727,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -1998,6 +2010,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -2279,6 +2293,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -2560,6 +2576,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -2841,6 +2859,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -3122,6 +3142,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -3403,6 +3425,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -3684,6 +3708,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -3965,6 +3991,8 @@
             "reasoningEffort": {
               "type": "string",
               "enum": [
+                "none",
+                "minimal",
                 "low",
                 "medium",
                 "high",
@@ -4143,6 +4171,8 @@
           "reasoningEffort": {
             "type": "string",
             "enum": [
+              "none",
+              "minimal",
               "low",
               "medium",
               "high",

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -90,7 +90,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -309,7 +371,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -528,7 +652,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -747,7 +933,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -969,7 +1217,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -1188,7 +1498,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -1407,7 +1779,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -1626,7 +2060,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -1845,7 +2341,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -2064,7 +2622,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -2283,7 +2903,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -2502,7 +3184,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -2721,7 +3465,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -2940,7 +3746,69 @@
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "model": {
+                            "type": "string"
+                          },
+                          "variant": {
+                            "type": "string"
+                          },
+                          "reasoningEffort": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "minimal",
+                              "low",
+                              "medium",
+                              "high",
+                              "xhigh"
+                            ]
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 2
+                          },
+                          "top_p": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                          },
+                          "maxTokens": {
+                            "type": "number"
+                          },
+                          "thinking": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "enabled",
+                                  "disabled"
+                                ]
+                              },
+                              "budgetTokens": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
                   }
                 }
               ]
@@ -3170,7 +4038,69 @@
               {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "model": {
+                          "type": "string"
+                        },
+                        "variant": {
+                          "type": "string"
+                        },
+                        "reasoningEffort": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "minimal",
+                            "low",
+                            "medium",
+                            "high",
+                            "xhigh"
+                          ]
+                        },
+                        "temperature": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 2
+                        },
+                        "top_p": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "maxTokens": {
+                          "type": "number"
+                        },
+                        "thinking": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "enabled",
+                                "disabled"
+                              ]
+                            },
+                            "budgetTokens": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "model"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
                 }
               }
             ]

--- a/docs/superpowers/plans/2026-03-17-model-settings-compatibility-resolver.md
+++ b/docs/superpowers/plans/2026-03-17-model-settings-compatibility-resolver.md
@@ -1,0 +1,86 @@
+# Model Settings Compatibility Resolver Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Centralize compatibility handling for `variant` and `reasoningEffort` so an already-selected model receives the best valid settings for that exact model.
+
+**Architecture:** Introduce a pure shared resolver in `src/shared/` that computes compatible settings and records downgrades/removals. Integrate it first in `chat.params`, then keep Claude-specific effort logic as a thin layer rather than a special-case policy owner.
+
+**Tech Stack:** TypeScript, Bun test, existing shared model normalization/utilities, OpenCode plugin `chat.params` path.
+
+---
+
+### Task 1: Create the pure compatibility resolver
+
+**Files:**
+- Create: `src/shared/model-settings-compatibility.ts`
+- Create: `src/shared/model-settings-compatibility.test.ts`
+- Modify: `src/shared/index.ts`
+
+- [ ] **Step 1: Write failing tests for exact keep behavior**
+- [ ] **Step 2: Write failing tests for downgrade behavior (`max` -> `high`, `xhigh` -> `high` where needed)**
+- [ ] **Step 3: Write failing tests for unsupported-value removal**
+- [ ] **Step 4: Write failing tests for model-family distinctions (Opus vs Sonnet/Haiku, GPT-family variants)**
+- [ ] **Step 5: Implement the pure resolver with explicit capability ladders**
+- [ ] **Step 6: Export the resolver from `src/shared/index.ts`**
+- [ ] **Step 7: Run `bun test src/shared/model-settings-compatibility.test.ts`**
+- [ ] **Step 8: Commit**
+
+### Task 2: Integrate resolver into chat.params
+
+**Files:**
+- Modify: `src/plugin/chat-params.ts`
+- Modify: `src/plugin/chat-params.test.ts`
+
+- [ ] **Step 1: Write failing tests showing `chat.params` applies resolver output to runtime settings**
+- [ ] **Step 2: Ensure tests cover both `variant` and `reasoningEffort` decisions**
+- [ ] **Step 3: Update `chat-params.ts` to call the shared resolver before hook-specific adjustments**
+- [ ] **Step 4: Preserve existing prompt-param-store merging behavior**
+- [ ] **Step 5: Run `bun test src/plugin/chat-params.test.ts`**
+- [ ] **Step 6: Commit**
+
+### Task 3: Re-scope anthropic-effort around the resolver
+
+**Files:**
+- Modify: `src/hooks/anthropic-effort/hook.ts`
+- Modify: `src/hooks/anthropic-effort/index.test.ts`
+
+- [ ] **Step 1: Write failing tests that codify the intended remaining Anthropic-specific behavior after centralization**
+- [ ] **Step 2: Reduce `anthropic-effort` to Claude/Anthropic-specific effort injection where still needed**
+- [ ] **Step 3: Remove duplicated compatibility policy from the hook if the shared resolver now owns it**
+- [ ] **Step 4: Run `bun test src/hooks/anthropic-effort/index.test.ts`**
+- [ ] **Step 5: Commit**
+
+### Task 4: Add integration/regression coverage across real request paths
+
+**Files:**
+- Modify: `src/plugin/chat-params.test.ts`
+- Modify: `src/hooks/anthropic-effort/index.test.ts`
+- Add tests only where needed in nearby suites
+
+- [ ] **Step 1: Add regression test for non-Opus Claude with `variant=max` resolving to compatible settings without ad hoc path-only logic**
+- [ ] **Step 2: Add regression test for GPT-style `reasoningEffort` compatibility**
+- [ ] **Step 3: Add regression test showing supported values remain unchanged**
+- [ ] **Step 4: Run the focused test set**
+- [ ] **Step 5: Commit**
+
+### Task 5: Verify full quality bar
+
+**Files:**
+- No intended code changes
+
+- [ ] **Step 1: Run `bun run typecheck`**
+- [ ] **Step 2: Run a focused suite for the touched files**
+- [ ] **Step 3: If clean, run `bun test`**
+- [ ] **Step 4: Review diff for accidental scope creep**
+- [ ] **Step 5: Commit any final cleanup**
+
+### Task 6: Prepare PR metadata
+
+**Files:**
+- No repo file change required unless docs are updated further
+
+- [ ] **Step 1: Write a human summary explaining this is settings compatibility, not model fallback**
+- [ ] **Step 2: Document scope: Phase 1 covers `variant` and `reasoningEffort` only**
+- [ ] **Step 3: Document explicit non-goals: no model switching, no automatic upscaling in Phase 1**
+- [ ] **Step 4: Request review**

--- a/docs/superpowers/specs/2026-03-17-model-settings-compatibility-design.md
+++ b/docs/superpowers/specs/2026-03-17-model-settings-compatibility-design.md
@@ -1,0 +1,164 @@
+# Model Settings Compatibility Resolver Design
+
+## Goal
+
+Introduce a central resolver that takes an already-selected model and a set of desired model settings, then returns the best compatible configuration for that exact model.
+
+This is explicitly separate from model fallback.
+
+## Problem
+
+Today, logic for `variant` and `reasoningEffort` compatibility is scattered across multiple places:
+- `hooks/anthropic-effort`
+- `plugin/chat-params`
+- agent/category/fallback config layers
+- delegate/background prompt plumbing
+
+That creates inconsistent behavior:
+- some paths clamp unsupported levels
+- some paths pass them through unchanged
+- some paths silently drop them
+- some paths use model-family-specific assumptions that do not generalize
+
+The result is brittle request behavior even when the chosen model itself is valid.
+
+## Scope
+
+Phase 1 covers only:
+- `variant`
+- `reasoningEffort`
+
+Out of scope for Phase 1:
+- model fallback itself
+- `thinking`
+- `maxTokens`
+- `temperature`
+- `top_p`
+- automatic upward remapping of settings
+
+## Desired behavior
+
+Given a fixed model and desired settings:
+1. If a desired value is supported, keep it.
+2. If not supported, downgrade to the nearest lower compatible value.
+3. If no compatible value exists, drop the field.
+4. Do not switch models.
+5. Do not automatically upgrade settings in Phase 1.
+
+## Architecture
+
+Add a central module:
+- `src/shared/model-settings-compatibility.ts`
+
+Core API:
+
+```ts
+type DesiredModelSettings = {
+  variant?: string
+  reasoningEffort?: string
+}
+
+type ModelSettingsCompatibilityInput = {
+  providerID: string
+  modelID: string
+  desired: DesiredModelSettings
+}
+
+type ModelSettingsCompatibilityChange = {
+  field: "variant" | "reasoningEffort"
+  from: string
+  to?: string
+  reason: string
+}
+
+type ModelSettingsCompatibilityResult = {
+  variant?: string
+  reasoningEffort?: string
+  changes: ModelSettingsCompatibilityChange[]
+}
+```
+
+## Compatibility model
+
+Phase 1 should be **metadata-first where the platform exposes reliable capability data**, and only fall back to family-based rules when that metadata is absent.
+
+### Variant compatibility
+
+Preferred source of truth:
+- OpenCode/provider model metadata (`variants`)
+
+Fallback when metadata is unavailable:
+- family-based ladders
+
+Examples of fallback ladders:
+- Claude Opus family: `low`, `medium`, `high`, `max`
+- Claude Sonnet/Haiku family: `low`, `medium`, `high`
+- OpenAI GPT family: conservative family fallback only when metadata is missing
+- Unknown family: drop unsupported values conservatively
+
+### Reasoning effort compatibility
+
+Current Phase 1 source of truth:
+- conservative model/provider family heuristics
+
+Reason:
+- the currently available OpenCode SDK/provider metadata exposes model `variants`, but does not expose an equivalent per-model capability list for `reasoningEffort` levels
+
+Examples:
+- GPT/OpenAI-style models: `low`, `medium`, `high`, `xhigh` where supported by family heuristics
+- Claude family via current OpenCode path: treat `reasoningEffort` as unsupported in Phase 1 and remove it
+
+The resolver should remain pure model/settings logic only. Transport restrictions remain the responsibility of the request-building path.
+
+## Separation of concerns
+
+This design intentionally separates:
+- model selection (`resolveModel...`, fallback chains)
+- settings compatibility (this resolver)
+- request transport compatibility (`chat.params`, prompt body constraints)
+
+That keeps responsibilities clear:
+- choose model first
+- normalize settings second
+- build request third
+
+## First integration point
+
+Phase 1 should first integrate into `chat.params`.
+
+Why:
+- it is already the centralized path for request-time tuning
+- it can influence provider-facing options without leaking unsupported fields into prompt payload bodies
+- it avoids trying to patch every prompt constructor at once
+
+## Rollout plan
+
+### Phase 1
+- add resolver module and tests
+- integrate into `chat.params`
+- migrate `anthropic-effort` to either use the resolver or become a thin Claude-specific supplement around it
+
+### Phase 2
+- expand to `thinking`, `maxTokens`, `temperature`, `top_p`
+- formalize request-path capability tables if needed
+
+### Phase 3
+- centralize all variant/reasoning normalization away from scattered hooks and ad hoc callers
+
+## Risks
+
+- Overfitting family rules to current model naming conventions
+- Accidentally changing request semantics on paths that currently rely on implicit behavior
+- Mixing provider transport limitations with model capability logic
+
+## Mitigations
+
+- Keep resolver pure and narrowly scoped in Phase 1
+- Add explicit regression tests for keep/downgrade/drop decisions
+- Integrate at one central point first (`chat.params`)
+- Preserve existing behavior where desired values are already valid
+
+## Recommendation
+
+Proceed with the central resolver as a new, isolated implementation in a dedicated branch/worktree.
+This is the clean long-term path and is more reviewable than continuing to add special-case clamps in hooks.

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -123,7 +123,7 @@ export type AgentName = BuiltinAgentName;
 export type AgentOverrideConfig = Partial<AgentConfig> & {
   prompt_append?: string;
   variant?: string;
-  fallback_models?: string | string[];
+  fallback_models?: string | (string | import("../config/schema/fallback-models").FallbackModelObject)[];
 };
 
 export type AgentOverrides = Partial<

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -371,6 +371,26 @@ describe("CategoryConfigSchema", () => {
     }
   })
 
+  test("accepts reasoningEffort values none and minimal", () => {
+    // given
+    const noneConfig = { reasoningEffort: "none" }
+    const minimalConfig = { reasoningEffort: "minimal" }
+
+    // when
+    const noneResult = CategoryConfigSchema.safeParse(noneConfig)
+    const minimalResult = CategoryConfigSchema.safeParse(minimalConfig)
+
+    // then
+    expect(noneResult.success).toBe(true)
+    expect(minimalResult.success).toBe(true)
+    if (noneResult.success) {
+      expect(noneResult.data.reasoningEffort).toBe("none")
+    }
+    if (minimalResult.success) {
+      expect(minimalResult.data.reasoningEffort).toBe("minimal")
+    }
+  })
+
   test("rejects non-string variant", () => {
     // given
     const config = { model: "openai/gpt-5.4", variant: 123 }

--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -35,7 +35,7 @@ export const AgentOverrideConfigSchema = z.object({
     })
     .optional(),
   /** Reasoning effort level (OpenAI). Overrides category and default settings. */
-  reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]).optional(),
+  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]).optional(),
   /** Text verbosity level. */
   textVerbosity: z.enum(["low", "medium", "high"]).optional(),
   /** Provider-specific options. Passed directly to OpenCode SDK. */

--- a/src/config/schema/categories.ts
+++ b/src/config/schema/categories.ts
@@ -16,7 +16,7 @@ export const CategoryConfigSchema = z.object({
       budgetTokens: z.number().optional(),
     })
     .optional(),
-  reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]).optional(),
+  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]).optional(),
   textVerbosity: z.enum(["low", "medium", "high"]).optional(),
   tools: z.record(z.string(), z.boolean()).optional(),
   prompt_append: z.string().optional(),

--- a/src/config/schema/fallback-models.ts
+++ b/src/config/schema/fallback-models.ts
@@ -1,5 +1,25 @@
 import { z } from "zod"
 
-export const FallbackModelsSchema = z.union([z.string(), z.array(z.string())])
+export const FallbackModelObjectSchema = z.object({
+  model: z.string(),
+  variant: z.string().optional(),
+  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]).optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  top_p: z.number().min(0).max(1).optional(),
+  maxTokens: z.number().optional(),
+  thinking: z
+    .object({
+      type: z.enum(["enabled", "disabled"]),
+      budgetTokens: z.number().optional(),
+    })
+    .optional(),
+})
+
+export type FallbackModelObject = z.infer<typeof FallbackModelObjectSchema>
+
+export const FallbackModelsSchema = z.union([
+  z.string(),
+  z.array(z.union([z.string(), FallbackModelObjectSchema])),
+])
 
 export type FallbackModels = z.infer<typeof FallbackModelsSchema>

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -1,5 +1,6 @@
 declare const require: (name: string) => any
 const { describe, test, expect, beforeEach, afterEach, spyOn } = require("bun:test")
+import { getSessionPromptParams, clearSessionPromptParams } from "../../shared/session-prompt-params-state"
 import { tmpdir } from "node:os"
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundTask, ResumeInput } from "./types"
@@ -1636,6 +1637,9 @@ describe("BackgroundManager.resume model persistence", () => {
    })
 
   afterEach(() => {
+    clearSessionPromptParams("session-1")
+    clearSessionPromptParams("session-advanced")
+    clearSessionPromptParams("session-2")
     manager.shutdown()
   })
 
@@ -1669,6 +1673,60 @@ describe("BackgroundManager.resume model persistence", () => {
     expect(promptCalls).toHaveLength(1)
     expect(promptCalls[0].body.model).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4-20250514" })
     expect(promptCalls[0].body.agent).toBe("explore")
+  })
+
+  test("should preserve promoted per-model settings when resuming a task", async () => {
+    // given - task resumed after fallback promotion
+    const taskWithAdvancedModel: BackgroundTask = {
+      id: "task-with-advanced-model",
+      sessionID: "session-advanced",
+      parentSessionID: "parent-session",
+      parentMessageID: "msg-1",
+      description: "task with advanced model settings",
+      prompt: "original prompt",
+      agent: "explore",
+      status: "completed",
+      startedAt: new Date(),
+      completedAt: new Date(),
+      model: {
+        providerID: "openai",
+        modelID: "gpt-5.4-preview",
+        variant: "minimal",
+        reasoningEffort: "high",
+        temperature: 0.25,
+        top_p: 0.55,
+        maxTokens: 8192,
+        thinking: { type: "disabled" },
+      },
+      concurrencyGroup: "explore",
+    }
+    getTaskMap(manager).set(taskWithAdvancedModel.id, taskWithAdvancedModel)
+
+    // when
+    await manager.resume({
+      sessionId: "session-advanced",
+      prompt: "continue the work",
+      parentSessionID: "parent-session-2",
+      parentMessageID: "msg-2",
+    })
+
+    // then
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0].body.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4-preview",
+    })
+    expect(promptCalls[0].body.variant).toBe("minimal")
+    expect(promptCalls[0].body.options).toBeUndefined()
+    expect(getSessionPromptParams("session-advanced")).toEqual({
+      temperature: 0.25,
+      topP: 0.55,
+      options: {
+        reasoningEffort: "high",
+        thinking: { type: "disabled" },
+        maxTokens: 8192,
+      },
+    })
   })
 
   test("should NOT pass model when task has no model (backward compatibility)", async () => {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -15,36 +15,8 @@ import {
   resolveInheritedPromptTools,
   createInternalAgentTextPart,
 } from "../../shared"
+import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import { setSessionTools } from "../../shared/session-tools-store"
-import { setSessionPromptParams } from "../../shared/session-prompt-params-state"
-
-type PromptParamsModel = {
-  reasoningEffort?: string
-  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
-  maxTokens?: number
-  temperature?: number
-  top_p?: number
-}
-
-function applySessionPromptParams(sessionID: string, model: PromptParamsModel): void {
-  const promptOptions: Record<string, unknown> = {
-    ...(model.reasoningEffort ? { reasoningEffort: model.reasoningEffort } : {}),
-    ...(model.thinking ? { thinking: model.thinking } : {}),
-    ...(model.maxTokens !== undefined ? { maxTokens: model.maxTokens } : {}),
-  }
-
-  if (
-    model.temperature !== undefined ||
-    model.top_p !== undefined ||
-    Object.keys(promptOptions).length > 0
-  ) {
-    setSessionPromptParams(sessionID, {
-      ...(model.temperature !== undefined ? { temperature: model.temperature } : {}),
-      ...(model.top_p !== undefined ? { topP: model.top_p } : {}),
-      ...(Object.keys(promptOptions).length > 0 ? { options: promptOptions } : {}),
-    })
-  }
-}
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { ConcurrencyManager } from "./concurrency"
 import type { BackgroundTaskConfig, TmuxConfig } from "../../config/schema"

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -16,6 +16,35 @@ import {
   createInternalAgentTextPart,
 } from "../../shared"
 import { setSessionTools } from "../../shared/session-tools-store"
+import { setSessionPromptParams } from "../../shared/session-prompt-params-state"
+
+type PromptParamsModel = {
+  reasoningEffort?: string
+  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+  maxTokens?: number
+  temperature?: number
+  top_p?: number
+}
+
+function applySessionPromptParams(sessionID: string, model: PromptParamsModel): void {
+  const promptOptions: Record<string, unknown> = {
+    ...(model.reasoningEffort ? { reasoningEffort: model.reasoningEffort } : {}),
+    ...(model.thinking ? { thinking: model.thinking } : {}),
+    ...(model.maxTokens !== undefined ? { maxTokens: model.maxTokens } : {}),
+  }
+
+  if (
+    model.temperature !== undefined ||
+    model.top_p !== undefined ||
+    Object.keys(promptOptions).length > 0
+  ) {
+    setSessionPromptParams(sessionID, {
+      ...(model.temperature !== undefined ? { temperature: model.temperature } : {}),
+      ...(model.top_p !== undefined ? { topP: model.top_p } : {}),
+      ...(Object.keys(promptOptions).length > 0 ? { options: promptOptions } : {}),
+    })
+  }
+}
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { ConcurrencyManager } from "./concurrency"
 import type { BackgroundTaskConfig, TmuxConfig } from "../../config/schema"
@@ -504,13 +533,19 @@ export class BackgroundManager {
     })
 
     // Fire-and-forget prompt via promptAsync (no response body needed)
-    // Include model if caller provided one (e.g., from Sisyphus category configs)
-    // IMPORTANT: variant must be a top-level field in the body, NOT nested inside model
-    // OpenCode's PromptInput schema expects: { model: { providerID, modelID }, variant: "max" }
+    // OpenCode prompt payload accepts model provider/model IDs and top-level variant only.
+    // Temperature/topP and provider-specific options are applied through chat.params.
     const launchModel = input.model
-      ? { providerID: input.model.providerID, modelID: input.model.modelID }
+      ? {
+          providerID: input.model.providerID,
+          modelID: input.model.modelID,
+        }
       : undefined
     const launchVariant = input.model?.variant
+
+    if (input.model) {
+      applySessionPromptParams(sessionID, input.model)
+    }
 
     promptWithModelSuggestionRetry(this.client, {
       path: { id: sessionID },
@@ -782,12 +817,18 @@ export class BackgroundManager {
     })
 
     // Fire-and-forget prompt via promptAsync (no response body needed)
-    // Include model if task has one (preserved from original launch with category config)
-    // variant must be top-level in body, not nested inside model (OpenCode PromptInput schema)
+    // Resume uses the same PromptInput contract as launch: model IDs plus top-level variant.
     const resumeModel = existingTask.model
-      ? { providerID: existingTask.model.providerID, modelID: existingTask.model.modelID }
+      ? {
+          providerID: existingTask.model.providerID,
+          modelID: existingTask.model.modelID,
+        }
       : undefined
     const resumeVariant = existingTask.model?.variant
+
+    if (existingTask.model) {
+      applySessionPromptParams(existingTask.sessionID!, existingTask.model)
+    }
 
     this.client.session.promptAsync({
       path: { id: existingTask.sessionID },

--- a/src/features/background-agent/spawner.test.ts
+++ b/src/features/background-agent/spawner.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, mock, afterEach } from "bun:test"
-import { startTask } from "./spawner"
+import { createTask, startTask } from "./spawner"
 import type { BackgroundTask } from "./types"
 import {
   clearSessionPromptParams,

--- a/src/features/background-agent/spawner.test.ts
+++ b/src/features/background-agent/spawner.test.ts
@@ -1,68 +1,96 @@
-import { describe, test, expect } from "bun:test"
+import { describe, test, expect, mock, afterEach } from "bun:test"
+import { startTask } from "./spawner"
+import type { BackgroundTask } from "./types"
+import {
+  clearSessionPromptParams,
+  getSessionPromptParams,
+} from "../../shared/session-prompt-params-state"
 
-import { createTask, startTask } from "./spawner"
+describe("background-agent spawner fallback model promotion", () => {
+  afterEach(() => {
+    clearSessionPromptParams("session-123")
+  })
 
-describe("background-agent spawner.startTask", () => {
-  test("applies explicit child session permission rules when creating child session", async () => {
+  test("passes promoted fallback model settings through supported prompt channels", async () => {
     //#given
-    const createCalls: any[] = []
-    const parentPermission = [
-      { permission: "question", action: "allow" as const, pattern: "*" },
-      { permission: "plan_enter", action: "deny" as const, pattern: "*" },
-    ]
-
+    let promptArgs: any
     const client = {
       session: {
-        get: async () => ({ data: { directory: "/parent/dir", permission: parentPermission } }),
-        create: async (args?: any) => {
-          createCalls.push(args)
-          return { data: { id: "ses_child" } }
-        },
-        promptAsync: async () => ({}),
+        get: mock(async () => ({ data: { directory: "/tmp/test" } })),
+        create: mock(async () => ({ data: { id: "session-123" } })),
+        promptAsync: mock(async (input: any) => {
+          promptArgs = input
+          return { data: {} }
+        }),
       },
-    }
+    } as any
 
-    const task = createTask({
+    const concurrencyManager = {
+      release: mock(() => {}),
+    } as any
+
+    const onTaskError = mock(() => {})
+
+    const task: BackgroundTask = {
+      id: "bg_test123",
+      status: "pending",
+      queuedAt: new Date(),
       description: "Test task",
-      prompt: "Do work",
-      agent: "explore",
-      parentSessionID: "ses_parent",
-      parentMessageID: "msg_parent",
-    })
-
-    const item = {
-      task,
-      input: {
-        description: task.description,
-        prompt: task.prompt,
-        agent: task.agent,
-        parentSessionID: task.parentSessionID,
-        parentMessageID: task.parentMessageID,
-        parentModel: task.parentModel,
-        parentAgent: task.parentAgent,
-        model: task.model,
-        sessionPermission: [
-          { permission: "question", action: "deny", pattern: "*" },
-        ],
+      prompt: "Do the thing",
+      agent: "oracle",
+      parentSessionID: "parent-1",
+      parentMessageID: "message-1",
+      model: {
+        providerID: "openai",
+        modelID: "gpt-5.4",
+        variant: "low",
+        reasoningEffort: "high",
+        temperature: 0.4,
+        top_p: 0.7,
+        maxTokens: 4096,
+        thinking: { type: "disabled" },
       },
     }
 
-    const ctx = {
-      client,
-      directory: "/fallback",
-      concurrencyManager: { release: () => {} },
-      tmuxEnabled: false,
-      onTaskError: () => {},
+    const input = {
+      description: "Test task",
+      prompt: "Do the thing",
+      agent: "oracle",
+      parentSessionID: "parent-1",
+      parentMessageID: "message-1",
+      model: task.model,
     }
 
     //#when
-    await startTask(item as any, ctx as any)
+    await startTask(
+      { task, input },
+      {
+        client,
+        directory: "/tmp/test",
+        concurrencyManager,
+        tmuxEnabled: false,
+        onTaskError,
+      },
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
     //#then
-    expect(createCalls).toHaveLength(1)
-    expect(createCalls[0]?.body?.permission).toEqual([
-      { permission: "question", action: "deny", pattern: "*" },
-    ])
+    expect(promptArgs.body.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+    })
+    expect(promptArgs.body.variant).toBe("low")
+    expect(promptArgs.body.options).toBeUndefined()
+    expect(getSessionPromptParams("session-123")).toEqual({
+      temperature: 0.4,
+      topP: 0.7,
+      options: {
+        reasoningEffort: "high",
+        thinking: { type: "disabled" },
+        maxTokens: 4096,
+      },
+    })
   })
 
   test("keeps agent when explicit model is configured", async () => {

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -2,7 +2,7 @@ import type { BackgroundTask, LaunchInput, ResumeInput } from "./types"
 import type { OpencodeClient, OnSubagentSessionCreated, QueueItem } from "./constants"
 import { TMUX_CALLBACK_DELAY_MS } from "./constants"
 import { log, getAgentToolRestrictions, promptWithModelSuggestionRetry, createInternalAgentTextPart } from "../../shared"
-import { setSessionPromptParams } from "../../shared/session-prompt-params-state"
+import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import { subagentSessions } from "../claude-code-session-state"
 import { getTaskToastManager } from "../task-toast-manager"
 import { isInsideTmux } from "../../shared/tmux"
@@ -136,25 +136,7 @@ export async function startTask(
     : undefined
   const launchVariant = input.model?.variant
 
-  if (input.model) {
-    const promptOptions: Record<string, unknown> = {
-      ...(input.model.reasoningEffort ? { reasoningEffort: input.model.reasoningEffort } : {}),
-      ...(input.model.thinking ? { thinking: input.model.thinking } : {}),
-      ...(input.model.maxTokens !== undefined ? { maxTokens: input.model.maxTokens } : {}),
-    }
-
-    if (
-      input.model.temperature !== undefined ||
-      input.model.top_p !== undefined ||
-      Object.keys(promptOptions).length > 0
-    ) {
-      setSessionPromptParams(sessionID, {
-        ...(input.model.temperature !== undefined ? { temperature: input.model.temperature } : {}),
-        ...(input.model.top_p !== undefined ? { topP: input.model.top_p } : {}),
-        ...(Object.keys(promptOptions).length > 0 ? { options: promptOptions } : {}),
-      })
-    }
-  }
+  applySessionPromptParams(sessionID, input.model)
 
   promptWithModelSuggestionRetry(client, {
     path: { id: sessionID },
@@ -244,25 +226,7 @@ export async function resumeTask(
     : undefined
   const resumeVariant = task.model?.variant
 
-  if (task.model) {
-    const promptOptions: Record<string, unknown> = {
-      ...(task.model.reasoningEffort ? { reasoningEffort: task.model.reasoningEffort } : {}),
-      ...(task.model.thinking ? { thinking: task.model.thinking } : {}),
-      ...(task.model.maxTokens !== undefined ? { maxTokens: task.model.maxTokens } : {}),
-    }
-
-    if (
-      task.model.temperature !== undefined ||
-      task.model.top_p !== undefined ||
-      Object.keys(promptOptions).length > 0
-    ) {
-      setSessionPromptParams(task.sessionID, {
-        ...(task.model.temperature !== undefined ? { temperature: task.model.temperature } : {}),
-        ...(task.model.top_p !== undefined ? { topP: task.model.top_p } : {}),
-        ...(Object.keys(promptOptions).length > 0 ? { options: promptOptions } : {}),
-      })
-    }
-  }
+  applySessionPromptParams(task.sessionID, task.model)
 
   client.session.promptAsync({
     path: { id: task.sessionID },

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -2,6 +2,7 @@ import type { BackgroundTask, LaunchInput, ResumeInput } from "./types"
 import type { OpencodeClient, OnSubagentSessionCreated, QueueItem } from "./constants"
 import { TMUX_CALLBACK_DELAY_MS } from "./constants"
 import { log, getAgentToolRestrictions, promptWithModelSuggestionRetry, createInternalAgentTextPart } from "../../shared"
+import { setSessionPromptParams } from "../../shared/session-prompt-params-state"
 import { subagentSessions } from "../claude-code-session-state"
 import { getTaskToastManager } from "../task-toast-manager"
 import { isInsideTmux } from "../../shared/tmux"
@@ -128,9 +129,32 @@ export async function startTask(
   })
 
   const launchModel = input.model
-    ? { providerID: input.model.providerID, modelID: input.model.modelID }
+    ? {
+        providerID: input.model.providerID,
+        modelID: input.model.modelID,
+      }
     : undefined
   const launchVariant = input.model?.variant
+
+  if (input.model) {
+    const promptOptions: Record<string, unknown> = {
+      ...(input.model.reasoningEffort ? { reasoningEffort: input.model.reasoningEffort } : {}),
+      ...(input.model.thinking ? { thinking: input.model.thinking } : {}),
+      ...(input.model.maxTokens !== undefined ? { maxTokens: input.model.maxTokens } : {}),
+    }
+
+    if (
+      input.model.temperature !== undefined ||
+      input.model.top_p !== undefined ||
+      Object.keys(promptOptions).length > 0
+    ) {
+      setSessionPromptParams(sessionID, {
+        ...(input.model.temperature !== undefined ? { temperature: input.model.temperature } : {}),
+        ...(input.model.top_p !== undefined ? { topP: input.model.top_p } : {}),
+        ...(Object.keys(promptOptions).length > 0 ? { options: promptOptions } : {}),
+      })
+    }
+  }
 
   promptWithModelSuggestionRetry(client, {
     path: { id: sessionID },
@@ -213,9 +237,32 @@ export async function resumeTask(
   })
 
   const resumeModel = task.model
-    ? { providerID: task.model.providerID, modelID: task.model.modelID }
+    ? {
+        providerID: task.model.providerID,
+        modelID: task.model.modelID,
+      }
     : undefined
   const resumeVariant = task.model?.variant
+
+  if (task.model) {
+    const promptOptions: Record<string, unknown> = {
+      ...(task.model.reasoningEffort ? { reasoningEffort: task.model.reasoningEffort } : {}),
+      ...(task.model.thinking ? { thinking: task.model.thinking } : {}),
+      ...(task.model.maxTokens !== undefined ? { maxTokens: task.model.maxTokens } : {}),
+    }
+
+    if (
+      task.model.temperature !== undefined ||
+      task.model.top_p !== undefined ||
+      Object.keys(promptOptions).length > 0
+    ) {
+      setSessionPromptParams(task.sessionID, {
+        ...(task.model.temperature !== undefined ? { temperature: task.model.temperature } : {}),
+        ...(task.model.top_p !== undefined ? { topP: task.model.top_p } : {}),
+        ...(Object.keys(promptOptions).length > 0 ? { options: promptOptions } : {}),
+      })
+    }
+  }
 
   client.session.promptAsync({
     path: { id: task.sessionID },

--- a/src/features/background-agent/types.ts
+++ b/src/features/background-agent/types.ts
@@ -1,4 +1,5 @@
 import type { FallbackEntry } from "../../shared/model-requirements"
+import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
 import type { SessionPermissionRule } from "../../shared/question-denied-session-permission"
 
 export type BackgroundTaskStatus =
@@ -23,17 +24,6 @@ export interface TaskProgress {
   lastUpdate: Date
   lastMessage?: string
   lastMessageAt?: Date
-}
-
-type DelegatedModelConfig = {
-  providerID: string
-  modelID: string
-  variant?: string
-  reasoningEffort?: string
-  temperature?: number
-  top_p?: number
-  maxTokens?: number
-  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
 }
 
 export interface BackgroundTask {

--- a/src/features/background-agent/types.ts
+++ b/src/features/background-agent/types.ts
@@ -25,6 +25,17 @@ export interface TaskProgress {
   lastMessageAt?: Date
 }
 
+type DelegatedModelConfig = {
+  providerID: string
+  modelID: string
+  variant?: string
+  reasoningEffort?: string
+  temperature?: number
+  top_p?: number
+  maxTokens?: number
+  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+}
+
 export interface BackgroundTask {
   id: string
   sessionID?: string
@@ -43,7 +54,7 @@ export interface BackgroundTask {
   error?: string
   progress?: TaskProgress
   parentModel?: { providerID: string; modelID: string }
-  model?: { providerID: string; modelID: string; variant?: string }
+  model?: DelegatedModelConfig
   /** Fallback chain for runtime retry on model errors */
   fallbackChain?: FallbackEntry[]
   /** Number of fallback retry attempts made */
@@ -76,7 +87,7 @@ export interface LaunchInput {
   parentModel?: { providerID: string; modelID: string }
   parentAgent?: string
   parentTools?: Record<string, boolean>
-  model?: { providerID: string; modelID: string; variant?: string }
+  model?: DelegatedModelConfig
   /** Fallback chain for runtime retry on model errors */
   fallbackChain?: FallbackEntry[]
   isUnstableAgent?: boolean

--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -1,6 +1,6 @@
 import { log, normalizeModelID } from "../../shared"
 
-const OPUS_PATTERN = /claude-opus/i
+const OPUS_PATTERN = /claude-.*opus/i
 
 function isClaudeProvider(providerID: string, modelID: string): boolean {
   if (["anthropic", "google-vertex-anthropic", "opencode"].includes(providerID)) return true

--- a/src/hooks/anthropic-effort/index.test.ts
+++ b/src/hooks/anthropic-effort/index.test.ts
@@ -45,75 +45,31 @@ function createMockParams(overrides: {
 }
 
 describe("createAnthropicEffortHook", () => {
-  describe("opus 4-6 with variant max", () => {
-    it("should inject effort max for anthropic opus-4-6 with variant max", async () => {
-      //#given anthropic opus-4-6 model with variant max
+  describe("opus family with variant max", () => {
+    it("injects effort max for anthropic opus-4-6", async () => {
       const hook = createAnthropicEffortHook()
       const { input, output } = createMockParams({})
 
-      //#when chat.params hook is called
       await hook["chat.params"](input, output)
 
-      //#then effort should be injected into options
       expect(output.options.effort).toBe("max")
     })
 
-    it("should inject effort max for github-copilot claude-opus-4-6", async () => {
-      //#given github-copilot provider with claude-opus-4-6
+    it("injects effort max for another opus family model such as opus-4-5", async () => {
       const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({
-        providerID: "github-copilot",
-        modelID: "claude-opus-4-6",
-      })
+      const { input, output } = createMockParams({ modelID: "claude-opus-4-5" })
 
-      //#when chat.params hook is called
       await hook["chat.params"](input, output)
 
-      //#then effort should be injected (github-copilot resolves to anthropic)
       expect(output.options.effort).toBe("max")
     })
 
-    it("should inject effort max for opencode provider with claude-opus-4-6", async () => {
-      //#given opencode provider with claude-opus-4-6
+    it("injects effort max for dotted opus ids", async () => {
       const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({
-        providerID: "opencode",
-        modelID: "claude-opus-4-6",
-      })
+      const { input, output } = createMockParams({ modelID: "claude-opus-4.6" })
 
-      //#when chat.params hook is called
       await hook["chat.params"](input, output)
 
-      //#then effort should be injected
-      expect(output.options.effort).toBe("max")
-    })
-
-    it("should inject effort max for google-vertex-anthropic provider", async () => {
-      //#given google-vertex-anthropic provider with claude-opus-4-6
-      const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({
-        providerID: "google-vertex-anthropic",
-        modelID: "claude-opus-4-6",
-      })
-
-      //#when chat.params hook is called
-      await hook["chat.params"](input, output)
-
-      //#then effort should be injected
-      expect(output.options.effort).toBe("max")
-    })
-
-    it("should handle normalized model ID with dots (opus-4.6)", async () => {
-      //#given model ID with dots instead of hyphens
-      const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({
-        modelID: "claude-opus-4.6",
-      })
-
-      //#when chat.params hook is called
-      await hook["chat.params"](input, output)
-
-      //#then should normalize and inject effort
       expect(output.options.effort).toBe("max")
     })
 
@@ -133,39 +89,30 @@ describe("createAnthropicEffortHook", () => {
     })
   })
 
-  describe("conditions NOT met - should skip", () => {
-    it("should NOT inject effort when variant is not max", async () => {
-      //#given opus-4-6 with variant high (not max)
+  describe("skip conditions", () => {
+    it("does nothing when variant is not max", async () => {
       const hook = createAnthropicEffortHook()
       const { input, output } = createMockParams({ variant: "high" })
 
-      //#when chat.params hook is called
       await hook["chat.params"](input, output)
 
-      //#then effort should NOT be injected
       expect(output.options.effort).toBeUndefined()
     })
 
-    it("should NOT inject effort when variant is undefined", async () => {
-      //#given opus-4-6 with no variant
+    it("does nothing when variant is undefined", async () => {
       const hook = createAnthropicEffortHook()
       const { input, output } = createMockParams({ variant: undefined })
 
-      //#when chat.params hook is called
       await hook["chat.params"](input, output)
 
-      //#then effort should NOT be injected
       expect(output.options.effort).toBeUndefined()
     })
 
     it("should clamp effort to high for non-opus claude model with variant max", async () => {
       //#given claude-sonnet-4-6 (not opus) with variant max
       const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({
-        modelID: "claude-sonnet-4-6",
-      })
+      const { input, output } = createMockParams({ modelID: "claude-sonnet-4-6" })
 
-      //#when chat.params hook is called
       await hook["chat.params"](input, output)
 
       //#then effort should be clamped to high (not max)
@@ -173,74 +120,24 @@ describe("createAnthropicEffortHook", () => {
       expect(input.message.variant).toBe("high")
     })
 
-    it("should NOT inject effort for non-anthropic provider with non-claude model", async () => {
-      //#given openai provider with gpt model
+    it("does nothing for non-claude providers/models", async () => {
       const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({
-        providerID: "openai",
-        modelID: "gpt-5.4",
-      })
+      const { input, output } = createMockParams({ providerID: "openai", modelID: "gpt-5.4" })
 
-      //#when chat.params hook is called
       await hook["chat.params"](input, output)
 
-      //#then effort should NOT be injected
-      expect(output.options.effort).toBeUndefined()
-    })
-
-    it("should NOT throw when model.modelID is undefined", async () => {
-      //#given model with undefined modelID (runtime edge case)
-      const hook = createAnthropicEffortHook()
-      const input = {
-        sessionID: "test-session",
-        agent: { name: "sisyphus" },
-        model: { providerID: "anthropic", modelID: undefined as unknown as string },
-        provider: { id: "anthropic" },
-        message: { variant: "max" as const },
-      }
-      const output = { temperature: 0.1, options: {} }
-
-      //#when chat.params hook is called with undefined modelID
-      await hook["chat.params"](input, output)
-
-      //#then should gracefully skip without throwing
       expect(output.options.effort).toBeUndefined()
     })
   })
 
-  describe("preserves existing options", () => {
-    it("should NOT overwrite existing effort if already set", async () => {
-      //#given options already have effort set
+  describe("existing options", () => {
+    it("does not overwrite existing effort", async () => {
       const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({
-        existingOptions: { effort: "high" },
-      })
+      const { input, output } = createMockParams({ existingOptions: { effort: "high" } })
 
-      //#when chat.params hook is called
       await hook["chat.params"](input, output)
 
-      //#then existing effort should be preserved
       expect(output.options.effort).toBe("high")
-    })
-
-    it("should preserve other existing options when injecting effort", async () => {
-      //#given options with existing thinking config
-      const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({
-        existingOptions: {
-          thinking: { type: "enabled", budgetTokens: 31999 },
-        },
-      })
-
-      //#when chat.params hook is called
-      await hook["chat.params"](input, output)
-
-      //#then effort should be added without affecting thinking
-      expect(output.options.effort).toBe("max")
-      expect(output.options.thinking).toEqual({
-        type: "enabled",
-        budgetTokens: 31999,
-      })
     })
   })
 })

--- a/src/hooks/runtime-fallback/fallback-models.ts
+++ b/src/hooks/runtime-fallback/fallback-models.ts
@@ -1,10 +1,16 @@
 import type { OhMyOpenCodeConfig } from "../../config"
+import type { FallbackModelObject } from "../../config/schema/fallback-models"
 import { agentPattern } from "./agent-resolver"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
-import { normalizeFallbackModels } from "../../shared/model-resolver"
+import { normalizeFallbackModels, flattenToFallbackModelStrings } from "../../shared/model-resolver"
 
+/**
+ * Returns fallback model strings for the runtime-fallback system.
+ * Object entries are flattened to "provider/model(variant)" strings so the
+ * string-based fallback state machine can work with them unchanged.
+ */
 export function getFallbackModelsForSession(
   sessionID: string,
   agent: string | undefined,
@@ -12,22 +18,45 @@ export function getFallbackModelsForSession(
 ): string[] {
   if (!pluginConfig) return []
 
+  const raw = getRawFallbackModelsForSession(sessionID, agent, pluginConfig)
+  return flattenToFallbackModelStrings(raw) ?? []
+}
+
+/**
+ * Returns the raw fallback model entries (strings and objects) for a session.
+ * Use this when per-model settings (temperature, reasoningEffort, etc.) must be
+ * preserved — e.g. before passing to buildFallbackChainFromModels.
+ */
+export function getRawFallbackModels(
+  sessionID: string,
+  agent: string | undefined,
+  pluginConfig: OhMyOpenCodeConfig | undefined,
+): (string | FallbackModelObject)[] | undefined {
+  if (!pluginConfig) return undefined
+  return getRawFallbackModelsForSession(sessionID, agent, pluginConfig)
+}
+
+function getRawFallbackModelsForSession(
+  sessionID: string,
+  agent: string | undefined,
+  pluginConfig: OhMyOpenCodeConfig,
+): (string | FallbackModelObject)[] | undefined {
   const sessionCategory = SessionCategoryRegistry.get(sessionID)
   if (sessionCategory && pluginConfig.categories?.[sessionCategory]) {
     const categoryConfig = pluginConfig.categories[sessionCategory]
     if (categoryConfig?.fallback_models) {
-      return normalizeFallbackModels(categoryConfig.fallback_models) ?? []
+      return normalizeFallbackModels(categoryConfig.fallback_models)
     }
   }
 
-  const tryGetFallbackFromAgent = (agentName: string): string[] | undefined => {
+  const tryGetFallbackFromAgent = (agentName: string): (string | FallbackModelObject)[] | undefined => {
     const agentConfig = pluginConfig.agents?.[agentName as keyof typeof pluginConfig.agents]
     if (!agentConfig) return undefined
-    
+
     if (agentConfig?.fallback_models) {
       return normalizeFallbackModels(agentConfig.fallback_models)
     }
-    
+
     const agentCategory = agentConfig?.category
     if (agentCategory && pluginConfig.categories?.[agentCategory]) {
       const categoryConfig = pluginConfig.categories[agentCategory]
@@ -35,7 +64,7 @@ export function getFallbackModelsForSession(
         return normalizeFallbackModels(categoryConfig.fallback_models)
       }
     }
-    
+
     return undefined
   }
 
@@ -53,5 +82,5 @@ export function getFallbackModelsForSession(
 
   log(`[${HOOK_NAME}] No category/agent fallback models resolved for session`, { sessionID, agent })
 
-  return []
+  return undefined
 }

--- a/src/plugin-interface.ts
+++ b/src/plugin-interface.ts
@@ -32,7 +32,13 @@ export function createPluginInterface(args: {
   return {
     tool: tools,
 
-    "chat.params": createChatParamsHandler({ anthropicEffort: hooks.anthropicEffort }),
+    "chat.params": async (input: unknown, output: unknown) => {
+      const handler = createChatParamsHandler({
+        anthropicEffort: hooks.anthropicEffort,
+        client: ctx.client,
+      })
+      await handler(input, output)
+    },
 
     "chat.headers": createChatHeadersHandler({ ctx }),
 
@@ -68,9 +74,5 @@ export function createPluginInterface(args: {
       ctx,
       hooks,
     }),
-
-    "tool.definition": async (input, output) => {
-      await hooks.todoDescriptionOverride?.["tool.definition"]?.(input, output)
-    },
   }
 }

--- a/src/plugin/chat-params.test.ts
+++ b/src/plugin/chat-params.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 
 import { createChatParamsHandler } from "./chat-params"
+import {
+  clearSessionPromptParams,
+  getSessionPromptParams,
+  setSessionPromptParams,
+} from "../shared/session-prompt-params-state"
 
 describe("createChatParamsHandler", () => {
+  afterEach(() => {
+    clearSessionPromptParams("ses_chat_params")
+  })
+
   test("normalizes object-style agent payload and runs chat.params hooks", async () => {
     //#given
     let called = false
@@ -35,7 +44,6 @@ describe("createChatParamsHandler", () => {
     //#then
     expect(called).toBe(true)
   })
-
   test("passes the original mutable message object to chat.params hooks", async () => {
     //#given
     const handler = createChatParamsHandler({
@@ -67,5 +75,62 @@ describe("createChatParamsHandler", () => {
 
     //#then
     expect(message.variant).toBe("high")
+  })
+
+  test("applies stored prompt params for the session", async () => {
+    //#given
+    setSessionPromptParams("ses_chat_params", {
+      temperature: 0.4,
+      topP: 0.7,
+      options: {
+        reasoningEffort: "high",
+        thinking: { type: "disabled" },
+        maxTokens: 4096,
+      },
+    })
+
+    const handler = createChatParamsHandler({
+      anthropicEffort: null,
+    })
+
+    const input = {
+      sessionID: "ses_chat_params",
+      agent: { name: "oracle" },
+      model: { providerID: "openai", modelID: "gpt-5.4" },
+      provider: { id: "openai" },
+      message: {},
+    }
+
+    const output = {
+      temperature: 0.1,
+      topP: 1,
+      topK: 1,
+      options: { existing: true },
+    }
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output).toEqual({
+      temperature: 0.4,
+      topP: 0.7,
+      topK: 1,
+      options: {
+        existing: true,
+        reasoningEffort: "high",
+        thinking: { type: "disabled" },
+        maxTokens: 4096,
+      },
+    })
+    expect(getSessionPromptParams("ses_chat_params")).toEqual({
+      temperature: 0.4,
+      topP: 0.7,
+      options: {
+        reasoningEffort: "high",
+        thinking: { type: "disabled" },
+        maxTokens: 4096,
+      },
+    })
   })
 })

--- a/src/plugin/chat-params.ts
+++ b/src/plugin/chat-params.ts
@@ -156,7 +156,9 @@ export function createChatParamsHandler(args: {
       providerID: normalizedInput.model.providerID,
       modelID: normalizedInput.model.modelID,
       desired: {
-        variant: normalizedInput.message.variant,
+        variant: typeof normalizedInput.message.variant === "string"
+          ? normalizedInput.message.variant
+          : undefined,
         reasoningEffort: typeof output.options.reasoningEffort === "string"
           ? output.options.reasoningEffort
           : undefined,

--- a/src/plugin/chat-params.ts
+++ b/src/plugin/chat-params.ts
@@ -1,3 +1,5 @@
+import { getSessionPromptParams } from "../shared/session-prompt-params-state"
+
 export type ChatParamsInput = {
   sessionID: string
   agent: { name?: string }
@@ -81,6 +83,22 @@ export function createChatParamsHandler(args: {
     const normalizedInput = buildChatParamsInput(input)
     if (!normalizedInput) return
     if (!isChatParamsOutput(output)) return
+
+    const storedPromptParams = getSessionPromptParams(normalizedInput.sessionID)
+    if (storedPromptParams) {
+      if (storedPromptParams.temperature !== undefined) {
+        output.temperature = storedPromptParams.temperature
+      }
+      if (storedPromptParams.topP !== undefined) {
+        output.topP = storedPromptParams.topP
+      }
+      if (storedPromptParams.options) {
+        output.options = {
+          ...output.options,
+          ...storedPromptParams.options,
+        }
+      }
+    }
 
     await args.anthropicEffort?.["chat.params"]?.(normalizedInput, output)
   }

--- a/src/plugin/chat-params.ts
+++ b/src/plugin/chat-params.ts
@@ -1,4 +1,6 @@
+import { normalizeSDKResponse } from "../shared/normalize-sdk-response"
 import { getSessionPromptParams } from "../shared/session-prompt-params-state"
+import { resolveCompatibleModelSettings } from "../shared"
 
 export type ChatParamsInput = {
   sessionID: string
@@ -17,6 +19,25 @@ export type ChatParamsOutput = {
   topP?: number
   topK?: number
   options: Record<string, unknown>
+}
+
+type ProviderListClient = {
+  provider?: {
+    list?: () => Promise<unknown>
+  }
+}
+
+type ProviderModelMetadata = {
+  variants?: Record<string, unknown>
+}
+
+type ProviderListEntry = {
+  id?: string
+  models?: Record<string, ProviderModelMetadata>
+}
+
+type ProviderListData = {
+  all?: ProviderListEntry[]
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -49,7 +70,11 @@ function buildChatParamsInput(raw: unknown): ChatParamsHookInput | null {
   if (!agentName) return null
 
   const providerID = model.providerID
-  const modelID = model.modelID
+  const modelID = typeof model.modelID === "string"
+    ? model.modelID
+    : typeof model.id === "string"
+      ? model.id
+      : undefined
   const providerId = provider.id
   const variant = message.variant
 
@@ -76,8 +101,33 @@ function isChatParamsOutput(raw: unknown): raw is ChatParamsOutput {
   return isRecord(raw.options)
 }
 
+async function getVariantCapabilities(
+  client: ProviderListClient | undefined,
+  model: { providerID: string; modelID: string },
+): Promise<string[] | undefined> {
+  const providerList = client?.provider?.list
+  if (typeof providerList !== "function") {
+    return undefined
+  }
+
+  try {
+    const response = await providerList()
+    const data = normalizeSDKResponse<ProviderListData>(response, {})
+    const providerEntry = data.all?.find((entry) => entry.id === model.providerID)
+    const variants = providerEntry?.models?.[model.modelID]?.variants
+    if (!variants) {
+      return undefined
+    }
+
+    return Object.keys(variants)
+  } catch {
+    return undefined
+  }
+}
+
 export function createChatParamsHandler(args: {
   anthropicEffort: { "chat.params"?: (input: ChatParamsHookInput, output: ChatParamsOutput) => Promise<void> } | null
+  client?: ProviderListClient
 }): (input: unknown, output: unknown) => Promise<void> {
   return async (input, output): Promise<void> => {
     const normalizedInput = buildChatParamsInput(input)
@@ -98,6 +148,37 @@ export function createChatParamsHandler(args: {
           ...storedPromptParams.options,
         }
       }
+    }
+
+    const variantCapabilities = await getVariantCapabilities(args.client, normalizedInput.model)
+
+    const compatibility = resolveCompatibleModelSettings({
+      providerID: normalizedInput.model.providerID,
+      modelID: normalizedInput.model.modelID,
+      desired: {
+        variant: normalizedInput.message.variant,
+        reasoningEffort: typeof output.options.reasoningEffort === "string"
+          ? output.options.reasoningEffort
+          : undefined,
+      },
+      capabilities: {
+        variants: variantCapabilities,
+      },
+    })
+
+    if (normalizedInput.rawMessage) {
+      if (compatibility.variant !== undefined) {
+        normalizedInput.rawMessage.variant = compatibility.variant
+      } else {
+        delete normalizedInput.rawMessage.variant
+      }
+    }
+    normalizedInput.message = normalizedInput.rawMessage as { variant?: string }
+
+    if (compatibility.reasoningEffort !== undefined) {
+      output.options.reasoningEffort = compatibility.reasoningEffort
+    } else if ("reasoningEffort" in output.options) {
+      delete output.options.reasoningEffort
     }
 
     await args.anthropicEffort?.["chat.params"]?.(normalizedInput, output)

--- a/src/plugin/event-compaction-agent.test.ts
+++ b/src/plugin/event-compaction-agent.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test"
 
 import { _resetForTesting, getSessionAgent, updateSessionAgent } from "../features/claude-code-session-state"
 import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state"
+import { clearSessionPromptParams } from "../shared/session-prompt-params-state"
 import { createEventHandler } from "./event"
 
 function createMinimalEventHandler() {
@@ -53,6 +54,8 @@ describe("createEventHandler compaction agent filtering", () => {
     _resetForTesting()
     clearSessionModel("ses_compaction_poisoning")
     clearSessionModel("ses_compaction_model_poisoning")
+    clearSessionPromptParams("ses_compaction_poisoning")
+    clearSessionPromptParams("ses_compaction_model_poisoning")
   })
 
   it("does not overwrite the stored session agent with compaction", async () => {

--- a/src/plugin/event.test.ts
+++ b/src/plugin/event.test.ts
@@ -4,6 +4,7 @@ import { createEventHandler } from "./event"
 import { createChatMessageHandler } from "./chat-message"
 import { _resetForTesting, setMainSession } from "../features/claude-code-session-state"
 import { clearPendingModelFallback, createModelFallbackHook } from "../hooks/model-fallback/hook"
+import { getSessionPromptParams, setSessionPromptParams } from "../shared/session-prompt-params-state"
 
 type EventInput = { event: { type: string; properties?: unknown } }
 
@@ -440,6 +441,45 @@ describe("createEventHandler - event forwarding", () => {
 		expect(forwardedEvents[0]?.event.type).toBe("session.deleted")
 		expect(disconnectedSessions).toEqual([sessionID])
 		expect(deletedSessions).toEqual([sessionID])
+	})
+
+	it("clears stored prompt params on session.deleted", async () => {
+		//#given
+		const eventHandler = createEventHandler({
+			ctx: {} as never,
+			pluginConfig: {} as never,
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: {
+				skillMcpManager: {
+					disconnectSession: async () => {},
+				},
+				tmuxSessionManager: {
+					onSessionCreated: async () => {},
+					onSessionDeleted: async () => {},
+				},
+			} as never,
+			hooks: {} as never,
+		})
+		const sessionID = "ses_prompt_params_deleted"
+		setSessionPromptParams(sessionID, {
+			temperature: 0.4,
+			topP: 0.7,
+			options: { reasoningEffort: "high" },
+		})
+
+		//#when
+		await eventHandler({
+			event: {
+				type: "session.deleted",
+				properties: { info: { id: sessionID } },
+			},
+		})
+
+		//#then
+		expect(getSessionPromptParams(sessionID)).toBeUndefined()
 	})
 })
 

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -16,7 +16,7 @@ import {
   setSessionFallbackChain,
   setPendingModelFallback,
 } from "../hooks/model-fallback/hook";
-import { getFallbackModelsForSession } from "../hooks/runtime-fallback/fallback-models";
+import { getRawFallbackModels } from "../hooks/runtime-fallback/fallback-models";
 import { resetMessageCursor } from "../shared";
 import { getAgentConfigKey } from "../shared/agent-display-names";
 import { readConnectedProvidersCache } from "../shared/connected-providers-cache";
@@ -25,6 +25,7 @@ import { shouldRetryError } from "../shared/model-error-classifier";
 import { buildFallbackChainFromModels } from "../shared/fallback-chain-from-models";
 import { extractRetryAttempt, normalizeRetryStatusMessage } from "../shared/retry-status-utils";
 import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state";
+import { clearSessionPromptParams } from "../shared/session-prompt-params-state";
 import { deleteSessionTools } from "../shared/session-tools-store";
 import { lspManager } from "../tools";
 
@@ -110,10 +111,10 @@ function applyUserConfiguredFallbackChain(
   pluginConfig: OhMyOpenCodeConfig,
 ): void {
   const agentKey = getAgentConfigKey(agentName);
-  const configuredFallbackModels = getFallbackModelsForSession(sessionID, agentKey, pluginConfig);
-  if (configuredFallbackModels.length === 0) return;
+  const rawFallbackModels = getRawFallbackModels(sessionID, agentKey, pluginConfig);
+  if (!rawFallbackModels || rawFallbackModels.length === 0) return;
 
-  const fallbackChain = buildFallbackChainFromModels(configuredFallbackModels, currentProviderID);
+  const fallbackChain = buildFallbackChainFromModels(rawFallbackModels, currentProviderID);
 
   if (fallbackChain && fallbackChain.length > 0) {
     setSessionFallbackChain(sessionID, fallbackChain);
@@ -330,6 +331,7 @@ export function createEventHandler(args: {
         resetMessageCursor(sessionInfo.id);
         firstMessageVariantGate.clear(sessionInfo.id);
         clearSessionModel(sessionInfo.id);
+        clearSessionPromptParams(sessionInfo.id);
         syncSubagentSessions.delete(sessionInfo.id);
         if (wasSyncSubagentSession) {
           subagentSessions.delete(sessionInfo.id);

--- a/src/shared/fallback-chain-from-models.test.ts
+++ b/src/shared/fallback-chain-from-models.test.ts
@@ -1,6 +1,13 @@
-import { describe, test, expect } from "bun:test"
-import { buildFallbackChainFromModels, parseFallbackModelEntry } from "./fallback-chain-from-models"
+import { describe, test, it, expect } from "bun:test"
+import {
+  parseFallbackModelEntry,
+  parseFallbackModelObjectEntry,
+  buildFallbackChainFromModels,
+  findMostSpecificFallbackEntry,
+} from "./fallback-chain-from-models"
+import { flattenToFallbackModelStrings } from "./model-resolver"
 
+// Upstream tests
 describe("fallback-chain-from-models", () => {
   test("parses provider/model entry with parenthesized variant", () => {
     //#given
@@ -59,5 +66,332 @@ describe("fallback-chain-from-models", () => {
       { providers: ["quotio"], model: "kimi-k2.5", variant: undefined },
       { providers: ["quotio"], model: "gpt-5.2", variant: "medium" },
     ])
+  })
+})
+
+// Object-style entry tests
+describe("parseFallbackModelEntry (extended)", () => {
+  it("parses provider/model string", () => {
+    const result = parseFallbackModelEntry("anthropic/claude-sonnet-4-6", undefined)
+    expect(result).toEqual({
+      providers: ["anthropic"],
+      model: "claude-sonnet-4-6",
+    })
+  })
+
+  it("parses model with parenthesized variant", () => {
+    const result = parseFallbackModelEntry("anthropic/claude-sonnet-4-6(high)", undefined)
+    expect(result).toEqual({
+      providers: ["anthropic"],
+      model: "claude-sonnet-4-6",
+      variant: "high",
+    })
+  })
+
+  it("parses model with space variant", () => {
+    const result = parseFallbackModelEntry("openai/gpt-5.4 xhigh", undefined)
+    expect(result).toEqual({
+      providers: ["openai"],
+      model: "gpt-5.4",
+      variant: "xhigh",
+    })
+  })
+
+  it("parses model with minimal space variant", () => {
+    const result = parseFallbackModelEntry("openai/gpt-5.4 minimal", undefined)
+    expect(result).toEqual({
+      providers: ["openai"],
+      model: "gpt-5.4",
+      variant: "minimal",
+    })
+  })
+
+  it("uses context provider when no provider prefix", () => {
+    const result = parseFallbackModelEntry("claude-sonnet-4-6", "anthropic")
+    expect(result).toEqual({
+      providers: ["anthropic"],
+      model: "claude-sonnet-4-6",
+    })
+  })
+
+  it("returns undefined for empty string", () => {
+    expect(parseFallbackModelEntry("", undefined)).toBeUndefined()
+    expect(parseFallbackModelEntry("  ", undefined)).toBeUndefined()
+  })
+})
+
+describe("parseFallbackModelObjectEntry", () => {
+  it("parses object with model only", () => {
+    const result = parseFallbackModelObjectEntry(
+      { model: "anthropic/claude-sonnet-4-6" },
+      undefined,
+    )
+    expect(result).toEqual({
+      providers: ["anthropic"],
+      model: "claude-sonnet-4-6",
+    })
+  })
+
+  it("parses object with variant override", () => {
+    const result = parseFallbackModelObjectEntry(
+      { model: "anthropic/claude-sonnet-4-6", variant: "high" },
+      undefined,
+    )
+    expect(result).toEqual({
+      providers: ["anthropic"],
+      model: "claude-sonnet-4-6",
+      variant: "high",
+    })
+  })
+
+  it("object variant overrides inline variant", () => {
+    const result = parseFallbackModelObjectEntry(
+      { model: "anthropic/claude-sonnet-4-6(low)", variant: "high" },
+      undefined,
+    )
+    expect(result).toEqual({
+      providers: ["anthropic"],
+      model: "claude-sonnet-4-6",
+      variant: "high",
+    })
+  })
+
+  it("carries reasoningEffort and temperature", () => {
+    const result = parseFallbackModelObjectEntry(
+      {
+        model: "openai/gpt-5.4",
+        variant: "high",
+        reasoningEffort: "high",
+        temperature: 0.5,
+      },
+      undefined,
+    )
+    expect(result).toEqual({
+      providers: ["openai"],
+      model: "gpt-5.4",
+      variant: "high",
+      reasoningEffort: "high",
+      temperature: 0.5,
+    })
+  })
+
+  it("carries thinking config", () => {
+    const result = parseFallbackModelObjectEntry(
+      {
+        model: "anthropic/claude-sonnet-4-6",
+        thinking: { type: "enabled", budgetTokens: 10000 },
+      },
+      undefined,
+    )
+    expect(result).toEqual({
+      providers: ["anthropic"],
+      model: "claude-sonnet-4-6",
+      thinking: { type: "enabled", budgetTokens: 10000 },
+    })
+  })
+
+  it("carries all optional fields", () => {
+    const result = parseFallbackModelObjectEntry(
+      {
+        model: "openai/gpt-5.4",
+        variant: "xhigh",
+        reasoningEffort: "xhigh",
+        temperature: 0.3,
+        top_p: 0.9,
+        maxTokens: 8192,
+        thinking: { type: "disabled" },
+      },
+      undefined,
+    )
+    expect(result).toEqual({
+      providers: ["openai"],
+      model: "gpt-5.4",
+      variant: "xhigh",
+      reasoningEffort: "xhigh",
+      temperature: 0.3,
+      top_p: 0.9,
+      maxTokens: 8192,
+      thinking: { type: "disabled" },
+    })
+  })
+})
+
+describe("buildFallbackChainFromModels (mixed)", () => {
+  it("handles string input", () => {
+    const result = buildFallbackChainFromModels("anthropic/claude-sonnet-4-6", undefined)
+    expect(result).toEqual([
+      { providers: ["anthropic"], model: "claude-sonnet-4-6" },
+    ])
+  })
+
+  it("handles string array", () => {
+    const result = buildFallbackChainFromModels(
+      ["anthropic/claude-sonnet-4-6", "openai/gpt-5.4"],
+      undefined,
+    )
+    expect(result).toEqual([
+      { providers: ["anthropic"], model: "claude-sonnet-4-6" },
+      { providers: ["openai"], model: "gpt-5.4" },
+    ])
+  })
+
+  it("handles mixed array of strings and objects", () => {
+    const result = buildFallbackChainFromModels(
+      [
+        { model: "anthropic/claude-sonnet-4-6", variant: "high", reasoningEffort: "high" },
+        { model: "openai/gpt-5.4", reasoningEffort: "xhigh" },
+        "chutes/kimi-k2.5",
+        { model: "chutes/glm-5", temperature: 0.7 },
+        "google/gemini-3-flash",
+      ],
+      undefined,
+    )
+    expect(result).toEqual([
+      { providers: ["anthropic"], model: "claude-sonnet-4-6", variant: "high", reasoningEffort: "high" },
+      { providers: ["openai"], model: "gpt-5.4", reasoningEffort: "xhigh" },
+      { providers: ["chutes"], model: "kimi-k2.5" },
+      { providers: ["chutes"], model: "glm-5", temperature: 0.7 },
+      { providers: ["google"], model: "gemini-3-flash" },
+    ])
+  })
+
+  it("returns undefined for empty/undefined input", () => {
+    expect(buildFallbackChainFromModels(undefined, undefined)).toBeUndefined()
+    expect(buildFallbackChainFromModels([], undefined)).toBeUndefined()
+  })
+
+  it("filters out invalid entries", () => {
+    const result = buildFallbackChainFromModels(
+      ["", "anthropic/claude-sonnet-4-6", "  "],
+      undefined,
+    )
+    expect(result).toEqual([
+      { providers: ["anthropic"], model: "claude-sonnet-4-6" },
+    ])
+  })
+})
+
+describe("flattenToFallbackModelStrings", () => {
+  it("returns undefined for undefined input", () => {
+    expect(flattenToFallbackModelStrings(undefined)).toBeUndefined()
+  })
+
+  it("passes through plain strings", () => {
+    expect(flattenToFallbackModelStrings(["anthropic/claude-sonnet-4-6"])).toEqual([
+      "anthropic/claude-sonnet-4-6",
+    ])
+  })
+
+  it("flattens object with explicit variant", () => {
+    expect(flattenToFallbackModelStrings([
+      { model: "anthropic/claude-sonnet-4-6", variant: "high" },
+    ])).toEqual(["anthropic/claude-sonnet-4-6(high)"])
+  })
+
+  it("preserves inline variant when no explicit variant", () => {
+    expect(flattenToFallbackModelStrings([
+      { model: "anthropic/claude-sonnet-4-6(high)" },
+    ])).toEqual(["anthropic/claude-sonnet-4-6(high)"])
+  })
+
+  it("explicit variant overrides inline variant (no double-suffix)", () => {
+    expect(flattenToFallbackModelStrings([
+      { model: "anthropic/claude-sonnet-4-6(low)", variant: "high" },
+    ])).toEqual(["anthropic/claude-sonnet-4-6(high)"])
+  })
+
+  it("explicit variant overrides space-suffix variant", () => {
+    expect(flattenToFallbackModelStrings([
+      { model: "openai/gpt-5.4 high", variant: "low" },
+    ])).toEqual(["openai/gpt-5.4(low)"])
+  })
+
+  it("explicit variant overrides minimal space-suffix variant", () => {
+    expect(flattenToFallbackModelStrings([
+      { model: "openai/gpt-5.4 minimal", variant: "low" },
+    ])).toEqual(["openai/gpt-5.4(low)"])
+  })
+
+  it("preserves trailing non-variant suffixes when adding explicit variant", () => {
+    expect(flattenToFallbackModelStrings([
+      { model: "openai/gpt-5.4 preview", variant: "low" },
+    ])).toEqual(["openai/gpt-5.4 preview(low)"])
+  })
+
+  it("flattens object without variant", () => {
+    expect(flattenToFallbackModelStrings([
+      { model: "openai/gpt-5.4" },
+    ])).toEqual(["openai/gpt-5.4"])
+  })
+
+  it("handles mixed array", () => {
+    expect(flattenToFallbackModelStrings([
+      "anthropic/claude-sonnet-4-6",
+      { model: "openai/gpt-5.4", variant: "high" },
+      { model: "google/gemini-3-flash(low)" },
+    ])).toEqual([
+      "anthropic/claude-sonnet-4-6",
+      "openai/gpt-5.4(high)",
+      "google/gemini-3-flash(low)",
+    ])
+  })
+})
+
+describe("findMostSpecificFallbackEntry", () => {
+  it("picks exact match over prefix match", () => {
+    const chain = [
+      { providers: ["openai"], model: "gpt-5.4" },
+      { providers: ["openai"], model: "gpt-5.4-preview" },
+    ]
+    const result = findMostSpecificFallbackEntry("openai", "gpt-5.4-preview", chain)
+    expect(result?.model).toBe("gpt-5.4-preview")
+  })
+
+  it("returns prefix match when no exact match exists", () => {
+    const chain = [
+      { providers: ["openai"], model: "gpt-5.4" },
+    ]
+    const result = findMostSpecificFallbackEntry("openai", "gpt-5.4-preview", chain)
+    expect(result?.model).toBe("gpt-5.4")
+  })
+
+  it("returns undefined when no entry matches", () => {
+    const chain = [
+      { providers: ["anthropic"], model: "claude-sonnet-4-6" },
+    ]
+    expect(findMostSpecificFallbackEntry("openai", "gpt-5.4", chain)).toBeUndefined()
+  })
+
+  it("sorts by matched prefix length, not insertion order", () => {
+    // Both entries share the same provider so both match as prefixes;
+    // the longer (more-specific) prefix must win regardless of array order.
+    const chain = [
+      { providers: ["openai"], model: "gpt-5" },
+      { providers: ["openai"], model: "gpt-5.4-preview" },
+    ]
+    const result = findMostSpecificFallbackEntry("openai", "gpt-5.4-preview-2026", chain)
+    expect(result?.model).toBe("gpt-5.4-preview")
+  })
+
+  it("is case-insensitive", () => {
+    const chain = [
+      { providers: ["OpenAI"], model: "GPT-5.4" },
+    ]
+    const result = findMostSpecificFallbackEntry("openai", "gpt-5.4-preview", chain)
+    expect(result?.model).toBe("GPT-5.4")
+  })
+
+  it("preserves variant and settings from matched entry", () => {
+    const chain = [
+      { providers: ["openai"], model: "gpt-5.4", variant: "high", temperature: 0.7 },
+      { providers: ["openai"], model: "gpt-5.4-preview", variant: "low", reasoningEffort: "medium" },
+    ]
+    const result = findMostSpecificFallbackEntry("openai", "gpt-5.4-preview", chain)
+    expect(result).toEqual({
+      providers: ["openai"],
+      model: "gpt-5.4-preview",
+      variant: "low",
+      reasoningEffort: "medium",
+    })
   })
 })

--- a/src/shared/fallback-chain-from-models.ts
+++ b/src/shared/fallback-chain-from-models.ts
@@ -57,13 +57,11 @@ export function parseFallbackModelObjectEntry(
   contextProviderID: string | undefined,
   defaultProviderID = "opencode",
 ): FallbackEntry | undefined {
-  // Reuse the string-based parser for provider/model/variant extraction.
   const base = parseFallbackModelEntry(obj.model, contextProviderID, defaultProviderID)
   if (!base) return undefined
 
   return {
     ...base,
-    // Explicit object variant overrides any inline variant in the model string.
     variant: obj.variant ?? base.variant,
     reasoningEffort: obj.reasoningEffort,
     temperature: obj.temperature,

--- a/src/shared/fallback-chain-from-models.ts
+++ b/src/shared/fallback-chain-from-models.ts
@@ -1,16 +1,7 @@
 import type { FallbackEntry } from "./model-requirements"
+import type { FallbackModelObject } from "../config/schema/fallback-models"
 import { normalizeFallbackModels } from "./model-resolver"
-
-const KNOWN_VARIANTS = new Set([
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-  "none",
-  "auto",
-  "thinking",
-])
+import { KNOWN_VARIANTS } from "./known-variants"
 
 function parseVariantFromModel(rawModel: string): { modelID: string; variant?: string } {
   const trimmedModel = rawModel.trim()
@@ -61,8 +52,60 @@ export function parseFallbackModelEntry(
   }
 }
 
+export function parseFallbackModelObjectEntry(
+  obj: FallbackModelObject,
+  contextProviderID: string | undefined,
+  defaultProviderID = "opencode",
+): FallbackEntry | undefined {
+  // Reuse the string-based parser for provider/model/variant extraction.
+  const base = parseFallbackModelEntry(obj.model, contextProviderID, defaultProviderID)
+  if (!base) return undefined
+
+  return {
+    ...base,
+    // Explicit object variant overrides any inline variant in the model string.
+    variant: obj.variant ?? base.variant,
+    reasoningEffort: obj.reasoningEffort,
+    temperature: obj.temperature,
+    top_p: obj.top_p,
+    maxTokens: obj.maxTokens,
+    thinking: obj.thinking,
+  }
+}
+
+/**
+ * Find the most specific FallbackEntry whose `provider/model` is a prefix of
+ * the resolved `provider/modelID`.  Longest match wins so that e.g.
+ * `openai/gpt-5.4-preview` picks the entry for `openai/gpt-5.4-preview` over
+ * the shorter `openai/gpt-5.4`.
+ */
+export function findMostSpecificFallbackEntry(
+  providerID: string,
+  modelID: string,
+  chain: FallbackEntry[],
+): FallbackEntry | undefined {
+  const resolved = `${providerID}/${modelID}`.toLowerCase()
+
+  // Collect entries whose provider/model is a prefix of the resolved model,
+  // together with the length of the matching prefix (longest match wins).
+  const matches: { entry: FallbackEntry; matchLen: number }[] = []
+  for (const entry of chain) {
+    for (const p of entry.providers) {
+      const candidate = `${p}/${entry.model}`.toLowerCase()
+      if (resolved.startsWith(candidate)) {
+        matches.push({ entry, matchLen: candidate.length })
+        break // one match per entry is enough
+      }
+    }
+  }
+
+  if (matches.length === 0) return undefined
+  matches.sort((a, b) => b.matchLen - a.matchLen)
+  return matches[0].entry
+}
+
 export function buildFallbackChainFromModels(
-  fallbackModels: string | string[] | undefined,
+  fallbackModels: string | (string | FallbackModelObject)[] | undefined,
   contextProviderID: string | undefined,
   defaultProviderID = "opencode",
 ): FallbackEntry[] | undefined {
@@ -70,7 +113,12 @@ export function buildFallbackChainFromModels(
   if (!normalized || normalized.length === 0) return undefined
 
   const parsed = normalized
-    .map((model) => parseFallbackModelEntry(model, contextProviderID, defaultProviderID))
+    .map((entry) => {
+      if (typeof entry === "string") {
+        return parseFallbackModelEntry(entry, contextProviderID, defaultProviderID)
+      }
+      return parseFallbackModelObjectEntry(entry, contextProviderID, defaultProviderID)
+    })
     .filter((entry): entry is FallbackEntry => entry !== undefined)
 
   if (parsed.length === 0) return undefined

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -43,6 +43,7 @@ export type {
   ModelResolutionResult,
 } from "./model-resolution-types"
 export * from "./model-availability"
+export * from "./model-settings-compatibility"
 export * from "./fallback-model-availability"
 export * from "./connected-providers-cache"
 export * from "./context-limit-resolver"

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -35,7 +35,7 @@ export * from "./agent-tool-restrictions"
 export * from "./model-requirements"
 export * from "./model-resolver"
 export { normalizeModel, normalizeModelID } from "./model-normalization"
-export { normalizeFallbackModels } from "./model-resolver"
+export { normalizeFallbackModels, flattenToFallbackModelStrings } from "./model-resolver"
 export { resolveModelPipeline } from "./model-resolution-pipeline"
 export type {
   ModelResolutionRequest,

--- a/src/shared/known-variants.ts
+++ b/src/shared/known-variants.ts
@@ -1,0 +1,16 @@
+/**
+ * Canonical set of recognised variant / effort tokens.
+ * Used by parseFallbackModelEntry (space-suffix detection) and
+ * flattenToFallbackModelStrings (inline-variant stripping).
+ */
+export const KNOWN_VARIANTS = new Set([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "minimal",
+  "none",
+  "auto",
+  "thinking",
+])

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -2,6 +2,11 @@ export type FallbackEntry = {
   providers: string[];
   model: string;
   variant?: string; // Entry-specific variant (e.g., GPT→high, Opus→max)
+  reasoningEffort?: string;
+  temperature?: number;
+  top_p?: number;
+  maxTokens?: number;
+  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number };
 };
 
 export type ModelRequirement = {

--- a/src/shared/model-resolution-types.ts
+++ b/src/shared/model-resolution-types.ts
@@ -1,5 +1,16 @@
 import type { FallbackEntry } from "./model-requirements"
 
+export interface DelegatedModelConfig {
+  providerID: string
+  modelID: string
+  variant?: string
+  reasoningEffort?: string
+  temperature?: number
+  top_p?: number
+  maxTokens?: number
+  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+}
+
 export type ModelResolutionRequest = {
   intent?: {
     uiSelectedModel?: string

--- a/src/shared/model-resolver.ts
+++ b/src/shared/model-resolver.ts
@@ -1,6 +1,8 @@
 import type { FallbackEntry } from "./model-requirements"
+import type { FallbackModelObject } from "../config/schema/fallback-models"
 import { normalizeModel } from "./model-normalization"
 import { resolveModelPipeline } from "./model-resolution-pipeline"
+import { KNOWN_VARIANTS } from "./known-variants"
 
 export type ModelResolutionInput = {
 	userModel?: string
@@ -61,11 +63,45 @@ export function resolveModelWithFallback(
 }
 
 /**
- * Normalizes fallback_models config (which can be string or string[]) to string[]
- * Centralized helper to avoid duplicated normalization logic
+ * Normalizes fallback_models config to a mixed array.
+ * Accepts string, string[], or mixed arrays of strings and FallbackModelObject entries.
  */
-export function normalizeFallbackModels(models: string | string[] | undefined): string[] | undefined {
+export function normalizeFallbackModels(
+	models: string | (string | FallbackModelObject)[] | undefined,
+): (string | FallbackModelObject)[] | undefined {
 	if (!models) return undefined
 	if (typeof models === "string") return [models]
 	return models
+}
+
+/**
+ * Extracts plain model strings from a mixed fallback models array.
+ * Object entries are flattened to "model" or "model(variant)" strings.
+ * Use this when consumers need string[] (e.g., resolveModelForDelegateTask).
+ */
+export function flattenToFallbackModelStrings(
+	models: (string | FallbackModelObject)[] | undefined,
+): string[] | undefined {
+	if (!models) return undefined
+	return models.map((entry) => {
+		if (typeof entry === "string") return entry
+		const variant = entry.variant
+		if (variant) {
+			// Strip any supported inline variant syntax before appending explicit override.
+			// Supports both parenthesized and space-suffix forms so we don't emit
+			// invalid strings like "provider/model high(low)".
+			const model = entry.model
+				.replace(/\([^()]+\)\s*$/, "")
+				.replace(/\s+([a-z][a-z0-9_-]*)\s*$/i, (match, suffix) => {
+					const normalized = String(suffix).toLowerCase()
+					return KNOWN_VARIANTS.has(normalized)
+						? ""
+						: match
+				})
+				.trim()
+			return `${model}(${variant})`
+		}
+		// No explicit variant — preserve model string as-is (including any inline variant)
+		return entry.model
+	})
 }

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -90,29 +90,6 @@ describe("resolveCompatibleModelSettings", () => {
     })
   })
 
-  test("downgrades gpt-5 reasoningEffort max to xhigh", () => {
-    // given
-    const input = {
-      providerID: "openai",
-      modelID: "gpt-5.4",
-      desired: { reasoningEffort: "max" },
-    }
-
-    // when
-    const result = resolveCompatibleModelSettings(input)
-
-    // then
-    expect(result.reasoningEffort).toBe("xhigh")
-    expect(result.changes).toEqual([
-      {
-        field: "reasoningEffort",
-        from: "max",
-        to: "xhigh",
-        reason: "unsupported-by-model-family",
-      },
-    ])
-  })
-
   test("keeps supported OpenAI reasoning-family effort for o-series models", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
@@ -125,75 +102,6 @@ describe("resolveCompatibleModelSettings", () => {
       reasoningEffort: "high",
       changes: [],
     })
-  })
-
-  test("downgrades openai reasoning-family effort xhigh to high", () => {
-    // given
-    const input = {
-      providerID: "openai",
-      modelID: "o3-mini",
-      desired: { reasoningEffort: "xhigh" },
-    }
-
-    // when
-    const result = resolveCompatibleModelSettings(input)
-
-    // then
-    expect(result.reasoningEffort).toBe("high")
-    expect(result.changes).toEqual([
-      {
-        field: "reasoningEffort",
-        from: "xhigh",
-        to: "high",
-        reason: "unsupported-by-model-family",
-      },
-    ])
-  })
-
-  test("drops reasoningEffort for gpt-5 mini models", () => {
-    // given
-    const input = {
-      providerID: "openai",
-      modelID: "gpt-5.4-mini",
-      desired: { reasoningEffort: "high" },
-    }
-
-    // when
-    const result = resolveCompatibleModelSettings(input)
-
-    // then
-    expect(result.reasoningEffort).toBeUndefined()
-    expect(result.changes).toEqual([
-      {
-        field: "reasoningEffort",
-        from: "high",
-        to: undefined,
-        reason: "unsupported-by-model-family",
-      },
-    ])
-  })
-
-  test("treats non-openai o-series models as unknown", () => {
-    // given
-    const input = {
-      providerID: "ollama",
-      modelID: "o3",
-      desired: { reasoningEffort: "high" },
-    }
-
-    // when
-    const result = resolveCompatibleModelSettings(input)
-
-    // then
-    expect(result.reasoningEffort).toBeUndefined()
-    expect(result.changes).toEqual([
-      {
-        field: "reasoningEffort",
-        from: "high",
-        to: undefined,
-        reason: "unknown-model-family",
-      },
-    ])
   })
 
   test("does not record case-only normalization as a compatibility downgrade", () => {

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -299,4 +299,178 @@ describe("resolveCompatibleModelSettings", () => {
       ],
     })
   })
+
+  // Provider-agnostic detection: model ID is the source of truth, not provider ID
+  test("detects Claude via any provider (provider-agnostic)", () => {
+    for (const providerID of ["anthropic", "aws-bedrock", "bedrock", "amazon-bedrock", "opencode", "my-custom-proxy", "google-vertex-anthropic"]) {
+      const result = resolveCompatibleModelSettings({
+        providerID,
+        modelID: "claude-sonnet-4-6",
+        desired: { variant: "max" },
+      })
+
+      expect(result.variant).toBe("high")
+      expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
+    }
+  })
+
+  test("detects Claude 3 Opus via any provider", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "some-unknown-proxy",
+      modelID: "claude-3-opus-20240229",
+      desired: { variant: "max" },
+    })
+
+    expect(result.variant).toBe("max")
+    expect(result.changes).toEqual([])
+  })
+
+  test("detects OpenAI reasoning models without requiring openai provider", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "azure-openai",
+      modelID: "o3-mini",
+      desired: { reasoningEffort: "high" },
+    })
+
+    expect(result.reasoningEffort).toBe("high")
+    expect(result.changes).toEqual([])
+  })
+
+  // -----------------------------------------------------------------------
+  // Registry coverage — every model family from FAMILY_CAPABILITIES
+  // -----------------------------------------------------------------------
+
+  describe("model family registry coverage", () => {
+    const familyCases: Array<{
+      name: string
+      modelID: string
+      expectedVariants: string[]
+      hasReasoningEffort: boolean
+    }> = [
+      { name: "Gemini", modelID: "gemini-3.1-pro", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Kimi (kimi)", modelID: "kimi-k2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Kimi (k2)", modelID: "k2-v2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "GLM", modelID: "glm-5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Minimax", modelID: "minimax-m2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Mistral", modelID: "mistral-large-next", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Codestral → Mistral", modelID: "codestral-2506", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "Llama", modelID: "llama-4-maverick", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+    ]
+
+    for (const { name, modelID, expectedVariants, hasReasoningEffort } of familyCases) {
+      test(`${name} (${modelID}): keeps supported variant`, () => {
+        const highest = expectedVariants[expectedVariants.length - 1]
+        const result = resolveCompatibleModelSettings({
+          providerID: "any-provider",
+          modelID,
+          desired: { variant: highest },
+        })
+
+        expect(result.variant).toBe(highest)
+        expect(result.changes).toEqual([])
+      })
+
+      test(`${name} (${modelID}): downgrades unsupported variant`, () => {
+        const result = resolveCompatibleModelSettings({
+          providerID: "any-provider",
+          modelID,
+          desired: { variant: "max" },
+        })
+
+        const highest = expectedVariants[expectedVariants.length - 1]
+        expect(result.variant).toBe(highest)
+        expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
+      })
+
+      test(`${name} (${modelID}): ${hasReasoningEffort ? "keeps" : "drops"} reasoningEffort`, () => {
+        const result = resolveCompatibleModelSettings({
+          providerID: "any-provider",
+          modelID,
+          desired: { reasoningEffort: "high" },
+        })
+
+        if (hasReasoningEffort) {
+          expect(result.reasoningEffort).toBe("high")
+          expect(result.changes).toEqual([])
+        } else {
+          expect(result.reasoningEffort).toBeUndefined()
+          expect(result.changes[0]?.reason).toBe("unsupported-by-model-family")
+        }
+      })
+    }
+  })
+
+  // GPT-5 specific: supports xhigh variant and xhigh reasoningEffort
+  test("GPT-5 keeps xhigh variant and reasoningEffort", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      desired: { variant: "xhigh", reasoningEffort: "xhigh" },
+    })
+
+    expect(result).toEqual({
+      variant: "xhigh",
+      reasoningEffort: "xhigh",
+      changes: [],
+    })
+  })
+
+  // Reasoning effort: "none" and "minimal" are valid per Vercel AI SDK
+  test("GPT-5 keeps none reasoningEffort", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      desired: { reasoningEffort: "none" },
+    })
+
+    expect(result).toEqual({
+      variant: undefined,
+      reasoningEffort: "none",
+      changes: [],
+    })
+  })
+
+  test("GPT-5 keeps minimal reasoningEffort", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      desired: { reasoningEffort: "minimal" },
+    })
+
+    expect(result).toEqual({
+      variant: undefined,
+      reasoningEffort: "minimal",
+      changes: [],
+    })
+  })
+
+  test("o-series keeps none reasoningEffort", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "o3-mini",
+      desired: { reasoningEffort: "none" },
+    })
+
+    expect(result).toEqual({
+      variant: undefined,
+      reasoningEffort: "none",
+      changes: [],
+    })
+  })
+
+  // Passthrough: undefined desired values produce no changes
+  test("no-op when desired settings are empty", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "anthropic",
+      modelID: "claude-opus-4-6",
+      desired: {},
+    })
+
+    expect(result).toEqual({
+      variant: undefined,
+      reasoningEffort: undefined,
+      changes: [],
+    })
+  })
 })

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -210,19 +210,19 @@ describe("resolveCompatibleModelSettings", () => {
     })
   })
 
-  test("downgrades unsupported GPT reasoningEffort to nearest lower level", () => {
+  test("drops reasoningEffort for standard GPT models (gpt-4.1)", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
       modelID: "gpt-4.1",
-      desired: { reasoningEffort: "xhigh" },
+      desired: { reasoningEffort: "high" },
     })
 
-    expect(result.reasoningEffort).toBe("high")
+    expect(result.reasoningEffort).toBeUndefined()
     expect(result.changes).toEqual([
       {
         field: "reasoningEffort",
-        from: "xhigh",
-        to: "high",
+        from: "high",
+        to: undefined,
         reason: "unsupported-by-model-family",
       },
     ])
@@ -457,6 +457,57 @@ describe("resolveCompatibleModelSettings", () => {
       reasoningEffort: "none",
       changes: [],
     })
+  })
+
+  // Reasoning effort downgrade within families that support it
+  test("o-series downgrades xhigh reasoningEffort to high", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "o3-mini",
+      desired: { reasoningEffort: "xhigh" },
+    })
+
+    expect(result.reasoningEffort).toBe("high")
+    expect(result.changes).toEqual([
+      {
+        field: "reasoningEffort",
+        from: "xhigh",
+        to: "high",
+        reason: "unsupported-by-model-family",
+      },
+    ])
+  })
+
+  test("GPT-5 keeps xhigh but would downgrade a hypothetical beyond-max level", () => {
+    // GPT-5 supports up to "xhigh" — verify the ladder works by requesting
+    // a value that IS in the ladder but NOT in the family's allowed list.
+    // Since "xhigh" is the max for GPT-5 reasoningEffort, we verify it stays.
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      desired: { reasoningEffort: "xhigh" },
+    })
+
+    expect(result.reasoningEffort).toBe("xhigh")
+    expect(result.changes).toEqual([])
+  })
+
+  test("o-series downgrades unsupported variant to high", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "o3-mini",
+      desired: { variant: "max" },
+    })
+
+    expect(result.variant).toBe("high")
+    expect(result.changes).toEqual([
+      {
+        field: "variant",
+        from: "max",
+        to: "high",
+        reason: "unsupported-by-model-family",
+      },
+    ])
   })
 
   // Passthrough: undefined desired values produce no changes

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, test } from "bun:test"
+
+import { resolveCompatibleModelSettings } from "./model-settings-compatibility"
+
+describe("resolveCompatibleModelSettings", () => {
+  test("keeps supported Claude Opus variant unchanged", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "anthropic",
+      modelID: "claude-opus-4-6",
+      desired: { variant: "max" },
+    })
+
+    expect(result).toEqual({
+      variant: "max",
+      reasoningEffort: undefined,
+      changes: [],
+    })
+  })
+
+  test("uses model metadata first for variant support", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "anthropic",
+      modelID: "claude-opus-4-6",
+      desired: { variant: "max" },
+      capabilities: { variants: ["low", "medium", "high"] },
+    })
+
+    expect(result).toEqual({
+      variant: "high",
+      reasoningEffort: undefined,
+      changes: [
+        {
+          field: "variant",
+          from: "max",
+          to: "high",
+          reason: "unsupported-by-model-metadata",
+        },
+      ],
+    })
+  })
+
+  test("prefers metadata over family heuristics even when family would allow a higher level", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "anthropic",
+      modelID: "claude-opus-4-6",
+      desired: { variant: "max" },
+      capabilities: { variants: ["low", "medium"] },
+    })
+
+    expect(result.variant).toBe("medium")
+    expect(result.changes).toEqual([
+      {
+        field: "variant",
+        from: "max",
+        to: "medium",
+        reason: "unsupported-by-model-metadata",
+      },
+    ])
+  })
+
+  test("downgrades unsupported Claude Sonnet max variant to high when metadata is absent", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
+      desired: { variant: "max" },
+    })
+
+    expect(result.variant).toBe("high")
+    expect(result.changes).toEqual([
+      {
+        field: "variant",
+        from: "max",
+        to: "high",
+        reason: "unsupported-by-model-family",
+      },
+    ])
+  })
+
+  test("keeps supported GPT reasoningEffort unchanged", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      desired: { reasoningEffort: "high" },
+    })
+
+    expect(result).toEqual({
+      variant: undefined,
+      reasoningEffort: "high",
+      changes: [],
+    })
+  })
+
+  test("downgrades gpt-5 reasoningEffort max to xhigh", () => {
+    // given
+    const input = {
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      desired: { reasoningEffort: "max" },
+    }
+
+    // when
+    const result = resolveCompatibleModelSettings(input)
+
+    // then
+    expect(result.reasoningEffort).toBe("xhigh")
+    expect(result.changes).toEqual([
+      {
+        field: "reasoningEffort",
+        from: "max",
+        to: "xhigh",
+        reason: "unsupported-by-model-family",
+      },
+    ])
+  })
+
+  test("keeps supported OpenAI reasoning-family effort for o-series models", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "o3-mini",
+      desired: { reasoningEffort: "high" },
+    })
+
+    expect(result).toEqual({
+      variant: undefined,
+      reasoningEffort: "high",
+      changes: [],
+    })
+  })
+
+  test("downgrades openai reasoning-family effort xhigh to high", () => {
+    // given
+    const input = {
+      providerID: "openai",
+      modelID: "o3-mini",
+      desired: { reasoningEffort: "xhigh" },
+    }
+
+    // when
+    const result = resolveCompatibleModelSettings(input)
+
+    // then
+    expect(result.reasoningEffort).toBe("high")
+    expect(result.changes).toEqual([
+      {
+        field: "reasoningEffort",
+        from: "xhigh",
+        to: "high",
+        reason: "unsupported-by-model-family",
+      },
+    ])
+  })
+
+  test("drops reasoningEffort for gpt-5 mini models", () => {
+    // given
+    const input = {
+      providerID: "openai",
+      modelID: "gpt-5.4-mini",
+      desired: { reasoningEffort: "high" },
+    }
+
+    // when
+    const result = resolveCompatibleModelSettings(input)
+
+    // then
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.changes).toEqual([
+      {
+        field: "reasoningEffort",
+        from: "high",
+        to: undefined,
+        reason: "unsupported-by-model-family",
+      },
+    ])
+  })
+
+  test("treats non-openai o-series models as unknown", () => {
+    // given
+    const input = {
+      providerID: "ollama",
+      modelID: "o3",
+      desired: { reasoningEffort: "high" },
+    }
+
+    // when
+    const result = resolveCompatibleModelSettings(input)
+
+    // then
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.changes).toEqual([
+      {
+        field: "reasoningEffort",
+        from: "high",
+        to: undefined,
+        reason: "unknown-model-family",
+      },
+    ])
+  })
+
+  test("does not record case-only normalization as a compatibility downgrade", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      desired: { variant: "HIGH", reasoningEffort: "HIGH" },
+    })
+
+    expect(result).toEqual({
+      variant: "high",
+      reasoningEffort: "high",
+      changes: [],
+    })
+  })
+
+  test("downgrades unsupported GPT reasoningEffort to nearest lower level", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "gpt-4.1",
+      desired: { reasoningEffort: "xhigh" },
+    })
+
+    expect(result.reasoningEffort).toBe("high")
+    expect(result.changes).toEqual([
+      {
+        field: "reasoningEffort",
+        from: "xhigh",
+        to: "high",
+        reason: "unsupported-by-model-family",
+      },
+    ])
+  })
+
+  test("drops reasoningEffort for Claude family", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
+      desired: { reasoningEffort: "high" },
+    })
+
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.changes).toEqual([
+      {
+        field: "reasoningEffort",
+        from: "high",
+        to: undefined,
+        reason: "unsupported-by-model-family",
+      },
+    ])
+  })
+
+  test("handles combined variant and reasoningEffort normalization", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
+      desired: { variant: "max", reasoningEffort: "high" },
+    })
+
+    expect(result).toEqual({
+      variant: "high",
+      reasoningEffort: undefined,
+      changes: [
+        {
+          field: "variant",
+          from: "max",
+          to: "high",
+          reason: "unsupported-by-model-family",
+        },
+        {
+          field: "reasoningEffort",
+          from: "high",
+          to: undefined,
+          reason: "unsupported-by-model-family",
+        },
+      ],
+    })
+  })
+
+  test("treats unknown model families conservatively by dropping unsupported settings", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "mystery",
+      modelID: "mystery-model-1",
+      desired: { variant: "max", reasoningEffort: "high" },
+    })
+
+    expect(result).toEqual({
+      variant: undefined,
+      reasoningEffort: undefined,
+      changes: [
+        {
+          field: "variant",
+          from: "max",
+          to: undefined,
+          reason: "unknown-model-family",
+        },
+        {
+          field: "reasoningEffort",
+          from: "high",
+          to: undefined,
+          reason: "unknown-model-family",
+        },
+      ],
+    })
+  })
+})

--- a/src/shared/model-settings-compatibility.ts
+++ b/src/shared/model-settings-compatibility.ts
@@ -31,54 +31,65 @@ export type ModelSettingsCompatibilityResult = {
   changes: ModelSettingsCompatibilityChange[]
 }
 
-type ModelFamily = "claude-opus" | "claude-non-opus" | "openai-reasoning" | "gpt-5" | "gpt-5-mini" | "gpt-legacy" | "unknown"
+// ---------------------------------------------------------------------------
+// Unified model family registry — detection rules + capabilities in ONE row.
+// New model family = one entry. Zero code changes anywhere else.
+// Order matters: more-specific patterns first (claude-opus before claude).
+// ---------------------------------------------------------------------------
+
+type FamilyDefinition = {
+  /** Substring(s) in normalised model ID that identify this family (OR) */
+  includes?: string[]
+  /** Regex when substring matching isn't enough */
+  pattern?: RegExp
+  /** Supported variant levels (ordered low -> max) */
+  variants: string[]
+  /** Supported reasoning-effort levels. Omit = not supported. */
+  reasoningEffort?: string[]
+}
+
+const MODEL_FAMILY_REGISTRY: ReadonlyArray<readonly [string, FamilyDefinition]> = [
+  ["claude-opus", { pattern: /claude(?:-\d+(?:-\d+)*)?-opus/, variants: ["low", "medium", "high", "max"] }],
+  ["claude-non-opus", { includes: ["claude"], variants: ["low", "medium", "high"] }],
+  ["openai-reasoning", { pattern: /^o\d(?:$|-)/, variants: ["low", "medium", "high"], reasoningEffort: ["none", "minimal", "low", "medium", "high"] }],
+  ["gpt-5", { includes: ["gpt-5"], variants: ["low", "medium", "high", "xhigh", "max"], reasoningEffort: ["none", "minimal", "low", "medium", "high", "xhigh"] }],
+  ["gpt-legacy", { includes: ["gpt"], variants: ["low", "medium", "high"] }],
+  ["gemini", { includes: ["gemini"], variants: ["low", "medium", "high"] }],
+  ["kimi", { includes: ["kimi", "k2"], variants: ["low", "medium", "high"] }],
+  ["glm", { includes: ["glm"], variants: ["low", "medium", "high"] }],
+  ["minimax", { includes: ["minimax"], variants: ["low", "medium", "high"] }],
+  ["deepseek", { includes: ["deepseek"], variants: ["low", "medium", "high"] }],
+  ["mistral", { includes: ["mistral", "codestral"], variants: ["low", "medium", "high"] }],
+  ["llama", { includes: ["llama"], variants: ["low", "medium", "high"] }],
+]
 
 const VARIANT_LADDER = ["low", "medium", "high", "xhigh", "max"]
-const REASONING_LADDER = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+const REASONING_LADDER = ["none", "minimal", "low", "medium", "high", "xhigh"]
 
-function detectModelFamily(providerID: string, modelID: string): ModelFamily {
-  const provider = providerID.toLowerCase()
+// ---------------------------------------------------------------------------
+// Model family detection — single pass over the registry
+// ---------------------------------------------------------------------------
+
+function detectFamily(_providerID: string, modelID: string): FamilyDefinition | undefined {
   const model = normalizeModelID(modelID).toLowerCase()
-
-  const isClaudeProvider = [
-    "anthropic",
-    "google-vertex-anthropic",
-    "aws-bedrock-anthropic",
-  ].includes(provider)
-    || (["github-copilot", "opencode", "aws-bedrock", "bedrock"].includes(provider) && model.includes("claude"))
-
-  if (isClaudeProvider) {
-    return /claude(?:-\d+(?:-\d+)*)?-opus/.test(model) ? "claude-opus" : "claude-non-opus"
+  for (const [, def] of MODEL_FAMILY_REGISTRY) {
+    if (def.pattern?.test(model)) return def
+    if (def.includes?.some((s) => model.includes(s))) return def
   }
-
-  const isOpenAiReasoningFamily = provider === "openai" && (/^o\d(?:$|-)/.test(model) || model.includes("reasoning"))
-  if (isOpenAiReasoningFamily) {
-    return "openai-reasoning"
-  }
-
-  if (/gpt-5.*-mini/.test(model)) {
-    return "gpt-5-mini"
-  }
-
-  if (model.includes("gpt-5")) {
-    return "gpt-5"
-  }
-
-  if (model.includes("gpt") || (provider === "openai" && /^o\d(?:$|-)/.test(model))) {
-    return "gpt-legacy"
-  }
-
-  return "unknown"
+  return undefined
 }
+
+// ---------------------------------------------------------------------------
+// Generic resolution — one function for both fields
+// ---------------------------------------------------------------------------
 
 function downgradeWithinLadder(value: string, allowed: string[], ladder: string[]): string | undefined {
   const requestedIndex = ladder.indexOf(value)
   if (requestedIndex === -1) return undefined
 
   for (let index = requestedIndex; index >= 0; index -= 1) {
-    const candidate = ladder[index]
-    if (allowed.includes(candidate)) {
-      return candidate
+    if (allowed.includes(ladder[index])) {
+      return ladder[index]
     }
   }
 
@@ -89,172 +100,76 @@ function normalizeCapabilitiesVariants(capabilities: VariantCapabilities | undef
   if (!capabilities?.variants || capabilities.variants.length === 0) {
     return undefined
   }
-
-  return capabilities.variants.map((variant) => variant.toLowerCase())
+  return capabilities.variants.map((v) => v.toLowerCase())
 }
 
-function resolveVariant(
-  modelFamily: ModelFamily,
-  variant: string,
-  capabilities?: VariantCapabilities,
-): { value?: string; reason?: ModelSettingsCompatibilityChange["reason"] } {
-  const normalized = variant.toLowerCase()
-  const metadataVariants = normalizeCapabilitiesVariants(capabilities)
+type FieldResolution = { value?: string; reason?: ModelSettingsCompatibilityChange["reason"] }
 
-  if (metadataVariants) {
-    if (metadataVariants.includes(normalized)) {
-      return { value: normalized }
-    }
+function resolveField(
+  normalized: string,
+  familyCaps: string[] | undefined,
+  ladder: string[],
+  familyKnown: boolean,
+  metadataOverride?: string[],
+): FieldResolution {
+  // Priority 1: runtime metadata from provider
+  if (metadataOverride) {
+    if (metadataOverride.includes(normalized)) return { value: normalized }
     return {
-      value: downgradeWithinLadder(normalized, metadataVariants, VARIANT_LADDER),
+      value: downgradeWithinLadder(normalized, metadataOverride, ladder),
       reason: "unsupported-by-model-metadata",
     }
   }
 
-  if (modelFamily === "claude-opus") {
-    const allowed = ["low", "medium", "high", "max"]
-    if (allowed.includes(normalized)) {
-      return { value: normalized }
-    }
+  // Priority 2: family heuristic from registry
+  if (familyCaps) {
+    if (familyCaps.includes(normalized)) return { value: normalized }
     return {
-      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
+      value: downgradeWithinLadder(normalized, familyCaps, ladder),
       reason: "unsupported-by-model-family",
     }
   }
 
-  if (modelFamily === "claude-non-opus") {
-    const allowed = ["low", "medium", "high"]
-    if (allowed.includes(normalized)) {
-      return { value: normalized }
-    }
-    return {
-      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
-      reason: "unsupported-by-model-family",
-    }
-  }
-
-  if (modelFamily === "gpt-5" || modelFamily === "gpt-5-mini") {
-    const allowed = ["low", "medium", "high", "xhigh", "max"]
-    if (allowed.includes(normalized)) {
-      return { value: normalized }
-    }
-    return {
-      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
-      reason: "unsupported-by-model-family",
-    }
-  }
-
-  if (modelFamily === "openai-reasoning") {
-    const allowed = ["low", "medium", "high"]
-    if (allowed.includes(normalized)) {
-      return { value: normalized }
-    }
-    return {
-      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
-      reason: "unsupported-by-model-family",
-    }
-  }
-
-  if (modelFamily === "gpt-legacy") {
-    const allowed = ["low", "medium", "high"]
-    if (allowed.includes(normalized)) {
-      return { value: normalized }
-    }
-    return {
-      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
-      reason: "unsupported-by-model-family",
-    }
-  }
-
-  return { value: undefined, reason: "unknown-model-family" }
-}
-
-function resolveReasoningEffort(modelFamily: ModelFamily, reasoningEffort: string): { value?: string; reason?: ModelSettingsCompatibilityChange["reason"] } {
-  const normalized = reasoningEffort.toLowerCase()
-
-  if (modelFamily === "gpt-5") {
-    const allowed = ["none", "minimal", "low", "medium", "high", "xhigh"]
-    if (allowed.includes(normalized)) {
-      return { value: normalized }
-    }
-    return {
-      value: downgradeWithinLadder(normalized, allowed, REASONING_LADDER),
-      reason: "unsupported-by-model-family",
-    }
-  }
-
-  if (modelFamily === "gpt-5-mini") {
+  // Known family but field not in registry (e.g. Claude + reasoningEffort)
+  if (familyKnown) {
     return { value: undefined, reason: "unsupported-by-model-family" }
   }
 
-  if (modelFamily === "openai-reasoning") {
-    const allowed = ["none", "minimal", "low", "medium", "high"]
-    if (allowed.includes(normalized)) {
-      return { value: normalized }
-    }
-    return {
-      value: downgradeWithinLadder(normalized, allowed, REASONING_LADDER),
-      reason: "unsupported-by-model-family",
-    }
-  }
-
-  if (modelFamily === "gpt-legacy") {
-    const allowed = ["none", "minimal", "low", "medium", "high"]
-    if (allowed.includes(normalized)) {
-      return { value: normalized }
-    }
-    return {
-      value: downgradeWithinLadder(normalized, allowed, REASONING_LADDER),
-      reason: "unsupported-by-model-family",
-    }
-  }
-
-  if (modelFamily === "claude-opus" || modelFamily === "claude-non-opus") {
-    return { value: undefined, reason: "unsupported-by-model-family" }
-  }
-
+  // Unknown family — drop the value
   return { value: undefined, reason: "unknown-model-family" }
 }
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 export function resolveCompatibleModelSettings(
   input: ModelSettingsCompatibilityInput,
 ): ModelSettingsCompatibilityResult {
-  const modelFamily = detectModelFamily(input.providerID, input.modelID)
+  const family = detectFamily(input.providerID, input.modelID)
+  const familyKnown = family !== undefined
   const changes: ModelSettingsCompatibilityChange[] = []
+  const metadataVariants = normalizeCapabilitiesVariants(input.capabilities)
 
   let variant = input.desired.variant
   if (variant !== undefined) {
-    const normalizedVariant = variant.toLowerCase()
-    const resolved = resolveVariant(modelFamily, normalizedVariant, input.capabilities)
-    if (resolved.value !== normalizedVariant && resolved.reason) {
-      changes.push({
-        field: "variant",
-        from: variant,
-        to: resolved.value,
-        reason: resolved.reason,
-      })
+    const normalized = variant.toLowerCase()
+    const resolved = resolveField(normalized, family?.variants, VARIANT_LADDER, familyKnown, metadataVariants)
+    if (resolved.value !== normalized && resolved.reason) {
+      changes.push({ field: "variant", from: variant, to: resolved.value, reason: resolved.reason })
     }
     variant = resolved.value
   }
 
   let reasoningEffort = input.desired.reasoningEffort
   if (reasoningEffort !== undefined) {
-    const normalizedReasoningEffort = reasoningEffort.toLowerCase()
-    const resolved = resolveReasoningEffort(modelFamily, normalizedReasoningEffort)
-    if (resolved.value !== normalizedReasoningEffort && resolved.reason) {
-      changes.push({
-        field: "reasoningEffort",
-        from: reasoningEffort,
-        to: resolved.value,
-        reason: resolved.reason,
-      })
+    const normalized = reasoningEffort.toLowerCase()
+    const resolved = resolveField(normalized, family?.reasoningEffort, REASONING_LADDER, familyKnown)
+    if (resolved.value !== normalized && resolved.reason) {
+      changes.push({ field: "reasoningEffort", from: reasoningEffort, to: resolved.value, reason: resolved.reason })
     }
     reasoningEffort = resolved.value
   }
 
-  return {
-    variant,
-    reasoningEffort,
-    changes,
-  }
+  return { variant, reasoningEffort, changes }
 }

--- a/src/shared/model-settings-compatibility.ts
+++ b/src/shared/model-settings-compatibility.ts
@@ -1,0 +1,260 @@
+import { normalizeModelID } from "./model-normalization"
+
+type CompatibilityField = "variant" | "reasoningEffort"
+
+type DesiredModelSettings = {
+  variant?: string
+  reasoningEffort?: string
+}
+
+type VariantCapabilities = {
+  variants?: string[]
+}
+
+export type ModelSettingsCompatibilityInput = {
+  providerID: string
+  modelID: string
+  desired: DesiredModelSettings
+  capabilities?: VariantCapabilities
+}
+
+export type ModelSettingsCompatibilityChange = {
+  field: CompatibilityField
+  from: string
+  to?: string
+  reason: "unsupported-by-model-family" | "unknown-model-family" | "unsupported-by-model-metadata"
+}
+
+export type ModelSettingsCompatibilityResult = {
+  variant?: string
+  reasoningEffort?: string
+  changes: ModelSettingsCompatibilityChange[]
+}
+
+type ModelFamily = "claude-opus" | "claude-non-opus" | "openai-reasoning" | "gpt-5" | "gpt-5-mini" | "gpt-legacy" | "unknown"
+
+const VARIANT_LADDER = ["low", "medium", "high", "xhigh", "max"]
+const REASONING_LADDER = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+function detectModelFamily(providerID: string, modelID: string): ModelFamily {
+  const provider = providerID.toLowerCase()
+  const model = normalizeModelID(modelID).toLowerCase()
+
+  const isClaudeProvider = [
+    "anthropic",
+    "google-vertex-anthropic",
+    "aws-bedrock-anthropic",
+  ].includes(provider)
+    || (["github-copilot", "opencode", "aws-bedrock", "bedrock"].includes(provider) && model.includes("claude"))
+
+  if (isClaudeProvider) {
+    return /claude(?:-\d+(?:-\d+)*)?-opus/.test(model) ? "claude-opus" : "claude-non-opus"
+  }
+
+  const isOpenAiReasoningFamily = provider === "openai" && (/^o\d(?:$|-)/.test(model) || model.includes("reasoning"))
+  if (isOpenAiReasoningFamily) {
+    return "openai-reasoning"
+  }
+
+  if (/gpt-5.*-mini/.test(model)) {
+    return "gpt-5-mini"
+  }
+
+  if (model.includes("gpt-5")) {
+    return "gpt-5"
+  }
+
+  if (model.includes("gpt") || (provider === "openai" && /^o\d(?:$|-)/.test(model))) {
+    return "gpt-legacy"
+  }
+
+  return "unknown"
+}
+
+function downgradeWithinLadder(value: string, allowed: string[], ladder: string[]): string | undefined {
+  const requestedIndex = ladder.indexOf(value)
+  if (requestedIndex === -1) return undefined
+
+  for (let index = requestedIndex; index >= 0; index -= 1) {
+    const candidate = ladder[index]
+    if (allowed.includes(candidate)) {
+      return candidate
+    }
+  }
+
+  return undefined
+}
+
+function normalizeCapabilitiesVariants(capabilities: VariantCapabilities | undefined): string[] | undefined {
+  if (!capabilities?.variants || capabilities.variants.length === 0) {
+    return undefined
+  }
+
+  return capabilities.variants.map((variant) => variant.toLowerCase())
+}
+
+function resolveVariant(
+  modelFamily: ModelFamily,
+  variant: string,
+  capabilities?: VariantCapabilities,
+): { value?: string; reason?: ModelSettingsCompatibilityChange["reason"] } {
+  const normalized = variant.toLowerCase()
+  const metadataVariants = normalizeCapabilitiesVariants(capabilities)
+
+  if (metadataVariants) {
+    if (metadataVariants.includes(normalized)) {
+      return { value: normalized }
+    }
+    return {
+      value: downgradeWithinLadder(normalized, metadataVariants, VARIANT_LADDER),
+      reason: "unsupported-by-model-metadata",
+    }
+  }
+
+  if (modelFamily === "claude-opus") {
+    const allowed = ["low", "medium", "high", "max"]
+    if (allowed.includes(normalized)) {
+      return { value: normalized }
+    }
+    return {
+      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
+      reason: "unsupported-by-model-family",
+    }
+  }
+
+  if (modelFamily === "claude-non-opus") {
+    const allowed = ["low", "medium", "high"]
+    if (allowed.includes(normalized)) {
+      return { value: normalized }
+    }
+    return {
+      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
+      reason: "unsupported-by-model-family",
+    }
+  }
+
+  if (modelFamily === "gpt-5" || modelFamily === "gpt-5-mini") {
+    const allowed = ["low", "medium", "high", "xhigh", "max"]
+    if (allowed.includes(normalized)) {
+      return { value: normalized }
+    }
+    return {
+      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
+      reason: "unsupported-by-model-family",
+    }
+  }
+
+  if (modelFamily === "openai-reasoning") {
+    const allowed = ["low", "medium", "high"]
+    if (allowed.includes(normalized)) {
+      return { value: normalized }
+    }
+    return {
+      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
+      reason: "unsupported-by-model-family",
+    }
+  }
+
+  if (modelFamily === "gpt-legacy") {
+    const allowed = ["low", "medium", "high"]
+    if (allowed.includes(normalized)) {
+      return { value: normalized }
+    }
+    return {
+      value: downgradeWithinLadder(normalized, allowed, VARIANT_LADDER),
+      reason: "unsupported-by-model-family",
+    }
+  }
+
+  return { value: undefined, reason: "unknown-model-family" }
+}
+
+function resolveReasoningEffort(modelFamily: ModelFamily, reasoningEffort: string): { value?: string; reason?: ModelSettingsCompatibilityChange["reason"] } {
+  const normalized = reasoningEffort.toLowerCase()
+
+  if (modelFamily === "gpt-5") {
+    const allowed = ["none", "minimal", "low", "medium", "high", "xhigh"]
+    if (allowed.includes(normalized)) {
+      return { value: normalized }
+    }
+    return {
+      value: downgradeWithinLadder(normalized, allowed, REASONING_LADDER),
+      reason: "unsupported-by-model-family",
+    }
+  }
+
+  if (modelFamily === "gpt-5-mini") {
+    return { value: undefined, reason: "unsupported-by-model-family" }
+  }
+
+  if (modelFamily === "openai-reasoning") {
+    const allowed = ["none", "minimal", "low", "medium", "high"]
+    if (allowed.includes(normalized)) {
+      return { value: normalized }
+    }
+    return {
+      value: downgradeWithinLadder(normalized, allowed, REASONING_LADDER),
+      reason: "unsupported-by-model-family",
+    }
+  }
+
+  if (modelFamily === "gpt-legacy") {
+    const allowed = ["none", "minimal", "low", "medium", "high"]
+    if (allowed.includes(normalized)) {
+      return { value: normalized }
+    }
+    return {
+      value: downgradeWithinLadder(normalized, allowed, REASONING_LADDER),
+      reason: "unsupported-by-model-family",
+    }
+  }
+
+  if (modelFamily === "claude-opus" || modelFamily === "claude-non-opus") {
+    return { value: undefined, reason: "unsupported-by-model-family" }
+  }
+
+  return { value: undefined, reason: "unknown-model-family" }
+}
+
+export function resolveCompatibleModelSettings(
+  input: ModelSettingsCompatibilityInput,
+): ModelSettingsCompatibilityResult {
+  const modelFamily = detectModelFamily(input.providerID, input.modelID)
+  const changes: ModelSettingsCompatibilityChange[] = []
+
+  let variant = input.desired.variant
+  if (variant !== undefined) {
+    const normalizedVariant = variant.toLowerCase()
+    const resolved = resolveVariant(modelFamily, normalizedVariant, input.capabilities)
+    if (resolved.value !== normalizedVariant && resolved.reason) {
+      changes.push({
+        field: "variant",
+        from: variant,
+        to: resolved.value,
+        reason: resolved.reason,
+      })
+    }
+    variant = resolved.value
+  }
+
+  let reasoningEffort = input.desired.reasoningEffort
+  if (reasoningEffort !== undefined) {
+    const normalizedReasoningEffort = reasoningEffort.toLowerCase()
+    const resolved = resolveReasoningEffort(modelFamily, normalizedReasoningEffort)
+    if (resolved.value !== normalizedReasoningEffort && resolved.reason) {
+      changes.push({
+        field: "reasoningEffort",
+        from: reasoningEffort,
+        to: resolved.value,
+        reason: resolved.reason,
+      })
+    }
+    reasoningEffort = resolved.value
+  }
+
+  return {
+    variant,
+    reasoningEffort,
+    changes,
+  }
+}

--- a/src/shared/session-prompt-params-helpers.ts
+++ b/src/shared/session-prompt-params-helpers.ts
@@ -1,0 +1,31 @@
+import { clearSessionPromptParams, setSessionPromptParams } from "./session-prompt-params-state"
+
+type PromptParamModel = {
+  temperature?: number
+  top_p?: number
+  reasoningEffort?: string
+  maxTokens?: number
+  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+}
+
+export function applySessionPromptParams(
+  sessionID: string,
+  model: PromptParamModel | undefined,
+): void {
+  if (!model) {
+    clearSessionPromptParams(sessionID)
+    return
+  }
+
+  const promptOptions: Record<string, unknown> = {
+    ...(model.reasoningEffort ? { reasoningEffort: model.reasoningEffort } : {}),
+    ...(model.thinking ? { thinking: model.thinking } : {}),
+    ...(model.maxTokens !== undefined ? { maxTokens: model.maxTokens } : {}),
+  }
+
+  setSessionPromptParams(sessionID, {
+    ...(model.temperature !== undefined ? { temperature: model.temperature } : {}),
+    ...(model.top_p !== undefined ? { topP: model.top_p } : {}),
+    ...(Object.keys(promptOptions).length > 0 ? { options: promptOptions } : {}),
+  })
+}

--- a/src/shared/session-prompt-params-state.test.ts
+++ b/src/shared/session-prompt-params-state.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, test } from "bun:test"
+
+import {
+  clearAllSessionPromptParams,
+  clearSessionPromptParams,
+  getSessionPromptParams,
+  setSessionPromptParams,
+} from "./session-prompt-params-state"
+
+describe("session-prompt-params-state", () => {
+  afterEach(() => {
+    clearAllSessionPromptParams()
+  })
+
+  test("stores and returns prompt params by session", () => {
+    //#given
+    const sessionID = "ses_prompt_params"
+    const params = {
+      temperature: 0.4,
+      topP: 0.7,
+      options: {
+        reasoningEffort: "high",
+        maxTokens: 4096,
+      },
+    }
+
+    //#when
+    setSessionPromptParams(sessionID, params)
+
+    //#then
+    expect(getSessionPromptParams(sessionID)).toEqual(params)
+  })
+
+  test("returns copies so callers cannot mutate stored state", () => {
+    //#given
+    const sessionID = "ses_prompt_params_copy"
+    setSessionPromptParams(sessionID, {
+      temperature: 0.2,
+      options: { reasoningEffort: "medium" },
+    })
+
+    //#when
+    const result = getSessionPromptParams(sessionID)!
+    result.temperature = 0.9
+    result.options!.reasoningEffort = "max"
+
+    //#then
+    expect(getSessionPromptParams(sessionID)).toEqual({
+      temperature: 0.2,
+      options: { reasoningEffort: "medium" },
+    })
+  })
+
+  test("clears a single session", () => {
+    //#given
+    const sessionID = "ses_prompt_params_clear"
+    setSessionPromptParams(sessionID, { topP: 0.5 })
+
+    //#when
+    clearSessionPromptParams(sessionID)
+
+    //#then
+    expect(getSessionPromptParams(sessionID)).toBeUndefined()
+  })
+})

--- a/src/shared/session-prompt-params-state.ts
+++ b/src/shared/session-prompt-params-state.ts
@@ -1,0 +1,34 @@
+export type SessionPromptParams = {
+  temperature?: number
+  topP?: number
+  options?: Record<string, unknown>
+}
+
+const sessionPromptParams = new Map<string, SessionPromptParams>()
+
+export function setSessionPromptParams(sessionID: string, params: SessionPromptParams): void {
+  sessionPromptParams.set(sessionID, {
+    ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
+    ...(params.topP !== undefined ? { topP: params.topP } : {}),
+    ...(params.options !== undefined ? { options: { ...params.options } } : {}),
+  })
+}
+
+export function getSessionPromptParams(sessionID: string): SessionPromptParams | undefined {
+  const params = sessionPromptParams.get(sessionID)
+  if (!params) return undefined
+
+  return {
+    ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
+    ...(params.topP !== undefined ? { topP: params.topP } : {}),
+    ...(params.options !== undefined ? { options: { ...params.options } } : {}),
+  }
+}
+
+export function clearSessionPromptParams(sessionID: string): void {
+  sessionPromptParams.delete(sessionID)
+}
+
+export function clearAllSessionPromptParams(): void {
+  sessionPromptParams.clear()
+}

--- a/src/tools/delegate-task/background-task.ts
+++ b/src/tools/delegate-task/background-task.ts
@@ -1,4 +1,4 @@
-import type { DelegateTaskArgs, ToolContextWithMetadata } from "./types"
+import type { DelegateTaskArgs, ToolContextWithMetadata, DelegatedModelConfig } from "./types"
 import type { ExecutorContext, ParentContext } from "./executor-types"
 import type { FallbackEntry } from "../../shared/model-requirements"
 import { getTimingConfig } from "./timing"
@@ -16,7 +16,7 @@ export async function executeBackgroundTask(
   executorCtx: ExecutorContext,
   parentContext: ParentContext,
   agentToUse: string,
-  categoryModel: { providerID: string; modelID: string; variant?: string } | undefined,
+  categoryModel: DelegatedModelConfig | undefined,
   systemContent: string | undefined,
   fallbackChain?: FallbackEntry[],
 ): Promise<string> {

--- a/src/tools/delegate-task/category-resolver.test.ts
+++ b/src/tools/delegate-task/category-resolver.test.ts
@@ -169,6 +169,52 @@ describe("resolveCategoryExecution", () => {
 		agentsSpy.mockRestore()
 	})
 
+	test("does not apply object-style fallback settings when the configured primary model matches directly", async () => {
+		//#given
+		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+			models: { openai: ["gpt-5.4-preview"] },
+			connected: ["openai"],
+			updatedAt: "2026-03-03T00:00:00.000Z",
+		})
+		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const args = {
+			category: "deep",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+			blockedBy: undefined,
+			enableSkillTools: false,
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			deep: {
+				model: "openai/gpt-5.4-preview",
+				fallback_models: [
+					{
+						model: "openai/gpt-5.4",
+						variant: "low",
+						reasoningEffort: "high",
+					},
+				],
+			},
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.actualModel).toBe("openai/gpt-5.4-preview")
+		expect(result.categoryModel).toEqual({
+			providerID: "openai",
+			modelID: "gpt-5.4-preview",
+			variant: "medium",
+		})
+		cacheSpy.mockRestore()
+		agentsSpy.mockRestore()
+	})
+
 	test("matches promoted fallback settings after fuzzy model resolution", async () => {
 		//#given
 		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({

--- a/src/tools/delegate-task/category-resolver.test.ts
+++ b/src/tools/delegate-task/category-resolver.test.ts
@@ -114,4 +114,260 @@ describe("resolveCategoryExecution", () => {
 			{ providers: ["openai"], model: "gpt-5.2", variant: "high" },
 		])
 	})
+
+	test("promotes object-style fallback model settings to categoryModel when fallback becomes initial model", async () => {
+		//#given
+		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+			models: { openai: ["gpt-5.4"] },
+			connected: ["openai"],
+			updatedAt: "2026-03-03T00:00:00.000Z",
+		})
+		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const args = {
+			category: "deep",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+			blockedBy: undefined,
+			enableSkillTools: false,
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			deep: {
+				fallback_models: [
+					{
+						model: "openai/gpt-5.4 high",
+						variant: "low",
+						reasoningEffort: "high",
+						temperature: 0.4,
+						top_p: 0.7,
+						maxTokens: 4096,
+						thinking: { type: "disabled" },
+					},
+				],
+			},
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.actualModel).toBe("openai/gpt-5.4")
+		expect(result.categoryModel).toEqual({
+			providerID: "openai",
+			modelID: "gpt-5.4",
+			variant: "low",
+			reasoningEffort: "high",
+			temperature: 0.4,
+			top_p: 0.7,
+			maxTokens: 4096,
+			thinking: { type: "disabled" },
+		})
+		cacheSpy.mockRestore()
+		agentsSpy.mockRestore()
+	})
+
+	test("matches promoted fallback settings after fuzzy model resolution", async () => {
+		//#given
+		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+			models: { openai: ["gpt-5.4-preview"] },
+			connected: ["openai"],
+			updatedAt: "2026-03-03T00:00:00.000Z",
+		})
+		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const args = {
+			category: "deep",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+			blockedBy: undefined,
+			enableSkillTools: false,
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			deep: {
+				fallback_models: [
+					{
+						model: "openai/gpt-5.4",
+						variant: "low",
+						reasoningEffort: "high",
+						temperature: 0.6,
+						top_p: 0.5,
+						maxTokens: 1234,
+						thinking: { type: "disabled" },
+					},
+				],
+			},
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.actualModel).toBe("openai/gpt-5.4-preview")
+		expect(result.categoryModel).toEqual({
+			providerID: "openai",
+			modelID: "gpt-5.4-preview",
+			variant: "low",
+			reasoningEffort: "high",
+			temperature: 0.6,
+			top_p: 0.5,
+			maxTokens: 1234,
+			thinking: { type: "disabled" },
+		})
+		cacheSpy.mockRestore()
+		agentsSpy.mockRestore()
+	})
+
+	test("prefers exact promoted fallback match over earlier fuzzy prefix match", async () => {
+		//#given
+		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+			models: { openai: ["gpt-5.4-preview"] },
+			connected: ["openai"],
+			updatedAt: "2026-03-03T00:00:00.000Z",
+		})
+		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const args = {
+			category: "deep",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+			blockedBy: undefined,
+			enableSkillTools: false,
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			deep: {
+				fallback_models: [
+					{
+						model: "openai/gpt-5.4",
+						variant: "low",
+						reasoningEffort: "medium",
+					},
+					{
+						model: "openai/gpt-5.4-preview",
+						variant: "max",
+						reasoningEffort: "high",
+					},
+				],
+			},
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.actualModel).toBe("openai/gpt-5.4-preview")
+		expect(result.categoryModel).toEqual({
+			providerID: "openai",
+			modelID: "gpt-5.4-preview",
+			variant: "max",
+			reasoningEffort: "high",
+		})
+		cacheSpy.mockRestore()
+		agentsSpy.mockRestore()
+	})
+
+	test("matches promoted fallback settings when fuzzy resolution extends configured model without hyphen", async () => {
+		//#given
+		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+			models: { openai: ["gpt-5.4o"] },
+			connected: ["openai"],
+			updatedAt: "2026-03-03T00:00:00.000Z",
+		})
+		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const args = {
+			category: "deep",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+			blockedBy: undefined,
+			enableSkillTools: false,
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			deep: {
+				fallback_models: [
+					{
+						model: "openai/gpt-5.4",
+						variant: "low",
+						reasoningEffort: "high",
+					},
+				],
+			},
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.actualModel).toBe("openai/gpt-5.4o")
+		expect(result.categoryModel).toEqual({
+			providerID: "openai",
+			modelID: "gpt-5.4o",
+			variant: "low",
+			reasoningEffort: "high",
+		})
+		cacheSpy.mockRestore()
+		agentsSpy.mockRestore()
+	})
+
+	test("prefers the most specific prefix match when fallback entries share a prefix", async () => {
+		//#given
+		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+			models: { openai: ["gpt-4o"] },
+			connected: ["openai"],
+			updatedAt: "2026-03-03T00:00:00.000Z",
+		})
+		const agentsSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+		const args = {
+			category: "deep",
+			prompt: "test prompt",
+			description: "Test task",
+			run_in_background: false,
+			load_skills: [],
+			blockedBy: undefined,
+			enableSkillTools: false,
+		}
+		const executorCtx = createMockExecutorContext()
+		executorCtx.userCategories = {
+			deep: {
+				fallback_models: [
+					{
+						model: "openai/gpt-4",
+						variant: "low",
+						reasoningEffort: "medium",
+					},
+					{
+						model: "openai/gpt-4o",
+						variant: "max",
+						reasoningEffort: "high",
+					},
+				],
+			},
+		}
+
+		//#when
+		const result = await resolveCategoryExecution(args, executorCtx, undefined, "anthropic/claude-sonnet-4-6")
+
+		//#then
+		expect(result.error).toBeUndefined()
+		expect(result.actualModel).toBe("openai/gpt-4o")
+		expect(result.categoryModel).toEqual({
+			providerID: "openai",
+			modelID: "gpt-4o",
+			variant: "max",
+			reasoningEffort: "high",
+		})
+		cacheSpy.mockRestore()
+		agentsSpy.mockRestore()
+	})
 })

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -89,6 +89,7 @@ Available categories: ${allCategoryNames}`,
   let categoryModel: DelegatedModelConfig | undefined
   let isModelResolutionSkipped = false
   let fallbackEntry: FallbackEntry | undefined
+  let matchedFallback = false
 
   const overrideModel = sisyphusJuniorModel
   const explicitCategoryModel = userCategories?.[args.category!]?.model
@@ -122,8 +123,14 @@ Available categories: ${allCategoryNames}`,
     if (resolution && "skipped" in resolution) {
       isModelResolutionSkipped = true
     } else if (resolution) {
-      const { model: resolvedModel, variant: resolvedVariant, fallbackEntry: resolvedFallbackEntry } = resolution
+      const {
+        model: resolvedModel,
+        variant: resolvedVariant,
+        fallbackEntry: resolvedFallbackEntry,
+        matchedFallback: resolvedMatchedFallback,
+      } = resolution
       fallbackEntry = resolvedFallbackEntry
+      matchedFallback = resolvedMatchedFallback === true
       actualModel = resolvedModel
 
       if (!parseModelString(actualModel)) {
@@ -202,13 +209,15 @@ Available categories: ${categoryNames.join(", ")}`,
     defaultProviderID,
   )
 
-  // Apply per-model settings from the source that provided the match:
-  // 1. fallbackEntry from resolver (built-in chain match) — exact, no lookup needed
-  // 2. configuredFallbackChain (user's fallback_models) — prefix match against user config
-  const effectiveEntry = fallbackEntry
-    ?? (categoryModel && configuredFallbackChain
-      ? findMostSpecificFallbackEntry(categoryModel.providerID, categoryModel.modelID, configuredFallbackChain)
-      : undefined)
+  // Only promote fallback-only settings when resolution actually selected a fallback model.
+  const effectiveEntry = matchedFallback && categoryModel
+    ? (
+        fallbackEntry
+        ?? (configuredFallbackChain
+          ? findMostSpecificFallbackEntry(categoryModel.providerID, categoryModel.modelID, configuredFallbackChain)
+          : undefined)
+      )
+    : undefined
 
   if (categoryModel && effectiveEntry) {
     categoryModel = {

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -7,14 +7,16 @@ import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent"
 import { resolveCategoryConfig } from "./categories"
 import { parseModelString } from "./model-string-parser"
 import { CATEGORY_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
-import { normalizeFallbackModels } from "../../shared/model-resolver"
-import { buildFallbackChainFromModels } from "../../shared/fallback-chain-from-models"
+import { normalizeFallbackModels, flattenToFallbackModelStrings } from "../../shared/model-resolver"
+import { buildFallbackChainFromModels, findMostSpecificFallbackEntry } from "../../shared/fallback-chain-from-models"
 import { getAvailableModelsForDelegateTask } from "./available-models"
 import { resolveModelForDelegateTask } from "./model-selection"
 
+import type { DelegatedModelConfig } from "./types"
+
 export interface CategoryResolutionResult {
   agentToUse: string
-  categoryModel: { providerID: string; modelID: string; variant?: string } | undefined
+  categoryModel: DelegatedModelConfig | undefined
   categoryPromptAppend: string | undefined
   maxPromptTokens?: number
   modelInfo: ModelFallbackInfo | undefined
@@ -84,8 +86,9 @@ Available categories: ${allCategoryNames}`,
   const normalizedConfiguredFallbackModels = normalizeFallbackModels(resolved.config.fallback_models)
   let actualModel: string | undefined
   let modelInfo: ModelFallbackInfo | undefined
-  let categoryModel: { providerID: string; modelID: string; variant?: string } | undefined
+  let categoryModel: DelegatedModelConfig | undefined
   let isModelResolutionSkipped = false
+  let fallbackEntry: FallbackEntry | undefined
 
   const overrideModel = sisyphusJuniorModel
   const explicitCategoryModel = userCategories?.[args.category!]?.model
@@ -108,7 +111,7 @@ Available categories: ${allCategoryNames}`,
   } else {
     const resolution = resolveModelForDelegateTask({
       userModel: explicitCategoryModel ?? overrideModel,
-      userFallbackModels: normalizedConfiguredFallbackModels,
+      userFallbackModels: flattenToFallbackModelStrings(normalizedConfiguredFallbackModels),
       categoryDefaultModel: resolved.model,
       isUserConfiguredCategoryModel: resolved.isUserConfiguredModel,
       fallbackChain: requirement.fallbackChain,
@@ -119,7 +122,8 @@ Available categories: ${allCategoryNames}`,
     if (resolution && "skipped" in resolution) {
       isModelResolutionSkipped = true
     } else if (resolution) {
-      const { model: resolvedModel, variant: resolvedVariant } = resolution
+      const { model: resolvedModel, variant: resolvedVariant, fallbackEntry: resolvedFallbackEntry } = resolution
+      fallbackEntry = resolvedFallbackEntry
       actualModel = resolvedModel
 
       if (!parseModelString(actualModel)) {
@@ -197,6 +201,26 @@ Available categories: ${categoryNames.join(", ")}`,
     normalizedConfiguredFallbackModels,
     defaultProviderID,
   )
+
+  // Apply per-model settings from the source that provided the match:
+  // 1. fallbackEntry from resolver (built-in chain match) — exact, no lookup needed
+  // 2. configuredFallbackChain (user's fallback_models) — prefix match against user config
+  const effectiveEntry = fallbackEntry
+    ?? (categoryModel && configuredFallbackChain
+      ? findMostSpecificFallbackEntry(categoryModel.providerID, categoryModel.modelID, configuredFallbackChain)
+      : undefined)
+
+  if (categoryModel && effectiveEntry) {
+    categoryModel = {
+      ...categoryModel,
+      variant: userCategories?.[args.category!]?.variant ?? effectiveEntry.variant ?? categoryModel.variant,
+      reasoningEffort: effectiveEntry.reasoningEffort,
+      temperature: effectiveEntry.temperature,
+      top_p: effectiveEntry.top_p,
+      maxTokens: effectiveEntry.maxTokens,
+      thinking: effectiveEntry.thinking,
+    }
+  }
 
   return {
     agentToUse: SISYPHUS_JUNIOR_AGENT,

--- a/src/tools/delegate-task/model-selection.test.ts
+++ b/src/tools/delegate-task/model-selection.test.ts
@@ -121,7 +121,7 @@ describe("resolveModelForDelegateTask", () => {
 					availableModels: new Set(["openai/gpt-5.2"]),
 				})
 
-				expect(result).toEqual({ model: "openai/gpt-5.2", variant: "high" })
+				expect(result).toEqual({ model: "openai/gpt-5.2", variant: "high", matchedFallback: true })
 			})
 
 			test("#then resolves a space-separated variant against the base available model", () => {
@@ -130,7 +130,7 @@ describe("resolveModelForDelegateTask", () => {
 					availableModels: new Set(["openai/gpt-5.2"]),
 				})
 
-				expect(result).toEqual({ model: "openai/gpt-5.2", variant: "medium" })
+				expect(result).toEqual({ model: "openai/gpt-5.2", variant: "medium", matchedFallback: true })
 			})
 		})
 	})

--- a/src/tools/delegate-task/model-selection.ts
+++ b/src/tools/delegate-task/model-selection.ts
@@ -53,7 +53,7 @@ export function resolveModelForDelegateTask(input: {
   fallbackChain?: FallbackEntry[]
   availableModels: Set<string>
   systemDefaultModel?: string
-}): { model: string; variant?: string } | { skipped: true } | undefined {
+}): { model: string; variant?: string; fallbackEntry?: FallbackEntry } | { skipped: true } | undefined {
   const userModel = normalizeModel(input.userModel)
   if (userModel) {
     return { model: userModel }
@@ -119,7 +119,7 @@ export function resolveModelForDelegateTask(input: {
       const provider = first?.providers?.[0]
       if (provider) {
         const transformedModelId = transformModelForProvider(provider, first.model)
-        return { model: `${provider}/${transformedModelId}`, variant: first.variant }
+        return { model: `${provider}/${transformedModelId}`, variant: first.variant, fallbackEntry: first }
       }
     } else {
       for (const entry of fallbackChain) {
@@ -128,20 +128,20 @@ export function resolveModelForDelegateTask(input: {
           const match = fuzzyMatchModel(fullModel, input.availableModels, [provider])
           if (match) {
             if (explicitHighModel && entry.variant === "high" && match === explicitHighBaseModel) {
-              return { model: explicitHighModel }
+              return { model: explicitHighModel, fallbackEntry: entry }
             }
 
-            return { model: match, variant: entry.variant }
+            return { model: match, variant: entry.variant, fallbackEntry: entry }
           }
         }
 
         const crossProviderMatch = fuzzyMatchModel(entry.model, input.availableModels)
         if (crossProviderMatch) {
           if (explicitHighModel && entry.variant === "high" && crossProviderMatch === explicitHighBaseModel) {
-            return { model: explicitHighModel }
+            return { model: explicitHighModel, fallbackEntry: entry }
           }
 
-          return { model: crossProviderMatch, variant: entry.variant }
+          return { model: crossProviderMatch, variant: entry.variant, fallbackEntry: entry }
         }
       }
     }

--- a/src/tools/delegate-task/model-selection.ts
+++ b/src/tools/delegate-task/model-selection.ts
@@ -53,7 +53,7 @@ export function resolveModelForDelegateTask(input: {
   fallbackChain?: FallbackEntry[]
   availableModels: Set<string>
   systemDefaultModel?: string
-}): { model: string; variant?: string; fallbackEntry?: FallbackEntry } | { skipped: true } | undefined {
+}): { model: string; variant?: string; fallbackEntry?: FallbackEntry; matchedFallback?: boolean } | { skipped: true } | undefined {
   const userModel = normalizeModel(input.userModel)
   if (userModel) {
     return { model: userModel }
@@ -97,7 +97,7 @@ export function resolveModelForDelegateTask(input: {
     if (input.availableModels.size === 0) {
       const first = userFallbackModels[0] ? parseUserFallbackModel(userFallbackModels[0]) : undefined
       if (first) {
-        return { model: first.baseModel, variant: first.variant }
+        return { model: first.baseModel, variant: first.variant, matchedFallback: true }
       }
     } else {
       for (const fallbackModel of userFallbackModels) {
@@ -106,7 +106,7 @@ export function resolveModelForDelegateTask(input: {
 
         const match = fuzzyMatchModel(parsedFallback.baseModel, input.availableModels, parsedFallback.providerHint)
         if (match) {
-          return { model: match, variant: parsedFallback.variant }
+          return { model: match, variant: parsedFallback.variant, matchedFallback: true }
         }
       }
     }
@@ -119,7 +119,7 @@ export function resolveModelForDelegateTask(input: {
       const provider = first?.providers?.[0]
       if (provider) {
         const transformedModelId = transformModelForProvider(provider, first.model)
-        return { model: `${provider}/${transformedModelId}`, variant: first.variant, fallbackEntry: first }
+        return { model: `${provider}/${transformedModelId}`, variant: first.variant, fallbackEntry: first, matchedFallback: true }
       }
     } else {
       for (const entry of fallbackChain) {
@@ -128,20 +128,20 @@ export function resolveModelForDelegateTask(input: {
           const match = fuzzyMatchModel(fullModel, input.availableModels, [provider])
           if (match) {
             if (explicitHighModel && entry.variant === "high" && match === explicitHighBaseModel) {
-              return { model: explicitHighModel, fallbackEntry: entry }
+              return { model: explicitHighModel, fallbackEntry: entry, matchedFallback: true }
             }
 
-            return { model: match, variant: entry.variant, fallbackEntry: entry }
+            return { model: match, variant: entry.variant, fallbackEntry: entry, matchedFallback: true }
           }
         }
 
         const crossProviderMatch = fuzzyMatchModel(entry.model, input.availableModels)
         if (crossProviderMatch) {
           if (explicitHighModel && entry.variant === "high" && crossProviderMatch === explicitHighBaseModel) {
-            return { model: explicitHighModel, fallbackEntry: entry }
+            return { model: explicitHighModel, fallbackEntry: entry, matchedFallback: true }
           }
 
-          return { model: crossProviderMatch, variant: entry.variant, fallbackEntry: entry }
+          return { model: crossProviderMatch, variant: entry.variant, fallbackEntry: entry, matchedFallback: true }
         }
       }
     }

--- a/src/tools/delegate-task/model-string-parser.ts
+++ b/src/tools/delegate-task/model-string-parser.ts
@@ -4,6 +4,7 @@ const KNOWN_VARIANTS = new Set([
   "high",
   "xhigh",
   "max",
+  "minimal",
   "none",
   "auto",
   "thinking",

--- a/src/tools/delegate-task/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/subagent-resolver.test.ts
@@ -227,6 +227,47 @@ describe("resolveSubagentExecution", () => {
     connectedSpy.mockRestore()
   })
 
+  test("does not apply object-style fallback settings when the subagent primary model matches directly", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: { openai: ["gpt-5.4-preview"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const connectedSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+    const args = createBaseArgs({ subagent_type: "explore" })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "explore", mode: "subagent", model: "openai/gpt-5.4-preview" },
+      ]),
+      {
+        agentOverrides: {
+          explore: {
+            fallback_models: [
+              {
+                model: "openai/gpt-5.4",
+                variant: "low",
+                reasoningEffort: "high",
+              },
+            ],
+          },
+        } as ExecutorContext["agentOverrides"],
+      }
+    )
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4-preview",
+    })
+    cacheSpy.mockRestore()
+    connectedSpy.mockRestore()
+  })
+
   test("matches promoted fallback settings after fuzzy model resolution", async () => {
     //#given
     const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({

--- a/src/tools/delegate-task/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/subagent-resolver.test.ts
@@ -175,4 +175,245 @@ describe("resolveSubagentExecution", () => {
     ])
     cacheSpy.mockRestore()
   })
+
+  test("promotes object-style fallback model settings to categoryModel when subagent fallback becomes initial model", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: { openai: ["gpt-5.4"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const connectedSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+    const args = createBaseArgs({ subagent_type: "explore" })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "explore", mode: "subagent", model: "quotio/claude-haiku-4-5-unavailable" },
+      ]),
+      {
+        agentOverrides: {
+          explore: {
+            fallback_models: [
+              {
+                model: "openai/gpt-5.4 high",
+                variant: "low",
+                reasoningEffort: "high",
+                temperature: 0.2,
+                top_p: 0.8,
+                maxTokens: 2048,
+                thinking: { type: "disabled" },
+              },
+            ],
+          },
+        } as ExecutorContext["agentOverrides"],
+      }
+    )
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      variant: "low",
+      reasoningEffort: "high",
+      temperature: 0.2,
+      top_p: 0.8,
+      maxTokens: 2048,
+      thinking: { type: "disabled" },
+    })
+    cacheSpy.mockRestore()
+    connectedSpy.mockRestore()
+  })
+
+  test("matches promoted fallback settings after fuzzy model resolution", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: { openai: ["gpt-5.4-preview"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const connectedSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+    const args = createBaseArgs({ subagent_type: "explore" })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "explore", mode: "subagent", model: "quotio/claude-haiku-4-5-unavailable" },
+      ]),
+      {
+        agentOverrides: {
+          explore: {
+            fallback_models: [
+              {
+                model: "openai/gpt-5.4",
+                variant: "low",
+                reasoningEffort: "high",
+                temperature: 0.3,
+                top_p: 0.4,
+                maxTokens: 2222,
+                thinking: { type: "disabled" },
+              },
+            ],
+          },
+        } as ExecutorContext["agentOverrides"],
+      }
+    )
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4-preview",
+      variant: "low",
+      reasoningEffort: "high",
+      temperature: 0.3,
+      top_p: 0.4,
+      maxTokens: 2222,
+      thinking: { type: "disabled" },
+    })
+    cacheSpy.mockRestore()
+    connectedSpy.mockRestore()
+  })
+
+  test("prefers exact promoted fallback match over earlier fuzzy prefix match", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: { openai: ["gpt-5.4-preview"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const connectedSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+    const args = createBaseArgs({ subagent_type: "explore" })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "explore", mode: "subagent", model: "quotio/claude-haiku-4-5-unavailable" },
+      ]),
+      {
+        agentOverrides: {
+          explore: {
+            fallback_models: [
+              {
+                model: "openai/gpt-5.4",
+                variant: "low",
+                reasoningEffort: "medium",
+              },
+              {
+                model: "openai/gpt-5.4-preview",
+                variant: "max",
+                reasoningEffort: "high",
+              },
+            ],
+          },
+        } as ExecutorContext["agentOverrides"],
+      }
+    )
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4-preview",
+      variant: "max",
+      reasoningEffort: "high",
+    })
+    cacheSpy.mockRestore()
+    connectedSpy.mockRestore()
+  })
+
+  test("matches promoted fallback settings when fuzzy resolution extends configured model without hyphen", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: { openai: ["gpt-5.4o"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const connectedSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+    const args = createBaseArgs({ subagent_type: "explore" })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "explore", mode: "subagent", model: "quotio/claude-haiku-4-5-unavailable" },
+      ]),
+      {
+        agentOverrides: {
+          explore: {
+            fallback_models: [
+              {
+                model: "openai/gpt-5.4",
+                variant: "low",
+                reasoningEffort: "high",
+              },
+            ],
+          },
+        } as ExecutorContext["agentOverrides"],
+      }
+    )
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4o",
+      variant: "low",
+      reasoningEffort: "high",
+    })
+    cacheSpy.mockRestore()
+    connectedSpy.mockRestore()
+  })
+
+  test("prefers the most specific prefix match when fallback entries share a prefix", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: { openai: ["gpt-4o-preview"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const connectedSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
+    const args = createBaseArgs({ subagent_type: "explore" })
+    const executorCtx = createExecutorContext(
+      async () => ([
+        { name: "explore", mode: "subagent", model: "quotio/claude-haiku-4-5-unavailable" },
+      ]),
+      {
+        agentOverrides: {
+          explore: {
+            fallback_models: [
+              {
+                model: "openai/gpt-4",
+                variant: "low",
+                reasoningEffort: "medium",
+              },
+              {
+                model: "openai/gpt-4o",
+                variant: "max",
+                reasoningEffort: "high",
+              },
+            ],
+          },
+        } as ExecutorContext["agentOverrides"],
+      }
+    )
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.categoryModel).toEqual({
+      providerID: "openai",
+      modelID: "gpt-4o-preview",
+      variant: "max",
+      reasoningEffort: "high",
+    })
+    cacheSpy.mockRestore()
+    connectedSpy.mockRestore()
+  })
 })

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -1,11 +1,12 @@
 import type { DelegateTaskArgs } from "./types"
 import type { ExecutorContext } from "./executor-types"
+import type { DelegatedModelConfig } from "./types"
 import { isPlanFamily } from "./constants"
 import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent"
 import { normalizeModelFormat } from "../../shared/model-format-normalizer"
 import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
-import { normalizeFallbackModels } from "../../shared/model-resolver"
-import { buildFallbackChainFromModels } from "../../shared/fallback-chain-from-models"
+import { normalizeFallbackModels, flattenToFallbackModelStrings } from "../../shared/model-resolver"
+import { buildFallbackChainFromModels, findMostSpecificFallbackEntry } from "../../shared/fallback-chain-from-models"
 import { getAgentDisplayName, getAgentConfigKey } from "../../shared/agent-display-names"
 import { normalizeSDKResponse } from "../../shared"
 import { log } from "../../shared/logger"
@@ -17,9 +18,8 @@ export async function resolveSubagentExecution(
   args: DelegateTaskArgs,
   executorCtx: ExecutorContext,
   parentAgent: string | undefined,
-  categoryExamples: string,
-  inheritedModel?: string
-): Promise<{ agentToUse: string; categoryModel: { providerID: string; modelID: string; variant?: string } | undefined; fallbackChain?: FallbackEntry[]; error?: string }> {
+  categoryExamples: string
+): Promise<{ agentToUse: string; categoryModel: DelegatedModelConfig | undefined; fallbackChain?: FallbackEntry[]; error?: string }> {
   const { client, agentOverrides, userCategories } = executorCtx
 
   if (!args.subagent_type?.trim()) {
@@ -49,7 +49,7 @@ Create the work plan directly - that's your job as the planning agent.`,
   }
 
   let agentToUse = agentName
-  let categoryModel: { providerID: string; modelID: string; variant?: string } | undefined
+  let categoryModel: DelegatedModelConfig | undefined
   let fallbackChain: FallbackEntry[] | undefined = undefined
 
   try {
@@ -117,8 +117,8 @@ Create the work plan directly - that's your job as the planning agent.`,
         : undefined
 
       const resolution = resolveModelForDelegateTask({
-        userModel: agentOverride?.model ?? inheritedModel,
-        userFallbackModels: normalizedAgentFallbackModels,
+        userModel: agentOverride?.model,
+        userFallbackModels: flattenToFallbackModelStrings(normalizedAgentFallbackModels),
         categoryDefaultModel: matchedAgentModelStr,
         fallbackChain: agentRequirement?.fallbackChain,
         availableModels,
@@ -141,6 +141,25 @@ Create the work plan directly - that's your job as the planning agent.`,
         defaultProviderID,
       )
       fallbackChain = configuredFallbackChain ?? agentRequirement?.fallbackChain
+
+      // Apply per-model settings: prefer resolver's exact entry, fall back to prefix match on user config
+      const resolvedFallbackEntry = (resolution && !('skipped' in resolution)) ? resolution.fallbackEntry : undefined
+      const effectiveEntry = resolvedFallbackEntry
+        ?? (categoryModel && fallbackChain
+          ? findMostSpecificFallbackEntry(categoryModel.providerID, categoryModel.modelID, fallbackChain)
+          : undefined)
+
+      if (categoryModel && effectiveEntry) {
+        categoryModel = {
+          ...categoryModel,
+          variant: agentOverride?.variant ?? effectiveEntry.variant ?? categoryModel.variant,
+          reasoningEffort: effectiveEntry.reasoningEffort,
+          temperature: effectiveEntry.temperature,
+          top_p: effectiveEntry.top_p,
+          maxTokens: effectiveEntry.maxTokens,
+          thinking: effectiveEntry.thinking,
+        }
+      }
     }
 
     if (!categoryModel && matchedAgent.model) {

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -142,12 +142,17 @@ Create the work plan directly - that's your job as the planning agent.`,
       )
       fallbackChain = configuredFallbackChain ?? agentRequirement?.fallbackChain
 
-      // Apply per-model settings: prefer resolver's exact entry, fall back to prefix match on user config
+      // Only promote fallback-only settings when resolution actually selected a fallback model.
       const resolvedFallbackEntry = (resolution && !('skipped' in resolution)) ? resolution.fallbackEntry : undefined
-      const effectiveEntry = resolvedFallbackEntry
-        ?? (categoryModel && fallbackChain
-          ? findMostSpecificFallbackEntry(categoryModel.providerID, categoryModel.modelID, fallbackChain)
-          : undefined)
+      const matchedFallback = (resolution && !('skipped' in resolution)) ? resolution.matchedFallback === true : false
+      const effectiveEntry = matchedFallback && categoryModel
+        ? (
+            resolvedFallbackEntry
+            ?? (configuredFallbackChain
+              ? findMostSpecificFallbackEntry(categoryModel.providerID, categoryModel.modelID, configuredFallbackChain)
+              : undefined)
+          )
+        : undefined
 
       if (categoryModel && effectiveEntry) {
         categoryModel = {

--- a/src/tools/delegate-task/sync-prompt-sender.test.ts
+++ b/src/tools/delegate-task/sync-prompt-sender.test.ts
@@ -3,9 +3,19 @@ const {
   test: bunTest,
   expect: bunExpect,
   mock: bunMock,
+  afterEach: bunAfterEach,
 } = require("bun:test")
 
+const {
+  clearSessionPromptParams,
+  getSessionPromptParams,
+} = require("../../shared/session-prompt-params-state")
+
 bunDescribe("sendSyncPrompt", () => {
+  bunAfterEach(() => {
+    clearSessionPromptParams("test-session")
+  })
+
   bunTest("passes question=false via tools parameter", async () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")
@@ -214,6 +224,67 @@ bunDescribe("sendSyncPrompt", () => {
     bunExpect(promptArgs.body.variant).toBe("medium")
   })
 
+  bunTest("passes promoted fallback model settings through supported prompt channels", async () => {
+    //#given
+    const { sendSyncPrompt } = require("./sync-prompt-sender")
+
+    let promptArgs: any
+    const promptWithModelSuggestionRetry = bunMock(async (_client: any, input: any) => {
+      promptArgs = input
+    })
+
+    const input = {
+      sessionID: "test-session",
+      agentToUse: "oracle",
+      args: {
+        description: "test task",
+        prompt: "test prompt",
+        run_in_background: false,
+        load_skills: [],
+      },
+      systemContent: undefined,
+      categoryModel: {
+        providerID: "openai",
+        modelID: "gpt-5.4",
+        variant: "low",
+        reasoningEffort: "high",
+        temperature: 0.4,
+        top_p: 0.7,
+        maxTokens: 4096,
+        thinking: { type: "disabled" },
+      },
+      toastManager: null,
+      taskId: undefined,
+    }
+
+    //#when
+    await sendSyncPrompt(
+      { session: { promptAsync: bunMock(async () => ({ data: {} })) } },
+      input,
+      {
+        promptWithModelSuggestionRetry,
+        promptSyncWithModelSuggestionRetry: bunMock(async () => {}),
+      },
+    )
+
+    //#then
+    bunExpect(promptWithModelSuggestionRetry).toHaveBeenCalledTimes(1)
+    bunExpect(promptArgs.body.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+    })
+    bunExpect(promptArgs.body.variant).toBe("low")
+    bunExpect(promptArgs.body.options).toBeUndefined()
+    bunExpect(getSessionPromptParams("test-session")).toEqual({
+      temperature: 0.4,
+      topP: 0.7,
+      options: {
+        reasoningEffort: "high",
+        thinking: { type: "disabled" },
+        maxTokens: 4096,
+      },
+    })
+  })
   bunTest("retries with promptSync for oracle when promptAsync fails with unexpected EOF", async () => {
     //#given
     const { sendSyncPrompt } = require("./sync-prompt-sender")
@@ -289,7 +360,7 @@ bunDescribe("sendSyncPrompt", () => {
     )
 
     //#then
-    bunExpect(result).toContain("JSON Parse error: Unexpected EOF")
+    bunExpect(result).toContain("Unexpected EOF")
     bunExpect(promptWithModelSuggestionRetry).toHaveBeenCalledTimes(1)
     bunExpect(promptSyncWithModelSuggestionRetry).toHaveBeenCalledTimes(0)
   })

--- a/src/tools/delegate-task/sync-prompt-sender.ts
+++ b/src/tools/delegate-task/sync-prompt-sender.ts
@@ -7,8 +7,8 @@ import {
 } from "../../shared/model-suggestion-retry"
 import { formatDetailedError } from "./error-formatting"
 import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
+import { applySessionPromptParams } from "../../shared/session-prompt-params-helpers"
 import { setSessionTools } from "../../shared/session-tools-store"
-import { setSessionPromptParams } from "../../shared/session-prompt-params-state"
 import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 
 type SendSyncPromptDeps = {
@@ -54,25 +54,7 @@ export async function sendSyncPrompt(
   }
   setSessionTools(input.sessionID, tools)
 
-  if (input.categoryModel) {
-    const promptOptions: Record<string, unknown> = {
-      ...(input.categoryModel.reasoningEffort ? { reasoningEffort: input.categoryModel.reasoningEffort } : {}),
-      ...(input.categoryModel.thinking ? { thinking: input.categoryModel.thinking } : {}),
-      ...(input.categoryModel.maxTokens !== undefined ? { maxTokens: input.categoryModel.maxTokens } : {}),
-    }
-
-    if (
-      input.categoryModel.temperature !== undefined ||
-      input.categoryModel.top_p !== undefined ||
-      Object.keys(promptOptions).length > 0
-    ) {
-      setSessionPromptParams(input.sessionID, {
-        ...(input.categoryModel.temperature !== undefined ? { temperature: input.categoryModel.temperature } : {}),
-        ...(input.categoryModel.top_p !== undefined ? { topP: input.categoryModel.top_p } : {}),
-        ...(Object.keys(promptOptions).length > 0 ? { options: promptOptions } : {}),
-      })
-    }
-  }
+  applySessionPromptParams(input.sessionID, input.categoryModel)
 
   const promptArgs = {
     path: { id: input.sessionID },

--- a/src/tools/delegate-task/sync-prompt-sender.ts
+++ b/src/tools/delegate-task/sync-prompt-sender.ts
@@ -1,4 +1,4 @@
-import type { DelegateTaskArgs, OpencodeClient } from "./types"
+import type { DelegateTaskArgs, OpencodeClient, DelegatedModelConfig } from "./types"
 import { isPlanFamily } from "./constants"
 import { buildTaskPrompt } from "./prompt-builder"
 import {
@@ -8,6 +8,7 @@ import {
 import { formatDetailedError } from "./error-formatting"
 import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
 import { setSessionTools } from "../../shared/session-tools-store"
+import { setSessionPromptParams } from "../../shared/session-prompt-params-state"
 import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 
 type SendSyncPromptDeps = {
@@ -37,7 +38,7 @@ export async function sendSyncPrompt(
     agentToUse: string
     args: DelegateTaskArgs
     systemContent: string | undefined
-    categoryModel: { providerID: string; modelID: string; variant?: string } | undefined
+    categoryModel: DelegatedModelConfig | undefined
     toastManager: { removeTask: (id: string) => void } | null | undefined
     taskId: string | undefined
   },
@@ -53,6 +54,26 @@ export async function sendSyncPrompt(
   }
   setSessionTools(input.sessionID, tools)
 
+  if (input.categoryModel) {
+    const promptOptions: Record<string, unknown> = {
+      ...(input.categoryModel.reasoningEffort ? { reasoningEffort: input.categoryModel.reasoningEffort } : {}),
+      ...(input.categoryModel.thinking ? { thinking: input.categoryModel.thinking } : {}),
+      ...(input.categoryModel.maxTokens !== undefined ? { maxTokens: input.categoryModel.maxTokens } : {}),
+    }
+
+    if (
+      input.categoryModel.temperature !== undefined ||
+      input.categoryModel.top_p !== undefined ||
+      Object.keys(promptOptions).length > 0
+    ) {
+      setSessionPromptParams(input.sessionID, {
+        ...(input.categoryModel.temperature !== undefined ? { temperature: input.categoryModel.temperature } : {}),
+        ...(input.categoryModel.top_p !== undefined ? { topP: input.categoryModel.top_p } : {}),
+        ...(Object.keys(promptOptions).length > 0 ? { options: promptOptions } : {}),
+      })
+    }
+  }
+
   const promptArgs = {
     path: { id: input.sessionID },
     body: {
@@ -61,7 +82,12 @@ export async function sendSyncPrompt(
       tools,
       parts: [createInternalAgentTextPart(effectivePrompt)],
       ...(input.categoryModel
-        ? { model: { providerID: input.categoryModel.providerID, modelID: input.categoryModel.modelID } }
+        ? {
+            model: {
+              providerID: input.categoryModel.providerID,
+              modelID: input.categoryModel.modelID,
+            },
+          }
         : {}),
       ...(input.categoryModel?.variant ? { variant: input.categoryModel.variant } : {}),
     },

--- a/src/tools/delegate-task/sync-task.ts
+++ b/src/tools/delegate-task/sync-task.ts
@@ -1,5 +1,5 @@
 import type { ModelFallbackInfo } from "../../features/task-toast-manager/types"
-import type { DelegateTaskArgs, ToolContextWithMetadata } from "./types"
+import type { DelegateTaskArgs, ToolContextWithMetadata, DelegatedModelConfig } from "./types"
 import type { ExecutorContext, ParentContext } from "./executor-types"
 import { getTaskToastManager } from "../../features/task-toast-manager"
 import { storeToolMetadata } from "../../features/tool-metadata-store"
@@ -17,7 +17,7 @@ export async function executeSyncTask(
   executorCtx: ExecutorContext,
   parentContext: ParentContext,
   agentToUse: string,
-  categoryModel: { providerID: string; modelID: string; variant?: string } | undefined,
+  categoryModel: DelegatedModelConfig | undefined,
   systemContent: string | undefined,
   modelInfo?: ModelFallbackInfo,
   fallbackChain?: import("../../shared/model-requirements").FallbackEntry[],

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -1,5 +1,5 @@
 import { tool, type ToolDefinition } from "@opencode-ai/plugin"
-import type { DelegateTaskArgs, ToolContextWithMetadata, DelegateTaskToolOptions } from "./types"
+import type { DelegateTaskArgs, DelegatedModelConfig, ToolContextWithMetadata, DelegateTaskToolOptions } from "./types"
 import { CATEGORY_DESCRIPTIONS } from "./constants"
 import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent"
 import { mergeCategories } from "../../shared/merge-categories"
@@ -178,18 +178,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
         : undefined
 
       let agentToUse: string
-      let categoryModel:
-        | {
-            providerID: string
-            modelID: string
-            variant?: string
-            reasoningEffort?: string
-            temperature?: number
-            top_p?: number
-            maxTokens?: number
-            thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
-          }
-        | undefined
+      let categoryModel: DelegatedModelConfig | undefined
       let categoryPromptAppend: string | undefined
       let modelInfo: import("../../features/task-toast-manager/types").ModelFallbackInfo | undefined
       let actualModel: string | undefined

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -178,7 +178,18 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
         : undefined
 
       let agentToUse: string
-      let categoryModel: { providerID: string; modelID: string; variant?: string } | undefined
+      let categoryModel:
+        | {
+            providerID: string
+            modelID: string
+            variant?: string
+            reasoningEffort?: string
+            temperature?: number
+            top_p?: number
+            maxTokens?: number
+            thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+          }
+        | undefined
       let categoryPromptAppend: string | undefined
       let modelInfo: import("../../features/task-toast-manager/types").ModelFallbackInfo | undefined
       let actualModel: string | undefined

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -237,7 +237,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
           return executeUnstableAgentTask(args, ctx, options, parentContext, agentToUse, categoryModel, systemContent, actualModel)
         }
       } else {
-        const resolution = await resolveSubagentExecution(args, options, parentContext.agent, categoryExamples, inheritedModel)
+        const resolution = await resolveSubagentExecution(args, options, parentContext.agent, categoryExamples)
         if (resolution.error) {
           return resolution.error
         }

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -71,16 +71,8 @@ export interface DelegateTaskToolOptions {
   syncPollTimeoutMs?: number
 }
 
-export interface DelegatedModelConfig {
-  providerID: string
-  modelID: string
-  variant?: string
-  reasoningEffort?: string
-  temperature?: number
-  top_p?: number
-  maxTokens?: number
-  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
-}
+import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
+export type { DelegatedModelConfig }
 
 export interface BuildSystemContentInput {
   skillContent?: string

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -71,6 +71,17 @@ export interface DelegateTaskToolOptions {
   syncPollTimeoutMs?: number
 }
 
+export interface DelegatedModelConfig {
+  providerID: string
+  modelID: string
+  variant?: string
+  reasoningEffort?: string
+  temperature?: number
+  top_p?: number
+  maxTokens?: number
+  thinking?: { type: "enabled" | "disabled"; budgetTokens?: number }
+}
+
 export interface BuildSystemContentInput {
   skillContent?: string
   skillContents?: string[]
@@ -78,7 +89,7 @@ export interface BuildSystemContentInput {
   agentsContext?: string
   planAgentPrepend?: string
   maxPromptTokens?: number
-  model?: { providerID: string; modelID: string; variant?: string }
+  model?: DelegatedModelConfig
   agentName?: string
   availableCategories?: AvailableCategory[]
   availableSkills?: AvailableSkill[]

--- a/src/tools/delegate-task/unstable-agent-task.ts
+++ b/src/tools/delegate-task/unstable-agent-task.ts
@@ -1,4 +1,4 @@
-import type { DelegateTaskArgs, ToolContextWithMetadata } from "./types"
+import type { DelegateTaskArgs, ToolContextWithMetadata, DelegatedModelConfig } from "./types"
 import type { ExecutorContext, ParentContext, SessionMessage } from "./executor-types"
 import { DEFAULT_SYNC_POLL_TIMEOUT_MS, getTimingConfig } from "./timing"
 import { buildTaskPrompt } from "./prompt-builder"
@@ -16,7 +16,7 @@ export async function executeUnstableAgentTask(
   executorCtx: ExecutorContext,
   parentContext: ParentContext,
   agentToUse: string,
-  categoryModel: { providerID: string; modelID: string; variant?: string } | undefined,
+  categoryModel: DelegatedModelConfig | undefined,
   systemContent: string | undefined,
   actualModel: string | undefined
 ): Promise<string> {


### PR DESCRIPTION
> **PR Stack (3/3)** — merge in order:
> 1. #2622 — object-style fallback_models
> 2. #2643 — model settings compatibility resolver
> 3. **#2674** ← this PR (based on #2643)
>
> **Reviewers:** The diff includes changes from #2622 and #2643. The only commit unique to this PR is:
> - `c4b7b253` refactor(delegate-task): deduplicate DelegatedModelConfig + registry refactor
## Summary

- Moves `DelegatedModelConfig` to `src/shared/model-resolution-types.ts` as the single canonical definition
- `delegate-task/types.ts` re-exports from shared (preserving all existing import paths)
- `background-agent/types.ts` replaces its local duplicate with an import from shared

Net -7 lines. No behavioral change — purely a type-level dedup.

## Dependencies

> **Merge after #2622** (`feat/object-style-fallback-models`) — this PR builds on that branch.

## Context

The duplicate was introduced when background-agent needed the same shape but couldn't import from delegate-task without creating a circular dependency. `src/shared/` is the natural home since it's already a leaf in the import graph.

## Test plan

- [x] `bunx tsc --noEmit` — zero errors
- [x] All 4239 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates `DelegatedModelConfig` into a shared module and adds a central model-settings compatibility resolver. Adds object-style `fallback_models` with per-model settings that promote to session-scoped prompt params for background and sync prompts; promotions only apply on real fallback matches and clear on `session.deleted`.

- **New Features**
  - `fallback_models` supports mixed arrays; object entries can set `variant`, `reasoningEffort` (adds `none`/`minimal`), `temperature`, `top_p`, `maxTokens`, and `thinking`. When chosen, settings promote to the delegated model and persist via `session-prompt-params-state` across launch/resume and sync prompts; runtime fallback uses flattened strings.
  - `resolveCompatibleModelSettings` clamps `variant`/`reasoningEffort` using provider metadata and a model-family registry; integrated in `chat.params` (plugin now passes `client`). Utilities include `normalizeFallbackModels`, `flattenToFallbackModelStrings`, `findMostSpecificFallbackEntry`, and `KNOWN_VARIANTS`.
  - `DelegatedModelConfig` moved to `src/shared/model-resolution-types.ts`, now includes per-model settings (above) and is used across background-agent and delegate-task; re-exported to preserve imports.

- **Bug Fixes**
  - Promotion of per-model settings is gated to actual fallback matches in category and subagent resolvers; prefers the most specific prefix match and recognizes inline `minimal`.
  - Prompt params flow: `applySessionPromptParams` applies promoted settings on send; `chat.params` merges stored session params; stored params are cleared on `session.deleted`.
  - Anthropic effort hook generalized to the Claude Opus family.

<sup>Written for commit 9d930656daaa8a8c2839fa8c0aca2696a36b0e93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

