### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -32,6 +32,7 @@ program
   .option("--zai-coding-plan <value>", "Z.ai Coding Plan subscription: no, yes (default: no)")
   .option("--kimi-for-coding <value>", "Kimi For Coding subscription: no, yes (default: no)")
   .option("--opencode-go <value>", "OpenCode Go subscription: no, yes (default: no)")
+  .option("--novita <value>", "Novita AI subscription: no, yes (default: no)")
   .option("--skip-auth", "Skip authentication setup hints")
   .addHelpText("after", `
 Examples:
@@ -39,7 +40,7 @@ Examples:
   $ bunx oh-my-opencode install --no-tui --claude=max20 --openai=yes --gemini=yes --copilot=no
   $ bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=yes --opencode-zen=yes
 
-Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
+Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi > Novita):
   Claude        Native anthropic/ models (Opus, Sonnet, Haiku)
   OpenAI        Native openai/ models (GPT-5.4 for Oracle)
   Gemini        Native google/ models (Gemini 3.1 Pro, Flash)
@@ -47,6 +48,7 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
   OpenCode Zen  opencode/ models (opencode/claude-opus-4-6, etc.)
    Z.ai          zai-coding-plan/glm-5 (visual-engineering fallback)
   Kimi          kimi-for-coding/k2p5 (Sisyphus/Prometheus fallback)
+  Novita        novita/ models (kimi-k2.5, glm-5, minimax-m2.5)
 `)
   .action(async (options) => {
     const args: InstallArgs = {
@@ -59,6 +61,7 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
       zaiCodingPlan: options.zaiCodingPlan,
       kimiForCoding: options.kimiForCoding,
       opencodeGo: options.opencodeGo,
+      novita: options.novita,
       skipAuth: options.skipAuth ?? false,
     }
     const exitCode = await install(args)

--- a/src/cli/config-manager/detect-current-config.ts
+++ b/src/cli/config-manager/detect-current-config.ts
@@ -11,6 +11,7 @@ function detectProvidersFromOmoConfig(): {
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
   hasOpencodeGo: boolean
+  hasNovita: boolean
 } {
   const omoConfigPath = getOmoConfigPath()
   if (!existsSync(omoConfigPath)) {
@@ -20,6 +21,7 @@ function detectProvidersFromOmoConfig(): {
       hasZaiCodingPlan: false,
       hasKimiForCoding: false,
       hasOpencodeGo: false,
+      hasNovita: false,
     }
   }
 
@@ -33,6 +35,7 @@ function detectProvidersFromOmoConfig(): {
         hasZaiCodingPlan: false,
         hasKimiForCoding: false,
         hasOpencodeGo: false,
+        hasNovita: false,
       }
     }
 
@@ -42,8 +45,9 @@ function detectProvidersFromOmoConfig(): {
     const hasZaiCodingPlan = configStr.includes('"zai-coding-plan/')
     const hasKimiForCoding = configStr.includes('"kimi-for-coding/')
     const hasOpencodeGo = configStr.includes('"opencode-go/')
+    const hasNovita = configStr.includes('"novita/')
 
-    return { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo }
+    return { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo, hasNovita }
   } catch {
     return {
       hasOpenAI: true,
@@ -51,6 +55,7 @@ function detectProvidersFromOmoConfig(): {
       hasZaiCodingPlan: false,
       hasKimiForCoding: false,
       hasOpencodeGo: false,
+      hasNovita: false,
     }
   }
 }
@@ -72,6 +77,7 @@ export function detectCurrentConfig(): DetectedConfig {
     hasZaiCodingPlan: false,
     hasKimiForCoding: false,
     hasOpencodeGo: false,
+    hasNovita: false,
   }
 
   const { format, path } = detectConfigFormat()
@@ -95,12 +101,13 @@ export function detectCurrentConfig(): DetectedConfig {
   const providers = openCodeConfig.provider as Record<string, unknown> | undefined
   result.hasGemini = providers ? "google" in providers : false
 
-  const { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo } = detectProvidersFromOmoConfig()
+  const { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo, hasNovita } = detectProvidersFromOmoConfig()
   result.hasOpenAI = hasOpenAI
   result.hasOpencodeZen = hasOpencodeZen
   result.hasZaiCodingPlan = hasZaiCodingPlan
   result.hasKimiForCoding = hasKimiForCoding
   result.hasOpencodeGo = hasOpencodeGo
+  result.hasNovita = hasNovita
 
   return result
 }

--- a/src/cli/install-validators.ts
+++ b/src/cli/install-validators.ts
@@ -40,6 +40,7 @@ export function formatConfigSummary(config: InstallConfig): string {
   lines.push(formatProvider("OpenCode Zen", config.hasOpencodeZen, "opencode/ models"))
   lines.push(formatProvider("Z.ai Coding Plan", config.hasZaiCodingPlan, "Librarian/Multimodal"))
   lines.push(formatProvider("Kimi For Coding", config.hasKimiForCoding, "Sisyphus/Prometheus fallback"))
+  lines.push(formatProvider("Novita AI", config.hasNovita, "kimi-k2.5, glm-5, minimax-m2.5"))
 
   lines.push("")
   lines.push(color.dim("─".repeat(40)))
@@ -153,6 +154,10 @@ export function validateNonTuiArgs(args: InstallArgs): { valid: boolean; errors:
     errors.push(`Invalid --kimi-for-coding value: ${args.kimiForCoding} (expected: no, yes)`)
   }
 
+  if (args.novita !== undefined && !["no", "yes"].includes(args.novita)) {
+    errors.push(`Invalid --novita value: ${args.novita} (expected: no, yes)`)
+  }
+
   return { valid: errors.length === 0, errors }
 }
 
@@ -167,6 +172,7 @@ export function argsToConfig(args: InstallArgs): InstallConfig {
     hasZaiCodingPlan: args.zaiCodingPlan === "yes",
 hasKimiForCoding: args.kimiForCoding === "yes",
     hasOpencodeGo: args.opencodeGo === "yes",
+    hasNovita: args.novita === "yes",
   }
 }
 
@@ -179,6 +185,7 @@ export function detectedToInitialValues(detected: DetectedConfig): {
   zaiCodingPlan: BooleanArg
 kimiForCoding: BooleanArg
   opencodeGo: BooleanArg
+  novita: BooleanArg
 } {
   let claude: ClaudeSubscription = "no"
   if (detected.hasClaude) {
@@ -194,5 +201,6 @@ kimiForCoding: BooleanArg
     zaiCodingPlan: detected.hasZaiCodingPlan ? "yes" : "no",
 kimiForCoding: detected.hasKimiForCoding ? "yes" : "no",
     opencodeGo: detected.hasOpencodeGo ? "yes" : "no",
+    novita: detected.hasNovita ? "yes" : "no",
   }
 }

--- a/src/cli/model-fallback-types.ts
+++ b/src/cli/model-fallback-types.ts
@@ -7,8 +7,9 @@ export interface ProviderAvailability {
 	opencodeZen: boolean
 	copilot: boolean
 	zai: boolean
-kimiForCoding: boolean
+	kimiForCoding: boolean
 	opencodeGo: boolean
+	novita: boolean
 	isMaxPlan: boolean
 }
 

--- a/src/cli/provider-availability.ts
+++ b/src/cli/provider-availability.ts
@@ -11,8 +11,9 @@ export function toProviderAvailability(config: InstallConfig): ProviderAvailabil
 		opencodeZen: config.hasOpencodeZen,
 		copilot: config.hasCopilot,
 		zai: config.hasZaiCodingPlan,
-kimiForCoding: config.hasKimiForCoding,
+		kimiForCoding: config.hasKimiForCoding,
 		opencodeGo: config.hasOpencodeGo,
+		novita: config.hasNovita,
 		isMaxPlan: config.isMax20,
 	}
 }
