### PR TITLE
fix(anthropic-recovery): clear session state after successful summarize (fixes #2225)

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.test.ts
@@ -98,9 +98,9 @@ describe("runSummarizeRetryStrategy", () => {
     }) as typeof setTimeout
 
     autoCompactState.retryStateBySession.set(sessionID, {
-      attempt: 1,
+      attempt: 0,
       lastAttemptTime: Date.now(),
-      firstAttemptTime: Date.now() - 119700,
+      firstAttemptTime: Date.now() - 119900,
     })
     summarizeMock.mockRejectedValueOnce(new Error("rate limited"))
 
@@ -117,6 +117,6 @@ describe("runSummarizeRetryStrategy", () => {
     //#then
     expect(timeoutCalls.length).toBe(1)
     expect(timeoutCalls[0]!.delay).toBeGreaterThan(0)
-    expect(timeoutCalls[0]!.delay).toBeLessThanOrEqual(500)
+    expect(timeoutCalls[0]!.delay).toBeLessThanOrEqual(300)
   })
 })

--- a/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.ts
@@ -114,6 +114,7 @@ export async function runSummarizeRetryStrategy(params: {
           body: summarizeBody as never,
           query: { directory: params.directory },
         })
+        clearSessionState(params.autoCompactState, params.sessionID)
         return
       } catch {
         const remainingTimeMs = SUMMARIZE_RETRY_TOTAL_TIMEOUT_MS - (Date.now() - retryState.firstAttemptTime)


### PR DESCRIPTION
Fixes the bugs found in review of PR #2671.

1. **CRITICAL**: Add missing `clearSessionState()` after successful summarize — retry state persisted after success
2. **MAJOR**: Fix timing-sensitive test (attempt: 0, adjusted firstAttemptTime)

Supersedes #2671.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears retry session state after a successful summarize in the Anthropic context-window recovery so we don’t keep retrying. Also fixes a flaky timing test. Fixes #2225.

- **Bug Fixes**
  - Added `clearSessionState()` after a successful summarize to prevent persisted retry state and unnecessary retries.
  - Updated test: set `attempt` to 0 and adjusted `firstAttemptTime`; tightened the max expected delay to ≤300ms.

<sup>Written for commit 69d0b23ab6a86ff90467e31991a7eba33a11f424. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

