### PR TITLE
fix(non-interactive-env): detect shell type for csh/tcsh env var syntax (fixes #2089)

### DIFF
--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
-import { log, buildEnvPrefix } from "../../shared"
+import { log, buildEnvPrefix, detectShellType } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -52,9 +52,9 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
       // for git commands to prevent interactive prompts.
 
-      // The bash tool always runs in a Unix-like shell (bash/sh), even on Windows
-      // (via Git Bash, WSL, etc.), so always use unix export syntax.
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
+      // Detect the current shell type for proper env var syntax (export for bash/zsh, setenv for csh/tcsh, etc.)
+      const shellType = detectShellType()
+      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
       
       // Check if the command already starts with the prefix to avoid stacking.
       // This maintains the non-interactive behavior and makes the operation idempotent.

--- a/src/shared/shell-env.ts
+++ b/src/shared/shell-env.ts
@@ -1,4 +1,4 @@
-export type ShellType = "unix" | "powershell" | "cmd"
+export type ShellType = "unix" | "powershell" | "cmd" | "csh"
 
 /**
  * Detect the current shell type based on environment variables.
@@ -14,6 +14,10 @@ export function detectShellType(): ShellType {
   }
 
   if (process.env.SHELL) {
+    const shell = process.env.SHELL
+    if (shell.includes("csh") || shell.includes("tcsh")) {
+      return "csh"
+    }
     return "unix"
   }
 
@@ -34,6 +38,7 @@ export function shellEscape(value: string, shellType: ShellType): string {
 
   switch (shellType) {
     case "unix":
+    case "csh":
       if (/[^a-zA-Z0-9_\-.:\/]/.test(value)) {
         return `'${value.replace(/'/g, "'\\''")}'`
       }
@@ -89,6 +94,13 @@ export function buildEnvPrefix(
         .map(([key, value]) => `${key}=${shellEscape(value, shellType)}`)
         .join(" ")
       return `export ${assignments};`
+    }
+
+    case "csh": {
+      const assignments = entries
+        .map(([key, value]) => `setenv ${key} ${shellEscape(value, shellType)}`)
+        .join("; ")
+      return `${assignments};`
     }
 
     case "powershell": {


### PR DESCRIPTION
## Summary
- Add csh/tcsh shell detection and `setenv` syntax to the non-interactive-env hook

## Problem
The non-interactive-env hook hardcodes `"unix"` as the shell type when building environment variable prefixes for git commands. This generates `export VAR=value` syntax which is incompatible with csh/tcsh shells, where `setenv VAR value` is required. Users running csh/tcsh see syntax errors when the hook prepends env vars to git commands.

## Fix
1. Added `"csh"` to the `ShellType` union in `shell-env.ts`
2. Updated `detectShellType()` to check `$SHELL` for csh/tcsh patterns
3. Added `setenv VAR value;` syntax generation in `buildEnvPrefix()` for csh
4. Replaced the hardcoded `"unix"` in the non-interactive-env hook with `detectShellType()` call

## Changes
| File | Change |
|------|--------|
| `src/shared/shell-env.ts` | Added "csh" to ShellType, csh detection in detectShellType(), csh cases in shellEscape() and buildEnvPrefix() |
| `src/hooks/non-interactive-env/non-interactive-env-hook.ts` | Import detectShellType, use it instead of hardcoded "unix" |

Fixes #2089

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects csh/tcsh shells and uses `setenv` syntax in the non-interactive env hook, preventing syntax errors in git commands. Restores non-interactive behavior for csh/tcsh users.

- **Bug Fixes**
  - Detects csh/tcsh via `$SHELL` and adds `"csh"` to `ShellType`.
  - Generates `setenv VAR value;` in `buildEnvPrefix()` for csh; reuses unix escaping.
  - Replaces hardcoded `"unix"` with `detectShellType()` in the non-interactive-env hook.

<sup>Written for commit 92509d8cfbfa25d425ebdf06d9d3a1cfedfe24e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

