### PR TITLE
fix(background-agent): decrement spawn budget on task completion, cancellation, error, and interrupt

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -1,162 +1,167 @@
-declare const require: (name: string) => any
-const { describe, test, expect, beforeEach, afterEach } = require("bun:test")
-import { tmpdir } from "node:os"
-import type { PluginInput } from "@opencode-ai/plugin"
-import type { BackgroundTask, ResumeInput } from "./types"
-import { MIN_IDLE_TIME_MS } from "./constants"
-import { BackgroundManager } from "./manager"
-import { ConcurrencyManager } from "./concurrency"
-import { initTaskToastManager, _resetTaskToastManagerForTesting } from "../task-toast-manager/manager"
+declare const require: (name: string) => any;
+const { describe, test, expect, beforeEach, afterEach } = require("bun:test");
 
+import { tmpdir } from "node:os";
+import type { PluginInput } from "@opencode-ai/plugin";
+import {
+  _resetTaskToastManagerForTesting,
+  initTaskToastManager,
+} from "../task-toast-manager/manager";
+import type { ConcurrencyManager } from "./concurrency";
+import { MIN_IDLE_TIME_MS } from "./constants";
+import { BackgroundManager } from "./manager";
+import type { BackgroundTask, ResumeInput } from "./types";
 
-const TASK_TTL_MS = 30 * 60 * 1000
+const TASK_TTL_MS = 30 * 60 * 1000;
 
 class MockBackgroundManager {
-  private tasks: Map<string, BackgroundTask> = new Map()
-  private notifications: Map<string, BackgroundTask[]> = new Map()
-  public resumeCalls: Array<{ sessionId: string; prompt: string }> = []
+  private tasks: Map<string, BackgroundTask> = new Map();
+  private notifications: Map<string, BackgroundTask[]> = new Map();
+  public resumeCalls: Array<{ sessionId: string; prompt: string }> = [];
 
   addTask(task: BackgroundTask): void {
-    this.tasks.set(task.id, task)
+    this.tasks.set(task.id, task);
   }
 
   getTask(id: string): BackgroundTask | undefined {
-    return this.tasks.get(id)
+    return this.tasks.get(id);
   }
 
   findBySession(sessionID: string): BackgroundTask | undefined {
     for (const task of this.tasks.values()) {
       if (task.sessionID === sessionID) {
-        return task
+        return task;
       }
     }
-    return undefined
+    return undefined;
   }
 
   getTasksByParentSession(sessionID: string): BackgroundTask[] {
-    const result: BackgroundTask[] = []
+    const result: BackgroundTask[] = [];
     for (const task of this.tasks.values()) {
       if (task.parentSessionID === sessionID) {
-        result.push(task)
+        result.push(task);
       }
     }
-    return result
+    return result;
   }
 
   getAllDescendantTasks(sessionID: string): BackgroundTask[] {
-    const result: BackgroundTask[] = []
-    const directChildren = this.getTasksByParentSession(sessionID)
+    const result: BackgroundTask[] = [];
+    const directChildren = this.getTasksByParentSession(sessionID);
 
     for (const child of directChildren) {
-      result.push(child)
+      result.push(child);
       if (child.sessionID) {
-        const descendants = this.getAllDescendantTasks(child.sessionID)
-        result.push(...descendants)
+        const descendants = this.getAllDescendantTasks(child.sessionID);
+        result.push(...descendants);
       }
     }
 
-    return result
+    return result;
   }
 
   markForNotification(task: BackgroundTask): void {
-    const queue = this.notifications.get(task.parentSessionID) ?? []
-    queue.push(task)
-    this.notifications.set(task.parentSessionID, queue)
+    const queue = this.notifications.get(task.parentSessionID) ?? [];
+    queue.push(task);
+    this.notifications.set(task.parentSessionID, queue);
   }
 
   getPendingNotifications(sessionID: string): BackgroundTask[] {
-    return this.notifications.get(sessionID) ?? []
+    return this.notifications.get(sessionID) ?? [];
   }
 
   private clearNotificationsForTask(taskId: string): void {
     for (const [sessionID, tasks] of this.notifications.entries()) {
-      const filtered = tasks.filter((t) => t.id !== taskId)
+      const filtered = tasks.filter((t) => t.id !== taskId);
       if (filtered.length === 0) {
-        this.notifications.delete(sessionID)
+        this.notifications.delete(sessionID);
       } else {
-        this.notifications.set(sessionID, filtered)
+        this.notifications.set(sessionID, filtered);
       }
     }
   }
 
   pruneStaleTasksAndNotifications(): { prunedTasks: string[]; prunedNotifications: number } {
-    const now = Date.now()
-    const prunedTasks: string[] = []
-    let prunedNotifications = 0
+    const now = Date.now();
+    const prunedTasks: string[] = [];
+    let prunedNotifications = 0;
 
     for (const [taskId, task] of this.tasks.entries()) {
-      if (!task.startedAt) continue
-      const age = now - task.startedAt.getTime()
+      if (!task.startedAt) continue;
+      const age = now - task.startedAt.getTime();
       if (age > TASK_TTL_MS) {
-        prunedTasks.push(taskId)
-        this.clearNotificationsForTask(taskId)
-        this.tasks.delete(taskId)
+        prunedTasks.push(taskId);
+        this.clearNotificationsForTask(taskId);
+        this.tasks.delete(taskId);
       }
     }
 
     for (const [sessionID, notifications] of this.notifications.entries()) {
       if (notifications.length === 0) {
-        this.notifications.delete(sessionID)
-        continue
+        this.notifications.delete(sessionID);
+        continue;
       }
       const validNotifications = notifications.filter((task) => {
-        if (!task.startedAt) return false
-        const age = now - task.startedAt.getTime()
-        return age <= TASK_TTL_MS
-      })
-      const removed = notifications.length - validNotifications.length
-      prunedNotifications += removed
+        if (!task.startedAt) return false;
+        const age = now - task.startedAt.getTime();
+        return age <= TASK_TTL_MS;
+      });
+      const removed = notifications.length - validNotifications.length;
+      prunedNotifications += removed;
       if (validNotifications.length === 0) {
-        this.notifications.delete(sessionID)
+        this.notifications.delete(sessionID);
       } else if (validNotifications.length !== notifications.length) {
-        this.notifications.set(sessionID, validNotifications)
+        this.notifications.set(sessionID, validNotifications);
       }
     }
 
-    return { prunedTasks, prunedNotifications }
+    return { prunedTasks, prunedNotifications };
   }
 
   getTaskCount(): number {
-    return this.tasks.size
+    return this.tasks.size;
   }
 
   getNotificationCount(): number {
-    let count = 0
+    let count = 0;
     for (const notifications of this.notifications.values()) {
-      count += notifications.length
+      count += notifications.length;
     }
-    return count
+    return count;
   }
 
   resume(input: ResumeInput): BackgroundTask {
-    const existingTask = this.findBySession(input.sessionId)
+    const existingTask = this.findBySession(input.sessionId);
     if (!existingTask) {
-      throw new Error(`Task not found for session: ${input.sessionId}`)
+      throw new Error(`Task not found for session: ${input.sessionId}`);
     }
 
     if (existingTask.status === "running") {
-      return existingTask
+      return existingTask;
     }
 
-    this.resumeCalls.push({ sessionId: input.sessionId, prompt: input.prompt })
+    this.resumeCalls.push({ sessionId: input.sessionId, prompt: input.prompt });
 
-    existingTask.status = "running"
-    existingTask.completedAt = undefined
-    existingTask.error = undefined
-    existingTask.parentSessionID = input.parentSessionID
-    existingTask.parentMessageID = input.parentMessageID
-    existingTask.parentModel = input.parentModel
+    existingTask.status = "running";
+    existingTask.completedAt = undefined;
+    existingTask.error = undefined;
+    existingTask.parentSessionID = input.parentSessionID;
+    existingTask.parentMessageID = input.parentMessageID;
+    existingTask.parentModel = input.parentModel;
 
     existingTask.progress = {
       toolCalls: existingTask.progress?.toolCalls ?? 0,
       lastUpdate: new Date(),
-    }
+    };
 
-    return existingTask
+    return existingTask;
   }
 }
 
-function createMockTask(overrides: Partial<BackgroundTask> & { id: string; sessionID: string; parentSessionID: string }): BackgroundTask {
+function createMockTask(
+  overrides: Partial<BackgroundTask> & { id: string; sessionID: string; parentSessionID: string },
+): BackgroundTask {
   return {
     parentMessageID: "mock-message-id",
     description: "test task",
@@ -165,7 +170,7 @@ function createMockTask(overrides: Partial<BackgroundTask> & { id: string; sessi
     status: "running",
     startedAt: new Date(),
     ...overrides,
-  }
+  };
 }
 
 function createBackgroundManager(): BackgroundManager {
@@ -175,108 +180,135 @@ function createBackgroundManager(): BackgroundManager {
       promptAsync: async () => ({}),
       abort: async () => ({}),
     },
-  }
-  return new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+  };
+  return new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput);
 }
 
 function getConcurrencyManager(manager: BackgroundManager): ConcurrencyManager {
-  return (manager as unknown as { concurrencyManager: ConcurrencyManager }).concurrencyManager
+  return (manager as unknown as { concurrencyManager: ConcurrencyManager }).concurrencyManager;
 }
 
 function getTaskMap(manager: BackgroundManager): Map<string, BackgroundTask> {
-  return (manager as unknown as { tasks: Map<string, BackgroundTask> }).tasks
+  return (manager as unknown as { tasks: Map<string, BackgroundTask> }).tasks;
 }
 
 function getPendingByParent(manager: BackgroundManager): Map<string, Set<string>> {
-  return (manager as unknown as { pendingByParent: Map<string, Set<string>> }).pendingByParent
+  return (manager as unknown as { pendingByParent: Map<string, Set<string>> }).pendingByParent;
 }
 
 function getPendingNotifications(manager: BackgroundManager): Map<string, string[]> {
-  return (manager as unknown as { pendingNotifications: Map<string, string[]> }).pendingNotifications
+  return (manager as unknown as { pendingNotifications: Map<string, string[]> })
+    .pendingNotifications;
 }
 
-function getCompletionTimers(manager: BackgroundManager): Map<string, ReturnType<typeof setTimeout>> {
-  return (manager as unknown as { completionTimers: Map<string, ReturnType<typeof setTimeout>> }).completionTimers
+function getCompletionTimers(
+  manager: BackgroundManager,
+): Map<string, ReturnType<typeof setTimeout>> {
+  return (manager as unknown as { completionTimers: Map<string, ReturnType<typeof setTimeout>> })
+    .completionTimers;
 }
 
 function getQueuesByKey(
-  manager: BackgroundManager
+  manager: BackgroundManager,
 ): Map<string, Array<{ task: BackgroundTask; input: import("./types").LaunchInput }>> {
-  return (manager as unknown as {
-    queuesByKey: Map<string, Array<{ task: BackgroundTask; input: import("./types").LaunchInput }>>
-  }).queuesByKey
+  return (
+    manager as unknown as {
+      queuesByKey: Map<
+        string,
+        Array<{ task: BackgroundTask; input: import("./types").LaunchInput }>
+      >;
+    }
+  ).queuesByKey;
 }
 
 async function processKeyForTest(manager: BackgroundManager, key: string): Promise<void> {
-  return (manager as unknown as { processKey: (key: string) => Promise<void> }).processKey(key)
+  return (manager as unknown as { processKey: (key: string) => Promise<void> }).processKey(key);
 }
 
 function pruneStaleTasksAndNotificationsForTest(manager: BackgroundManager): void {
-  ;(manager as unknown as { pruneStaleTasksAndNotifications: () => void }).pruneStaleTasksAndNotifications()
+  (
+    manager as unknown as { pruneStaleTasksAndNotifications: () => void }
+  ).pruneStaleTasksAndNotifications();
 }
 
-async function tryCompleteTaskForTest(manager: BackgroundManager, task: BackgroundTask): Promise<boolean> {
-  return (manager as unknown as { tryCompleteTask: (task: BackgroundTask, source: string) => Promise<boolean> })
-    .tryCompleteTask(task, "test")
+async function tryCompleteTaskForTest(
+  manager: BackgroundManager,
+  task: BackgroundTask,
+): Promise<boolean> {
+  return (
+    manager as unknown as {
+      tryCompleteTask: (task: BackgroundTask, source: string) => Promise<boolean>;
+    }
+  ).tryCompleteTask(task, "test");
 }
 
 function stubNotifyParentSession(manager: BackgroundManager): void {
-  ;(manager as unknown as { notifyParentSession: () => Promise<void> }).notifyParentSession = async () => {}
+  (manager as unknown as { notifyParentSession: () => Promise<void> }).notifyParentSession =
+    async () => {};
 }
 
 async function flushBackgroundNotifications(): Promise<void> {
   for (let i = 0; i < 6; i++) {
-    await Promise.resolve()
+    await Promise.resolve();
   }
 }
 
-function createToastRemoveTaskTracker(): { removeTaskCalls: string[]; resetToastManager: () => void } {
-  _resetTaskToastManagerForTesting()
+function createToastRemoveTaskTracker(): {
+  removeTaskCalls: string[];
+  resetToastManager: () => void;
+} {
+  _resetTaskToastManagerForTesting();
   const toastManager = initTaskToastManager({
     tui: { showToast: async () => {} },
-  } as unknown as PluginInput["client"])
-  const removeTaskCalls: string[] = []
-  const originalRemoveTask = toastManager.removeTask.bind(toastManager)
+  } as unknown as PluginInput["client"]);
+  const removeTaskCalls: string[] = [];
+  const originalRemoveTask = toastManager.removeTask.bind(toastManager);
   toastManager.removeTask = (taskId: string): void => {
-    removeTaskCalls.push(taskId)
-    originalRemoveTask(taskId)
-  }
+    removeTaskCalls.push(taskId);
+    originalRemoveTask(taskId);
+  };
   return {
     removeTaskCalls,
     resetToastManager: _resetTaskToastManagerForTesting,
-  }
+  };
 }
 
 function getCleanupSignals(): Array<NodeJS.Signals | "beforeExit" | "exit"> {
-  const signals: Array<NodeJS.Signals | "beforeExit" | "exit"> = ["SIGINT", "SIGTERM", "beforeExit", "exit"]
+  const signals: Array<NodeJS.Signals | "beforeExit" | "exit"> = [
+    "SIGINT",
+    "SIGTERM",
+    "beforeExit",
+    "exit",
+  ];
   if (process.platform === "win32") {
-    signals.push("SIGBREAK")
+    signals.push("SIGBREAK");
   }
-  return signals
+  return signals;
 }
 
-function getListenerCounts(signals: Array<NodeJS.Signals | "beforeExit" | "exit">): Record<string, number> {
-  return Object.fromEntries(signals.map((signal) => [signal, process.listenerCount(signal)]))
+function getListenerCounts(
+  signals: Array<NodeJS.Signals | "beforeExit" | "exit">,
+): Record<string, number> {
+  return Object.fromEntries(signals.map((signal) => [signal, process.listenerCount(signal)]));
 }
-
 
 describe("BackgroundManager.getAllDescendantTasks", () => {
-  let manager: MockBackgroundManager
+  let manager: MockBackgroundManager;
 
   beforeEach(() => {
     // given
-    manager = new MockBackgroundManager()
-  })
+    manager = new MockBackgroundManager();
+  });
 
   test("should return empty array when no tasks exist", () => {
     // given - empty manager
 
     // when
-    const result = manager.getAllDescendantTasks("session-a")
+    const result = manager.getAllDescendantTasks("session-a");
 
     // then
-    expect(result).toEqual([])
-  })
+    expect(result).toEqual([]);
+  });
 
   test("should return direct children only when no nested tasks", () => {
     // given
@@ -284,16 +316,16 @@ describe("BackgroundManager.getAllDescendantTasks", () => {
       id: "task-b",
       sessionID: "session-b",
       parentSessionID: "session-a",
-    })
-    manager.addTask(taskB)
+    });
+    manager.addTask(taskB);
 
     // when
-    const result = manager.getAllDescendantTasks("session-a")
+    const result = manager.getAllDescendantTasks("session-a");
 
     // then
-    expect(result).toHaveLength(1)
-    expect(result[0].id).toBe("task-b")
-  })
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("task-b");
+  });
 
   test("should return all nested descendants (2 levels deep)", () => {
     // given
@@ -302,23 +334,23 @@ describe("BackgroundManager.getAllDescendantTasks", () => {
       id: "task-b",
       sessionID: "session-b",
       parentSessionID: "session-a",
-    })
+    });
     const taskC = createMockTask({
       id: "task-c",
       sessionID: "session-c",
       parentSessionID: "session-b",
-    })
-    manager.addTask(taskB)
-    manager.addTask(taskC)
+    });
+    manager.addTask(taskB);
+    manager.addTask(taskC);
 
     // when
-    const result = manager.getAllDescendantTasks("session-a")
+    const result = manager.getAllDescendantTasks("session-a");
 
     // then
-    expect(result).toHaveLength(2)
-    expect(result.map(t => t.id)).toContain("task-b")
-    expect(result.map(t => t.id)).toContain("task-c")
-  })
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.id)).toContain("task-b");
+    expect(result.map((t) => t.id)).toContain("task-c");
+  });
 
   test("should return all nested descendants (3 levels deep)", () => {
     // given
@@ -327,30 +359,30 @@ describe("BackgroundManager.getAllDescendantTasks", () => {
       id: "task-b",
       sessionID: "session-b",
       parentSessionID: "session-a",
-    })
+    });
     const taskC = createMockTask({
       id: "task-c",
       sessionID: "session-c",
       parentSessionID: "session-b",
-    })
+    });
     const taskD = createMockTask({
       id: "task-d",
       sessionID: "session-d",
       parentSessionID: "session-c",
-    })
-    manager.addTask(taskB)
-    manager.addTask(taskC)
-    manager.addTask(taskD)
+    });
+    manager.addTask(taskB);
+    manager.addTask(taskC);
+    manager.addTask(taskD);
 
     // when
-    const result = manager.getAllDescendantTasks("session-a")
+    const result = manager.getAllDescendantTasks("session-a");
 
     // then
-    expect(result).toHaveLength(3)
-    expect(result.map(t => t.id)).toContain("task-b")
-    expect(result.map(t => t.id)).toContain("task-c")
-    expect(result.map(t => t.id)).toContain("task-d")
-  })
+    expect(result).toHaveLength(3);
+    expect(result.map((t) => t.id)).toContain("task-b");
+    expect(result.map((t) => t.id)).toContain("task-c");
+    expect(result.map((t) => t.id)).toContain("task-d");
+  });
 
   test("should handle multiple branches (tree structure)", () => {
     // given
@@ -360,37 +392,37 @@ describe("BackgroundManager.getAllDescendantTasks", () => {
       id: "task-b1",
       sessionID: "session-b1",
       parentSessionID: "session-a",
-    })
+    });
     const taskB2 = createMockTask({
       id: "task-b2",
       sessionID: "session-b2",
       parentSessionID: "session-a",
-    })
+    });
     const taskC1 = createMockTask({
       id: "task-c1",
       sessionID: "session-c1",
       parentSessionID: "session-b1",
-    })
+    });
     const taskC2 = createMockTask({
       id: "task-c2",
       sessionID: "session-c2",
       parentSessionID: "session-b2",
-    })
-    manager.addTask(taskB1)
-    manager.addTask(taskB2)
-    manager.addTask(taskC1)
-    manager.addTask(taskC2)
+    });
+    manager.addTask(taskB1);
+    manager.addTask(taskB2);
+    manager.addTask(taskC1);
+    manager.addTask(taskC2);
 
     // when
-    const result = manager.getAllDescendantTasks("session-a")
+    const result = manager.getAllDescendantTasks("session-a");
 
     // then
-    expect(result).toHaveLength(4)
-    expect(result.map(t => t.id)).toContain("task-b1")
-    expect(result.map(t => t.id)).toContain("task-b2")
-    expect(result.map(t => t.id)).toContain("task-c1")
-    expect(result.map(t => t.id)).toContain("task-c2")
-  })
+    expect(result).toHaveLength(4);
+    expect(result.map((t) => t.id)).toContain("task-b1");
+    expect(result.map((t) => t.id)).toContain("task-b2");
+    expect(result.map((t) => t.id)).toContain("task-c1");
+    expect(result.map((t) => t.id)).toContain("task-c2");
+  });
 
   test("should not include tasks from unrelated sessions", () => {
     // given
@@ -400,23 +432,23 @@ describe("BackgroundManager.getAllDescendantTasks", () => {
       id: "task-b",
       sessionID: "session-b",
       parentSessionID: "session-a",
-    })
+    });
     const taskY = createMockTask({
       id: "task-y",
       sessionID: "session-y",
       parentSessionID: "session-x",
-    })
-    manager.addTask(taskB)
-    manager.addTask(taskY)
+    });
+    manager.addTask(taskB);
+    manager.addTask(taskY);
 
     // when
-    const result = manager.getAllDescendantTasks("session-a")
+    const result = manager.getAllDescendantTasks("session-a");
 
     // then
-    expect(result).toHaveLength(1)
-    expect(result[0].id).toBe("task-b")
-    expect(result.map(t => t.id)).not.toContain("task-y")
-  })
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("task-b");
+    expect(result.map((t) => t.id)).not.toContain("task-y");
+  });
 
   test("getTasksByParentSession should only return direct children (not recursive)", () => {
     // given
@@ -425,99 +457,99 @@ describe("BackgroundManager.getAllDescendantTasks", () => {
       id: "task-b",
       sessionID: "session-b",
       parentSessionID: "session-a",
-    })
+    });
     const taskC = createMockTask({
       id: "task-c",
       sessionID: "session-c",
       parentSessionID: "session-b",
-    })
-    manager.addTask(taskB)
-    manager.addTask(taskC)
+    });
+    manager.addTask(taskB);
+    manager.addTask(taskC);
 
     // when
-    const result = manager.getTasksByParentSession("session-a")
+    const result = manager.getTasksByParentSession("session-a");
 
     // then
-    expect(result).toHaveLength(1)
-    expect(result[0].id).toBe("task-b")
-  })
-})
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("task-b");
+  });
+});
 
 describe("BackgroundManager.notifyParentSession - release ordering", () => {
   test("should unblock queued task even when prompt hangs", async () => {
     // given - concurrency limit 1, task1 running, task2 waiting
-    const { ConcurrencyManager } = await import("./concurrency")
-    const concurrencyManager = new ConcurrencyManager({ defaultConcurrency: 1 })
+    const { ConcurrencyManager } = await import("./concurrency");
+    const concurrencyManager = new ConcurrencyManager({ defaultConcurrency: 1 });
 
-    await concurrencyManager.acquire("explore")
+    await concurrencyManager.acquire("explore");
 
-    let task2Resolved = false
+    let task2Resolved = false;
     const task2Promise = concurrencyManager.acquire("explore").then(() => {
-      task2Resolved = true
-    })
+      task2Resolved = true;
+    });
 
-    await Promise.resolve()
-    expect(task2Resolved).toBe(false)
+    await Promise.resolve();
+    expect(task2Resolved).toBe(false);
 
     // when - simulate notifyParentSession: release BEFORE prompt (fixed behavior)
-    let promptStarted = false
+    let promptStarted = false;
     const simulateNotifyParentSession = async () => {
-      concurrencyManager.release("explore")
+      concurrencyManager.release("explore");
 
-      promptStarted = true
-      await new Promise(() => {})
-    }
+      promptStarted = true;
+      await new Promise(() => {});
+    };
 
-    simulateNotifyParentSession()
+    simulateNotifyParentSession();
 
-    await Promise.resolve()
-    await Promise.resolve()
+    await Promise.resolve();
+    await Promise.resolve();
 
     // then - task2 should be unblocked even though prompt never completes
-    expect(promptStarted).toBe(true)
-    await task2Promise
-    expect(task2Resolved).toBe(true)
-  })
+    expect(promptStarted).toBe(true);
+    await task2Promise;
+    expect(task2Resolved).toBe(true);
+  });
 
   test("should keep queue blocked if release is after prompt (demonstrates the bug)", async () => {
     // given - same setup
-    const { ConcurrencyManager } = await import("./concurrency")
-    const concurrencyManager = new ConcurrencyManager({ defaultConcurrency: 1 })
+    const { ConcurrencyManager } = await import("./concurrency");
+    const concurrencyManager = new ConcurrencyManager({ defaultConcurrency: 1 });
 
-    await concurrencyManager.acquire("explore")
+    await concurrencyManager.acquire("explore");
 
-    let task2Resolved = false
+    let task2Resolved = false;
     concurrencyManager.acquire("explore").then(() => {
-      task2Resolved = true
-    })
+      task2Resolved = true;
+    });
 
-    await Promise.resolve()
-    expect(task2Resolved).toBe(false)
+    await Promise.resolve();
+    expect(task2Resolved).toBe(false);
 
     // when - simulate BUGGY behavior: release AFTER prompt (in finally)
     const simulateBuggyNotifyParentSession = async () => {
       try {
-        await new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 50))
+        await new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 50));
       } finally {
-        concurrencyManager.release("explore")
+        concurrencyManager.release("explore");
       }
-    }
+    };
 
-    await simulateBuggyNotifyParentSession().catch(() => {})
+    await simulateBuggyNotifyParentSession().catch(() => {});
 
     // then - task2 resolves only after prompt completes (blocked during hang)
-    await Promise.resolve()
-    expect(task2Resolved).toBe(true)
-  })
-})
+    await Promise.resolve();
+    expect(task2Resolved).toBe(true);
+  });
+});
 
 describe("BackgroundManager.pruneStaleTasksAndNotifications", () => {
-  let manager: MockBackgroundManager
+  let manager: MockBackgroundManager;
 
   beforeEach(() => {
     // given
-    manager = new MockBackgroundManager()
-  })
+    manager = new MockBackgroundManager();
+  });
 
   test("should not prune fresh tasks", () => {
     // given
@@ -526,123 +558,125 @@ describe("BackgroundManager.pruneStaleTasksAndNotifications", () => {
       sessionID: "session-fresh",
       parentSessionID: "session-parent",
       startedAt: new Date(),
-    })
-    manager.addTask(task)
+    });
+    manager.addTask(task);
 
     // when
-    const result = manager.pruneStaleTasksAndNotifications()
+    const result = manager.pruneStaleTasksAndNotifications();
 
     // then
-    expect(result.prunedTasks).toHaveLength(0)
-    expect(manager.getTaskCount()).toBe(1)
-  })
+    expect(result.prunedTasks).toHaveLength(0);
+    expect(manager.getTaskCount()).toBe(1);
+  });
 
   test("should prune tasks older than 30 minutes", () => {
     // given
-    const staleDate = new Date(Date.now() - 31 * 60 * 1000)
+    const staleDate = new Date(Date.now() - 31 * 60 * 1000);
     const task = createMockTask({
       id: "task-stale",
       sessionID: "session-stale",
       parentSessionID: "session-parent",
       startedAt: staleDate,
-    })
-    manager.addTask(task)
+    });
+    manager.addTask(task);
 
     // when
-    const result = manager.pruneStaleTasksAndNotifications()
+    const result = manager.pruneStaleTasksAndNotifications();
 
     // then
-    expect(result.prunedTasks).toContain("task-stale")
-    expect(manager.getTaskCount()).toBe(0)
-  })
+    expect(result.prunedTasks).toContain("task-stale");
+    expect(manager.getTaskCount()).toBe(0);
+  });
 
   test("should prune stale notifications", () => {
     // given
-    const staleDate = new Date(Date.now() - 31 * 60 * 1000)
+    const staleDate = new Date(Date.now() - 31 * 60 * 1000);
     const task = createMockTask({
       id: "task-stale",
       sessionID: "session-stale",
       parentSessionID: "session-parent",
       startedAt: staleDate,
-    })
-    manager.markForNotification(task)
+    });
+    manager.markForNotification(task);
 
     // when
-    const result = manager.pruneStaleTasksAndNotifications()
+    const result = manager.pruneStaleTasksAndNotifications();
 
     // then
-    expect(result.prunedNotifications).toBe(1)
-    expect(manager.getNotificationCount()).toBe(0)
-  })
+    expect(result.prunedNotifications).toBe(1);
+    expect(manager.getNotificationCount()).toBe(0);
+  });
 
   test("should clean up notifications when task is pruned", () => {
     // given
-    const staleDate = new Date(Date.now() - 31 * 60 * 1000)
+    const staleDate = new Date(Date.now() - 31 * 60 * 1000);
     const task = createMockTask({
       id: "task-stale",
       sessionID: "session-stale",
       parentSessionID: "session-parent",
       startedAt: staleDate,
-    })
-    manager.addTask(task)
-    manager.markForNotification(task)
+    });
+    manager.addTask(task);
+    manager.markForNotification(task);
 
     // when
-    manager.pruneStaleTasksAndNotifications()
+    manager.pruneStaleTasksAndNotifications();
 
     // then
-    expect(manager.getTaskCount()).toBe(0)
-    expect(manager.getNotificationCount()).toBe(0)
-  })
+    expect(manager.getTaskCount()).toBe(0);
+    expect(manager.getNotificationCount()).toBe(0);
+  });
 
   test("should keep fresh tasks while pruning stale ones", () => {
     // given
-    const staleDate = new Date(Date.now() - 31 * 60 * 1000)
+    const staleDate = new Date(Date.now() - 31 * 60 * 1000);
     const staleTask = createMockTask({
       id: "task-stale",
       sessionID: "session-stale",
       parentSessionID: "session-parent",
       startedAt: staleDate,
-    })
+    });
     const freshTask = createMockTask({
       id: "task-fresh",
       sessionID: "session-fresh",
       parentSessionID: "session-parent",
       startedAt: new Date(),
-    })
-    manager.addTask(staleTask)
-    manager.addTask(freshTask)
+    });
+    manager.addTask(staleTask);
+    manager.addTask(freshTask);
 
     // when
-    const result = manager.pruneStaleTasksAndNotifications()
+    const result = manager.pruneStaleTasksAndNotifications();
 
     // then
-    expect(result.prunedTasks).toHaveLength(1)
-    expect(result.prunedTasks).toContain("task-stale")
-    expect(manager.getTaskCount()).toBe(1)
-    expect(manager.getTask("task-fresh")).toBeDefined()
-  })
-})
+    expect(result.prunedTasks).toHaveLength(1);
+    expect(result.prunedTasks).toContain("task-stale");
+    expect(manager.getTaskCount()).toBe(1);
+    expect(manager.getTask("task-fresh")).toBeDefined();
+  });
+});
 
 describe("BackgroundManager.resume", () => {
-  let manager: MockBackgroundManager
+  let manager: MockBackgroundManager;
 
   beforeEach(() => {
     // given
-    manager = new MockBackgroundManager()
-  })
+    manager = new MockBackgroundManager();
+  });
 
   test("should throw error when task not found", () => {
     // given - empty manager
 
     // when / #then
-    expect(() => manager.resume({
-      sessionId: "non-existent",
-      prompt: "continue",
-      parentSessionID: "session-new",
-      parentMessageID: "msg-new",
-    })).toThrow("Task not found for session: non-existent")
-  })
+    expect(() =>
+      manager.resume({
+        sessionId: "non-existent",
+        prompt: "continue",
+        parentSessionID: "session-new",
+        parentMessageID: "msg-new",
+      }),
+    ).toThrow("Task not found for session: non-existent");
+  });
 
   test("should resume existing task and reset state to running", () => {
     // given
@@ -651,10 +685,10 @@ describe("BackgroundManager.resume", () => {
       sessionID: "session-a",
       parentSessionID: "session-parent",
       status: "completed",
-    })
-    completedTask.completedAt = new Date()
-    completedTask.error = "previous error"
-    manager.addTask(completedTask)
+    });
+    completedTask.completedAt = new Date();
+    completedTask.error = "previous error";
+    manager.addTask(completedTask);
 
     // when
     const result = manager.resume({
@@ -662,15 +696,15 @@ describe("BackgroundManager.resume", () => {
       prompt: "continue the work",
       parentSessionID: "session-new-parent",
       parentMessageID: "msg-new",
-    })
+    });
 
     // then
-    expect(result.status).toBe("running")
-    expect(result.completedAt).toBeUndefined()
-    expect(result.error).toBeUndefined()
-    expect(result.parentSessionID).toBe("session-new-parent")
-    expect(result.parentMessageID).toBe("msg-new")
-  })
+    expect(result.status).toBe("running");
+    expect(result.completedAt).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    expect(result.parentSessionID).toBe("session-new-parent");
+    expect(result.parentMessageID).toBe("msg-new");
+  });
 
   test("should preserve task identity while updating parent context", () => {
     // given
@@ -681,8 +715,8 @@ describe("BackgroundManager.resume", () => {
       description: "original description",
       agent: "explore",
       status: "completed",
-    })
-    manager.addTask(existingTask)
+    });
+    manager.addTask(existingTask);
 
     // when
     const result = manager.resume({
@@ -691,15 +725,15 @@ describe("BackgroundManager.resume", () => {
       parentSessionID: "new-parent",
       parentMessageID: "new-msg",
       parentModel: { providerID: "anthropic", modelID: "claude-opus" },
-    })
+    });
 
     // then
-    expect(result.id).toBe("task-a")
-    expect(result.sessionID).toBe("session-a")
-    expect(result.description).toBe("original description")
-    expect(result.agent).toBe("explore")
-    expect(result.parentModel).toEqual({ providerID: "anthropic", modelID: "claude-opus" })
-  })
+    expect(result.id).toBe("task-a");
+    expect(result.sessionID).toBe("session-a");
+    expect(result.description).toBe("original description");
+    expect(result.agent).toBe("explore");
+    expect(result.parentModel).toEqual({ providerID: "anthropic", modelID: "claude-opus" });
+  });
 
   test("should track resume calls with prompt", () => {
     // given
@@ -708,8 +742,8 @@ describe("BackgroundManager.resume", () => {
       sessionID: "session-a",
       parentSessionID: "session-parent",
       status: "completed",
-    })
-    manager.addTask(task)
+    });
+    manager.addTask(task);
 
     // when
     manager.resume({
@@ -717,15 +751,15 @@ describe("BackgroundManager.resume", () => {
       prompt: "continue with additional context",
       parentSessionID: "session-new",
       parentMessageID: "msg-new",
-    })
+    });
 
     // then
-    expect(manager.resumeCalls).toHaveLength(1)
+    expect(manager.resumeCalls).toHaveLength(1);
     expect(manager.resumeCalls[0]).toEqual({
       sessionId: "session-a",
       prompt: "continue with additional context",
-    })
-  })
+    });
+  });
 
   test("should preserve existing tool call count in progress", () => {
     // given
@@ -734,13 +768,13 @@ describe("BackgroundManager.resume", () => {
       sessionID: "session-a",
       parentSessionID: "session-parent",
       status: "completed",
-    })
+    });
     taskWithProgress.progress = {
       toolCalls: 42,
       lastTool: "read",
       lastUpdate: new Date(),
-    }
-    manager.addTask(taskWithProgress)
+    };
+    manager.addTask(taskWithProgress);
 
     // when
     const result = manager.resume({
@@ -748,11 +782,11 @@ describe("BackgroundManager.resume", () => {
       prompt: "continue",
       parentSessionID: "session-new",
       parentMessageID: "msg-new",
-    })
+    });
 
     // then
-    expect(result.progress?.toolCalls).toBe(42)
-  })
+    expect(result.progress?.toolCalls).toBe(42);
+  });
 
   test("should ignore resume when task is already running", () => {
     // given
@@ -761,8 +795,8 @@ describe("BackgroundManager.resume", () => {
       sessionID: "session-a",
       parentSessionID: "session-parent",
       status: "running",
-    })
-    manager.addTask(runningTask)
+    });
+    manager.addTask(runningTask);
 
     // when
     const result = manager.resume({
@@ -770,13 +804,13 @@ describe("BackgroundManager.resume", () => {
       prompt: "resume should be ignored",
       parentSessionID: "new-parent",
       parentMessageID: "new-msg",
-    })
+    });
 
     // then
