### PR TITLE
fix(tmux-subagent): fallback to localhost when serverUrl has port 0 in serve+attach mode

### DIFF
--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -248,7 +248,7 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(manager).toBeDefined()
-      // The manager should have been created with the fallback URL
+      expect(manager.getServerUrl()).toMatch(/^http:\/\/localhost:\d+$/)
     })
 
     test('falls back to localhost when serverUrl is undefined', async () => {
@@ -272,6 +272,7 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(manager).toBeDefined()
+      expect(manager.getServerUrl()).toMatch(/^http:\/\/localhost:\d+$/)
     })
 
     test('uses valid serverUrl with proper port', async () => {
@@ -295,6 +296,31 @@ describe('TmuxSessionManager', () => {
 
       // then
       expect(manager).toBeDefined()
+      expect(manager.getServerUrl()).toBe('http://localhost:54220/')
+    })
+
+    test('uses valid serverUrl with empty port (protocol default)', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = {
+        serverUrl: new URL('http://localhost'),
+        client: createMockContext().client,
+      } as any
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+
+      // when
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      // then
+      expect(manager).toBeDefined()
+      expect(manager.getServerUrl()).toBe('http://localhost/')
     })
   })
 

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -226,6 +226,76 @@ describe('TmuxSessionManager', () => {
       // then
       expect(manager).toBeDefined()
     })
+
+    test('falls back to localhost when serverUrl has port 0 (serve+attach mode)', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = {
+        serverUrl: new URL('http://127.0.0.1:0/'),
+        client: createMockContext().client,
+      } as any
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+
+      // when
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      // then
+      expect(manager).toBeDefined()
+      // The manager should have been created with the fallback URL
+    })
+
+    test('falls back to localhost when serverUrl is undefined', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = {
+        serverUrl: undefined,
+        client: createMockContext().client,
+      } as any
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+
+      // when
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      // then
+      expect(manager).toBeDefined()
+    })
+
+    test('uses valid serverUrl with proper port', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = {
+        serverUrl: new URL('http://localhost:54220'),
+        client: createMockContext().client,
+      } as any
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+
+      // when
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      // then
+      expect(manager).toBeDefined()
+    })
   })
 
   describe('onSessionCreated', () => {

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -74,7 +74,8 @@ export class TmuxSessionManager {
     this.deps = deps
     const defaultPort = process.env.OPENCODE_PORT ?? "4096"
     try {
-      this.serverUrl = ctx.serverUrl?.toString() ?? `http://localhost:${defaultPort}`
+      const rawUrl = ctx.serverUrl?.toString()
+      this.serverUrl = this.validateServerUrl(rawUrl) ?? `http://localhost:${defaultPort}`
     } catch {
       this.serverUrl = `http://localhost:${defaultPort}`
     }
@@ -93,6 +94,36 @@ export class TmuxSessionManager {
   }
   private isEnabled(): boolean {
     return this.tmuxConfig.enabled && this.deps.isInsideTmux()
+  }
+
+  /**
+   * Validates a server URL and returns it if valid, or null if invalid.
+   * URLs with port 0 are considered invalid because they indicate
+   * the server URL was not properly resolved (e.g., in serve+attach mode).
+   */
+  private validateServerUrl(url: string | undefined): string | null {
+    if (!url) {
+      return null
+    }
+
+    try {
+      const parsed = new URL(url)
+      // Port 0 means the server URL was not properly resolved
+      // This commonly happens in serve+attach mode where ctx.serverUrl
+      // resolves to http://127.0.0.1:0/
+      if (parsed.port === "0" || parsed.port === "") {
+        log("[tmux-session-manager] detected invalid serverUrl with port 0 or empty, falling back to default", {
+          originalUrl: url
+        })
+        return null
+      }
+      return url
+    } catch {
+      log("[tmux-session-manager] failed to parse serverUrl, falling back to default", {
+        originalUrl: url
+      })
+      return null
+    }
   }
 
   private getCapacityConfig(): CapacityConfig {

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -98,8 +98,8 @@ export class TmuxSessionManager {
 
   /**
    * Validates a server URL and returns it if valid, or null if invalid.
-   * URLs with port 0 are considered invalid because they indicate
-   * the server URL was not properly resolved (e.g., in serve+attach mode).
+   * Only port 0 is considered invalid (indicates unresolved URL in serve+attach mode).
+   * Empty port is allowed as it means using the protocol's default port.
    */
   private validateServerUrl(url: string | undefined): string | null {
     if (!url) {
@@ -111,8 +111,9 @@ export class TmuxSessionManager {
       // Port 0 means the server URL was not properly resolved
       // This commonly happens in serve+attach mode where ctx.serverUrl
       // resolves to http://127.0.0.1:0/
-      if (parsed.port === "0" || parsed.port === "") {
-        log("[tmux-session-manager] detected invalid serverUrl with port 0 or empty, falling back to default", {
+      // Empty port is allowed - it means use the protocol's default port (e.g., 80 for http)
+      if (parsed.port === "0") {
+        log("[tmux-session-manager] detected invalid serverUrl with port 0, falling back to default", {
           originalUrl: url
         })
         return null
@@ -124,6 +125,11 @@ export class TmuxSessionManager {
       })
       return null
     }
+  }
+
+  /** Exposed for testing purposes only */
+  getServerUrl(): string {
+    return this.serverUrl
   }
 
   private getCapacityConfig(): CapacityConfig {


### PR DESCRIPTION
## Summary

- Fix tmux pane spawning failure when running `opencode serve` + `opencode attach`
- Root cause: `ctx.serverUrl` resolves to `http://127.0.0.1:0/` which fails the server health check
- Added `validateServerUrl()` method to detect invalid port 0 URLs and fallback to `http://localhost:${OPENCODE_PORT:-4096}`

## Changes

- `src/features/tmux-subagent/manager.ts`:
  - Added `validateServerUrl()` private method that detects invalid URLs (port 0 or empty port)
  - Modified constructor to use `validateServerUrl()` for server URL validation
  - Added logging for invalid URL detection

- `src/features/tmux-subagent/manager.test.ts`:
  - Added 3 test cases in `constructor` describe block:
    - `falls back to localhost when serverUrl has port 0 (serve+attach mode)` - verifies port 0 detection
    - `falls back to localhost when serverUrl is undefined` - verifies undefined handling
    - `uses valid serverUrl with proper port` - verifies valid URL passthrough

## Screenshots

<!-- Not applicable for this fix -->

## Testing

```bash
bun test src/features/tmux-subagent/manager.test.ts  # 28 pass
bun test src/features/tmux-subagent/                 # 88 pass
bun test src/tools/delegate-task/                    # 208 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tmux pane creation in serve+attach by rejecting server URLs with port 0 and falling back to localhost using OPENCODE_PORT (default 4096). Allows empty ports (protocol default) so the health check uses a valid port and subagent panes start reliably.

- **Bug Fixes**
  - Added validateServerUrl() in TmuxSessionManager to reject only port 0 or parse errors; otherwise accept URLs (empty port allowed) and fall back to http://localhost:${OPENCODE_PORT:-4096} with logging.
  - Exposed getServerUrl() for tests and added cases for port-0 fallback, undefined URL fallback, valid URL passthrough, and empty-port acceptance.

<sup>Written for commit 3d5ad7e3b01fafddf0b46721ad71d40b3d6766e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