@@ -25,8 +26,9 @@ export function isProviderAvailable(provider: string, availability: ProviderAvai
 		"github-copilot": availability.copilot,
 		opencode: availability.opencodeZen,
 		"zai-coding-plan": availability.zai,
-"kimi-for-coding": availability.kimiForCoding,
+		"kimi-for-coding": availability.kimiForCoding,
 		"opencode-go": availability.opencodeGo,
+		novita: availability.novita,
 	}
 	return mapping[provider] ?? false
 }

--- a/src/cli/tui-install-prompts.ts
+++ b/src/cli/tui-install-prompts.ts
@@ -110,6 +110,16 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
   })
   if (!opencodeGo) return null
 
+  const novita = await selectOrCancel({
+    message: "Do you have a Novita AI subscription?",
+    options: [
+      { value: "no", label: "No", hint: "Will use other configured providers" },
+      { value: "yes", label: "Yes", hint: "Novita AI for kimi-k2.5, glm-5, minimax-m2.5" },
+    ],
+    initialValue: initial.novita,
+  })
+  if (!novita) return null
+
   return {
     hasClaude: claude !== "no",
     isMax20: claude === "max20",
@@ -120,5 +130,6 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
     hasZaiCodingPlan: zaiCodingPlan === "yes",
     hasKimiForCoding: kimiForCoding === "yes",
     hasOpencodeGo: opencodeGo === "yes",
+    hasNovita: novita === "yes",
   }
 }

