### PR TITLE
feat(skill): merge native OpenCode skills into skill tool discovery

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -4858,6 +4858,147 @@
       ],
       "additionalProperties": false
     },
+    "openclaw": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "gateways": {
+          "default": {},
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "default": "http",
+                "type": "string",
+                "enum": [
+                  "http",
+                  "command"
+                ]
+              },
+              "url": {
+                "type": "string"
+              },
+              "method": {
+                "default": "POST",
+                "type": "string"
+              },
+              "headers": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "command": {
+                "type": "string"
+              },
+              "timeout": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "type",
+              "method"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "hooks": {
+          "default": {},
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "default": true,
+                "type": "boolean"
+              },
+              "gateway": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "enabled",
+              "gateway",
+              "instruction"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "replyListener": {
+          "type": "object",
+          "properties": {
+            "discordBotToken": {
+              "type": "string"
+            },
+            "discordChannelId": {
+              "type": "string"
+            },
+            "discordMention": {
+              "type": "string"
+            },
+            "authorizedDiscordUserIds": {
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "telegramBotToken": {
+              "type": "string"
+            },
+            "telegramChatId": {
+              "type": "string"
+            },
+            "pollIntervalMs": {
+              "default": 3000,
+              "type": "number"
+            },
+            "rateLimitPerMinute": {
+              "default": 10,
+              "type": "number"
+            },
+            "maxMessageLength": {
+              "default": 500,
+              "type": "number"
+            },
+            "includePrefix": {
+              "default": true,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "authorizedDiscordUserIds",
+            "pollIntervalMs",
+            "rateLimitPerMinute",
+            "maxMessageLength",
+            "includePrefix"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "enabled",
+        "gateways",
+        "hooks"
+      ],
+      "additionalProperties": false
+    },
     "babysitting": {
       "type": "object",
       "properties": {

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from "@opencode-ai/plugin"
+import type { SkillLoadOptions } from "../tools/skill/types"
 
 import type {
   AvailableCategory,
@@ -112,6 +113,8 @@ export function createToolRegistry(args: {
     mcpManager: managers.skillMcpManager,
     getSessionID: getSessionIDForMcp,
     gitMasterConfig: pluginConfig.git_master,
+    // ctx.skills is available when OpenCode >= TBD; safe to access since nativeSkills is optional
+    nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
   })
 
   const taskSystemEnabled = pluginConfig.experimental?.task_system ?? false

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -190,10 +190,34 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
   const getSkills = async (): Promise<LoadedSkill[]> => {
     clearSkillCache()
     const discovered = await getAllSkills({disabledSkills: options?.disabledSkills})
-    if (!options.skills) return discovered
-    const discoveredNames = new Set(discovered.map(s => s.name))
-    const extras = options.skills.filter(s => !discoveredNames.has(s.name))
-    return [...discovered, ...extras]
+    const allSkills = !options.skills
+      ? discovered
+      : [...discovered, ...options.skills.filter(s => !new Set(discovered.map(d => d.name)).has(s.name))]
+
+    // Merge skills from OpenCode's native discovery (config.skills.paths, etc.)
+    if (options.nativeSkills) {
+      const knownNames = new Set(allSkills.map(s => s.name))
+      try {
+        const nativeAll = await options.nativeSkills.all()
+        for (const native of nativeAll) {
+          if (knownNames.has(native.name)) continue
+          allSkills.push({
+            name: native.name,
+            path: native.location,
+            definition: {
+              name: native.name,
+              description: native.description,
+              template: native.content,
+            },
+            scope: "config",
+          })
+        }
+      } catch {
+        // Native skill discovery may not be available — proceed without
+      }
+    }
+
+    return allSkills
   }
 
   const getCommands = (): CommandInfo[] => {

--- a/src/tools/skill/types.ts
+++ b/src/tools/skill/types.ts
@@ -37,4 +37,10 @@ export interface SkillLoadOptions {
   pluginsEnabled?: boolean
   /** Override plugin enablement from Claude settings by plugin key */
   enabledPluginsOverride?: Record<string, boolean>
+  /** Native skill accessor from PluginInput for discovering skills registered via config.skills.paths */
+  nativeSkills?: {
+    all(): Promise<{ name: string; description: string; location: string; content: string }[]>
+    get(name: string): Promise<{ name: string; description: string; location: string; content: string } | undefined>
+    dirs(): Promise<string[]>
+  }
 }


### PR DESCRIPTION
## Summary

Fixes code-yeongyu/oh-my-openagent#2754
Depends on anomalyco/opencode#18686

When OpenCode exposes `PluginInput.skills`, use it as an additional source in the skill tool so skills registered by other plugins via `config.skills.paths` (e.g. superpowers) are discoverable.

## Changes

- **`src/tools/skill/types.ts`**: Added `nativeSkills` option to `SkillLoadOptions`
- **`src/plugin/tool-registry.ts`**: Passes `ctx.skills` through (with `"skills" in ctx` runtime check for backward compat with older OpenCode)
- **`src/tools/skill/tools.ts`**: Merges native skills into `getSkills()`, converting to `LoadedSkill` format, deduplicating by name

## Backward Compatibility

The `"skills" in ctx` check ensures this works with both old and new OpenCode versions. When the accessor isn't available, `nativeSkills` is `undefined` and the merge step is skipped.

## Testing

- 21/21 skill tool tests pass
- Build succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates OpenCode’s native skill discovery into the skill tool so skills registered via `config.skills.paths` are found across plugins. Backward compatible; behavior is unchanged when `PluginInput.skills` isn’t available.

- New Features
  - Added `nativeSkills` to `SkillLoadOptions`.
  - Passed `ctx.skills` through the tool registry with a runtime check for older OpenCode.
  - Merged native skills into `getSkills()`, converting to `LoadedSkill`, deduping by name, and gracefully falling back if native discovery fails.
  - Extended config schema with `openclaw` settings (gateways, hooks, reply listener).

- Dependencies
  - Uses OpenCode `PluginInput.skills` when present; otherwise falls back to existing discovery only.

<sup>Written for commit 1e4863d7c4f7dc84c1d49c3276441219d5f090cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

