### PR TITLE
fix(models): remove stale Gemini 3 Pro references

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -176,7 +176,7 @@ The `opencode-antigravity-auth` plugin uses different model names than the built
 
 **Available models (Gemini CLI quota)**:
 
-- `google/gemini-2.5-flash`, `google/gemini-2.5-pro`, `google/gemini-3-flash-preview`, `google/gemini-3-pro-preview`
+- `google/gemini-2.5-flash`, `google/gemini-2.5-pro`, `google/gemini-3-flash-preview`, `google/gemini-3.1-pro-preview`
 
 > **Note**: Legacy tier-suffixed names like `google/antigravity-gemini-3-pro-high` still work but variants are recommended. Use `--variant=high` with the base model name instead.
 
@@ -294,7 +294,7 @@ Not all models behave the same way. Understanding which models are "similar" hel
 
 | Model                 | Provider(s)                      | Notes                                                       |
 | --------------------- | -------------------------------- | ----------------------------------------------------------- |
-| **Gemini 3 Pro**      | google, github-copilot, opencode | Excels at visual/frontend tasks. Different reasoning style. |
+| **Gemini 3.1 Pro**    | google, github-copilot, opencode | Excels at visual/frontend tasks. Different reasoning style. |
 | **Gemini 3 Flash**    | google, github-copilot, opencode | Fast, good for doc search and light tasks.                  |
 | **MiniMax M2.5**      | venice                           | Fast and smart. Good for utility tasks.                     |
 | **MiniMax M2.5 Free** | opencode                         | Free-tier MiniMax. Fast for search/retrieval.               |
@@ -317,7 +317,7 @@ Based on your subscriptions, here's how the agents were configured:
 | Agent        | Role             | Default Chain                                   | What It Does                                                                             |
 | ------------ | ---------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | **Sisyphus** | Main ultraworker | Opus (max) → Kimi K2.5 → GLM 5 → Big Pickle     | Primary coding agent. Orchestrates everything. **Never use GPT — no GPT prompt exists.** |
-| **Metis**    | Plan review      | Opus (max) → Kimi K2.5 → GPT-5.4 → Gemini 3 Pro | Reviews Prometheus plans for gaps.                                                       |
+| **Metis**    | Plan review      | Opus (max) → Kimi K2.5 → GPT-5.4 → Gemini 3.1 Pro | Reviews Prometheus plans for gaps.                                                       |
 
 **Dual-Prompt Agents** (auto-switch between Claude and GPT prompts):
 
@@ -327,7 +327,7 @@ Priority: **Claude > GPT > Claude-like models**
 
 | Agent          | Role              | Default Chain                                              | GPT Prompt?                                                      |
 | -------------- | ----------------- | ---------------------------------------------------------- | ---------------------------------------------------------------- |
