### PR TITLE
fix(hashline-edit): scope formatter cache by directory

### DIFF
--- a/src/tools/hashline-edit/formatter-trigger-cache.test.ts
+++ b/src/tools/hashline-edit/formatter-trigger-cache.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+
+import { clearFormatterCache, resolveFormatters, type FormatterClient } from "./formatter-trigger"
+
+function createDirectoryAwareClient(
+  resolveConfig: (directory: string) => Promise<Record<string, unknown> | undefined>,
+): FormatterClient {
+  return {
+    config: {
+      get: mock(async ({ query }: { query?: { directory?: string } } = {}) => ({
+        data: await resolveConfig(query?.directory ?? ""),
+      })),
+    },
+  }
+}
+
+describe("resolveFormatters cache behavior", () => {
+  beforeEach(() => {
+    clearFormatterCache()
+  })
+
+  it("caches formatter resolution per directory", async () => {
+    //#given
+    const client = createDirectoryAwareClient(async (directory) => {
+      if (directory === "/project-a") {
+        return {
+          formatter: {
+            prettier: {
+              command: ["prettier", "--write", "$FILE"],
+              extensions: [".ts"],
+            },
+          },
+        }
+      }
+
+      return {
+        formatter: {
+          biome: {
+            command: ["biome", "format", "$FILE"],
+            extensions: [".ts"],
+          },
+        },
+      }
+    })
+
+    //#when
+    const firstProjectAResult = await resolveFormatters(client, "/project-a")
+    const projectBResult = await resolveFormatters(client, "/project-b")
+    const secondProjectAResult = await resolveFormatters(client, "/project-a")
+
+    //#then
+    expect(client.config.get).toHaveBeenCalledTimes(2)
+    expect(firstProjectAResult.get(".ts")?.[0]?.command).toEqual(["prettier", "--write", "$FILE"])
+    expect(projectBResult.get(".ts")?.[0]?.command).toEqual(["biome", "format", "$FILE"])
+    expect(secondProjectAResult).toBe(firstProjectAResult)
+  })
+
+  it("does not cache transient config fetch failures", async () => {
+    //#given
+    const get = mock(async () => ({
+      data: {
+        formatter: {
+          prettier: {
+            command: ["prettier", "--write", "$FILE"],
+            extensions: [".ts"],
+          },
+        },
+      },
+    }))
+
+    get.mockImplementationOnce(async () => {
+      throw new Error("network error")
+    })
+
+    const client: FormatterClient = {
+      config: { get },
+    }
+
+    //#when
+    const firstResult = await resolveFormatters(client, "/project-a")
+    const secondResult = await resolveFormatters(client, "/project-a")
+
+    //#then
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(firstResult.size).toBe(0)
+    expect(secondResult.get(".ts")?.[0]?.command).toEqual(["prettier", "--write", "$FILE"])
+  })
+
+  it("does not cache missing config data", async () => {
+    //#given
+    let callCount = 0
+    const client = createDirectoryAwareClient(async () => {
+      callCount += 1
+      if (callCount === 1) {
+        return undefined
+      }
+
+      return {
+        formatter: {
+          prettier: {
+            command: ["prettier", "--write", "$FILE"],
+            extensions: [".ts"],
+          },
+        },
+      }
+    })
+
+    //#when
+    const firstResult = await resolveFormatters(client, "/project-a")
+    const secondResult = await resolveFormatters(client, "/project-a")
+
+    //#then
+    expect(client.config.get).toHaveBeenCalledTimes(2)
+    expect(firstResult.size).toBe(0)
+    expect(secondResult.get(".ts")?.[0]?.command).toEqual(["prettier", "--write", "$FILE"])
+  })
+})

--- a/src/tools/hashline-edit/formatter-trigger.ts
+++ b/src/tools/hashline-edit/formatter-trigger.ts
@@ -25,15 +25,24 @@ export interface FormatterClient {
   }
 }
 
-let cachedFormatters: Map<string, Array<{ command: string[]; environment: Record<string, string> }>> | null = null
+type FormatterDefinition = { command: string[]; environment: Record<string, string> }
+type FormatterMap = Map<string, FormatterDefinition[]>
+
+const cachedFormattersByDirectory = new Map<string, FormatterMap>()
+
+function getFormatterCacheKey(directory: string): string {
+  return path.resolve(directory)
+}
 
 export async function resolveFormatters(
   client: FormatterClient,
   directory: string,
-): Promise<Map<string, Array<{ command: string[]; environment: Record<string, string> }>>> {
+): Promise<FormatterMap> {
+  const cacheKey = getFormatterCacheKey(directory)
+  const cachedFormatters = cachedFormattersByDirectory.get(cacheKey)
   if (cachedFormatters) return cachedFormatters
 
-  const result = new Map<string, Array<{ command: string[]; environment: Record<string, string> }>>()
+  const result = new Map<string, FormatterDefinition[]>()
 
   try {
     const response = await client.config.get({ query: { directory } })
@@ -68,11 +77,12 @@ export async function resolveFormatters(
         result.set(normalizedExt, existing)
       }
     }
+
+    cachedFormattersByDirectory.set(cacheKey, result)
   } catch (error) {
     log("[formatter-trigger] Failed to fetch formatter config", { error })
   }
 
-  cachedFormatters = result
   return result
 }
 
@@ -118,5 +128,5 @@ export async function runFormattersForFile(
 }
 
 export function clearFormatterCache(): void {
-  cachedFormatters = null
+  cachedFormattersByDirectory.clear()
 }


### PR DESCRIPTION
## Problem
The hashline formatter cache used a single global variable not keyed by directory. The first project's formatters won for all subsequent projects in the same process. Transient config failures were also cached permanently.

## Fix
- Key the formatter cache by project directory
- Don't cache transient config.get() failures
- Added regression test for multi-project isolation

## Review
All 5 review-work lanes passed (goal, QA, code quality, security, context mining).
Tests passed, typecheck passed, build passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the hashline formatter cache by project directory and avoids caching transient config failures. This prevents one project's formatter settings from affecting others in the same process.

- **Bug Fixes**
  - Cache formatters per normalized directory to isolate projects.
  - Do not cache when `config.get()` errors or returns no data; retry on next call.
  - Added tests for multi-project isolation and non-caching of failures.

<sup>Written for commit 6da4d2dae0ba9cceb6a2456ff911f49257b2ce0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

