### PR TITLE
fix(windows): resolve symlinked config paths and plugin name parsing (fixes #2271)

### DIFF
--- a/src/cli/doctor/checks/system-loaded-version.test.ts
+++ b/src/cli/doctor/checks/system-loaded-version.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 
@@ -103,6 +103,31 @@ describe("system loaded version", () => {
       expect(loadedVersion.installedPackagePath).toBe(join(cacheDir, "node_modules", PACKAGE_NAME, "package.json"))
       expect(loadedVersion.expectedVersion).toBe("2.3.4")
       expect(loadedVersion.loadedVersion).toBe("2.3.4")
+    })
+
+    it("resolves symlinked config directories before selecting install path", () => {
+      //#given
+      const realConfigDir = createTemporaryDirectory("omo-real-config-")
+      const symlinkBaseDir = createTemporaryDirectory("omo-symlink-base-")
+      const symlinkConfigDir = join(symlinkBaseDir, "config-link")
+
+      symlinkSync(realConfigDir, symlinkConfigDir, process.platform === "win32" ? "junction" : "dir")
+      process.env.OPENCODE_CONFIG_DIR = symlinkConfigDir
+
+      writeJson(join(realConfigDir, "package.json"), {
+        dependencies: { [PACKAGE_NAME]: "4.5.6" },
+      })
+      writeJson(join(realConfigDir, "node_modules", PACKAGE_NAME, "package.json"), {
+        version: "4.5.6",
+      })
+
+      //#when
+      const loadedVersion = getLoadedPluginVersion()
+
+      //#then
+      expect(loadedVersion.cacheDir).toBe(realpathSync(symlinkConfigDir))
+      expect(loadedVersion.expectedVersion).toBe("4.5.6")
+      expect(loadedVersion.loadedVersion).toBe("4.5.6")
     })
   })
 

--- a/src/cli/doctor/checks/system-loaded-version.ts
+++ b/src/cli/doctor/checks/system-loaded-version.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, readFileSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 
@@ -36,6 +36,16 @@ function resolveOpenCodeCacheDir(): string {
   return platformDefault
 }
 
