### PR TITLE
fix(publish): align repo guard and test topology

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,7 @@ jobs:
           bun test src/cli/doctor/format-default.test.ts
           bun test src/tools/call-omo-agent/sync-executor.test.ts
           bun test src/tools/call-omo-agent/session-creator.test.ts
+          bun test src/tools/session-manager
           bun test src/features/opencode-skill-loader/loader.test.ts
           bun test src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
           bun test src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
@@ -66,9 +67,8 @@ jobs:
           # Enumerate subdirectories/files explicitly to EXCLUDE mock-heavy files
           # that were already run in isolation above.
           # Excluded from src/cli: doctor/formatter.test.ts, doctor/format-default.test.ts
-          # Excluded from src/tools: call-omo-agent/sync-executor.test.ts, call-omo-agent/session-creator.test.ts
+          # Excluded from src/tools: call-omo-agent/sync-executor.test.ts, call-omo-agent/session-creator.test.ts, session-manager (all)
           # Excluded from src/hooks/anthropic-context-window-limit-recovery: recovery-hook.test.ts, executor.test.ts
-          # Excluded from src/tools: call-omo-agent/sync-executor.test.ts, call-omo-agent/session-creator.test.ts
           bun test bin script src/config src/mcp src/index.test.ts \
             src/agents src/shared \
             src/cli/run src/cli/config-manager src/cli/mcp-oauth \
@@ -77,7 +77,7 @@ jobs:
             src/cli/doctor/runner.test.ts src/cli/doctor/checks \
             src/tools/ast-grep src/tools/background-task src/tools/delegate-task \
             src/tools/glob src/tools/grep src/tools/interactive-bash \
-            src/tools/look-at src/tools/lsp src/tools/session-manager \
+            src/tools/look-at src/tools/lsp \
             src/tools/skill src/tools/skill-mcp src/tools/slashcommand src/tools/task \
             src/tools/call-omo-agent/background-agent-executor.test.ts \
             src/tools/call-omo-agent/background-executor.test.ts \
@@ -121,7 +121,7 @@ jobs:
   publish-main:
     runs-on: ubuntu-latest
     needs: [test, typecheck]
-    if: github.repository == 'code-yeongyu/oh-my-openagent'
+    if: github.repository == 'code-yeongyu/oh-my-opencode'
     outputs:
       version: ${{ steps.version.outputs.version }}
       dist_tag: ${{ steps.version.outputs.dist_tag }}


### PR DESCRIPTION
## Summary
- fix `publish-main` so it runs from the canonical `code-yeongyu/oh-my-opencode` repository instead of no-oping on the redirected legacy slug
- align `publish.yml` test gating with `ci.yml` by isolating `src/tools/session-manager` in the mock-heavy test block and removing it from the batched remainder
- update the exclusion comment so the documented publish test topology matches the actual commands

## Testing
- `bun test src/tools/session-manager`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/publish.yml'); puts 'workflow yaml parse ok'"`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix publish workflow to run on the canonical `code-yeongyu/oh-my-opencode` repo and align publish test topology with `ci.yml` by isolating mock-heavy `src/tools/session-manager` tests.

- **Bug Fixes**
  - Corrected `publish-main` repo guard: `oh-my-openagent` → `oh-my-opencode`.
  - Run `bun test src/tools/session-manager` separately and remove it from the batched test set; updated exclusion comments to match.

<sup>Written for commit e0de06851d3a9f4d2ddcc20c502dfd083b361fc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

