### PR TITLE
fix(lsp): wrap initialization config in initializationOptions field

### DIFF
--- a/src/tools/lsp/lsp-client-connection.ts
+++ b/src/tools/lsp/lsp-client-connection.ts
@@ -55,7 +55,7 @@ export class LSPClientConnection extends LSPClientTransport {
           },
         },
       },
-      ...this.server.initialization,
+      initializationOptions: this.server.initialization,
     })
     this.sendNotification("initialized")
     this.sendNotification("workspace/didChangeConfiguration", {


### PR DESCRIPTION
## Summary
- Wrap `initialization` config in `initializationOptions` field per LSP spec

## Why
The LSP `initialize` request expects custom server options in the `initializationOptions` field, but the current code spreads `this.server.initialization` directly into the root params object. This causes LSP servers that depend on `initializationOptions` (like pyright, eslint-language-server, etc.) to not receive their configuration.

Closes #2665

## Test plan
- [x] LSP servers that need `initializationOptions` now receive them correctly
- [x] Backwards compatible — servers that don't use `initializationOptions` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap the server’s initialization config under `initializationOptions` in the LSP `initialize` request to match the spec. This ensures servers that rely on `initializationOptions` (e.g., `pyright`, `eslint-language-server`) receive their config, while others are unaffected.

<sup>Written for commit 04637ff0f1a8a58833fc284af20e69071bad7885. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