-    expect(result.parentSessionID).toBe("session-parent")
-    expect(manager.resumeCalls).toHaveLength(0)
-  })
-})
+    expect(result.parentSessionID).toBe("session-parent");
+    expect(manager.resumeCalls).toHaveLength(0);
+  });
+});
 
 describe("LaunchInput.skillContent", () => {
   test("skillContent should be optional in LaunchInput type", () => {
@@ -787,11 +821,11 @@ describe("LaunchInput.skillContent", () => {
       agent: "explore",
       parentSessionID: "parent-session",
       parentMessageID: "parent-msg",
-    }
+    };
 
     // when / #then - should compile without skillContent
-    expect(input.skillContent).toBeUndefined()
-  })
+    expect(input.skillContent).toBeUndefined();
+  });
 
   test("skillContent can be provided in LaunchInput", () => {
     // given
@@ -802,28 +836,28 @@ describe("LaunchInput.skillContent", () => {
       parentSessionID: "parent-session",
       parentMessageID: "parent-msg",
       skillContent: "You are a playwright expert",
-    }
+    };
 
     // when / #then
-    expect(input.skillContent).toBe("You are a playwright expert")
-  })
-})
+    expect(input.skillContent).toBe("You are a playwright expert");
+  });
+});
 
 interface CurrentMessage {
-  agent?: string
-  model?: { providerID?: string; modelID?: string }
+  agent?: string;
+  model?: { providerID?: string; modelID?: string };
 }
 
 describe("BackgroundManager.notifyParentSession - dynamic message lookup", () => {
   test("should skip compaction agent and use nearest non-compaction message", async () => {
     //#given
-    let capturedBody: Record<string, unknown> | undefined
+    let capturedBody: Record<string, unknown> | undefined;
     const client = {
       session: {
         prompt: async () => ({}),
         promptAsync: async (args: { body: Record<string, unknown> }) => {
-          capturedBody = args.body
-          return {}
+          capturedBody = args.body;
+          return {};
         },
         abort: async () => ({}),
         messages: async () => ({
@@ -843,8 +877,11 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
           ],
         }),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
     const task: BackgroundTask = {
       id: "task-skip-compaction",
       sessionID: "session-child",
@@ -857,19 +894,20 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
       startedAt: new Date(),
       completedAt: new Date(),
       parentAgent: "fallback-agent",
-    }
-    getPendingByParent(manager).set("session-parent", new Set([task.id, "still-running"]))
+    };
+    getPendingByParent(manager).set("session-parent", new Set([task.id, "still-running"]));
 
     //#when
-    await (manager as unknown as { notifyParentSession: (value: BackgroundTask) => Promise<void> })
-      .notifyParentSession(task)
+    await (
+      manager as unknown as { notifyParentSession: (value: BackgroundTask) => Promise<void> }
+    ).notifyParentSession(task);
 
     //#then
-    expect(capturedBody?.agent).toBe("sisyphus")
-    expect(capturedBody?.model).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-6" })
+    expect(capturedBody?.agent).toBe("sisyphus");
+    expect(capturedBody?.model).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-6" });
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should use currentMessage model/agent when available", async () => {
     // given - currentMessage has model and agent
@@ -886,19 +924,19 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
       completedAt: new Date(),
       parentAgent: "OldAgent",
       parentModel: { providerID: "old", modelID: "old-model" },
-    }
+    };
     const currentMessage: CurrentMessage = {
       agent: "sisyphus",
       model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
-    }
+    };
 
     // when
-    const promptBody = buildNotificationPromptBody(task, currentMessage)
+    const promptBody = buildNotificationPromptBody(task, currentMessage);
 
     // then - uses currentMessage values, not task.parentModel/parentAgent
-    expect(promptBody.agent).toBe("sisyphus")
-    expect(promptBody.model).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-6" })
-  })
+    expect(promptBody.agent).toBe("sisyphus");
+    expect(promptBody.model).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-6" });
+  });
 
   test("should fallback to parentAgent when currentMessage.agent is undefined", async () => {
     // given
@@ -915,16 +953,16 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
       completedAt: new Date(),
       parentAgent: "FallbackAgent",
       parentModel: undefined,
-    }
-    const currentMessage: CurrentMessage = { agent: undefined, model: undefined }
+    };
+    const currentMessage: CurrentMessage = { agent: undefined, model: undefined };
 
     // when
-    const promptBody = buildNotificationPromptBody(task, currentMessage)
+    const promptBody = buildNotificationPromptBody(task, currentMessage);
 
     // then - falls back to task.parentAgent
-    expect(promptBody.agent).toBe("FallbackAgent")
-    expect("model" in promptBody).toBe(false)
-  })
+    expect(promptBody.agent).toBe("FallbackAgent");
+    expect("model" in promptBody).toBe(false);
+  });
 
   test("should not pass model when currentMessage.model is incomplete", async () => {
     // given - model missing modelID
@@ -941,19 +979,19 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
       completedAt: new Date(),
       parentAgent: "sisyphus",
       parentModel: { providerID: "anthropic", modelID: "claude-opus" },
-    }
+    };
     const currentMessage: CurrentMessage = {
       agent: "sisyphus",
       model: { providerID: "anthropic" },
-    }
+    };
 
     // when
-    const promptBody = buildNotificationPromptBody(task, currentMessage)
+    const promptBody = buildNotificationPromptBody(task, currentMessage);
 
     // then - model not passed due to incomplete data
-    expect(promptBody.agent).toBe("sisyphus")
-    expect("model" in promptBody).toBe(false)
-  })
+    expect(promptBody.agent).toBe("sisyphus");
+    expect("model" in promptBody).toBe(false);
+  });
 
   test("should handle null currentMessage gracefully", async () => {
     // given - no message found (messageDir lookup failed)
@@ -970,38 +1008,41 @@ describe("BackgroundManager.notifyParentSession - dynamic message lookup", () =>
       completedAt: new Date(),
       parentAgent: "sisyphus",
       parentModel: { providerID: "anthropic", modelID: "claude-opus" },
-    }
+    };
 
     // when
-    const promptBody = buildNotificationPromptBody(task, null)
+    const promptBody = buildNotificationPromptBody(task, null);
 
     // then - falls back to task.parentAgent, no model
-    expect(promptBody.agent).toBe("sisyphus")
-    expect("model" in promptBody).toBe(false)
-  })
-})
+    expect(promptBody.agent).toBe("sisyphus");
+    expect("model" in promptBody).toBe(false);
+  });
+});
 
 describe("BackgroundManager.notifyParentSession - aborted parent", () => {
   test("should fall back and still notify when parent session messages are aborted", async () => {
     //#given
-    let promptCalled = false
+    let promptCalled = false;
     const promptMock = async () => {
-      promptCalled = true
-      return {}
-    }
+      promptCalled = true;
+      return {};
+    };
     const client = {
       session: {
         prompt: promptMock,
         promptAsync: promptMock,
         abort: async () => ({}),
         messages: async () => {
-          const error = new Error("User aborted")
-          error.name = "MessageAbortedError"
-          throw error
+          const error = new Error("User aborted");
+          error.name = "MessageAbortedError";
+          throw error;
         },
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
     const task: BackgroundTask = {
       id: "task-aborted-parent",
       sessionID: "session-child",
@@ -1013,28 +1054,29 @@ describe("BackgroundManager.notifyParentSession - aborted parent", () => {
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
-    getPendingByParent(manager).set("session-parent", new Set([task.id, "task-remaining"]))
+    };
+    getPendingByParent(manager).set("session-parent", new Set([task.id, "task-remaining"]));
 
     //#when
-    await (manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> })
-      .notifyParentSession(task)
+    await (
+      manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> }
+    ).notifyParentSession(task);
 
     //#then
-    expect(promptCalled).toBe(true)
+    expect(promptCalled).toBe(true);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should swallow aborted error from prompt", async () => {
     //#given
-    let promptCalled = false
+    let promptCalled = false;
     const promptMock = async () => {
-      promptCalled = true
-      const error = new Error("User aborted")
-      error.name = "MessageAbortedError"
-      throw error
-    }
+      promptCalled = true;
+      const error = new Error("User aborted");
+      error.name = "MessageAbortedError";
+      throw error;
+    };
     const client = {
       session: {
         prompt: promptMock,
@@ -1042,8 +1084,11 @@ describe("BackgroundManager.notifyParentSession - aborted parent", () => {
         abort: async () => ({}),
         messages: async () => ({ data: [] }),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
     const task: BackgroundTask = {
       id: "task-aborted-prompt",
       sessionID: "session-child",
@@ -1055,26 +1100,27 @@ describe("BackgroundManager.notifyParentSession - aborted parent", () => {
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
-    getPendingByParent(manager).set("session-parent", new Set([task.id]))
+    };
+    getPendingByParent(manager).set("session-parent", new Set([task.id]));
 
     //#when
-    await (manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> })
-      .notifyParentSession(task)
+    await (
+      manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> }
+    ).notifyParentSession(task);
 
     //#then
-    expect(promptCalled).toBe(true)
+    expect(promptCalled).toBe(true);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should queue notification when promptAsync aborts while parent is idle", async () => {
     //#given
     const promptMock = async () => {
-      const error = new Error("Request aborted while waiting for input")
-      error.name = "MessageAbortedError"
-      throw error
-    }
+      const error = new Error("Request aborted while waiting for input");
+      error.name = "MessageAbortedError";
+      throw error;
+    };
     const client = {
       session: {
         prompt: promptMock,
@@ -1082,8 +1128,11 @@ describe("BackgroundManager.notifyParentSession - aborted parent", () => {
         abort: async () => ({}),
         messages: async () => ({ data: [] }),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
     const task: BackgroundTask = {
       id: "task-aborted-idle-queue",
       sessionID: "session-child",
@@ -1095,31 +1144,32 @@ describe("BackgroundManager.notifyParentSession - aborted parent", () => {
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
-    getPendingByParent(manager).set("session-parent", new Set([task.id]))
+    };
+    getPendingByParent(manager).set("session-parent", new Set([task.id]));
 
     //#when
-    await (manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> })
-      .notifyParentSession(task)
+    await (
+      manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> }
+    ).notifyParentSession(task);
 
     //#then
-    const queuedNotifications = getPendingNotifications(manager).get("session-parent") ?? []
-    expect(queuedNotifications).toHaveLength(1)
-    expect(queuedNotifications[0]).toContain("<system-reminder>")
-    expect(queuedNotifications[0]).toContain("[ALL BACKGROUND TASKS COMPLETE]")
+    const queuedNotifications = getPendingNotifications(manager).get("session-parent") ?? [];
+    expect(queuedNotifications).toHaveLength(1);
+    expect(queuedNotifications[0]).toContain("<system-reminder>");
+    expect(queuedNotifications[0]).toContain("[ALL BACKGROUND TASKS COMPLETE]");
 
-    manager.shutdown()
-  })
-})
+    manager.shutdown();
+  });
+});
 
 describe("BackgroundManager.notifyParentSession - notifications toggle", () => {
   test("should skip parent prompt injection when notifications are disabled", async () => {
     //#given
-    let promptCalled = false
+    let promptCalled = false;
     const promptMock = async () => {
-      promptCalled = true
-      return {}
-    }
+      promptCalled = true;
+      return {};
+    };
     const client = {
       session: {
         prompt: promptMock,
@@ -1127,12 +1177,12 @@ describe("BackgroundManager.notifyParentSession - notifications toggle", () => {
         abort: async () => ({}),
         messages: async () => ({ data: [] }),
       },
-    }
+    };
     const manager = new BackgroundManager(
       { client, directory: tmpdir() } as unknown as PluginInput,
       undefined,
       { enableParentSessionNotifications: false },
-    )
+    );
     const task: BackgroundTask = {
       id: "task-no-parent-notification",
       sessionID: "session-child",
@@ -1144,84 +1194,94 @@ describe("BackgroundManager.notifyParentSession - notifications toggle", () => {
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
-    getPendingByParent(manager).set("session-parent", new Set([task.id]))
+    };
+    getPendingByParent(manager).set("session-parent", new Set([task.id]));
 
     //#when
-    await (manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> })
-      .notifyParentSession(task)
+    await (
+      manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> }
+    ).notifyParentSession(task);
 
     //#then
-    expect(promptCalled).toBe(false)
+    expect(promptCalled).toBe(false);
 
-    manager.shutdown()
-  })
-})
+    manager.shutdown();
+  });
+});
 
 describe("BackgroundManager.injectPendingNotificationsIntoChatMessage", () => {
   test("should prepend queued notifications to first text part and clear queue", () => {
     // given
-    const manager = createBackgroundManager()
-    manager.queuePendingNotification("session-parent", "<system-reminder>queued-one</system-reminder>")
-    manager.queuePendingNotification("session-parent", "<system-reminder>queued-two</system-reminder>")
+    const manager = createBackgroundManager();
+    manager.queuePendingNotification(
+      "session-parent",
+      "<system-reminder>queued-one</system-reminder>",
+    );
+    manager.queuePendingNotification(
+      "session-parent",
+      "<system-reminder>queued-two</system-reminder>",
+    );
     const output = {
       parts: [{ type: "text", text: "User prompt" }],
-    }
+    };
 
     // when
-    manager.injectPendingNotificationsIntoChatMessage(output, "session-parent")
+    manager.injectPendingNotificationsIntoChatMessage(output, "session-parent");
 
     // then
-    expect(output.parts[0].text).toContain("<system-reminder>queued-one</system-reminder>")
-    expect(output.parts[0].text).toContain("<system-reminder>queued-two</system-reminder>")
-    expect(output.parts[0].text).toContain("User prompt")
-    expect(getPendingNotifications(manager).get("session-parent")).toBeUndefined()
+    expect(output.parts[0].text).toContain("<system-reminder>queued-one</system-reminder>");
+    expect(output.parts[0].text).toContain("<system-reminder>queued-two</system-reminder>");
+    expect(output.parts[0].text).toContain("User prompt");
+    expect(getPendingNotifications(manager).get("session-parent")).toBeUndefined();
 
-    manager.shutdown()
-  })
-})
+    manager.shutdown();
+  });
+});
 
 function buildNotificationPromptBody(
   task: BackgroundTask,
-  currentMessage: CurrentMessage | null
+  currentMessage: CurrentMessage | null,
 ): Record<string, unknown> {
   const body: Record<string, unknown> = {
-    parts: [{ type: "text", text: `[BACKGROUND TASK COMPLETED] Task "${task.description}" finished.` }],
-  }
+    parts: [
+      { type: "text", text: `[BACKGROUND TASK COMPLETED] Task "${task.description}" finished.` },
+    ],
+  };
 
-  const agent = currentMessage?.agent ?? task.parentAgent
-  const model = currentMessage?.model?.providerID && currentMessage?.model?.modelID
-    ? { providerID: currentMessage.model.providerID, modelID: currentMessage.model.modelID }
-    : undefined
+  const agent = currentMessage?.agent ?? task.parentAgent;
+  const model =
+    currentMessage?.model?.providerID && currentMessage?.model?.modelID
+      ? { providerID: currentMessage.model.providerID, modelID: currentMessage.model.modelID }
+      : undefined;
 
   if (agent !== undefined) {
-    body.agent = agent
+    body.agent = agent;
   }
   if (model !== undefined) {
-    body.model = model
+    body.model = model;
   }
 
-  return body
+  return body;
 }
 
 describe("BackgroundManager.tryCompleteTask", () => {
-  let manager: BackgroundManager
+  let manager: BackgroundManager;
 
   beforeEach(() => {
     // given
-    manager = createBackgroundManager()
-    stubNotifyParentSession(manager)
-  })
+    manager = createBackgroundManager();
+    stubNotifyParentSession(manager);
+  });
 
   afterEach(() => {
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should release concurrency and clear key on completion", async () => {
     // given
-    const concurrencyKey = "anthropic/claude-opus-4-6"
-    const concurrencyManager = getConcurrencyManager(manager)
-    await concurrencyManager.acquire(concurrencyKey)
+    const concurrencyKey = "anthropic/claude-opus-4-6";
+    const concurrencyManager = getConcurrencyManager(manager);
+    await concurrencyManager.acquire(concurrencyKey);
 
     const task: BackgroundTask = {
       id: "task-1",
@@ -1234,23 +1294,23 @@ describe("BackgroundManager.tryCompleteTask", () => {
       status: "running",
       startedAt: new Date(),
       concurrencyKey,
-    }
+    };
 
     // when
-    const completed = await tryCompleteTaskForTest(manager, task)
+    const completed = await tryCompleteTaskForTest(manager, task);
 
     // then
-    expect(completed).toBe(true)
-    expect(task.status).toBe("completed")
-    expect(task.concurrencyKey).toBeUndefined()
-    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
-  })
+    expect(completed).toBe(true);
+    expect(task.status).toBe("completed");
+    expect(task.concurrencyKey).toBeUndefined();
+    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0);
+  });
 
   test("should prevent double completion and double release", async () => {
     // given
-    const concurrencyKey = "anthropic/claude-opus-4-6"
-    const concurrencyManager = getConcurrencyManager(manager)
-    await concurrencyManager.acquire(concurrencyKey)
+    const concurrencyKey = "anthropic/claude-opus-4-6";
+    const concurrencyManager = getConcurrencyManager(manager);
+    await concurrencyManager.acquire(concurrencyKey);
 
     const task: BackgroundTask = {
       id: "task-1",
@@ -1263,35 +1323,35 @@ describe("BackgroundManager.tryCompleteTask", () => {
       status: "running",
       startedAt: new Date(),
       concurrencyKey,
-    }
+    };
 
     // when
-    await tryCompleteTaskForTest(manager, task)
-    const secondAttempt = await tryCompleteTaskForTest(manager, task)
+    await tryCompleteTaskForTest(manager, task);
+    const secondAttempt = await tryCompleteTaskForTest(manager, task);
 
     // then
-    expect(secondAttempt).toBe(false)
-    expect(task.status).toBe("completed")
-    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
-  })
+    expect(secondAttempt).toBe(false);
+    expect(task.status).toBe("completed");
+    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0);
+  });
 
-   test("should abort session on completion", async () => {
-     // #given
-     const abortedSessionIDs: string[] = []
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async (args: { path: { id: string } }) => {
-           abortedSessionIDs.push(args.path.id)
-           return {}
-         },
-         messages: async () => ({ data: [] }),
-       },
-     }
-    manager.shutdown()
-    manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
-    stubNotifyParentSession(manager)
+  test("should abort session on completion", async () => {
+    // #given
+    const abortedSessionIDs: string[] = [];
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async (args: { path: { id: string } }) => {
+          abortedSessionIDs.push(args.path.id);
+          return {};
+        },
+        messages: async () => ({ data: [] }),
+      },
+    };
+    manager.shutdown();
+    manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput);
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-1",
@@ -1303,14 +1363,14 @@ describe("BackgroundManager.tryCompleteTask", () => {
       agent: "explore",
       status: "running",
       startedAt: new Date(),
-    }
+    };
 
     // #when
-    await tryCompleteTaskForTest(manager, task)
+    await tryCompleteTaskForTest(manager, task);
 
     // #then
-    expect(abortedSessionIDs).toEqual(["session-1"])
-  })
+    expect(abortedSessionIDs).toEqual(["session-1"]);
+  });
 
   test("should clean pendingByParent even when promptAsync notification fails", async () => {
     // given
@@ -1318,14 +1378,14 @@ describe("BackgroundManager.tryCompleteTask", () => {
       session: {
         prompt: async () => ({}),
         promptAsync: async () => {
-          throw new Error("notify failed")
+          throw new Error("notify failed");
         },
         abort: async () => ({}),
         messages: async () => ({ data: [] }),
       },
-    }
-    manager.shutdown()
-    manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    manager.shutdown();
+    manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput);
 
     const task: BackgroundTask = {
       id: "task-pending-cleanup",
@@ -1337,21 +1397,21 @@ describe("BackgroundManager.tryCompleteTask", () => {
       agent: "explore",
       status: "running",
       startedAt: new Date(),
-    }
-    getTaskMap(manager).set(task.id, task)
-    getPendingByParent(manager).set(task.parentSessionID, new Set([task.id]))
+    };
+    getTaskMap(manager).set(task.id, task);
+    getPendingByParent(manager).set(task.parentSessionID, new Set([task.id]));
 
     // when
-    await tryCompleteTaskForTest(manager, task)
+    await tryCompleteTaskForTest(manager, task);
 
     // then
-    expect(task.status).toBe("completed")
-    expect(getPendingByParent(manager).get(task.parentSessionID)).toBeUndefined()
-  })
+    expect(task.status).toBe("completed");
+    expect(getPendingByParent(manager).get(task.parentSessionID)).toBeUndefined();
+  });
 
   test("should remove toast tracking before notifying completed task", async () => {
     // given
-    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
+    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker();
 
     const task: BackgroundTask = {
       id: "task-toast-complete",
@@ -1363,23 +1423,23 @@ describe("BackgroundManager.tryCompleteTask", () => {
       agent: "explore",
       status: "running",
       startedAt: new Date(),
-    }
+    };
 
     try {
       // when
-      await tryCompleteTaskForTest(manager, task)
+      await tryCompleteTaskForTest(manager, task);
 
       // then
-      expect(removeTaskCalls).toContain(task.id)
+      expect(removeTaskCalls).toContain(task.id);
     } finally {
-      resetToastManager()
+      resetToastManager();
     }
-  })
+  });
 
   test("should release task concurrencyKey when startTask throws after assigning it", async () => {
     // given
-    const concurrencyKey = "anthropic/claude-opus-4-6"
-    const concurrencyManager = getConcurrencyManager(manager)
+    const concurrencyKey = "anthropic/claude-opus-4-6";
+    const concurrencyManager = getConcurrencyManager(manager);
 
     const task = createMockTask({
       id: "task-process-key-concurrency",
@@ -1387,7 +1447,7 @@ describe("BackgroundManager.tryCompleteTask", () => {
       parentSessionID: "parent-process-key-concurrency",
       status: "pending",
       agent: "explore",
-    })
+    });
     const input = {
       description: task.description,
       prompt: task.prompt,
@@ -1395,27 +1455,31 @@ describe("BackgroundManager.tryCompleteTask", () => {
       parentSessionID: task.parentSessionID,
       parentMessageID: task.parentMessageID,
       model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
-    }
-    getTaskMap(manager).set(task.id, task)
-    getQueuesByKey(manager).set(concurrencyKey, [{ task, input }])
+    };
+    getTaskMap(manager).set(task.id, task);
+    getQueuesByKey(manager).set(concurrencyKey, [{ task, input }]);
 
-    ;(manager as unknown as { startTask: (item: { task: BackgroundTask; input: typeof input }) => Promise<void> }).startTask = async (item) => {
-      item.task.concurrencyKey = concurrencyKey
-      throw new Error("startTask failed after assigning concurrencyKey")
-    }
+    (
+      manager as unknown as {
+        startTask: (item: { task: BackgroundTask; input: typeof input }) => Promise<void>;
+      }
+    ).startTask = async (item) => {
+      item.task.concurrencyKey = concurrencyKey;
+      throw new Error("startTask failed after assigning concurrencyKey");
+    };
 
     // when
-    await processKeyForTest(manager, concurrencyKey)
+    await processKeyForTest(manager, concurrencyKey);
 
     // then
-    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
-    expect(task.concurrencyKey).toBeUndefined()
-  })
+    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0);
+    expect(task.concurrencyKey).toBeUndefined();
+  });
 
   test("should release queue slot when queued task is already interrupt", async () => {
     // given
-    const concurrencyKey = "anthropic/claude-opus-4-6"
-    const concurrencyManager = getConcurrencyManager(manager)
+    const concurrencyKey = "anthropic/claude-opus-4-6";
+    const concurrencyManager = getConcurrencyManager(manager);
 
     const task = createMockTask({
       id: "task-process-key-interrupt",
@@ -1423,7 +1487,7 @@ describe("BackgroundManager.tryCompleteTask", () => {
       parentSessionID: "parent-process-key-interrupt",
       status: "interrupt",
       agent: "explore",
-    })
+    });
     const input = {
       description: task.description,
       prompt: task.prompt,
@@ -1431,37 +1495,37 @@ describe("BackgroundManager.tryCompleteTask", () => {
       parentSessionID: task.parentSessionID,
       parentMessageID: task.parentMessageID,
       model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
-    }
-    getTaskMap(manager).set(task.id, task)
-    getQueuesByKey(manager).set(concurrencyKey, [{ task, input }])
+    };
+    getTaskMap(manager).set(task.id, task);
+    getQueuesByKey(manager).set(concurrencyKey, [{ task, input }]);
 
     // when
-    await processKeyForTest(manager, concurrencyKey)
+    await processKeyForTest(manager, concurrencyKey);
 
     // then
-    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
-    expect(getQueuesByKey(manager).get(concurrencyKey)).toEqual([])
-  })
+    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0);
+    expect(getQueuesByKey(manager).get(concurrencyKey)).toEqual([]);
+  });
 
   test("should avoid overlapping promptAsync calls when tasks complete concurrently", async () => {
     // given
-    type PromptAsyncBody = Record<string, unknown> & { noReply?: boolean }
+    type PromptAsyncBody = Record<string, unknown> & { noReply?: boolean };
 
-    let resolveMessages: ((value: { data: unknown[] }) => void) | undefined
+    let resolveMessages: ((value: { data: unknown[] }) => void) | undefined;
     const messagesBarrier = new Promise<{ data: unknown[] }>((resolve) => {
-      resolveMessages = resolve
-    })
+      resolveMessages = resolve;
+    });
 
-    const promptBodies: PromptAsyncBody[] = []
-    let promptInFlight = false
-    let rejectedCount = 0
-    let promptCallCount = 0
+    const promptBodies: PromptAsyncBody[] = [];
+    let promptInFlight = false;
+    let rejectedCount = 0;
+    let promptCallCount = 0;
 
-    let releaseFirstPrompt: (() => void) | undefined
-    let resolveFirstStarted: (() => void) | undefined
+    let releaseFirstPrompt: (() => void) | undefined;
+    let resolveFirstStarted: (() => void) | undefined;
     const firstStarted = new Promise<void>((resolve) => {
-      resolveFirstStarted = resolve
-    })
+      resolveFirstStarted = resolve;
+    });
 
     const client = {
       session: {
@@ -1469,86 +1533,86 @@ describe("BackgroundManager.tryCompleteTask", () => {
         abort: async () => ({}),
         messages: async () => messagesBarrier,
         promptAsync: async (args: { path: { id: string }; body: PromptAsyncBody }) => {
-          promptBodies.push(args.body)
+          promptBodies.push(args.body);
 
           if (!promptInFlight) {
-            promptCallCount += 1
+            promptCallCount += 1;
             if (promptCallCount === 1) {
-              promptInFlight = true
-              resolveFirstStarted?.()
+              promptInFlight = true;
+              resolveFirstStarted?.();
               return await new Promise((resolve) => {
                 releaseFirstPrompt = () => {
-                  promptInFlight = false
-                  resolve({})
-                }
-              })
+                  promptInFlight = false;
+                  resolve({});
+                };
+              });
             }
 
-            return {}
+            return {};
           }
 
-          rejectedCount += 1
-          throw new Error("BUSY")
+          rejectedCount += 1;
+          throw new Error("BUSY");
         },
       },
-    }
+    };
 
-    manager.shutdown()
-    manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    manager.shutdown();
+    manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput);
 
-    const parentSessionID = "parent-session"
+    const parentSessionID = "parent-session";
     const taskA = createMockTask({
       id: "task-a",
       sessionID: "session-a",
       parentSessionID,
-    })
+    });
     const taskB = createMockTask({
       id: "task-b",
       sessionID: "session-b",
       parentSessionID,
-    })
+    });
 
-    getTaskMap(manager).set(taskA.id, taskA)
-    getTaskMap(manager).set(taskB.id, taskB)
-    getPendingByParent(manager).set(parentSessionID, new Set([taskA.id, taskB.id]))
+    getTaskMap(manager).set(taskA.id, taskA);
+    getTaskMap(manager).set(taskB.id, taskB);
+    getPendingByParent(manager).set(parentSessionID, new Set([taskA.id, taskB.id]));
 
     // when
-    const completionA = tryCompleteTaskForTest(manager, taskA)
-    const completionB = tryCompleteTaskForTest(manager, taskB)
-    resolveMessages?.({ data: [] })
+    const completionA = tryCompleteTaskForTest(manager, taskA);
+    const completionB = tryCompleteTaskForTest(manager, taskB);
+    resolveMessages?.({ data: [] });
 
-    await firstStarted
+    await firstStarted;
 
     // Give the second completion a chance to attempt promptAsync while the first is in-flight.
     // In the buggy implementation, this triggers an overlap and increments rejectedCount.
     for (let i = 0; i < 20; i++) {
-      await Promise.resolve()
-      if (rejectedCount > 0) break
-      if (promptBodies.length >= 2) break
+      await Promise.resolve();
+      if (rejectedCount > 0) break;
+      if (promptBodies.length >= 2) break;
     }
 
-    releaseFirstPrompt?.()
-    await Promise.all([completionA, completionB])
+    releaseFirstPrompt?.();
+    await Promise.all([completionA, completionB]);
 
     // then
-    expect(rejectedCount).toBe(0)
-    expect(promptBodies.length).toBe(2)
-    expect(promptBodies.filter((body) => body.noReply === false)).toHaveLength(1)
-  })
-})
+    expect(rejectedCount).toBe(0);
+    expect(promptBodies.length).toBe(2);
+    expect(promptBodies.filter((body) => body.noReply === false)).toHaveLength(1);
+  });
+});
 
 describe("BackgroundManager.trackTask", () => {
-  let manager: BackgroundManager
+  let manager: BackgroundManager;
 
   beforeEach(() => {
     // given
-    manager = createBackgroundManager()
-    stubNotifyParentSession(manager)
-  })
+    manager = createBackgroundManager();
+    stubNotifyParentSession(manager);
+  });
 
   afterEach(() => {
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should not double acquire on duplicate registration", async () => {
     // given
@@ -1559,31 +1623,31 @@ describe("BackgroundManager.trackTask", () => {
       description: "external task",
       agent: "task",
       concurrencyKey: "external-key",
-    }
+    };
 
     // when
-    await manager.trackTask(input)
-    await manager.trackTask(input)
+    await manager.trackTask(input);
+    await manager.trackTask(input);
 
     // then
-    const concurrencyManager = getConcurrencyManager(manager)
-    expect(concurrencyManager.getCount("external-key")).toBe(1)
-    expect(getTaskMap(manager).size).toBe(1)
-  })
-})
+    const concurrencyManager = getConcurrencyManager(manager);
+    expect(concurrencyManager.getCount("external-key")).toBe(1);
+    expect(getTaskMap(manager).size).toBe(1);
+  });
+});
 
 describe("BackgroundManager.resume concurrency key", () => {
-  let manager: BackgroundManager
+  let manager: BackgroundManager;
 
   beforeEach(() => {
     // given
-    manager = createBackgroundManager()
-    stubNotifyParentSession(manager)
-  })
+    manager = createBackgroundManager();
+    stubNotifyParentSession(manager);
+  });
 
   afterEach(() => {
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should re-acquire using external task concurrency key", async () => {
     // given
@@ -1594,9 +1658,9 @@ describe("BackgroundManager.resume concurrency key", () => {
       description: "external task",
       agent: "task",
       concurrencyKey: "external-key",
-    })
+    });
 
-    await tryCompleteTaskForTest(manager, task)
+    await tryCompleteTaskForTest(manager, task);
 
     // when
     await manager.resume({
@@ -1604,40 +1668,40 @@ describe("BackgroundManager.resume concurrency key", () => {
       prompt: "resume",
       parentSessionID: "parent-session-2",
       parentMessageID: "msg-2",
-    })
+    });
 
     // then
