### PR TITLE
fix(runtime-fallback): detect bare 429 rate-limit signals (fixes #2677)

### DIFF
--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -31,6 +31,20 @@ describe("runtime-fallback error classifier", () => {
     expect(signal).toBeDefined()
   })
 
+  test("detects too-many-requests auto-retry status signals without countdown text", () => {
+    //#given
+    const info = {
+      status:
+        "Too Many Requests: Sorry, you've exhausted this model's rate limit. Please try a different model.",
+    }
+
+    //#when
+    const signal = extractAutoRetrySignal(info)
+
+    //#then
+    expect(signal).toBeDefined()
+  })
+
   test("treats cooling-down retry messages as retryable", () => {
     //#given
     const error = {

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -145,7 +145,7 @@ export function extractAutoRetrySignal(info: Record<string, unknown> | undefined
   const combined = candidates.join("\n")
   if (!combined) return undefined
 
-  const isAutoRetry = AUTO_RETRY_PATTERNS.every((test) => test(combined))
+  const isAutoRetry = AUTO_RETRY_PATTERNS.some((test) => test(combined))
   if (isAutoRetry) {
     return { signal: combined }
   }

--- a/src/hooks/runtime-fallback/message-update-handler.test.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import type { RuntimeFallbackPluginInput } from "./types"
 import { hasVisibleAssistantResponse } from "./visible-assistant-response"
+import { extractAutoRetrySignal } from "./error-classifier"
 
 function createContext(messagesResponse: unknown): RuntimeFallbackPluginInput {
   return {
@@ -52,5 +53,30 @@ describe("hasVisibleAssistantResponse", () => {
 
     // then
     expect(result).toBe(true)
+  })
+
+  it("#given a too-many-requests assistant reply #when visibility is checked #then it is treated as an auto-retry signal", async () => {
+    // given
+    const checkVisibleResponse = hasVisibleAssistantResponse(extractAutoRetrySignal)
+    const ctx = createContext({
+      data: [
+        { info: { role: "user" }, parts: [{ type: "text", text: "latest question" }] },
+        {
+          info: { role: "assistant" },
+          parts: [
+            {
+              type: "text",
+              text: "Too Many Requests: Sorry, you've exhausted this model's rate limit. Please try a different model.",
+            },
+          ],
+        },
+      ],
+    })
+
+    // when
+    const result = await checkVisibleResponse(ctx, "session-rate-limit", undefined)
+
+    // then
+    expect(result).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Treat plain \"Too Many Requests\" / rate-limit provider messages as runtime auto-retry signals, even when no \"retrying in\" countdown is present.
- Prevent these assistant messages from being treated as successful visible responses so fallback timeout/retry flow stays active.
- Add regression tests for both signal extraction and assistant-response visibility behavior.

## Problem
Issue #2677 reports that when providers return a 429-style message like \"Too Many Requests\", sessions can get stuck instead of progressing via runtime fallback. The previous auto-retry signal detection required both a rate-limit phrase and a \"retrying in\" phrase, so bare 429 messages were missed.

## Fix
I updated runtime fallback signal classification so either known rate-limit text or explicit retry-countdown text is enough to mark the message as an auto-retry signal. This keeps runtime fallback engaged for bare 429 responses and avoids incorrectly clearing fallback wait state. I also added targeted tests covering the reported 429 phrasing and visibility handling to prevent regressions.

## Changes
| File | Change |
|------|--------|
| `src/hooks/runtime-fallback/error-classifier.ts` | Changed auto-retry signal matching from requiring all patterns to accepting any retry/rate-limit signal. |
| `src/hooks/runtime-fallback/error-classifier.test.ts` | Added regression test for plain \"Too Many Requests\" signal detection. |
| `src/hooks/runtime-fallback/message-update-handler.test.ts` | Added regression test to ensure bare 429 assistant text is not treated as a visible final response. |

Fixes #2677

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects plain "Too Many Requests" responses as auto-retry signals and stops them from being treated as final assistant replies. Keeps runtime fallback moving instead of hanging. Fixes #2677.

- **Bug Fixes**
  - Updated auto-retry detection to match any rate-limit or retry-countdown text, so bare 429 messages trigger fallback.
  - Prevented "Too Many Requests" replies from counting as visible responses; added regression tests for detection and visibility.

<sup>Written for commit 3773e370ec278cfb551e3246b4b698484549f09c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

