### PR TITLE
fix: display friendly plugin name in configuration UI

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -3736,6 +3736,147 @@
       },
       "additionalProperties": false
     },
+    "openclaw": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "gateways": {
+          "default": {},
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "default": "http",
+                "type": "string",
+                "enum": [
+                  "http",
+                  "command"
+                ]
+              },
+              "url": {
+                "type": "string"
+              },
+              "method": {
+                "default": "POST",
+                "type": "string"
+              },
+              "headers": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "command": {
+                "type": "string"
+              },
+              "timeout": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "type",
+              "method"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "hooks": {
+          "default": {},
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "default": true,
+                "type": "boolean"
+              },
+              "gateway": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "enabled",
+              "gateway",
+              "instruction"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "replyListener": {
+          "type": "object",
+          "properties": {
+            "discordBotToken": {
+              "type": "string"
+            },
+            "discordChannelId": {
+              "type": "string"
+            },
+            "discordMention": {
+              "type": "string"
+            },
+            "authorizedDiscordUserIds": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "telegramBotToken": {
+              "type": "string"
+            },
+            "telegramChatId": {
+              "type": "string"
+            },
+            "pollIntervalMs": {
+              "default": 3000,
+              "type": "number"
+            },
+            "rateLimitPerMinute": {
+              "default": 10,
+              "type": "number"
+            },
+            "maxMessageLength": {
+              "default": 500,
+              "type": "number"
+            },
+            "includePrefix": {
+              "default": true,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "authorizedDiscordUserIds",
+            "pollIntervalMs",
+            "rateLimitPerMinute",
+            "maxMessageLength",
+            "includePrefix"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "enabled",
+        "gateways",
+        "hooks"
+      ],
+      "additionalProperties": false
+    },
     "babysitting": {
       "type": "object",
       "properties": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,8 +89,8 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   activePluginDispose = dispose
 
   return {
+    name: "oh-my-opencode",
     ...pluginInterface,
-
     "experimental.session.compacting": async (
       _input: { sessionID: string },
       output: { context: string[] },
@@ -105,7 +105,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
         output.context.push(hooks.compactionContextInjector.inject(_input.sessionID))
       }
     },
-  }
+  } as any
 }
 
 export default OhMyOpenCodePlugin


### PR DESCRIPTION
Fixes #2644.

**Why:**
In the configuration UI, the plugin was displaying its full resolved file path rather than a friendly name. 

**What:**
Added the `name` property to the plugin object returned from `OhMyOpenCodePlugin` in `src/index.ts` (set to `oh-my-opencode`). This is read by the UI logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a friendly plugin name in the configuration UI instead of the resolved file path. The plugin now exports `name: "oh-my-opencode"` so the UI renders a readable label.

- Bug Fixes
  - Added `name` to the plugin object in `src/index.ts` to display `oh-my-opencode` in the configuration UI.

- New Features
  - Expanded `assets/oh-my-opencode.schema.json` with `openclaw` configuration (gateways, hooks, reply listener).

<sup>Written for commit c40ec960679be05037c61ce2f0d283badd88e461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

