### PR TITLE
fix(background-task): register fallback chain for background sessions (fixes #2203)

### DIFF
--- a/src/tools/delegate-task/background-task.ts
+++ b/src/tools/delegate-task/background-task.ts
@@ -8,6 +8,7 @@ import { formatDetailedError } from "./error-formatting"
 import { getSessionTools } from "../../shared/session-tools-store"
 import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { QUESTION_DENIED_SESSION_PERMISSION } from "../../shared/question-denied-session-permission"
+import { setSessionFallbackChain } from "../../hooks/model-fallback/hook"
 
 export async function executeBackgroundTask(
   args: DelegateTaskArgs,
@@ -56,6 +57,9 @@ export async function executeBackgroundTask(
       sessionId = updated?.sessionID
     }
 
+    if (sessionId) {
+      setSessionFallbackChain(sessionId, fallbackChain)
+    }
     if (args.category && sessionId) {
       SessionCategoryRegistry.register(sessionId, args.category)
     }


### PR DESCRIPTION
## Summary
- Register user-configured fallback_models for background task sessions so runtime-fallback uses the correct chain

## Problem
When a background task encounters a model error (rate limit, quota, etc.), the runtime-fallback hook checks `sessionFallbackChains.get(sessionID)` to find the user's configured fallback models. For background tasks, this map entry was never set because `executeBackgroundTask()` passes the `fallbackChain` to `manager.launch()` as input but never calls `setSessionFallbackChain()` to register it.

In `sync-task.ts` (line 66), `setSessionFallbackChain(sessionID, fallbackChain)` is called after session creation. Background tasks lacked this call, causing `sessionFallbackChains.get(sessionID)` to return `undefined`. The fallback hook then falls through to the hardcoded `requirements?.fallbackChain` instead of using the user's configured `fallback_models`.

## Fix
Added `setSessionFallbackChain(sessionId, fallbackChain)` call in `executeBackgroundTask()` after the session ID becomes available (after the wait-for-session loop), matching the pattern used in `executeSyncTask()`.

## Changes
| File | Change |
|------|--------|
| `src/tools/delegate-task/background-task.ts` | Import `setSessionFallbackChain`, call it after session ID is resolved |

Fixes #2203

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Register the user-configured fallback chain for background task sessions so runtime fallback uses the correct models. Fixes #2203.

- **Bug Fixes**
  - Background tasks didn’t register `fallbackChain`, causing fallback to use defaults.
  - After resolving `sessionId`, call `setSessionFallbackChain(sessionId, fallbackChain)` in `executeBackgroundTask()` (mirrors sync path).

<sup>Written for commit d2d48fc9ff88c4da4dcc38cebf7378ba57361d08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

