### PR TITLE
fix: stabilize background-agent stale timeout tests (Date.now race condition)

### DIFF
--- a/src/features/background-agent/constants.ts
+++ b/src/features/background-agent/constants.ts
@@ -4,8 +4,8 @@ import type { BackgroundTask, LaunchInput } from "./types"
 export const TASK_TTL_MS = 30 * 60 * 1000
 export const TERMINAL_TASK_TTL_MS = 30 * 60 * 1000
 export const MIN_STABILITY_TIME_MS = 10 * 1000
-export const DEFAULT_STALE_TIMEOUT_MS = 1_200_000
-export const DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS = 1_800_000
+export const DEFAULT_STALE_TIMEOUT_MS = 2_700_000
+export const DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS = 3_600_000
 export const DEFAULT_MAX_TOOL_CALLS = 4000
 export const DEFAULT_CIRCUIT_BREAKER_CONSECUTIVE_THRESHOLD = 20
 export const DEFAULT_CIRCUIT_BREAKER_ENABLED = true

--- a/src/features/background-agent/default-message-staleness-timeout.test.ts
+++ b/src/features/background-agent/default-message-staleness-timeout.test.ts
@@ -21,9 +21,9 @@ function createRunningTask(startedAt: Date): BackgroundTask {
 }
 
 describe("DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS", () => {
-  test("uses a 30 minute default", () => {
+  test("uses a 60 minute default", () => {
     // #given
-    const expectedTimeout = 30 * 60 * 1000
+    const expectedTimeout = 60 * 60 * 1000
 
     // #when
     const timeout = DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS

--- a/src/features/background-agent/default-stale-timeout.test.ts
+++ b/src/features/background-agent/default-stale-timeout.test.ts
@@ -4,9 +4,9 @@ const { describe, expect, test } = require("bun:test")
 import { DEFAULT_STALE_TIMEOUT_MS } from "./constants"
 
 describe("DEFAULT_STALE_TIMEOUT_MS", () => {
-  test("uses a 20 minute default", () => {
+  test("uses a 45 minute default", () => {
     // #given
-    const expectedTimeout = 20 * 60 * 1000
+    const expectedTimeout = 45 * 60 * 1000
 
     // #when
     const timeout = DEFAULT_STALE_TIMEOUT_MS

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -3027,10 +3027,10 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
       prompt: "Test",
       agent: "test-agent",
       status: "running",
-      startedAt: new Date(Date.now() - 25 * 60 * 1000),
+      startedAt: new Date(Date.now() - 50 * 60 * 1000),
       progress: {
         toolCalls: 1,
-        lastUpdate: new Date(Date.now() - 21 * 60 * 1000),
+        lastUpdate: new Date(Date.now() - 46 * 60 * 1000),
       },
     }
 

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -1,5 +1,5 @@
 declare const require: (name: string) => any
-const { describe, test, expect, beforeEach, afterEach } = require("bun:test")
+const { describe, test, expect, beforeEach, afterEach, spyOn } = require("bun:test")
 import { tmpdir } from "node:os"
 import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundTask, ResumeInput } from "./types"
@@ -2781,6 +2781,18 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
 })
 
 describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
+  const originalDateNow = Date.now
+  let fixedTime: number
+
+  beforeEach(() => {
+    fixedTime = Date.now()
+    spyOn(globalThis.Date, "now").mockReturnValue(fixedTime)
+  })
+
+  afterEach(() => {
+    Date.now = originalDateNow
+  })
+
    test("should NOT interrupt task running less than 30 seconds (min runtime guard)", async () => {
      const client = {
        session: {

--- a/src/features/background-agent/task-poller.test.ts
+++ b/src/features/background-agent/task-poller.test.ts
@@ -117,13 +117,13 @@ describe("checkAndInterruptStaleTasks", () => {
   })
 
   it("should use DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS when messageStalenessTimeoutMs is not configured", async () => {
-    //#given — task started 35 minutes ago, no config for messageStalenessTimeoutMs
+    //#given — task started 65 minutes ago, no config for messageStalenessTimeoutMs
     const task = createRunningTask({
-      startedAt: new Date(Date.now() - 35 * 60 * 1000),
+      startedAt: new Date(Date.now() - 65 * 60 * 1000),
       progress: undefined,
     })
 
-    //#when — default is 30 minutes (1_800_000ms)
+    //#when — default is 60 minutes (3_600_000ms)
     await checkAndInterruptStaleTasks({
       tasks: [task],
       client: mockClient as never,

--- a/src/features/background-agent/task-poller.test.ts
+++ b/src/features/background-agent/task-poller.test.ts
@@ -1,5 +1,5 @@
 declare const require: (name: string) => any
-const { describe, it, expect, mock } = require("bun:test")
+const { describe, it, expect, mock, spyOn, beforeEach, afterEach } = require("bun:test")
 
 import { checkAndInterruptStaleTasks, pruneStaleTasksAndNotifications } from "./task-poller"
 import type { BackgroundTask } from "./types"
@@ -29,6 +29,18 @@ describe("checkAndInterruptStaleTasks", () => {
       ...overrides,
     }
   }
+  const originalDateNow = Date.now
+  let fixedTime: number
+
+  beforeEach(() => {
+    fixedTime = Date.now()
+    spyOn(globalThis.Date, "now").mockReturnValue(fixedTime)
+  })
+
+  afterEach(() => {
+    Date.now = originalDateNow
+  })
+
 
   it("should interrupt tasks with lastUpdate exceeding stale timeout", async () => {
     //#given

--- a/src/features/background-agent/task-poller.ts
+++ b/src/features/background-agent/task-poller.ts
@@ -130,7 +130,7 @@ export async function checkAndInterruptStaleTasks(args: {
 
       const staleMinutes = Math.round(runtime / 60000)
       task.status = "cancelled"
-      task.error = `Stale timeout (no activity for ${staleMinutes}min since start)`
+      task.error = `Stale timeout (no activity for ${staleMinutes}min since start). This is a FINAL cancellation - do NOT create a replacement task. If the timeout is too short, increase 'background_task.staleTimeoutMs' in .opencode/oh-my-opencode.json.`
       task.completedAt = new Date()
 
       if (task.concurrencyKey) {
@@ -159,10 +159,10 @@ export async function checkAndInterruptStaleTasks(args: {
     if (timeSinceLastUpdate <= staleTimeoutMs) continue
     if (task.status !== "running") continue
 
-    const staleMinutes = Math.round(timeSinceLastUpdate / 60000)
-    task.status = "cancelled"
-    task.error = `Stale timeout (no activity for ${staleMinutes}min)`
-    task.completedAt = new Date()
+     const staleMinutes = Math.round(timeSinceLastUpdate / 60000)
+     task.status = "cancelled"
+     task.error = `Stale timeout (no activity for ${staleMinutes}min). This is a FINAL cancellation - do NOT create a replacement task. If the timeout is too short, increase 'background_task.staleTimeoutMs' in .opencode/oh-my-opencode.json.`
+     task.completedAt = new Date()
 
     if (task.concurrencyKey) {
       concurrencyManager.release(task.concurrencyKey)


### PR DESCRIPTION
## Problem

Two tests in CI fail with `Expected: "cancelled", Received: "running"`:
- `BackgroundManager.checkAndInterruptStaleTasks > should use default timeout when config not provided` (manager.test.ts:3041)
- `checkAndInterruptStaleTasks > should use DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS when not configured` (task-poller.test.ts:136)

Builds on top of PR #2774's changes.

## Root Cause

`Date.now()` is called twice — once during test setup (`new Date(Date.now() - X)`) and again inside `checkAndInterruptStaleTasks()`. On slower CI machines, the time drift between these calls pushes borderline values across the threshold, so tasks that should be stale remain "running".

## Fix

Mock `Date.now` with `spyOn(globalThis.Date, "now").mockReturnValue(fixedTime)` in both test files to ensure consistent timeout calculations regardless of execution speed.

All 358 background-agent tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes background-agent stale-timeout tests by fixing a Date.now race, and updates default timeouts to 45 min (stale) and 60 min (message) with clearer final-cancellation messages.

- **Bug Fixes**
  - Mocked `Date.now` in `manager.test.ts` and `task-poller.test.ts` to remove drift that caused flaky “running” vs “cancelled” results in `checkAndInterruptStaleTasks`.
  - Updated test timings to avoid borderline thresholds on slower CI.

- **New Features**
  - Increased `DEFAULT_STALE_TIMEOUT_MS` to 2,700,000 (45 min) and `DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS` to 3,600,000 (60 min).
  - Improved cancellation errors in `checkAndInterruptStaleTasks` to mark them as FINAL and point to configuring `background_task.staleTimeoutMs` if needed.

<sup>Written for commit 0078b736b97cd3d99b59f3a1740b3de2a8135f6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

