### PR TITLE
fix: trigger compaction before continue after session error recovery (fixes #390)

### DIFF
--- a/src/plugin/event.test.ts
+++ b/src/plugin/event.test.ts
@@ -585,3 +585,123 @@ describe("createEventHandler - retry dedupe lifecycle", () => {
 		expect(promptCalls).toEqual([sessionID, sessionID])
 	})
 })
+
+describe("createEventHandler - session recovery compaction", () => {
+	it("triggers compaction before sending continue after session error recovery", async () => {
+		//#given
+		const sessionID = "ses_recovery_compaction"
+		setMainSession(sessionID)
+		const callOrder: string[] = []
+
+		const eventHandler = createEventHandler({
+			ctx: {
+				directory: "/tmp",
+				client: {
+					session: {
+						abort: async () => ({}),
+						summarize: async () => {
+							callOrder.push("summarize")
+							return {}
+						},
+						prompt: async () => {
+							callOrder.push("prompt")
+							return {}
+						},
+					},
+				},
+			} as any,
+			pluginConfig: {} as any,
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: {
+				tmuxSessionManager: {
+					onSessionCreated: async () => {},
+					onSessionDeleted: async () => {},
+				},
+			} as any,
+			hooks: {
+				sessionRecovery: {
+					isRecoverableError: () => true,
+					handleSessionRecovery: async () => true,
+				},
+				stopContinuationGuard: { isStopped: () => false },
+			} as any,
+		})
+
+		//#when
+		await eventHandler({
+			event: {
+				type: "session.error",
+				properties: {
+					sessionID,
+					messageID: "msg_123",
+					error: { name: "Error", message: "tool_result block(s) that are not immediately" },
+				},
+			},
+		} as any)
+
+		//#then - summarize (compaction) must be called before prompt (continue)
+		expect(callOrder).toEqual(["summarize", "prompt"])
+	})
+
+	it("sends continue even if compaction fails", async () => {
+		//#given
+		const sessionID = "ses_recovery_compaction_fail"
+		setMainSession(sessionID)
+		const callOrder: string[] = []
+
+		const eventHandler = createEventHandler({
+			ctx: {
+				directory: "/tmp",
+				client: {
+					session: {
+						abort: async () => ({}),
+						summarize: async () => {
+							callOrder.push("summarize")
+							throw new Error("compaction failed")
+						},
+						prompt: async () => {
+							callOrder.push("prompt")
+							return {}
+						},
+					},
+				},
+			} as any,
+			pluginConfig: {} as any,
+			firstMessageVariantGate: {
+				markSessionCreated: () => {},
+				clear: () => {},
+			},
+			managers: {
+				tmuxSessionManager: {
+					onSessionCreated: async () => {},
+					onSessionDeleted: async () => {},
+				},
+			} as any,
+			hooks: {
+				sessionRecovery: {
+					isRecoverableError: () => true,
+					handleSessionRecovery: async () => true,
+				},
+				stopContinuationGuard: { isStopped: () => false },
+			} as any,
+		})
+
+		//#when
+		await eventHandler({
+			event: {
+				type: "session.error",
+				properties: {
+					sessionID,
+					messageID: "msg_456",
+					error: { name: "Error", message: "tool_result block(s) that are not immediately" },
+				},
+			},
+		} as any)
+
+		//#then - continue is still sent even when compaction fails
+		expect(callOrder).toEqual(["summarize", "prompt"])
+	})
+})

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -148,6 +148,8 @@ export function createEventHandler(args: {
           body: { parts: Array<{ type: "text"; text: string }> };
           query: { directory: string };
         }) => Promise<unknown>;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        summarize: (...args: any[]) => Promise<unknown>;
       };
     };
   };
@@ -502,6 +504,17 @@ export function createEventHandler(args: {
             sessionID === getMainSessionID() &&
             !hooks.stopContinuationGuard?.isStopped(sessionID)
           ) {
+            // Trigger compaction before sending "continue" to avoid double-sending continuation
+            await pluginContext.client.session
+              .summarize({
+                path: { id: sessionID },
+                body: { auto: true },
+                query: { directory: pluginContext.directory },
+              })
+              .catch((err: unknown) => {
+                log("[event] compaction before recovery continue failed:", { sessionID, error: err });
+              });
+
             await pluginContext.client.session
               .prompt({
                 path: { id: sessionID },


### PR DESCRIPTION
## Problem
After session error recovery, "continue" is sent to resume without compaction, potentially causing duplicate continuation or oversized context.

## Fix
Trigger compaction before sending "continue" in the session error recovery handler.

Fixes #390

*Automated fix by Sisyphus (oh-my-opencode)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger compaction before resuming after session error recovery to prevent duplicate continuation and oversized context. If compaction fails, we still resume. Fixes #390.

- **Bug Fixes**
  - Call `session.summarize` before `session.prompt` in the recovery path; log failures without blocking resume.
  - Add tests to verify summarize-before-prompt order and fallback when compaction errors.

<sup>Written for commit 4c4760a4eebe74635f81ac595e186d237a79983d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