-    const concurrencyManager = getConcurrencyManager(manager)
-    expect(concurrencyManager.getCount("external-key")).toBe(1)
-    expect(task.concurrencyKey).toBe("external-key")
-  })
-})
+    const concurrencyManager = getConcurrencyManager(manager);
+    expect(concurrencyManager.getCount("external-key")).toBe(1);
+    expect(task.concurrencyKey).toBe("external-key");
+  });
+});
 
 describe("BackgroundManager.resume model persistence", () => {
-   let manager: BackgroundManager
-   let promptCalls: Array<{ path: { id: string }; body: Record<string, unknown> }>
+  let manager: BackgroundManager;
+  let promptCalls: Array<{ path: { id: string }; body: Record<string, unknown> }>;
 
-   beforeEach(() => {
-     // given
-     promptCalls = []
-     const promptMock = async (args: { path: { id: string }; body: Record<string, unknown> }) => {
-       promptCalls.push(args)
-       return {}
-     }
-     const client = {
-       session: {
-         prompt: promptMock,
-         promptAsync: promptMock,
-         abort: async () => ({}),
-       },
-     }
-     manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
-     stubNotifyParentSession(manager)
-   })
+  beforeEach(() => {
+    // given
+    promptCalls = [];
+    const promptMock = async (args: { path: { id: string }; body: Record<string, unknown> }) => {
+      promptCalls.push(args);
+      return {};
+    };
+    const client = {
+      session: {
+        prompt: promptMock,
+        promptAsync: promptMock,
+        abort: async () => ({}),
+      },
+    };
+    manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput);
+    stubNotifyParentSession(manager);
+  });
 
   afterEach(() => {
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should pass model when task has a configured model", async () => {
     // given - task with model from category config
@@ -1654,8 +1718,8 @@ describe("BackgroundManager.resume model persistence", () => {
       completedAt: new Date(),
       model: { providerID: "anthropic", modelID: "claude-sonnet-4-20250514" },
       concurrencyGroup: "explore",
-    }
-    getTaskMap(manager).set(taskWithModel.id, taskWithModel)
+    };
+    getTaskMap(manager).set(taskWithModel.id, taskWithModel);
 
     // when
     await manager.resume({
@@ -1663,13 +1727,16 @@ describe("BackgroundManager.resume model persistence", () => {
       prompt: "continue the work",
       parentSessionID: "parent-session-2",
       parentMessageID: "msg-2",
-    })
+    });
 
     // then - model should be passed in prompt body
-    expect(promptCalls).toHaveLength(1)
-    expect(promptCalls[0].body.model).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4-20250514" })
-    expect(promptCalls[0].body.agent).toBe("explore")
-  })
+    expect(promptCalls).toHaveLength(1);
+    expect(promptCalls[0].body.model).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-20250514",
+    });
+    expect(promptCalls[0].body.agent).toBe("explore");
+  });
 
   test("should NOT pass model when task has no model (backward compatibility)", async () => {
     // given - task without model (default behavior)
@@ -1685,8 +1752,8 @@ describe("BackgroundManager.resume model persistence", () => {
       startedAt: new Date(),
       completedAt: new Date(),
       concurrencyGroup: "explore",
-    }
-    getTaskMap(manager).set(taskWithoutModel.id, taskWithoutModel)
+    };
+    getTaskMap(manager).set(taskWithoutModel.id, taskWithoutModel);
 
     // when
     await manager.resume({
@@ -1694,93 +1761,96 @@ describe("BackgroundManager.resume model persistence", () => {
       prompt: "continue the work",
       parentSessionID: "parent-session-2",
       parentMessageID: "msg-2",
-    })
+    });
 
     // then - model should NOT be in prompt body
-    expect(promptCalls).toHaveLength(1)
-    expect("model" in promptCalls[0].body).toBe(false)
-    expect(promptCalls[0].body.agent).toBe("explore")
-  })
-})
+    expect(promptCalls).toHaveLength(1);
+    expect("model" in promptCalls[0].body).toBe(false);
+    expect(promptCalls[0].body.agent).toBe("explore");
+  });
+});
 
 describe("BackgroundManager process cleanup", () => {
   test("should remove listeners after last shutdown", () => {
     // given
-    const signals = getCleanupSignals()
-    const baseline = getListenerCounts(signals)
-    const managerA = createBackgroundManager()
-    const managerB = createBackgroundManager()
+    const signals = getCleanupSignals();
+    const baseline = getListenerCounts(signals);
+    const managerA = createBackgroundManager();
+    const managerB = createBackgroundManager();
 
     // when
-    const afterCreate = getListenerCounts(signals)
-    managerA.shutdown()
-    const afterFirstShutdown = getListenerCounts(signals)
-    managerB.shutdown()
-    const afterSecondShutdown = getListenerCounts(signals)
+    const afterCreate = getListenerCounts(signals);
+    managerA.shutdown();
+    const afterFirstShutdown = getListenerCounts(signals);
+    managerB.shutdown();
+    const afterSecondShutdown = getListenerCounts(signals);
 
     // then
     for (const signal of signals) {
-      expect(afterCreate[signal]).toBe(baseline[signal] + 1)
-      expect(afterFirstShutdown[signal]).toBe(baseline[signal] + 1)
-      expect(afterSecondShutdown[signal]).toBe(baseline[signal])
+      expect(afterCreate[signal]).toBe(baseline[signal] + 1);
+      expect(afterFirstShutdown[signal]).toBe(baseline[signal] + 1);
+      expect(afterSecondShutdown[signal]).toBe(baseline[signal]);
     }
-  })
-})
+  });
+});
 
 describe("BackgroundManager - Non-blocking Queue Integration", () => {
-  let manager: BackgroundManager
-  let mockClient: ReturnType<typeof createMockClient>
+  let manager: BackgroundManager;
+  let mockClient: ReturnType<typeof createMockClient>;
 
-    function createMockClient() {
-      return {
-        session: {
-          create: async (_args?: any) => ({ data: { id: `ses_${crypto.randomUUID()}` } }),
-          get: async () => ({ data: { directory: "/test/dir" } }),
-          prompt: async () => ({}),
-          promptAsync: async () => ({}),
-          messages: async () => ({ data: [] }),
-         todo: async () => ({ data: [] }),
-         status: async () => ({ data: {} }),
-         abort: async () => ({}),
-       },
-     }
-   }
+  function createMockClient() {
+    return {
+      session: {
+        create: async (_args?: any) => ({ data: { id: `ses_${crypto.randomUUID()}` } }),
+        get: async () => ({ data: { directory: "/test/dir" } }),
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        messages: async () => ({ data: [] }),
+        todo: async () => ({ data: [] }),
+        status: async () => ({ data: {} }),
+        abort: async () => ({}),
+      },
+    };
+  }
 
   function createMockClientWithSessionChain(
-      sessions: Record<string, { directory: string; parentID?: string }>,
-      options?: { sessionLookupError?: Error }
-    ) {
-      return {
-        session: {
-          create: async (_args?: any) => ({ data: { id: `ses_${crypto.randomUUID()}` } }),
-          get: async ({ path }: { path: { id: string } }) => {
-            if (options?.sessionLookupError) {
-              throw options.sessionLookupError
-            }
+    sessions: Record<string, { directory: string; parentID?: string }>,
+    options?: { sessionLookupError?: Error },
+  ) {
+    return {
+      session: {
+        create: async (_args?: any) => ({ data: { id: `ses_${crypto.randomUUID()}` } }),
+        get: async ({ path }: { path: { id: string } }) => {
+          if (options?.sessionLookupError) {
+            throw options.sessionLookupError;
+          }
 
-            return {
-              data: sessions[path.id] ?? { directory: "/test/dir" },
-            }
-          },
-          prompt: async () => ({}),
-          promptAsync: async () => ({}),
-          messages: async () => ({ data: [] }),
-          todo: async () => ({ data: [] }),
-          status: async () => ({ data: {} }),
-          abort: async () => ({}),
+          return {
+            data: sessions[path.id] ?? { directory: "/test/dir" },
+          };
         },
-      }
-    }
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        messages: async () => ({ data: [] }),
+        todo: async () => ({ data: [] }),
+        status: async () => ({ data: {} }),
+        abort: async () => ({}),
+      },
+    };
+  }
 
   beforeEach(() => {
     // given
-    mockClient = createMockClient()
-    manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput)
-  })
+    mockClient = createMockClient();
+    manager = new BackgroundManager({
+      client: mockClient,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
+  });
 
   afterEach(() => {
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   describe("launch() returns immediately with pending status", () => {
     test("should return task with pending status immediately", async () => {
@@ -1791,26 +1861,29 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const task = await manager.launch(input)
+      const task = await manager.launch(input);
 
       // then
-      expect(task.status).toBe("pending")
-      expect(task.id).toMatch(/^bg_/)
-      expect(task.description).toBe("Test task")
-      expect(task.agent).toBe("test-agent")
-      expect(task.queuedAt).toBeInstanceOf(Date)
-      expect(task.startedAt).toBeUndefined()
-      expect(task.sessionID).toBeUndefined()
-    })
+      expect(task.status).toBe("pending");
+      expect(task.id).toMatch(/^bg_/);
+      expect(task.description).toBe("Test task");
+      expect(task.agent).toBe("test-agent");
+      expect(task.queuedAt).toBeInstanceOf(Date);
+      expect(task.startedAt).toBeUndefined();
+      expect(task.sessionID).toBeUndefined();
+    });
 
     test("should return immediately even with concurrency limit", async () => {
       // given
-      const config = { defaultConcurrency: 1 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 1 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -1818,25 +1891,28 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const startTime = Date.now()
-      const task1 = await manager.launch(input)
-      const task2 = await manager.launch(input)
-      const endTime = Date.now()
+      const startTime = Date.now();
+      const task1 = await manager.launch(input);
+      const task2 = await manager.launch(input);
+      const endTime = Date.now();
 
       // then
-      expect(endTime - startTime).toBeLessThan(100) // Should be instant
-      expect(task1.status).toBe("pending")
-      expect(task2.status).toBe("pending")
-    })
+      expect(endTime - startTime).toBeLessThan(100); // Should be instant
+      expect(task1.status).toBe("pending");
+      expect(task2.status).toBe("pending");
+    });
 
     test("should queue multiple tasks without blocking", async () => {
       // given
-      const config = { defaultConcurrency: 2 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 2 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -1844,7 +1920,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
       const tasks = await Promise.all([
@@ -1853,31 +1929,31 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         manager.launch(input),
         manager.launch(input),
         manager.launch(input),
-      ])
+      ]);
 
       // then
-      expect(tasks).toHaveLength(5)
-      tasks.forEach(task => {
-        expect(task.status).toBe("pending")
-        expect(task.queuedAt).toBeInstanceOf(Date)
-      })
-    })
-  })
+      expect(tasks).toHaveLength(5);
+      tasks.forEach((task) => {
+        expect(task.status).toBe("pending");
+        expect(task.queuedAt).toBeInstanceOf(Date);
+      });
+    });
+  });
 
   describe("task transitions pending→running when slot available", () => {
     test("does not override parent session permission when creating child session", async () => {
       // given
-      const createCalls: any[] = []
+      const createCalls: any[] = [];
       const parentPermission = [
         { permission: "question", action: "allow" as const, pattern: "*" },
         { permission: "plan_enter", action: "deny" as const, pattern: "*" },
-      ]
+      ];
 
       const customClient = {
         session: {
           create: async (args?: any) => {
-            createCalls.push(args)
-            return { data: { id: `ses_${crypto.randomUUID()}` } }
+            createCalls.push(args);
+            return { data: { id: `ses_${crypto.randomUUID()}` } };
           },
           get: async () => ({ data: { directory: "/test/dir", permission: parentPermission } }),
           prompt: async () => ({}),
@@ -1887,11 +1963,14 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
           status: async () => ({ data: {} }),
           abort: async () => ({}),
         },
-      }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: customClient, directory: tmpdir() } as unknown as PluginInput, {
-        defaultConcurrency: 5,
-      })
+      };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: customClient, directory: tmpdir() } as unknown as PluginInput,
+        {
+          defaultConcurrency: 5,
+        },
+      );
 
       const input = {
         description: "Test task",
@@ -1899,22 +1978,25 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await manager.launch(input);
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // then
-      expect(createCalls).toHaveLength(1)
-      expect(createCalls[0]?.body?.permission).toBeUndefined()
-    })
+      expect(createCalls).toHaveLength(1);
+      expect(createCalls[0]?.body?.permission).toBeUndefined();
+    });
 
     test("should transition first task to running immediately", async () => {
       // given
-      const config = { defaultConcurrency: 5 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 5 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -1922,27 +2004,30 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const task = await manager.launch(input)
+      const task = await manager.launch(input);
 
       // Give processKey time to run
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // then
-      const updatedTask = manager.getTask(task.id)
-      expect(updatedTask?.status).toBe("running")
-      expect(updatedTask?.startedAt).toBeInstanceOf(Date)
-      expect(updatedTask?.sessionID).toBeDefined()
-      expect(updatedTask?.sessionID).toBeTruthy()
-    })
+      const updatedTask = manager.getTask(task.id);
+      expect(updatedTask?.status).toBe("running");
+      expect(updatedTask?.startedAt).toBeInstanceOf(Date);
+      expect(updatedTask?.sessionID).toBeDefined();
+      expect(updatedTask?.sessionID).toBeTruthy();
+    });
 
     test("should set startedAt when transitioning to running", async () => {
       // given
-      const config = { defaultConcurrency: 5 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 5 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -1950,26 +2035,26 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const task = await manager.launch(input)
-      const queuedAt = task.queuedAt
+      const task = await manager.launch(input);
+      const queuedAt = task.queuedAt;
 
       // Wait for transition
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // then
-      const updatedTask = manager.getTask(task.id)
-      expect(updatedTask?.startedAt).toBeInstanceOf(Date)
+      const updatedTask = manager.getTask(task.id);
+      expect(updatedTask?.startedAt).toBeInstanceOf(Date);
       if (updatedTask?.startedAt && queuedAt) {
-        expect(updatedTask.startedAt.getTime()).toBeGreaterThanOrEqual(queuedAt.getTime())
+        expect(updatedTask.startedAt.getTime()).toBeGreaterThanOrEqual(queuedAt.getTime());
       }
-    })
+    });
 
     test("should track rootSessionID and spawnDepth from the parent chain", async () => {
       // given
-      manager.shutdown()
+      manager.shutdown();
       manager = new BackgroundManager(
         {
           client: createMockClientWithSessionChain({
@@ -1980,7 +2065,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
           directory: tmpdir(),
         } as unknown as PluginInput,
         { maxDepth: 3 },
-      )
+      );
 
       const input = {
         description: "Test task",
@@ -1988,19 +2073,19 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "session-depth-2",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const task = await manager.launch(input)
+      const task = await manager.launch(input);
 
       // then
-      expect(task.rootSessionID).toBe("session-root")
-      expect(task.spawnDepth).toBe(3)
-    })
+      expect(task.rootSessionID).toBe("session-root");
+      expect(task.spawnDepth).toBe(3);
+    });
 
     test("should block launches that exceed maxDepth", async () => {
       // given
-      manager.shutdown()
+      manager.shutdown();
       manager = new BackgroundManager(
         {
           client: createMockClientWithSessionChain({
@@ -2012,7 +2097,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
           directory: tmpdir(),
         } as unknown as PluginInput,
         { maxDepth: 3 },
-      )
+      );
 
       const input = {
         description: "Test task",
@@ -2020,18 +2105,18 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "session-depth-3",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const result = manager.launch(input)
+      const result = manager.launch(input);
 
       // then
-      await expect(result).rejects.toThrow("background_task.maxDepth=3")
-    })
+      await expect(result).rejects.toThrow("background_task.maxDepth=3");
+    });
 
     test("should block launches when maxDescendants is reached", async () => {
       // given
-      manager.shutdown()
+      manager.shutdown();
       manager = new BackgroundManager(
         {
           client: createMockClientWithSessionChain({
@@ -2040,7 +2125,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
           directory: tmpdir(),
         } as unknown as PluginInput,
         { maxDescendants: 1 },
-      )
+      );
 
       const input = {
         description: "Test task",
@@ -2048,20 +2133,20 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "session-root",
         parentMessageID: "parent-message",
-      }
+      };
 
-      await manager.launch(input)
+      await manager.launch(input);
 
       // when
-      const result = manager.launch(input)
+      const result = manager.launch(input);
 
       // then
-      await expect(result).rejects.toThrow("background_task.maxDescendants=1")
-    })
+      await expect(result).rejects.toThrow("background_task.maxDescendants=1");
+    });
 
     test("should consume descendant quota for reserved sync spawns", async () => {
       // given
-      manager.shutdown()
+      manager.shutdown();
       manager = new BackgroundManager(
         {
           client: createMockClientWithSessionChain({
@@ -2070,32 +2155,32 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
           directory: tmpdir(),
         } as unknown as PluginInput,
         { maxDescendants: 1 },
-      )
+      );
 
-      await manager.reserveSubagentSpawn("session-root")
+      await manager.reserveSubagentSpawn("session-root");
 
       // when
-      const result = manager.assertCanSpawn("session-root")
+      const result = manager.assertCanSpawn("session-root");
 
       // then
-      await expect(result).rejects.toThrow("background_task.maxDescendants=1")
-    })
+      await expect(result).rejects.toThrow("background_task.maxDescendants=1");
+    });
 
     test("should fail closed when session lineage lookup fails", async () => {
       // given
-      manager.shutdown()
+      manager.shutdown();
       manager = new BackgroundManager(
         {
           client: createMockClientWithSessionChain(
             {
               "session-root": { directory: "/test/dir" },
             },
-            { sessionLookupError: new Error("session lookup failed") }
+            { sessionLookupError: new Error("session lookup failed") },
           ),
           directory: tmpdir(),
         } as unknown as PluginInput,
         { maxDescendants: 1 },
-      )
+      );
 
       const input = {
         description: "Test task",
@@ -2103,18 +2188,20 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "session-root",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const result = manager.launch(input)
+      const result = manager.launch(input);
 
       // then
-      await expect(result).rejects.toThrow("background_task.maxDescendants cannot be enforced safely")
-    })
+      await expect(result).rejects.toThrow(
+        "background_task.maxDescendants cannot be enforced safely",
+      );
+    });
 
     test("should release descendant quota when queued task is cancelled before session starts", async () => {
       // given
-      manager.shutdown()
+      manager.shutdown();
       manager = new BackgroundManager(
         {
           client: createMockClientWithSessionChain({
@@ -2123,7 +2210,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
           directory: tmpdir(),
         } as unknown as PluginInput,
         { defaultConcurrency: 1, maxDescendants: 2 },
-      )
+      );
 
       const input = {
         description: "Test task",
@@ -2131,37 +2218,37 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "session-root",
         parentMessageID: "parent-message",
-      }
+      };
 
-      await manager.launch(input)
-      const queuedTask = await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
-      expect(manager.getTask(queuedTask.id)?.status).toBe("pending")
+      await manager.launch(input);
+      const queuedTask = await manager.launch(input);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(manager.getTask(queuedTask.id)?.status).toBe("pending");
 
       // when
-      const cancelled = manager.cancelPendingTask(queuedTask.id)
-      const replacementTask = await manager.launch(input)
+      const cancelled = manager.cancelPendingTask(queuedTask.id);
+      const replacementTask = await manager.launch(input);
 
       // then
-      expect(cancelled).toBe(true)
-      expect(replacementTask.status).toBe("pending")
-    })
+      expect(cancelled).toBe(true);
+      expect(replacementTask.status).toBe("pending");
+    });
 
     test("should release descendant quota when session creation fails before session starts", async () => {
       // given
-      let createAttempts = 0
-      manager.shutdown()
+      let createAttempts = 0;
+      manager.shutdown();
       manager = new BackgroundManager(
         {
           client: {
             session: {
               create: async () => {
-                createAttempts += 1
+                createAttempts += 1;
                 if (createAttempts === 1) {
-                  return { error: "session create failed", data: undefined }
+                  return { error: "session create failed", data: undefined };
                 }
 
-                return { data: { id: `ses_${crypto.randomUUID()}` } }
+                return { data: { id: `ses_${crypto.randomUUID()}` } };
               },
               get: async () => ({ data: { directory: "/test/dir" } }),
               prompt: async () => ({}),
@@ -2175,7 +2262,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
           directory: tmpdir(),
         } as unknown as PluginInput,
         { maxDescendants: 1 },
-      )
+      );
 
       const input = {
         description: "Test task",
@@ -2183,58 +2270,58 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "session-root",
         parentMessageID: "parent-message",
-      }
+      };
 
-      await manager.launch(input)
-      await new Promise(resolve => setTimeout(resolve, 50))
-      expect(createAttempts).toBe(1)
+      await manager.launch(input);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(createAttempts).toBe(1);
 
       // when
-      const retryTask = await manager.launch(input)
+      const retryTask = await manager.launch(input);
 
       // then
-      expect(retryTask.status).toBe("pending")
-    })
+      expect(retryTask.status).toBe("pending");
+    });
 
     test("should keep the next queued task when the first task is cancelled during session creation", async () => {
       // given
-      const firstSessionID = "ses-first-cancelled-during-create"
-      const secondSessionID = "ses-second-survives-queue"
-      let createCallCount = 0
-      let resolveFirstCreate: ((value: { data: { id: string } }) => void) | undefined
-      let resolveFirstCreateStarted: (() => void) | undefined
-      let resolveSecondPromptAsync: (() => void) | undefined
+      const firstSessionID = "ses-first-cancelled-during-create";
+      const secondSessionID = "ses-second-survives-queue";
+      let createCallCount = 0;
+      let resolveFirstCreate: ((value: { data: { id: string } }) => void) | undefined;
+      let resolveFirstCreateStarted: (() => void) | undefined;
+      let resolveSecondPromptAsync: (() => void) | undefined;
       const firstCreateStarted = new Promise<void>((resolve) => {
-        resolveFirstCreateStarted = resolve
-      })
+        resolveFirstCreateStarted = resolve;
+      });
       const secondPromptAsyncStarted = new Promise<void>((resolve) => {
-        resolveSecondPromptAsync = resolve
-      })
+        resolveSecondPromptAsync = resolve;
+      });
 
-      manager.shutdown()
+      manager.shutdown();
       manager = new BackgroundManager(
         {
           client: {
             session: {
               create: async () => {
-                createCallCount += 1
+                createCallCount += 1;
                 if (createCallCount === 1) {
-                  resolveFirstCreateStarted?.()
+                  resolveFirstCreateStarted?.();
                   return await new Promise<{ data: { id: string } }>((resolve) => {
-                    resolveFirstCreate = resolve
-                  })
+                    resolveFirstCreate = resolve;
+                  });
                 }
 
-                return { data: { id: secondSessionID } }
+                return { data: { id: secondSessionID } };
               },
               get: async () => ({ data: { directory: "/test/dir" } }),
               prompt: async () => ({}),
               promptAsync: async ({ path }: { path: { id: string } }) => {
                 if (path.id === secondSessionID) {
-                  resolveSecondPromptAsync?.()
+                  resolveSecondPromptAsync?.();
                 }
 
-                return {}
+                return {};
               },
               messages: async () => ({ data: [] }),
               todo: async () => ({ data: [] }),
@@ -2244,8 +2331,8 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
           },
           directory: tmpdir(),
         } as unknown as PluginInput,
-        { defaultConcurrency: 1 }
-      )
+        { defaultConcurrency: 1 },
+      );
 
       const input = {
         description: "Test task",
@@ -2253,78 +2340,78 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
-      const firstTask = await manager.launch(input)
-      const secondTask = await manager.launch(input)
-      await firstCreateStarted
+      const firstTask = await manager.launch(input);
+      const secondTask = await manager.launch(input);
+      await firstCreateStarted;
 
       // when
       const cancelled = await manager.cancelTask(firstTask.id, {
         source: "test",
         abortSession: false,
-      })
-      resolveFirstCreate?.({ data: { id: firstSessionID } })
+      });
+      resolveFirstCreate?.({ data: { id: firstSessionID } });
 
       await Promise.race([
         secondPromptAsyncStarted,
         new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 100)),
-      ])
+      ]);
 
       // then
-      expect(cancelled).toBe(true)
-      expect(createCallCount).toBe(2)
-      expect(manager.getTask(firstTask.id)?.status).toBe("cancelled")
-      expect(manager.getTask(secondTask.id)?.status).toBe("running")
-      expect(manager.getTask(secondTask.id)?.sessionID).toBe(secondSessionID)
-    })
+      expect(cancelled).toBe(true);
+      expect(createCallCount).toBe(2);
+      expect(manager.getTask(firstTask.id)?.status).toBe("cancelled");
+      expect(manager.getTask(secondTask.id)?.status).toBe("running");
+      expect(manager.getTask(secondTask.id)?.sessionID).toBe(secondSessionID);
+    });
 
     test("should keep task cancelled and abort the session when cancellation wins during session creation", async () => {
       // given
-      const createdSessionID = "ses-cancelled-during-create"
-      let resolveCreate: ((value: { data: { id: string } }) => void) | undefined
-      let resolveCreateStarted: (() => void) | undefined
-      let resolveAbortCalled: (() => void) | undefined
+      const createdSessionID = "ses-cancelled-during-create";
+      let resolveCreate: ((value: { data: { id: string } }) => void) | undefined;
+      let resolveCreateStarted: (() => void) | undefined;
+      let resolveAbortCalled: (() => void) | undefined;
       const createStarted = new Promise<void>((resolve) => {
-        resolveCreateStarted = resolve
-      })
+        resolveCreateStarted = resolve;
+      });
       const abortCalled = new Promise<void>((resolve) => {
-        resolveAbortCalled = resolve
-      })
-      const abortCalls: string[] = []
-      const promptAsyncSessionIDs: string[] = []
+        resolveAbortCalled = resolve;
+      });
+      const abortCalls: string[] = [];
+      const promptAsyncSessionIDs: string[] = [];
 
-      manager.shutdown()
+      manager.shutdown();
       manager = new BackgroundManager(
         {
           client: {
             session: {
               create: async () => {
-                resolveCreateStarted?.()
+                resolveCreateStarted?.();
                 return await new Promise<{ data: { id: string } }>((resolve) => {
-                  resolveCreate = resolve
-                })
+                  resolveCreate = resolve;
+                });
               },
               get: async () => ({ data: { directory: "/test/dir" } }),
               prompt: async () => ({}),
               promptAsync: async ({ path }: { path: { id: string } }) => {
-                promptAsyncSessionIDs.push(path.id)
-                return {}
+                promptAsyncSessionIDs.push(path.id);
+                return {};
               },
               messages: async () => ({ data: [] }),
               todo: async () => ({ data: [] }),
               status: async () => ({ data: {} }),
               abort: async ({ path }: { path: { id: string } }) => {
-                abortCalls.push(path.id)
-                resolveAbortCalled?.()
-                return {}
+                abortCalls.push(path.id);
+                resolveAbortCalled?.();
+                return {};
               },
             },
           },
           directory: tmpdir(),
         } as unknown as PluginInput,
-        { defaultConcurrency: 1 }
-      )
+        { defaultConcurrency: 1 },
+      );
 
       const input = {
         description: "Test task",
@@ -2332,41 +2419,201 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
-      const task = await manager.launch(input)
-      await createStarted
+      const task = await manager.launch(input);
+      await createStarted;
 
       // when
       const cancelled = await manager.cancelTask(task.id, {
         source: "test",
         abortSession: false,
-      })
-      resolveCreate?.({ data: { id: createdSessionID } })
+      });
+      resolveCreate?.({ data: { id: createdSessionID } });
 
       await Promise.race([
         abortCalled,
         new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 100)),
-      ])
-      await Promise.resolve()
+      ]);
+      await Promise.resolve();
 
       // then
-      const updatedTask = manager.getTask(task.id)
-      expect(cancelled).toBe(true)
-      expect(updatedTask?.status).toBe("cancelled")
-      expect(updatedTask?.sessionID).toBeUndefined()
-      expect(promptAsyncSessionIDs).not.toContain(createdSessionID)
-      expect(abortCalls).toEqual([createdSessionID])
-      expect(getConcurrencyManager(manager).getCount("test-agent")).toBe(0)
-    })
-  })
+      const updatedTask = manager.getTask(task.id);
+      expect(cancelled).toBe(true);
+      expect(updatedTask?.status).toBe("cancelled");
+      expect(updatedTask?.sessionID).toBeUndefined();
+      expect(promptAsyncSessionIDs).not.toContain(createdSessionID);
+      expect(abortCalls).toEqual([createdSessionID]);
+      expect(getConcurrencyManager(manager).getCount("test-agent")).toBe(0);
+    });
+
+    test("should release descendant quota when task completes", async () => {
+      // given
+      manager.shutdown();
+      manager = new BackgroundManager(
+        {
+          client: createMockClientWithSessionChain({
+            "session-root": { directory: "/test/dir" },
+          }),
+          directory: tmpdir(),
+        } as unknown as PluginInput,
+        { maxDescendants: 1 },
+      );
+
+      const input = {
+        description: "Test task",
+        prompt: "Do something",
+        agent: "test-agent",
+        parentSessionID: "session-root",
+        parentMessageID: "parent-message",
+      };
+
+      // Launch first task and move it to running state
+      const task = await manager.launch(input);
+      const internalTask = getTaskMap(manager).get(task.id)!;
+      internalTask.status = "running";
+      internalTask.sessionID = "child-session-complete";
+
+      // Simulate task completing via session.status terminal event
+      manager.handleEvent({
+        type: "session.status",
+        properties: { sessionID: internalTask.sessionID, status: { type: "complete" } },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // when — launch second task (should succeed if quota was released on completion)
+      const result = manager.launch(input);
+
+      // then — should NOT throw maxDescendants error
+      await expect(result).resolves.toBeDefined();
+    });
+
+    test("should release descendant quota when running task is cancelled", async () => {
+      // given
+      manager.shutdown();
+      manager = new BackgroundManager(
+        {
+          client: createMockClientWithSessionChain({
+            "session-root": { directory: "/test/dir" },
+          }),
+          directory: tmpdir(),
+        } as unknown as PluginInput,
+        { maxDescendants: 1 },
+      );
+
+      const input = {
+        description: "Test task",
+        prompt: "Do something",
+        agent: "test-agent",
+        parentSessionID: "session-root",
+        parentMessageID: "parent-message",
+      };
+
+      // Launch first task and move it to running state
+      const task = await manager.launch(input);
+      const internalTask = getTaskMap(manager).get(task.id)!;
+      internalTask.status = "running";
+      internalTask.sessionID = "child-session-cancel";
+
+      // Cancel the running task
+      await manager.cancelTask(task.id);
+
+      // when — launch second task (should succeed if quota was released on cancellation)
+      const result = manager.launch(input);
+
+      // then
+      await expect(result).resolves.toBeDefined();
+    });
+
+    test("should release descendant quota when task errors", async () => {
+      // given
+      manager.shutdown();
+      manager = new BackgroundManager(
+        {
+          client: createMockClientWithSessionChain({
+            "session-root": { directory: "/test/dir" },
+          }),
+          directory: tmpdir(),
+        } as unknown as PluginInput,
+        { maxDescendants: 1 },
+      );
+
+      const input = {
+        description: "Test task",
+        prompt: "Do something",
+        agent: "test-agent",
+        parentSessionID: "session-root",
+        parentMessageID: "parent-message",
+      };
+
+      // Launch first task and move it to running state
+      const task = await manager.launch(input);
+      const internalTask = getTaskMap(manager).get(task.id)!;
+      internalTask.status = "running";
+      internalTask.sessionID = "child-session-error";
+
+      // Simulate session error event
+      manager.handleEvent({
+        type: "session.error",
+        properties: { sessionID: internalTask.sessionID, info: { id: internalTask.sessionID } },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // when — launch second task (should succeed if quota was released on error)
+      const result = manager.launch(input);
+
+      // then
+      await expect(result).resolves.toBeDefined();
+    });
+
+    test("should not double-decrement quota when pending task is cancelled", async () => {
+      // given — pending cancellation already works via rollbackPreStartDescendantReservation
+      manager.shutdown();
+      manager = new BackgroundManager(
+        {
+          client: createMockClientWithSessionChain({
+            "session-root": { directory: "/test/dir" },
+          }),
+          directory: tmpdir(),
+        } as unknown as PluginInput,
+        { maxDescendants: 2 },
+      );
+
+      const input = {
+        description: "Test task",
+        prompt: "Do something",
+        agent: "test-agent",
+        parentSessionID: "session-root",
+        parentMessageID: "parent-message",
+      };
+
+      // Launch 2 tasks (both start as pending)
+      const task1 = await manager.launch(input);
+      const task2 = await manager.launch(input);
+
+      // Cancel both pending tasks (rollbackPreStartDescendantReservation handles decrement)
+      await manager.cancelTask(task1.id);
+      await manager.cancelTask(task2.id);
+
+      // when — launch 2 more (quota should be fully restored, no double-decrement)
+      const result1 = manager.launch(input);
+      const result2 = manager.launch(input);
+
+      // then — both should succeed
+      await expect(result1).resolves.toBeDefined();
+      await expect(result2).resolves.toBeDefined();
+    });
+  });
 
   describe("pending task can be cancelled", () => {
     test("should cancel pending task successfully", async () => {
       // given
-      const config = { defaultConcurrency: 1 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 1 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -2374,29 +2621,32 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
-      const task1 = await manager.launch(input)
-      const task2 = await manager.launch(input)
+      const task1 = await manager.launch(input);
+      const task2 = await manager.launch(input);
 
       // Wait for first task to start
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // when
-      const cancelled = manager.cancelPendingTask(task2.id)
+      const cancelled = manager.cancelPendingTask(task2.id);
 
       // then
-      expect(cancelled).toBe(true)
-      const updatedTask2 = manager.getTask(task2.id)
-      expect(updatedTask2?.status).toBe("cancelled")
-      expect(updatedTask2?.completedAt).toBeInstanceOf(Date)
-    })
+      expect(cancelled).toBe(true);
+      const updatedTask2 = manager.getTask(task2.id);
+      expect(updatedTask2?.status).toBe("cancelled");
+      expect(updatedTask2?.completedAt).toBeInstanceOf(Date);
+    });
 
     test("should not cancel running task", async () => {
       // given
-      const config = { defaultConcurrency: 5 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 5 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -2404,27 +2654,30 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
-      const task = await manager.launch(input)
+      const task = await manager.launch(input);
 
       // Wait for task to start
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // when
-      const cancelled = manager.cancelPendingTask(task.id)
+      const cancelled = manager.cancelPendingTask(task.id);
 
       // then
-      expect(cancelled).toBe(false)
-      const updatedTask = manager.getTask(task.id)
-      expect(updatedTask?.status).toBe("running")
-    })
+      expect(cancelled).toBe(false);
+      const updatedTask = manager.getTask(task.id);
+      expect(updatedTask?.status).toBe("running");
+    });
 
     test("should remove cancelled task from queue", async () => {
       // given
-      const config = { defaultConcurrency: 1 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 1 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -2432,38 +2685,38 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
-      const task1 = await manager.launch(input)
-      const task2 = await manager.launch(input)
-      const task3 = await manager.launch(input)
+      const task1 = await manager.launch(input);
+      const task2 = await manager.launch(input);
+      const task3 = await manager.launch(input);
 
       // Wait for first task to start
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // when - cancel middle task
-      const cancelledTask2 = manager.getTask(task2.id)
-      expect(cancelledTask2?.status).toBe("pending")
-      
-      manager.cancelPendingTask(task2.id)
-      
-      const afterCancel = manager.getTask(task2.id)
-      expect(afterCancel?.status).toBe("cancelled")
+      const cancelledTask2 = manager.getTask(task2.id);
+      expect(cancelledTask2?.status).toBe("pending");
+
+      manager.cancelPendingTask(task2.id);
+
+      const afterCancel = manager.getTask(task2.id);
+      expect(afterCancel?.status).toBe("cancelled");
 
       // then - verify task3 is still pending (task1 still running)
-      const task3BeforeRelease = manager.getTask(task3.id)
-      expect(task3BeforeRelease?.status).toBe("pending")
-    })
-  })
+      const task3BeforeRelease = manager.getTask(task3.id);
+      expect(task3BeforeRelease?.status).toBe("pending");
+    });
+  });
 
   describe("cancelTask", () => {
     test("should cancel running task and release concurrency", async () => {
       // given
-      const manager = createBackgroundManager()
+      const manager = createBackgroundManager();
 
-      const concurrencyManager = getConcurrencyManager(manager)
-      const concurrencyKey = "test-provider/test-model"
-      await concurrencyManager.acquire(concurrencyKey)
+      const concurrencyManager = getConcurrencyManager(manager);
+      const concurrencyKey = "test-provider/test-model";
+      await concurrencyManager.acquire(concurrencyKey);
 
       const task = createMockTask({
         id: "task-cancel-running",
@@ -2471,60 +2724,63 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         parentSessionID: "parent-cancel",
         status: "running",
         concurrencyKey,
-      })
+      });
 
-      getTaskMap(manager).set(task.id, task)
-      const pendingByParent = getPendingByParent(manager)
-      pendingByParent.set(task.parentSessionID, new Set([task.id]))
+      getTaskMap(manager).set(task.id, task);
+      const pendingByParent = getPendingByParent(manager);
+      pendingByParent.set(task.parentSessionID, new Set([task.id]));
 
       // when
-      const cancelled = await manager.cancelTask(task.id, { source: "test" })
+      const cancelled = await manager.cancelTask(task.id, { source: "test" });
 
       // then
-      const updatedTask = manager.getTask(task.id)
-      expect(cancelled).toBe(true)
-      expect(updatedTask?.status).toBe("cancelled")
-      expect(updatedTask?.completedAt).toBeInstanceOf(Date)
-      expect(updatedTask?.concurrencyKey).toBeUndefined()
-      expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
+      const updatedTask = manager.getTask(task.id);
+      expect(cancelled).toBe(true);
+      expect(updatedTask?.status).toBe("cancelled");
+      expect(updatedTask?.completedAt).toBeInstanceOf(Date);
+      expect(updatedTask?.concurrencyKey).toBeUndefined();
+      expect(concurrencyManager.getCount(concurrencyKey)).toBe(0);
 
-      const pendingSet = pendingByParent.get(task.parentSessionID)
-      expect(pendingSet?.has(task.id) ?? false).toBe(false)
-    })
+      const pendingSet = pendingByParent.get(task.parentSessionID);
+      expect(pendingSet?.has(task.id) ?? false).toBe(false);
+    });
 
     test("should remove task from toast manager when notification is skipped", async () => {
       //#given
-      const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
-      const manager = createBackgroundManager()
+      const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker();
+      const manager = createBackgroundManager();
       const task = createMockTask({
         id: "task-cancel-skip-notification",
         sessionID: "session-cancel-skip-notification",
         parentSessionID: "parent-cancel-skip-notification",
         status: "running",
-      })
-      getTaskMap(manager).set(task.id, task)
+      });
+      getTaskMap(manager).set(task.id, task);
 
       //#when
       const cancelled = await manager.cancelTask(task.id, {
         source: "test",
         skipNotification: true,
-      })
+      });
 
       //#then
-      expect(cancelled).toBe(true)
-      expect(removeTaskCalls).toContain(task.id)
+      expect(cancelled).toBe(true);
+      expect(removeTaskCalls).toContain(task.id);
 
-      manager.shutdown()
-      resetToastManager()
-    })
-  })
+      manager.shutdown();
+      resetToastManager();
+    });
+  });
 
   describe("multiple keys process in parallel", () => {
     test("should process different concurrency keys in parallel", async () => {
       // given
-      const config = { defaultConcurrency: 1 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 1 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input1 = {
         description: "Task 1",
@@ -2532,7 +2788,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "agent-a",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       const input2 = {
         description: "Task 2",
@@ -2540,28 +2796,31 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "agent-b",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const task1 = await manager.launch(input1)
-      const task2 = await manager.launch(input2)
+      const task1 = await manager.launch(input1);
+      const task2 = await manager.launch(input2);
 
       // Wait for both to start
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // then - both should be running despite limit of 1 (different keys)
-      const updatedTask1 = manager.getTask(task1.id)
-      const updatedTask2 = manager.getTask(task2.id)
+      const updatedTask1 = manager.getTask(task1.id);
+      const updatedTask2 = manager.getTask(task2.id);
 
-      expect(updatedTask1?.status).toBe("running")
-      expect(updatedTask2?.status).toBe("running")
-    })
+      expect(updatedTask1?.status).toBe("running");
+      expect(updatedTask2?.status).toBe("running");
+    });
 
     test("should respect per-key concurrency limits", async () => {
       // given
-      const config = { defaultConcurrency: 1 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 1 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -2569,28 +2828,31 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const task1 = await manager.launch(input)
-      const task2 = await manager.launch(input)
+      const task1 = await manager.launch(input);
+      const task2 = await manager.launch(input);
 
       // Wait for processing
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // then - same key should respect limit
-      const updatedTask1 = manager.getTask(task1.id)
-      const updatedTask2 = manager.getTask(task2.id)
+      const updatedTask1 = manager.getTask(task1.id);
+      const updatedTask2 = manager.getTask(task2.id);
 
-      expect(updatedTask1?.status).toBe("running")
-      expect(updatedTask2?.status).toBe("pending")
-    })
+      expect(updatedTask1?.status).toBe("running");
+      expect(updatedTask2?.status).toBe("pending");
+    });
 
     test("should process model-based keys in parallel", async () => {
       // given
-      const config = { defaultConcurrency: 1 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 1 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input1 = {
         description: "Task 1",
@@ -2599,7 +2861,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       const input2 = {
         description: "Task 2",
@@ -2608,30 +2870,33 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         model: { providerID: "openai", modelID: "gpt-5.4" },
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const task1 = await manager.launch(input1)
-      const task2 = await manager.launch(input2)
+      const task1 = await manager.launch(input1);
+      const task2 = await manager.launch(input2);
 
       // Wait for both to start
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // then - different models should run in parallel
-      const updatedTask1 = manager.getTask(task1.id)
-      const updatedTask2 = manager.getTask(task2.id)
+      const updatedTask1 = manager.getTask(task1.id);
+      const updatedTask2 = manager.getTask(task2.id);
 
-      expect(updatedTask1?.status).toBe("running")
-      expect(updatedTask2?.status).toBe("running")
-    })
-  })
+      expect(updatedTask1?.status).toBe("running");
+      expect(updatedTask2?.status).toBe("running");
+    });
+  });
 
   describe("TTL uses queuedAt for pending, startedAt for running", () => {
     test("should use queuedAt for pending task TTL", async () => {
       // given
-      const config = { defaultConcurrency: 1 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 1 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -2639,34 +2904,37 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // Launch two tasks (second will be pending)
-      await manager.launch(input)
-      const task2 = await manager.launch(input)
+      await manager.launch(input);
+      const task2 = await manager.launch(input);
 
       // Wait for first to start
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // when
-      const pendingTask = manager.getTask(task2.id)
+      const pendingTask = manager.getTask(task2.id);
 
       // then
-      expect(pendingTask?.status).toBe("pending")
-      expect(pendingTask?.queuedAt).toBeInstanceOf(Date)
-      expect(pendingTask?.startedAt).toBeUndefined()
+      expect(pendingTask?.status).toBe("pending");
+      expect(pendingTask?.queuedAt).toBeInstanceOf(Date);
+      expect(pendingTask?.startedAt).toBeUndefined();
 
       // Verify TTL would use queuedAt (implementation detail check)
-      const now = Date.now()
-      const age = now - pendingTask!.queuedAt!.getTime()
-      expect(age).toBeGreaterThanOrEqual(0)
-    })
+      const now = Date.now();
+      const age = now - pendingTask!.queuedAt!.getTime();
+      expect(age).toBeGreaterThanOrEqual(0);
+    });
 
     test("should use startedAt for running task TTL", async () => {
       // given
-      const config = { defaultConcurrency: 5 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 5 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -2674,30 +2942,33 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const task = await manager.launch(input)
+      const task = await manager.launch(input);
 
       // Wait for task to start
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // then
-      const runningTask = manager.getTask(task.id)
-      expect(runningTask?.status).toBe("running")
-      expect(runningTask?.startedAt).toBeInstanceOf(Date)
+      const runningTask = manager.getTask(task.id);
+      expect(runningTask?.status).toBe("running");
+      expect(runningTask?.startedAt).toBeInstanceOf(Date);
 
       // Verify TTL would use startedAt (implementation detail check)
-      const now = Date.now()
-      const age = now - runningTask!.startedAt!.getTime()
-      expect(age).toBeGreaterThanOrEqual(0)
-    })
+      const now = Date.now();
+      const age = now - runningTask!.startedAt!.getTime();
+      expect(age).toBeGreaterThanOrEqual(0);
+    });
 
     test("should have different timestamps for queuedAt and startedAt", async () => {
       // given
-      const config = { defaultConcurrency: 1 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 1 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -2705,43 +2976,46 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // Launch task that will queue
-      await manager.launch(input)
-      const task2 = await manager.launch(input)
+      await manager.launch(input);
+      const task2 = await manager.launch(input);
 
-      const queuedAt = task2.queuedAt!
+      const queuedAt = task2.queuedAt!;
 
       // Wait for first task to complete and second to start
-      await new Promise(resolve => setTimeout(resolve, 50))
+      await new Promise((resolve) => setTimeout(resolve, 50));
 
       // Simulate first task completion
-      const tasks = Array.from(getTaskMap(manager).values())
-      const runningTask = tasks.find(t => t.status === "running" && t.id !== task2.id)
+      const tasks = Array.from(getTaskMap(manager).values());
+      const runningTask = tasks.find((t) => t.status === "running" && t.id !== task2.id);
       if (runningTask?.concurrencyKey) {
-        runningTask.status = "completed"
-        getConcurrencyManager(manager).release(runningTask.concurrencyKey)
+        runningTask.status = "completed";
+        getConcurrencyManager(manager).release(runningTask.concurrencyKey);
       }
 
       // Wait for second task to start
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
-      const startedTask = manager.getTask(task2.id)
+      const startedTask = manager.getTask(task2.id);
       if (startedTask?.status === "running" && startedTask.startedAt) {
-        expect(startedTask.startedAt).toBeInstanceOf(Date)
-        expect(startedTask.startedAt.getTime()).toBeGreaterThan(queuedAt.getTime())
+        expect(startedTask.startedAt).toBeInstanceOf(Date);
+        expect(startedTask.startedAt.getTime()).toBeGreaterThan(queuedAt.getTime());
       }
-    })
-  })
+    });
+  });
 
   describe("manual verification scenario", () => {
     test("should handle 10 tasks with limit 5 returning immediately", async () => {
       // given
-      const config = { defaultConcurrency: 5 }
-      manager.shutdown()
-      manager = new BackgroundManager({ client: mockClient, directory: tmpdir() } as unknown as PluginInput, config)
+      const config = { defaultConcurrency: 5 };
+      manager.shutdown();
+      manager = new BackgroundManager(
+        { client: mockClient, directory: tmpdir() } as unknown as PluginInput,
+        config,
+      );
 
       const input = {
         description: "Test task",
@@ -2749,47 +3023,48 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         agent: "test-agent",
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
-      }
+      };
 
       // when
-      const startTime = Date.now()
-      const tasks = await Promise.all(
-        Array.from({ length: 10 }, () => manager.launch(input))
-      )
-      const endTime = Date.now()
+      const startTime = Date.now();
+      const tasks = await Promise.all(Array.from({ length: 10 }, () => manager.launch(input)));
+      const endTime = Date.now();
 
       // then
-      expect(endTime - startTime).toBeLessThan(200) // Should be very fast
-      expect(tasks).toHaveLength(10)
-      tasks.forEach(task => {
-        expect(task.status).toBe("pending")
-        expect(task.id).toMatch(/^bg_/)
-      })
+      expect(endTime - startTime).toBeLessThan(200); // Should be very fast
+      expect(tasks).toHaveLength(10);
+      tasks.forEach((task) => {
+        expect(task.status).toBe("pending");
+        expect(task.id).toMatch(/^bg_/);
+      });
 
       // Wait for processing
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Verify 5 running, 5 pending
-      const updatedTasks = tasks.map(t => manager.getTask(t.id))
-      const runningCount = updatedTasks.filter(t => t?.status === "running").length
-      const pendingCount = updatedTasks.filter(t => t?.status === "pending").length
+      const updatedTasks = tasks.map((t) => manager.getTask(t.id));
+      const runningCount = updatedTasks.filter((t) => t?.status === "running").length;
+      const pendingCount = updatedTasks.filter((t) => t?.status === "pending").length;
 
-      expect(runningCount).toBe(5)
-      expect(pendingCount).toBe(5)
-    })
-  })
-})
+      expect(runningCount).toBe(5);
+      expect(pendingCount).toBe(5);
+    });
+  });
+});
 
 describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
