### PR TITLE
fix(circuit-breaker): treat unknown tool input as non-comparable to prevent false positives on flat events

### DIFF
--- a/src/features/background-agent/loop-detector.test.ts
+++ b/src/features/background-agent/loop-detector.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, test } from "bun:test"
 import {
   createToolCallSignature,
@@ -19,7 +21,7 @@ function buildWindow(
 }
 
 function buildWindowWithInputs(
-  calls: Array<{ tool: string; input?: Record<string, unknown> }>,
+  calls: Array<{ tool: string; input?: Record<string, unknown> | null }>,
   override?: Parameters<typeof resolveCircuitBreakerSettings>[0]
 ) {
   const settings = resolveCircuitBreakerSettings(override)
@@ -148,7 +150,12 @@ describe("loop-detector", () => {
 
     describe("#given the same tool is called consecutively", () => {
       test("#when evaluated #then it triggers", () => {
-        const window = buildWindow(Array.from({ length: 20 }, () => "read"))
+        const window = buildWindowWithInputs(
+          Array.from({ length: 20 }, () => ({
+            tool: "read",
+            input: { filePath: "/src/same.ts" },
+          }))
+        )
 
         const result = detectRepetitiveToolUse(window)
 
@@ -176,7 +183,12 @@ describe("loop-detector", () => {
 
     describe("#given threshold boundary", () => {
       test("#when below threshold #then it does not trigger", () => {
-        const belowThresholdWindow = buildWindow(Array.from({ length: 19 }, () => "read"))
+        const belowThresholdWindow = buildWindowWithInputs(
+          Array.from({ length: 19 }, () => ({
+            tool: "read",
+            input: { filePath: "/src/same.ts" },
+          }))
+        )
 
         const result = detectRepetitiveToolUse(belowThresholdWindow)
 
@@ -184,7 +196,12 @@ describe("loop-detector", () => {
       })
 
       test("#when equal to threshold #then it triggers", () => {
-        const atThresholdWindow = buildWindow(Array.from({ length: 20 }, () => "read"))
+        const atThresholdWindow = buildWindowWithInputs(
+          Array.from({ length: 20 }, () => ({
+            tool: "read",
+            input: { filePath: "/src/same.ts" },
+          }))
+        )
 
         const result = detectRepetitiveToolUse(atThresholdWindow)
 
@@ -224,16 +241,22 @@ describe("loop-detector", () => {
       })
     })
 
-    describe("#given tool calls with no input", () => {
-      test("#when evaluated #then it triggers", () => {
+    describe("#given tool calls with undefined input", () => {
+      test("#when evaluated #then it does not trigger", () => {
         const calls = Array.from({ length: 20 }, () => ({ tool: "read" }))
         const window = buildWindowWithInputs(calls)
         const result = detectRepetitiveToolUse(window)
-        expect(result).toEqual({
-          triggered: true,
-          toolName: "read",
-          repeatedCount: 20,
-        })
+        expect(result).toEqual({ triggered: false })
+      })
+    })
+
+    describe("#given tool calls with null input", () => {
+      test("#when evaluated #then it does not trigger", () => {
+        const calls = Array.from({ length: 20 }, () => ({ tool: "read", input: null }))
+        const window = buildWindowWithInputs(calls)
+        const result = detectRepetitiveToolUse(window)
+
+        expect(result).toEqual({ triggered: false })
       })
     })
   })

--- a/src/features/background-agent/loop-detector.ts
+++ b/src/features/background-agent/loop-detector.ts
@@ -36,6 +36,14 @@ export function recordToolCall(
   settings: CircuitBreakerSettings,
   toolInput?: Record<string, unknown> | null
 ): ToolCallWindow {
+  if (toolInput === undefined || toolInput === null) {
+    return {
+      lastSignature: `${toolName}::__unknown-input__`,
+      consecutiveCount: 1,
+      threshold: settings.consecutiveThreshold,
+    }
+  }
+
   const signature = createToolCallSignature(toolName, toolInput)
 
   if (window && window.lastSignature === signature) {

--- a/src/features/background-agent/manager-circuit-breaker.test.ts
+++ b/src/features/background-agent/manager-circuit-breaker.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, test } from "bun:test"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { tmpdir } from "node:os"
@@ -38,8 +40,8 @@ async function flushAsyncWork() {
 }
 
 describe("BackgroundManager circuit breaker", () => {
-  describe("#given the same tool is called consecutively", () => {
-    test("#when consecutive tool events arrive #then the task is cancelled", async () => {
+  describe("#given flat-format tool events have no state.input", () => {
+    test("#when 20 consecutive read events arrive #then the task keeps running", async () => {
       const manager = createManager({
         circuitBreaker: {
           consecutiveThreshold: 20,
@@ -71,8 +73,8 @@ describe("BackgroundManager circuit breaker", () => {
 
       await flushAsyncWork()
 
-      expect(task.status).toBe("cancelled")
-      expect(task.error).toContain("read 20 consecutive times")
+      expect(task.status).toBe("running")
+      expect(task.progress?.toolCalls).toBe(20)
     })
   })
 
@@ -126,7 +128,7 @@ describe("BackgroundManager circuit breaker", () => {
   })
 
   describe("#given the absolute cap is configured lower than the repetition detector needs", () => {
-    test("#when the raw tool-call cap is reached #then the backstop still cancels the task", async () => {
+    test("#when repeated flat-format tool events reach maxToolCalls #then the backstop still cancels the task", async () => {
       const manager = createManager({
         maxToolCalls: 3,
         circuitBreaker: {
@@ -150,10 +152,10 @@ describe("BackgroundManager circuit breaker", () => {
       }
       getTaskMap(manager).set(task.id, task)
 
-      for (const toolName of ["read", "grep", "edit"]) {
+      for (let i = 0; i < 3; i++) {
         manager.handleEvent({
           type: "message.part.updated",
-          properties: { sessionID: task.sessionID, type: "tool", tool: toolName },
+          properties: { sessionID: task.sessionID, type: "tool", tool: "read" },
         })
       }
 


### PR DESCRIPTION
## Summary

- Fix remaining circuit breaker false positives after #2655 + refactor `d48ea025`, specifically when events arrive in flat format without `state.input`
- Unknown tool input (`undefined`/`null`) is now treated as non-comparable — consecutive counter resets to 1 each time, instead of accumulating on bare tool name signatures

## Context

#2655 introduced target-aware signatures (`toolName::sortedJson(input)`) to fix false-positive cancellations. Then `d48ea025` refactored detection from sliding-window to consecutive-count. Both changes are correct individually, but together they leave a gap:

`createToolCallSignature()` falls back to bare tool name when `toolInput` is `undefined`/`null`:

```typescript
if (toolInput === undefined || toolInput === null) {
  return toolName  // bare "read" — all flat-format calls look identical
}
```

This matters because `resolveMessagePartInfo()` has two event paths:

| Path | Condition | `state.input` | Signature |
|------|-----------|---------------|-----------|
| A (nested) | `properties.part` exists | ✅ present | `read::{"filePath":"/a.ts"}` — differentiates |
| B (flat) | no `properties.part` | ❌ undefined | `read` — bare, all calls "identical" |

With consecutive-count detection, 20 flat-format `read` events (reading 20 different files) all produce signature `"read"`, hitting the threshold. This is the exact scenario reported in #2652 — agents like Oracle/Explore/Librarian doing legitimate multi-file reads get cancelled.

## Changes

**`src/features/background-agent/loop-detector.ts`**

Early return in `recordToolCall()` when `toolInput` is `undefined`/`null`: returns a unique sentinel signature (`toolName::__unknown-input__`) with `consecutiveCount: 1`. This means:

- **Unknown input** → counter never accumulates → no false positive
- **Known identical input** → existing signature logic → still detects true loops
- **Absolute `maxToolCalls` cap** → unaffected, still catches runaway agents

**`src/features/background-agent/loop-detector.test.ts`**

- Updated consecutive-trigger tests to use known input (matching real loop behavior)
- Added tests: 20 calls with `undefined` input → does NOT trigger
- Added tests: 20 calls with `null` input → does NOT trigger

**`src/features/background-agent/manager-circuit-breaker.test.ts`**

- Updated flat-format event test: 20 consecutive `read` events without `state.input` → task keeps running
- Strengthened absolute cap test with repeated flat-format events hitting `maxToolCalls`

## Testing

```bash
bun test src/features/background-agent/loop-detector.test.ts        # 18 pass
bun test src/features/background-agent/manager-circuit-breaker.test.ts  # 8 pass
bun run typecheck  # clean
```

## Related Issues

Follow-up to #2655 / #2652

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes circuit breaker false positives on flat-format tool events with no input. Unknown tool input is now treated as non-comparable, so consecutive counts reset and valid multi-file reads aren’t cancelled.

- **Bug Fixes**
  - In `recordToolCall()`, `undefined`/`null` input returns `toolName::__unknown-input__` with `consecutiveCount = 1`.
  - Keeps loop detection for identical known inputs; `maxToolCalls` backstop unchanged.
  - Updated tests for undefined/null input and flat-format events; threshold tests now use known input.

<sup>Written for commit b9fa2a3ebc8a281ef1e6aa3e428e36f5286a69af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

