### PR TITLE
fix(atlas): restore agent mismatch guard for subagent boulder continuation

### DIFF
--- a/src/hooks/atlas/idle-event-lineage.test.ts
+++ b/src/hooks/atlas/idle-event-lineage.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { clearBoulderState, readBoulderState, writeBoulderState } from "../../features/boulder-state"
 import type { BoulderState } from "../../features/boulder-state"
-import { _resetForTesting, subagentSessions } from "../../features/claude-code-session-state"
+import { _resetForTesting, setSessionAgent, subagentSessions } from "../../features/claude-code-session-state"
 
 const { createAtlasHook } = await import("./index")
 
@@ -16,7 +16,7 @@ describe("atlas hook idle-event session lineage", () => {
   let testDirectory = ""
   let promptCalls: Array<unknown> = []
 
-  function writeIncompleteBoulder(): void {
+  function writeIncompleteBoulder(overrides: Partial<BoulderState> = {}): void {
     const planPath = join(testDirectory, "test-plan.md")
     writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
 
@@ -25,6 +25,7 @@ describe("atlas hook idle-event session lineage", () => {
       started_at: "2026-01-02T10:00:00Z",
       session_ids: [MAIN_SESSION_ID],
       plan_name: "test-plan",
+      ...overrides,
     }
 
     writeBoulderState(testDirectory, state)
@@ -103,6 +104,7 @@ describe("atlas hook idle-event session lineage", () => {
 
     writeIncompleteBoulder()
     subagentSessions.add(subagentSessionID)
+    setSessionAgent(subagentSessionID, "atlas")
 
     const hook = createHook({
       [subagentSessionID]: intermediateParentSessionID,
@@ -117,6 +119,65 @@ describe("atlas hook idle-event session lineage", () => {
     })
 
     assert.equal(readBoulderState(testDirectory)?.session_ids.includes(subagentSessionID), true)
+    assert.equal(promptCalls.length, 1)
+  })
+
+  it("does not inject continuation for boulder-lineage subagent with non-matching agent", async () => {
+    const subagentSessionID = "subagent-session-agent-mismatch"
+
+    writeIncompleteBoulder({ agent: "atlas" })
+    subagentSessions.add(subagentSessionID)
+    setSessionAgent(subagentSessionID, "sisyphus-junior")
+
+    const hook = createHook({
+      [subagentSessionID]: MAIN_SESSION_ID,
+    })
+
+    await hook.handler({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: subagentSessionID },
+      },
+    })
+
+    assert.equal(readBoulderState(testDirectory)?.session_ids.includes(subagentSessionID), true)
+    assert.equal(promptCalls.length, 0)
+  })
+
+  it("injects continuation for boulder-lineage subagent with matching agent", async () => {
+    const subagentSessionID = "subagent-session-agent-match"
+
+    writeIncompleteBoulder({ agent: "atlas" })
+    subagentSessions.add(subagentSessionID)
+    setSessionAgent(subagentSessionID, "atlas")
+
+    const hook = createHook({
+      [subagentSessionID]: MAIN_SESSION_ID,
+    })
+
+    await hook.handler({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: subagentSessionID },
+      },
+    })
+
+    assert.equal(promptCalls.length, 1)
+  })
+
+  it("injects continuation for explicitly tracked boulder session regardless of agent", async () => {
+    writeIncompleteBoulder({ agent: "atlas" })
+    setSessionAgent(MAIN_SESSION_ID, "hephaestus")
+
+    const hook = createHook()
+
+    await hook.handler({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: MAIN_SESSION_ID },
+      },
+    })
+
     assert.equal(promptCalls.length, 1)
   })
 })

--- a/src/hooks/atlas/idle-event.ts
+++ b/src/hooks/atlas/idle-event.ts
@@ -5,6 +5,8 @@ import {
   readBoulderState,
   readCurrentTopLevelTask,
 } from "../../features/boulder-state"
+import { getSessionAgent, subagentSessions } from "../../features/claude-code-session-state"
+import { getAgentConfigKey } from "../../shared/agent-display-names"
 import { log } from "../../shared/logger"
 import { injectBoulderContinuation } from "./boulder-continuation-injector"
 import { HOOK_NAME } from "./hook-name"