-   test("should NOT interrupt task running less than 30 seconds (min runtime guard)", async () => {
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-       },
-     }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
+  test("should NOT interrupt task running less than 30 seconds (min runtime guard)", async () => {
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+      },
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
 
     const task: BackgroundTask = {
       id: "task-1",
@@ -2805,24 +3080,27 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 0,
         lastUpdate: new Date(Date.now() - 200_000),
       },
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
-    await manager["checkAndInterruptStaleTasks"]()
+    await manager["checkAndInterruptStaleTasks"]();
 
-    expect(task.status).toBe("running")
-  })
+    expect(task.status).toBe("running");
+  });
 
-   test("should NOT interrupt task with recent lastUpdate", async () => {
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
+  test("should NOT interrupt task with recent lastUpdate", async () => {
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+      },
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
 
     const task: BackgroundTask = {
       id: "task-2",
@@ -2838,25 +3116,28 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 5,
         lastUpdate: new Date(Date.now() - 30_000),
       },
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
-    await manager["checkAndInterruptStaleTasks"]()
+    await manager["checkAndInterruptStaleTasks"]();
 
-    expect(task.status).toBe("running")
-  })
+    expect(task.status).toBe("running");
+  });
 
-   test("should interrupt task with stale lastUpdate (> 3min)", async () => {
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
+  test("should interrupt task with stale lastUpdate (> 3min)", async () => {
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
-    stubNotifyParentSession(manager)
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-3",
@@ -2872,28 +3153,31 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 2,
         lastUpdate: new Date(Date.now() - 200_000),
       },
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
-    await manager["checkAndInterruptStaleTasks"]()
+    await manager["checkAndInterruptStaleTasks"]();
 
-    expect(task.status).toBe("cancelled")
-    expect(task.error).toContain("Stale timeout")
-    expect(task.error).toContain("3min")
-    expect(task.completedAt).toBeDefined()
-  })
+    expect(task.status).toBe("cancelled");
+    expect(task.error).toContain("Stale timeout");
+    expect(task.error).toContain("3min");
+    expect(task.completedAt).toBeDefined();
+  });
 
-   test("should respect custom staleTimeoutMs config", async () => {
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
+  test("should respect custom staleTimeoutMs config", async () => {
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 60_000 })
-    stubNotifyParentSession(manager)
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 60_000 },
+    );
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-4",
@@ -2909,26 +3193,29 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 1,
         lastUpdate: new Date(Date.now() - 90_000),
       },
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
-    await manager["checkAndInterruptStaleTasks"]()
+    await manager["checkAndInterruptStaleTasks"]();
 
-    expect(task.status).toBe("cancelled")
-    expect(task.error).toContain("Stale timeout")
-  })
+    expect(task.status).toBe("cancelled");
+    expect(task.error).toContain("Stale timeout");
+  });
 
-   test("should release concurrency before abort", async () => {
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-       },
-     }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
-    stubNotifyParentSession(manager)
+  test("should release concurrency before abort", async () => {
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+      },
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-5",
@@ -2945,26 +3232,29 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         lastUpdate: new Date(Date.now() - 200_000),
       },
       concurrencyKey: "test-agent",
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
-    await manager["checkAndInterruptStaleTasks"]()
+    await manager["checkAndInterruptStaleTasks"]();
 
-    expect(task.concurrencyKey).toBeUndefined()
-    expect(task.status).toBe("cancelled")
-  })
+    expect(task.concurrencyKey).toBeUndefined();
+    expect(task.status).toBe("cancelled");
+  });
 
-   test("should handle multiple stale tasks in same poll cycle", async () => {
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-       },
-     }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
-    stubNotifyParentSession(manager)
+  test("should handle multiple stale tasks in same poll cycle", async () => {
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+      },
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
+    stubNotifyParentSession(manager);
 
     const task1: BackgroundTask = {
       id: "task-6",
@@ -2980,7 +3270,7 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 1,
         lastUpdate: new Date(Date.now() - 200_000),
       },
-    }
+    };
 
     const task2: BackgroundTask = {
       id: "task-7",
@@ -2996,27 +3286,30 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 2,
         lastUpdate: new Date(Date.now() - 250_000),
       },
-    }
+    };
 
-    getTaskMap(manager).set(task1.id, task1)
-    getTaskMap(manager).set(task2.id, task2)
+    getTaskMap(manager).set(task1.id, task1);
+    getTaskMap(manager).set(task2.id, task2);
 
-    await manager["checkAndInterruptStaleTasks"]()
+    await manager["checkAndInterruptStaleTasks"]();
 
-    expect(task1.status).toBe("cancelled")
-    expect(task2.status).toBe("cancelled")
-  })
+    expect(task1.status).toBe("cancelled");
+    expect(task2.status).toBe("cancelled");
+  });
 
-   test("should use default timeout when config not provided", async () => {
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-       },
-     }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
-    stubNotifyParentSession(manager)
+  test("should use default timeout when config not provided", async () => {
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+      },
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-8",
@@ -3032,14 +3325,14 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 1,
         lastUpdate: new Date(Date.now() - 21 * 60 * 1000),
       },
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
-     await manager["checkAndInterruptStaleTasks"]()
+    await manager["checkAndInterruptStaleTasks"]();
 
-    expect(task.status).toBe("cancelled")
-  })
+    expect(task.status).toBe("cancelled");
+  });
 
   test("should NOT interrupt task when session is running, even with stale lastUpdate", async () => {
     //#given
@@ -3049,8 +3342,11 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
 
     const task: BackgroundTask = {
       id: "task-running-session",
@@ -3066,16 +3362,16 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 2,
         lastUpdate: new Date(Date.now() - 300_000),
       },
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
     //#when — session is actively running
-    await manager["checkAndInterruptStaleTasks"]({ "session-running": { type: "running" } })
+    await manager["checkAndInterruptStaleTasks"]({ "session-running": { type: "running" } });
 
     //#then — task survives because session is running
-    expect(task.status).toBe("running")
-  })
+    expect(task.status).toBe("running");
+  });
 
   test("should interrupt task when session is idle and lastUpdate exceeds stale timeout", async () => {
     //#given
@@ -3085,9 +3381,12 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
-    stubNotifyParentSession(manager)
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-idle-session",
@@ -3103,17 +3402,17 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 2,
         lastUpdate: new Date(Date.now() - 300_000),
       },
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
     //#when — session is idle
-    await manager["checkAndInterruptStaleTasks"]({ "session-idle": { type: "idle" } })
+    await manager["checkAndInterruptStaleTasks"]({ "session-idle": { type: "idle" } });
 
     //#then — killed because session is idle with stale lastUpdate
-    expect(task.status).toBe("cancelled")
-    expect(task.error).toContain("Stale timeout")
-  })
+    expect(task.status).toBe("cancelled");
+    expect(task.error).toContain("Stale timeout");
+  });
 
   test("should NOT interrupt running session even with very old lastUpdate (no safety net)", async () => {
     //#given
@@ -3123,8 +3422,11 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
 
     const task: BackgroundTask = {
       id: "task-long-running",
@@ -3140,16 +3442,16 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         toolCalls: 5,
         lastUpdate: new Date(Date.now() - 900_000),
       },
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
     //#when — session is running, lastUpdate 15min old
-    await manager["checkAndInterruptStaleTasks"]({ "session-long": { type: "running" } })
+    await manager["checkAndInterruptStaleTasks"]({ "session-long": { type: "running" } });
 
     //#then — running sessions are NEVER stale-killed
-    expect(task.status).toBe("running")
-  })
+    expect(task.status).toBe("running");
+  });
 
   test("should NOT interrupt running session with no progress (undefined lastUpdate)", async () => {
     //#given — no progress at all, but session is running
@@ -3159,8 +3461,11 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { messageStalenessTimeoutMs: 600_000 })
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { messageStalenessTimeoutMs: 600_000 },
+    );
 
     const task: BackgroundTask = {
       id: "task-running-no-progress",
@@ -3173,16 +3478,16 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
       status: "running",
       startedAt: new Date(Date.now() - 15 * 60 * 1000),
       progress: undefined,
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
     //#when — session is running despite no progress
-    await manager["checkAndInterruptStaleTasks"]({ "session-rnp": { type: "running" } })
+    await manager["checkAndInterruptStaleTasks"]({ "session-rnp": { type: "running" } });
 
     //#then — running sessions are NEVER killed
-    expect(task.status).toBe("running")
-  })
+    expect(task.status).toBe("running");
+  });
 
   test("should interrupt task with no lastUpdate after messageStalenessTimeout", async () => {
     //#given
@@ -3192,9 +3497,12 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { messageStalenessTimeoutMs: 600_000 })
-    stubNotifyParentSession(manager)
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { messageStalenessTimeoutMs: 600_000 },
+    );
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-no-update",
@@ -3207,17 +3515,17 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
       status: "running",
       startedAt: new Date(Date.now() - 15 * 60 * 1000),
       progress: undefined,
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
     //#when — no progress update for 15 minutes
-    await manager["checkAndInterruptStaleTasks"]({})
+    await manager["checkAndInterruptStaleTasks"]({});
 
     //#then — killed after messageStalenessTimeout
-    expect(task.status).toBe("cancelled")
-    expect(task.error).toContain("no activity")
-  })
+    expect(task.status).toBe("cancelled");
+    expect(task.error).toContain("no activity");
+  });
 
   test("should NOT interrupt task with no lastUpdate within messageStalenessTimeout", async () => {
     //#given
@@ -3227,8 +3535,11 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { messageStalenessTimeoutMs: 600_000 })
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { messageStalenessTimeoutMs: 600_000 },
+    );
 
     const task: BackgroundTask = {
       id: "task-fresh-no-update",
@@ -3241,33 +3552,36 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
       status: "running",
       startedAt: new Date(Date.now() - 5 * 60 * 1000),
       progress: undefined,
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
     //#when — only 5 min since start, within 10min timeout
-    await manager["checkAndInterruptStaleTasks"]({})
+    await manager["checkAndInterruptStaleTasks"]({});
 
     //#then — task survives
-    expect(task.status).toBe("running")
-  })
-})
+    expect(task.status).toBe("running");
+  });
+});
 
 describe("BackgroundManager.shutdown session abort", () => {
-   test("should call session.abort for all running tasks during shutdown", () => {
-     // given
-     const abortedSessionIDs: string[] = []
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async (args: { path: { id: string } }) => {
-           abortedSessionIDs.push(args.path.id)
-           return {}
-         },
-       },
-     }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+  test("should call session.abort for all running tasks during shutdown", () => {
+    // given
+    const abortedSessionIDs: string[] = [];
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async (args: { path: { id: string } }) => {
+          abortedSessionIDs.push(args.path.id);
+          return {};
+        },
+      },
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
 
     const task1: BackgroundTask = {
       id: "task-1",
@@ -3279,7 +3593,7 @@ describe("BackgroundManager.shutdown session abort", () => {
       agent: "test-agent",
       status: "running",
       startedAt: new Date(),
-    }
+    };
     const task2: BackgroundTask = {
       id: "task-2",
       sessionID: "session-2",
@@ -3290,34 +3604,37 @@ describe("BackgroundManager.shutdown session abort", () => {
       agent: "test-agent",
       status: "running",
       startedAt: new Date(),
-    }
+    };
 
-    getTaskMap(manager).set(task1.id, task1)
-    getTaskMap(manager).set(task2.id, task2)
+    getTaskMap(manager).set(task1.id, task1);
+    getTaskMap(manager).set(task2.id, task2);
 
     // when
-    manager.shutdown()
+    manager.shutdown();
 
     // then
-    expect(abortedSessionIDs).toContain("session-1")
-    expect(abortedSessionIDs).toContain("session-2")
-    expect(abortedSessionIDs).toHaveLength(2)
-  })
+    expect(abortedSessionIDs).toContain("session-1");
+    expect(abortedSessionIDs).toContain("session-2");
+    expect(abortedSessionIDs).toHaveLength(2);
+  });
 
-   test("should not call session.abort for completed or cancelled tasks", () => {
-     // given
-     const abortedSessionIDs: string[] = []
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async (args: { path: { id: string } }) => {
-           abortedSessionIDs.push(args.path.id)
-           return {}
-         },
-       },
-     }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+  test("should not call session.abort for completed or cancelled tasks", () => {
+    // given
+    const abortedSessionIDs: string[] = [];
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async (args: { path: { id: string } }) => {
+          abortedSessionIDs.push(args.path.id);
+          return {};
+        },
+      },
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
 
     const completedTask: BackgroundTask = {
       id: "task-completed",
@@ -3330,7 +3647,7 @@ describe("BackgroundManager.shutdown session abort", () => {
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
+    };
     const cancelledTask: BackgroundTask = {
       id: "task-cancelled",
       sessionID: "session-cancelled",
@@ -3342,7 +3659,7 @@ describe("BackgroundManager.shutdown session abort", () => {
       status: "cancelled",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
+    };
     const pendingTask: BackgroundTask = {
       id: "task-pending",
       parentSessionID: "parent-3",
@@ -3352,87 +3669,87 @@ describe("BackgroundManager.shutdown session abort", () => {
       agent: "test-agent",
       status: "pending",
       queuedAt: new Date(),
-    }
+    };
 
-    getTaskMap(manager).set(completedTask.id, completedTask)
-    getTaskMap(manager).set(cancelledTask.id, cancelledTask)
-    getTaskMap(manager).set(pendingTask.id, pendingTask)
+    getTaskMap(manager).set(completedTask.id, completedTask);
+    getTaskMap(manager).set(cancelledTask.id, cancelledTask);
+    getTaskMap(manager).set(pendingTask.id, pendingTask);
 
     // when
-    manager.shutdown()
+    manager.shutdown();
 
     // then
-    expect(abortedSessionIDs).toHaveLength(0)
-  })
+    expect(abortedSessionIDs).toHaveLength(0);
+  });
 
-   test("should call onShutdown callback during shutdown", () => {
-     // given
-     let shutdownCalled = false
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-       },
-     }
+  test("should call onShutdown callback during shutdown", () => {
+    // given
+    let shutdownCalled = false;
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+      },
+    };
     const manager = new BackgroundManager(
       { client, directory: tmpdir() } as unknown as PluginInput,
       undefined,
       {
         onShutdown: () => {
-          shutdownCalled = true
+          shutdownCalled = true;
         },
-      }
-    )
+      },
+    );
 
     // when
-    manager.shutdown()
+    manager.shutdown();
 
     // then
-    expect(shutdownCalled).toBe(true)
-  })
+    expect(shutdownCalled).toBe(true);
+  });
 
-   test("should not throw when onShutdown callback throws", () => {
-     // given
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-       },
-     }
+  test("should not throw when onShutdown callback throws", () => {
+    // given
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+      },
+    };
     const manager = new BackgroundManager(
       { client, directory: tmpdir() } as unknown as PluginInput,
       undefined,
       {
         onShutdown: () => {
-          throw new Error("cleanup failed")
+          throw new Error("cleanup failed");
         },
-      }
-    )
+      },
+    );
 
     // when / #then
-    expect(() => manager.shutdown()).not.toThrow()
-  })
-})
+    expect(() => manager.shutdown()).not.toThrow();
+  });
+});
 
 describe("BackgroundManager.handleEvent - session.deleted cascade", () => {
   test("should cancel descendant tasks and keep them until delayed cleanup", async () => {
     // given
-    const manager = createBackgroundManager()
-    const parentSessionID = "session-parent"
+    const manager = createBackgroundManager();
+    const parentSessionID = "session-parent";
     const childTask = createMockTask({
       id: "task-child",
       sessionID: "session-child",
       parentSessionID,
       status: "running",
-    })
+    });
     const siblingTask = createMockTask({
       id: "task-sibling",
       sessionID: "session-sibling",
       parentSessionID,
       status: "running",
-    })
+    });
     const grandchildTask = createMockTask({
       id: "task-grandchild",
       sessionID: "session-grandchild",
@@ -3440,60 +3757,60 @@ describe("BackgroundManager.handleEvent - session.deleted cascade", () => {
       status: "pending",
       startedAt: undefined,
       queuedAt: new Date(),
-    })
+    });
     const unrelatedTask = createMockTask({
       id: "task-unrelated",
       sessionID: "session-unrelated",
       parentSessionID: "other-parent",
       status: "running",
-    })
+    });
 
-    const taskMap = getTaskMap(manager)
-    taskMap.set(childTask.id, childTask)
-    taskMap.set(siblingTask.id, siblingTask)
-    taskMap.set(grandchildTask.id, grandchildTask)
-    taskMap.set(unrelatedTask.id, unrelatedTask)
+    const taskMap = getTaskMap(manager);
+    taskMap.set(childTask.id, childTask);
+    taskMap.set(siblingTask.id, siblingTask);
+    taskMap.set(grandchildTask.id, grandchildTask);
+    taskMap.set(unrelatedTask.id, unrelatedTask);
 
-    const pendingByParent = getPendingByParent(manager)
-    pendingByParent.set(parentSessionID, new Set([childTask.id, siblingTask.id]))
-    pendingByParent.set("session-child", new Set([grandchildTask.id]))
+    const pendingByParent = getPendingByParent(manager);
+    pendingByParent.set(parentSessionID, new Set([childTask.id, siblingTask.id]));
+    pendingByParent.set("session-child", new Set([grandchildTask.id]));
 
     // when
     manager.handleEvent({
       type: "session.deleted",
       properties: { info: { id: parentSessionID } },
-    })
+    });
 
-    await flushBackgroundNotifications()
+    await flushBackgroundNotifications();
 
     // then
-    expect(taskMap.has(childTask.id)).toBe(true)
-    expect(taskMap.has(siblingTask.id)).toBe(true)
-    expect(taskMap.has(grandchildTask.id)).toBe(true)
-    expect(taskMap.has(unrelatedTask.id)).toBe(true)
-    expect(childTask.status).toBe("cancelled")
-    expect(siblingTask.status).toBe("cancelled")
-    expect(grandchildTask.status).toBe("cancelled")
-    expect(pendingByParent.get(parentSessionID)).toBeUndefined()
-    expect(pendingByParent.get("session-child")).toBeUndefined()
-    expect(getCompletionTimers(manager).has(childTask.id)).toBe(true)
-    expect(getCompletionTimers(manager).has(siblingTask.id)).toBe(true)
-    expect(getCompletionTimers(manager).has(grandchildTask.id)).toBe(true)
+    expect(taskMap.has(childTask.id)).toBe(true);
+    expect(taskMap.has(siblingTask.id)).toBe(true);
+    expect(taskMap.has(grandchildTask.id)).toBe(true);
+    expect(taskMap.has(unrelatedTask.id)).toBe(true);
+    expect(childTask.status).toBe("cancelled");
+    expect(siblingTask.status).toBe("cancelled");
+    expect(grandchildTask.status).toBe("cancelled");
+    expect(pendingByParent.get(parentSessionID)).toBeUndefined();
+    expect(pendingByParent.get("session-child")).toBeUndefined();
+    expect(getCompletionTimers(manager).has(childTask.id)).toBe(true);
+    expect(getCompletionTimers(manager).has(siblingTask.id)).toBe(true);
+    expect(getCompletionTimers(manager).has(grandchildTask.id)).toBe(true);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should remove cancelled tasks from toast manager while preserving delayed cleanup", async () => {
     //#given
-    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
-    const manager = createBackgroundManager()
-    const parentSessionID = "session-parent-toast"
+    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker();
+    const manager = createBackgroundManager();
+    const parentSessionID = "session-parent-toast";
     const childTask = createMockTask({
       id: "task-child-toast",
       sessionID: "session-child-toast",
       parentSessionID,
       status: "running",
-    })
+    });
     const grandchildTask = createMockTask({
       id: "task-grandchild-toast",
       sessionID: "session-grandchild-toast",
@@ -3501,69 +3818,73 @@ describe("BackgroundManager.handleEvent - session.deleted cascade", () => {
       status: "pending",
       startedAt: undefined,
       queuedAt: new Date(),
-    })
-    const taskMap = getTaskMap(manager)
-    taskMap.set(childTask.id, childTask)
-    taskMap.set(grandchildTask.id, grandchildTask)
+    });
+    const taskMap = getTaskMap(manager);
+    taskMap.set(childTask.id, childTask);
+    taskMap.set(grandchildTask.id, grandchildTask);
 
     //#when
     manager.handleEvent({
       type: "session.deleted",
       properties: { info: { id: parentSessionID } },
-    })
+    });
 
-    await flushBackgroundNotifications()
+    await flushBackgroundNotifications();
 
     //#then
-    expect(removeTaskCalls).toContain(childTask.id)
-    expect(removeTaskCalls).toContain(grandchildTask.id)
-    expect(getCompletionTimers(manager).has(childTask.id)).toBe(true)
-    expect(getCompletionTimers(manager).has(grandchildTask.id)).toBe(true)
+    expect(removeTaskCalls).toContain(childTask.id);
+    expect(removeTaskCalls).toContain(grandchildTask.id);
+    expect(getCompletionTimers(manager).has(childTask.id)).toBe(true);
+    expect(getCompletionTimers(manager).has(grandchildTask.id)).toBe(true);
 
-    manager.shutdown()
-    resetToastManager()
-  })
+    manager.shutdown();
+    resetToastManager();
+  });
 
   test("should clean pending notifications for deleted sessions", () => {
     //#given
-    const manager = createBackgroundManager()
-    const sessionID = "session-pending-notifications"
+    const manager = createBackgroundManager();
+    const sessionID = "session-pending-notifications";
 
-    manager.queuePendingNotification(sessionID, "<system-reminder>queued</system-reminder>")
+    manager.queuePendingNotification(sessionID, "<system-reminder>queued</system-reminder>");
     expect(getPendingNotifications(manager).get(sessionID)).toEqual([
       "<system-reminder>queued</system-reminder>",
-    ])
+    ]);
 
     //#when
     manager.handleEvent({
       type: "session.deleted",
       properties: { info: { id: sessionID } },
-    })
+    });
 
     //#then
-    expect(getPendingNotifications(manager).has(sessionID)).toBe(false)
+    expect(getPendingNotifications(manager).has(sessionID)).toBe(false);
 
-    manager.shutdown()
-  })
-})
+    manager.shutdown();
+  });
+});
 
 describe("BackgroundManager.handleEvent - session.error", () => {
   const defaultRetryFallbackChain = [
     { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
     { providers: ["anthropic"], model: "gpt-5.3-codex", variant: "high" },
-  ]
+  ];
 
   const stubProcessKey = (manager: BackgroundManager) => {
-    ;(manager as unknown as { processKey: (key: string) => Promise<void> }).processKey = async () => {}
-  }
+    (manager as unknown as { processKey: (key: string) => Promise<void> }).processKey =
+      async () => {};
+  };
 
-  const createRetryTask = (manager: BackgroundManager, input: {
-    id: string
-    sessionID: string
-    description: string
-    concurrencyKey?: string
-    fallbackChain?: typeof defaultRetryFallbackChain
-  }) => {
+  const createRetryTask = (
+    manager: BackgroundManager,
+    input: {
+      id: string;
+      sessionID: string;
+      description: string;
+      concurrencyKey?: string;
+      fallbackChain?: typeof defaultRetryFallbackChain;
+    },
+  ) => {
     const task = createMockTask({
       id: input.id,
       sessionID: input.sessionID,
@@ -3576,19 +3897,19 @@ describe("BackgroundManager.handleEvent - session.error", () => {
       model: { providerID: "anthropic", modelID: "claude-opus-4-6-thinking" },
       fallbackChain: input.fallbackChain ?? defaultRetryFallbackChain,
       attemptCount: 0,
-    })
-    getTaskMap(manager).set(task.id, task)
-    return task
-  }
+    });
+    getTaskMap(manager).set(task.id, task);
+    return task;
+  };
 
   test("sets task to error, releases concurrency, and keeps it until delayed cleanup", async () => {
     //#given
-    const manager = createBackgroundManager()
-    const concurrencyManager = getConcurrencyManager(manager)
-    const concurrencyKey = "test-provider/test-model"
-    await concurrencyManager.acquire(concurrencyKey)
+    const manager = createBackgroundManager();
+    const concurrencyManager = getConcurrencyManager(manager);
+    const concurrencyKey = "test-provider/test-model";
+    await concurrencyManager.acquire(concurrencyKey);
 
-    const sessionID = "ses_error_1"
+    const sessionID = "ses_error_1";
     const task = createMockTask({
       id: "task-session-error",
       sessionID,
@@ -3598,9 +3919,9 @@ describe("BackgroundManager.handleEvent - session.error", () => {
       agent: "explore",
       status: "running",
       concurrencyKey,
-    })
-    getTaskMap(manager).set(task.id, task)
-    getPendingByParent(manager).set(task.parentSessionID, new Set([task.id]))
+    });
+    getTaskMap(manager).set(task.id, task);
+    getPendingByParent(manager).set(task.parentSessionID, new Set([task.id]));
 
     //#when
     manager.handleEvent({
@@ -3612,34 +3933,34 @@ describe("BackgroundManager.handleEvent - session.error", () => {
           data: { message: "Model not found: kimi-for-coding/k2p5." },
         },
       },
-    })
+    });
 
-    await flushBackgroundNotifications()
+    await flushBackgroundNotifications();
 
     //#then
-    expect(task.status).toBe("error")
-    expect(task.error).toBe("Model not found: kimi-for-coding/k2p5.")
-    expect(task.completedAt).toBeInstanceOf(Date)
-    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
-    expect(getTaskMap(manager).has(task.id)).toBe(true)
-    expect(getPendingByParent(manager).get(task.parentSessionID)).toBeUndefined()
-    expect(getCompletionTimers(manager).has(task.id)).toBe(true)
+    expect(task.status).toBe("error");
+    expect(task.error).toBe("Model not found: kimi-for-coding/k2p5.");
+    expect(task.completedAt).toBeInstanceOf(Date);
+    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0);
+    expect(getTaskMap(manager).has(task.id)).toBe(true);
+    expect(getPendingByParent(manager).get(task.parentSessionID)).toBeUndefined();
+    expect(getCompletionTimers(manager).has(task.id)).toBe(true);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should remove errored task from toast manager while preserving delayed cleanup", async () => {
     //#given
-    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
-    const manager = createBackgroundManager()
-    const sessionID = "ses_error_toast"
+    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker();
+    const manager = createBackgroundManager();
+    const sessionID = "ses_error_toast";
     const task = createMockTask({
       id: "task-session-error-toast",
       sessionID,
       parentSessionID: "parent-session",
       status: "running",
-    })
-    getTaskMap(manager).set(task.id, task)
+    });
+    getTaskMap(manager).set(task.id, task);
 
     //#when
     manager.handleEvent({
@@ -3648,22 +3969,22 @@ describe("BackgroundManager.handleEvent - session.error", () => {
         sessionID,
         error: { name: "UnknownError", message: "boom" },
       },
-    })
+    });
 
-    await flushBackgroundNotifications()
+    await flushBackgroundNotifications();
 
     //#then
-    expect(removeTaskCalls).toContain(task.id)
-    expect(getCompletionTimers(manager).has(task.id)).toBe(true)
+    expect(removeTaskCalls).toContain(task.id);
+    expect(getCompletionTimers(manager).has(task.id)).toBe(true);
 
-    manager.shutdown()
-    resetToastManager()
-  })
+    manager.shutdown();
+    resetToastManager();
+  });
 
   test("ignores session.error for non-running tasks", () => {
     //#given
-    const manager = createBackgroundManager()
-    const sessionID = "ses_error_ignored"
+    const manager = createBackgroundManager();
+    const sessionID = "ses_error_ignored";
     const task = createMockTask({
       id: "task-non-running",
       sessionID,
@@ -3672,10 +3993,10 @@ describe("BackgroundManager.handleEvent - session.error", () => {
       description: "task already done",
       agent: "explore",
       status: "completed",
-    })
-    task.completedAt = new Date()
-    task.error = "previous"
-    getTaskMap(manager).set(task.id, task)
+    });
+    task.completedAt = new Date();
+    task.error = "previous";
+    getTaskMap(manager).set(task.id, task);
 
     //#when
     manager.handleEvent({
@@ -3684,19 +4005,19 @@ describe("BackgroundManager.handleEvent - session.error", () => {
         sessionID,
         error: { name: "UnknownError", message: "should not matter" },
       },
-    })
+    });
 
     //#then
-    expect(task.status).toBe("completed")
-    expect(task.error).toBe("previous")
-    expect(getTaskMap(manager).has(task.id)).toBe(true)
+    expect(task.status).toBe("completed");
+    expect(task.error).toBe("previous");
+    expect(getTaskMap(manager).has(task.id)).toBe(true);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("ignores session.error for unknown session", () => {
     //#given
-    const manager = createBackgroundManager()
+    const manager = createBackgroundManager();
 
     //#when
     const handler = () =>
@@ -3706,24 +4027,24 @@ describe("BackgroundManager.handleEvent - session.error", () => {
           sessionID: "ses_unknown",
           error: { name: "UnknownError", message: "Model not found" },
         },
-      })
+      });
 
     //#then
-    expect(handler).not.toThrow()
+    expect(handler).not.toThrow();
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("retry path releases current concurrency slot and prefers current provider in fallback entry", async () => {
     //#given
-    const manager = createBackgroundManager()
-    const concurrencyManager = getConcurrencyManager(manager)
-    const concurrencyKey = "anthropic/claude-opus-4-6-thinking"
-    await concurrencyManager.acquire(concurrencyKey)
+    const manager = createBackgroundManager();
+    const concurrencyManager = getConcurrencyManager(manager);
+    const concurrencyKey = "anthropic/claude-opus-4-6-thinking";
+    await concurrencyManager.acquire(concurrencyKey);
 
-    stubProcessKey(manager)
+    stubProcessKey(manager);
 
-    const sessionID = "ses_error_retry"
+    const sessionID = "ses_error_retry";
     const task = createRetryTask(manager, {
       id: "task-session-error-retry",
       sessionID,
@@ -3733,7 +4054,7 @@ describe("BackgroundManager.handleEvent - session.error", () => {
         { providers: ["anthropic"], model: "claude-opus-4-6", variant: "max" },
         { providers: ["anthropic"], model: "claude-opus-4-5", variant: "max" },
       ],
-    })
+    });
 
     //#when
     manager.handleEvent({
@@ -3744,37 +4065,37 @@ describe("BackgroundManager.handleEvent - session.error", () => {
           name: "UnknownError",
           data: {
             message:
-              "Bad Gateway: {\"error\":{\"message\":\"unknown provider for model claude-opus-4-6-thinking\"}}",
+              'Bad Gateway: {"error":{"message":"unknown provider for model claude-opus-4-6-thinking"}}',
           },
         },
       },
-    })
+    });
 
     //#then
-    expect(task.status).toBe("pending")
-    expect(task.attemptCount).toBe(1)
+    expect(task.status).toBe("pending");
+    expect(task.attemptCount).toBe(1);
     expect(task.model).toEqual({
       providerID: "anthropic",
       modelID: "claude-opus-4-6",
       variant: "max",
-    })
-    expect(task.concurrencyKey).toBeUndefined()
-    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0)
+    });
+    expect(task.concurrencyKey).toBeUndefined();
+    expect(concurrencyManager.getCount(concurrencyKey)).toBe(0);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("retry path triggers on session.status retry events", async () => {
     //#given
-    const manager = createBackgroundManager()
-    stubProcessKey(manager)
+    const manager = createBackgroundManager();
+    stubProcessKey(manager);
 
-    const sessionID = "ses_status_retry"
+    const sessionID = "ses_status_retry";
     const task = createRetryTask(manager, {
       id: "task-status-retry",
       sessionID,
       description: "task that should retry on status",
-    })
+    });
 
     //#when
     manager.handleEvent({
@@ -3786,31 +4107,31 @@ describe("BackgroundManager.handleEvent - session.error", () => {
           message: "Provider is overloaded",
         },
       },
-    })
+    });
 
     //#then
-    expect(task.status).toBe("pending")
-    expect(task.attemptCount).toBe(1)
+    expect(task.status).toBe("pending");
+    expect(task.attemptCount).toBe(1);
     expect(task.model).toEqual({
       providerID: "anthropic",
       modelID: "claude-opus-4-6",
       variant: "max",
-    })
+    });
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("retry path triggers on message.updated assistant error events", async () => {
     //#given
-    const manager = createBackgroundManager()
-    stubProcessKey(manager)
+    const manager = createBackgroundManager();
+    stubProcessKey(manager);
 
-    const sessionID = "ses_message_updated_retry"
+    const sessionID = "ses_message_updated_retry";
     const task = createRetryTask(manager, {
       id: "task-message-updated-retry",
       sessionID,
       description: "task that should retry on message.updated",
-    })
+    });
 
     //#when
     const messageInfo = {
@@ -3821,30 +4142,30 @@ describe("BackgroundManager.handleEvent - session.error", () => {
         name: "UnknownError",
         data: {
           message:
-            "Bad Gateway: {\"error\":{\"message\":\"unknown provider for model claude-opus-4-6-thinking\"}}",
+            'Bad Gateway: {"error":{"message":"unknown provider for model claude-opus-4-6-thinking"}}',
         },
       },
-    }
+    };
 
     manager.handleEvent({
       type: "message.updated",
       properties: {
         info: messageInfo,
       },
-    })
+    });
 
     //#then
