### PR TITLE
fix(prometheus): respect agent model override instead of using global opencode.json model (fixes #2693)

### DIFF
--- a/src/plugin-handlers/prometheus-agent-config-builder.ts
+++ b/src/plugin-handlers/prometheus-agent-config-builder.ts
@@ -38,10 +38,14 @@ export async function buildPrometheusAgentConfig(params: {
     connectedProviders: connectedProviders ?? undefined,
   });
 
+  const configuredPrometheusModel =
+    params.pluginPrometheusOverride?.model ?? categoryConfig?.model;
+
   const modelResolution = resolveModelPipeline({
     intent: {
-      uiSelectedModel: params.currentModel,
-      userModel: params.pluginPrometheusOverride?.model ?? categoryConfig?.model,
+      uiSelectedModel: configuredPrometheusModel ? undefined : params.currentModel,
+      userModel: params.pluginPrometheusOverride?.model,
+      categoryDefaultModel: categoryConfig?.model,
     },
     constraints: { availableModels },
     policy: {


### PR DESCRIPTION
## Summary
- Skip the global opencode.json model (uiSelectedModel) when the user explicitly configures a Prometheus-specific model override
- Separate category model into its correct pipeline slot (categoryDefaultModel) instead of folding into userModel

## Problem
When `opencode.json` sets a global model to Gemini (e.g., `"model": "google/gemini-3.1-pro-preview"`) and the user explicitly configures `agents.prometheus.model` to a Claude model in `oh-my-opencode.json`, Prometheus still uses the Gemini model and its Gemini-specific prompt.

Root cause: `buildPrometheusAgentConfig()` passes `params.currentModel` (the global model) as `uiSelectedModel` unconditionally. Since `uiSelectedModel` is Step 1 (highest priority) in `resolveModelPipeline()`, it short-circuits before ever reaching Step 2 where the user's Prometheus-specific model override lives.

All other agents guard against this:
- **Sisyphus** (`sisyphus-agent.ts`): `uiSelectedModel: sisyphusOverride?.model ? undefined : uiSelectedModel`
- **Atlas** (`atlas-agent.ts`): `uiSelectedModel: orchestratorOverride?.model ? undefined : uiSelectedModel`
- **General agents** (`general-agents.ts`): `uiSelectedModel: (isPrimaryAgent && !override?.model) ? uiSelectedModel : undefined`

Prometheus lacked this guard.

## Fix
Applied the same guard pattern used by all other agents:

```typescript
const configuredPrometheusModel =
  params.pluginPrometheusOverride?.model ?? categoryConfig?.model;

resolveModelPipeline({
  intent: {
    uiSelectedModel: configuredPrometheusModel ? undefined : params.currentModel,
    userModel: params.pluginPrometheusOverride?.model,
    categoryDefaultModel: categoryConfig?.model,
  },
  ...
});
```

When the user explicitly configures a Prometheus model (via `agents.prometheus.model` or category config), `uiSelectedModel` is set to `undefined`, allowing the user's override to take priority. Additionally, `categoryConfig?.model` is now correctly placed in `categoryDefaultModel` instead of being folded into `userModel`.

## Changes
| File | Change |
|------|--------|
| `src/plugin-handlers/prometheus-agent-config-builder.ts` | Added uiSelectedModel guard matching other agents; separated categoryDefaultModel from userModel |

Fixes #2693

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Prometheus to honor its agent-specific model override instead of the global `opencode.json` model, and put the category model in the correct pipeline slot. Fixes #2693.

- Bug Fixes
  - Ignore `uiSelectedModel` when a Prometheus-specific or category model is set, so the override wins in `resolveModelPipeline()`.
  - Use `categoryDefaultModel` for the category model instead of `userModel`.

<sup>Written for commit 11f1d71c93dad97e41da5a853c684494207fc457. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

