### PR TITLE
fix(fallback): handle Claude token refresh/auth failures as retryable

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -232,6 +232,24 @@ bunx oh-my-opencode doctor --verbose
 bunx oh-my-opencode doctor --category authentication
 ```
 
+### "Token refresh failed: 429" or "Failed to authorize"
+
+This usually means your shell resolves multiple `claude` binaries (for example `~/.local/bin/claude` and `/usr/local/bin/claude`) or you have stale local OAuth cache.
+
+```bash
+# Inspect resolved binaries
+which -a claude
+
+# Diagnose with doctor (Tools section will warn on multiple Claude binaries)
+bunx oh-my-opencode doctor --verbose
+```
+
+Recommended recovery:
+
+1. Keep a single `claude` installation in PATH precedence.
+2. Close concurrent Claude/OpenCode sessions.
+3. Re-open terminal and login again.
+
 ---
 
 ## Non-Interactive Mode

--- a/src/cli/doctor/checks/tools-claude-binary.test.ts
+++ b/src/cli/doctor/checks/tools-claude-binary.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test"
+import {
+  parseLookupOutput,
+  resolveClaudeBinaryDiagnostics,
+  type CommandExecutionResult,
+} from "./tools-claude-binary"
+
+describe("tools-claude-binary", () => {
+  describe("parseLookupOutput", () => {
+    it("deduplicates and trims lookup output", () => {
+      const output = " /usr/local/bin/claude \n/Users/me/.local/bin/claude\n/usr/local/bin/claude\n"
+      const result = parseLookupOutput(output)
+      expect(result).toEqual(["/usr/local/bin/claude", "/Users/me/.local/bin/claude"])
+    })
+  })
+
+  describe("resolveClaudeBinaryDiagnostics", () => {
+    it("reports conflict when multiple binaries are returned", async () => {
+      const executeCommand = async (_command: string[]): Promise<CommandExecutionResult> => ({
+        exitCode: 0,
+        stdout: "/Users/me/.local/bin/claude\n/usr/local/bin/claude\n",
+      })
+      const result = await resolveClaudeBinaryDiagnostics(executeCommand)
+      expect(result.activePath).toBe("/Users/me/.local/bin/claude")
+      expect(result.discoveredPaths.length).toBe(2)
+      expect(result.hasConflict).toBe(true)
+    })
+
+    it("returns empty diagnostics when no lookup command succeeds", async () => {
+      const executeCommand = async (_command: string[]): Promise<CommandExecutionResult> => {
+        throw new Error("missing")
+      }
+      const result = await resolveClaudeBinaryDiagnostics(executeCommand)
+      expect(result.activePath).toBeNull()
+      expect(result.discoveredPaths).toEqual([])
+      expect(result.hasConflict).toBe(false)
+    })
+  })
+})

--- a/src/cli/doctor/checks/tools-claude-binary.ts
+++ b/src/cli/doctor/checks/tools-claude-binary.ts
@@ -1,0 +1,73 @@
+import { spawnWithWindowsHide } from "../../../shared/spawn-with-windows-hide"
+
+export interface ClaudeBinaryDiagnostics {
+  activePath: string | null
+  discoveredPaths: string[]
+  hasConflict: boolean
+}
+
+export interface CommandExecutionResult {
+  exitCode: number | null
+  stdout: string
+}
+
+export type CommandExecutor = (command: string[]) => Promise<CommandExecutionResult>
+
+const LOOKUP_COMMAND_CANDIDATES = [
+  ["where", "claude"],
+  ["which", "-a", "claude"],
+  ["which", "claude"],
+]
+
+function uniquePaths(paths: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const path of paths) {
+    const trimmed = path.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    result.push(trimmed)
+  }
+
+  return result
+}
+
+export function parseLookupOutput(output: string): string[] {
+  return uniquePaths(output.split(/\r?\n/))
+}
+
+export async function resolveClaudeBinaryDiagnostics(
+  executeCommand: CommandExecutor,
+): Promise<ClaudeBinaryDiagnostics> {
+  for (const command of LOOKUP_COMMAND_CANDIDATES) {
+    try {
+      const result = await executeCommand(command)
+      if (result.exitCode !== 0) continue
+
+      const discoveredPaths = parseLookupOutput(result.stdout)
+      if (discoveredPaths.length === 0) continue
+
+      return {
+        activePath: discoveredPaths[0] ?? null,
+        discoveredPaths,
+        hasConflict: discoveredPaths.length > 1,
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return {
+    activePath: null,
+    discoveredPaths: [],
+    hasConflict: false,
+  }
+}
+
+export async function executeLookupCommand(command: string[]): Promise<CommandExecutionResult> {
+  const proc = spawnWithWindowsHide(command, { stdout: "pipe", stderr: "pipe" })
+  const stdout = await new Response(proc.stdout).text()
+  await proc.exited
+  return { exitCode: proc.exitCode, stdout }
+}

--- a/src/cli/doctor/checks/tools.ts
+++ b/src/cli/doctor/checks/tools.ts
@@ -1,4 +1,5 @@
 import { checkAstGrepCli, checkAstGrepNapi, checkCommentChecker } from "./dependencies"
+import { executeLookupCommand, resolveClaudeBinaryDiagnostics } from "./tools-claude-binary"
 import { getGhCliInfo } from "./tools-gh"
 import { getLspServerStats, getLspServersInfo } from "./tools-lsp"
 import { getBuiltinMcpInfo, getUserMcpInfo } from "./tools-mcp"
@@ -34,7 +35,10 @@ export async function gatherToolsSummary(): Promise<ToolsSummary> {
   }
 }
 
-function buildToolIssues(summary: ToolsSummary): DoctorIssue[] {
+function buildToolIssues(
+  summary: ToolsSummary,
+  claudeDiagnostics: { hasConflict: boolean; discoveredPaths: string[] },
+): DoctorIssue[] {
   const issues: DoctorIssue[] = []
 
   if (!summary.astGrepCli && !summary.astGrepNapi) {
@@ -84,14 +88,27 @@ function buildToolIssues(summary: ToolsSummary): DoctorIssue[] {
     })
   }
 
+  if (claudeDiagnostics.hasConflict) {
+    issues.push({
+      title: "Multiple Claude CLI binaries detected",
+      description:
+        "More than one claude executable is available in PATH. On macOS/Linux this can cause token refresh/auth inconsistencies when different shells resolve different binaries.",
+      fix:
+        "Keep one claude install, ensure your shell resolves the intended binary first (which -a claude), then restart terminal sessions.",
+      severity: "warning",
+      affects: ["Claude login", "Token refresh"],
+    })
+  }
+
   return issues
 }
 
 export async function checkTools(): Promise<CheckResult> {
   const summary = await gatherToolsSummary()
+  const claudeDiagnostics = await resolveClaudeBinaryDiagnostics(executeLookupCommand)
   const userMcpServers = getUserMcpInfo()
   const invalidUserMcpServers = userMcpServers.filter((server) => !server.valid)
-  const issues = buildToolIssues(summary)
+  const issues = buildToolIssues(summary, claudeDiagnostics)
 
   if (invalidUserMcpServers.length > 0) {
     issues.push({
@@ -112,6 +129,7 @@ export async function checkTools(): Promise<CheckResult> {
       `LSP: ${summary.lspInstalled}/${summary.lspTotal}`,
       `GH CLI: ${summary.ghCli.installed ? "installed" : "missing"}${summary.ghCli.authenticated ? " (authenticated)" : ""}`,
       `MCP: builtin=${summary.mcpBuiltin.length}, user=${summary.mcpUser.length}`,
+      `Claude CLI paths: ${claudeDiagnostics.discoveredPaths.length > 0 ? claudeDiagnostics.discoveredPaths.length : 0}${claudeDiagnostics.activePath ? ` (active: ${claudeDiagnostics.activePath})` : ""}`,
     ],
     issues,
   }

--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -34,6 +34,8 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /service.?unavailable/i,
   /overloaded/i,
   /temporarily.?unavailable/i,
+  /token\s+refresh\s+failed/i,
+  /failed\s+to\s+authorize/i,
   /try.?again/i,
   /credit.*balance.*too.*low/i,
   /insufficient.?(?:credits?|funds?|balance)/i,

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -31,6 +31,32 @@ describe("runtime-fallback error classifier", () => {
     expect(signal).toBeDefined()
   })
 
+  test("detects token refresh 429 as auto-retry signal", () => {
+    //#given
+    const info = {
+      status: "Error: Token refresh failed: 429",
+    }
+
+    //#when
+    const signal = extractAutoRetrySignal(info)
+
+    //#then
+    expect(signal).toBeDefined()
+  })
+
+  test("detects failed to authorize as auto-retry signal", () => {
+    //#given
+    const info = {
+      message: "Failed to authorize",
+    }
+
+    //#when
+    const signal = extractAutoRetrySignal(info)
+
+    //#then
+    expect(signal).toBeDefined()
+  })
+
   test("treats cooling-down retry messages as retryable", () => {
     //#given
     const error = {

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "bun:test"
+declare const require: (name: string) => any
+const { describe, expect, test } = require("bun:test")
 
 import { classifyErrorType, extractAutoRetrySignal, isRetryableError } from "./error-classifier"
 
@@ -62,6 +63,19 @@ describe("runtime-fallback error classifier", () => {
     const error = {
       message:
         "All credentials for model claude-opus-4-6-thinking are cooling down [retrying in ~5 days attempt #1]",
+    }
+
+    //#when
+    const retryable = isRetryableError(error, [400, 403, 408, 429, 500, 502, 503, 504, 529])
+
+    //#then
+    expect(retryable).toBe(true)
+  })
+
+  test("treats failed to authorize message as retryable for session.error path", () => {
+    //#given
+    const error = {
+      message: "Failed to authorize",
     }
 
     //#when

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -112,7 +112,7 @@ export interface AutoRetrySignal {
 export const AUTO_RETRY_PATTERNS: Array<(combined: string) => boolean> = [
   (combined) => /retrying\s+in/i.test(combined),
   (combined) =>
-    /(?:too\s+many\s+requests|quota\s*exceeded|quota\s+will\s+reset\s+after|usage\s+limit|rate\s+limit|limit\s+reached|all\s+credentials\s+for\s+model|cool(?:ing)?\s*down|exhausted\s+your\s+capacity)/i.test(combined),
+    /(?:too\s+many\s+requests|quota\s*exceeded|quota\s+will\s+reset\s+after|usage\s+limit|rate\s+limit|limit\s+reached|all\s+credentials\s+for\s+model|cool(?:ing)?\s*down|exhausted\s+your\s+capacity|token\s+refresh\s+failed|failed\s+to\s+authorize)/i.test(combined),
 ]
 
 export function extractAutoRetrySignal(info: Record<string, unknown> | undefined): AutoRetrySignal | undefined {
@@ -135,7 +135,7 @@ export function extractAutoRetrySignal(info: Record<string, unknown> | undefined
   const combined = candidates.join("\n")
   if (!combined) return undefined
 
-  const isAutoRetry = AUTO_RETRY_PATTERNS.every((test) => test(combined))
+  const isAutoRetry = AUTO_RETRY_PATTERNS.some((test) => test(combined))
   if (isAutoRetry) {
     return { signal: combined }
   }

--- a/src/shared/model-error-classifier.test.ts
+++ b/src/shared/model-error-classifier.test.ts
@@ -40,6 +40,28 @@ describe("model-error-classifier", () => {
     expect(result).toBe(true)
   })
 
+  test("treats token refresh 429 message as retryable", () => {
+    //#given
+    const error = { message: "Error: Token refresh failed: 429" }
+
+    //#when
+    const result = shouldRetryError(error)
+
+    //#then
+    expect(result).toBe(true)
+  })
+
+  test("treats failed to authorize message as retryable", () => {
+    //#given
+    const error = { message: "Failed to authorize" }
+
+    //#when
+    const result = shouldRetryError(error)
+
+    //#then
+    expect(result).toBe(true)
+  })
+
   test("selectFallbackProvider prefers first connected provider in preference order", () => {
     //#given
     readConnectedProvidersCacheMock.mockReturnValue(["anthropic", "nvidia"])

--- a/src/shared/model-error-classifier.ts
+++ b/src/shared/model-error-classifier.ts
@@ -56,6 +56,8 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   "timeout",
   "service unavailable",
   "internal_server_error",
+  "token refresh failed",
+  "failed to authorize",
   "free usage",
   "usage exceeded",
   "credit",


### PR DESCRIPTION
## Summary
- close the previous diagnostics-only approach and implement runtime/shared classifier fixes for real recovery paths
- treat `Token refresh failed: 429` and `Failed to authorize` as retryable signals in runtime-fallback and shared model fallback classifiers
- add regression tests covering auto-retry signal detection and retryability classification for these auth failure strings

## Why
The previous PR only improved diagnostics and did not resolve repeated Claude conversation failures. This update makes the fallback system consistently classify these failures as retryable so model fallback paths can engage.

## Validation
- bun test src/hooks/runtime-fallback/error-classifier.test.ts src/shared/model-error-classifier.test.ts
- bun run typecheck
- bun run build

Closes #2708

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Claude token refresh/auth failures as retryable so fallback can auto-switch models, and add a doctor check to detect conflicting `claude` binaries. Fixes #2708 by preventing stuck sessions and guiding users to resolve PATH issues.

- **Bug Fixes**
  - Mark "Token refresh failed: 429" and "Failed to authorize" as retryable and auto-retry signals in runtime and shared classifiers to trigger model fallback.
  - Auto-retry detection now matches any known pattern (not all).
  - Added tests for signal detection and retryability.

- **New Features**
  - `oh-my-opencode doctor` checks for multiple `claude` binaries and warns on conflicts; shows the active path in the summary.
  - Docs add recovery steps for these auth errors.

<sup>Written for commit 960d3f8fa26590d822368223cf50c40383f731e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

