### PR TITLE
fix: add fetch mock to install test to prevent CI timeout

### DIFF
--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -53,6 +53,14 @@ describe("install CLI - binary check behavior", () => {
     isOpenCodeInstalledSpy = spyOn(configManager, "isOpenCodeInstalled").mockResolvedValue(false)
     getOpenCodeVersionSpy = spyOn(configManager, "getOpenCodeVersion").mockResolvedValue(null)
 
+    // given mock npm fetch
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ latest: "3.0.0" }),
+      } as Response)
+    ) as unknown as typeof fetch
+
     const args: InstallArgs = {
       tui: false,
       claude: "yes",


### PR DESCRIPTION
## Problem

The first test case in `src/cli/install.test.ts` — *"non-TUI mode: should show warning but continue when OpenCode binary not found"* — was failing with a 5-second timeout in CI.

## Root Cause

This test didn't mock `globalThis.fetch`, so the `install()` call chain went all the way to `fetchNpmDistTags()`, which makes a real HTTP request to npm registry with a 5-second timeout (`NPM_FETCH_TIMEOUT_MS`). In CI environments, this timeout collides with the test's own 5-second limit.

The other two tests in the same file already had proper fetch mocks — this one was simply missed.

## Fix

Added the same `globalThis.fetch` mock pattern used by the neighboring tests:

```typescript
globalThis.fetch = mock(() =>
  Promise.resolve({
    ok: true,
    json: () => Promise.resolve({ latest: "3.0.0" }),
  } as Response)
) as unknown as typeof fetch
```

Test runtime: **5000ms+ → ~2ms**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mocked `globalThis.fetch` in the first test in `src/cli/install.test.ts` to prevent real npm registry calls. This removes the CI 5s timeout and reduces the test runtime to ~2ms.

<sup>Written for commit 6e9128e060c1680ac02fa1d6acde8f2d23c646a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