-    expect(task.status).toBe("pending")
-    expect(task.attemptCount).toBe(1)
+    expect(task.status).toBe("pending");
+    expect(task.attemptCount).toBe(1);
     expect(task.model).toEqual({
       providerID: "anthropic",
       modelID: "claude-opus-4-6",
       variant: "max",
-    })
+    });
 
-    manager.shutdown()
-  })
-})
+    manager.shutdown();
+  });
+});
 
 describe("BackgroundManager queue processing - error tasks are skipped", () => {
   test("does not start tasks with status=error", async () => {
@@ -3855,13 +4176,13 @@ describe("BackgroundManager queue processing - error tasks are skipped", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
+    };
     const manager = new BackgroundManager(
       { client, directory: tmpdir() } as unknown as PluginInput,
-      { defaultConcurrency: 1 }
-    )
+      { defaultConcurrency: 1 },
+    );
 
-    const key = "test-key"
+    const key = "test-key";
     const task: BackgroundTask = {
       id: "task-error-queued",
       parentSessionID: "parent-session",
@@ -3871,7 +4192,7 @@ describe("BackgroundManager queue processing - error tasks are skipped", () => {
       agent: "test-agent",
       status: "error",
       queuedAt: new Date(),
-    }
+    };
 
     const input: import("./types").LaunchInput = {
       description: task.description,
@@ -3879,32 +4200,33 @@ describe("BackgroundManager queue processing - error tasks are skipped", () => {
       agent: task.agent,
       parentSessionID: task.parentSessionID,
       parentMessageID: task.parentMessageID,
-    }
+    };
 
-    let startCalled = false
-    ;(manager as unknown as { startTask: (item: unknown) => Promise<void> }).startTask = async () => {
-      startCalled = true
-    }
+    let startCalled = false;
+    (manager as unknown as { startTask: (item: unknown) => Promise<void> }).startTask =
+      async () => {
+        startCalled = true;
+      };
 
-    getTaskMap(manager).set(task.id, task)
-    getQueuesByKey(manager).set(key, [{ task, input }])
+    getTaskMap(manager).set(task.id, task);
+    getQueuesByKey(manager).set(key, [{ task, input }]);
 
     //#when
-    await processKeyForTest(manager, key)
+    await processKeyForTest(manager, key);
 
     //#then
-    expect(startCalled).toBe(false)
-    expect(getQueuesByKey(manager).get(key)?.length ?? 0).toBe(0)
+    expect(startCalled).toBe(false);
+    expect(getQueuesByKey(manager).get(key)?.length ?? 0).toBe(0);
 
-    manager.shutdown()
-  })
-})
+    manager.shutdown();
+  });
+});
 
 describe("BackgroundManager.pruneStaleTasksAndNotifications - removes pruned tasks from queuesByKey", () => {
   test("removes stale pending task from queue", () => {
     //#given
-    const manager = createBackgroundManager()
-    const queuedAt = new Date(Date.now() - 31 * 60 * 1000)
+    const manager = createBackgroundManager();
+    const queuedAt = new Date(Date.now() - 31 * 60 * 1000);
     const task: BackgroundTask = {
       id: "task-stale-pending",
       parentSessionID: "parent-session",
@@ -3914,8 +4236,8 @@ describe("BackgroundManager.pruneStaleTasksAndNotifications - removes pruned tas
       agent: "test-agent",
       status: "pending",
       queuedAt,
-    }
-    const key = task.agent
+    };
+    const key = task.agent;
 
     const input: import("./types").LaunchInput = {
       description: task.description,
@@ -3923,115 +4245,129 @@ describe("BackgroundManager.pruneStaleTasksAndNotifications - removes pruned tas
       agent: task.agent,
       parentSessionID: task.parentSessionID,
       parentMessageID: task.parentMessageID,
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
-    getQueuesByKey(manager).set(key, [{ task, input }])
+    getTaskMap(manager).set(task.id, task);
+    getQueuesByKey(manager).set(key, [{ task, input }]);
 
     //#when
-    pruneStaleTasksAndNotificationsForTest(manager)
+    pruneStaleTasksAndNotificationsForTest(manager);
 
     //#then
-    expect(getQueuesByKey(manager).get(key)).toBeUndefined()
+    expect(getQueuesByKey(manager).get(key)).toBeUndefined();
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("removes stale task from toast manager", async () => {
     //#given
-    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
-    const manager = createBackgroundManager()
+    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker();
+    const manager = createBackgroundManager();
     const staleTask = createMockTask({
       id: "task-stale-toast",
       sessionID: "session-stale-toast",
       parentSessionID: "parent-session",
       status: "running",
       startedAt: new Date(Date.now() - 31 * 60 * 1000),
-    })
-    getTaskMap(manager).set(staleTask.id, staleTask)
+    });
+    getTaskMap(manager).set(staleTask.id, staleTask);
 
     //#when
-    pruneStaleTasksAndNotificationsForTest(manager)
-    await flushBackgroundNotifications()
+    pruneStaleTasksAndNotificationsForTest(manager);
+    await flushBackgroundNotifications();
 
     //#then
-    expect(removeTaskCalls).toContain(staleTask.id)
+    expect(removeTaskCalls).toContain(staleTask.id);
 
-    manager.shutdown()
-    resetToastManager()
-  })
+    manager.shutdown();
+    resetToastManager();
+  });
 
   test("keeps stale task until notification cleanup after notifying parent", async () => {
     //#given
-    const notifications: string[] = []
-    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker()
+    const notifications: string[] = [];
+    const { removeTaskCalls, resetToastManager } = createToastRemoveTaskTracker();
     const client = {
       session: {
         prompt: async () => ({}),
-        promptAsync: async (args: { path: { id: string }; body: Record<string, unknown> & { noReply?: boolean; parts?: unknown[] } }) => {
-          const firstPart = args.body.parts?.[0]
-          if (firstPart && typeof firstPart === "object" && "text" in firstPart && typeof firstPart.text === "string") {
-            notifications.push(firstPart.text)
+        promptAsync: async (args: {
+          path: { id: string };
+          body: Record<string, unknown> & { noReply?: boolean; parts?: unknown[] };
+        }) => {
+          const firstPart = args.body.parts?.[0];
+          if (
+            firstPart &&
+            typeof firstPart === "object" &&
+            "text" in firstPart &&
+            typeof firstPart.text === "string"
+          ) {
+            notifications.push(firstPart.text);
           }
-          return {}
+          return {};
         },
         abort: async () => ({}),
         messages: async () => ({ data: [] }),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
     const staleTask = createMockTask({
       id: "task-stale-notify-cleanup",
       sessionID: "session-stale-notify-cleanup",
       parentSessionID: "parent-stale-notify-cleanup",
       status: "running",
       startedAt: new Date(Date.now() - 31 * 60 * 1000),
-    })
-    getTaskMap(manager).set(staleTask.id, staleTask)
-    getPendingByParent(manager).set(staleTask.parentSessionID, new Set([staleTask.id]))
+    });
+    getTaskMap(manager).set(staleTask.id, staleTask);
+    getPendingByParent(manager).set(staleTask.parentSessionID, new Set([staleTask.id]));
 
     //#when
-    pruneStaleTasksAndNotificationsForTest(manager)
-    await flushBackgroundNotifications()
+    pruneStaleTasksAndNotificationsForTest(manager);
+    await flushBackgroundNotifications();
 
     //#then
-    const retainedTask = getTaskMap(manager).get(staleTask.id)
-    expect(retainedTask?.status).toBe("error")
-    expect(getTaskMap(manager).has(staleTask.id)).toBe(true)
-    expect(notifications).toHaveLength(1)
-    expect(notifications[0]).toContain("[ALL BACKGROUND TASKS COMPLETE]")
-    expect(notifications[0]).toContain(staleTask.description)
-    expect(getCompletionTimers(manager).has(staleTask.id)).toBe(true)
-    expect(removeTaskCalls).toContain(staleTask.id)
+    const retainedTask = getTaskMap(manager).get(staleTask.id);
+    expect(retainedTask?.status).toBe("error");
+    expect(getTaskMap(manager).has(staleTask.id)).toBe(true);
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toContain("[ALL BACKGROUND TASKS COMPLETE]");
+    expect(notifications[0]).toContain(staleTask.description);
+    expect(getCompletionTimers(manager).has(staleTask.id)).toBe(true);
+    expect(removeTaskCalls).toContain(staleTask.id);
 
-    manager.shutdown()
-    resetToastManager()
-  })
-})
+    manager.shutdown();
+    resetToastManager();
+  });
+});
 
 describe("BackgroundManager.completionTimers - Memory Leak Fix", () => {
   function setCompletionTimer(manager: BackgroundManager, taskId: string): void {
-    const completionTimers = getCompletionTimers(manager)
-    const timer = setTimeout(() => {
-      completionTimers.delete(taskId)
-    }, 5 * 60 * 1000)
-    completionTimers.set(taskId, timer)
+    const completionTimers = getCompletionTimers(manager);
+    const timer = setTimeout(
+      () => {
+        completionTimers.delete(taskId);
+      },
+      5 * 60 * 1000,
+    );
+    completionTimers.set(taskId, timer);
   }
 
   test("should have completionTimers Map initialized", () => {
     // given
-    const manager = createBackgroundManager()
+    const manager = createBackgroundManager();
 
     // when
-    const completionTimers = getCompletionTimers(manager)
+    const completionTimers = getCompletionTimers(manager);
 
     // then
-    expect(completionTimers).toBeDefined()
-    expect(completionTimers).toBeInstanceOf(Map)
-    expect(completionTimers.size).toBe(0)
+    expect(completionTimers).toBeDefined();
+    expect(completionTimers).toBeInstanceOf(Map);
+    expect(completionTimers.size).toBe(0);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should start per-task cleanup timers independently of sibling completion", async () => {
     // given
@@ -4041,8 +4377,11 @@ describe("BackgroundManager.completionTimers - Memory Leak Fix", () => {
         abort: async () => ({}),
         messages: async () => ({ data: [] }),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
     const taskA: BackgroundTask = {
       id: "task-timer-a",
       sessionID: "session-timer-a",
@@ -4054,7 +4393,7 @@ describe("BackgroundManager.completionTimers - Memory Leak Fix", () => {
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
+    };
     const taskB: BackgroundTask = {
       id: "task-timer-b",
       sessionID: "session-timer-b",
@@ -4066,53 +4405,55 @@ describe("BackgroundManager.completionTimers - Memory Leak Fix", () => {
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
-    getTaskMap(manager).set(taskA.id, taskA)
-    getTaskMap(manager).set(taskB.id, taskB)
-    ;(manager as unknown as { pendingByParent: Map<string, Set<string>> }).pendingByParent.set(
+    };
+    getTaskMap(manager).set(taskA.id, taskA);
+    getTaskMap(manager).set(taskB.id, taskB);
+    (manager as unknown as { pendingByParent: Map<string, Set<string>> }).pendingByParent.set(
       "parent-session",
-      new Set([taskA.id, taskB.id])
-    )
+      new Set([taskA.id, taskB.id]),
+    );
 
     // when
-    await (manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> })
-      .notifyParentSession(taskA)
+    await (
+      manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> }
+    ).notifyParentSession(taskA);
 
     // then
-    const completionTimers = getCompletionTimers(manager)
-    expect(completionTimers.size).toBe(1)
+    const completionTimers = getCompletionTimers(manager);
+    expect(completionTimers.size).toBe(1);
 
     // when
-    await (manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> })
-      .notifyParentSession(taskB)
+    await (
+      manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> }
+    ).notifyParentSession(taskB);
 
     // then
-    expect(completionTimers.size).toBe(2)
-    expect(completionTimers.has(taskA.id)).toBe(true)
-    expect(completionTimers.has(taskB.id)).toBe(true)
+    expect(completionTimers.size).toBe(2);
+    expect(completionTimers.has(taskA.id)).toBe(true);
+    expect(completionTimers.has(taskB.id)).toBe(true);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should clear all completion timers on shutdown", () => {
     // given
-    const manager = createBackgroundManager()
-    setCompletionTimer(manager, "task-1")
-    setCompletionTimer(manager, "task-2")
+    const manager = createBackgroundManager();
+    setCompletionTimer(manager, "task-1");
+    setCompletionTimer(manager, "task-2");
 
-    const completionTimers = getCompletionTimers(manager)
-    expect(completionTimers.size).toBe(2)
+    const completionTimers = getCompletionTimers(manager);
+    expect(completionTimers.size).toBe(2);
 
     // when
-    manager.shutdown()
+    manager.shutdown();
 
     // then
-    expect(completionTimers.size).toBe(0)
-  })
+    expect(completionTimers.size).toBe(0);
+  });
 
   test("should preserve cleanup timer when terminal task session is deleted", () => {
     // given
-    const manager = createBackgroundManager()
+    const manager = createBackgroundManager();
     const task: BackgroundTask = {
       id: "task-timer-4",
       sessionID: "session-timer-4",
@@ -4123,12 +4464,12 @@ describe("BackgroundManager.completionTimers - Memory Leak Fix", () => {
       agent: "explore",
       status: "completed",
       startedAt: new Date(),
-    }
-    getTaskMap(manager).set(task.id, task)
-    setCompletionTimer(manager, task.id)
+    };
+    getTaskMap(manager).set(task.id, task);
+    setCompletionTimer(manager, task.id);
 
-    const completionTimers = getCompletionTimers(manager)
-    expect(completionTimers.size).toBe(1)
+    const completionTimers = getCompletionTimers(manager);
+    expect(completionTimers.size).toBe(1);
 
     // when
     manager.handleEvent({
@@ -4136,61 +4477,64 @@ describe("BackgroundManager.completionTimers - Memory Leak Fix", () => {
       properties: {
         info: { id: "session-timer-4" },
       },
-    })
+    });
 
     // then
-    expect(completionTimers.has(task.id)).toBe(true)
+    expect(completionTimers.has(task.id)).toBe(true);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should not leak timers across multiple shutdown calls", () => {
     // given
-    const manager = createBackgroundManager()
-    setCompletionTimer(manager, "task-1")
+    const manager = createBackgroundManager();
+    setCompletionTimer(manager, "task-1");
 
     // when
-    manager.shutdown()
-    manager.shutdown()
+    manager.shutdown();
+    manager.shutdown();
 
     // then
-    const completionTimers = getCompletionTimers(manager)
-    expect(completionTimers.size).toBe(0)
-  })
-})
+    const completionTimers = getCompletionTimers(manager);
+    expect(completionTimers.size).toBe(0);
+  });
+});
 
 describe("BackgroundManager.handleEvent - early session.idle deferral", () => {
   test("should defer and retry when session.idle fires before MIN_IDLE_TIME_MS", async () => {
     //#given - a running task started less than MIN_IDLE_TIME_MS ago
-    const sessionID = "session-early-idle"
-    const messagesCalls: string[] = []
-    const realDateNow = Date.now
-    const baseNow = realDateNow()
+    const sessionID = "session-early-idle";
+    const messagesCalls: string[] = [];
+    const realDateNow = Date.now;
+    const baseNow = realDateNow();
 
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-         messages: async (args: { path: { id: string } }) => {
-           messagesCalls.push(args.path.id)
-           return {
-             data: [
-               {
-                 info: { role: "assistant" },
-                 parts: [{ type: "text", text: "ok" }],
-               },
-             ],
-          }
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+        messages: async (args: { path: { id: string } }) => {
+          messagesCalls.push(args.path.id);
+          return {
+            data: [
+              {
+                info: { role: "assistant" },
+                parts: [{ type: "text", text: "ok" }],
+              },
+            ],
+          };
         },
         todo: async () => ({ data: [] }),
       },
-    }
+    };
 
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
-    stubNotifyParentSession(manager)
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
+    stubNotifyParentSession(manager);
 
-    const remainingMs = 1200
+    const remainingMs = 1200;
     const task: BackgroundTask = {
       id: "task-early-idle",
       sessionID,
@@ -4201,51 +4545,54 @@ describe("BackgroundManager.handleEvent - early session.idle deferral", () => {
       agent: "explore",
       status: "running",
       startedAt: new Date(baseNow),
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
     //#when - session.idle fires
     try {
-      Date.now = () => baseNow + (MIN_IDLE_TIME_MS - 100)
-      manager.handleEvent({ type: "session.idle", properties: { sessionID } })
+      Date.now = () => baseNow + (MIN_IDLE_TIME_MS - 100);
+      manager.handleEvent({ type: "session.idle", properties: { sessionID } });
 
       // Advance time so deferred callback (if any) sees elapsed >= MIN_IDLE_TIME_MS
-      Date.now = () => baseNow + (MIN_IDLE_TIME_MS + 10)
+      Date.now = () => baseNow + (MIN_IDLE_TIME_MS + 10);
 
       //#then - idle should be deferred (not dropped), and task should eventually complete
-      expect(task.status).toBe("running")
-      await new Promise((resolve) => setTimeout(resolve, 220))
-      expect(task.status).toBe("completed")
-      expect(messagesCalls).toEqual([sessionID])
+      expect(task.status).toBe("running");
+      await new Promise((resolve) => setTimeout(resolve, 220));
+      expect(task.status).toBe("completed");
+      expect(messagesCalls).toEqual([sessionID]);
     } finally {
-      Date.now = realDateNow
-      manager.shutdown()
+      Date.now = realDateNow;
+      manager.shutdown();
     }
-  })
+  });
 
   test("should not defer when session.idle fires after MIN_IDLE_TIME_MS", async () => {
-     //#given - a running task started more than MIN_IDLE_TIME_MS ago
-     const sessionID = "session-late-idle"
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-         messages: async () => ({
-           data: [
-             {
-               info: { role: "assistant" },
-               parts: [{ type: "text", text: "ok" }],
-             },
-           ],
-         }),
-         todo: async () => ({ data: [] }),
-       },
-     }
+    //#given - a running task started more than MIN_IDLE_TIME_MS ago
+    const sessionID = "session-late-idle";
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+        messages: async () => ({
+          data: [
+            {
+              info: { role: "assistant" },
+              parts: [{ type: "text", text: "ok" }],
+            },
+          ],
+        }),
+        todo: async () => ({ data: [] }),
+      },
+    };
 
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
-    stubNotifyParentSession(manager)
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-late-idle",
@@ -4257,51 +4604,54 @@ describe("BackgroundManager.handleEvent - early session.idle deferral", () => {
       agent: "explore",
       status: "running",
       startedAt: new Date(Date.now() - (MIN_IDLE_TIME_MS + 10)),
-    }
+    };
 
-    getTaskMap(manager).set(task.id, task)
+    getTaskMap(manager).set(task.id, task);
 
     //#when
-    manager.handleEvent({ type: "session.idle", properties: { sessionID } })
+    manager.handleEvent({ type: "session.idle", properties: { sessionID } });
 
     //#then - should be processed immediately
-    await new Promise((resolve) => setTimeout(resolve, 10))
-    expect(task.status).toBe("completed")
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(task.status).toBe("completed");
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should not process deferred idle if task already completed by other means", async () => {
     //#given - a running task
-    const sessionID = "session-deferred-noop"
-    let messagesCallCount = 0
-    const realDateNow = Date.now
-    const baseNow = realDateNow()
+    const sessionID = "session-deferred-noop";
+    let messagesCallCount = 0;
+    const realDateNow = Date.now;
+    const baseNow = realDateNow();
 
-     const client = {
-       session: {
-         prompt: async () => ({}),
-         promptAsync: async () => ({}),
-         abort: async () => ({}),
-         messages: async () => {
-           messagesCallCount += 1
-           return {
-             data: [
-               {
-                 info: { role: "assistant" },
-                 parts: [{ type: "text", text: "ok" }],
-               },
-             ],
-           }
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+        messages: async () => {
+          messagesCallCount += 1;
+          return {
+            data: [
+              {
+                info: { role: "assistant" },
+                parts: [{ type: "text", text: "ok" }],
+              },
+            ],
+          };
         },
         todo: async () => ({ data: [] }),
       },
-    }
+    };
 
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
-    stubNotifyParentSession(manager)
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
+    stubNotifyParentSession(manager);
 
-    const remainingMs = 120
+    const remainingMs = 120;
     const task: BackgroundTask = {
       id: "task-deferred-noop",
       sessionID,
@@ -4312,31 +4662,31 @@ describe("BackgroundManager.handleEvent - early session.idle deferral", () => {
       agent: "explore",
       status: "running",
       startedAt: new Date(baseNow),
-    }
-    getTaskMap(manager).set(task.id, task)
+    };
+    getTaskMap(manager).set(task.id, task);
 
     //#when - session.idle fires early, then task completes via another path before defer timer
     try {
-      Date.now = () => baseNow + (MIN_IDLE_TIME_MS - remainingMs)
-      manager.handleEvent({ type: "session.idle", properties: { sessionID } })
-      expect(messagesCallCount).toBe(0)
+      Date.now = () => baseNow + (MIN_IDLE_TIME_MS - remainingMs);
+      manager.handleEvent({ type: "session.idle", properties: { sessionID } });
+      expect(messagesCallCount).toBe(0);
 
-      await tryCompleteTaskForTest(manager, task)
-      expect(task.status).toBe("completed")
+      await tryCompleteTaskForTest(manager, task);
+      expect(task.status).toBe("completed");
 
       // Advance time so deferred callback (if any) sees elapsed >= MIN_IDLE_TIME_MS
-      Date.now = () => baseNow + (MIN_IDLE_TIME_MS + 10)
+      Date.now = () => baseNow + (MIN_IDLE_TIME_MS + 10);
 
       //#then - deferred callback should be a no-op
-      await new Promise((resolve) => setTimeout(resolve, remainingMs + 80))
-      expect(task.status).toBe("completed")
-      expect(messagesCallCount).toBe(0)
+      await new Promise((resolve) => setTimeout(resolve, remainingMs + 80));
+      expect(task.status).toBe("completed");
+      expect(messagesCallCount).toBe(0);
     } finally {
-      Date.now = realDateNow
-      manager.shutdown()
+      Date.now = realDateNow;
+      manager.shutdown();
     }
-  })
-})
+  });
+});
 
 describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
   test("should update lastUpdate on text-type message.part.updated event", () => {
@@ -4347,10 +4697,13 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
 
-    const oldUpdate = new Date(Date.now() - 300_000)
+    const oldUpdate = new Date(Date.now() - 300_000);
     const task: BackgroundTask = {
       id: "task-text-1",
       sessionID: "session-text-1",
@@ -4365,19 +4718,19 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
         toolCalls: 2,
         lastUpdate: oldUpdate,
       },
-    }
-    getTaskMap(manager).set(task.id, task)
+    };
+    getTaskMap(manager).set(task.id, task);
 
     //#when - a text-type message.part.updated event arrives
     manager.handleEvent({
       type: "message.part.updated",
       properties: { sessionID: "session-text-1", type: "text" },
-    })
+    });
 
     //#then - lastUpdate should be refreshed, toolCalls should NOT change
-    expect(task.progress!.lastUpdate.getTime()).toBeGreaterThan(oldUpdate.getTime())
-    expect(task.progress!.toolCalls).toBe(2)
-  })
+    expect(task.progress!.lastUpdate.getTime()).toBeGreaterThan(oldUpdate.getTime());
+    expect(task.progress!.toolCalls).toBe(2);
+  });
 
   test("should update lastUpdate on thinking-type message.part.updated event", () => {
     //#given - a running task with stale lastUpdate
@@ -4387,10 +4740,13 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
 
-    const oldUpdate = new Date(Date.now() - 300_000)
+    const oldUpdate = new Date(Date.now() - 300_000);
     const task: BackgroundTask = {
       id: "task-thinking-1",
       sessionID: "session-thinking-1",
@@ -4405,19 +4761,19 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
         toolCalls: 0,
         lastUpdate: oldUpdate,
       },
-    }
-    getTaskMap(manager).set(task.id, task)
+    };
+    getTaskMap(manager).set(task.id, task);
 
     //#when - a thinking-type message.part.updated event arrives
     manager.handleEvent({
       type: "message.part.updated",
       properties: { sessionID: "session-thinking-1", type: "thinking" },
-    })
+    });
 
     //#then - lastUpdate should be refreshed, toolCalls should remain 0
-    expect(task.progress!.lastUpdate.getTime()).toBeGreaterThan(oldUpdate.getTime())
-    expect(task.progress!.toolCalls).toBe(0)
-  })
+    expect(task.progress!.lastUpdate.getTime()).toBeGreaterThan(oldUpdate.getTime());
+    expect(task.progress!.toolCalls).toBe(0);
+  });
 
   test("should initialize progress on first non-tool event", () => {
     //#given - a running task with NO progress field
@@ -4427,8 +4783,11 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
 
     const task: BackgroundTask = {
       id: "task-init-1",
@@ -4440,20 +4799,20 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
       agent: "oracle",
       status: "running",
       startedAt: new Date(Date.now() - 60_000),
-    }
-    getTaskMap(manager).set(task.id, task)
+    };
+    getTaskMap(manager).set(task.id, task);
 
     //#when - a text-type event arrives before any tool call
     manager.handleEvent({
       type: "message.part.updated",
       properties: { sessionID: "session-init-1", type: "text" },
-    })
+    });
 
     //#then - progress should be initialized with toolCalls: 0 and fresh lastUpdate
-    expect(task.progress).toBeDefined()
-    expect(task.progress!.toolCalls).toBe(0)
-    expect(task.progress!.lastUpdate.getTime()).toBeGreaterThan(Date.now() - 5000)
-  })
+    expect(task.progress).toBeDefined();
+    expect(task.progress!.toolCalls).toBe(0);
+    expect(task.progress!.lastUpdate.getTime()).toBeGreaterThan(Date.now() - 5000);
+  });
 
   test("should NOT mark thinking model as stale when text events refresh lastUpdate", async () => {
     //#given - a running task where text events keep lastUpdate fresh
@@ -4463,9 +4822,12 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
-    stubNotifyParentSession(manager)
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-alive-1",
@@ -4481,19 +4843,19 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
         toolCalls: 0,
         lastUpdate: new Date(Date.now() - 300_000),
       },
-    }
-    getTaskMap(manager).set(task.id, task)
+    };
+    getTaskMap(manager).set(task.id, task);
 
     //#when - a text event arrives, then stale check runs
     manager.handleEvent({
       type: "message.part.updated",
       properties: { sessionID: "session-alive-1", type: "text" },
-    })
-    await manager["checkAndInterruptStaleTasks"]()
+    });
+    await manager["checkAndInterruptStaleTasks"]();
 
     //#then - task should still be running (text event refreshed lastUpdate)
-    expect(task.status).toBe("running")
-  })
+    expect(task.status).toBe("running");
+  });
 
   test("should refresh lastUpdate on message.part.delta events (OpenCode >=1.2.0)", async () => {
     //#given - a running task with stale lastUpdate
@@ -4503,9 +4865,12 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput, { staleTimeoutMs: 180_000 })
-    stubNotifyParentSession(manager)
+    };
+    const manager = new BackgroundManager(
+      { client, directory: tmpdir() } as unknown as PluginInput,
+      { staleTimeoutMs: 180_000 },
+    );
+    stubNotifyParentSession(manager);
 
     const task: BackgroundTask = {
       id: "task-delta-1",
@@ -4521,20 +4886,20 @@ describe("BackgroundManager.handleEvent - non-tool event lastUpdate", () => {
         toolCalls: 0,
         lastUpdate: new Date(Date.now() - 300_000),
       },
-    }
-    getTaskMap(manager).set(task.id, task)
+    };
+    getTaskMap(manager).set(task.id, task);
 
     //#when - a message.part.delta event arrives (reasoning-delta or text-delta in OpenCode >=1.2.0)
     manager.handleEvent({
       type: "message.part.delta",
       properties: { sessionID: "session-delta-1", field: "text", delta: "thinking..." },
-    })
-    await manager["checkAndInterruptStaleTasks"]()
+    });
+    await manager["checkAndInterruptStaleTasks"]();
 
     //#then - task should still be running (delta event refreshed lastUpdate)
-    expect(task.status).toBe("running")
-  })
-})
+    expect(task.status).toBe("running");
+  });
+});
 
 describe("BackgroundManager regression fixes - resume and aborted notification", () => {
   test("should keep resumed task in memory after previous completion timer deadline", async () => {
@@ -4545,8 +4910,11 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
         promptAsync: async () => ({}),
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
 
     const task: BackgroundTask = {
       id: "task-resume-timer-regression",
@@ -4560,15 +4928,15 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
       startedAt: new Date(),
       completedAt: new Date(),
       concurrencyGroup: "explore",
-    }
-    getTaskMap(manager).set(task.id, task)
+    };
+    getTaskMap(manager).set(task.id, task);
 
-    const completionTimers = getCompletionTimers(manager)
+    const completionTimers = getCompletionTimers(manager);
     const timer = setTimeout(() => {
-      completionTimers.delete(task.id)
-      getTaskMap(manager).delete(task.id)
-    }, 25)
-    completionTimers.set(task.id, timer)
+      completionTimers.delete(task.id);
+      getTaskMap(manager).delete(task.id);
+    }, 25);
+    completionTimers.set(task.id, timer);
 
     //#when
     await manager.resume({
@@ -4576,15 +4944,15 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
       prompt: "resume task",
       parentSessionID: "parent-session-2",
       parentMessageID: "msg-2",
-    })
-    await new Promise((resolve) => setTimeout(resolve, 60))
+    });
+    await new Promise((resolve) => setTimeout(resolve, 60));
 
     //#then
-    expect(getTaskMap(manager).has(task.id)).toBe(true)
-    expect(completionTimers.has(task.id)).toBe(false)
+    expect(getTaskMap(manager).has(task.id)).toBe(true);
+    expect(completionTimers.has(task.id)).toBe(false);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("should start cleanup timer even when promptAsync aborts", async () => {
     //#given
@@ -4592,15 +4960,18 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
       session: {
         prompt: async () => ({}),
         promptAsync: async () => {
-          const error = new Error("User aborted")
-          error.name = "MessageAbortedError"
-          throw error
+          const error = new Error("User aborted");
+          error.name = "MessageAbortedError";
+          throw error;
         },
         abort: async () => ({}),
         messages: async () => ({ data: [] }),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
     const task: BackgroundTask = {
       id: "task-aborted-cleanup-regression",
       sessionID: "session-aborted-cleanup-regression",
@@ -4612,35 +4983,40 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
-    getTaskMap(manager).set(task.id, task)
-    getPendingByParent(manager).set(task.parentSessionID, new Set([task.id]))
+    };
+    getTaskMap(manager).set(task.id, task);
+    getPendingByParent(manager).set(task.parentSessionID, new Set([task.id]));
 
     //#when
-    await (manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> }).notifyParentSession(task)
+    await (
+      manager as unknown as { notifyParentSession: (task: BackgroundTask) => Promise<void> }
+    ).notifyParentSession(task);
 
     //#then
-    expect(getCompletionTimers(manager).has(task.id)).toBe(true)
+    expect(getCompletionTimers(manager).has(task.id)).toBe(true);
 
-    manager.shutdown()
-  })
-})
+    manager.shutdown();
+  });
+});
 
 describe("BackgroundManager - tool permission spread order", () => {
   test("startTask respects explore agent restrictions", async () => {
     //#given
-    let capturedTools: Record<string, unknown> | undefined
+    let capturedTools: Record<string, unknown> | undefined;
     const client = {
       session: {
         get: async () => ({ data: { directory: "/test/dir" } }),
         create: async () => ({ data: { id: "session-1" } }),
         promptAsync: async (args: { path: { id: string }; body: Record<string, unknown> }) => {
-          capturedTools = args.body.tools as Record<string, unknown>
-          return {}
+          capturedTools = args.body.tools as Record<string, unknown>;
+          return {};
         },
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
     const task: BackgroundTask = {
       id: "task-1",
       status: "pending",
@@ -4650,42 +5026,51 @@ describe("BackgroundManager - tool permission spread order", () => {
       agent: "explore",
       parentSessionID: "parent-session",
       parentMessageID: "parent-message",
-    }
+    };
     const input: import("./types").LaunchInput = {
       description: task.description,
       prompt: task.prompt,
       agent: task.agent,
       parentSessionID: task.parentSessionID,
       parentMessageID: task.parentMessageID,
-    }
+    };
 
     //#when
-    await (manager as unknown as { startTask: (item: { task: BackgroundTask; input: import("./types").LaunchInput }) => Promise<void> })
-      .startTask({ task, input })
+    await (
+      manager as unknown as {
+        startTask: (item: {
+          task: BackgroundTask;
+          input: import("./types").LaunchInput;
+        }) => Promise<void>;
+      }
+    ).startTask({ task, input });
 
     //#then
-    expect(capturedTools).toBeDefined()
-    expect(capturedTools?.call_omo_agent).toBe(false)
-    expect(capturedTools?.task).toBe(false)
-    expect(capturedTools?.write).toBe(false)
-    expect(capturedTools?.edit).toBe(false)
+    expect(capturedTools).toBeDefined();
+    expect(capturedTools?.call_omo_agent).toBe(false);
+    expect(capturedTools?.task).toBe(false);
+    expect(capturedTools?.write).toBe(false);
+    expect(capturedTools?.edit).toBe(false);
 
-    manager.shutdown()
-  })
+    manager.shutdown();
+  });
 
   test("resume respects explore agent restrictions", async () => {
     //#given
-    let capturedTools: Record<string, unknown> | undefined
+    let capturedTools: Record<string, unknown> | undefined;
     const client = {
       session: {
         promptAsync: async (args: { path: { id: string }; body: Record<string, unknown> }) => {
-          capturedTools = args.body.tools as Record<string, unknown>
-          return {}
+          capturedTools = args.body.tools as Record<string, unknown>;
+          return {};
         },
         abort: async () => ({}),
       },
-    }
-    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    };
+    const manager = new BackgroundManager({
+      client,
+      directory: tmpdir(),
+    } as unknown as PluginInput);
     const task: BackgroundTask = {
       id: "task-2",
       sessionID: "session-2",
@@ -4697,8 +5082,8 @@ describe("BackgroundManager - tool permission spread order", () => {
       status: "completed",
       startedAt: new Date(),
       completedAt: new Date(),
-    }
-    getTaskMap(manager).set(task.id, task)
+    };
+    getTaskMap(manager).set(task.id, task);
 
     //#when
     await manager.resume({
@@ -4706,15 +5091,15 @@ describe("BackgroundManager - tool permission spread order", () => {
       prompt: "continue",
       parentSessionID: "parent-session",
       parentMessageID: "parent-message",
-    })
+    });
 
     //#then
-    expect(capturedTools).toBeDefined()
-    expect(capturedTools?.call_omo_agent).toBe(false)
-    expect(capturedTools?.task).toBe(false)
-    expect(capturedTools?.write).toBe(false)
-    expect(capturedTools?.edit).toBe(false)
+    expect(capturedTools).toBeDefined();
+    expect(capturedTools?.call_omo_agent).toBe(false);
+    expect(capturedTools?.task).toBe(false);
+    expect(capturedTools?.write).toBe(false);
+    expect(capturedTools?.edit).toBe(false);
 
-    manager.shutdown()
-  })
-})
+    manager.shutdown();
+  });
+});

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -2468,18 +2468,18 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         parentMessageID: "parent-message",
       };
 
+      stubNotifyParentSession(manager);
+
       // Launch first task and move it to running state
       const task = await manager.launch(input);
       const internalTask = getTaskMap(manager).get(task.id)!;
       internalTask.status = "running";
       internalTask.sessionID = "child-session-complete";
+      internalTask.rootSessionID = "session-root";
 