@@ -134,6 +136,23 @@ export async function handleAtlasSessionIdle(input: {
       sessionID,
       plan: boulderState.plan_name,
     })
+  }
+
+  if (subagentSessions.has(sessionID)) {
+    const sessionAgent = getSessionAgent(sessionID)
+    const agentKey = getAgentConfigKey(sessionAgent ?? "")
+    const requiredAgentKey = getAgentConfigKey(boulderState.agent ?? "atlas")
+    const agentMatches =
+      agentKey === requiredAgentKey ||
+      (requiredAgentKey === getAgentConfigKey("atlas") && agentKey === getAgentConfigKey("sisyphus"))
+    if (!agentMatches) {
+      log(`[${HOOK_NAME}] Skipped: subagent agent does not match boulder agent`, {
+        sessionID,
+        agent: sessionAgent ?? "unknown",
+        requiredAgent: boulderState.agent ?? "atlas",
+      })
+      return
+    }
   }
 
   const sessionState = getState(sessionID)

--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -1282,6 +1282,7 @@ session_id: ses_untrusted_999
       }
       writeBoulderState(TEST_DIR, state)
       subagentSessions.add(subagentSessionID)
+      updateSessionAgent(subagentSessionID, "atlas")
 
       const mockInput = createMockPluginInput()
       const hook = createAtlasHook(mockInput)


### PR DESCRIPTION
## Summary

Restores the agent mismatch guard for boulder continuation that was accidentally removed on Mar 9 (`vmxzmltv` / `53337ad6`), preventing worker subagent sessions from receiving plan-scoped continuation that overrides their single-task constraint.

- Add agent check in `idle-event.ts`: subagent sessions only get boulder continuation if their agent matches the boulder's required agent (atlas/sisyphus)
- Orchestrator sessions (not in `subagentSessions`) bypass the check entirely
- Add 3 new tests + update existing adoption test to cover agent-based filtering

Closes #18681

## Problem

The atlas hook's `resolveActiveBoulderSession()` adopts task-spawned subagent sessions into the boulder via lineage walking. Once adopted, `BOULDER_CONTINUATION_PROMPT` ("read the plan file, do all tasks") is injected regardless of the subagent's agent type.

This causes worker subagents running as `sisyphus-junior`, `oracle`, `explore`, etc. to override their single-task constraint and race through the entire plan in parallel, stepping on each other's file edits.

## Root Cause

The original atlas hook had a `shouldSkipForAgentMismatch` guard that only allowed sessions whose agent matched the boulder's required agent. This guard was removed in commit `vmxzmltv` ("fix(atlas): append idle subagent sessions to active boulder") when the adoption mechanism was refactored. The subsequent lineage restriction (`kovyrtor`) did not restore it.

## Fix

Add an agent mismatch guard in `handleAtlasSessionIdle()` after the adoption/append log block and before continuation injection:

- If session is in `subagentSessions` (task-spawned), verify agent matches boulder's required agent
- Allow `sisyphus` for `atlas`-agent boulders (original pre-regression allowance)
- Sessions NOT in `subagentSessions` (the orchestrator) always bypass the check
- The adoption mechanism (lineage check + `appendSessionId`) remains intact for tracking purposes

## Testing

- 91 atlas tests pass (0 fail)
- `bun run typecheck` clean
- 3 new tests added:
  - Non-matching agent subagent → adopted but NO continuation
  - Matching agent subagent → adopted + continuation
  - Tracked boulder session with any agent → always gets continuation
- Existing adoption test updated to set matching agent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the agent mismatch guard for boulder continuation so only matching subagents receive continuation; prevents worker subagents from bypassing their single-task constraint. Addresses Linear #18681.

- **Bug Fixes**
  - Reintroduce guard in `handleAtlasSessionIdle`: for sessions in `subagentSessions`, require agent match with boulder agent; allow `sisyphus` when boulder agent is `atlas`.
  - Orchestrator sessions bypass the check.
  - Add 3 tests (match, mismatch, tracked session) and update adoption test.

<sup>Written for commit 5777bf9894c0b5c1bc1b29e7202bc42c79ba22d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

