### PR TITLE
docs: remove OpenClaw hyperlink

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 > [!TIP]
 > **Building in Public**
 >
-> メンテナーが Jobdori を使い、oh-my-opencode をリアルタイムで開発・メンテナンスしています。Jobdori は [OpenClaw](https://github.com/openclaw/openclaw) をベースに大幅カスタマイズされた AI アシスタントです。
+> メンテナーが Jobdori を使い、oh-my-opencode をリアルタイムで開発・メンテナンスしています。Jobdori は OpenClaw をベースに大幅カスタマイズされた AI アシスタントです。
 > すべての機能開発、修正、Issue トリアージを Discord でライブでご覧いただけます。
 >
 > [![Building in Public](./.github/assets/building-in-public.png)](https://discord.gg/PUwSMR9XNk)

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 > [!TIP]
 > **Building in Public**
 >
-> 메인테이너가 Jobdori를 통해 oh-my-opencode를 실시간으로 개발하고 있습니다. Jobdori는 [OpenClaw](https://github.com/openclaw/openclaw)를 기반으로 대폭 커스터마이징된 AI 어시스턴트입니다.
+> 메인테이너가 Jobdori를 통해 oh-my-opencode를 실시간으로 개발하고 있습니다. Jobdori는 OpenClaw를 기반으로 대폭 커스터마이징된 AI 어시스턴트입니다.
 > 모든 기능 개발, 버그 수정, 이슈 트리아지를 Discord에서 실시간으로 확인하세요.
 >
 > [![Building in Public](./.github/assets/building-in-public.png)](https://discord.gg/PUwSMR9XNk)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > [!TIP]
 > **Building in Public**
 >
-> The maintainer builds and maintains oh-my-opencode in real-time with Jobdori, an AI assistant built on a heavily customized fork of [OpenClaw](https://github.com/openclaw/openclaw).
+> The maintainer builds and maintains oh-my-opencode in real-time with Jobdori, an AI assistant built on a heavily customized fork of OpenClaw.
 > Every feature, every fix, every issue triage — live in our Discord.
 >
 > [![Building in Public](./.github/assets/building-in-public.png)](https://discord.gg/PUwSMR9XNk)

--- a/README.ru.md
+++ b/README.ru.md
@@ -7,7 +7,7 @@
 > [!TIP]
 > **Building in Public**
 >
-> Мейнтейнер разрабатывает и поддерживает oh-my-opencode в режиме реального времени с помощью Jobdori — ИИ-ассистента на базе глубоко кастомизированной версии [OpenClaw](https://github.com/openclaw/openclaw).
+> Мейнтейнер разрабатывает и поддерживает oh-my-opencode в режиме реального времени с помощью Jobdori — ИИ-ассистента на базе глубоко кастомизированной версии OpenClaw.
 > Каждая фича, каждый фикс, каждый триаж issue — в прямом эфире в нашем Discord.
 >
 > [![Building in Public](./.github/assets/building-in-public.png)](https://discord.gg/PUwSMR9XNk)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -7,7 +7,7 @@
 > [!TIP]
 > **Building in Public**
 >
-> 维护者正在使用 Jobdori 实时开发和维护 oh-my-opencode。Jobdori 是基于 [OpenClaw](https://github.com/openclaw/openclaw) 深度定制的 AI 助手。
+> 维护者正在使用 Jobdori 实时开发和维护 oh-my-opencode。Jobdori 是基于 OpenClaw 深度定制的 AI 助手。
 > 每个功能开发、每次修复、每次 Issue 分类，都在 Discord 上实时进行。
 >
 > [![Building in Public](./.github/assets/building-in-public.png)](https://discord.gg/PUwSMR9XNk)


### PR DESCRIPTION
Remove hyperlink, keep plain text mention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `OpenClaw` link from the “Building in Public” note across all README translations. OpenClaw now appears as plain text for consistent, cleaner docs.

<sup>Written for commit b5e2ead4e19e0ca6421f50098e8da5b4fdf00b3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