-      // Simulate task completing via session.status terminal event
-      manager.handleEvent({
-        type: "session.status",
-        properties: { sessionID: internalTask.sessionID, status: { type: "complete" } },
-      });
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // Complete the task directly via the internal method (session.status events
+      // go through the poller, not handleEvent — use tryCompleteTaskForTest instead)
+      await tryCompleteTaskForTest(manager, internalTask);
 
       // when — launch second task (should succeed if quota was released on completion)
       const result = manager.launch(input);

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1,64 +1,47 @@
-
-import type { PluginInput } from "@opencode-ai/plugin"
-import type {
-  BackgroundTask,
-  LaunchInput,
-  ResumeInput,
-} from "./types"
-import { TaskHistory } from "./task-history"
+import { join } from "node:path";
+import type { PluginInput } from "@opencode-ai/plugin";
+import type { BackgroundTaskConfig, TmuxConfig } from "../../config/schema";
 import {
-  log,
+  createInternalAgentTextPart,
   getAgentToolRestrictions,
+  log,
   normalizePromptTools,
   normalizeSDKResponse,
   promptWithModelSuggestionRetry,
   resolveInheritedPromptTools,
-  createInternalAgentTextPart,
-} from "../../shared"
-import { setSessionTools } from "../../shared/session-tools-store"
-import { SessionCategoryRegistry } from "../../shared/session-category-registry"
-import { ConcurrencyManager } from "./concurrency"
-import type { BackgroundTaskConfig, TmuxConfig } from "../../config/schema"
-import { isInsideTmux } from "../../shared/tmux"
-import {
-  shouldRetryError,
-  hasMoreFallbacks,
-} from "../../shared/model-error-classifier"
-import {
-  POLLING_INTERVAL_MS,
-  TASK_CLEANUP_DELAY_MS,
-  TASK_TTL_MS,
-} from "./constants"
-
-import { subagentSessions } from "../claude-code-session-state"
-import { getTaskToastManager } from "../task-toast-manager"
-import { formatDuration } from "./duration-formatter"
-import {
-  isAbortedSessionError,
-  extractErrorName,
-  extractErrorMessage,
-  getSessionErrorMessage,
-  isRecord,
-} from "./error-classifier"
-import { tryFallbackRetry } from "./fallback-retry-handler"
-import { registerManagerForCleanup, unregisterManagerForCleanup } from "./process-cleanup"
+} from "../../shared";
+import { hasMoreFallbacks, shouldRetryError } from "../../shared/model-error-classifier";
+import { SessionCategoryRegistry } from "../../shared/session-category-registry";
+import { setSessionTools } from "../../shared/session-tools-store";
+import { isInsideTmux } from "../../shared/tmux";
+import { subagentSessions } from "../claude-code-session-state";
+import { MESSAGE_STORAGE } from "../hook-message-injector";
+import { getTaskToastManager } from "../task-toast-manager";
 import {
   findNearestMessageExcludingCompaction,
   resolvePromptContextFromSessionMessages,
-} from "./compaction-aware-message-resolver"
-import { handleSessionIdleBackgroundEvent } from "./session-idle-event-handler"
-import { MESSAGE_STORAGE } from "../hook-message-injector"
-import { join } from "node:path"
-import { pruneStaleTasksAndNotifications } from "./task-poller"
-import { checkAndInterruptStaleTasks } from "./task-poller"
-import { removeTaskToastTracking } from "./remove-task-toast-tracking"
-import { isActiveSessionStatus, isTerminalSessionStatus } from "./session-status-classifier"
+} from "./compaction-aware-message-resolver";
+import { ConcurrencyManager } from "./concurrency";
+import { POLLING_INTERVAL_MS, TASK_CLEANUP_DELAY_MS, TASK_TTL_MS } from "./constants";
+import { formatDuration } from "./duration-formatter";
 import {
+  extractErrorMessage,
+  extractErrorName,
+  getSessionErrorMessage,
+  isAbortedSessionError,
+  isRecord,
+} from "./error-classifier";
+import { tryFallbackRetry } from "./fallback-retry-handler";
+import {
+  type CircuitBreakerSettings,
   detectRepetitiveToolUse,
   recordToolCall,
   resolveCircuitBreakerSettings,
-  type CircuitBreakerSettings,
-} from "./loop-detector"
+} from "./loop-detector";
+import { registerManagerForCleanup, unregisterManagerForCleanup } from "./process-cleanup";
+import { removeTaskToastTracking } from "./remove-task-toast-tracking";
+import { handleSessionIdleBackgroundEvent } from "./session-idle-event-handler";
+import { isActiveSessionStatus, isTerminalSessionStatus } from "./session-status-classifier";
 import {
   createSubagentDepthLimitError,
   createSubagentDescendantLimitError,
@@ -66,206 +49,209 @@ import {
   getMaxSubagentDepth,
   resolveSubagentSpawnContext,
   type SubagentSpawnContext,
-} from "./subagent-spawn-limits"
+} from "./subagent-spawn-limits";
+import { TaskHistory } from "./task-history";
+import { checkAndInterruptStaleTasks, pruneStaleTasksAndNotifications } from "./task-poller";
+import type { BackgroundTask, LaunchInput, ResumeInput } from "./types";
 
-type OpencodeClient = PluginInput["client"]
-
+type OpencodeClient = PluginInput["client"];
 
 interface MessagePartInfo {
-  id?: string
-  sessionID?: string
-  type?: string
-  tool?: string
-  state?: { status?: string; input?: Record<string, unknown> }
+  id?: string;
+  sessionID?: string;
+  type?: string;
+  tool?: string;
+  state?: { status?: string; input?: Record<string, unknown> };
 }
 
 interface EventProperties {
-  sessionID?: string
-  info?: { id?: string }
-  [key: string]: unknown
+  sessionID?: string;
+  info?: { id?: string };
+  [key: string]: unknown;
 }
 
 interface Event {
-  type: string
-  properties?: EventProperties
+  type: string;
+  properties?: EventProperties;
 }
 
-function resolveMessagePartInfo(properties: EventProperties | undefined): MessagePartInfo | undefined {
+function resolveMessagePartInfo(
+  properties: EventProperties | undefined,
+): MessagePartInfo | undefined {
   if (!properties || typeof properties !== "object") {
-    return undefined
+    return undefined;
   }
 
-  const nestedPart = properties.part
+  const nestedPart = properties.part;
   if (nestedPart && typeof nestedPart === "object") {
-    return nestedPart as MessagePartInfo
+    return nestedPart as MessagePartInfo;
   }
 
-  return properties as MessagePartInfo
+  return properties as MessagePartInfo;
 }
 
 interface Todo {
-  content: string
-  status: string
-  priority: string
-  id: string
+  content: string;
+  status: string;
+  priority: string;
+  id: string;
 }
 
 interface QueueItem {
-  task: BackgroundTask
-  input: LaunchInput
+  task: BackgroundTask;
+  input: LaunchInput;
 }
 
 export interface SubagentSessionCreatedEvent {
-  sessionID: string
-  parentID: string
-  title: string
+  sessionID: string;
+  parentID: string;
+  title: string;
 }
 
-export type OnSubagentSessionCreated = (event: SubagentSessionCreatedEvent) => Promise<void>
+export type OnSubagentSessionCreated = (event: SubagentSessionCreatedEvent) => Promise<void>;
 
-const MAX_TASK_REMOVAL_RESCHEDULES = 6
+const MAX_TASK_REMOVAL_RESCHEDULES = 6;
 
 export class BackgroundManager {
+  private tasks: Map<string, BackgroundTask>;
+  private notifications: Map<string, BackgroundTask[]>;
+  private pendingNotifications: Map<string, string[]>;
+  private pendingByParent: Map<string, Set<string>>; // Track pending tasks per parent for batching
+  private client: OpencodeClient;
+  private directory: string;
+  private pollingInterval?: ReturnType<typeof setInterval>;
+  private pollingInFlight = false;
+  private concurrencyManager: ConcurrencyManager;
+  private shutdownTriggered = false;
+  private config?: BackgroundTaskConfig;
+  private tmuxEnabled: boolean;
+  private onSubagentSessionCreated?: OnSubagentSessionCreated;
+  private onShutdown?: () => void | Promise<void>;
 
-
-  private tasks: Map<string, BackgroundTask>
-  private notifications: Map<string, BackgroundTask[]>
-  private pendingNotifications: Map<string, string[]>
-  private pendingByParent: Map<string, Set<string>>  // Track pending tasks per parent for batching
-  private client: OpencodeClient
-  private directory: string
-  private pollingInterval?: ReturnType<typeof setInterval>
-  private pollingInFlight = false
-  private concurrencyManager: ConcurrencyManager
-  private shutdownTriggered = false
-  private config?: BackgroundTaskConfig
-  private tmuxEnabled: boolean
-  private onSubagentSessionCreated?: OnSubagentSessionCreated
-  private onShutdown?: () => void | Promise<void>
-
-  private queuesByKey: Map<string, QueueItem[]> = new Map()
-  private processingKeys: Set<string> = new Set()
-  private completionTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
-  private completedTaskSummaries: Map<string, Array<{id: string, description: string}>> = new Map()
-  private idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
-  private notificationQueueByParent: Map<string, Promise<void>> = new Map()
-  private rootDescendantCounts: Map<string, number>
-  private preStartDescendantReservations: Set<string>
-  private enableParentSessionNotifications: boolean
-  readonly taskHistory = new TaskHistory()
-  private cachedCircuitBreakerSettings?: CircuitBreakerSettings
+  private queuesByKey: Map<string, QueueItem[]> = new Map();
+  private processingKeys: Set<string> = new Set();
+  private completionTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private completedTaskSummaries: Map<string, Array<{ id: string; description: string }>> =
+    new Map();
+  private idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private notificationQueueByParent: Map<string, Promise<void>> = new Map();
+  private rootDescendantCounts: Map<string, number>;
+  private preStartDescendantReservations: Set<string>;
+  private enableParentSessionNotifications: boolean;
+  readonly taskHistory = new TaskHistory();
+  private cachedCircuitBreakerSettings?: CircuitBreakerSettings;
 
   constructor(
     ctx: PluginInput,
     config?: BackgroundTaskConfig,
     options?: {
-      tmuxConfig?: TmuxConfig
-      onSubagentSessionCreated?: OnSubagentSessionCreated
-      onShutdown?: () => void | Promise<void>
-      enableParentSessionNotifications?: boolean
-    }
+      tmuxConfig?: TmuxConfig;
+      onSubagentSessionCreated?: OnSubagentSessionCreated;
+      onShutdown?: () => void | Promise<void>;
+      enableParentSessionNotifications?: boolean;
+    },
   ) {
-    this.tasks = new Map()
-    this.notifications = new Map()
-    this.pendingNotifications = new Map()
-    this.pendingByParent = new Map()
-    this.client = ctx.client
-    this.directory = ctx.directory
-    this.concurrencyManager = new ConcurrencyManager(config)
-    this.config = config
-    this.tmuxEnabled = options?.tmuxConfig?.enabled ?? false
-    this.onSubagentSessionCreated = options?.onSubagentSessionCreated
-    this.onShutdown = options?.onShutdown
-    this.rootDescendantCounts = new Map()
-    this.preStartDescendantReservations = new Set()
-    this.enableParentSessionNotifications = options?.enableParentSessionNotifications ?? true
-    this.registerProcessCleanup()
+    this.tasks = new Map();
+    this.notifications = new Map();
+    this.pendingNotifications = new Map();
+    this.pendingByParent = new Map();
+    this.client = ctx.client;
+    this.directory = ctx.directory;
+    this.concurrencyManager = new ConcurrencyManager(config);
+    this.config = config;
+    this.tmuxEnabled = options?.tmuxConfig?.enabled ?? false;
+    this.onSubagentSessionCreated = options?.onSubagentSessionCreated;
+    this.onShutdown = options?.onShutdown;
+    this.rootDescendantCounts = new Map();
+    this.preStartDescendantReservations = new Set();
+    this.enableParentSessionNotifications = options?.enableParentSessionNotifications ?? true;
+    this.registerProcessCleanup();
   }
 
   async assertCanSpawn(parentSessionID: string): Promise<SubagentSpawnContext> {
-    const spawnContext = await resolveSubagentSpawnContext(this.client, parentSessionID)
-    const maxDepth = getMaxSubagentDepth(this.config)
+    const spawnContext = await resolveSubagentSpawnContext(this.client, parentSessionID);
+    const maxDepth = getMaxSubagentDepth(this.config);
     if (spawnContext.childDepth > maxDepth) {
       throw createSubagentDepthLimitError({
         childDepth: spawnContext.childDepth,
         maxDepth,
         parentSessionID,
         rootSessionID: spawnContext.rootSessionID,
-      })
+      });
     }
 
-    const maxRootSessionSpawnBudget = getMaxRootSessionSpawnBudget(this.config)
-    const descendantCount = this.rootDescendantCounts.get(spawnContext.rootSessionID) ?? 0
+    const maxRootSessionSpawnBudget = getMaxRootSessionSpawnBudget(this.config);
+    const descendantCount = this.rootDescendantCounts.get(spawnContext.rootSessionID) ?? 0;
     if (descendantCount >= maxRootSessionSpawnBudget) {
       throw createSubagentDescendantLimitError({
         rootSessionID: spawnContext.rootSessionID,
         descendantCount,
         maxDescendants: maxRootSessionSpawnBudget,
-      })
+      });
     }
 
-    return spawnContext
+    return spawnContext;
   }
 
   async reserveSubagentSpawn(parentSessionID: string): Promise<{
-    spawnContext: SubagentSpawnContext
-    descendantCount: number
-    commit: () => number
-    rollback: () => void
+    spawnContext: SubagentSpawnContext;
+    descendantCount: number;
+    commit: () => number;
+    rollback: () => void;
   }> {
-    const spawnContext = await this.assertCanSpawn(parentSessionID)
-    const descendantCount = this.registerRootDescendant(spawnContext.rootSessionID)
-    let settled = false
+    const spawnContext = await this.assertCanSpawn(parentSessionID);
+    const descendantCount = this.registerRootDescendant(spawnContext.rootSessionID);
+    let settled = false;
 
     return {
       spawnContext,
       descendantCount,
       commit: () => {
-        settled = true
-        return descendantCount
+        settled = true;
+        return descendantCount;
       },
       rollback: () => {
-        if (settled) return
-        settled = true
-        this.unregisterRootDescendant(spawnContext.rootSessionID)
+        if (settled) return;
+        settled = true;
+        this.unregisterRootDescendant(spawnContext.rootSessionID);
       },
-    }
+    };
   }
 
   private registerRootDescendant(rootSessionID: string): number {
-    const nextCount = (this.rootDescendantCounts.get(rootSessionID) ?? 0) + 1
-    this.rootDescendantCounts.set(rootSessionID, nextCount)
-    return nextCount
+    const nextCount = (this.rootDescendantCounts.get(rootSessionID) ?? 0) + 1;
+    this.rootDescendantCounts.set(rootSessionID, nextCount);
+    return nextCount;
   }
 
   private unregisterRootDescendant(rootSessionID: string): void {
-    const currentCount = this.rootDescendantCounts.get(rootSessionID) ?? 0
+    const currentCount = this.rootDescendantCounts.get(rootSessionID) ?? 0;
     if (currentCount <= 1) {
-      this.rootDescendantCounts.delete(rootSessionID)
-      return
+      this.rootDescendantCounts.delete(rootSessionID);
+      return;
     }
 
-    this.rootDescendantCounts.set(rootSessionID, currentCount - 1)
+    this.rootDescendantCounts.set(rootSessionID, currentCount - 1);
   }
 
   private markPreStartDescendantReservation(task: BackgroundTask): void {
-    this.preStartDescendantReservations.add(task.id)
+    this.preStartDescendantReservations.add(task.id);
   }
 
   private settlePreStartDescendantReservation(task: BackgroundTask): void {
-    this.preStartDescendantReservations.delete(task.id)
+    this.preStartDescendantReservations.delete(task.id);
   }
 
   private rollbackPreStartDescendantReservation(task: BackgroundTask): void {
     if (!this.preStartDescendantReservations.delete(task.id)) {
-      return
+      return;
     }
 
     if (!task.rootSessionID) {
-      return
+      return;
     }
 
-    this.unregisterRootDescendant(task.rootSessionID)
+    this.unregisterRootDescendant(task.rootSessionID);
   }
 
   async launch(input: LaunchInput): Promise<BackgroundTask> {
@@ -274,13 +260,13 @@ export class BackgroundManager {
       model: input.model,
       description: input.description,
       parentSessionID: input.parentSessionID,
-    })
+    });
 
     if (!input.agent || input.agent.trim() === "") {
-      throw new Error("Agent parameter is required")
+      throw new Error("Agent parameter is required");
     }
 
-    const spawnReservation = await this.reserveSubagentSpawn(input.parentSessionID)
+    const spawnReservation = await this.reserveSubagentSpawn(input.parentSessionID);
 
     try {
       log("[background-agent] spawn guard passed", {
@@ -288,7 +274,7 @@ export class BackgroundManager {
         rootSessionID: spawnReservation.spawnContext.rootSessionID,
         childDepth: spawnReservation.spawnContext.childDepth,
         descendantCount: spawnReservation.descendantCount,
-      })
+      });
 
       // Create task immediately with status="pending"
       const task: BackgroundTask = {
@@ -311,27 +297,33 @@ export class BackgroundManager {
         fallbackChain: input.fallbackChain,
         attemptCount: 0,
         category: input.category,
-      }
+      };
 
-      this.tasks.set(task.id, task)
-      this.taskHistory.record(input.parentSessionID, { id: task.id, agent: input.agent, description: input.description, status: "pending", category: input.category })
+      this.tasks.set(task.id, task);
+      this.taskHistory.record(input.parentSessionID, {
+        id: task.id,
+        agent: input.agent,
+        description: input.description,
+        status: "pending",
+        category: input.category,
+      });
 
       // Track for batched notifications immediately (pending state)
       if (input.parentSessionID) {
-        const pending = this.pendingByParent.get(input.parentSessionID) ?? new Set()
-        pending.add(task.id)
-        this.pendingByParent.set(input.parentSessionID, pending)
+        const pending = this.pendingByParent.get(input.parentSessionID) ?? new Set();
+        pending.add(task.id);
+        this.pendingByParent.set(input.parentSessionID, pending);
       }
 
       // Add to queue
-      const key = this.getConcurrencyKeyFromInput(input)
-      const queue = this.queuesByKey.get(key) ?? []
-      queue.push({ task, input })
-      this.queuesByKey.set(key, queue)
+      const key = this.getConcurrencyKeyFromInput(input);
+      const queue = this.queuesByKey.get(key) ?? [];
+      queue.push({ task, input });
+      this.queuesByKey.set(key, queue);
 
-      log("[background-agent] Task queued:", { taskId: task.id, key, queueLength: queue.length })
+      log("[background-agent] Task queued:", { taskId: task.id, key, queueLength: queue.length });
 
-      const toastManager = getTaskToastManager()
+      const toastManager = getTaskToastManager();
       if (toastManager) {
         toastManager.addTask({
           id: task.id,
@@ -340,82 +332,90 @@ export class BackgroundManager {
           isBackground: true,
           status: "queued",
           skills: input.skills,
-        })
+        });
       }
 
-      spawnReservation.commit()
-      this.markPreStartDescendantReservation(task)
+      spawnReservation.commit();
+      this.markPreStartDescendantReservation(task);
 
       // Trigger processing (fire-and-forget)
-      this.processKey(key)
+      this.processKey(key);
 
-      return { ...task }
+      return { ...task };
     } catch (error) {
-      spawnReservation.rollback()
-      throw error
+      spawnReservation.rollback();
+      throw error;
     }
   }
 
   private async processKey(key: string): Promise<void> {
     if (this.processingKeys.has(key)) {
-      return
+      return;
     }
 
-    this.processingKeys.add(key)
+    this.processingKeys.add(key);
 
     try {
-      const queue = this.queuesByKey.get(key)
+      const queue = this.queuesByKey.get(key);
       while (queue && queue.length > 0) {
-        const item = queue.shift()
+        const item = queue.shift();
         if (!item) {
-          continue
+          continue;
         }
 
-        await this.concurrencyManager.acquire(key)
+        await this.concurrencyManager.acquire(key);
 
-        if (item.task.status === "cancelled" || item.task.status === "error" || item.task.status === "interrupt") {
-          this.rollbackPreStartDescendantReservation(item.task)
-          this.concurrencyManager.release(key)
-          continue
+        if (
+          item.task.status === "cancelled" ||
+          item.task.status === "error" ||
+          item.task.status === "interrupt"
+        ) {
+          this.rollbackPreStartDescendantReservation(item.task);
+          this.concurrencyManager.release(key);
+          continue;
         }
 
         try {
-          await this.startTask(item)
+          await this.startTask(item);
         } catch (error) {
-          log("[background-agent] Error starting task:", error)
-          this.rollbackPreStartDescendantReservation(item.task)
+          log("[background-agent] Error starting task:", error);
+          this.rollbackPreStartDescendantReservation(item.task);
           if (item.task.concurrencyKey) {
-            this.concurrencyManager.release(item.task.concurrencyKey)
-            item.task.concurrencyKey = undefined
+            this.concurrencyManager.release(item.task.concurrencyKey);
+            item.task.concurrencyKey = undefined;
           } else {
-            this.concurrencyManager.release(key)
+            this.concurrencyManager.release(key);
           }
         }
       }
     } finally {
-      this.processingKeys.delete(key)
+      this.processingKeys.delete(key);
     }
   }
 
   private async startTask(item: QueueItem): Promise<void> {
-    const { task, input } = item
+    const { task, input } = item;
 
     log("[background-agent] Starting task:", {
       taskId: task.id,
       agent: input.agent,
       model: input.model,
-    })
+    });
 
-    const concurrencyKey = this.getConcurrencyKeyFromInput(input)
+    const concurrencyKey = this.getConcurrencyKeyFromInput(input);
 
