### PR TITLE
fix(plugin): preserve selected model across messages

### DIFF
--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -7,8 +7,10 @@ import * as shared from "../shared"
 import * as sisyphusJunior from "../agents/sisyphus-junior"
 import type { OhMyOpenCodeConfig } from "../config"
 import * as agentLoader from "../features/claude-code-agent-loader"
+import * as sessionState from "../features/claude-code-session-state"
 import * as skillLoader from "../features/opencode-skill-loader"
 import { getAgentDisplayName } from "../shared/agent-display-names"
+import * as sessionModelState from "../shared/session-model-state"
 import { applyAgentConfig } from "./agent-config-handler"
 import type { PluginComponents } from "./plugin-components-loader"
 
@@ -53,6 +55,8 @@ describe("applyAgentConfig builtin override protection", () => {
   let discoverOpencodeProjectSkillsSpy: ReturnType<typeof spyOn>
   let loadUserAgentsSpy: ReturnType<typeof spyOn>
   let loadProjectAgentsSpy: ReturnType<typeof spyOn>
+  let getMainSessionIDSpy: ReturnType<typeof spyOn>
+  let getSessionModelSpy: ReturnType<typeof spyOn>
   let migrateAgentConfigSpy: ReturnType<typeof spyOn>
   let logSpy: ReturnType<typeof spyOn>
 
@@ -123,6 +127,8 @@ describe("applyAgentConfig builtin override protection", () => {
 
     loadUserAgentsSpy = spyOn(agentLoader, "loadUserAgents").mockReturnValue({})
     loadProjectAgentsSpy = spyOn(agentLoader, "loadProjectAgents").mockReturnValue({})
+    getMainSessionIDSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(undefined)
+    getSessionModelSpy = spyOn(sessionModelState, "getSessionModel").mockReturnValue(undefined)
 
     migrateAgentConfigSpy = spyOn(shared, "migrateAgentConfig").mockImplementation(
       (config: Record<string, unknown>) => config,
@@ -140,6 +146,8 @@ describe("applyAgentConfig builtin override protection", () => {
     discoverOpencodeProjectSkillsSpy.mockRestore()
     loadUserAgentsSpy.mockRestore()
     loadProjectAgentsSpy.mockRestore()
+    getMainSessionIDSpy.mockRestore()
+    getSessionModelSpy.mockRestore()
     migrateAgentConfigSpy.mockRestore()
     logSpy.mockRestore()
   })
@@ -164,6 +172,56 @@ describe("applyAgentConfig builtin override protection", () => {
 
     // then
     expect(result[BUILTIN_SISYPHUS_DISPLAY_NAME]).toEqual(builtinSisyphusConfig)
+  })
+
+  test("reuses the main session model when config.model is missing", async () => {
+    // given
+    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+      mock: { calls: unknown[][] }
+    }
+    getMainSessionIDSpy.mockReturnValue("ses_main")
+    getSessionModelSpy.mockReturnValue({ providerID: "openai", modelID: "gpt-5.4" })
+
+    const config: Record<string, unknown> = {
+      agent: {},
+    }
+
+    // when
+    await applyAgentConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    expect(createBuiltinAgentsMock.mock.calls).toHaveLength(1)
+    expect(createBuiltinAgentsMock.mock.calls[0]?.[3]).toBe("openai/gpt-5.4")
+    expect(createBuiltinAgentsMock.mock.calls[0]?.[9]).toBe("openai/gpt-5.4")
+  })
+
+  test("prefers config.model over the persisted main session model when both exist", async () => {
+    // given
+    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+      mock: { calls: unknown[][] }
+    }
+    getMainSessionIDSpy.mockReturnValue("ses_main")
+    getSessionModelSpy.mockReturnValue({ providerID: "openai", modelID: "gpt-5.4" })
+
+    const config = createBaseConfig()
+
+    // when
+    await applyAgentConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    expect(createBuiltinAgentsMock.mock.calls).toHaveLength(1)
+    expect(createBuiltinAgentsMock.mock.calls[0]?.[3]).toBe("anthropic/claude-opus-4-6")
+    expect(createBuiltinAgentsMock.mock.calls[0]?.[9]).toBe("anthropic/claude-opus-4-6")
   })
 
   test("filters user agents whose key differs from a builtin key only by case", async () => {

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -2,8 +2,10 @@ import { createBuiltinAgents } from "../agents";
 import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
 import type { OhMyOpenCodeConfig } from "../config";
 import { log, migrateAgentConfig } from "../shared";
+import { getMainSessionID } from "../features/claude-code-session-state";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { getAgentDisplayName } from "../shared/agent-display-names";
+import { getSessionModel } from "../shared/session-model-state";
 import {
   discoverConfigSourceSkills,
   discoverOpencodeGlobalSkills,
@@ -26,6 +28,28 @@ type AgentConfigRecord = Record<string, Record<string, unknown> | undefined> & {
   build?: Record<string, unknown>;
   plan?: Record<string, unknown>;
 };
+
+function resolveCurrentModel(config: Record<string, unknown>): string | undefined {
+  const configModel = config.model;
+  if (typeof configModel === "string") {
+    const trimmedModel = configModel.trim();
+    if (trimmedModel.length > 0) {
+      return trimmedModel;
+    }
+  }
+
+  const mainSessionID = getMainSessionID();
+  if (!mainSessionID) {
+    return undefined;
+  }
+
+  const sessionModel = getSessionModel(mainSessionID);
+  if (!sessionModel?.providerID || !sessionModel.modelID) {
+    return undefined;
+  }
+
+  return `${sessionModel.providerID}/${sessionModel.modelID}`;
+}
 
 function getConfiguredDefaultAgent(config: Record<string, unknown>): string | undefined {
   const defaultAgent = config.default_agent;
@@ -77,7 +101,7 @@ export async function applyAgentConfig(params: {
 
   const browserProvider =
     params.pluginConfig.browser_automation_engine?.provider ?? "playwright";
-  const currentModel = params.config.model as string | undefined;
+  const currentModel = resolveCurrentModel(params.config);
   const disabledSkills = new Set<string>(params.pluginConfig.disabled_skills ?? []);
   const useTaskSystem = params.pluginConfig.experimental?.task_system ?? false;
   const disableOmoEnv = params.pluginConfig.experimental?.disable_omo_env ?? false;


### PR DESCRIPTION
## Summary
- Reuse the current main session's selected model during config-time agent rebuilds when `config.model` is missing.
- Keep explicit `config.model` precedence unchanged, so direct UI-provided model selections still win when present.
- Add regressions proving primary-agent config loading falls back to persisted session model instead of snapping back to the default model.

## Verification
- `bun test src/plugin-handlers/agent-config-handler.test.ts`
- `bun test src/plugin-handlers/config-handler.test.ts src/plugin/chat-message.test.ts`
- `bun run typecheck`
- `bun run build`

## Context
- This addresses the same general class as #2788, but a different gap: later config-time agent rebuilds were ignoring session-scoped model state when `config.model` was absent.
- Fixes #2353


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the user's selected model across messages by reusing the main session model during agent rebuilds when `config.model` is missing, fixing #2353. Explicit `config.model` still takes precedence.

- **Bug Fixes**
  - Added `resolveCurrentModel` to prefer `config.model`, else fall back to the main session model from `getMainSessionID` and `getSessionModel`.
  - Updated `applyAgentConfig` to use the resolved model so sessions don’t snap back to the default after each send.
  - Added tests to cover session model reuse and precedence over `config.model`.

<sup>Written for commit bad70f5e24b8e5622ae42ff4e2afdf88d799975d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

