### PR TITLE
fix: validate serverUrl port before tmux pane spawn (fixes #2729)

### DIFF
--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -226,6 +226,29 @@ describe('TmuxSessionManager', () => {
       // then
       expect(manager).toBeDefined()
     })
+
+    test('falls back to default port when serverUrl has port 0', async () => {
+      // given
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const ctx = {
+        ...createMockContext(),
+        serverUrl: new URL('http://127.0.0.1:0/'),
+      }
+      const config: TmuxConfig = {
+        enabled: true,
+        layout: 'main-vertical',
+        main_pane_size: 60,
+        main_pane_min_width: 80,
+        agent_pane_min_width: 40,
+      }
+
+      // when
+      const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
+
+      // then
+      expect((manager as any).serverUrl).toBe('http://localhost:4096')
+    })
   })
 
   describe('onSessionCreated', () => {

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -73,10 +73,18 @@ export class TmuxSessionManager {
     this.tmuxConfig = tmuxConfig
     this.deps = deps
     const defaultPort = process.env.OPENCODE_PORT ?? "4096"
+    const fallbackUrl = `http://localhost:${defaultPort}`
     try {
-      this.serverUrl = ctx.serverUrl?.toString() ?? `http://localhost:${defaultPort}`
+      const raw = ctx.serverUrl?.toString()
+      if (raw) {
+        const parsed = new URL(raw)
+        const port = parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
+        this.serverUrl = port === '0' ? fallbackUrl : raw
+      } else {
+        this.serverUrl = fallbackUrl
+      }
     } catch {
-      this.serverUrl = `http://localhost:${defaultPort}`
+      this.serverUrl = fallbackUrl
     }
     this.sourcePaneId = deps.getCurrentPaneId()
     this.pollingManager = new TmuxPollingManager(


### PR DESCRIPTION
## Problem
When using `serve+attach` mode, `ctx.serverUrl` can contain `http://127.0.0.1:0/` (port 0), causing tmux pane spawn to fail.

## Fix
Add port validation in `src/features/tmux-subagent/manager.ts` — if port is 0 or invalid, fall back to default port lookup.

Fixes #2729

*Automated fix by Sisyphus (oh-my-opencode)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the server URL port before spawning the tmux pane to prevent failures when `serve+attach` sets port 0; if invalid, fall back to the default port from `OPENCODE_PORT` or 4096. Fixes #2729.

- **Bug Fixes**
  - Parse `ctx.serverUrl` and treat port "0" as invalid; use a computed `fallbackUrl`.
  - Added a unit test to ensure the fallback is used when port 0 is provided.

<sup>Written for commit 0810e37240115c5efbfb2fccf95a24834fb2f495. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

