### PR TITLE
fix(ralph-loop): add semantic completion detection as fallback for natural language (fixes #2489)

### DIFF
--- a/src/hooks/ralph-loop/completion-promise-detector.test.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.test.ts
@@ -273,6 +273,28 @@ describe("detectCompletionInSessionMessages", () => {
       // #then
       expect(detected).toBe(true)
     })
+
+    test("#when promise is VERIFIED #then semantic completion should NOT trigger", async () => {
+      // #given
+      const messages: SessionMessage[] = [
+        {
+          info: { role: "assistant" },
+          parts: [{ type: "text", text: "The task is complete. All work has been finished." }],
+        },
+      ]
+      const ctx = createPluginInput(messages)
+
+      // #when
+      const detected = await detectCompletionInSessionMessages(ctx, {
+        sessionID: "session-123",
+        promise: "VERIFIED",
+        apiTimeoutMs: 1000,
+        directory: "/tmp",
+      })
+
+      // #then
+      expect(detected).toBe(false)
+    })
   })
 })
 

--- a/src/hooks/ralph-loop/completion-promise-detector.test.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 import { describe, expect, test } from "bun:test"
 import type { PluginInput } from "@opencode-ai/plugin"
-import { detectCompletionInSessionMessages } from "./completion-promise-detector"
+import { detectCompletionInSessionMessages, detectSemanticCompletion } from "./completion-promise-detector"
 
 type SessionMessage = {
   info?: { role?: string }
@@ -182,6 +182,128 @@ describe("detectCompletionInSessionMessages", () => {
       })
 
       expect(detected).toBe(false)
+    })
+  })
+
+  describe("#given semantic completion patterns", () => {
+    test("#when agent says 'task is complete' #then should detect semantic completion", async () => {
+      // #given
+      const messages: SessionMessage[] = [
+        {
+          info: { role: "assistant" },
+          parts: [{ type: "text", text: "The task is complete. All work has been finished." }],
+        },
+      ]
+      const ctx = createPluginInput(messages)
+
+      // #when
+      const detected = await detectCompletionInSessionMessages(ctx, {
+        sessionID: "session-123",
+        promise: "DONE",
+        apiTimeoutMs: 1000,
+        directory: "/tmp",
+      })
+
+      // #then
+      expect(detected).toBe(true)
+    })
+
+    test("#when agent says 'all items are done' #then should detect semantic completion", async () => {
+      // #given
+      const messages: SessionMessage[] = [
+        {
+          info: { role: "assistant" },
+          parts: [{ type: "text", text: "All items are done and marked as complete." }],
+        },
+      ]
+      const ctx = createPluginInput(messages)
+
+      // #when
+      const detected = await detectCompletionInSessionMessages(ctx, {
+        sessionID: "session-123",
+        promise: "DONE",
+        apiTimeoutMs: 1000,
+        directory: "/tmp",
+      })
+
+      // #then
+      expect(detected).toBe(true)
+    })
+
+    test("#when agent says 'nothing left to do' #then should detect semantic completion", async () => {
+      // #given
+      const messages: SessionMessage[] = [
+        {
+          info: { role: "assistant" },
+          parts: [{ type: "text", text: "There is nothing left to do. Everything is finished." }],
+        },
+      ]
+      const ctx = createPluginInput(messages)
+
+      // #when
+      const detected = await detectCompletionInSessionMessages(ctx, {
+        sessionID: "session-123",
+        promise: "DONE",
+        apiTimeoutMs: 1000,
+        directory: "/tmp",
+      })
+
+      // #then
+      expect(detected).toBe(true)
+    })
+
+    test("#when agent says 'successfully completed all' #then should detect semantic completion", async () => {
+      // #given
+      const messages: SessionMessage[] = [
+        {
+          info: { role: "assistant" },
+          parts: [{ type: "text", text: "I have successfully completed all the required tasks." }],
+        },
+      ]
+      const ctx = createPluginInput(messages)
+
+      // #when
+      const detected = await detectCompletionInSessionMessages(ctx, {
+        sessionID: "session-123",
+        promise: "DONE",
+        apiTimeoutMs: 1000,
+        directory: "/tmp",
+      })
+
+      // #then
+      expect(detected).toBe(true)
+    })
+  })
+})
+
+describe("detectSemanticCompletion", () => {
+  describe("#given semantic completion patterns", () => {
+    test("#when text contains 'task is complete' #then should return true", () => {
+      expect(detectSemanticCompletion("The task is complete.")).toBe(true)
+    })
+
+    test("#when text contains 'all items are done' #then should return true", () => {
+      expect(detectSemanticCompletion("All items are done.")).toBe(true)
+    })
+
+    test("#when text contains 'nothing left to do' #then should return true", () => {
+      expect(detectSemanticCompletion("There is nothing left to do.")).toBe(true)
+    })
+
+    test("#when text contains 'successfully completed all' #then should return true", () => {
+      expect(detectSemanticCompletion("Successfully completed all tasks.")).toBe(true)
+    })
+
+    test("#when text contains 'everything is finished' #then should return true", () => {
+      expect(detectSemanticCompletion("Everything is finished.")).toBe(true)
+    })
+
+    test("#when text does NOT contain completion patterns #then should return false", () => {
+      expect(detectSemanticCompletion("Working on the next task.")).toBe(false)
+    })
+
+    test("#when text is empty #then should return false", () => {
+      expect(detectSemanticCompletion("")).toBe(false)
     })
   })
 })