+function resolveExistingDir(dirPath: string): string {
+  if (!existsSync(dirPath)) return dirPath
+
+  try {
+    return realpathSync(dirPath)
+  } catch {
+    return dirPath
+  }
+}
+
 function readPackageJson(filePath: string): PackageJsonShape | null {
   if (!existsSync(filePath)) return null
 
@@ -55,12 +65,13 @@ function normalizeVersion(value: string | undefined): string | null {
 
 export function getLoadedPluginVersion(): LoadedVersionInfo {
   const configPaths = getOpenCodeConfigPaths({ binary: "opencode" })
-  const cacheDir = resolveOpenCodeCacheDir()
+  const configDir = resolveExistingDir(configPaths.configDir)
+  const cacheDir = resolveExistingDir(resolveOpenCodeCacheDir())
   const candidates = [
     {
-      cacheDir: configPaths.configDir,
-      cachePackagePath: configPaths.packageJson,
-      installedPackagePath: join(configPaths.configDir, "node_modules", PACKAGE_NAME, "package.json"),
+      cacheDir: configDir,
+      cachePackagePath: join(configDir, "package.json"),
+      installedPackagePath: join(configDir, "node_modules", PACKAGE_NAME, "package.json"),
     },
     {
       cacheDir,

--- a/src/features/claude-code-plugin-loader/discovery.test.ts
+++ b/src/features/claude-code-plugin-loader/discovery.test.ts
@@ -32,6 +32,41 @@ describe("discoverInstalledPlugins", () => {
     }
   })
 
+  it("preserves scoped package name from npm plugin keys", () => {
+    //#given
+    const pluginsHome = process.env.CLAUDE_PLUGINS_HOME as string
+    const installPath = join(createTemporaryDirectory("omo-plugin-install-"), "@myorg", "my-plugin")
+    mkdirSync(installPath, { recursive: true })
+
+    const databasePath = join(pluginsHome, "installed_plugins.json")
+    writeFileSync(
+      databasePath,
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          "@myorg/my-plugin@1.0.0": [
+            {
+              scope: "user",
+              installPath,
+              version: "1.0.0",
+              installedAt: "2026-03-25T00:00:00Z",
+              lastUpdated: "2026-03-25T00:00:00Z",
+            },
+          ],
+        },
+      }),
+      "utf-8",
+    )
+
+    //#when
+    const discovered = discoverInstalledPlugins()
+
+    //#then
+    expect(discovered.errors).toHaveLength(0)
+    expect(discovered.plugins).toHaveLength(1)
+    expect(discovered.plugins[0]?.name).toBe("@myorg/my-plugin")
+  })
+
   it("derives package name from file URL plugin keys", () => {
     //#given
     const pluginsHome = process.env.CLAUDE_PLUGINS_HOME as string

--- a/src/features/claude-code-plugin-loader/discovery.test.ts
+++ b/src/features/claude-code-plugin-loader/discovery.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { discoverInstalledPlugins } from "./discovery"
+
+const originalClaudePluginsHome = process.env.CLAUDE_PLUGINS_HOME
+const temporaryDirectories: string[] = []
+
+function createTemporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+describe("discoverInstalledPlugins", () => {
+  beforeEach(() => {
+    const pluginsHome = createTemporaryDirectory("omo-claude-plugins-")
+    process.env.CLAUDE_PLUGINS_HOME = pluginsHome
+  })
+
+  afterEach(() => {
+    if (originalClaudePluginsHome === undefined) {
+      delete process.env.CLAUDE_PLUGINS_HOME
+    } else {
+      process.env.CLAUDE_PLUGINS_HOME = originalClaudePluginsHome
+    }
+
+    for (const directory of temporaryDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("derives package name from file URL plugin keys", () => {
+    //#given
+    const pluginsHome = process.env.CLAUDE_PLUGINS_HOME as string
+    const installPath = join(createTemporaryDirectory("omo-plugin-install-"), "oh-my-opencode")
+    mkdirSync(installPath, { recursive: true })
+
+    const databasePath = join(pluginsHome, "installed_plugins.json")
+    writeFileSync(
+      databasePath,
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          "file:///D:/configs/user-configs/.config/opencode/node_modules/oh-my-opencode@latest": [
+            {
+              scope: "user",
+              installPath,
+              version: "3.10.0",
+              installedAt: "2026-03-20T00:00:00Z",
+              lastUpdated: "2026-03-20T00:00:00Z",
+            },
+          ],
+        },
+      }),
+      "utf-8",
+    )
+
+    //#when
+    const discovered = discoverInstalledPlugins()
+
+    //#then
+    expect(discovered.errors).toHaveLength(0)
+    expect(discovered.plugins).toHaveLength(1)
+    expect(discovered.plugins[0]?.name).toBe("oh-my-opencode")
+  })
+})

--- a/src/features/claude-code-plugin-loader/discovery.ts
+++ b/src/features/claude-code-plugin-loader/discovery.ts
@@ -81,7 +81,14 @@ function loadPluginManifest(installPath: string): PluginManifest | null {
 
 function derivePluginNameFromKey(pluginKey: string): string {
   const keyWithoutSource = pluginKey.startsWith("npm:") ? pluginKey.slice(4) : pluginKey
-  const versionSeparator = keyWithoutSource.lastIndexOf("@")
+
+  let versionSeparator: number
+  if (keyWithoutSource.startsWith("@")) {
+    const scopeEnd = keyWithoutSource.indexOf("/")
+    versionSeparator = scopeEnd > 0 ? keyWithoutSource.indexOf("@", scopeEnd) : -1
+  } else {
+    versionSeparator = keyWithoutSource.lastIndexOf("@")
+  }
   const keyWithoutVersion = versionSeparator > 0 ? keyWithoutSource.slice(0, versionSeparator) : keyWithoutSource
 
   if (keyWithoutVersion.startsWith("file://")) {
@@ -90,6 +97,10 @@ function derivePluginNameFromKey(pluginKey: string): string {
     } catch {
       return basename(keyWithoutVersion)
     }
+  }
+
+  if (keyWithoutVersion.startsWith("@") && keyWithoutVersion.includes("/")) {
+    return keyWithoutVersion
   }
 
   if (keyWithoutVersion.includes("/") || keyWithoutVersion.includes("\\")) {

--- a/src/features/claude-code-plugin-loader/discovery.ts
+++ b/src/features/claude-code-plugin-loader/discovery.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "fs"
 import { homedir } from "os"
-import { join } from "path"
+import { basename, join } from "path"
+import { fileURLToPath } from "url"
 import { log } from "../../shared/logger"
 import type {
   InstalledPluginsDatabase,
@@ -79,8 +80,23 @@ function loadPluginManifest(installPath: string): PluginManifest | null {
 }
 
 function derivePluginNameFromKey(pluginKey: string): string {
-  const atIndex = pluginKey.indexOf("@")
-  return atIndex > 0 ? pluginKey.substring(0, atIndex) : pluginKey
+  const keyWithoutSource = pluginKey.startsWith("npm:") ? pluginKey.slice(4) : pluginKey
+  const versionSeparator = keyWithoutSource.lastIndexOf("@")
+  const keyWithoutVersion = versionSeparator > 0 ? keyWithoutSource.slice(0, versionSeparator) : keyWithoutSource
+
+  if (keyWithoutVersion.startsWith("file://")) {
+    try {
+      return basename(fileURLToPath(keyWithoutVersion))
+    } catch {
+      return basename(keyWithoutVersion)
+    }
+  }
+
+  if (keyWithoutVersion.includes("/") || keyWithoutVersion.includes("\\")) {
+    return basename(keyWithoutVersion)
+  }
+
+  return keyWithoutVersion
 }
 
 function isPluginEnabled(

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs"
+import { existsSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
 import { join, resolve } from "node:path"
 
@@ -42,14 +42,25 @@ function getTauriConfigDir(identifier: string): string {
   }
 }
 
+function resolveConfigPath(pathValue: string): string {
+  const resolvedPath = resolve(pathValue)
+  if (!existsSync(resolvedPath)) return resolvedPath
+
+  try {
+    return realpathSync(resolvedPath)
+  } catch {
+    return resolvedPath
+  }
+}
+
 function getCliConfigDir(): string {
   const envConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim()
   if (envConfigDir) {
-    return resolve(envConfigDir)
+    return resolveConfigPath(envConfigDir)
   }
 
   const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
-  return join(xdgConfig, "opencode")
+  return resolveConfigPath(join(xdgConfig, "opencode"))
 }
 
 export function getOpenCodeConfigDir(options: OpenCodeConfigDirOptions): string {
@@ -60,7 +71,7 @@ export function getOpenCodeConfigDir(options: OpenCodeConfigDirOptions): string 
   }
 
   const identifier = isDevBuild(version) ? TAURI_APP_IDENTIFIER_DEV : TAURI_APP_IDENTIFIER
-  const tauriDir = getTauriConfigDir(identifier)
+  const tauriDir = resolveConfigPath(getTauriConfigDir(identifier))
 
   if (checkExisting) {
     const legacyDir = getCliConfigDir()
@@ -92,7 +103,7 @@ export function detectExistingConfigDir(binary: OpenCodeBinaryType, version?: st
 
   const envConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim()
   if (envConfigDir) {
-    locations.push(resolve(envConfigDir))
+    locations.push(resolveConfigPath(envConfigDir))
   }
 
   if (binary === "opencode-desktop") {


### PR DESCRIPTION
## Summary
- Resolve OpenCode config paths through `realpathSync` before deriving config file and install locations
- Resolve symlinked config/cache directories in doctor loaded-version checks to avoid stale version mismatches on Windows junction/symlink setups
- Harden Claude plugin key parsing so `file://...@latest` entries derive the package basename (`oh-my-opencode`) instead of partial path segments

## Problem
On Windows setups where `~/.config` is symlinked or junctioned, path handling could mix symlink aliases and canonical paths. That broke version/source detection and caused plugin name derivation to fall back to path fragments for file-based entries.

## Fix
Canonicalize config paths before they are used by config discovery and doctor version checks. Also parse plugin keys by stripping source/version suffixes safely and extracting basename from file URLs/paths.

## Changes
| File | Change |
|------|--------|
| `src/shared/opencode-config-dir.ts` | Added symlink-aware config path resolver and applied it to CLI/Tauri/env config resolution |
| `src/cli/doctor/checks/system-loaded-version.ts` | Canonicalized config/cache directories before selecting installed package paths |
| `src/cli/doctor/checks/system-loaded-version.test.ts` | Added regression test for symlinked `OPENCODE_CONFIG_DIR` |
| `src/features/claude-code-plugin-loader/discovery.ts` | Improved plugin key name derivation for file URLs, paths, scoped/npm specs |
| `src/features/claude-code-plugin-loader/discovery.test.ts` | Added regression test for file URL plugin key parsing |

## Verification
- `lsp_diagnostics`: clean for all changed files
- `bun test src/features/claude-code-plugin-loader/discovery.test.ts`: pass
- `bun test src/cli/doctor/checks/system-loaded-version.test.ts`: fails in this environment due unresolved `picocolors` dependency import in `src/cli/doctor/constants.ts`
- `bun run build`: fails in this environment due broader package resolution issues (`zod`/`js-yaml` not resolved by Bun loader despite install)

Fixes #2271

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows handling of symlinked config/cache dirs by resolving canonical paths across config discovery, plugin detection, and doctor checks. Also fix plugin key parsing to preserve scoped npm names and derive correct names from file URLs (e.g., `@myorg/my-plugin`, `oh-my-opencode`). Fixes #2271.

- **Bug Fixes**
  - Canonicalize config and cache dirs before reading `package.json`, selecting install paths, or detecting installed versions (CLI, Tauri, doctor).
  - Normalize doctor loaded-version detection when the config dir is a junction/symlink on Windows; also resolve the cache dir.
  - Parse Claude plugin keys by stripping source/version, preserving scoped npm names, and deriving basenames for file URLs/paths; add regression tests.

<sup>Written for commit d7a1945b270e0644e854b6e470ab9904c0202d3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

