### PR TITLE
fix(agents): preserve uiSelectedModel when agent override has no model (fixes #2351)

### DIFF
--- a/src/agents/builtin-agents/atlas-agent.ts
+++ b/src/agents/builtin-agents/atlas-agent.ts
@@ -39,7 +39,7 @@ export function maybeCreateAtlasConfig(input: {
   const atlasRequirement = AGENT_MODEL_REQUIREMENTS["atlas"]
 
   const atlasResolution = applyModelResolution({
-    uiSelectedModel: orchestratorOverride?.model ? undefined : uiSelectedModel,
+    uiSelectedModel: orchestratorOverride?.model !== undefined ? undefined : uiSelectedModel,
     userModel: orchestratorOverride?.model,
     requirement: atlasRequirement,
     availableModels,

--- a/src/agents/builtin-agents/general-agents.ts
+++ b/src/agents/builtin-agents/general-agents.ts
@@ -69,7 +69,7 @@ export function collectPendingBuiltinAgents(input: {
     const isPrimaryAgent = isFactory(source) && source.mode === "primary"
 
     let resolution = applyModelResolution({
-      uiSelectedModel: (isPrimaryAgent && !override?.model) ? uiSelectedModel : undefined,
+      uiSelectedModel: (isPrimaryAgent && override?.model === undefined) ? uiSelectedModel : undefined,
       userModel: override?.model,
       requirement,
       availableModels,

--- a/src/agents/builtin-agents/sisyphus-agent.ts
+++ b/src/agents/builtin-agents/sisyphus-agent.ts
@@ -52,7 +52,7 @@ export function maybeCreateSisyphusConfig(input: {
   if (disabledAgents.includes("sisyphus") || !meetsSisyphusAnyModelRequirement) return undefined
 
   let sisyphusResolution = applyModelResolution({
-    uiSelectedModel: sisyphusOverride?.model ? undefined : uiSelectedModel,
+    uiSelectedModel: sisyphusOverride?.model !== undefined ? undefined : uiSelectedModel,
     userModel: sisyphusOverride?.model,
     requirement: sisyphusRequirement,
     availableModels,


### PR DESCRIPTION
Fixes the second root cause from #2351 that PR #2670 missed.

Three agent builders used falsy checks that nullified uiSelectedModel:
- `sisyphusOverride?.model ?` → `sisyphusOverride?.model !== undefined ?`
- `orchestratorOverride?.model ?` → `orchestratorOverride?.model !== undefined ?`
- `!override?.model` → `override?.model === undefined`

Supersedes #2670.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `uiSelectedModel` when an agent override exists without a `model`, preventing unwanted resets to default models. Replaces falsy checks with explicit undefined checks in the atlas, sisyphus, and general agent builders, fixing #2351.

<sup>Written for commit d8fe61131c3baeb59d039503430933b31989e475. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