-    const parentSession = await this.client.session.get({
-      path: { id: input.parentSessionID },
-    }).catch((err) => {
-      log(`[background-agent] Failed to get parent session: ${err}`)
-      return null
-    })
-    const parentDirectory = parentSession?.data?.directory ?? this.directory
-    log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, using: ${parentDirectory}`)
+    const parentSession = await this.client.session
+      .get({
+        path: { id: input.parentSessionID },
+      })
+      .catch((err) => {
+        log(`[background-agent] Failed to get parent session: ${err}`);
+        return null;
+      });
+    const parentDirectory = parentSession?.data?.directory ?? this.directory;
+    log(
+      `[background-agent] Parent dir: ${parentSession?.data?.directory}, using: ${parentDirectory}`,
+    );
 
     const createResult = await this.client.session.create({
       body: {
@@ -426,30 +426,32 @@ export class BackgroundManager {
       query: {
         directory: parentDirectory,
       },
-    })
+    });
 
     if (createResult.error) {
-      throw new Error(`Failed to create background session: ${createResult.error}`)
+      throw new Error(`Failed to create background session: ${createResult.error}`);
     }
 
     if (!createResult.data?.id) {
-      throw new Error("Failed to create background session: API returned no session ID")
+      throw new Error("Failed to create background session: API returned no session ID");
     }
 
-    const sessionID = createResult.data.id
+    const sessionID = createResult.data.id;
 
     if (task.status === "cancelled") {
-      await this.client.session.abort({
-        path: { id: sessionID },
-      }).catch((error) => {
-        log("[background-agent] Failed to abort cancelled pre-start session:", error)
-      })
-      this.concurrencyManager.release(concurrencyKey)
-      return
+      await this.client.session
+        .abort({
+          path: { id: sessionID },
+        })
+        .catch((error) => {
+          log("[background-agent] Failed to abort cancelled pre-start session:", error);
+        });
+      this.concurrencyManager.release(concurrencyKey);
+      return;
     }
 
-    this.settlePreStartDescendantReservation(task)
-    subagentSessions.add(sessionID)
+    this.settlePreStartDescendantReservation(task);
+    subagentSessions.add(sessionID);
 
     log("[background-agent] tmux callback check", {
       hasCallback: !!this.onSubagentSessionCreated,
@@ -457,42 +459,50 @@ export class BackgroundManager {
       isInsideTmux: isInsideTmux(),
       sessionID,
       parentID: input.parentSessionID,
-    })
+    });
 
     if (this.onSubagentSessionCreated && this.tmuxEnabled && isInsideTmux()) {
-      log("[background-agent] Invoking tmux callback NOW", { sessionID })
+      log("[background-agent] Invoking tmux callback NOW", { sessionID });
       await this.onSubagentSessionCreated({
         sessionID,
         parentID: input.parentSessionID,
         title: input.description,
       }).catch((err) => {
-        log("[background-agent] Failed to spawn tmux pane:", err)
-      })
-      log("[background-agent] tmux callback completed, waiting 200ms")
-      await new Promise(r => setTimeout(r, 200))
+        log("[background-agent] Failed to spawn tmux pane:", err);
+      });
+      log("[background-agent] tmux callback completed, waiting 200ms");
+      await new Promise((r) => setTimeout(r, 200));
     } else {
-      log("[background-agent] SKIP tmux callback - conditions not met")
+      log("[background-agent] SKIP tmux callback - conditions not met");
     }
 
     // Update task to running state
-    task.status = "running"
-    task.startedAt = new Date()
-    task.sessionID = sessionID
+    task.status = "running";
+    task.startedAt = new Date();
+    task.sessionID = sessionID;
     task.progress = {
       toolCalls: 0,
       lastUpdate: new Date(),
-    }
-    task.concurrencyKey = concurrencyKey
-    task.concurrencyGroup = concurrencyKey
+    };
+    task.concurrencyKey = concurrencyKey;
+    task.concurrencyGroup = concurrencyKey;
 
-    this.taskHistory.record(input.parentSessionID, { id: task.id, sessionID, agent: input.agent, description: input.description, status: "running", category: input.category, startedAt: task.startedAt })
-    this.startPolling()
+    this.taskHistory.record(input.parentSessionID, {
+      id: task.id,
+      sessionID,
+      agent: input.agent,
+      description: input.description,
+      status: "running",
+      category: input.category,
+      startedAt: task.startedAt,
+    });
+    this.startPolling();
 
-    log("[background-agent] Launching task:", { taskId: task.id, sessionID, agent: input.agent })
+    log("[background-agent] Launching task:", { taskId: task.id, sessionID, agent: input.agent });
 
-    const toastManager = getTaskToastManager()
+    const toastManager = getTaskToastManager();
     if (toastManager) {
-      toastManager.updateTask(task.id, "running")
+      toastManager.updateTask(task.id, "running");
     }
 
     log("[background-agent] Calling prompt (fire-and-forget) for launch with:", {
@@ -501,7 +511,7 @@ export class BackgroundManager {
       model: input.model,
       hasSkillContent: !!input.skillContent,
       promptLength: input.prompt.length,
-    })
+    });
 
     // Fire-and-forget prompt via promptAsync (no response body needed)
     // Include model if caller provided one (e.g., from Sisyphus category configs)
@@ -509,8 +519,8 @@ export class BackgroundManager {
     // OpenCode's PromptInput schema expects: { model: { providerID, modelID }, variant: "max" }
     const launchModel = input.model
       ? { providerID: input.model.providerID, modelID: input.model.modelID }
-      : undefined
-    const launchVariant = input.model?.variant
+      : undefined;
+    const launchVariant = input.model?.variant;
 
     promptWithModelSuggestionRetry(this.client, {
       path: { id: sessionID },
@@ -525,87 +535,94 @@ export class BackgroundManager {
             call_omo_agent: true,
             question: false,
             ...getAgentToolRestrictions(input.agent),
-          }
-          setSessionTools(sessionID, tools)
-          return tools
+          };
+          setSessionTools(sessionID, tools);
+          return tools;
         })(),
         parts: [createInternalAgentTextPart(input.prompt)],
       },
     }).catch((error) => {
-      log("[background-agent] promptAsync error:", error)
-      const existingTask = this.findBySession(sessionID)
+      log("[background-agent] promptAsync error:", error);
+      const existingTask = this.findBySession(sessionID);
       if (existingTask) {
-        existingTask.status = "interrupt"
-        const errorMessage = error instanceof Error ? error.message : String(error)
+        existingTask.status = "interrupt";
+        const errorMessage = error instanceof Error ? error.message : String(error);
         if (errorMessage.includes("agent.name") || errorMessage.includes("undefined")) {
-          existingTask.error = `Agent "${input.agent}" not found. Make sure the agent is registered in your opencode.json or provided by a plugin.`
+          existingTask.error = `Agent "${input.agent}" not found. Make sure the agent is registered in your opencode.json or provided by a plugin.`;
         } else {
-          existingTask.error = errorMessage
+          existingTask.error = errorMessage;
         }
-        existingTask.completedAt = new Date()
+        existingTask.completedAt = new Date();
+        if (existingTask.rootSessionID) {
+          this.unregisterRootDescendant(existingTask.rootSessionID);
+        }
         if (existingTask.concurrencyKey) {
-          this.concurrencyManager.release(existingTask.concurrencyKey)
-          existingTask.concurrencyKey = undefined
+          this.concurrencyManager.release(existingTask.concurrencyKey);
+          existingTask.concurrencyKey = undefined;
         }
 
-        removeTaskToastTracking(existingTask.id)
+        removeTaskToastTracking(existingTask.id);
 
         // Abort the session to prevent infinite polling hang
-        this.client.session.abort({
-          path: { id: sessionID },
-        }).catch(() => {})
+        this.client.session
+          .abort({
+            path: { id: sessionID },
+          })
+          .catch(() => {});
 
-        this.markForNotification(existingTask)
-        this.enqueueNotificationForParent(existingTask.parentSessionID, () => this.notifyParentSession(existingTask)).catch(err => {
-          log("[background-agent] Failed to notify on error:", err)
-        })
+        this.markForNotification(existingTask);
+        this.enqueueNotificationForParent(existingTask.parentSessionID, () =>
+          this.notifyParentSession(existingTask),
+        ).catch((err) => {
+          log("[background-agent] Failed to notify on error:", err);
+        });
       }
-    })
+    });
   }
 
   getTask(id: string): BackgroundTask | undefined {
-    return this.tasks.get(id)
+    return this.tasks.get(id);
   }
 
   getTasksByParentSession(sessionID: string): BackgroundTask[] {
-    const result: BackgroundTask[] = []
+    const result: BackgroundTask[] = [];
     for (const task of this.tasks.values()) {
       if (task.parentSessionID === sessionID) {
-        result.push(task)
+        result.push(task);
       }
     }
-    return result
+    return result;
   }
 
   getAllDescendantTasks(sessionID: string): BackgroundTask[] {
-    const result: BackgroundTask[] = []
-    const directChildren = this.getTasksByParentSession(sessionID)
+    const result: BackgroundTask[] = [];
+    const directChildren = this.getTasksByParentSession(sessionID);
 
     for (const child of directChildren) {
-      result.push(child)
+      result.push(child);
       if (child.sessionID) {
-        const descendants = this.getAllDescendantTasks(child.sessionID)
-        result.push(...descendants)
+        const descendants = this.getAllDescendantTasks(child.sessionID);
+        result.push(...descendants);
       }
     }
 
-    return result
+    return result;
   }
 
   findBySession(sessionID: string): BackgroundTask | undefined {
     for (const task of this.tasks.values()) {
       if (task.sessionID === sessionID) {
-        return task
+        return task;
       }
     }
-    return undefined
+    return undefined;
   }
 
   private getConcurrencyKeyFromInput(input: LaunchInput): string {
     if (input.model) {
-      return `${input.model.providerID}/${input.model.modelID}`
+      return `${input.model.providerID}/${input.model.modelID}`;
     }
-    return input.agent
+    return input.agent;
   }
 
   /**
@@ -613,55 +630,59 @@ export class BackgroundManager {
    * This allows tasks created by other tools to receive the same toast/prompt notifications.
    */
   async trackTask(input: {
-    taskId: string
-    sessionID: string
-    parentSessionID: string
-    description: string
-    agent?: string
-    parentAgent?: string
-    concurrencyKey?: string
+    taskId: string;
+    sessionID: string;
+    parentSessionID: string;
+    description: string;
+    agent?: string;
+    parentAgent?: string;
+    concurrencyKey?: string;
   }): Promise<BackgroundTask> {
-    const existingTask = this.tasks.get(input.taskId)
+    const existingTask = this.tasks.get(input.taskId);
     if (existingTask) {
       // P2 fix: Clean up old parent's pending set BEFORE changing parent
       // Otherwise cleanupPendingByParent would use the new parent ID
-      const parentChanged = input.parentSessionID !== existingTask.parentSessionID
+      const parentChanged = input.parentSessionID !== existingTask.parentSessionID;
       if (parentChanged) {
-        this.cleanupPendingByParent(existingTask)  // Clean from OLD parent
-        existingTask.parentSessionID = input.parentSessionID
+        this.cleanupPendingByParent(existingTask); // Clean from OLD parent
+        existingTask.parentSessionID = input.parentSessionID;
       }
       if (input.parentAgent !== undefined) {
-        existingTask.parentAgent = input.parentAgent
+        existingTask.parentAgent = input.parentAgent;
       }
       if (!existingTask.concurrencyGroup) {
-        existingTask.concurrencyGroup = input.concurrencyKey ?? existingTask.agent
+        existingTask.concurrencyGroup = input.concurrencyKey ?? existingTask.agent;
       }
 
       if (existingTask.sessionID) {
-        subagentSessions.add(existingTask.sessionID)
+        subagentSessions.add(existingTask.sessionID);
       }
-      this.startPolling()
+      this.startPolling();
 
       // Track for batched notifications if task is pending or running
       if (existingTask.status === "pending" || existingTask.status === "running") {
-        const pending = this.pendingByParent.get(input.parentSessionID) ?? new Set()
-        pending.add(existingTask.id)
-        this.pendingByParent.set(input.parentSessionID, pending)
+        const pending = this.pendingByParent.get(input.parentSessionID) ?? new Set();
+        pending.add(existingTask.id);
+        this.pendingByParent.set(input.parentSessionID, pending);
       } else if (!parentChanged) {
         // Only clean up if parent didn't change (already cleaned above if it did)
-        this.cleanupPendingByParent(existingTask)
+        this.cleanupPendingByParent(existingTask);
       }
 
-      log("[background-agent] External task already registered:", { taskId: existingTask.id, sessionID: existingTask.sessionID, status: existingTask.status })
+      log("[background-agent] External task already registered:", {
+        taskId: existingTask.id,
+        sessionID: existingTask.sessionID,
+        status: existingTask.status,
+      });
 
-      return existingTask
+      return existingTask;
     }
 
-    const concurrencyGroup = input.concurrencyKey ?? input.agent ?? "task"
+    const concurrencyGroup = input.concurrencyKey ?? input.agent ?? "task";
 
     // Acquire concurrency slot if a key is provided
     if (input.concurrencyKey) {
-      await this.concurrencyManager.acquire(input.concurrencyKey)
+      await this.concurrencyManager.acquire(input.concurrencyKey);
     }
 
     const task: BackgroundTask = {
@@ -681,274 +702,297 @@ export class BackgroundManager {
       parentAgent: input.parentAgent,
       concurrencyKey: input.concurrencyKey,
       concurrencyGroup,
-    }
+    };
 
-    this.tasks.set(task.id, task)
-    subagentSessions.add(input.sessionID)
-    this.startPolling()
-    this.taskHistory.record(input.parentSessionID, { id: task.id, sessionID: input.sessionID, agent: input.agent || "task", description: input.description, status: "running", startedAt: task.startedAt })
+    this.tasks.set(task.id, task);
+    subagentSessions.add(input.sessionID);
+    this.startPolling();
+    this.taskHistory.record(input.parentSessionID, {
+      id: task.id,
+      sessionID: input.sessionID,
+      agent: input.agent || "task",
+      description: input.description,
+      status: "running",
+      startedAt: task.startedAt,
+    });
 
     if (input.parentSessionID) {
-      const pending = this.pendingByParent.get(input.parentSessionID) ?? new Set()
-      pending.add(task.id)
-      this.pendingByParent.set(input.parentSessionID, pending)
+      const pending = this.pendingByParent.get(input.parentSessionID) ?? new Set();
+      pending.add(task.id);
+      this.pendingByParent.set(input.parentSessionID, pending);
     }
 
-    log("[background-agent] Registered external task:", { taskId: task.id, sessionID: input.sessionID })
+    log("[background-agent] Registered external task:", {
+      taskId: task.id,
+      sessionID: input.sessionID,
+    });
 
-    return task
+    return task;
   }
 
   async resume(input: ResumeInput): Promise<BackgroundTask> {
-    const existingTask = this.findBySession(input.sessionId)
+    const existingTask = this.findBySession(input.sessionId);
     if (!existingTask) {
-      throw new Error(`Task not found for session: ${input.sessionId}`)
+      throw new Error(`Task not found for session: ${input.sessionId}`);
     }
 
     if (!existingTask.sessionID) {
-      throw new Error(`Task has no sessionID: ${existingTask.id}`)
+      throw new Error(`Task has no sessionID: ${existingTask.id}`);
     }
 
     if (existingTask.status === "running") {
       log("[background-agent] Resume skipped - task already running:", {
         taskId: existingTask.id,
         sessionID: existingTask.sessionID,
-      })
-      return existingTask
+      });
+      return existingTask;
     }
 
-    const completionTimer = this.completionTimers.get(existingTask.id)
+    const completionTimer = this.completionTimers.get(existingTask.id);
     if (completionTimer) {
-      clearTimeout(completionTimer)
-      this.completionTimers.delete(existingTask.id)
+      clearTimeout(completionTimer);
+      this.completionTimers.delete(existingTask.id);
     }
 
     // Re-acquire concurrency using the persisted concurrency group
-    const concurrencyKey = existingTask.concurrencyGroup ?? existingTask.agent
-    await this.concurrencyManager.acquire(concurrencyKey)
-    existingTask.concurrencyKey = concurrencyKey
-    existingTask.concurrencyGroup = concurrencyKey
+    const concurrencyKey = existingTask.concurrencyGroup ?? existingTask.agent;
+    await this.concurrencyManager.acquire(concurrencyKey);
+    existingTask.concurrencyKey = concurrencyKey;
+    existingTask.concurrencyGroup = concurrencyKey;
 
-
-    existingTask.status = "running"
-    existingTask.completedAt = undefined
-    existingTask.error = undefined
-    existingTask.parentSessionID = input.parentSessionID
-    existingTask.parentMessageID = input.parentMessageID
-    existingTask.parentModel = input.parentModel
-    existingTask.parentAgent = input.parentAgent
+    existingTask.status = "running";
+    existingTask.completedAt = undefined;
+    existingTask.error = undefined;
+    existingTask.parentSessionID = input.parentSessionID;
+    existingTask.parentMessageID = input.parentMessageID;
+    existingTask.parentModel = input.parentModel;
+    existingTask.parentAgent = input.parentAgent;
     if (input.parentTools) {
-      existingTask.parentTools = input.parentTools
+      existingTask.parentTools = input.parentTools;
     }
     // Reset startedAt on resume to prevent immediate completion
     // The MIN_IDLE_TIME_MS check uses startedAt, so resumed tasks need fresh timing
-    existingTask.startedAt = new Date()
+    existingTask.startedAt = new Date();
 
     existingTask.progress = {
       toolCalls: existingTask.progress?.toolCalls ?? 0,
       toolCallWindow: existingTask.progress?.toolCallWindow,
       countedToolPartIDs: existingTask.progress?.countedToolPartIDs,
       lastUpdate: new Date(),
-    }
+    };
 
-    this.startPolling()
+    this.startPolling();
     if (existingTask.sessionID) {
-      subagentSessions.add(existingTask.sessionID)
+      subagentSessions.add(existingTask.sessionID);
     }
 
     if (input.parentSessionID) {
-      const pending = this.pendingByParent.get(input.parentSessionID) ?? new Set()
-      pending.add(existingTask.id)
-      this.pendingByParent.set(input.parentSessionID, pending)
+      const pending = this.pendingByParent.get(input.parentSessionID) ?? new Set();
+      pending.add(existingTask.id);
+      this.pendingByParent.set(input.parentSessionID, pending);
     }
 
-    const toastManager = getTaskToastManager()
+    const toastManager = getTaskToastManager();
     if (toastManager) {
       toastManager.addTask({
         id: existingTask.id,
         description: existingTask.description,
         agent: existingTask.agent,
         isBackground: true,
-      })
+      });
     }
 
-    log("[background-agent] Resuming task:", { taskId: existingTask.id, sessionID: existingTask.sessionID })
+    log("[background-agent] Resuming task:", {
+      taskId: existingTask.id,
+      sessionID: existingTask.sessionID,
+    });
 
     log("[background-agent] Resuming task - calling prompt (fire-and-forget) with:", {
       sessionID: existingTask.sessionID,
       agent: existingTask.agent,
       model: existingTask.model,
       promptLength: input.prompt.length,
-    })
+    });
 
     // Fire-and-forget prompt via promptAsync (no response body needed)
     // Include model if task has one (preserved from original launch with category config)
     // variant must be top-level in body, not nested inside model (OpenCode PromptInput schema)
     const resumeModel = existingTask.model
       ? { providerID: existingTask.model.providerID, modelID: existingTask.model.modelID }
-      : undefined
-    const resumeVariant = existingTask.model?.variant
+      : undefined;
+    const resumeVariant = existingTask.model?.variant;
 
-    this.client.session.promptAsync({
-      path: { id: existingTask.sessionID },
-      body: {
-        agent: existingTask.agent,
-        ...(resumeModel ? { model: resumeModel } : {}),
-        ...(resumeVariant ? { variant: resumeVariant } : {}),
-        tools: (() => {
-          const tools = {
-            task: false,
-            call_omo_agent: true,
-            question: false,
-            ...getAgentToolRestrictions(existingTask.agent),
-          }
-          setSessionTools(existingTask.sessionID!, tools)
-          return tools
-        })(),
-        parts: [createInternalAgentTextPart(input.prompt)],
-      },
-    }).catch((error) => {
-      log("[background-agent] resume prompt error:", error)
-      existingTask.status = "interrupt"
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      existingTask.error = errorMessage
-      existingTask.completedAt = new Date()
-
-      // Release concurrency on error to prevent slot leaks
-      if (existingTask.concurrencyKey) {
-        this.concurrencyManager.release(existingTask.concurrencyKey)
-        existingTask.concurrencyKey = undefined
-      }
-
-      removeTaskToastTracking(existingTask.id)
-
-      // Abort the session to prevent infinite polling hang
-      if (existingTask.sessionID) {
-        this.client.session.abort({
-          path: { id: existingTask.sessionID },
-        }).catch(() => {})
-      }
-
-      this.markForNotification(existingTask)
-      this.enqueueNotificationForParent(existingTask.parentSessionID, () => this.notifyParentSession(existingTask)).catch(err => {
-        log("[background-agent] Failed to notify on resume error:", err)
+    this.client.session
+      .promptAsync({
+        path: { id: existingTask.sessionID },
+        body: {
+          agent: existingTask.agent,
+          ...(resumeModel ? { model: resumeModel } : {}),
+          ...(resumeVariant ? { variant: resumeVariant } : {}),
+          tools: (() => {
+            const tools = {
+              task: false,
+              call_omo_agent: true,
+              question: false,
+              ...getAgentToolRestrictions(existingTask.agent),
+            };
+            setSessionTools(existingTask.sessionID!, tools);
+            return tools;
+          })(),
+          parts: [createInternalAgentTextPart(input.prompt)],
+        },
       })
-    })
+      .catch((error) => {
+        log("[background-agent] resume prompt error:", error);
+        existingTask.status = "interrupt";
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        existingTask.error = errorMessage;
+        existingTask.completedAt = new Date();
+        if (existingTask.rootSessionID) {
+          this.unregisterRootDescendant(existingTask.rootSessionID);
+        }
 
-    return existingTask
+        // Release concurrency on error to prevent slot leaks
+        if (existingTask.concurrencyKey) {
+          this.concurrencyManager.release(existingTask.concurrencyKey);
+          existingTask.concurrencyKey = undefined;
+        }
+
+        removeTaskToastTracking(existingTask.id);
+
+        // Abort the session to prevent infinite polling hang
+        if (existingTask.sessionID) {
+          this.client.session
+            .abort({
+              path: { id: existingTask.sessionID },
+            })
+            .catch(() => {});
+        }
+
+        this.markForNotification(existingTask);
+        this.enqueueNotificationForParent(existingTask.parentSessionID, () =>
+          this.notifyParentSession(existingTask),
+        ).catch((err) => {
+          log("[background-agent] Failed to notify on resume error:", err);
+        });
+      });
+
+    return existingTask;
   }
 
   private async checkSessionTodos(sessionID: string): Promise<boolean> {
     try {
       const response = await this.client.session.todo({
         path: { id: sessionID },
-      })
-      const todos = normalizeSDKResponse(response, [] as Todo[], { preferResponseOnMissingData: true })
-      if (!todos || todos.length === 0) return false
+      });
+      const todos = normalizeSDKResponse(response, [] as Todo[], {
+        preferResponseOnMissingData: true,
+      });
+      if (!todos || todos.length === 0) return false;
 
-      const incomplete = todos.filter(
-        (t) => t.status !== "completed" && t.status !== "cancelled"
-      )
-      return incomplete.length > 0
+      const incomplete = todos.filter((t) => t.status !== "completed" && t.status !== "cancelled");
+      return incomplete.length > 0;
     } catch {
-      return false
+      return false;
     }
   }
 
   handleEvent(event: Event): void {
-    const props = event.properties
+    const props = event.properties;
 
     if (event.type === "message.updated") {
-      const info = props?.info
-      if (!info || typeof info !== "object") return
+      const info = props?.info;
+      if (!info || typeof info !== "object") return;
 
-      const sessionID = (info as Record<string, unknown>)["sessionID"]
-      const role = (info as Record<string, unknown>)["role"]
-      if (typeof sessionID !== "string" || role !== "assistant") return
+      const sessionID = (info as Record<string, unknown>)["sessionID"];
+      const role = (info as Record<string, unknown>)["role"];
+      if (typeof sessionID !== "string" || role !== "assistant") return;
 
-      const task = this.findBySession(sessionID)
-      if (!task || task.status !== "running") return
+      const task = this.findBySession(sessionID);
+      if (!task || task.status !== "running") return;
 
-      const assistantError = (info as Record<string, unknown>)["error"]
-      if (!assistantError) return
+      const assistantError = (info as Record<string, unknown>)["error"];
+      if (!assistantError) return;
 
       const errorInfo = {
         name: extractErrorName(assistantError),
         message: extractErrorMessage(assistantError),
-      }
-      this.tryFallbackRetry(task, errorInfo, "message.updated")
+      };
+      this.tryFallbackRetry(task, errorInfo, "message.updated");
     }
 
     if (event.type === "message.part.updated" || event.type === "message.part.delta") {
-      const partInfo = resolveMessagePartInfo(props)
-      const sessionID = partInfo?.sessionID
-      if (!sessionID) return
+      const partInfo = resolveMessagePartInfo(props);
+      const sessionID = partInfo?.sessionID;
+      if (!sessionID) return;
 
-      const task = this.findBySession(sessionID)
-      if (!task) return
+      const task = this.findBySession(sessionID);
+      if (!task) return;
 
       // Clear any pending idle deferral timer since the task is still active
-      const existingTimer = this.idleDeferralTimers.get(task.id)
+      const existingTimer = this.idleDeferralTimers.get(task.id);
       if (existingTimer) {
-        clearTimeout(existingTimer)
-        this.idleDeferralTimers.delete(task.id)
+        clearTimeout(existingTimer);
+        this.idleDeferralTimers.delete(task.id);
       }
 
       if (!task.progress) {
         task.progress = {
           toolCalls: 0,
           lastUpdate: new Date(),
-        }
+        };
       }
-      task.progress.lastUpdate = new Date()
+      task.progress.lastUpdate = new Date();
 
       if (partInfo?.type === "tool" || partInfo?.tool) {
-        const countedToolPartIDs = task.progress.countedToolPartIDs ?? new Set<string>()
+        const countedToolPartIDs = task.progress.countedToolPartIDs ?? new Set<string>();
         const shouldCountToolCall =
           !partInfo.id ||
           partInfo.state?.status !== "running" ||
-          !countedToolPartIDs.has(partInfo.id)
+          !countedToolPartIDs.has(partInfo.id);
 
         if (!shouldCountToolCall) {
-          return
+          return;
         }
 
         if (partInfo.id && partInfo.state?.status === "running") {
-          countedToolPartIDs.add(partInfo.id)
-          task.progress.countedToolPartIDs = countedToolPartIDs
+          countedToolPartIDs.add(partInfo.id);
+          task.progress.countedToolPartIDs = countedToolPartIDs;
         }
 
-        task.progress.toolCalls += 1
-        task.progress.lastTool = partInfo.tool
-        const circuitBreaker = this.cachedCircuitBreakerSettings ?? (this.cachedCircuitBreakerSettings = resolveCircuitBreakerSettings(this.config))
+        task.progress.toolCalls += 1;
+        task.progress.lastTool = partInfo.tool;
+        const circuitBreaker =
+          this.cachedCircuitBreakerSettings ??
+          (this.cachedCircuitBreakerSettings = resolveCircuitBreakerSettings(this.config));
         if (partInfo.tool) {
-         task.progress.toolCallWindow = recordToolCall(
-             task.progress.toolCallWindow,
-             partInfo.tool,
-             circuitBreaker,
-             partInfo.state?.input
-           )
+          task.progress.toolCallWindow = recordToolCall(
+            task.progress.toolCallWindow,
+            partInfo.tool,
+            circuitBreaker,
+            partInfo.state?.input,
+          );
 
-           if (circuitBreaker.enabled) {
-             const loopDetection = detectRepetitiveToolUse(task.progress.toolCallWindow)
-             if (loopDetection.triggered) {
-               log("[background-agent] Circuit breaker: consecutive tool usage detected", {
-                 taskId: task.id,
-                 agent: task.agent,
-                 sessionID,
-                 toolName: loopDetection.toolName,
-                 repeatedCount: loopDetection.repeatedCount,
-               })
-               void this.cancelTask(task.id, {
-                 source: "circuit-breaker",
-                 reason: `Subagent called ${loopDetection.toolName} ${loopDetection.repeatedCount} consecutive times (threshold: ${circuitBreaker.consecutiveThreshold}). This usually indicates an infinite loop. The task was automatically cancelled to prevent excessive token usage.`,
-               })
-               return
-             }
-           }
+          if (circuitBreaker.enabled) {
+            const loopDetection = detectRepetitiveToolUse(task.progress.toolCallWindow);
+            if (loopDetection.triggered) {
+              log("[background-agent] Circuit breaker: consecutive tool usage detected", {
+                taskId: task.id,
+                agent: task.agent,
+                sessionID,
+                toolName: loopDetection.toolName,
+                repeatedCount: loopDetection.repeatedCount,
+              });
+              void this.cancelTask(task.id, {
+                source: "circuit-breaker",
+                reason: `Subagent called ${loopDetection.toolName} ${loopDetection.repeatedCount} consecutive times (threshold: ${circuitBreaker.consecutiveThreshold}). This usually indicates an infinite loop. The task was automatically cancelled to prevent excessive token usage.`,
+              });
+              return;
+            }
+          }
         }
 
-        const maxToolCalls = circuitBreaker.maxToolCalls
+        const maxToolCalls = circuitBreaker.maxToolCalls;
         if (task.progress.toolCalls >= maxToolCalls) {
           log("[background-agent] Circuit breaker: tool call limit reached", {
             taskId: task.id,
@@ -956,17 +1000,17 @@ export class BackgroundManager {
             maxToolCalls,
             agent: task.agent,
             sessionID,
-          })
+          });
           void this.cancelTask(task.id, {
             source: "circuit-breaker",
             reason: `Subagent exceeded maximum tool call limit (${maxToolCalls}). This usually indicates an infinite loop. The task was automatically cancelled to prevent excessive token usage.`,
-          })
+          });
         }
       }
     }
 
     if (event.type === "session.idle") {
-      if (!props || typeof props !== "object") return
+      if (!props || typeof props !== "object") return;
       handleSessionIdleBackgroundEvent({
         properties: props as Record<string, unknown>,
         findBySession: (id) => this.findBySession(id),
@@ -974,146 +1018,169 @@ export class BackgroundManager {
         validateSessionHasOutput: (id) => this.validateSessionHasOutput(id),
         checkSessionTodos: (id) => this.checkSessionTodos(id),
         tryCompleteTask: (task, source) => this.tryCompleteTask(task, source),
-        emitIdleEvent: (sessionID) => this.handleEvent({ type: "session.idle", properties: { sessionID } }),
-      })
+        emitIdleEvent: (sessionID) =>
+          this.handleEvent({ type: "session.idle", properties: { sessionID } }),
+      });
     }
 
     if (event.type === "session.error") {
-      const sessionID = typeof props?.sessionID === "string" ? props.sessionID : undefined
-      if (!sessionID) return
+      const sessionID = typeof props?.sessionID === "string" ? props.sessionID : undefined;
+      if (!sessionID) return;
 
-      const task = this.findBySession(sessionID)
-      if (!task || task.status !== "running") return
+      const task = this.findBySession(sessionID);
+      if (!task || task.status !== "running") return;
 
-      const errorObj = props?.error as { name?: string; message?: string } | undefined
-      const errorName = errorObj?.name
-      const errorMessage = props ? getSessionErrorMessage(props) : undefined
+      const errorObj = props?.error as { name?: string; message?: string } | undefined;
+      const errorName = errorObj?.name;
+      const errorMessage = props ? getSessionErrorMessage(props) : undefined;
 
-      const errorInfo = { name: errorName, message: errorMessage }
-      if (this.tryFallbackRetry(task, errorInfo, "session.error")) return
+      const errorInfo = { name: errorName, message: errorMessage };
+      if (this.tryFallbackRetry(task, errorInfo, "session.error")) return;
 
       // Original error handling (no retry)
-      const errorMsg = errorMessage ?? "Session error"
+      const errorMsg = errorMessage ?? "Session error";
       const canRetry =
         shouldRetryError(errorInfo) &&
         !!task.fallbackChain &&
-        hasMoreFallbacks(task.fallbackChain, task.attemptCount ?? 0)
+        hasMoreFallbacks(task.fallbackChain, task.attemptCount ?? 0);
       log("[background-agent] Session error - no retry:", {
         taskId: task.id,
         errorName,
         errorMessage: errorMsg?.slice(0, 100),
         hasFallbackChain: !!task.fallbackChain,
         canRetry,
-      })
+      });
 
-      task.status = "error"
-      task.error = errorMsg
-      task.completedAt = new Date()
-      this.taskHistory.record(task.parentSessionID, { id: task.id, sessionID: task.sessionID, agent: task.agent, description: task.description, status: "error", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
+      task.status = "error";
+      task.error = errorMsg;
+      task.completedAt = new Date();
+      if (task.rootSessionID) {
+        this.unregisterRootDescendant(task.rootSessionID);
+      }
+      this.taskHistory.record(task.parentSessionID, {
+        id: task.id,
+        sessionID: task.sessionID,
+        agent: task.agent,
+        description: task.description,
+        status: "error",
+        category: task.category,
+        startedAt: task.startedAt,
+        completedAt: task.completedAt,
+      });
 
       if (task.concurrencyKey) {
-        this.concurrencyManager.release(task.concurrencyKey)
-        task.concurrencyKey = undefined
+        this.concurrencyManager.release(task.concurrencyKey);
+        task.concurrencyKey = undefined;
       }
 
-      const completionTimer = this.completionTimers.get(task.id)
+      const completionTimer = this.completionTimers.get(task.id);
       if (completionTimer) {
-        clearTimeout(completionTimer)
-        this.completionTimers.delete(task.id)
+        clearTimeout(completionTimer);
+        this.completionTimers.delete(task.id);
       }
 
-      const idleTimer = this.idleDeferralTimers.get(task.id)
+      const idleTimer = this.idleDeferralTimers.get(task.id);
       if (idleTimer) {
-        clearTimeout(idleTimer)
-        this.idleDeferralTimers.delete(task.id)
+        clearTimeout(idleTimer);
+        this.idleDeferralTimers.delete(task.id);
       }
 
-      this.cleanupPendingByParent(task)
-      this.clearNotificationsForTask(task.id)
-      const toastManager = getTaskToastManager()
+      this.cleanupPendingByParent(task);
+      this.clearNotificationsForTask(task.id);
+      const toastManager = getTaskToastManager();
       if (toastManager) {
-        toastManager.removeTask(task.id)
+        toastManager.removeTask(task.id);
       }
-      this.scheduleTaskRemoval(task.id)
+      this.scheduleTaskRemoval(task.id);
       if (task.sessionID) {
-        SessionCategoryRegistry.remove(task.sessionID)
+        SessionCategoryRegistry.remove(task.sessionID);
       }
 
-      this.markForNotification(task)
-      this.enqueueNotificationForParent(task.parentSessionID, () => this.notifyParentSession(task)).catch(err => {
-        log("[background-agent] Error in notifyParentSession for errored task:", { taskId: task.id, error: err })
-      })
+      this.markForNotification(task);
+      this.enqueueNotificationForParent(task.parentSessionID, () =>
+        this.notifyParentSession(task),
+      ).catch((err) => {
+        log("[background-agent] Error in notifyParentSession for errored task:", {
+          taskId: task.id,
+          error: err,
+        });
+      });
     }
 
     if (event.type === "session.deleted") {
-      const info = props?.info
-      if (!info || typeof info.id !== "string") return
-      const sessionID = info.id
+      const info = props?.info;
+      if (!info || typeof info.id !== "string") return;
+      const sessionID = info.id;
 
-      const tasksToCancel = new Map<string, BackgroundTask>()
-      const directTask = this.findBySession(sessionID)
+      const tasksToCancel = new Map<string, BackgroundTask>();
+      const directTask = this.findBySession(sessionID);
       if (directTask) {
-        tasksToCancel.set(directTask.id, directTask)
+        tasksToCancel.set(directTask.id, directTask);
       }
       for (const descendant of this.getAllDescendantTasks(sessionID)) {
-        tasksToCancel.set(descendant.id, descendant)
+        tasksToCancel.set(descendant.id, descendant);
       }
 
-      this.pendingNotifications.delete(sessionID)
+      this.pendingNotifications.delete(sessionID);
 
       if (tasksToCancel.size === 0) {
-        this.clearTaskHistoryWhenParentTasksGone(sessionID)
-        return
+        this.clearTaskHistoryWhenParentTasksGone(sessionID);
+        return;
       }
 
-      const parentSessionsToClear = new Set<string>()
+      const parentSessionsToClear = new Set<string>();
 
-      const deletedSessionIDs = new Set<string>([sessionID])
+      const deletedSessionIDs = new Set<string>([sessionID]);
       for (const task of tasksToCancel.values()) {
         if (task.sessionID) {
-          deletedSessionIDs.add(task.sessionID)
+          deletedSessionIDs.add(task.sessionID);
         }
       }
 
       for (const task of tasksToCancel.values()) {
-        parentSessionsToClear.add(task.parentSessionID)
+        parentSessionsToClear.add(task.parentSessionID);
 
         if (task.status === "running" || task.status === "pending") {
           void this.cancelTask(task.id, {
             source: "session.deleted",
             reason: "Session deleted",
-          }).then(() => {
-            if (deletedSessionIDs.has(task.parentSessionID)) {
-              this.pendingNotifications.delete(task.parentSessionID)
-            }
-          }).catch(err => {
-            if (deletedSessionIDs.has(task.parentSessionID)) {
-              this.pendingNotifications.delete(task.parentSessionID)
-            }
-            log("[background-agent] Failed to cancel task on session.deleted:", { taskId: task.id, error: err })
           })
+            .then(() => {
+              if (deletedSessionIDs.has(task.parentSessionID)) {
+                this.pendingNotifications.delete(task.parentSessionID);
+              }
+            })
+            .catch((err) => {
+              if (deletedSessionIDs.has(task.parentSessionID)) {
+                this.pendingNotifications.delete(task.parentSessionID);
+              }
+              log("[background-agent] Failed to cancel task on session.deleted:", {
+                taskId: task.id,
+                error: err,
+              });
+            });
         }
       }
 
       for (const parentSessionID of parentSessionsToClear) {
-        this.clearTaskHistoryWhenParentTasksGone(parentSessionID)
+        this.clearTaskHistoryWhenParentTasksGone(parentSessionID);
       }
 
-      this.rootDescendantCounts.delete(sessionID)
-      SessionCategoryRegistry.remove(sessionID)
+      this.rootDescendantCounts.delete(sessionID);
+      SessionCategoryRegistry.remove(sessionID);
     }
 
     if (event.type === "session.status") {
-      const sessionID = props?.sessionID as string | undefined
-      const status = props?.status as { type?: string; message?: string } | undefined
-      if (!sessionID || status?.type !== "retry") return
+      const sessionID = props?.sessionID as string | undefined;
+      const status = props?.status as { type?: string; message?: string } | undefined;
+      if (!sessionID || status?.type !== "retry") return;
 
-      const task = this.findBySession(sessionID)
-      if (!task || task.status !== "running") return
+      const task = this.findBySession(sessionID);
+      if (!task || task.status !== "running") return;
 
-      const errorMessage = typeof status.message === "string" ? status.message : undefined
-      const errorInfo = { name: "SessionRetry", message: errorMessage }
-      this.tryFallbackRetry(task, errorInfo, "session.status")
+      const errorMessage = typeof status.message === "string" ? status.message : undefined;
+      const errorInfo = { name: "SessionRetry", message: errorMessage };
+      this.tryFallbackRetry(task, errorInfo, "session.status");
     }
   }
 
@@ -1122,7 +1189,7 @@ export class BackgroundManager {
     errorInfo: { name?: string; message?: string },
     source: string,
   ): boolean {
-    const previousSessionID = task.sessionID
+    const previousSessionID = task.sessionID;
     const result = tryFallbackRetry({
       task,
       errorInfo,
@@ -1132,51 +1199,54 @@ export class BackgroundManager {
       idleDeferralTimers: this.idleDeferralTimers,
       queuesByKey: this.queuesByKey,
       processKey: (key: string) => this.processKey(key),
-    })
+    });
     if (result && previousSessionID) {
-      subagentSessions.delete(previousSessionID)
+      subagentSessions.delete(previousSessionID);
     }
-    return result
+    return result;
   }
 
   markForNotification(task: BackgroundTask): void {
-    const queue = this.notifications.get(task.parentSessionID) ?? []
-    queue.push(task)
-    this.notifications.set(task.parentSessionID, queue)
+    const queue = this.notifications.get(task.parentSessionID) ?? [];
+    queue.push(task);
+    this.notifications.set(task.parentSessionID, queue);
   }
 
   getPendingNotifications(sessionID: string): BackgroundTask[] {
-    return this.notifications.get(sessionID) ?? []
+    return this.notifications.get(sessionID) ?? [];
   }
 
   clearNotifications(sessionID: string): void {
-    this.notifications.delete(sessionID)
+    this.notifications.delete(sessionID);
   }
 
   queuePendingNotification(sessionID: string | undefined, notification: string): void {
-    if (!sessionID) return
-    const existingNotifications = this.pendingNotifications.get(sessionID) ?? []
-    existingNotifications.push(notification)
-    this.pendingNotifications.set(sessionID, existingNotifications)
+    if (!sessionID) return;
+    const existingNotifications = this.pendingNotifications.get(sessionID) ?? [];
+    existingNotifications.push(notification);
+    this.pendingNotifications.set(sessionID, existingNotifications);
   }
 
-  injectPendingNotificationsIntoChatMessage(output: { parts: Array<{ type: string; text?: string; [key: string]: unknown }> }, sessionID: string): void {
-    const pendingNotifications = this.pendingNotifications.get(sessionID)
+  injectPendingNotificationsIntoChatMessage(
+    output: { parts: Array<{ type: string; text?: string; [key: string]: unknown }> },
+    sessionID: string,
+  ): void {
+    const pendingNotifications = this.pendingNotifications.get(sessionID);
     if (!pendingNotifications || pendingNotifications.length === 0) {
-      return
+      return;
     }
 
-    this.pendingNotifications.delete(sessionID)
-    const notificationContent = pendingNotifications.join("\n\n")
-    const firstTextPartIndex = output.parts.findIndex((part) => part.type === "text")
+    this.pendingNotifications.delete(sessionID);
+    const notificationContent = pendingNotifications.join("\n\n");
+    const firstTextPartIndex = output.parts.findIndex((part) => part.type === "text");
 
     if (firstTextPartIndex === -1) {
-      output.parts.unshift(createInternalAgentTextPart(notificationContent))
-      return
+      output.parts.unshift(createInternalAgentTextPart(notificationContent));
+      return;
     }
 
-    const originalText = output.parts[firstTextPartIndex].text ?? ""
-    output.parts[firstTextPartIndex].text = `${notificationContent}\n\n---\n\n${originalText}`
+    const originalText = output.parts[firstTextPartIndex].text ?? "";
+    output.parts[firstTextPartIndex].text = `${notificationContent}\n\n---\n\n${originalText}`;
   }
 
   /**
@@ -1187,19 +1257,21 @@ export class BackgroundManager {
     try {
       const response = await this.client.session.messages({
         path: { id: sessionID },
-      })
+      });
 
-      const messages = normalizeSDKResponse(response, [] as Array<{ info?: { role?: string } }>, { preferResponseOnMissingData: true })
-      
+      const messages = normalizeSDKResponse(response, [] as Array<{ info?: { role?: string } }>, {
+        preferResponseOnMissingData: true,
+      });
+
       // Check for at least one assistant or tool message
       const hasAssistantOrToolMessage = messages.some(
-        (m: { info?: { role?: string } }) => 
-          m.info?.role === "assistant" || m.info?.role === "tool"
-      )
+        (m: { info?: { role?: string } }) =>
+          m.info?.role === "assistant" || m.info?.role === "tool",
+      );
 
       if (!hasAssistantOrToolMessage) {
-        log("[background-agent] No assistant/tool messages found in session:", sessionID)
-        return false
+        log("[background-agent] No assistant/tool messages found in session:", sessionID);
+        return false;
       }
 
       // Additionally check that at least one message has content (not just empty)
@@ -1210,42 +1282,44 @@ export class BackgroundManager {
       // - "step-start"/"step-finish" (metadata, no content)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const hasContent = messages.some((m: any) => {
-        if (m.info?.role !== "assistant" && m.info?.role !== "tool") return false
-        const parts = m.parts ?? []
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return parts.some((p: any) => 
-        // Text content (final output)
-        (p.type === "text" && p.text && p.text.trim().length > 0) ||
-        // Reasoning content (thinking blocks)
-        (p.type === "reasoning" && p.text && p.text.trim().length > 0) ||
-        // Tool calls (indicates work was done)
-        p.type === "tool" ||
-        // Tool results (output from executed tools) - important for tool-only tasks
-        (p.type === "tool_result" && p.content && 
-          (typeof p.content === "string" ? p.content.trim().length > 0 : p.content.length > 0))
-      )
-      })
+        if (m.info?.role !== "assistant" && m.info?.role !== "tool") return false;
+        const parts = m.parts ?? [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return parts.some(
+          (p: any) =>
+            // Text content (final output)
+            (p.type === "text" && p.text && p.text.trim().length > 0) ||
+            // Reasoning content (thinking blocks)
+            (p.type === "reasoning" && p.text && p.text.trim().length > 0) ||
+            // Tool calls (indicates work was done)
+            p.type === "tool" ||
+            // Tool results (output from executed tools) - important for tool-only tasks
+            (p.type === "tool_result" &&
+              p.content &&
+              (typeof p.content === "string" ? p.content.trim().length > 0 : p.content.length > 0)),
+        );
+      });
 
       if (!hasContent) {
-        log("[background-agent] Messages exist but no content found in session:", sessionID)
-        return false
+        log("[background-agent] Messages exist but no content found in session:", sessionID);
+        return false;
       }
 
-      return true
+      return true;
     } catch (error) {
-      log("[background-agent] Error validating session output:", error)
+      log("[background-agent] Error validating session output:", error);
       // On error, allow completion to proceed (don't block indefinitely)
-      return true
+      return true;
     }
   }
 
   private clearNotificationsForTask(taskId: string): void {
     for (const [sessionID, tasks] of this.notifications.entries()) {
-      const filtered = tasks.filter((t) => t.id !== taskId)
+      const filtered = tasks.filter((t) => t.id !== taskId);
       if (filtered.length === 0) {
-        this.notifications.delete(sessionID)
+        this.notifications.delete(sessionID);
       } else {
-        this.notifications.set(sessionID, filtered)
+        this.notifications.set(sessionID, filtered);
       }
     }
   }
@@ -1255,143 +1329,172 @@ export class BackgroundManager {
    * Cleans up the parent entry if no pending tasks remain.
    */
   private cleanupPendingByParent(task: BackgroundTask): void {
-    if (!task.parentSessionID) return
-    const pending = this.pendingByParent.get(task.parentSessionID)
+    if (!task.parentSessionID) return;
+    const pending = this.pendingByParent.get(task.parentSessionID);
     if (pending) {
-      pending.delete(task.id)
+      pending.delete(task.id);
       if (pending.size === 0) {
-        this.pendingByParent.delete(task.parentSessionID)
+        this.pendingByParent.delete(task.parentSessionID);
       }
     }
   }
 
   private clearTaskHistoryWhenParentTasksGone(parentSessionID: string | undefined): void {
-    if (!parentSessionID) return
-    if (this.getTasksByParentSession(parentSessionID).length > 0) return
-    this.taskHistory.clearSession(parentSessionID)
-    this.completedTaskSummaries.delete(parentSessionID)
+    if (!parentSessionID) return;
+    if (this.getTasksByParentSession(parentSessionID).length > 0) return;
+    this.taskHistory.clearSession(parentSessionID);
+    this.completedTaskSummaries.delete(parentSessionID);
   }
 
   private scheduleTaskRemoval(taskId: string, rescheduleCount = 0): void {
-    const existingTimer = this.completionTimers.get(taskId)
+    const existingTimer = this.completionTimers.get(taskId);
     if (existingTimer) {
-      clearTimeout(existingTimer)
-      this.completionTimers.delete(taskId)
+      clearTimeout(existingTimer);
+      this.completionTimers.delete(taskId);
     }
 
     const timer = setTimeout(() => {
-      this.completionTimers.delete(taskId)
-      const task = this.tasks.get(taskId)
-      if (!task) return
+      this.completionTimers.delete(taskId);
+      const task = this.tasks.get(taskId);
+      if (!task) return;
 
       if (task.parentSessionID) {
-        const siblings = this.getTasksByParentSession(task.parentSessionID)
+        const siblings = this.getTasksByParentSession(task.parentSessionID);
         const runningOrPendingSiblings = siblings.filter(
-          sibling => sibling.id !== taskId && (sibling.status === "running" || sibling.status === "pending"),
-        )
-        const completedAtTimestamp = task.completedAt?.getTime()
-        const reachedTaskTtl = completedAtTimestamp !== undefined && (Date.now() - completedAtTimestamp) >= TASK_TTL_MS
-        if (runningOrPendingSiblings.length > 0 && rescheduleCount < MAX_TASK_REMOVAL_RESCHEDULES && !reachedTaskTtl) {
-          this.scheduleTaskRemoval(taskId, rescheduleCount + 1)
-          return
+          (sibling) =>
+            sibling.id !== taskId && (sibling.status === "running" || sibling.status === "pending"),
+        );
+        const completedAtTimestamp = task.completedAt?.getTime();
+        const reachedTaskTtl =
+          completedAtTimestamp !== undefined && Date.now() - completedAtTimestamp >= TASK_TTL_MS;
+        if (
+          runningOrPendingSiblings.length > 0 &&
+          rescheduleCount < MAX_TASK_REMOVAL_RESCHEDULES &&
+          !reachedTaskTtl
+        ) {
+          this.scheduleTaskRemoval(taskId, rescheduleCount + 1);
+          return;
         }
       }
 
-      this.clearNotificationsForTask(taskId)
-      this.tasks.delete(taskId)
-      this.clearTaskHistoryWhenParentTasksGone(task.parentSessionID)
+      this.clearNotificationsForTask(taskId);
+      this.tasks.delete(taskId);
+      this.clearTaskHistoryWhenParentTasksGone(task.parentSessionID);
       if (task.sessionID) {
-        subagentSessions.delete(task.sessionID)
-        SessionCategoryRegistry.remove(task.sessionID)
+        subagentSessions.delete(task.sessionID);
+        SessionCategoryRegistry.remove(task.sessionID);
       }
-      log("[background-agent] Removed completed task from memory:", taskId)
-    }, TASK_CLEANUP_DELAY_MS)
+      log("[background-agent] Removed completed task from memory:", taskId);
+    }, TASK_CLEANUP_DELAY_MS);
 
-    this.completionTimers.set(taskId, timer)
+    this.completionTimers.set(taskId, timer);
   }
 
   async cancelTask(
     taskId: string,
-    options?: { source?: string; reason?: string; abortSession?: boolean; skipNotification?: boolean }
+    options?: {
+      source?: string;
+      reason?: string;
+      abortSession?: boolean;
+      skipNotification?: boolean;
+    },
   ): Promise<boolean> {
-    const task = this.tasks.get(taskId)
+    const task = this.tasks.get(taskId);
     if (!task || (task.status !== "running" && task.status !== "pending")) {
-      return false
+      return false;
     }
 
-    const source = options?.source ?? "cancel"
-    const abortSession = options?.abortSession !== false
-    const reason = options?.reason
+    const source = options?.source ?? "cancel";
+    const abortSession = options?.abortSession !== false;
+    const reason = options?.reason;
 
     if (task.status === "pending") {
-      const key = task.model
-        ? `${task.model.providerID}/${task.model.modelID}`
-        : task.agent
-      const queue = this.queuesByKey.get(key)
+      const key = task.model ? `${task.model.providerID}/${task.model.modelID}` : task.agent;
+      const queue = this.queuesByKey.get(key);
       if (queue) {
-        const index = queue.findIndex(item => item.task.id === taskId)
+        const index = queue.findIndex((item) => item.task.id === taskId);
         if (index !== -1) {
-          queue.splice(index, 1)
+          queue.splice(index, 1);
           if (queue.length === 0) {
-            this.queuesByKey.delete(key)
+            this.queuesByKey.delete(key);
           }
         }
       }
-      this.rollbackPreStartDescendantReservation(task)
-      log("[background-agent] Cancelled pending task:", { taskId, key })
+      this.rollbackPreStartDescendantReservation(task);
+      log("[background-agent] Cancelled pending task:", { taskId, key });
     }
 
-    task.status = "cancelled"
-    task.completedAt = new Date()
-    if (reason) {
-      task.error = reason
+    const wasRunning = task.status === "running";
+    task.status = "cancelled";
+    task.completedAt = new Date();
+    if (wasRunning && task.rootSessionID) {
+      this.unregisterRootDescendant(task.rootSessionID);
     }
-    this.taskHistory.record(task.parentSessionID, { id: task.id, sessionID: task.sessionID, agent: task.agent, description: task.description, status: "cancelled", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
+    if (reason) {
+      task.error = reason;
+    }
+    this.taskHistory.record(task.parentSessionID, {
+      id: task.id,
+      sessionID: task.sessionID,
+      agent: task.agent,
+      description: task.description,
+      status: "cancelled",
+      category: task.category,
+      startedAt: task.startedAt,
+      completedAt: task.completedAt,
+    });
 
     if (task.concurrencyKey) {
-      this.concurrencyManager.release(task.concurrencyKey)
-      task.concurrencyKey = undefined
+      this.concurrencyManager.release(task.concurrencyKey);
+      task.concurrencyKey = undefined;
     }
 
-    const existingTimer = this.completionTimers.get(task.id)
+    const existingTimer = this.completionTimers.get(task.id);
     if (existingTimer) {
-      clearTimeout(existingTimer)
-      this.completionTimers.delete(task.id)
+      clearTimeout(existingTimer);
+      this.completionTimers.delete(task.id);
     }
 
-    const idleTimer = this.idleDeferralTimers.get(task.id)
+    const idleTimer = this.idleDeferralTimers.get(task.id);
     if (idleTimer) {
-      clearTimeout(idleTimer)
-      this.idleDeferralTimers.delete(task.id)
+      clearTimeout(idleTimer);
+      this.idleDeferralTimers.delete(task.id);
     }
 
     if (abortSession && task.sessionID) {
-      this.client.session.abort({
-        path: { id: task.sessionID },
-      }).catch(() => {})
+      this.client.session
+        .abort({
+          path: { id: task.sessionID },
+        })
+        .catch(() => {});
 
-      SessionCategoryRegistry.remove(task.sessionID)
+      SessionCategoryRegistry.remove(task.sessionID);
     }
 
-    removeTaskToastTracking(task.id)
+    removeTaskToastTracking(task.id);
 
     if (options?.skipNotification) {
-      this.cleanupPendingByParent(task)
-      this.scheduleTaskRemoval(task.id)
-      log(`[background-agent] Task cancelled via ${source} (notification skipped):`, task.id)
-      return true
+      this.cleanupPendingByParent(task);
+      this.scheduleTaskRemoval(task.id);
+      log(`[background-agent] Task cancelled via ${source} (notification skipped):`, task.id);
+      return true;
     }
 
-    this.markForNotification(task)
+    this.markForNotification(task);
 
     try {
-      await this.enqueueNotificationForParent(task.parentSessionID, () => this.notifyParentSession(task))
-      log(`[background-agent] Task cancelled via ${source}:`, task.id)
+      await this.enqueueNotificationForParent(task.parentSessionID, () =>
+        this.notifyParentSession(task),
+      );
+      log(`[background-agent] Task cancelled via ${source}:`, task.id);
     } catch (err) {
-      log("[background-agent] Error in notifyParentSession for cancelled task:", { taskId: task.id, error: err })
+      log("[background-agent] Error in notifyParentSession for cancelled task:", {
+        taskId: task.id,
+        error: err,
+      });
     }
 
-    return true
+    return true;
   }
 
   /**
@@ -1399,52 +1502,51 @@ export class BackgroundManager {
    * Does NOT abort session (no session exists yet) or release concurrency slot (wasn't acquired).
    */
   cancelPendingTask(taskId: string): boolean {
-    const task = this.tasks.get(taskId)
+    const task = this.tasks.get(taskId);
     if (!task || task.status !== "pending") {
-      return false
+      return false;
     }
 
-    void this.cancelTask(taskId, { source: "cancelPendingTask", abortSession: false })
-    return true
+    void this.cancelTask(taskId, { source: "cancelPendingTask", abortSession: false });
+    return true;
   }
 
   private startPolling(): void {
-    if (this.pollingInterval) return
+    if (this.pollingInterval) return;
 
     this.pollingInterval = setInterval(() => {
-      this.pollRunningTasks()
-    }, POLLING_INTERVAL_MS)
-    this.pollingInterval.unref()
+      this.pollRunningTasks();
+    }, POLLING_INTERVAL_MS);
+    this.pollingInterval.unref();
   }
 
   private stopPolling(): void {
     if (this.pollingInterval) {
-      clearInterval(this.pollingInterval)
-      this.pollingInterval = undefined
+      clearInterval(this.pollingInterval);
+      this.pollingInterval = undefined;
     }
   }
 
   private registerProcessCleanup(): void {
-    registerManagerForCleanup(this)
+    registerManagerForCleanup(this);
   }
 
   private unregisterProcessCleanup(): void {
-    unregisterManagerForCleanup(this)
+    unregisterManagerForCleanup(this);
   }
-
 
   /**
    * Get all running tasks (for compaction hook)
    */
   getRunningTasks(): BackgroundTask[] {
-    return Array.from(this.tasks.values()).filter(t => t.status === "running")
+    return Array.from(this.tasks.values()).filter((t) => t.status === "running");
   }
 
   /**
    * Get all non-running tasks still in memory (for compaction hook)
    */
   getNonRunningTasks(): BackgroundTask[] {
-    return Array.from(this.tasks.values()).filter(t => t.status !== "running")
+    return Array.from(this.tasks.values()).filter((t) => t.status !== "running");
   }
 
   /**
@@ -1454,125 +1556,152 @@ export class BackgroundManager {
   private async tryCompleteTask(task: BackgroundTask, source: string): Promise<boolean> {
     // Guard: Check if task is still running (could have been completed by another path)
     if (task.status !== "running") {
-      log("[background-agent] Task already completed, skipping:", { taskId: task.id, status: task.status, source })
-      return false
+      log("[background-agent] Task already completed, skipping:", {
+        taskId: task.id,
+        status: task.status,
+        source,
+      });
+      return false;
     }
 
     // Atomically mark as completed to prevent race conditions
-    task.status = "completed"
-    task.completedAt = new Date()
-    this.taskHistory.record(task.parentSessionID, { id: task.id, sessionID: task.sessionID, agent: task.agent, description: task.description, status: "completed", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
+    task.status = "completed";
+    task.completedAt = new Date();
+    this.taskHistory.record(task.parentSessionID, {
+      id: task.id,
+      sessionID: task.sessionID,
+      agent: task.agent,
+      description: task.description,
+      status: "completed",
+      category: task.category,
+      startedAt: task.startedAt,
+      completedAt: task.completedAt,
+    });
 
-    removeTaskToastTracking(task.id)
+    if (task.rootSessionID) {
+      this.unregisterRootDescendant(task.rootSessionID);
+    }
+
+    removeTaskToastTracking(task.id);
 
     // Release concurrency BEFORE any async operations to prevent slot leaks
     if (task.concurrencyKey) {
-      this.concurrencyManager.release(task.concurrencyKey)
-      task.concurrencyKey = undefined
+      this.concurrencyManager.release(task.concurrencyKey);
+      task.concurrencyKey = undefined;
     }
 
-    this.markForNotification(task)
+    this.markForNotification(task);
 
-    const idleTimer = this.idleDeferralTimers.get(task.id)
+    const idleTimer = this.idleDeferralTimers.get(task.id);
     if (idleTimer) {
-      clearTimeout(idleTimer)
-      this.idleDeferralTimers.delete(task.id)
+      clearTimeout(idleTimer);
+      this.idleDeferralTimers.delete(task.id);
     }
 
     if (task.sessionID) {
-      this.client.session.abort({
-        path: { id: task.sessionID },
-      }).catch(() => {})
+      this.client.session
+        .abort({
+          path: { id: task.sessionID },
+        })
+        .catch(() => {});
 
-      SessionCategoryRegistry.remove(task.sessionID)
+      SessionCategoryRegistry.remove(task.sessionID);
     }
 
     try {
-      await this.enqueueNotificationForParent(task.parentSessionID, () => this.notifyParentSession(task))
-      log(`[background-agent] Task completed via ${source}:`, task.id)
+      await this.enqueueNotificationForParent(task.parentSessionID, () =>
+        this.notifyParentSession(task),
+      );
+      log(`[background-agent] Task completed via ${source}:`, task.id);
     } catch (err) {
-      log("[background-agent] Error in notifyParentSession:", { taskId: task.id, error: err })
+      log("[background-agent] Error in notifyParentSession:", { taskId: task.id, error: err });
       // Concurrency already released, notification failed but task is complete
     }
 
-    return true
+    return true;
   }
 
   private async notifyParentSession(task: BackgroundTask): Promise<void> {
     // Note: Callers must release concurrency before calling this method
     // to ensure slots are freed even if notification fails
 
-    const duration = formatDuration(task.startedAt ?? new Date(), task.completedAt)
+    const duration = formatDuration(task.startedAt ?? new Date(), task.completedAt);
 
-    log("[background-agent] notifyParentSession called for task:", task.id)
+    log("[background-agent] notifyParentSession called for task:", task.id);
 
     // Show toast notification
-    const toastManager = getTaskToastManager()
+    const toastManager = getTaskToastManager();
     if (toastManager) {
       toastManager.showCompletionToast({
         id: task.id,
         description: task.description,
         duration,
-      })
+      });
     }
 
     if (!this.completedTaskSummaries.has(task.parentSessionID)) {
-      this.completedTaskSummaries.set(task.parentSessionID, [])
+      this.completedTaskSummaries.set(task.parentSessionID, []);
     }
     this.completedTaskSummaries.get(task.parentSessionID)!.push({
       id: task.id,
       description: task.description,
-    })
+    });
 
     // Update pending tracking and check if all tasks complete
-    const pendingSet = this.pendingByParent.get(task.parentSessionID)
-    let allComplete = false
-    let remainingCount = 0
+    const pendingSet = this.pendingByParent.get(task.parentSessionID);
+    let allComplete = false;
+    let remainingCount = 0;
     if (pendingSet) {
-      pendingSet.delete(task.id)
-      remainingCount = pendingSet.size
-      allComplete = remainingCount === 0
+      pendingSet.delete(task.id);
+      remainingCount = pendingSet.size;
+      allComplete = remainingCount === 0;
       if (allComplete) {
-        this.pendingByParent.delete(task.parentSessionID)
+        this.pendingByParent.delete(task.parentSessionID);
       }
     } else {
-      remainingCount = Array.from(this.tasks.values())
-        .filter(t => t.parentSessionID === task.parentSessionID && t.id !== task.id && (t.status === "running" || t.status === "pending"))
-        .length
-      allComplete = remainingCount === 0
+      remainingCount = Array.from(this.tasks.values()).filter(
+        (t) =>
+          t.parentSessionID === task.parentSessionID &&
+          t.id !== task.id &&
+          (t.status === "running" || t.status === "pending"),
+      ).length;
+      allComplete = remainingCount === 0;
     }
 
     const completedTasks = allComplete
-      ? (this.completedTaskSummaries.get(task.parentSessionID) ?? [{ id: task.id, description: task.description }])
-      : []
+      ? (this.completedTaskSummaries.get(task.parentSessionID) ?? [
+          { id: task.id, description: task.description },
+        ])
+      : [];
 
     if (allComplete) {
-      this.completedTaskSummaries.delete(task.parentSessionID)
+      this.completedTaskSummaries.delete(task.parentSessionID);
     }
 
-    const statusText = task.status === "completed"
-      ? "COMPLETED"
-      : task.status === "interrupt"
-        ? "INTERRUPTED"
-        : task.status === "error"
-          ? "ERROR"
-          : "CANCELLED"
-    const errorInfo = task.error ? `\n**Error:** ${task.error}` : ""
+    const statusText =
+      task.status === "completed"
+        ? "COMPLETED"
+        : task.status === "interrupt"
+          ? "INTERRUPTED"
+          : task.status === "error"
+            ? "ERROR"
+            : "CANCELLED";
+    const errorInfo = task.error ? `\n**Error:** ${task.error}` : "";
 
-    let notification: string
+    let notification: string;
     if (allComplete) {
-        const completedTasksText = completedTasks
-          .map(t => `- \`${t.id}\`: ${t.description}`)
-          .join("\n")
+      const completedTasksText = completedTasks
+        .map((t) => `- \`${t.id}\`: ${t.description}`)
+        .join("\n");
 