--- a/src/cli/tui-installer.ts
+++ b/src/cli/tui-installer.ts
@@ -75,7 +75,7 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
     console.log()
   }
 
-  if (!config.hasClaude && !config.hasOpenAI && !config.hasGemini && !config.hasCopilot && !config.hasOpencodeZen) {
+  if (!config.hasClaude && !config.hasOpenAI && !config.hasGemini && !config.hasCopilot && !config.hasOpencodeZen && !config.hasNovita) {
     p.log.warn("No model providers configured. Using opencode/big-pickle as fallback.")
   }
 

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -9,8 +9,9 @@ export interface InstallArgs {
   copilot?: BooleanArg
   opencodeZen?: BooleanArg
   zaiCodingPlan?: BooleanArg
-kimiForCoding?: BooleanArg
+  kimiForCoding?: BooleanArg
   opencodeGo?: BooleanArg
+  novita?: BooleanArg
   skipAuth?: boolean
 }
 
@@ -24,6 +25,7 @@ export interface InstallConfig {
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
   hasOpencodeGo: boolean
+  hasNovita: boolean
 }
 
 export interface ConfigMergeResult {
@@ -43,4 +45,5 @@ export interface DetectedConfig {
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
   hasOpencodeGo: boolean
+  hasNovita: boolean
 }

--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -28,10 +28,10 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     const sisyphus = AGENT_MODEL_REQUIREMENTS["sisyphus"]
 
     // #when - accessing Sisyphus requirement
-    // #then - fallbackChain has 7 entries with correct ordering
+    // #then - fallbackChain has 9 entries with correct ordering
     expect(sisyphus).toBeDefined()
     expect(sisyphus.fallbackChain).toBeArray()
-    expect(sisyphus.fallbackChain).toHaveLength(7)
+    expect(sisyphus.fallbackChain).toHaveLength(9)
     expect(sisyphus.requiresAnyModel).toBe(true)
 
     const primary = sisyphus.fallbackChain[0]
@@ -51,15 +51,23 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(fourth.model).toBe("kimi-k2.5")
 
     const fifth = sisyphus.fallbackChain[4]
-    expect(fifth.providers).toContain("openai")
-    expect(fifth.model).toBe("gpt-5.4")
-    expect(fifth.variant).toBe("medium")
+    expect(fifth.providers).toEqual(["novita"])
+    expect(fifth.model).toBe("moonshotai/kimi-k2.5")
 
     const sixth = sisyphus.fallbackChain[5]
-    expect(sixth.providers[0]).toBe("zai-coding-plan")
-    expect(sixth.model).toBe("glm-5")
+    expect(sixth.providers).toContain("openai")
+    expect(sixth.model).toBe("gpt-5.4")
+    expect(sixth.variant).toBe("medium")
 
-    const last = sisyphus.fallbackChain[6]
+    const seventh = sisyphus.fallbackChain[6]
+    expect(seventh.providers[0]).toBe("zai-coding-plan")
+    expect(seventh.model).toBe("glm-5")
+
+    const eighth = sisyphus.fallbackChain[7]
+    expect(eighth.providers[0]).toBe("novita")
+    expect(eighth.model).toBe("zai-org/glm-5")
+
+    const last = sisyphus.fallbackChain[8]
     expect(last.providers[0]).toBe("opencode")
     expect(last.model).toBe("big-pickle")
   })
