### PR TITLE
fix(background-agent): increase default stale timeouts and improve cancellation messages (fixes #2684)

### DIFF
--- a/src/features/background-agent/constants.ts
+++ b/src/features/background-agent/constants.ts
@@ -4,8 +4,8 @@ import type { BackgroundTask, LaunchInput } from "./types"
 export const TASK_TTL_MS = 30 * 60 * 1000
 export const TERMINAL_TASK_TTL_MS = 30 * 60 * 1000
 export const MIN_STABILITY_TIME_MS = 10 * 1000
-export const DEFAULT_STALE_TIMEOUT_MS = 1_200_000
-export const DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS = 1_800_000
+export const DEFAULT_STALE_TIMEOUT_MS = 2_700_000
+export const DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS = 3_600_000
 export const DEFAULT_MAX_TOOL_CALLS = 4000
 export const DEFAULT_CIRCUIT_BREAKER_CONSECUTIVE_THRESHOLD = 20
 export const DEFAULT_CIRCUIT_BREAKER_ENABLED = true

--- a/src/features/background-agent/default-message-staleness-timeout.test.ts
+++ b/src/features/background-agent/default-message-staleness-timeout.test.ts
@@ -21,9 +21,9 @@ function createRunningTask(startedAt: Date): BackgroundTask {
 }
 
 describe("DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS", () => {
-  test("uses a 30 minute default", () => {
+  test("uses a 60 minute default", () => {
     // #given
-    const expectedTimeout = 30 * 60 * 1000
+    const expectedTimeout = 60 * 60 * 1000
 
     // #when
     const timeout = DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS

--- a/src/features/background-agent/default-stale-timeout.test.ts
+++ b/src/features/background-agent/default-stale-timeout.test.ts
@@ -4,9 +4,9 @@ const { describe, expect, test } = require("bun:test")
 import { DEFAULT_STALE_TIMEOUT_MS } from "./constants"
 
 describe("DEFAULT_STALE_TIMEOUT_MS", () => {
-  test("uses a 20 minute default", () => {
+  test("uses a 45 minute default", () => {
     // #given
-    const expectedTimeout = 20 * 60 * 1000
+    const expectedTimeout = 45 * 60 * 1000
 
     // #when
     const timeout = DEFAULT_STALE_TIMEOUT_MS

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -3027,10 +3027,10 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
       prompt: "Test",
       agent: "test-agent",
       status: "running",
-      startedAt: new Date(Date.now() - 25 * 60 * 1000),
+      startedAt: new Date(Date.now() - 50 * 60 * 1000),
       progress: {
         toolCalls: 1,
-        lastUpdate: new Date(Date.now() - 21 * 60 * 1000),
+        lastUpdate: new Date(Date.now() - 46 * 60 * 1000),
       },
     }
 

--- a/src/features/background-agent/task-poller.test.ts
+++ b/src/features/background-agent/task-poller.test.ts
@@ -117,13 +117,13 @@ describe("checkAndInterruptStaleTasks", () => {
   })
 
   it("should use DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS when messageStalenessTimeoutMs is not configured", async () => {
-    //#given — task started 35 minutes ago, no config for messageStalenessTimeoutMs
+    //#given — task started 65 minutes ago, no config for messageStalenessTimeoutMs
     const task = createRunningTask({
-      startedAt: new Date(Date.now() - 35 * 60 * 1000),
+      startedAt: new Date(Date.now() - 65 * 60 * 1000),
       progress: undefined,
     })
 
-    //#when — default is 30 minutes (1_800_000ms)
+    //#when — default is 60 minutes (3_600_000ms)
     await checkAndInterruptStaleTasks({
       tasks: [task],
       client: mockClient as never,

--- a/src/features/background-agent/task-poller.ts
+++ b/src/features/background-agent/task-poller.ts
@@ -130,7 +130,7 @@ export async function checkAndInterruptStaleTasks(args: {
 
       const staleMinutes = Math.round(runtime / 60000)
       task.status = "cancelled"
-      task.error = `Stale timeout (no activity for ${staleMinutes}min since start)`
+      task.error = `Stale timeout (no activity for ${staleMinutes}min since start). This is a FINAL cancellation - do NOT create a replacement task. If the timeout is too short, increase 'background_task.staleTimeoutMs' in .opencode/oh-my-opencode.json.`
       task.completedAt = new Date()
 
       if (task.concurrencyKey) {
@@ -159,10 +159,10 @@ export async function checkAndInterruptStaleTasks(args: {
     if (timeSinceLastUpdate <= staleTimeoutMs) continue
     if (task.status !== "running") continue
 
-    const staleMinutes = Math.round(timeSinceLastUpdate / 60000)
-    task.status = "cancelled"
-    task.error = `Stale timeout (no activity for ${staleMinutes}min)`
-    task.completedAt = new Date()
+     const staleMinutes = Math.round(timeSinceLastUpdate / 60000)
+     task.status = "cancelled"
+     task.error = `Stale timeout (no activity for ${staleMinutes}min). This is a FINAL cancellation - do NOT create a replacement task. If the timeout is too short, increase 'background_task.staleTimeoutMs' in .opencode/oh-my-opencode.json.`
+     task.completedAt = new Date()
 
     if (task.concurrencyKey) {
       concurrencyManager.release(task.concurrencyKey)


### PR DESCRIPTION
## Summary
- Increase default background agent timeouts from 20/30 min to 45/60 min and improve cancellation messages to prevent duplicate agent creation

## Problem
Background agents have short default timeouts (20min stale, 30min message staleness). For long-running tasks like complex analysis or large-scale refactoring, agents frequently hit these timeouts. When a timeout occurs, the parent agent receives a vague error message, interprets it as a retriable failure, and creates duplicate replacement agents — wasting tokens and causing confusion.

## Fix
1. **Increased default timeouts**: `staleTimeoutMs` from 20 to 45 minutes, `messageStalenessTimeoutMs` from 30 to 60 minutes — better suited for real-world long-running tasks
2. **Improved cancellation messages**: Timeout error messages now explicitly state "This is a FINAL cancellation - do NOT create a replacement task" and point users to the config option to increase timeouts further

Note: Both timeouts remain user-configurable via `background_task.staleTimeoutMs` and `background_task.messageStalenessTimeoutMs` in oh-my-opencode.json.

## Changes
| File | Change |
|------|--------|
| `src/features/background-agent/constants.ts` | Increase DEFAULT_STALE_TIMEOUT_MS to 45min, DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS to 60min |
| `src/features/background-agent/task-poller.ts` | Improve cancellation error messages with "do NOT retry" guidance |
| `src/features/background-agent/default-stale-timeout.test.ts` | Update expected timeout value |
| `src/features/background-agent/default-message-staleness-timeout.test.ts` | Update expected timeout value |

Fixes #2684

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase background agent default timeouts (stale 45m, message staleness 60m) and make cancellation messages explicit to stop duplicate agent creation. Prevents premature cancels during long tasks and saves tokens. Fixes #2684.

- **Bug Fixes**
  - Raise defaults: `DEFAULT_STALE_TIMEOUT_MS` to 45m, `DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS` to 60m (tests and fixtures updated).
  - Cancellation errors now state it’s a final stop and include guidance to adjust timeouts in `.opencode/oh-my-opencode.json`.

<sup>Written for commit 6d7f69625b3c14329d6597c56d391987c543433c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

