### PR TITLE
fix(tool-execute-before): strip null bytes from bash commands to prevent crash (fixes #2220)

### DIFF
--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -41,6 +41,16 @@ export function createToolExecuteBeforeHandler(args: {
   }
 
   return async (input, output): Promise<void> => {
+    if (input.tool.toLowerCase() === "bash" && typeof output.args.command === "string") {
+      if (output.args.command.includes("\x00")) {
+        output.args.command = output.args.command.replace(/\x00/g, "")
+        log("[tool-execute-before] Stripped null bytes from bash command", {
+          sessionID: input.sessionID,
+          callID: input.callID,
+        })
+      }
+    }
+
     await hooks.writeExistingFileGuard?.["tool.execute.before"]?.(input, output)
     await hooks.questionLabelTruncator?.["tool.execute.before"]?.(input, output)
     await hooks.claudeCodeHooks?.["tool.execute.before"]?.(input, output)


### PR DESCRIPTION
## Summary
- Sanitize null bytes from bash tool command arguments before execution to prevent shell process crashes

## Problem
When context compaction or model fallback occurs, the LLM can hallucinate null bytes (\x00) in tool call arguments. Node.js child_process rejects these with: `The shell argument must be a string without null bytes. Received "\0"`. This crashes the bash tool and leaves the session in an error state.

This affects long-running sessions with context management features enabled (aggressive_truncation, preemptive_compaction, dynamic_context_pruning) and model fallback chains.

## Fix
Added null byte sanitization at the very beginning of the `tool.execute.before` handler chain in `tool-execute-before.ts`. When the tool is `bash` and the command string contains null bytes, they are stripped before any other hooks process the command. A log entry is emitted for debugging.

This runs before all other hooks to ensure clean input for downstream processing.

## Changes
| File | Change |
|------|--------|
| `src/plugin/tool-execute-before.ts` | Added null byte detection and removal for bash commands at the top of the handler chain |

Fixes #2220

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes null bytes from `bash` tool commands before execution to stop Node `child_process` from rejecting the shell args and crashing. This prevents session failures when models emit `\x00` during context compaction or fallback. Fixes #2220.

- **Bug Fixes**
  - Sanitizes `bash` command strings in the earliest `tool.execute.before` handler by stripping `\x00`, and logs the event for debugging.

<sup>Written for commit c56a01c15de7d5d1541083e619281f0da7a8d42c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