--- a/src/hooks/ralph-loop/completion-promise-detector.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.ts
@@ -49,8 +49,9 @@ export function detectCompletionInTranscript(
 				if (entry.type === "user") continue
 				if (startedAt && entry.timestamp && entry.timestamp < startedAt) continue
 				if (pattern.test(line)) return true
-				// Fallback: check for semantic completion
-				if (detectSemanticCompletion(line)) {
+				// Fallback: semantic completion only for DONE promise and assistant entries
+				const isAssistantEntry = entry.type === "assistant" || entry.type === "text"
+				if (promise === "DONE" && isAssistantEntry && detectSemanticCompletion(line)) {
 					log("[ralph-loop] WARNING: Semantic completion detected in transcript (agent used natural language instead of <promise>DONE</promise>)")
 					return true
 				}
@@ -118,8 +119,8 @@ export async function detectCompletionInSessionMessages(
 				return true
 			}
 
-			// Fallback: check for semantic completion
-			if (detectSemanticCompletion(responseText)) {
+			// Fallback: semantic completion only for DONE promise
+			if (options.promise === "DONE" && detectSemanticCompletion(responseText)) {
 				log("[ralph-loop] WARNING: Semantic completion detected (agent used natural language instead of <promise>DONE</promise>)", {
 					sessionID: options.sessionID,
 				})

--- a/src/hooks/ralph-loop/completion-promise-detector.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.ts
@@ -9,6 +9,20 @@ interface OpenCodeSessionMessage {
 	parts?: Array<{ type: string; text?: string }>
 }
 
+interface TranscriptEntry {
+	type?: string
+	timestamp?: string
+	content?: string
+	tool_output?: { output?: string } | string
+}
+
+function extractTranscriptEntryText(entry: TranscriptEntry): string {
+	if (typeof entry.content === "string") return entry.content
+	if (typeof entry.tool_output === "string") return entry.tool_output
+	if (entry.tool_output && typeof entry.tool_output === "object" && typeof entry.tool_output.output === "string") return entry.tool_output.output
+	return ""
+}
+
 function escapeRegex(str: string): string {
 	return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
@@ -45,13 +59,15 @@ export function detectCompletionInTranscript(
 
 		for (const line of lines) {
 			try {
-				const entry = JSON.parse(line) as { type?: string; timestamp?: string }
+				const entry = JSON.parse(line) as TranscriptEntry
 				if (entry.type === "user") continue
 				if (startedAt && entry.timestamp && entry.timestamp < startedAt) continue
-				if (pattern.test(line)) return true
+				const entryText = extractTranscriptEntryText(entry)
+				if (!entryText) continue
+				if (pattern.test(entryText)) return true
 				// Fallback: semantic completion only for DONE promise and assistant entries
 				const isAssistantEntry = entry.type === "assistant" || entry.type === "text"
-				if (promise === "DONE" && isAssistantEntry && detectSemanticCompletion(line)) {
+				if (promise === "DONE" && isAssistantEntry && detectSemanticCompletion(entryText)) {
 					log("[ralph-loop] WARNING: Semantic completion detected in transcript (agent used natural language instead of <promise>DONE</promise>)")
 					return true
 				}

--- a/src/hooks/ralph-loop/completion-promise-detector.ts
+++ b/src/hooks/ralph-loop/completion-promise-detector.ts
@@ -17,6 +17,18 @@ function buildPromisePattern(promise: string): RegExp {
 	return new RegExp(`<promise>\\s*${escapeRegex(promise)}\\s*</promise>`, "is")
 }
 
+const SEMANTIC_COMPLETION_PATTERNS = [
+	/\b(?:task|work|implementation|all\s+tasks?)\s+(?:is|are)\s+(?:complete|completed|done|finished)\b/i,
+	/\ball\s+(?:items?|todos?|steps?)\s+(?:are\s+)?(?:complete|completed|done|finished|marked)\b/i,
+	/\b(?:everything|all\s+work)\s+(?:is\s+)?(?:complete|completed|done|finished)\b/i,
+	/\bsuccessfully\s+completed?\s+all\b/i,
+	/\bnothing\s+(?:left|more|remaining)\s+to\s+(?:do|implement|fix)\b/i,
+]
+
+export function detectSemanticCompletion(text: string): boolean {
+	return SEMANTIC_COMPLETION_PATTERNS.some((pattern) => pattern.test(text))
+}
+
 export function detectCompletionInTranscript(
 	transcriptPath: string | undefined,
 	promise: string,
@@ -37,6 +49,11 @@ export function detectCompletionInTranscript(
 				if (entry.type === "user") continue
 				if (startedAt && entry.timestamp && entry.timestamp < startedAt) continue
 				if (pattern.test(line)) return true
+				// Fallback: check for semantic completion
+				if (detectSemanticCompletion(line)) {
+					log("[ralph-loop] WARNING: Semantic completion detected in transcript (agent used natural language instead of <promise>DONE</promise>)")
+					return true
+				}
 			} catch {
 				continue
 			}
@@ -98,6 +115,14 @@ export async function detectCompletionInSessionMessages(
 			}
 
 			if (pattern.test(responseText)) {
+				return true
+			}
+
+			// Fallback: check for semantic completion
+			if (detectSemanticCompletion(responseText)) {
+				log("[ralph-loop] WARNING: Semantic completion detected (agent used natural language instead of <promise>DONE</promise>)", {
+					sessionID: options.sessionID,
+				})
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary
- Add fuzzy/semantic completion detection as a fallback when agents output natural language instead of the literal `<promise>DONE</promise>` tag

## Problem
The ralph-loop/ulw-loop only checks for the literal `<promise>DONE</promise>` tag to detect task completion. Some models (especially non-English or smaller models) output natural language completion phrases like "task completed", "all done", or localized equivalents instead of the exact tag. This causes the loop to continue indefinitely, wasting tokens and user time.

## Fix
Added `detectSemanticCompletion()` function with 5 regex patterns that catch common completion phrases:
- "task/work is complete/done/finished"
- "all items/todos/steps are done/completed"  
- "everything is complete/finished"
- "successfully completed all"
- "nothing left/remaining to do"

The semantic detection is a **fallback only** - the literal `<promise>DONE</promise>` tag remains the primary detection method. When semantic detection triggers, a warning is logged to help identify agents that need prompt improvements.

## Changes
| File | Change |
|------|--------|
| `src/hooks/ralph-loop/completion-promise-detector.ts` | Add `SEMANTIC_COMPLETION_PATTERNS` and `detectSemanticCompletion()`, integrate as fallback in both transcript and session message detection |
| `src/hooks/ralph-loop/completion-promise-detector.test.ts` | Add 11 tests for semantic completion patterns |

Fixes #2489

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add semantic completion fallback in `ralph-loop` when agents use natural language instead of `<promise>DONE</promise>`. It only applies to the `DONE` promise and assistant/text messages to avoid false positives, preventing loops and saving tokens.

- **Bug Fixes**
  - Implemented `detectSemanticCompletion()` with 5 regex patterns; exported for direct tests.
  - Integrated fallback in transcript and session checks; gated on `promise === 'DONE'` and skips `tool_use`/`tool_result`; `<promise>DONE</promise>` remains primary.
  - Added tests, including a regression to ensure `VERIFIED` does not trigger; warns when semantic detection fires.

<sup>Written for commit 774d0bd84dc7c183a5b82942d8f0926fc07adcfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