-        notification = `<system-reminder>
+      notification = `<system-reminder>
 [ALL BACKGROUND TASKS COMPLETE]
 
 **Completed:**
 ${completedTasksText || `- \`${task.id}\`: ${task.description}`}
 
 Use \`background_output(task_id="<id>")\` to retrieve each result.
-</system-reminder>`
+</system-reminder>`;
     } else {
       // Individual completion - silent notification
       notification = `<system-reminder>
@@ -1585,110 +1714,123 @@ Use \`background_output(task_id="<id>")\` to retrieve each result.
 Do NOT poll - continue productive work.
 
 Use \`background_output(task_id="${task.id}")\` to retrieve this result when ready.
-</system-reminder>`
+</system-reminder>`;
     }
 
-      let agent: string | undefined = task.parentAgent
-      let model: { providerID: string; modelID: string } | undefined
-      let tools: Record<string, boolean> | undefined = task.parentTools
+    let agent: string | undefined = task.parentAgent;
+    let model: { providerID: string; modelID: string } | undefined;
+    let tools: Record<string, boolean> | undefined = task.parentTools;
 
-      if (this.enableParentSessionNotifications) {
-        try {
-          const messagesResp = await this.client.session.messages({ path: { id: task.parentSessionID } })
-          const messages = normalizeSDKResponse(messagesResp, [] as Array<{
+    if (this.enableParentSessionNotifications) {
+      try {
+        const messagesResp = await this.client.session.messages({
+          path: { id: task.parentSessionID },
+        });
+        const messages = normalizeSDKResponse(
+          messagesResp,
+          [] as Array<{
             info?: {
-              agent?: string
-              model?: { providerID: string; modelID: string }
-              modelID?: string
-              providerID?: string
-              tools?: Record<string, boolean | "allow" | "deny" | "ask">
-            }
-          }>)
-          const promptContext = resolvePromptContextFromSessionMessages(
-            messages,
-            task.parentSessionID,
-          )
-          const normalizedTools = isRecord(promptContext?.tools)
-            ? normalizePromptTools(promptContext.tools)
-            : undefined
+              agent?: string;
+              model?: { providerID: string; modelID: string };
+              modelID?: string;
+              providerID?: string;
+              tools?: Record<string, boolean | "allow" | "deny" | "ask">;
+            };
+          }>,
+        );
+        const promptContext = resolvePromptContextFromSessionMessages(
+          messages,
+          task.parentSessionID,
+        );
+        const normalizedTools = isRecord(promptContext?.tools)
+          ? normalizePromptTools(promptContext.tools)
+          : undefined;
 
-          if (promptContext?.agent || promptContext?.model || normalizedTools) {
-            agent = promptContext?.agent ?? task.parentAgent
-            model = promptContext?.model?.providerID && promptContext.model.modelID
+        if (promptContext?.agent || promptContext?.model || normalizedTools) {
+          agent = promptContext?.agent ?? task.parentAgent;
+          model =
+            promptContext?.model?.providerID && promptContext.model.modelID
               ? { providerID: promptContext.model.providerID, modelID: promptContext.model.modelID }
-              : undefined
-            tools = normalizedTools ?? tools
-          }
-        } catch (error) {
-          if (isAbortedSessionError(error)) {
-            log("[background-agent] Parent session aborted while loading messages; using messageDir fallback:", {
+              : undefined;
+          tools = normalizedTools ?? tools;
+        }
+      } catch (error) {
+        if (isAbortedSessionError(error)) {
+          log(
+            "[background-agent] Parent session aborted while loading messages; using messageDir fallback:",
+            {
               taskId: task.id,
               parentSessionID: task.parentSessionID,
-            })
-          }
-          const messageDir = join(MESSAGE_STORAGE, task.parentSessionID)
-          const currentMessage = messageDir
-            ? findNearestMessageExcludingCompaction(messageDir, task.parentSessionID)
-            : null
-          agent = currentMessage?.agent ?? task.parentAgent
-          model = currentMessage?.model?.providerID && currentMessage?.model?.modelID
-            ? { providerID: currentMessage.model.providerID, modelID: currentMessage.model.modelID }
-            : undefined
-          tools = normalizePromptTools(currentMessage?.tools) ?? tools
-        }
-
-        const resolvedTools = resolveInheritedPromptTools(task.parentSessionID, tools)
-
-        log("[background-agent] notifyParentSession context:", {
-          taskId: task.id,
-          resolvedAgent: agent,
-          resolvedModel: model,
-        })
-
-        try {
-          await this.client.session.promptAsync({
-            path: { id: task.parentSessionID },
-            body: {
-              noReply: !allComplete,
-              ...(agent !== undefined ? { agent } : {}),
-              ...(model !== undefined ? { model } : {}),
-              ...(resolvedTools ? { tools: resolvedTools } : {}),
-              parts: [createInternalAgentTextPart(notification)],
             },
-          })
-          log("[background-agent] Sent notification to parent session:", {
-            taskId: task.id,
-            allComplete,
-            noReply: !allComplete,
-          })
-        } catch (error) {
-          if (isAbortedSessionError(error)) {
-            log("[background-agent] Parent session aborted while sending notification; continuing cleanup:", {
-              taskId: task.id,
-              parentSessionID: task.parentSessionID,
-            })
-            this.queuePendingNotification(task.parentSessionID, notification)
-          } else {
-            log("[background-agent] Failed to send notification:", error)
-          }
+          );
         }
-      } else {
-        log("[background-agent] Parent session notifications disabled, skipping prompt injection:", {
-          taskId: task.id,
-          parentSessionID: task.parentSessionID,
-        })
+        const messageDir = join(MESSAGE_STORAGE, task.parentSessionID);
+        const currentMessage = messageDir
+          ? findNearestMessageExcludingCompaction(messageDir, task.parentSessionID)
+          : null;
+        agent = currentMessage?.agent ?? task.parentAgent;
+        model =
+          currentMessage?.model?.providerID && currentMessage?.model?.modelID
+            ? { providerID: currentMessage.model.providerID, modelID: currentMessage.model.modelID }
+            : undefined;
+        tools = normalizePromptTools(currentMessage?.tools) ?? tools;
       }
 
+      const resolvedTools = resolveInheritedPromptTools(task.parentSessionID, tools);
+
+      log("[background-agent] notifyParentSession context:", {
+        taskId: task.id,
+        resolvedAgent: agent,
+        resolvedModel: model,
+      });
+
+      try {
+        await this.client.session.promptAsync({
+          path: { id: task.parentSessionID },
+          body: {
+            noReply: !allComplete,
+            ...(agent !== undefined ? { agent } : {}),
+            ...(model !== undefined ? { model } : {}),
+            ...(resolvedTools ? { tools: resolvedTools } : {}),
+            parts: [createInternalAgentTextPart(notification)],
+          },
+        });
+        log("[background-agent] Sent notification to parent session:", {
+          taskId: task.id,
+          allComplete,
+          noReply: !allComplete,
+        });
+      } catch (error) {
+        if (isAbortedSessionError(error)) {
+          log(
+            "[background-agent] Parent session aborted while sending notification; continuing cleanup:",
+            {
+              taskId: task.id,
+              parentSessionID: task.parentSessionID,
+            },
+          );
+          this.queuePendingNotification(task.parentSessionID, notification);
+        } else {
+          log("[background-agent] Failed to send notification:", error);
+        }
+      }
+    } else {
+      log("[background-agent] Parent session notifications disabled, skipping prompt injection:", {
+        taskId: task.id,
+        parentSessionID: task.parentSessionID,
+      });
+    }
+
     if (task.status !== "running" && task.status !== "pending") {
-      this.scheduleTaskRemoval(task.id)
+      this.scheduleTaskRemoval(task.id);
     }
   }
 
   private hasRunningTasks(): boolean {
     for (const task of this.tasks.values()) {
-      if (task.status === "running") return true
+      if (task.status === "running") return true;
     }
-    return false
+    return false;
   }
 
   private pruneStaleTasksAndNotifications(): void {
@@ -1696,49 +1838,73 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
       tasks: this.tasks,
       notifications: this.notifications,
       onTaskPruned: (taskId, task, errorMessage) => {
-        const wasPending = task.status === "pending"
-        log("[background-agent] Pruning stale task:", { taskId, status: task.status, age: Math.round(((wasPending ? task.queuedAt?.getTime() : task.startedAt?.getTime()) ? (Date.now() - (wasPending ? task.queuedAt!.getTime() : task.startedAt!.getTime())) : 0) / 1000) + "s" })
-        task.status = "error"
-        task.error = errorMessage
-        task.completedAt = new Date()
-        this.taskHistory.record(task.parentSessionID, { id: task.id, sessionID: task.sessionID, agent: task.agent, description: task.description, status: "error", category: task.category, startedAt: task.startedAt, completedAt: task.completedAt })
+        const wasPending = task.status === "pending";
+        log("[background-agent] Pruning stale task:", {
+          taskId,
+          status: task.status,
+          age:
+            Math.round(
+              ((wasPending ? task.queuedAt?.getTime() : task.startedAt?.getTime())
+                ? Date.now() - (wasPending ? task.queuedAt!.getTime() : task.startedAt!.getTime())
+                : 0) / 1000,
+            ) + "s",
+        });
+        task.status = "error";
+        task.error = errorMessage;
+        task.completedAt = new Date();
+        if (!wasPending && task.rootSessionID) {
+          this.unregisterRootDescendant(task.rootSessionID);
+        }
+        this.taskHistory.record(task.parentSessionID, {
+          id: task.id,
+          sessionID: task.sessionID,
+          agent: task.agent,
+          description: task.description,
+          status: "error",
+          category: task.category,
+          startedAt: task.startedAt,
+          completedAt: task.completedAt,
+        });
         if (task.concurrencyKey) {
-          this.concurrencyManager.release(task.concurrencyKey)
-          task.concurrencyKey = undefined
+          this.concurrencyManager.release(task.concurrencyKey);
+          task.concurrencyKey = undefined;
         }
-        removeTaskToastTracking(task.id)
-        const existingTimer = this.completionTimers.get(taskId)
+        removeTaskToastTracking(task.id);
+        const existingTimer = this.completionTimers.get(taskId);
         if (existingTimer) {
-          clearTimeout(existingTimer)
-          this.completionTimers.delete(taskId)
+          clearTimeout(existingTimer);
+          this.completionTimers.delete(taskId);
         }
-        const idleTimer = this.idleDeferralTimers.get(taskId)
+        const idleTimer = this.idleDeferralTimers.get(taskId);
         if (idleTimer) {
-          clearTimeout(idleTimer)
-          this.idleDeferralTimers.delete(taskId)
+          clearTimeout(idleTimer);
+          this.idleDeferralTimers.delete(taskId);
         }
         if (wasPending) {
-          const key = task.model
-            ? `${task.model.providerID}/${task.model.modelID}`
-            : task.agent
-          const queue = this.queuesByKey.get(key)
+          const key = task.model ? `${task.model.providerID}/${task.model.modelID}` : task.agent;
+          const queue = this.queuesByKey.get(key);
           if (queue) {
-            const index = queue.findIndex((item) => item.task.id === taskId)
+            const index = queue.findIndex((item) => item.task.id === taskId);
             if (index !== -1) {
-              queue.splice(index, 1)
+              queue.splice(index, 1);
               if (queue.length === 0) {
-                this.queuesByKey.delete(key)
+                this.queuesByKey.delete(key);
               }
             }
           }
         }
-        this.cleanupPendingByParent(task)
-        this.markForNotification(task)
-        this.enqueueNotificationForParent(task.parentSessionID, () => this.notifyParentSession(task)).catch(err => {
-          log("[background-agent] Error in notifyParentSession for stale-pruned task:", { taskId: task.id, error: err })
-        })
+        this.cleanupPendingByParent(task);
+        this.markForNotification(task);
+        this.enqueueNotificationForParent(task.parentSessionID, () =>
+          this.notifyParentSession(task),
+        ).catch((err) => {
+          log("[background-agent] Error in notifyParentSession for stale-pruned task:", {
+            taskId: task.id,
+            error: err,
+          });
+        });
       },
-    })
+    });
   }
 
   private async checkAndInterruptStaleTasks(
@@ -1749,101 +1915,112 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
       client: this.client,
       config: this.config,
       concurrencyManager: this.concurrencyManager,
-      notifyParentSession: (task) => this.enqueueNotificationForParent(task.parentSessionID, () => this.notifyParentSession(task)),
+      notifyParentSession: (task) =>
+        this.enqueueNotificationForParent(task.parentSessionID, () =>
+          this.notifyParentSession(task),
+        ),
       sessionStatuses: allStatuses,
-    })
+    });
   }
 
   private async pollRunningTasks(): Promise<void> {
-    if (this.pollingInFlight) return
-    this.pollingInFlight = true
+    if (this.pollingInFlight) return;
+    this.pollingInFlight = true;
     try {
-    this.pruneStaleTasksAndNotifications()
+      this.pruneStaleTasksAndNotifications();
 
-    const statusResult = await this.client.session.status()
-    const allStatuses = normalizeSDKResponse(statusResult, {} as Record<string, { type: string }>)
+      const statusResult = await this.client.session.status();
+      const allStatuses = normalizeSDKResponse(
+        statusResult,
+        {} as Record<string, { type: string }>,
+      );
 
-    await this.checkAndInterruptStaleTasks(allStatuses)
+      await this.checkAndInterruptStaleTasks(allStatuses);
 
-    for (const task of this.tasks.values()) {
-      if (task.status !== "running") continue
-      
-      const sessionID = task.sessionID
-      if (!sessionID) continue
+      for (const task of this.tasks.values()) {
+        if (task.status !== "running") continue;
 
-      try {
-        const sessionStatus = allStatuses[sessionID]
-        // Handle retry before checking running state
-        if (sessionStatus?.type === "retry") {
-          const retryMessage = typeof (sessionStatus as { message?: string }).message === "string"
-            ? (sessionStatus as { message?: string }).message
-            : undefined
-          const errorInfo = { name: "SessionRetry", message: retryMessage }
-          if (this.tryFallbackRetry(task, errorInfo, "polling:session.status")) {
-            continue
+        const sessionID = task.sessionID;
+        if (!sessionID) continue;
+
+        try {
+          const sessionStatus = allStatuses[sessionID];
+          // Handle retry before checking running state
+          if (sessionStatus?.type === "retry") {
+            const retryMessage =
+              typeof (sessionStatus as { message?: string }).message === "string"
+                ? (sessionStatus as { message?: string }).message
+                : undefined;
+            const errorInfo = { name: "SessionRetry", message: retryMessage };
+            if (this.tryFallbackRetry(task, errorInfo, "polling:session.status")) {
+              continue;
+            }
           }
+
+          // Only skip completion when session status is actively running.
+          // Unknown or terminal statuses (like "interrupted") fall through to completion.
+          if (sessionStatus && isActiveSessionStatus(sessionStatus.type)) {
+            log("[background-agent] Session still running, relying on event-based progress:", {
+              taskId: task.id,
+              sessionID,
+              sessionStatus: sessionStatus.type,
+              toolCalls: task.progress?.toolCalls ?? 0,
+            });
+            continue;
+          }
+
+          // Explicit terminal non-idle status (e.g., "interrupted") — complete immediately,
+          // skipping output validation (session will never produce more output).
+          // Unknown statuses fall through to the idle/gone path with output validation.
+          if (sessionStatus && isTerminalSessionStatus(sessionStatus.type)) {
+            await this.tryCompleteTask(
+              task,
+              `polling (terminal session status: ${sessionStatus.type})`,
+            );
+            continue;
+          }
+
+          // Unknown non-idle status — not active, not terminal, not idle.
+          // Fall through to idle/gone completion path with output validation.
+          if (sessionStatus && sessionStatus.type !== "idle") {
+            log("[background-agent] Unknown session status, treating as potentially idle:", {
+              taskId: task.id,
+              sessionID,
+              sessionStatus: sessionStatus.type,
+            });
+          }
+
+          // Session is idle or no longer in status response (completed/disappeared)
+          const completionSource =
+            sessionStatus?.type === "idle"
+              ? "polling (idle status)"
+              : "polling (session gone from status)";
+          const hasValidOutput = await this.validateSessionHasOutput(sessionID);
+          if (!hasValidOutput) {
+            log("[background-agent] Polling idle/gone but no valid output yet, waiting:", task.id);
+            continue;
+          }
+
+          // Re-check status after async operation
+          if (task.status !== "running") continue;
+
+          const hasIncompleteTodos = await this.checkSessionTodos(sessionID);
+          if (hasIncompleteTodos) {
+            log("[background-agent] Task has incomplete todos via polling, waiting:", task.id);
+            continue;
+          }
+
+          await this.tryCompleteTask(task, completionSource);
+        } catch (error) {
+          log("[background-agent] Poll error for task:", { taskId: task.id, error });
         }
-
-        // Only skip completion when session status is actively running.
-        // Unknown or terminal statuses (like "interrupted") fall through to completion.
-        if (sessionStatus && isActiveSessionStatus(sessionStatus.type)) {
-          log("[background-agent] Session still running, relying on event-based progress:", {
-            taskId: task.id,
-            sessionID,
-            sessionStatus: sessionStatus.type,
-            toolCalls: task.progress?.toolCalls ?? 0,
-          })
-          continue
-        }
-
-        // Explicit terminal non-idle status (e.g., "interrupted") — complete immediately,
-        // skipping output validation (session will never produce more output).
-        // Unknown statuses fall through to the idle/gone path with output validation.
-        if (sessionStatus && isTerminalSessionStatus(sessionStatus.type)) {
-          await this.tryCompleteTask(task, `polling (terminal session status: ${sessionStatus.type})`)
-          continue
-        }
-
-        // Unknown non-idle status — not active, not terminal, not idle.
-        // Fall through to idle/gone completion path with output validation.
-        if (sessionStatus && sessionStatus.type !== "idle") {
-          log("[background-agent] Unknown session status, treating as potentially idle:", {
-            taskId: task.id,
-            sessionID,
-            sessionStatus: sessionStatus.type,
-          })
-        }
-
-        // Session is idle or no longer in status response (completed/disappeared)
-        const completionSource = sessionStatus?.type === "idle"
-          ? "polling (idle status)"
-          : "polling (session gone from status)"
-        const hasValidOutput = await this.validateSessionHasOutput(sessionID)
-        if (!hasValidOutput) {
-          log("[background-agent] Polling idle/gone but no valid output yet, waiting:", task.id)
-          continue
-        }
-
-        // Re-check status after async operation
-        if (task.status !== "running") continue
-
-        const hasIncompleteTodos = await this.checkSessionTodos(sessionID)
-        if (hasIncompleteTodos) {
-          log("[background-agent] Task has incomplete todos via polling, waiting:", task.id)
-          continue
-        }
-
-        await this.tryCompleteTask(task, completionSource)
-      } catch (error) {
-        log("[background-agent] Poll error for task:", { taskId: task.id, error })
       }
-    }
 
-    if (!this.hasRunningTasks()) {
-      this.stopPolling()
-    }
+      if (!this.hasRunningTasks()) {
+        this.stopPolling();
+      }
     } finally {
-      this.pollingInFlight = false
+      this.pollingInFlight = false;
     }
   }
 
@@ -1853,94 +2030,95 @@ Use \`background_output(task_id="${task.id}")\` to retrieve this result when rea
    * Should be called when the plugin is unloaded.
    */
   async shutdown(): Promise<void> {
-    if (this.shutdownTriggered) return
-    this.shutdownTriggered = true
-    log("[background-agent] Shutting down BackgroundManager")
-    this.stopPolling()
-    const trackedSessionIDs = new Set<string>()
+    if (this.shutdownTriggered) return;
+    this.shutdownTriggered = true;
+    log("[background-agent] Shutting down BackgroundManager");
+    this.stopPolling();
+    const trackedSessionIDs = new Set<string>();
 
     // Abort all running sessions to prevent zombie processes (#1240)
     for (const task of this.tasks.values()) {
       if (task.sessionID) {
-        trackedSessionIDs.add(task.sessionID)
+        trackedSessionIDs.add(task.sessionID);
       }
 
       if (task.status === "running" && task.sessionID) {
-        this.client.session.abort({
-          path: { id: task.sessionID },
-        }).catch(() => {})
+        this.client.session
+          .abort({
+            path: { id: task.sessionID },
+          })
+          .catch(() => {});
       }
     }
 
     // Notify shutdown listeners (e.g., tmux cleanup)
     if (this.onShutdown) {
       try {
-        await this.onShutdown()
+        await this.onShutdown();
       } catch (error) {
-        log("[background-agent] Error in onShutdown callback:", error)
+        log("[background-agent] Error in onShutdown callback:", error);
       }
     }
 
     // Release concurrency for all running tasks
     for (const task of this.tasks.values()) {
       if (task.concurrencyKey) {
-        this.concurrencyManager.release(task.concurrencyKey)
-        task.concurrencyKey = undefined
+        this.concurrencyManager.release(task.concurrencyKey);
+        task.concurrencyKey = undefined;
       }
     }
 
     for (const timer of this.completionTimers.values()) {
-      clearTimeout(timer)
+      clearTimeout(timer);
     }
-    this.completionTimers.clear()
+    this.completionTimers.clear();
 
     for (const timer of this.idleDeferralTimers.values()) {
-      clearTimeout(timer)
+      clearTimeout(timer);
     }
-    this.idleDeferralTimers.clear()
+    this.idleDeferralTimers.clear();
 
     for (const sessionID of trackedSessionIDs) {
-      subagentSessions.delete(sessionID)
-      SessionCategoryRegistry.remove(sessionID)
+      subagentSessions.delete(sessionID);
+      SessionCategoryRegistry.remove(sessionID);
     }
 
-    this.concurrencyManager.clear()
-    this.tasks.clear()
-    this.notifications.clear()
-    this.pendingNotifications.clear()
-    this.pendingByParent.clear()
-    this.notificationQueueByParent.clear()
-    this.rootDescendantCounts.clear()
-    this.queuesByKey.clear()
-    this.processingKeys.clear()
-    this.taskHistory.clearAll()
-    this.completedTaskSummaries.clear()
-    this.unregisterProcessCleanup()
-    log("[background-agent] Shutdown complete")
-
+    this.concurrencyManager.clear();
+    this.tasks.clear();
+    this.notifications.clear();
+    this.pendingNotifications.clear();
+    this.pendingByParent.clear();
+    this.notificationQueueByParent.clear();
+    this.rootDescendantCounts.clear();
+    this.queuesByKey.clear();
+    this.processingKeys.clear();
+    this.taskHistory.clearAll();
+    this.completedTaskSummaries.clear();
+    this.unregisterProcessCleanup();
+    log("[background-agent] Shutdown complete");
   }
 
   private enqueueNotificationForParent(
     parentSessionID: string | undefined,
-    operation: () => Promise<void>
+    operation: () => Promise<void>,
   ): Promise<void> {
     if (!parentSessionID) {
-      return operation()
+      return operation();
     }
 
-    const previous = this.notificationQueueByParent.get(parentSessionID) ?? Promise.resolve()
-    const current = previous
-      .catch(() => {})
-      .then(operation)
+    const previous = this.notificationQueueByParent.get(parentSessionID) ?? Promise.resolve();
+    const current = previous.catch(() => {}).then(operation);
 
-    this.notificationQueueByParent.set(parentSessionID, current)
+    this.notificationQueueByParent.set(parentSessionID, current);
 
-    void current.finally(() => {
-      if (this.notificationQueueByParent.get(parentSessionID) === current) {
-        this.notificationQueueByParent.delete(parentSessionID)
-      }
-    }).catch(() => {})
+    void current
+      .finally(() => {
+        if (this.notificationQueueByParent.get(parentSessionID) === current) {
+          this.notificationQueueByParent.delete(parentSessionID);
+        }
+      })
+      .catch(() => {});
 
-    return current
+    return current;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2700 — subagents stop spawning after 50 total per session.

## Root Cause

`rootDescendantCounts` in `BackgroundManager` increments on every spawn but only decrements on pre-start rollback or root session deletion. Task completion, cancellation, error, and interrupt never decrement the counter. This makes `background_task.maxDescendants` (default: 50) a **session-lifetime quota** instead of its intended semantics as a **concurrent-active agent cap**.

After 50 total spawns across a session (completed + cancelled + errored), no new subagents can be created — even if all 50 have finished.

## Fix

Add `this.unregisterRootDescendant(task.rootSessionID)` in five terminal-state handlers:

1. `tryCompleteTask()` — task completes successfully
2. `cancelTask()` — running task cancelled (with `wasRunning` guard: pending tasks already decrement via `rollbackPreStartDescendantReservation` to prevent double-decrement)
3. `session.error` handler — task errors
4. `promptAsync` catch in `startTask` — task interrupted on launch
5. `promptAsync` catch in `resume` — task interrupted on resume
6. `onTaskPruned` callback — stale task pruned (with `wasPending` guard)

## Tests

Four regression tests added to `manager.test.ts`:
- Completed task releases quota (was blocked before fix, passes after)
- Cancelled running task releases quota (was blocked before fix, passes after)
- Errored task releases quota (was blocked before fix, passes after)
- No double-decrement for pending cancellation (guard correctness)

## Verification

Before fix: spawn 51st agent after 1st completes → blocked with maxDescendants=50 error
After fix:  spawn 51st agent after 1st completes → succeeds

Full test suite: 121 pass, 3 fail (3 pre-existing failures in unrelated session.error retry path tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes spawn budget accounting so finished tasks release their slot. `background_task.maxDescendants` now enforces a concurrent-active cap instead of a session-lifetime quota.

- **Bug Fixes**
  - Decrement root descendant count on: completion, cancel (running only), error, interrupt on start/resume, and prune (pending guarded).
  - Add guards to prevent double-decrement when pending cancels already rolled back reservations.
  - Add regression tests to verify slot release across terminal states and guard correctness.

<sup>Written for commit 30e56ed3994202e088559eb27b03382a7fd2a0d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

