### PR TITLE
fix(schema): strip contentEncoding from MCP tool schemas for Gemini (fixes #2200)

### DIFF
--- a/src/plugin/normalize-tool-arg-schemas.ts
+++ b/src/plugin/normalize-tool-arg-schemas.ts
@@ -40,3 +40,37 @@ export function normalizeToolArgSchemas<TDefinition extends Pick<ToolDefinition,
 
   return toolDefinition
 }
+
+// Schema keywords unsupported by Gemini — strip them from MCP tool schemas
+const UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["contentEncoding", "contentMediaType"])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function sanitizeJsonSchema(value: unknown, depth = 0, isPropertyName = false): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeJsonSchema(item, depth + 1, false))
+  }
+
+  if (!isRecord(value)) {
+    return value
+  }
+
+  const sanitized: Record<string, unknown> = {}
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (!isPropertyName && UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
+      continue
+    }
+
+    if (depth === 0 && key === "$schema") {
+      continue
+    }
+
+    const childIsPropertyName = key === "properties" && !isPropertyName
+    sanitized[key] = sanitizeJsonSchema(nestedValue, depth + 1, childIsPropertyName)
+  }
+
+  return sanitized
+}

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -7,6 +7,7 @@ import { getAllSkills, extractSkillTemplate, clearSkillCache } from "../../featu
 import { injectGitMasterConfig } from "../../features/opencode-skill-loader/skill-content"
 import type { SkillMcpManager, SkillMcpClientInfo, SkillMcpServerContext } from "../../features/skill-mcp-manager"
 import type { Tool, Resource, Prompt } from "@modelcontextprotocol/sdk/types.js"
+import { sanitizeJsonSchema } from "../../plugin/normalize-tool-arg-schemas"
 import { discoverCommandsSync } from "../slashcommand/command-discovery"
 import type { CommandInfo } from "../slashcommand/types"
 import { formatLoadedCommand } from "../slashcommand/command-output-formatter"
@@ -155,7 +156,7 @@ async function formatMcpCapabilities(
           sections.push("")
           sections.push("**inputSchema:**")
           sections.push("```json")
-          sections.push(JSON.stringify(t.inputSchema, null, 2))
+          sections.push(JSON.stringify(sanitizeJsonSchema(t.inputSchema), null, 2))
           sections.push("```")
           sections.push("")
         }


### PR DESCRIPTION
PR #2666 only sanitized omo plugin tools but MCP tool schemas bypassed it entirely.

This adds `sanitizeJsonSchema()` and applies it to MCP tool `inputSchema` in `formatMcpCapabilities`, fixing Gemini 400 errors from `contentEncoding` in MCP server schemas.

Supersedes #2666.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes MCP tool input schemas to remove unsupported JSON Schema fields before sending to Gemini, preventing 400 errors. Applies the same cleanup to MCP tools that we already use for plugin tools.

- **Bug Fixes**
  - Added `sanitizeJsonSchema` to strip `contentEncoding`, `contentMediaType`, and root `$schema`.
  - Applied sanitization when serializing MCP tool `inputSchema` in `formatMcpCapabilities`.
  - Fixes Gemini 400s from MCP server schemas; fixes #2200.

<sup>Written for commit 5e856b4fde3e760228b5ba77e01d7f48316f0be7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

