### PR TITLE
docs: add Building in Public section to all READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,6 +4,15 @@
 > コアメンテナーのQが負傷したため、今週は Issue/PR への返信とリリースが遅れる可能性があります。
 > ご理解とご支援に感謝します。
 
+> [!TIP]
+> **Building in Public**
+>
+> メンテナーが Jobdori を使い、oh-my-opencode をリアルタイムで開発・メンテナンスしています。Jobdori は [OpenClaw](https://github.com/openclaw/openclaw) をベースに大幅カスタマイズされた AI アシスタントです。
+> すべての機能開発、修正、Issue トリアージを Discord でライブでご覧いただけます。
+>
+> [**→ #building-in-public で確認する**](https://discord.gg/PUwSMR9XNk)
+
+
 > [!NOTE]
 >
 > [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)

--- a/README.ko.md
+++ b/README.ko.md
@@ -5,6 +5,15 @@
 > 양해와 응원에 감사드립니다.
 
 > [!TIP]
+> **Building in Public**
+>
+> 메인테이너가 Jobdori를 통해 oh-my-opencode를 실시간으로 개발하고 있습니다. Jobdori는 [OpenClaw](https://github.com/openclaw/openclaw)를 기반으로 대폭 커스터마이징된 AI 어시스턴트입니다.
+> 모든 기능 개발, 버그 수정, 이슈 트리아지를 Discord에서 실시간으로 확인하세요.
+>
+> [**→ #building-in-public에서 확인하기**](https://discord.gg/PUwSMR9XNk)
+
+
+> [!TIP]
 > 저희와 함께 하세요!
 >
 > | [<img alt="Discord link" src="https://img.shields.io/discord/1452487457085063218?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square" width="156px" />](https://discord.gg/PUwSMR9XNk) | [Discord 커뮤니티](https://discord.gg/PUwSMR9XNk)에 가입하여 기여자 및 다른 `oh-my-opencode` 사용자들과 소통하세요. |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!TIP]
+> **Building in Public**
+>
+> The maintainer builds and maintains oh-my-opencode in real-time with Jobdori, an AI assistant built on a heavily customized fork of [OpenClaw](https://github.com/openclaw/openclaw).
+> Every feature, every fix, every issue triage — live in our Discord.
+>
+> [**→ Watch it happen in #building-in-public**](https://discord.gg/PUwSMR9XNk)
+
 > [!NOTE]
 >
 > [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)

--- a/README.ru.md
+++ b/README.ru.md
@@ -4,6 +4,15 @@
 > Ключевой мейнтейнер Q получил травму, поэтому на этой неделе ответы по issue/PR и релизы могут задерживаться.
 > Спасибо за терпение и поддержку.
 
+> [!TIP]
+> **Building in Public**
+>
+> Мейнтейнер разрабатывает и поддерживает oh-my-opencode в режиме реального времени с помощью Jobdori — ИИ-ассистента на базе глубоко кастомизированной версии [OpenClaw](https://github.com/openclaw/openclaw).
+> Каждая фича, каждый фикс, каждый триаж issue — в прямом эфире в нашем Discord.
+>
+> [**→ Смотрите в #building-in-public**](https://discord.gg/PUwSMR9XNk)
+
+
 > [!NOTE]
 >
 > [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -4,6 +4,15 @@
 > 核心维护者 Q 因受伤，本周 issue/PR 回复和发布可能会延迟。
 > 感谢你的耐心与支持。
 
+> [!TIP]
+> **Building in Public**
+>
+> 维护者正在使用 Jobdori 实时开发和维护 oh-my-opencode。Jobdori 是基于 [OpenClaw](https://github.com/openclaw/openclaw) 深度定制的 AI 助手。
+> 每个功能开发、每次修复、每次 Issue 分类，都在 Discord 上实时进行。
+>
+> [**→ 在 #building-in-public 频道中查看**](https://discord.gg/PUwSMR9XNk)
+
+
 > [!NOTE]
 >
 > [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)


### PR DESCRIPTION
## Summary
Add a **Building in Public** TIP box to all 5 README variants (EN, KO, JA, ZH-CN, RU).

## Changes
- New TIP box positioned above the waitlist section for maximum visibility
- Links to `#building-in-public` Discord channel where the maintainer develops oh-my-opencode in real-time with Jobdori
- Mentions [OpenClaw](https://github.com/openclaw/openclaw) as the base framework (noting it's heavily customized)

## Files Changed
- `README.md` (English)
- `README.ko.md` (Korean)
- `README.ja.md` (Japanese)
- `README.zh-cn.md` (Simplified Chinese)
- `README.ru.md` (Russian)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Building in Public" TIP box to all five READMEs (EN, KO, JA, ZH-CN, RU), placed above the waitlist for visibility. It links to the #building-in-public Discord channel and notes the maintainer uses Jobdori built on a heavily customized fork of `openclaw/openclaw`.

<sup>Written for commit b37b877c457ec10e20da19f2830af0d07ebd6046. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

