### PR TITLE
fix(look-at): respect configured multimodal-looker model instead of overriding via dynamic fallback

### DIFF
--- a/src/tools/look-at/multimodal-agent-metadata.test.ts
+++ b/src/tools/look-at/multimodal-agent-metadata.test.ts
@@ -65,8 +65,8 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
     })
   })
 
-  test("preserves hardcoded fallback variant when the registered model matches a cache-derived entry", async () => {
-    // given
+  test("returns registered model variant directly without merging from dynamic resolution", async () => {
+    // given - registered model is in the vision-capable cache
     setVisionCapableModelsCache(new Map([
       [
         "openai/gpt-5.4",
@@ -87,15 +87,15 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
     // when
     const result = await resolveMultimodalLookerAgentMetadata(ctx)
 
-    // then
+    // then - returns registered metadata directly, variant is undefined since none was set
     expect(result).toEqual({
       agentModel: { providerID: "openai", modelID: "gpt-5.4" },
-      agentVariant: "medium",
+      agentVariant: undefined,
     })
   })
 
-  test("prefers connected vision-capable provider models before the hardcoded fallback chain", async () => {
-    // given
+  test("prefers registered model over dynamically resolved vision-capable model", async () => {
+    // given - registered model is openai/gpt-5.4, dynamic would resolve to rundao model
     setVisionCapableModelsCache(new Map([
       [
         "rundao/public/qwen3.5-397b",
@@ -117,10 +117,10 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
     // when
     const result = await resolveMultimodalLookerAgentMetadata(ctx)
 
-    // then
+    // then - registered model takes priority even when not in vision cache
     expect(result).toEqual({
-      agentModel: { providerID: "rundao", modelID: "public/qwen3.5-397b" },
-      agentVariant: undefined,
+      agentModel: { providerID: "openai", modelID: "gpt-5.4" },
+      agentVariant: "medium",
     })
   })
 
@@ -148,8 +148,8 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
     })
   })
 
-  test("does not return a registered model when no vision-capable model is available", async () => {
-    // given
+  test("returns registered model even when not in vision-capable cache", async () => {
+    // given - registered model exists but is NOT in the vision-capable cache
     spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(
       new Set(["openai/gpt-5.4"]),
     )
@@ -164,7 +164,10 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
     // when
     const result = await resolveMultimodalLookerAgentMetadata(ctx)
 
-    // then
-    expect(result).toEqual({})
+    // then - trusts user's configured model regardless of vision cache
+    expect(result).toEqual({
+      agentModel: { providerID: "openai", modelID: "gpt-5.4" },
+      agentVariant: undefined,
+    })
   })
 })

--- a/src/tools/look-at/multimodal-agent-metadata.ts
+++ b/src/tools/look-at/multimodal-agent-metadata.ts
@@ -130,29 +130,32 @@ export async function resolveMultimodalLookerAgentMetadata(
   try {
     const registeredMetadata = await resolveRegisteredAgentMetadata(ctx)
     const visionCapableModels = readVisionCapableModelsCache()
-    const registeredModelIsVisionCapable = isVisionCapableAgentModel(
-      registeredMetadata.agentModel,
-      visionCapableModels,
-    )
+
+    if (registeredMetadata.agentModel) {
+      const registeredModelIsVisionCapable = isVisionCapableAgentModel(
+        registeredMetadata.agentModel,
+        visionCapableModels,
+      )
+
+      if (registeredModelIsVisionCapable) {
+        log("[look_at] Using registered multimodal-looker model (vision-capable)", {
+          model: getFullModelKey(registeredMetadata.agentModel),
+        })
+        return registeredMetadata
+      }
+
+      log("[look_at] Registered multimodal-looker model not in vision-capable cache, using it anyway", {
+        model: getFullModelKey(registeredMetadata.agentModel),
+      })
+      return registeredMetadata
+    }
 
     const dynamicMetadata = await resolveDynamicAgentMetadata(ctx, visionCapableModels)
-
-    if (
-      registeredModelIsVisionCapable &&
-      isConfiguredVisionModel(registeredMetadata.agentModel, dynamicMetadata.agentModel)
-    ) {
-      return {
-        agentModel: registeredMetadata.agentModel,
-        agentVariant: registeredMetadata.agentVariant ?? dynamicMetadata.agentVariant,
-      }
-    }
-
     if (dynamicMetadata.agentModel) {
+      log("[look_at] No registered model, using dynamic resolution", {
+        model: getFullModelKey(dynamicMetadata.agentModel),
+      })
       return dynamicMetadata
-    }
-
-    if (registeredModelIsVisionCapable) {
-      return registeredMetadata
     }
 
     return {}

--- a/src/tools/look-at/tools.ts
+++ b/src/tools/look-at/tools.ts
@@ -4,7 +4,6 @@ import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin
 import { LOOK_AT_DESCRIPTION, MULTIMODAL_LOOKER_AGENT } from "./constants"
 import type { LookAtArgs } from "./types"
 import { log, promptSyncWithModelSuggestionRetry } from "../../shared"
-import { readVisionCapableModelsCache } from "../../shared/vision-capable-models-cache"
 import { extractLatestAssistantText } from "./assistant-message-extractor"
 import type { LookAtArgsWithAlias } from "./look-at-arguments"
 import { normalizeArgs, validateArgs } from "./look-at-arguments"
@@ -39,15 +38,6 @@ function getTemporaryConversionPath(error: unknown): string | null {
   return null
 }
 
-function isVisionCapableResolvedModel(model: {
-  providerID: string
-  modelID: string
-}): boolean {
-  return readVisionCapableModelsCache().some((visionCapableModel) =>
-    visionCapableModel.providerID === model.providerID &&
-    visionCapableModel.modelID === model.modelID,
-  )
-}
 
 export { normalizeArgs, validateArgs } from "./look-at-arguments"
 
@@ -148,12 +138,6 @@ Be thorough on what was requested, concise on everything else.
 If the requested information is not found, clearly state what is missing.`
 
       const { agentModel, agentVariant } = await resolveMultimodalLookerAgentMetadata(ctx)
-      if (agentModel && !isVisionCapableResolvedModel(agentModel)) {
-        log("[look_at] Resolved model is not vision-capable, blocking", {
-          resolvedModel: agentModel,
-        })
-        return "Error: Resolved multimodal-looker model is not vision-capable"
-      }
 
       log(`[look_at] Creating session with parent: ${toolContext.sessionID}`)
       const parentSession = await ctx.client.session.get({


### PR DESCRIPTION
## Summary

The `look_at` tool's model resolution (`resolveMultimodalLookerAgentMetadata`) was silently overriding the user's configured `multimodal-looker` model with a dynamically resolved one from the vision-capable models cache. This caused failures when the dynamically selected model (e.g., an Antigravity-prefixed Gemini model) was incompatible with the provider's API.

## Problem

When a user configures `multimodal-looker` with a specific model (e.g., `openai/gpt-5.4`), the resolution function:

1. Checks if the configured model is in the vision-capable cache (populated from `provider.*.models` with `modalities.input: ["image"]`)
2. If NOT in the cache (e.g., OpenAI models without explicit modality declarations), falls through to dynamic resolution
3. Dynamic resolution picks the first available vision-capable model from the cache, which may be an incompatible model
4. The configured model is silently replaced

This was confirmed via logs: the tool resolved to `google/antigravity-gemini-3-pro` instead of the configured `openai/gpt-5.4`, causing prompt failures.

## Fix

- If the user explicitly configured a model for `multimodal-looker`, use it regardless of the vision-capable cache. The cache is incomplete (only includes models with explicit `modalities.input` declarations in the provider config).
- Dynamic fallback is only used when no model is registered at all.
- Removed the redundant `isVisionCapableResolvedModel` gate in `tools.ts` that would block the configured model for the same reason.

## Testing

- Updated 3 existing tests to match new behavior
- All 52 look-at tests pass
- Typecheck clean
- Verified via real OpenCode session: configured GPT-5.4 is now used and returns successful responses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures `look_at` uses the configured `multimodal-looker` model and variant, only falling back to dynamic resolution when none is set. Prevents silent overrides to incompatible vision models and the resulting prompt failures.

- **Bug Fixes**
  - Always return the registered model and variant as-is; no merging from dynamic resolution.
  - Only run dynamic resolution when no model is configured; add clear logs with the chosen path and model.
  - Remove the vision-capable gate and blocking error in `tools.ts`.
  - Update tests for the new behavior; all look-at tests pass.

<sup>Written for commit db32bad0042830aafa4de0d279f631d9122cd039. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

