### PR TITLE
fix(plugin): display friendly name in configuration UI instead of file path (fixes #2644)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
   activePluginDispose = dispose
 
   return {
+    name: "oh-my-openagent",
     ...pluginInterface,
 
     "experimental.session.compacting": async (


### PR DESCRIPTION
## Summary
- Add the name property to the plugin return object so OpenCode displays a friendly name

## Problem
In the OpenCode configuration UI, the plugin name displays as a full file path (e.g., file:///Users/xxx/.config/opencode/node_modules/oh-my-opencode/dist/index.js) instead of a friendly name. This is because the plugin object returned from OhMyOpenCodePlugin did not include a name property.

## Fix
Added name: "oh-my-openagent" to the plugin return object in src/index.ts. OpenCode reads this property to display a readable label in its configuration UI.

## Changes
| File | Change |
|------|--------|
| src/index.ts | Added name property to plugin return object |

Fixes #2644

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display a friendly plugin name in the OpenCode configuration UI by adding `name: "oh-my-openagent"` to the plugin return object. Replaces the full file path label and fixes #2644.

<sup>Written for commit 29a7bc2d314cee2c2ed9c34605983aec79b85ea3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

