### PR TITLE
fix(hooks): add bash-file-read-guard to warn agents against cat/head/tail (fixes #2096)

### DIFF
--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -47,6 +47,7 @@ export const HookNameSchema = z.enum([
   "tasks-todowrite-disabler",
   "runtime-fallback",
   "write-existing-file-guard",
+  "bash-file-read-guard",
   "anthropic-effort",
   "hashline-read-enhancer",
   "read-image-resizer",

--- a/src/hooks/bash-file-read-guard.ts
+++ b/src/hooks/bash-file-read-guard.ts
@@ -1,0 +1,44 @@
+import type { Hooks } from "@opencode-ai/plugin"
+
+import { log } from "../shared"
+
+const WARNING_MESSAGE = "Prefer the Read tool over `cat`/`head`/`tail` for reading file contents. The Read tool provides line numbers and hash anchors for precise editing."
+
+const FILE_READ_PATTERNS = [
+  /^\s*cat\s+(?!-)[^\s|&;]+\s*$/,
+  /^\s*head\s+(-n\s+\d+\s+)?(?!-)[^\s|&;]+\s*$/,
+  /^\s*tail\s+(-n\s+\d+\s+)?(?!-)[^\s|&;]+\s*$/,
+]
+
+function isSimpleFileReadCommand(command: string): boolean {
+  return FILE_READ_PATTERNS.some((pattern) => pattern.test(command))
+}
+
+export function createBashFileReadGuardHook(): Hooks {
+  return {
+    "tool.execute.before": async (
+      input: { tool: string; sessionID: string; callID: string },
+      output: { args: Record<string, unknown>; message?: string },
+    ): Promise<void> => {
+      if (input.tool.toLowerCase() !== "bash") {
+        return
+      }
+
+      const command = output.args.command
+      if (typeof command !== "string") {
+        return
+      }
+
+      if (!isSimpleFileReadCommand(command)) {
+        return
+      }
+
+      output.message = WARNING_MESSAGE
+
+      log("[bash-file-read-guard] warned on bash file read command", {
+        sessionID: input.sessionID,
+        command,
+      })
+    },
+  }
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -48,6 +48,7 @@ export { createPreemptiveCompactionHook } from "./preemptive-compaction";
 export { createTasksTodowriteDisablerHook } from "./tasks-todowrite-disabler";
 export { createRuntimeFallbackHook, type RuntimeFallbackHook, type RuntimeFallbackOptions } from "./runtime-fallback";
 export { createWriteExistingFileGuardHook } from "./write-existing-file-guard";
+export { createBashFileReadGuardHook } from "./bash-file-read-guard";
 export { createHashlineReadEnhancerHook } from "./hashline-read-enhancer";
 export { createJsonErrorRecoveryHook, JSON_ERROR_TOOL_EXCLUDE_LIST, JSON_ERROR_PATTERNS, JSON_ERROR_REMINDER } from "./json-error-recovery";
 export { createReadImageResizerHook } from "./read-image-resizer"

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -11,6 +11,7 @@ import {
   createRulesInjectorHook,
   createTasksTodowriteDisablerHook,
   createWriteExistingFileGuardHook,
+  createBashFileReadGuardHook,
   createHashlineReadEnhancerHook,
   createReadImageResizerHook,
   createJsonErrorRecoveryHook,
@@ -33,6 +34,7 @@ export type ToolGuardHooks = {
   rulesInjector: ReturnType<typeof createRulesInjectorHook> | null
   tasksTodowriteDisabler: ReturnType<typeof createTasksTodowriteDisablerHook> | null
   writeExistingFileGuard: ReturnType<typeof createWriteExistingFileGuardHook> | null
+  bashFileReadGuard: ReturnType<typeof createBashFileReadGuardHook> | null
   hashlineReadEnhancer: ReturnType<typeof createHashlineReadEnhancerHook> | null
   jsonErrorRecovery: ReturnType<typeof createJsonErrorRecoveryHook> | null
   readImageResizer: ReturnType<typeof createReadImageResizerHook> | null
@@ -101,6 +103,10 @@ export function createToolGuardHooks(args: {
     ? safeHook("write-existing-file-guard", () => createWriteExistingFileGuardHook(ctx))
     : null
 
+  const bashFileReadGuard = isHookEnabled("bash-file-read-guard")
+    ? safeHook("bash-file-read-guard", () => createBashFileReadGuardHook())
+    : null
+
   const hashlineReadEnhancer = isHookEnabled("hashline-read-enhancer")
     ? safeHook("hashline-read-enhancer", () => createHashlineReadEnhancerHook(ctx, { hashline_edit: { enabled: pluginConfig.hashline_edit ?? false } }))
     : null
@@ -126,6 +132,7 @@ export function createToolGuardHooks(args: {
     rulesInjector,
     tasksTodowriteDisabler,
     writeExistingFileGuard,
+    bashFileReadGuard,
     hashlineReadEnhancer,
     jsonErrorRecovery,
     readImageResizer,

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -45,6 +45,7 @@ export function createToolExecuteBeforeHandler(args: {
     await hooks.questionLabelTruncator?.["tool.execute.before"]?.(input, output)
     await hooks.claudeCodeHooks?.["tool.execute.before"]?.(input, output)
     await hooks.nonInteractiveEnv?.["tool.execute.before"]?.(input, output)
+    await hooks.bashFileReadGuard?.["tool.execute.before"]?.(input, output)
     await hooks.commentChecker?.["tool.execute.before"]?.(input, output)
     await hooks.directoryAgentsInjector?.["tool.execute.before"]?.(input, output)
     await hooks.directoryReadmeInjector?.["tool.execute.before"]?.(input, output)


### PR DESCRIPTION
## Summary
- Add a new tool guard hook that warns agents when they use `cat`/`head`/`tail` for file reading instead of the built-in Read tool

## Problem
Agents (particularly Gemini models) frequently use bash commands like `cat src/file.ts`, `head -n 200 src/file.ts` to read files instead of the Read tool. This bypasses the hash-anchored line IDs that the Read tool provides, leading to less precise edits and missed context.

## Fix
Created a new `bash-file-read-guard` hook (`tool.execute.before`) that:
- Detects simple standalone file-reading patterns (`cat <file>`, `head [-n N] <file>`, `tail [-n N] <file>`)
- Adds a warning message guiding the agent to use the Read tool instead
- Does NOT block/reject the command — only warns
- Does NOT warn for piped/compound commands (e.g., `cat file | grep pattern`) which have legitimate uses
- Can be disabled via `disabled_hooks: ["bash-file-read-guard"]`

## Changes
| File | Change |
|------|--------|
| `src/hooks/bash-file-read-guard.ts` | New hook: detects file-reading bash patterns, warns to use Read tool |
| `src/hooks/index.ts` | Export the new hook factory |
| `src/plugin/hooks/create-tool-guard-hooks.ts` | Register hook in tool guard composition |
| `src/config/schema/hooks.ts` | Add hook name to HookNameSchema for disable support |
| `src/plugin/tool-execute-before.ts` | Wire hook into tool.execute.before execution chain |

Fixes #2096

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `bash-file-read-guard` hook that warns on `cat`/`head`/`tail` file reads and guides agents to use the Read tool for hash-anchored line IDs, improving edit precision without blocking commands. Fixes #2096.

- **Bug Fixes**
  - Detects `cat`/`head`/`tail` file reads and warns to use the Read tool.
  - Skips piped/compound commands; does not block execution.
  - Registered in `tool.execute.before`; added to the hook schema and exports.
  - Can be disabled via `disabled_hooks: ["bash-file-read-guard"]`.

<sup>Written for commit 2f801f6c28b9f9a111219fe73b5e4b78fbd72c1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

