### PR TITLE
fix(config): prefer canonical plugin config filenames

### DIFF
--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -166,7 +166,7 @@ export function loadPluginConfig(
   const userConfigPath =
     userDetected.format !== "none"
       ? userDetected.path
-      : path.join(configDir, "oh-my-openagent.json");
+      : path.join(configDir, "oh-my-opencode.json");
 
   // Project-level config path - prefer .jsonc over .json
   const projectBasePath = path.join(directory, ".opencode");
@@ -174,7 +174,7 @@ export function loadPluginConfig(
   const projectConfigPath =
     projectDetected.format !== "none"
       ? projectDetected.path
-      : path.join(projectBasePath, "oh-my-openagent.json");
+      : path.join(projectBasePath, "oh-my-opencode.json");
 
   // Load user config first (base)
   let config: OhMyOpenCodeConfig =

--- a/src/shared/jsonc-parser.test.ts
+++ b/src/shared/jsonc-parser.test.ts
@@ -268,7 +268,7 @@ describe("detectConfigFile", () => {
 describe("detectPluginConfigFile", () => {
   const testDir = join(__dirname, ".test-detect-plugin")
 
-  test("prefers oh-my-openagent over oh-my-opencode", () => {
+  test("prefers oh-my-opencode over oh-my-openagent", () => {
     // given
     if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
     writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}")
@@ -279,7 +279,7 @@ describe("detectPluginConfigFile", () => {
 
     // then
     expect(result.format).toBe("jsonc")
-    expect(result.path).toBe(join(testDir, "oh-my-openagent.jsonc"))
+    expect(result.path).toBe(join(testDir, "oh-my-opencode.jsonc"))
 
     rmSync(testDir, { recursive: true, force: true })
   })
@@ -324,23 +324,23 @@ describe("detectPluginConfigFile", () => {
 
     // then
     expect(result.format).toBe("none")
-    expect(result.path).toBe(join(emptyDir, "oh-my-openagent.json"))
+    expect(result.path).toBe(join(emptyDir, "oh-my-opencode.json"))
 
     rmSync(testDir, { recursive: true, force: true })
   })
 
-  test("prefers oh-my-openagent.json over oh-my-opencode.jsonc", () => {
+  test("prefers oh-my-opencode.json over oh-my-openagent.jsonc", () => {
     // given
     if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    writeFileSync(join(testDir, "oh-my-openagent.json"), "{}")
-    writeFileSync(join(testDir, "oh-my-opencode.jsonc"), "{}")
+    writeFileSync(join(testDir, "oh-my-opencode.json"), "{}")
+    writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}")
 
     // when
     const result = detectPluginConfigFile(testDir)
 
     // then
     expect(result.format).toBe("json")
-    expect(result.path).toBe(join(testDir, "oh-my-openagent.json"))
+    expect(result.path).toBe(join(testDir, "oh-my-opencode.json"))
 
     rmSync(testDir, { recursive: true, force: true })
   })

--- a/src/shared/jsonc-parser.ts
+++ b/src/shared/jsonc-parser.ts
@@ -66,7 +66,7 @@ export function detectConfigFile(basePath: string): {
   return { format: "none", path: jsonPath }
 }
 
-const PLUGIN_CONFIG_NAMES = ["oh-my-openagent", "oh-my-opencode"] as const
+const PLUGIN_CONFIG_NAMES = ["oh-my-opencode", "oh-my-openagent"] as const
 
 export function detectPluginConfigFile(dir: string): {
   format: "json" | "jsonc" | "none"


### PR DESCRIPTION
## Problem
`detectPluginConfigFile()` preferred `oh-my-openagent.json` over `oh-my-opencode.jsonc` (name before extension), while writers/installers canonicalize to `oh-my-opencode`. Users with both files got unpredictable behavior.

## Fix
- Ensure `oh-my-opencode` filenames always take precedence over legacy `oh-my-openagent` filenames regardless of extension ordering
- Added regression tests for canonical-vs-legacy mixed-extension precedence

## Review
All 5 review-work lanes passed (goal, QA, code quality, security, context mining).
Tests passed, typecheck passed, build passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer canonical `oh-my-opencode` plugin config files over legacy `oh-my-openagent`, regardless of `.json` vs `.jsonc`. This aligns readers with the writer/installer and removes confusion when both files exist.

- **Bug Fixes**
  - Reordered detection so `oh-my-opencode` always wins for both extensions.
  - Updated default fallbacks to `oh-my-opencode.json` for user and project configs.
  - Added regression tests for mixed-extension precedence.

<sup>Written for commit 32035d153e0bf44e7cbdaa2692205c9b061162f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