@@ -79,15 +87,19 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(primary.model).toBe("minimax-m2.5")
 
     const second = librarian.fallbackChain[1]
-    expect(second.providers[0]).toBe("opencode")
-    expect(second.model).toBe("minimax-m2.5-free")
+    expect(second.providers[0]).toBe("novita")
+    expect(second.model).toBe("minimax/minimax-m2.5")
 
     const tertiary = librarian.fallbackChain[2]
-    expect(tertiary.providers).toContain("anthropic")
-    expect(tertiary.model).toBe("claude-haiku-4-5")
+    expect(tertiary.providers[0]).toBe("opencode")
+    expect(tertiary.model).toBe("minimax-m2.5-free")
 
     const quaternary = librarian.fallbackChain[3]
-    expect(quaternary.model).toBe("gpt-5-nano")
+    expect(quaternary.providers).toContain("anthropic")
+    expect(quaternary.model).toBe("claude-haiku-4-5")
+
+    const fifth = librarian.fallbackChain[4]
+    expect(fifth.model).toBe("gpt-5-nano")
   })
 
   test("explore has valid fallbackChain with grok-code-fast-1 as primary", () => {
@@ -95,10 +107,10 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     const explore = AGENT_MODEL_REQUIREMENTS["explore"]
 
     // when - accessing explore requirement
-    // then - fallbackChain: grok → opencode-go/minimax → minimax-free → haiku → nano
+    // then - fallbackChain: grok → opencode-go/minimax → novita/minimax → minimax-free → haiku → nano
     expect(explore).toBeDefined()
     expect(explore.fallbackChain).toBeArray()
-    expect(explore.fallbackChain).toHaveLength(5)
+    expect(explore.fallbackChain).toHaveLength(6)
 
     const primary = explore.fallbackChain[0]
     expect(primary.providers).toContain("github-copilot")
@@ -109,16 +121,20 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(secondary.model).toBe("minimax-m2.5")
 
     const tertiary = explore.fallbackChain[2]
-    expect(tertiary.providers).toContain("opencode")
-    expect(tertiary.model).toBe("minimax-m2.5-free")
+    expect(tertiary.providers).toContain("novita")
+    expect(tertiary.model).toBe("minimax/minimax-m2.5")
 
     const quaternary = explore.fallbackChain[3]
-    expect(quaternary.providers).toContain("anthropic")
-    expect(quaternary.model).toBe("claude-haiku-4-5")
+    expect(quaternary.providers).toContain("opencode")
+    expect(quaternary.model).toBe("minimax-m2.5-free")
 
     const fifth = explore.fallbackChain[4]
-    expect(fifth.providers).toContain("opencode")
-    expect(fifth.model).toBe("gpt-5-nano")
+    expect(fifth.providers).toContain("anthropic")
+    expect(fifth.model).toBe("claude-haiku-4-5")
+
+    const sixth = explore.fallbackChain[5]
+    expect(sixth.providers).toContain("opencode")
+    expect(sixth.model).toBe("gpt-5-nano")
   })
 
   test("multimodal-looker has valid fallbackChain with gpt-5.4 as primary", () => {
@@ -126,10 +142,10 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     const multimodalLooker = AGENT_MODEL_REQUIREMENTS["multimodal-looker"]
 
     // when - accessing multimodal-looker requirement
-    // then - fallbackChain: gpt-5.4 -> opencode-go/kimi-k2.5 -> glm-4.6v -> gpt-5-nano
+    // then - fallbackChain: gpt-5.4 -> opencode-go/kimi-k2.5 -> novita/kimi-k2.5 -> glm-4.6v -> gpt-5-nano
     expect(multimodalLooker).toBeDefined()
     expect(multimodalLooker.fallbackChain).toBeArray()
-    expect(multimodalLooker.fallbackChain).toHaveLength(4)
+    expect(multimodalLooker.fallbackChain).toHaveLength(5)
 
     const primary = multimodalLooker.fallbackChain[0]
     expect(primary.providers).toEqual(["openai", "opencode"])
@@ -141,9 +157,13 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(secondary.model).toBe("kimi-k2.5")
 
     const tertiary = multimodalLooker.fallbackChain[2]
-    expect(tertiary.model).toBe("glm-4.6v")
+    expect(tertiary.providers).toEqual(["novita"])
+    expect(tertiary.model).toBe("moonshotai/kimi-k2.5")
 
-    const last = multimodalLooker.fallbackChain[3]
+    const fourth = multimodalLooker.fallbackChain[3]
+    expect(fourth.model).toBe("glm-4.6v")
+
+    const last = multimodalLooker.fallbackChain[4]
     expect(last.providers).toEqual(["openai", "github-copilot", "opencode"])
     expect(last.model).toBe("gpt-5-nano")
   })
