### PR TITLE
fix(doctor): detect conflicting Claude binaries for auth 429 troubleshooting

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -232,6 +232,24 @@ bunx oh-my-opencode doctor --verbose
 bunx oh-my-opencode doctor --category authentication
 ```
 
+### "Token refresh failed: 429" or "Failed to authorize"
+
+This usually means your shell resolves multiple `claude` binaries (for example `~/.local/bin/claude` and `/usr/local/bin/claude`) or you have stale local OAuth cache.
+
+```bash
+# Inspect resolved binaries
+which -a claude
+
+# Diagnose with doctor (Tools section will warn on multiple Claude binaries)
+bunx oh-my-opencode doctor --verbose
+```
+
+Recommended recovery:
+
+1. Keep a single `claude` installation in PATH precedence.
+2. Close concurrent Claude/OpenCode sessions.
+3. Re-open terminal and login again.
+
 ---
 
 ## Non-Interactive Mode

--- a/src/cli/doctor/checks/tools-claude-binary.test.ts
+++ b/src/cli/doctor/checks/tools-claude-binary.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test"
+import {
+  parseLookupOutput,
+  resolveClaudeBinaryDiagnostics,
+  type CommandExecutionResult,
+} from "./tools-claude-binary"
+
+describe("tools-claude-binary", () => {
+  describe("parseLookupOutput", () => {
+    it("deduplicates and trims lookup output", () => {
+      const output = " /usr/local/bin/claude \n/Users/me/.local/bin/claude\n/usr/local/bin/claude\n"
+      const result = parseLookupOutput(output)
+      expect(result).toEqual(["/usr/local/bin/claude", "/Users/me/.local/bin/claude"])
+    })
+  })
+
+  describe("resolveClaudeBinaryDiagnostics", () => {
+    it("reports conflict when multiple binaries are returned", async () => {
+      const executeCommand = async (_command: string[]): Promise<CommandExecutionResult> => ({
+        exitCode: 0,
+        stdout: "/Users/me/.local/bin/claude\n/usr/local/bin/claude\n",
+      })
+      const result = await resolveClaudeBinaryDiagnostics(executeCommand)
+      expect(result.activePath).toBe("/Users/me/.local/bin/claude")
+      expect(result.discoveredPaths.length).toBe(2)
+      expect(result.hasConflict).toBe(true)
+    })
+
+    it("returns empty diagnostics when no lookup command succeeds", async () => {
+      const executeCommand = async (_command: string[]): Promise<CommandExecutionResult> => {
+        throw new Error("missing")
+      }
+      const result = await resolveClaudeBinaryDiagnostics(executeCommand)
+      expect(result.activePath).toBeNull()
+      expect(result.discoveredPaths).toEqual([])
+      expect(result.hasConflict).toBe(false)
+    })
+  })
+})

--- a/src/cli/doctor/checks/tools-claude-binary.ts
+++ b/src/cli/doctor/checks/tools-claude-binary.ts
@@ -1,0 +1,73 @@
+import { spawnWithWindowsHide } from "../../../shared/spawn-with-windows-hide"
+
+export interface ClaudeBinaryDiagnostics {
+  activePath: string | null
+  discoveredPaths: string[]
+  hasConflict: boolean
+}
+
+export interface CommandExecutionResult {
+  exitCode: number | null
+  stdout: string
+}
+
+export type CommandExecutor = (command: string[]) => Promise<CommandExecutionResult>
+
+const LOOKUP_COMMAND_CANDIDATES = [
+  ["where", "claude"],
+  ["which", "-a", "claude"],
+  ["which", "claude"],
+]
+
+function uniquePaths(paths: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const path of paths) {
+    const trimmed = path.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+
+  return result
+}
+
+export function parseLookupOutput(output: string): string[] {
+  return uniquePaths(output.split(/\r?\n/))
+}
+
+export async function resolveClaudeBinaryDiagnostics(
+  executeCommand: CommandExecutor,
+): Promise<ClaudeBinaryDiagnostics> {
+  for (const command of LOOKUP_COMMAND_CANDIDATES) {
+    try {
+      const result = await executeCommand(command)
+      if (result.exitCode !== 0) continue
+
+      const discoveredPaths = parseLookupOutput(result.stdout)
+      if (discoveredPaths.length === 0) continue
+
+      return {
+        activePath: discoveredPaths[0] ?? null,
+        discoveredPaths,
+        hasConflict: discoveredPaths.length > 1,
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return {
+    activePath: null,
+    discoveredPaths: [],
+    hasConflict: false,
+  }
+}
+
+export async function executeLookupCommand(command: string[]): Promise<CommandExecutionResult> {
+  const proc = spawnWithWindowsHide(command, { stdout: "pipe", stderr: "pipe" })
+  const stdout = await new Response(proc.stdout).text()
+  await proc.exited
+  return { exitCode: proc.exitCode, stdout }
+}

--- a/src/cli/doctor/checks/tools.ts
+++ b/src/cli/doctor/checks/tools.ts
@@ -1,4 +1,5 @@
 import { checkAstGrepCli, checkAstGrepNapi, checkCommentChecker } from "./dependencies"
+import { executeLookupCommand, resolveClaudeBinaryDiagnostics } from "./tools-claude-binary"
 import { getGhCliInfo } from "./tools-gh"
 import { getLspServerStats, getLspServersInfo } from "./tools-lsp"
 import { getBuiltinMcpInfo, getUserMcpInfo } from "./tools-mcp"
@@ -34,7 +35,10 @@ export async function gatherToolsSummary(): Promise<ToolsSummary> {
   }
 }
 
-function buildToolIssues(summary: ToolsSummary): DoctorIssue[] {
+function buildToolIssues(
+  summary: ToolsSummary,
+  claudeDiagnostics: { hasConflict: boolean; discoveredPaths: string[] },
+): DoctorIssue[] {
   const issues: DoctorIssue[] = []
 
   if (!summary.astGrepCli && !summary.astGrepNapi) {
@@ -84,14 +88,27 @@ function buildToolIssues(summary: ToolsSummary): DoctorIssue[] {
     })
   }
 
+  if (claudeDiagnostics.hasConflict) {
+    issues.push({
+      title: "Multiple Claude CLI binaries detected",
+      description:
+        "More than one claude executable is available in PATH. On macOS/Linux this can cause token refresh/auth inconsistencies when different shells resolve different binaries.",
+      fix:
+        "Keep one claude install, ensure your shell resolves the intended binary first (which -a claude), then restart terminal sessions.",
+      severity: "warning",
+      affects: ["Claude login", "Token refresh"],
+    })
+  }
+
   return issues
 }
 
 export async function checkTools(): Promise<CheckResult> {
   const summary = await gatherToolsSummary()
+  const claudeDiagnostics = await resolveClaudeBinaryDiagnostics(executeLookupCommand)
   const userMcpServers = getUserMcpInfo()
   const invalidUserMcpServers = userMcpServers.filter((server) => !server.valid)
-  const issues = buildToolIssues(summary)
+  const issues = buildToolIssues(summary, claudeDiagnostics)
 
   if (invalidUserMcpServers.length > 0) {
     issues.push({
@@ -112,6 +129,7 @@ export async function checkTools(): Promise<CheckResult> {
       `LSP: ${summary.lspInstalled}/${summary.lspTotal}`,
       `GH CLI: ${summary.ghCli.installed ? "installed" : "missing"}${summary.ghCli.authenticated ? " (authenticated)" : ""}`,
       `MCP: builtin=${summary.mcpBuiltin.length}, user=${summary.mcpUser.length}`,
+      `Claude CLI paths: ${claudeDiagnostics.discoveredPaths.length > 0 ? claudeDiagnostics.discoveredPaths.length : 0}${claudeDiagnostics.activePath ? ` (active: ${claudeDiagnostics.activePath})` : ""}`,
     ],
     issues,
   }


### PR DESCRIPTION
## Summary
- add a new doctor check to detect multiple `claude` binaries resolved from PATH and warn about auth/token-refresh instability on macOS/Linux
- include detailed doctor output for Claude binary path count + active path so users can quickly diagnose path shadowing
- document recovery steps for `Token refresh failed: 429` / `Failed to authorize` in CLI troubleshooting

## Why
Users reported cross-platform auth instability where macOS and Ubuntu failed with `Token refresh failed: 429` / `Failed to authorize` while Windows remained stable. A recurring cause is conflicting `claude` binaries in PATH (shell-dependent resolution), which currently has low visibility in OMO diagnostics.

## Validation
- `bun test src/cli/doctor/checks/tools-claude-binary.test.ts`
- `bun run typecheck`
- `bun run build`

Closes #2708

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a doctor check that detects multiple `claude` binaries in PATH and warns to prevent auth/token-refresh 429 errors on macOS/Linux. Also shows the active path and path count in Tools output, and adds CLI troubleshooting steps. Addresses #2708.

- **New Features**
  - New doctor check runs `which -a`/`where` to list `claude` binaries, de-duplicates, reports `activePath`, and warns on conflicts.
  - Tools summary now shows: Claude CLI paths count and the active path to highlight PATH shadowing.
  - CLI docs updated with recovery steps for `Token refresh failed: 429` / `Failed to authorize`, including `which -a claude` and cleanup guidance.

<sup>Written for commit c69ea6e35b0344ec084400fdc1d477d786782ee2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

