### PR TITLE
fix: respect OPENCODE_DISABLE_CLAUDE_CODE env vars (fixes #2037)

### DIFF
--- a/src/features/claude-code-plugin-loader/loader.test.ts
+++ b/src/features/claude-code-plugin-loader/loader.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import type { PluginComponentsResult } from "./loader"
+
+describe("loadAllPluginComponents", () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE
+    delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PLUGINS
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  describe("when OPENCODE_DISABLE_CLAUDE_CODE is set to 'true'", () => {
+    it("returns empty result without loading any plugins", async () => {
+      // given
+      process.env.OPENCODE_DISABLE_CLAUDE_CODE = "true"
+
+      // when
+      const { loadAllPluginComponents } = await import("./loader")
+      const result: PluginComponentsResult = await loadAllPluginComponents()
+
+      // then
+      expect(result.commands).toEqual({})
+      expect(result.skills).toEqual({})
+      expect(result.agents).toEqual({})
+      expect(result.mcpServers).toEqual({})
+      expect(result.hooksConfigs).toEqual([])
+      expect(result.plugins).toEqual([])
+      expect(result.errors).toEqual([])
+    })
+  })
+
+  describe("when OPENCODE_DISABLE_CLAUDE_CODE is set to '1'", () => {
+    it("returns empty result without loading any plugins", async () => {
+      // given
+      process.env.OPENCODE_DISABLE_CLAUDE_CODE = "1"
+
+      // when
+      const { loadAllPluginComponents } = await import("./loader")
+      const result: PluginComponentsResult = await loadAllPluginComponents()
+
+      // then
+      expect(result.commands).toEqual({})
+      expect(result.plugins).toEqual([])
+    })
+  })
+
+  describe("when OPENCODE_DISABLE_CLAUDE_CODE_PLUGINS is set to 'true'", () => {
+    it("returns empty result without loading any plugins", async () => {
+      // given
+      process.env.OPENCODE_DISABLE_CLAUDE_CODE_PLUGINS = "true"
+
+      // when
+      const { loadAllPluginComponents } = await import("./loader")
+      const result: PluginComponentsResult = await loadAllPluginComponents()
+
+      // then
+      expect(result.commands).toEqual({})
+      expect(result.plugins).toEqual([])
+    })
+  })
+
+  describe("when OPENCODE_DISABLE_CLAUDE_CODE_PLUGINS is set to '1'", () => {
+    it("returns empty result without loading any plugins", async () => {
+      // given
+      process.env.OPENCODE_DISABLE_CLAUDE_CODE_PLUGINS = "1"
+
+      // when
+      const { loadAllPluginComponents } = await import("./loader")
+      const result: PluginComponentsResult = await loadAllPluginComponents()
+
+      // then
+      expect(result.commands).toEqual({})
+      expect(result.plugins).toEqual([])
+    })
+  })
+
+  describe("when neither env var is set", () => {
+    it("does not skip plugin loading", async () => {
+      // given
+      delete process.env.OPENCODE_DISABLE_CLAUDE_CODE
+      delete process.env.OPENCODE_DISABLE_CLAUDE_CODE_PLUGINS
+
+      // when
+      const { loadAllPluginComponents } = await import("./loader")
+      const result: PluginComponentsResult = await loadAllPluginComponents()
+
+      // then — should attempt to load (may find 0 plugins, but shouldn't early-return)
+      expect(result).toBeDefined()
+      expect(result).toHaveProperty("commands")
+      expect(result).toHaveProperty("plugins")
+    })
+  })
+
+  describe("when env var is set to unrecognized value", () => {
+    it("does not skip plugin loading", async () => {
+      // given
+      process.env.OPENCODE_DISABLE_CLAUDE_CODE = "yes"
+
+      // when
+      const { loadAllPluginComponents } = await import("./loader")
+      const result: PluginComponentsResult = await loadAllPluginComponents()
+
+      // then — "yes" is not "true" or "1", should not skip
+      expect(result).toBeDefined()
+      expect(result).toHaveProperty("plugins")
+    })
+  })
+})

--- a/src/features/claude-code-plugin-loader/loader.ts
+++ b/src/features/claude-code-plugin-loader/loader.ts
@@ -27,7 +27,26 @@ export interface PluginComponentsResult {
   errors: PluginLoadError[]
 }
 
+function isClaudeCodePluginsDisabled(): boolean {
+  const disableFlag = process.env.OPENCODE_DISABLE_CLAUDE_CODE
+  const disablePluginsFlag = process.env.OPENCODE_DISABLE_CLAUDE_CODE_PLUGINS
+  return disableFlag === "true" || disableFlag === "1" || disablePluginsFlag === "true" || disablePluginsFlag === "1"
+}
+
 export async function loadAllPluginComponents(options?: PluginLoaderOptions): Promise<PluginComponentsResult> {
+  if (isClaudeCodePluginsDisabled()) {
+    log("Claude Code plugin loading disabled via OPENCODE_DISABLE_CLAUDE_CODE env var")
+    return {
+      commands: {},
+      skills: {},
+      agents: {},
+      mcpServers: {},
+      hooksConfigs: [],
+      plugins: [],
+      errors: [],
+    }
+  }
+
   const { plugins, errors } = discoverInstalledPlugins(options)
 
   const [commands, skills, agents, mcpServers, hooksConfigs] = await Promise.all([


### PR DESCRIPTION
## Problem
Claude plugin commands leak into OpenCode despite `OPENCODE_DISABLE_CLAUDE_CODE*` env vars being set.

## Fix
Check `OPENCODE_DISABLE_CLAUDE_CODE` and `OPENCODE_DISABLE_CLAUDE_CODE_PLUGINS` env vars before loading Claude Code plugins. Tests added (6 pass).

Fixes #2037

*Automated fix by Sisyphus (oh-my-opencode)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect `OPENCODE_DISABLE_CLAUDE_CODE` and `OPENCODE_DISABLE_CLAUDE_CODE_PLUGINS` to fully disable Claude Code plugin loading and stop command leakage into OpenCode. Fixes #2037.

- **Bug Fixes**
  - Recognize "true" and "1" for both env vars; short-circuit `loadAllPluginComponents` and return an empty result when disabled.
  - Added tests for disabled, enabled, and invalid values to verify no-load behavior and default loading path.

<sup>Written for commit f3c2138ef4588aea893198dfe70b960337b2729d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

