### PR TITLE
fix: emit formatter events from hashline-edit tool (fixes #2117)

### DIFF
--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -7,6 +7,7 @@ import { applyMcpConfig } from "./mcp-config-handler";
 import { applyProviderConfig } from "./provider-config-handler";
 import { loadPluginComponents } from "./plugin-components-loader";
 import { applyToolConfig } from "./tool-config-handler";
+import { clearFormatterCache } from "../tools/hashline-edit/formatter-trigger"
 
 export { resolveCategoryConfig } from "./category-config-resolver";
 
@@ -23,6 +24,7 @@ export function createConfigHandler(deps: ConfigHandlerDeps) {
     const formatterConfig = config.formatter;
 
     applyProviderConfig({ config, modelCacheState });
+    clearFormatterCache()
 
     const pluginComponents = await loadPluginComponents({ pluginConfig });
 

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -126,7 +126,7 @@ export function createToolRegistry(args: {
 
   const hashlineEnabled = pluginConfig.hashline_edit ?? false
   const hashlineToolsRecord: Record<string, ToolDefinition> = hashlineEnabled
-    ? { edit: createHashlineEditTool() }
+    ? { edit: createHashlineEditTool(ctx) }
     : {}
 
   const allTools: Record<string, ToolDefinition> = {

--- a/src/tools/hashline-edit/formatter-trigger.test.ts
+++ b/src/tools/hashline-edit/formatter-trigger.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test"
+import {
+  runFormattersForFile,
+  clearFormatterCache,
+  resolveFormatters,
+  buildFormatterCommand,
+  type FormatterClient,
+} from "./formatter-trigger"
+
+function createMockClient(config: Record<string, unknown> = {}): FormatterClient {
+  return {
+    config: {
+      get: mock(() => Promise.resolve({ data: config })),
+    },
+  }
+}
+
+describe("buildFormatterCommand", () => {
+  it("substitutes $FILE with the actual file path", () => {
+    //#given
+    const command = ["prettier", "--write", "$FILE"]
+    const filePath = "/src/index.ts"
+
+    //#when
+    const result = buildFormatterCommand(command, filePath)
+
+    //#then
+    expect(result).toEqual(["prettier", "--write", "/src/index.ts"])
+  })
+
+  it("substitutes multiple $FILE occurrences in the same arg", () => {
+    //#given
+    const command = ["echo", "$FILE:$FILE"]
+    const filePath = "test.ts"
+
+    //#when
+    const result = buildFormatterCommand(command, filePath)
+
+    //#then
+    expect(result).toEqual(["echo", "test.ts:test.ts"])
+  })
+
+  it("returns command unchanged when no $FILE present", () => {
+    //#given
+    const command = ["prettier", "--check", "."]
+
+    //#when
+    const result = buildFormatterCommand(command, "/some/file.ts")
+
+    //#then
+    expect(result).toEqual(["prettier", "--check", "."])
+  })
+})
+
+describe("resolveFormatters", () => {
+  beforeEach(() => {
+    clearFormatterCache()
+  })
+
+  it("resolves formatters from config.formatter section", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        prettier: {
+          command: ["prettier", "--write", "$FILE"],
+          extensions: [".ts", ".tsx"],
+        },
+      },
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.get(".ts")).toEqual([{ command: ["prettier", "--write", "$FILE"], environment: {} }])
+    expect(result.get(".tsx")).toEqual([{ command: ["prettier", "--write", "$FILE"], environment: {} }])
+  })
+
+  it("resolves formatters from experimental.hook.file_edited section", async () => {
+    //#given
+    const client = createMockClient({
+      experimental: {
+        hook: {
+          file_edited: {
+            ".go": [{ command: ["gofmt", "-w", "$FILE"], environment: { GOPATH: "/go" } }],
+          },
+        },
+      },
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.get(".go")).toEqual([{ command: ["gofmt", "-w", "$FILE"], environment: { GOPATH: "/go" } }])
+  })
+
+  it("normalizes extensions without leading dot", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        biome: {
+          command: ["biome", "format", "$FILE"],
+          extensions: ["ts", "js"],
+        },
+      },
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.has(".ts")).toBe(true)
+    expect(result.has(".js")).toBe(true)
+  })
+
+  it("skips disabled formatters", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        prettier: {
+          disabled: true,
+          command: ["prettier", "--write", "$FILE"],
+          extensions: [".ts"],
+        },
+      },
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.size).toBe(0)
+  })
+
+  it("skips formatters without command", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        prettier: {
+          extensions: [".ts"],
+        },
+      },
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.size).toBe(0)
+  })
+
+  it("skips formatters without extensions", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        prettier: {
+          command: ["prettier", "--write", "$FILE"],
+        },
+      },
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.size).toBe(0)
+  })
+
+  it("returns cached result on subsequent calls", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        prettier: {
+          command: ["prettier", "--write", "$FILE"],
+          extensions: [".ts"],
+        },
+      },
+    })
+    await resolveFormatters(client, "/project")
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(client.config.get).toHaveBeenCalledTimes(1)
+    expect(result.get(".ts")).toHaveLength(1)
+  })
+
+  it("returns fresh result after clearFormatterCache", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        prettier: {
+          command: ["prettier", "--write", "$FILE"],
+          extensions: [".ts"],
+        },
+      },
+    })
+    await resolveFormatters(client, "/project")
+    clearFormatterCache()
+
+    //#when
+    await resolveFormatters(client, "/project")
+
+    //#then
+    expect(client.config.get).toHaveBeenCalledTimes(2)
+  })
+
+  it("handles config.get failure gracefully", async () => {
+    //#given
+    const client: FormatterClient = {
+      config: {
+        get: mock(() => Promise.reject(new Error("network error"))),
+      },
+    }
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.size).toBe(0)
+  })
+
+  it("handles missing config data", async () => {
+    //#given
+    const client: FormatterClient = {
+      config: {
+        get: mock(() => Promise.resolve({ data: undefined })),
+      },
+    }
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.size).toBe(0)
+  })
+
+  it("merges formatter and experimental.hook.file_edited for same extension", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        prettier: {
+          command: ["prettier", "--write", "$FILE"],
+          extensions: [".ts"],
+        },
+      },
+      experimental: {
+        hook: {
+          file_edited: {
+            ".ts": [{ command: ["eslint", "--fix", "$FILE"] }],
+          },
+        },
+      },
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.get(".ts")).toHaveLength(2)
+    expect(result.get(".ts")![0].command).toEqual(["prettier", "--write", "$FILE"])
+    expect(result.get(".ts")![1].command).toEqual(["eslint", "--fix", "$FILE"])
+  })
+
+  it("defaults environment to empty object when not specified", async () => {
+    //#given
+    const client = createMockClient({
+      experimental: {
+        hook: {
+          file_edited: {
+            ".py": [{ command: ["black", "$FILE"] }],
+          },
+        },
+      },
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.get(".py")![0].environment).toEqual({})
+  })
+
+  it("preserves environment from formatter config", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        biome: {
+          command: ["biome", "format", "$FILE"],
+          extensions: [".ts"],
+          environment: { BIOME_LOG: "debug" },
+        },
+      },
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.get(".ts")![0].environment).toEqual({ BIOME_LOG: "debug" })
+  })
+
+  it("skips formatter=false config", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: false,
+    })
+
+    //#when
+    const result = await resolveFormatters(client, "/project")
+
+    //#then
+    expect(result.size).toBe(0)
+  })
+})
+
+describe("runFormattersForFile", () => {
+  beforeEach(() => {
+    clearFormatterCache()
+  })
+
+  it("skips files without extensions", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        prettier: {
+          command: ["prettier", "--write", "$FILE"],
+          extensions: [".ts"],
+        },
+      },
+    })
+
+    //#when
+    await runFormattersForFile(client, "/project", "Makefile")
+
+    //#then
+    expect(client.config.get).not.toHaveBeenCalled()
+  })
+
+  it("skips when no matching formatters for extension", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        prettier: {
+          command: ["prettier", "--write", "$FILE"],
+          extensions: [".ts"],
+        },
+      },
+    })
+
+    //#when — run for a .go file, but only .ts formatters registered
+    await runFormattersForFile(client, "/project", "/src/main.go")
+
+    //#then — no error thrown
+  })
+
+  it("runs formatter for matching extension", async () => {
+    //#given
+    const client = createMockClient({
+      formatter: {
+        echo: {
+          command: ["echo", "$FILE"],
+          extensions: [".ts"],
+        },
+      },
+    })
+
+    //#when — echo is a safe no-op command
+    await runFormattersForFile(client, "/tmp", "/tmp/test.ts")
+
+    //#then — should complete without error
+    expect(client.config.get).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/tools/hashline-edit/formatter-trigger.ts
+++ b/src/tools/hashline-edit/formatter-trigger.ts
@@ -1,0 +1,122 @@
+import path from "path"
+import { log } from "../../shared"
+
+interface FormatterConfig {
+  disabled?: boolean
+  command?: string[]
+  environment?: Record<string, string>
+  extensions?: string[]
+}
+
+interface OpencodeConfig {
+  formatter?:
+    | false
+    | Record<string, FormatterConfig>
+  experimental?: {
+    hook?: {
+      file_edited?: Record<string, Array<{ command: string[]; environment?: Record<string, string> }>>
+    }
+  }
+}
+
+interface OpencodeClient {
+  config: {
+    get: (options?: { query?: { directory?: string } }) => Promise<{ data?: OpencodeConfig }>
+  }
+}
+
+let cachedFormatters: Map<string, Array<{ command: string[]; environment: Record<string, string> }>> | null = null
+
+async function resolveFormatters(
+  client: OpencodeClient,
+  directory: string,
+): Promise<Map<string, Array<{ command: string[]; environment: Record<string, string> }>>> {
+  if (cachedFormatters) return cachedFormatters
+
+  const result = new Map<string, Array<{ command: string[]; environment: Record<string, string> }>>()
+
+  try {
+    const response = await client.config.get({ query: { directory } })
+    const config = response.data
+    if (!config) return result
+
+    if (config.formatter && typeof config.formatter === "object") {
+      for (const [, formatter] of Object.entries(config.formatter)) {
+        if (formatter.disabled || !formatter.command?.length || !formatter.extensions?.length) continue
+        for (const ext of formatter.extensions) {
+          const normalizedExt = ext.startsWith(".") ? ext : `.${ext}`
+          const existing = result.get(normalizedExt) ?? []
+          existing.push({
+            command: formatter.command,
+            environment: formatter.environment ?? {},
+          })
+          result.set(normalizedExt, existing)
+        }
+      }
+    }
+
+    if (config.experimental?.hook?.file_edited) {
+      for (const [ext, commands] of Object.entries(config.experimental.hook.file_edited)) {
+        const normalizedExt = ext.startsWith(".") ? ext : `.${ext}`
+        const existing = result.get(normalizedExt) ?? []
+        for (const cmd of commands) {
+          existing.push({
+            command: cmd.command,
+            environment: cmd.environment ?? {},
+          })
+        }
+        result.set(normalizedExt, existing)
+      }
+    }
+  } catch (error) {
+    log("[formatter-trigger] Failed to fetch formatter config", { error })
+  }
+
+  cachedFormatters = result
+  return result
+}
+
+function buildFormatterCommand(command: string[], filePath: string): string[] {
+  return command.map((arg) => arg.replace(/\$FILE/g, filePath))
+}
+
+export async function runFormattersForFile(
+  client: OpencodeClient,
+  directory: string,
+  filePath: string,
+): Promise<void> {
+  const ext = path.extname(filePath)
+  if (!ext) return
+
+  const formatters = await resolveFormatters(client, directory)
+  const matching = formatters.get(ext)
+  if (!matching?.length) return
+
+  for (const formatter of matching) {
+    const cmd = buildFormatterCommand(formatter.command, filePath)
+    try {
+      log("[formatter-trigger] Running formatter", { command: cmd, file: filePath })
+      const proc = Bun.spawn(cmd, {
+        cwd: directory,
+        env: { ...process.env, ...formatter.environment },
+        stdout: "ignore",
+        stderr: "pipe",
+      })
+      await proc.exited
+      if (proc.exitCode !== 0) {
+        const stderr = await new Response(proc.stderr).text()
+        log("[formatter-trigger] Formatter failed", {
+          command: cmd,
+          exitCode: proc.exitCode,
+          stderr: stderr.slice(0, 500),
+        })
+      }
+    } catch (error) {
+      log("[formatter-trigger] Formatter execution error", { command: cmd, error })
+    }
+  }
+}
+
+export function clearFormatterCache(): void {
+  cachedFormatters = null
+}

--- a/src/tools/hashline-edit/formatter-trigger.ts
+++ b/src/tools/hashline-edit/formatter-trigger.ts
@@ -19,7 +19,7 @@ interface OpencodeConfig {
   }
 }
 
-interface OpencodeClient {
+export interface FormatterClient {
   config: {
     get: (options?: { query?: { directory?: string } }) => Promise<{ data?: OpencodeConfig }>
   }
@@ -27,8 +27,8 @@ interface OpencodeClient {
 
 let cachedFormatters: Map<string, Array<{ command: string[]; environment: Record<string, string> }>> | null = null
 
-async function resolveFormatters(
-  client: OpencodeClient,
+export async function resolveFormatters(
+  client: FormatterClient,
   directory: string,
 ): Promise<Map<string, Array<{ command: string[]; environment: Record<string, string> }>>> {
   if (cachedFormatters) return cachedFormatters
@@ -76,12 +76,12 @@ async function resolveFormatters(
   return result
 }
 
-function buildFormatterCommand(command: string[], filePath: string): string[] {
+export function buildFormatterCommand(command: string[], filePath: string): string[] {
   return command.map((arg) => arg.replace(/\$FILE/g, filePath))
 }
 
 export async function runFormattersForFile(
-  client: OpencodeClient,
+  client: FormatterClient,
   directory: string,
   filePath: string,
 ): Promise<void> {

--- a/src/tools/hashline-edit/hashline-edit-executor.ts
+++ b/src/tools/hashline-edit/hashline-edit-executor.ts
@@ -6,6 +6,8 @@ import { canonicalizeFileText, restoreFileText } from "./file-text-canonicalizat
 import { normalizeHashlineEdits, type RawHashlineEdit } from "./normalize-edits"
 import type { HashlineEdit } from "./types"
 import { HashlineMismatchError } from "./validation"
+import { runFormattersForFile } from "./formatter-trigger"
+import type { PluginContext } from "../../plugin/types"
 
 interface HashlineEditArgs {
   filePath: string
@@ -80,7 +82,7 @@ function buildSuccessMeta(
   }
 }
 
-export async function executeHashlineEditTool(args: HashlineEditArgs, context: ToolContext): Promise<string> {
+export async function executeHashlineEditTool(args: HashlineEditArgs, context: ToolContext, pluginCtx?: PluginContext): Promise<string> {
   try {
     const metadataContext = context as ToolContextWithMetadata
     const filePath = args.filePath
@@ -128,6 +130,34 @@ export async function executeHashlineEditTool(args: HashlineEditArgs, context: T
     const writeContent = restoreFileText(canonicalNewContent, oldEnvelope)
 
     await Bun.write(filePath, writeContent)
+
+    if (pluginCtx?.client) {
+      await runFormattersForFile(pluginCtx.client as any, context.directory, filePath)
+      const formattedContent = Buffer.from(await Bun.file(filePath).arrayBuffer()).toString("utf8")
+      if (formattedContent !== writeContent) {
+        const formattedEnvelope = canonicalizeFileText(formattedContent)
+        const formattedMeta = buildSuccessMeta(
+          filePath,
+          oldEnvelope.content,
+          formattedEnvelope.content,
+          applyResult.noopEdits,
+          applyResult.deduplicatedEdits
+        )
+        if (typeof metadataContext.metadata === "function") {
+          metadataContext.metadata(formattedMeta)
+        }
+        const callID = resolveToolCallID(metadataContext)
+        if (callID) {
+          storeToolMetadata(context.sessionID, callID, formattedMeta)
+        }
+        if (rename && rename !== filePath) {
+          await Bun.write(rename, formattedContent)
+          await Bun.file(filePath).delete()
+          return `Moved ${filePath} to ${rename}`
+        }
+        return `Updated ${filePath}`
+      }
+    }
 
     if (rename && rename !== filePath) {
       await Bun.write(rename, writeContent)

--- a/src/tools/hashline-edit/hashline-edit-executor.ts
+++ b/src/tools/hashline-edit/hashline-edit-executor.ts
@@ -6,7 +6,7 @@ import { canonicalizeFileText, restoreFileText } from "./file-text-canonicalizat
 import { normalizeHashlineEdits, type RawHashlineEdit } from "./normalize-edits"
 import type { HashlineEdit } from "./types"
 import { HashlineMismatchError } from "./validation"
-import { runFormattersForFile } from "./formatter-trigger"
+import { runFormattersForFile, type FormatterClient } from "./formatter-trigger"
 import type { PluginContext } from "../../plugin/types"
 
 interface HashlineEditArgs {
@@ -132,7 +132,7 @@ export async function executeHashlineEditTool(args: HashlineEditArgs, context: T
     await Bun.write(filePath, writeContent)
 
     if (pluginCtx?.client) {
-      await runFormattersForFile(pluginCtx.client as any, context.directory, filePath)
+      await runFormattersForFile(pluginCtx.client as FormatterClient, context.directory, filePath)
       const formattedContent = Buffer.from(await Bun.file(filePath).arrayBuffer()).toString("utf8")
       if (formattedContent !== writeContent) {
         const formattedEnvelope = canonicalizeFileText(formattedContent)

--- a/src/tools/hashline-edit/tools.ts
+++ b/src/tools/hashline-edit/tools.ts
@@ -2,6 +2,7 @@ import { tool, type ToolContext, type ToolDefinition } from "@opencode-ai/plugin
 import { executeHashlineEditTool } from "./hashline-edit-executor"
 import { HASHLINE_EDIT_DESCRIPTION } from "./tool-description"
 import type { RawHashlineEdit } from "./normalize-edits"
+import type { PluginContext } from "../../plugin/types"
 
 interface HashlineEditArgs {
   filePath: string
@@ -10,7 +11,7 @@ interface HashlineEditArgs {
   rename?: string
 }
 
-export function createHashlineEditTool(): ToolDefinition {
+export function createHashlineEditTool(ctx?: PluginContext): ToolDefinition {
   return tool({
     description: HASHLINE_EDIT_DESCRIPTION,
     args: {
@@ -36,6 +37,6 @@ export function createHashlineEditTool(): ToolDefinition {
         )
         .describe("Array of edit operations to apply (empty when delete=true)"),
     },
-    execute: async (args: HashlineEditArgs, context: ToolContext) => executeHashlineEditTool(args, context),
+    execute: async (args: HashlineEditArgs, context: ToolContext) => executeHashlineEditTool(args, context, ctx),
   })
 }


### PR DESCRIPTION
## Problem
The hashline-edit tool completely replaces OpenCode's built-in edit tool but does not emit formatter/afterEdit events, so user-configured formatters (prettier, eslint --fix, etc.) never run after edits.

## Fix
Added `formatter-trigger.ts` that emits the same formatter events as OpenCode's native edit tool after successful hashline-edit operations. Also updated `tool-registry.ts` and `hashline-edit-executor.ts` to integrate the formatter trigger.

**Changes:**
- New: `src/tools/hashline-edit/formatter-trigger.ts` (122 lines)
- Modified: `hashline-edit-executor.ts` — call formatter trigger after edit
- Modified: `tools.ts` — pass context for formatter integration
- Modified: `tool-registry.ts` — minor fix

4 files changed, 157 insertions(+), 4 deletions(-)

Fixes #2117

*Automated fix by Sisyphus (oh-my-opencode)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures user-configured formatters run after `hashline-edit` by emitting formatter events like the built-in edit tool. Fixes #2117 so tools like `prettier`/`eslint --fix` and `file_edited` hooks execute and their changes are saved.

- **Bug Fixes**
  - Added `src/tools/hashline-edit/formatter-trigger.ts` to resolve per-extension formatters from client config and run commands with `$FILE` substitution and env vars.
  - Integrated trigger into `hashline-edit-executor` to run after writes, then update metadata and handle renames if formatting changes content.
  - Passed `PluginContext` through `createHashlineEditTool(ctx)` and `tool-registry` so the trigger can access `client.config`.
  - Clear formatter cache on config reload via `config-handler` to pick up new formatter settings.
  - Added tests for the formatter trigger (resolution, caching, error handling, and command building) and tightened typings (`FormatterClient`).

<sup>Written for commit 4ba2da7ebb9be60f2f76751d3903b13eee9eb202. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

