### PR TITLE
fix(keyword-detector): remove duplicate separator from ultrawork templates

### DIFF
--- a/src/hooks/keyword-detector/ultrawork/default.ts
+++ b/src/hooks/keyword-detector/ultrawork/default.ts
@@ -293,8 +293,6 @@ NOW.
 
 </ultrawork-mode>
 
----
-
 `
 
 export function getDefaultUltraworkMessage(): string {

--- a/src/hooks/keyword-detector/ultrawork/gemini.ts
+++ b/src/hooks/keyword-detector/ultrawork/gemini.ts
@@ -283,8 +283,6 @@ NOW.
 
 </ultrawork-mode>
 
----
-
 `
 
 export function getGeminiUltraworkMessage(): string {

--- a/src/hooks/keyword-detector/ultrawork/gpt.ts
+++ b/src/hooks/keyword-detector/ultrawork/gpt.ts
@@ -166,8 +166,6 @@ A task is complete when:
 
 </ultrawork-mode>
 
----
-
 `;
 
 export function getGptUltraworkMessage(): string {

--- a/src/hooks/keyword-detector/ultrawork/planner.ts
+++ b/src/hooks/keyword-detector/ultrawork/planner.ts
@@ -136,7 +136,5 @@ ${ULTRAWORK_PLANNER_SECTION}
 
 </ultrawork-mode>
 
----
-
 `
 }


### PR DESCRIPTION
## Summary

- Remove trailing `---` separator from all 4 ultrawork template files (default, gpt, gemini, planner)
- The keyword-detector hook (`hook.ts:120`) already injects `---` between the injected message and the user's original text, causing a double `---` when ultrawork mode activates

## Problem

The `keyword-detector` hook concatenates keyword messages with user text using:

```typescript
output.parts[textPartIndex].text = `${allMessages}\n\n---\n\n${originalText}`
```

All ultrawork templates also end with `\n\n---\n\n`, resulting in:

```
</ultrawork-mode>

---

---

[user message]
```

The `search` and `analyze` keyword messages do not include a trailing `---`, producing the correct single separator. This inconsistency was introduced in the initial commit (`64825158`) and carried forward to all subsequent ultrawork variants (gpt, gemini, planner).

## Changes

Removed the trailing `\n\n---\n\n` from the template string in each file, leaving `\n\n` so the hook's separator is the only one rendered.

- `src/hooks/keyword-detector/ultrawork/default.ts`
- `src/hooks/keyword-detector/ultrawork/gpt.ts`
- `src/hooks/keyword-detector/ultrawork/gemini.ts`
- `src/hooks/keyword-detector/ultrawork/planner.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the trailing `---` from all ultrawork templates to prevent double separators when ultrawork mode activates. The `keyword-detector` hook already inserts `---` between the injected message and the user's text, so only one divider is shown.

<sup>Written for commit 07ea8debdc793c13587583f89b63c867dea89468. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