@@ -222,7 +242,11 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(secondary.providers[0]).toBe("opencode-go")
 
     const tertiary = atlas.fallbackChain[2]
-    expect(tertiary).toEqual({
+    expect(tertiary.model).toBe("moonshotai/kimi-k2.5")
+    expect(tertiary.providers[0]).toBe("novita")
+
+    const quaternary = atlas.fallbackChain[3]
+    expect(quaternary).toEqual({
       providers: ["openai", "github-copilot", "opencode"],
       model: "gpt-5.4",
       variant: "medium",
@@ -334,10 +358,10 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     const visualEngineering = CATEGORY_MODEL_REQUIREMENTS["visual-engineering"]
 
     // when - accessing visual-engineering requirement
-    // then - fallbackChain: gemini-3.1-pro(high) → glm-5 → opus-4-6(max) → opencode-go/glm-5 → k2p5
+    // then - fallbackChain: gemini-3.1-pro(high) → glm-5 → novita/glm-5 → opus-4-6(max) → opencode-go/glm-5 → k2p5
     expect(visualEngineering).toBeDefined()
     expect(visualEngineering.fallbackChain).toBeArray()
-    expect(visualEngineering.fallbackChain).toHaveLength(5)
+    expect(visualEngineering.fallbackChain).toHaveLength(6)
 
     const primary = visualEngineering.fallbackChain[0]
     expect(primary.providers[0]).toBe("google")
@@ -349,16 +373,20 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     expect(second.model).toBe("glm-5")
 
     const third = visualEngineering.fallbackChain[2]
-    expect(third.model).toBe("claude-opus-4-6")
-    expect(third.variant).toBe("max")
+    expect(third.providers[0]).toBe("novita")
+    expect(third.model).toBe("zai-org/glm-5")
 
     const fourth = visualEngineering.fallbackChain[3]
-    expect(fourth.providers[0]).toBe("opencode-go")
-    expect(fourth.model).toBe("glm-5")
+    expect(fourth.model).toBe("claude-opus-4-6")
+    expect(fourth.variant).toBe("max")
 
     const fifth = visualEngineering.fallbackChain[4]
-    expect(fifth.providers[0]).toBe("kimi-for-coding")
-    expect(fifth.model).toBe("k2p5")
+    expect(fifth.providers[0]).toBe("opencode-go")
+    expect(fifth.model).toBe("glm-5")
+
+    const sixth = visualEngineering.fallbackChain[5]
+    expect(sixth.providers[0]).toBe("kimi-for-coding")
+    expect(sixth.model).toBe("k2p5")
   })
 
   test("quick has valid fallbackChain with gpt-5.4-mini as primary and claude-haiku-4-5 as secondary", () => {
@@ -437,10 +465,10 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     const writing = CATEGORY_MODEL_REQUIREMENTS["writing"]
 
     // when - accessing writing requirement
-    // then - fallbackChain: gemini-3-flash -> kimi-k2.5 -> claude-sonnet-4-6
+    // then - fallbackChain: gemini-3-flash -> kimi-k2.5 -> novita/kimi-k2.5 -> claude-sonnet-4-6
     expect(writing).toBeDefined()
     expect(writing.fallbackChain).toBeArray()
-    expect(writing.fallbackChain).toHaveLength(3)
+    expect(writing.fallbackChain).toHaveLength(4)
 
     const primary = writing.fallbackChain[0]
     expect(primary.model).toBe("gemini-3-flash")
@@ -451,8 +479,12 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     expect(second.providers[0]).toBe("opencode-go")
 
     const third = writing.fallbackChain[2]
-    expect(third.model).toBe("claude-sonnet-4-6")
-    expect(third.providers[0]).toBe("anthropic")
+    expect(third.model).toBe("moonshotai/kimi-k2.5")
+    expect(third.providers[0]).toBe("novita")
+
+    const fourth = writing.fallbackChain[3]
+    expect(fourth.model).toBe("claude-sonnet-4-6")
+    expect(fourth.providers[0]).toBe("anthropic")
   })
 
   test("all 8 categories have valid fallbackChain arrays", () => {
@@ -547,7 +579,7 @@ describe("ModelRequirement type", () => {
     expect(requirement.variant).toBeUndefined()
   })
 
-  test("no model in fallbackChain has provider prefix", () => {
+  test("no model in fallbackChain has provider prefix except Novita models", () => {
     // given - all agent and category requirements
     const allRequirements = [
       ...Object.values(AGENT_MODEL_REQUIREMENTS),
@@ -555,10 +587,15 @@ describe("ModelRequirement type", () => {
     ]
 
     // when - checking each model in fallbackChain
-    // then - none contain "/" (provider prefix)
+    // then - only Novita provider entries contain "/" (Novita model IDs include provider prefix)
     for (const req of allRequirements) {
       for (const entry of req.fallbackChain) {
-        expect(entry.model).not.toContain("/")
+        if (entry.providers.includes("novita")) {
+          // Novita models have provider prefix (e.g., "moonshotai/kimi-k2.5")
+          expect(entry.model).toContain("/")
+        } else {
+          expect(entry.model).not.toContain("/")
+        }
       }
     }
   })

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -33,8 +33,10 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         ],
         model: "kimi-k2.5",
       },
+      { providers: ["novita"], model: "moonshotai/kimi-k2.5" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.4", variant: "medium" },
       { providers: ["zai-coding-plan", "opencode"], model: "glm-5" },
+      { providers: ["novita"], model: "zai-org/glm-5" },
       { providers: ["opencode"], model: "big-pickle" },
     ],
     requiresAnyModel: true,
@@ -73,6 +75,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   librarian: {
     fallbackChain: [
       { providers: ["opencode-go"], model: "minimax-m2.5" },
+      { providers: ["novita"], model: "minimax/minimax-m2.5" },
       { providers: ["opencode"], model: "minimax-m2.5-free" },
       { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
       { providers: ["opencode"], model: "gpt-5-nano" },
@@ -82,6 +85,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       { providers: ["github-copilot"], model: "grok-code-fast-1" },
       { providers: ["opencode-go"], model: "minimax-m2.5" },
+      { providers: ["novita"], model: "minimax/minimax-m2.5" },
       { providers: ["opencode"], model: "minimax-m2.5-free" },
       { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
       { providers: ["opencode"], model: "gpt-5-nano" },
@@ -91,6 +95,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       { providers: ["openai", "opencode"], model: "gpt-5.4", variant: "medium" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
+      { providers: ["novita"], model: "moonshotai/kimi-k2.5" },
       { providers: ["zai-coding-plan"], model: "glm-4.6v" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5-nano" },
     ],
@@ -108,6 +113,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["opencode-go"], model: "glm-5" },
+      { providers: ["novita"], model: "zai-org/glm-5" },
       {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3.1-pro",
@@ -127,6 +133,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["opencode-go"], model: "glm-5" },
+      { providers: ["novita"], model: "zai-org/glm-5" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
     ],
   },
@@ -148,12 +155,14 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["opencode-go"], model: "glm-5" },
+      { providers: ["novita"], model: "zai-org/glm-5" },
     ],
   },
   atlas: {
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-6" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
+      { providers: ["novita"], model: "moonshotai/kimi-k2.5" },
       {
         providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.4",
@@ -165,6 +174,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-6" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
+      { providers: ["novita"], model: "moonshotai/kimi-k2.5" },
       {
         providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.4",
@@ -184,6 +194,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["zai-coding-plan", "opencode"], model: "glm-5" },
+      { providers: ["novita"], model: "zai-org/glm-5" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-opus-4-6",
@@ -211,6 +222,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "max",
       },
       { providers: ["opencode-go"], model: "glm-5" },
+      { providers: ["novita"], model: "zai-org/glm-5" },
     ],
   },
   deep: {
@@ -264,6 +276,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "gemini-3-flash",
       },
       { providers: ["opencode-go"], model: "minimax-m2.5" },
+      { providers: ["novita"], model: "minimax/minimax-m2.5" },
       { providers: ["opencode"], model: "gpt-5-nano" },
     ],
   },
@@ -279,6 +292,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "medium",
       },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
+      { providers: ["novita"], model: "moonshotai/kimi-k2.5" },
       {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3-flash",
@@ -298,9 +312,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["zai-coding-plan", "opencode"], model: "glm-5" },
+      { providers: ["novita"], model: "zai-org/glm-5" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode-go"], model: "glm-5" },
       { providers: ["opencode"], model: "kimi-k2.5" },
+      { providers: ["novita"], model: "moonshotai/kimi-k2.5" },
       {
         providers: [
           "opencode",
@@ -321,6 +337,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "gemini-3-flash",
       },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
+      { providers: ["novita"], model: "moonshotai/kimi-k2.5" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

Add [Novita AI](https://novita.ai) as a new LLM provider. Novita offers an OpenAI-compatible API with competitive pricing and a wide selection of open-source models.

### Changes
- New Novita provider following existing provider patterns
- API key configuration via `NOVITA_API_KEY` environment variable
- Support for chat, completion, and embedding models

### Configuration
```
NOVITA_API_KEY=your_key_here
```

**Endpoint**: `https://api.novita.ai/openai`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Novita AI as a provider in the installer and model fallback chains, enabling `moonshotai/kimi-k2.5`, `zai-org/glm-5`, and `minimax/minimax-m2.5` via Novita’s OpenAI-compatible API. Includes a new `--novita` flag and TUI prompt, provider detection, and updated tests.

- **New Features**
  - `--novita <yes|no>` CLI option and TUI prompt; input validation and summary display.
  - Provider detection from config, availability mapping, and `isProviderAvailable('novita')` support.
  - Fallback chains updated to include Novita model IDs where relevant across agents and categories.
  - Help text shows Novita in provider priority; warning logic includes Novita when checking for configured providers.
  - Tests updated for new chain positions and to allow provider-prefixed Novita model IDs.

- **Migration**
  - Set `NOVITA_API_KEY` and use endpoint `https://api.novita.ai/openai` if not auto-configured.
  - Run `bunx oh-my-opencode install` and select Novita, or pass `--novita=yes`.
  - No breaking changes to existing providers.

<sup>Written for commit b1f23bde639cf5fca9030ff6507102734c3295eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

