### PR TITLE
fix(permissions): ensure omo permission overrides take precedence over opencode defaults

### DIFF
--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -116,9 +116,9 @@ export function applyToolConfig(params: {
   }
 
   params.config.permission = {
+    ...(params.config.permission as Record<string, unknown>),
     webfetch: "allow",
     external_directory: "allow",
-    ...(params.config.permission as Record<string, unknown>),
     task: "deny",
   };
 }


### PR DESCRIPTION
## Problem

The spread order in `applyToolConfig` was incorrect:

```typescript
// Before (bug): omo's overrides get overwritten
params.config.permission = {
    external_directory: "allow",     // omo sets this
    ...(params.config.permission),    // opencode's "ask" OVERWRITES
    task: "deny",
};
```

opencode's `agent.ts` defaults `external_directory` to `"ask"`. Since the spread comes AFTER omo's value, it overwrites `"allow"` with `"ask"`.

This causes `write` and `edit` tools to hang indefinitely on headless `opencode serve` sessions — the permission prompt waits for TUI interaction that never comes.

## Fix

```typescript
// After (fix): omo's overrides always win
params.config.permission = {
    ...(params.config.permission),    // base config first
    external_directory: "allow",     // omo override wins
    task: "deny",
};
```

## Impact

- Fixes write/edit tool hangs in headless `opencode serve` mode
- Fixes CI/CD and automation pipelines using omo
- 1-line change, no behavioral difference for TUI users (already "allow")

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the permission merge in `applyToolConfig` so `omo` overrides take precedence over `opencode` defaults. This prevents write/edit tools from hanging in headless `opencode serve` by preserving `external_directory: "allow"` and `task: "deny"`.

<sup>Written for commit f9d354b63e168d616040bd0a3198a627a3a8a030. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

