### PR TITLE
fix: clarify Prometheus file permission error message (fixes #2150)

### DIFF
--- a/src/hooks/prometheus-md-only/constants.ts
+++ b/src/hooks/prometheus-md-only/constants.ts
@@ -17,7 +17,7 @@ export const PLANNING_CONSULT_WARNING = `
 
 ${createSystemDirective(SystemDirectiveTypes.PROMETHEUS_READ_ONLY)}
 
-You are being invoked by ${getAgentDisplayName("prometheus")}, a READ-ONLY planning agent.
+You are being invoked by ${getAgentDisplayName("prometheus")}, a planning agent restricted to .sisyphus/*.md plan files only.
 
 **CRITICAL CONSTRAINTS:**
 - DO NOT modify any files (no Write, Edit, or any file mutations)

--- a/src/hooks/prometheus-md-only/hook.ts
+++ b/src/hooks/prometheus-md-only/hook.ts
@@ -23,12 +23,12 @@ export function createPrometheusMdOnlyHook(ctx: PluginInput) {
 
       const toolName = input.tool
 
-      // Inject read-only warning for task tools called by Prometheus
+      // Inject planning-only warning for task tools called by Prometheus
        if (TASK_TOOLS.includes(toolName)) {
          const prompt = output.args.prompt as string | undefined
          if (prompt && !prompt.includes(SYSTEM_DIRECTIVE_PREFIX)) {
            output.args.prompt = PLANNING_CONSULT_WARNING + prompt
-          log(`[${HOOK_NAME}] Injected read-only planning warning to ${toolName}`, {
+          log(`[${HOOK_NAME}] Injected planning warning to ${toolName}`, {
             sessionID: input.sessionID,
             tool: toolName,
             agent: agentName,
@@ -54,9 +54,8 @@ export function createPrometheusMdOnlyHook(ctx: PluginInput) {
            agent: agentName,
          })
          throw new Error(
-           `[${HOOK_NAME}] ${getAgentDisplayName("prometheus")} can only write/edit .md files inside .sisyphus/ directory. ` +
+           `[${HOOK_NAME}] Prometheus is a planning agent. File operations restricted to .sisyphus/*.md plan files only. Use task() to delegate implementation. ` +
            `Attempted to modify: ${filePath}. ` +
-           `${getAgentDisplayName("prometheus")} is a READ-ONLY planner. Use /start-work to execute the plan. ` +
            `APOLOGIZE TO THE USER, REMIND OF YOUR PLAN WRITING PROCESSES, TELL USER WHAT YOU WILL GOING TO DO AS THE PROCESS, WRITE THE PLAN`
          )
        }

--- a/src/hooks/prometheus-md-only/index.test.ts
+++ b/src/hooks/prometheus-md-only/index.test.ts
@@ -66,7 +66,7 @@ describe("prometheus-md-only", () => {
       //#when //#then
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("can only write/edit .md files")
+      ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
     })
 
     test("should enforce md-only restriction for Prometheus display name Plan Builder", async () => {
@@ -85,7 +85,7 @@ describe("prometheus-md-only", () => {
       //#when //#then
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("can only write/edit .md files")
+      ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
     })
 
     test("should enforce md-only restriction for Prometheus display name Planner", async () => {
@@ -104,7 +104,7 @@ describe("prometheus-md-only", () => {
       //#when //#then
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("can only write/edit .md files")
+      ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
     })
 
     test("should enforce md-only restriction for uppercase PROMETHEUS", async () => {
@@ -123,7 +123,7 @@ describe("prometheus-md-only", () => {
       //#when //#then
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("can only write/edit .md files")
+      ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
     })
 
     test("should not enforce restriction for non-Prometheus agent", async () => {
@@ -185,7 +185,7 @@ describe("prometheus-md-only", () => {
       // when / #then
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("can only write/edit .md files")
+      ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
     })
 
     test("should allow Prometheus to write .md files inside .sisyphus/", async () => {
@@ -262,7 +262,7 @@ describe("prometheus-md-only", () => {
       // when / #then
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("can only write/edit .md files inside .sisyphus/")
+      ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
     })
 
     test("should block Edit tool for non-.md files", async () => {
@@ -280,7 +280,7 @@ describe("prometheus-md-only", () => {
       // when / #then
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("can only write/edit .md files")
+      ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
     })
 
     test("should allow bash commands from Prometheus", async () => {
@@ -337,7 +337,7 @@ describe("prometheus-md-only", () => {
       ).resolves.toBeUndefined()
     })
 
-    test("should inject read-only warning when Prometheus calls task", async () => {
+    test("should inject planning warning when Prometheus calls task", async () => {
       // given
       const hook = createPrometheusMdOnlyHook(createMockPluginInput())
       const input = {
@@ -357,7 +357,7 @@ describe("prometheus-md-only", () => {
       expect(output.args.prompt).toContain("DO NOT modify any files")
     })
 
-    test("should inject read-only warning when Prometheus calls task", async () => {
+    test("should inject planning warning when Prometheus calls task", async () => {
       // given
       const hook = createPrometheusMdOnlyHook(createMockPluginInput())
       const input = {
@@ -376,7 +376,7 @@ describe("prometheus-md-only", () => {
       expect(output.args.prompt).toContain(SYSTEM_DIRECTIVE_PREFIX)
     })
 
-    test("should inject read-only warning when Prometheus calls call_omo_agent", async () => {
+    test("should inject planning warning when Prometheus calls call_omo_agent", async () => {
       // given
       const hook = createPrometheusMdOnlyHook(createMockPluginInput())
       const input = {
@@ -540,7 +540,7 @@ describe("prometheus-md-only", () => {
       // when / then - should block because boulder says prometheus
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("can only write/edit .md files")
+      ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
     })
 
     test("should fall back to message files when session not in boulder", async () => {
@@ -573,7 +573,7 @@ describe("prometheus-md-only", () => {
       // when / then - should block because falls back to message files (prometheus)
       await expect(
         hook["tool.execute.before"](input, output)
-      ).rejects.toThrow("can only write/edit .md files")
+      ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
     })
   })
 
@@ -675,7 +675,7 @@ describe("prometheus-md-only", () => {
        // when / #then
        await expect(
          hook["tool.execute.before"](input, output)
-       ).rejects.toThrow("can only write/edit .md files inside .sisyphus/")
+       ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
      })
 
      test("should allow nested .sisyphus directories (ctx.directory may be parent)", async () => {
@@ -713,7 +713,7 @@ describe("prometheus-md-only", () => {
        // when / #then
        await expect(
          hook["tool.execute.before"](input, output)
-       ).rejects.toThrow("can only write/edit .md files inside .sisyphus/")
+       ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
      })
 
      test("should allow case-insensitive .SISYPHUS directory", async () => {
@@ -790,7 +790,7 @@ describe("prometheus-md-only", () => {
        // when / #then
        await expect(
          hook["tool.execute.before"](input, output)
-       ).rejects.toThrow("can only write/edit .md files")
+       ).rejects.toThrow("File operations restricted to .sisyphus/*.md plan files only")
      })
   })
 })


### PR DESCRIPTION
## Problem
Prometheus error message contradicts itself — says both "can only write .md files inside .sisyphus/" AND "is a READ-ONLY planner".

## Fix
Clarify the error message to accurately describe Prometheus permissions: planning agent restricted to `.sisyphus/*.md` plan files, use `task()` for implementation.

Fixes #2150

*Automated fix by Sisyphus (oh-my-opencode)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified Prometheus permission messaging to state it’s a planning-only agent restricted to writing `.sisyphus/*.md` plan files, and to use `task()` for implementation. Fixes #2150.

- **Bug Fixes**
  - Updated `PLANNING_CONSULT_WARNING` and thrown error text to remove “READ-ONLY” contradiction and clearly state `.sisyphus/*.md` restriction with `task()` guidance.
  - Aligned hook comments/logs with the new copy and updated tests to assert the new error message.

<sup>Written for commit a64e364fa6313b93c9a8b26963f04d32fb32d643. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

