### PR TITLE
fix(plugin): restore permission merge order precedence

### DIFF
--- a/src/plugin-handlers/tool-config-handler.test.ts
+++ b/src/plugin-handlers/tool-config-handler.test.ts
@@ -23,6 +23,36 @@ function createParams(overrides: {
 }
 
 describe("applyToolConfig", () => {
+  describe("#given config permission sets webfetch and external_directory", () => {
+    describe("#when applying tool config", () => {
+      it("#then should preserve explicit deny over OmO defaults", () => {
+        const params = createParams({})
+        params.config.permission = {
+          webfetch: "deny",
+          external_directory: "deny",
+        }
+
+        applyToolConfig(params)
+
+        const permission = params.config.permission as Record<string, unknown>
+        expect(permission.webfetch).toBe("deny")
+        expect(permission.external_directory).toBe("deny")
+        expect(permission.task).toBe("deny")
+      })
+
+      it("#then should allow webfetch and external_directory by default", () => {
+        const params = createParams({})
+
+        applyToolConfig(params)
+
+        const permission = params.config.permission as Record<string, unknown>
+        expect(permission.webfetch).toBe("allow")
+        expect(permission.external_directory).toBe("allow")
+        expect(permission.task).toBe("deny")
+      })
+    })
+  })
+
   describe("#given task_system is enabled", () => {
     describe("#when applying tool config", () => {
       it("#then should deny todowrite and todoread globally", () => {

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -116,9 +116,9 @@ export function applyToolConfig(params: {
   }
 
   params.config.permission = {
-    ...(params.config.permission as Record<string, unknown>),
     webfetch: "allow",
     external_directory: "allow",
+    ...(params.config.permission as Record<string, unknown>),
     task: "deny",
   };
 }


### PR DESCRIPTION
## Problem
In `tool-config-handler.ts`, OmO permissions were placed first in the merge order, meaning `webfetch: "allow"` and `external_directory: "allow"` overrode any explicit user/OpenCode `deny` settings. This widened access silently.

## Fix
- Ensure user/OpenCode explicit deny settings always take precedence over OmO default allows
- Merge order: OmO defaults first (base), then OpenCode defaults, then user overrides on top
- Added regression test for explicit deny precedence

## Review
All 5 review-work lanes passed (goal, QA, code quality, security, context mining).
Tests passed, typecheck passed, build passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes permission merge order so explicit user/OpenCode `deny` values override OmO default `allow` for `webfetch` and `external_directory`, preventing silent permission widening.

- **Bug Fixes**
  - Reordered merge in `tool-config-handler.ts`: OmO defaults → OpenCode defaults → user overrides; keeps `task: "deny"`.
  - Added tests in `tool-config-handler.test.ts` to ensure explicit `deny` is preserved and defaults apply when unset.

<sup>Written for commit 0b614b751c8190fabf9345ca6ae513f8fc2250bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