-| **Prometheus** | Strategic planner | Opus (max) → **GPT-5.4 (high)** → Kimi K2.5 → Gemini 3 Pro | Yes — XML-tagged, principle-driven (~300 lines vs ~1,100 Claude) |
+| **Prometheus** | Strategic planner | Opus (max) → **GPT-5.4 (high)** → Kimi K2.5 → Gemini 3.1 Pro | Yes — XML-tagged, principle-driven (~300 lines vs ~1,100 Claude) |
 | **Atlas**      | Todo orchestrator | **Kimi K2.5** → Sonnet → GPT-5.4                           | Yes — GPT-optimized todo management                              |
 
 **GPT-Native Agents** (built for GPT, don't override to Claude):
@@ -335,8 +335,8 @@ Priority: **Claude > GPT > Claude-like models**
 | Agent          | Role                   | Default Chain                          | Notes                                                  |
 | -------------- | ---------------------- | -------------------------------------- | ------------------------------------------------------ |
 | **Hephaestus** | Deep autonomous worker | GPT-5.3-codex (medium) only            | "Codex on steroids." No fallback. Requires GPT access. |
-| **Oracle**     | Architecture/debugging | GPT-5.4 (high) → Gemini 3 Pro → Opus   | High-IQ strategic backup. GPT preferred.               |
-| **Momus**      | High-accuracy reviewer | GPT-5.4 (medium) → Opus → Gemini 3 Pro | Verification agent. GPT preferred.                     |
+| **Oracle**     | Architecture/debugging | GPT-5.4 (high) → Gemini 3.1 Pro → Opus  | High-IQ strategic backup. GPT preferred.               |
+| **Momus**      | High-accuracy reviewer | GPT-5.4 (medium) → Opus → Gemini 3.1 Pro | Verification agent. GPT preferred.                     |
 
 **Utility Agents** (speed over intelligence):
 

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -220,7 +220,7 @@ You can override specific agents or categories in your config:
 
 **Different-behavior models**:
 
-- Gemini 3 Pro — excels at visual/frontend tasks
+- Gemini 3.1 Pro — excels at visual/frontend tasks
 - MiniMax M2.5 — fast and smart for utility tasks
 - Grok Code Fast 1 — optimized for code grep/search
 

--- a/src/agents/dynamic-agent-prompt-builder.test.ts
+++ b/src/agents/dynamic-agent-prompt-builder.test.ts
@@ -181,7 +181,7 @@ describe("buildParallelDelegationSection", () => {
 
   it("#given non-Claude model with deep category #when building #then returns aggressive delegation section", () => {
     //#given
-    const model = "google/gemini-3-pro"
+    const model = "google/gemini-3.1-pro"
     const categories = [deepCategory, otherCategory]
 
     //#when
@@ -237,7 +237,7 @@ describe("buildParallelDelegationSection", () => {
 describe("buildNonClaudePlannerSection", () => {
   it("#given non-Claude model #when building #then returns plan agent section", () => {
     //#given
-    const model = "google/gemini-3-pro"
+    const model = "google/gemini-3.1-pro"
 
     //#when
     const result = buildNonClaudePlannerSection(model)
@@ -271,5 +271,4 @@ describe("buildNonClaudePlannerSection", () => {
     expect(result).not.toBe("")
   })
 })
-
 

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -42,7 +42,7 @@ Examples:
 Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
   Claude        Native anthropic/ models (Opus, Sonnet, Haiku)
   OpenAI        Native openai/ models (GPT-5.4 for Oracle)
-  Gemini        Native google/ models (Gemini 3 Pro, Flash)
+  Gemini        Native google/ models (Gemini 3.1 Pro, Flash)
   Copilot       github-copilot/ models (fallback)
   OpenCode Zen  opencode/ models (opencode/claude-opus-4-6, etc.)
    Z.ai          zai-coding-plan/glm-5 (visual-engineering fallback)

--- a/src/cli/tui-install-prompts.ts
+++ b/src/cli/tui-install-prompts.ts
@@ -54,7 +54,7 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
     message: "Will you integrate Google Gemini?",
     options: [
       { value: "no", label: "No", hint: "Frontend/docs agents will use fallback" },
-      { value: "yes", label: "Yes", hint: "Beautiful UI generation with Gemini 3 Pro" },
+      { value: "yes", label: "Yes", hint: "Beautiful UI generation with Gemini 3.1 Pro" },
     ],
     initialValue: initial.gemini,
   })

--- a/src/hooks/model-fallback/hook.test.ts
+++ b/src/hooks/model-fallback/hook.test.ts
@@ -337,7 +337,7 @@ describe("model fallback hook", () => {
     clearPendingModelFallback(sessionID)
   })
 
-  test("transforms model names for google provider via fallback chain", async () => {
+  test("preserves canonical google preview model names via fallback chain", async () => {
     //#given
     const sessionID = "ses_model_fallback_google"
     clearPendingModelFallback(sessionID)
@@ -351,20 +351,20 @@ describe("model fallback hook", () => {
 
     // Set a custom fallback chain that routes through google
     setSessionFallbackChain(sessionID, [
-      { providers: ["google"], model: "gemini-3-pro" },
+      { providers: ["google"], model: "gemini-3.1-pro-preview" },
     ])
 
     const set = setPendingModelFallback(
       sessionID,
       "Oracle",
       "google",
-      "gemini-3-pro",
+      "gemini-3.1-pro-preview",
     )
     expect(set).toBe(true)
 
     const output = {
       message: {
-        model: { providerID: "google", modelID: "gemini-3-pro" },
+        model: { providerID: "google", modelID: "gemini-3.1-pro-preview" },
       },
       parts: [{ type: "text", text: "continue" }],
     }
@@ -372,10 +372,10 @@ describe("model fallback hook", () => {
     //#when
     await hook["chat.message"]?.({ sessionID }, output)
 
-    //#then — model name should remain gemini-3-pro because no google transform exists for this ID
+    //#then: model name should remain gemini-3.1-pro-preview because no google transform exists for this ID
     expect(output.message["model"]).toEqual({
       providerID: "google",
-      modelID: "gemini-3-pro",
+      modelID: "gemini-3.1-pro-preview",
     })
 
     clearPendingModelFallback(sessionID)


### PR DESCRIPTION
## Summary
- update repo-owned CLI, docs, and test fixtures from stale Gemini 3 Pro wording to Gemini 3.1 Pro
- keep selector and provider catalog behavior unchanged because the stale selector entries come from upstream model metadata, not local label generation
- align the google fallback test fixture with current preview naming and preserve given/when/then coverage

## Verification
- bun run typecheck
- bun run build
- bun test src/hooks/model-fallback/hook.test.ts src/agents/dynamic-agent-prompt-builder.test.ts
- bun run src/cli/index.ts install --help
- review-work: goal verification, QA, code quality, security, and context mining all passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace stale Gemini 3 Pro references with Gemini 3.1 Pro across CLI, docs, and tests to match current Google naming. Selector/provider catalog behavior stays the same; the Google fallback test now asserts canonical `google/gemini-3.1-pro-preview` is preserved.

- **Bug Fixes**
  - CLI: help text and install prompt now reference `Gemini 3.1 Pro`.
  - Docs: model lists and agent chains updated to `Gemini 3.1 Pro`.
  - Tests: planner/delegation fixtures use `google/gemini-3.1-pro`; fallback test uses `google/gemini-3.1-pro-preview` and verifies no transform.

<sup>Written for commit 535ecee318101758ed255aa12593d621935fa05e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

