### PR TITLE
fix(non-interactive-env): force unix prefix for bash git commands

### DIFF
--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
-import { log, buildEnvPrefix, detectShellType } from "../../shared"
+import { log, buildEnvPrefix } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -52,9 +52,7 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
       // for git commands to prevent interactive prompts.
 
-      // Detect the current shell type for proper env var syntax (export for bash/zsh, setenv for csh/tcsh, etc.)
-      const shellType = detectShellType()
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
+      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
       
       // Check if the command already starts with the prefix to avoid stacking.
       // This maintains the non-interactive behavior and makes the operation idempotent.


### PR DESCRIPTION
## Summary
- force the non-interactive bash hook to always use Unix `export` syntax for git commands, even on win32 host shells
- keep the fix hook-local so shared shell detection continues to behave normally for other consumers
- verify the regression with targeted tests, typecheck, build, manual QA, and a full review-work pass

## Testing
- `bun test src/hooks/non-interactive-env/index.test.ts`
- `bun test src/shared/shell-env.test.ts`
- `bun run typecheck`
- `bun run build`
- manual QA: simulated `win32` + PowerShell env still prints an `export ...; git status` command for the bash tool

## Review
- `review-work`: PASS
- Goal verification: PASS
- QA execution: PASS
- Code quality: PASS
- Security review: PASS
- Context mining: PASS


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force Unix `export` prefix for non-interactive bash git commands to prevent prompts on Windows shells. Change is scoped to the non-interactive env hook; shared shell detection stays unchanged.

<sup>Written for commit e000a3bb0da38c5f249f512864c35e58785436df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

