### PR TITLE
fix(category-resolver): respect is_unstable_agent config override (fixes #2061)

### DIFF
--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -188,7 +188,7 @@ Available categories: ${categoryNames.join(", ")}`,
   }
 
   const resolvedModel = actualModel?.toLowerCase()
-  const isUnstableAgent = resolved.config.is_unstable_agent === true || (resolvedModel ? resolvedModel.includes("gemini") || resolvedModel.includes("minimax") || resolvedModel.includes("kimi") : false)
+  const isUnstableAgent = resolved.config.is_unstable_agent ?? (resolvedModel ? resolvedModel.includes("gemini") || resolvedModel.includes("minimax") || resolvedModel.includes("kimi") : false)
 
   const defaultProviderID = categoryModel?.providerID
     ?? parseModelString(actualModel ?? "")?.providerID


### PR DESCRIPTION
## Summary
- Allow `is_unstable_agent: false` to override automatic model-name-based unstable detection for Gemini/Minimax/Kimi categories

## Problem
The `isUnstableAgent` flag in `category-resolver.ts` uses a boolean OR (`||`) that unconditionally overrides explicit user configuration. When a user sets `is_unstable_agent: false` in their category config, the model name check (`includes("gemini")`) still forces `isUnstableAgent = true`. This routes all Gemini/Minimax/Kimi categories to the broken `executeUnstableAgentTask()` path, causing tasks to fail with 30-second timeouts.

Because `false || true === true`, the config option is completely non-functional.

## Fix
Replaced `||` with nullish coalescing (`??`) so that explicit user configuration takes priority:

- `is_unstable_agent: true` forces unstable path
- `is_unstable_agent: false` forces stable path
- `undefined` (no config) auto-detects from model name (preserves current default behavior)

## Changes
| File | Change |
|------|--------|
| `src/tools/delegate-task/category-resolver.ts` | Changed `=== true ||` to `??` for `isUnstableAgent` computation |

Fixes #2061

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect `is_unstable_agent` in the category resolver so explicit `false` is honored, preventing Gemini/Minimax/Kimi categories from being forced into the unstable path and timing out. Fixes #2061.

- **Bug Fixes**
  - Use nullish coalescing (`??`) instead of `||` to compute `isUnstableAgent`, so `true/false` config is respected.
  - Keep default behavior: when unset, auto-detect from model name (`gemini`, `minimax`, `kimi`).

<sup>Written for commit 41a43c62fce66b6ee90679ea094332e3bfd1c73c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

