### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -416,7 +416,7 @@ GPT (5.3-codex, 5.2) > Claude Opus (decent fallback) > Gemini (acceptable)
 When multiple providers are available, oh-my-openagent uses this priority:
 
 ```
-Native (anthropic/, openai/, google/) > Kimi for Coding > GitHub Copilot > Venice > OpenCode Zen > Z.ai Coding Plan
+Native (anthropic/, openai/, google/) > Kimi for Coding > GitHub Copilot > Venice > OpenCode Zen > Z.ai Coding Plan > MiniMax
 ```
 
 ### ⚠️ Warning

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -78,7 +78,7 @@ Ask the user these questions to determine CLI options:
    - If **yes** → `--minimax=yes`
    - If **no** → `--minimax=no` (default)
 
-**Provider Priority**: Native (anthropic/, openai/, google/) > MiniMax > Kimi for Coding > GitHub Copilot > OpenCode Go > OpenCode Zen > Z.ai Coding Plan
+**Provider Priority**: Native (anthropic/, openai/, google/) > Kimi for Coding > GitHub Copilot > OpenCode Go > OpenCode Zen > Z.ai Coding Plan > MiniMax
 
 MUST STRONGLY WARNING, WHEN USER SAID THEY DON'T HAVE CLAUDE SUBSCRIPTION, SISYPHUS AGENT MIGHT NOT WORK IDEALLY.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -73,7 +73,12 @@ Ask the user these questions to determine CLI options:
    - If **yes** → `--opencode-go=yes`
    - If **no** → `--opencode-go=no` (default)
 
-**Provider Priority**: Native (anthropic/, openai/, google/) > Kimi for Coding > GitHub Copilot > OpenCode Go > OpenCode Zen > Z.ai Coding Plan
+8. **Do you have a MiniMax subscription?**
+   - MiniMax provides MiniMax-M2.7 for all agents at excellent speed
+   - If **yes** → `--minimax=yes`
+   - If **no** → `--minimax=no` (default)
+
+**Provider Priority**: Native (anthropic/, openai/, google/) > MiniMax > Kimi for Coding > GitHub Copilot > OpenCode Go > OpenCode Zen > Z.ai Coding Plan
 
 MUST STRONGLY WARNING, WHEN USER SAID THEY DON'T HAVE CLAUDE SUBSCRIPTION, SISYPHUS AGENT MIGHT NOT WORK IDEALLY.
 
@@ -96,19 +101,20 @@ Spawn a subagent to handle installation and report back - to save context.
 Based on user's answers, run the CLI installer with appropriate flags:
 
 ```bash
-bunx oh-my-openagent install --no-tui --claude=<yes|no|max20> --gemini=<yes|no> --copilot=<yes|no> [--openai=<yes|no>] [--opencode-go=<yes|no>] [--opencode-zen=<yes|no>] [--zai-coding-plan=<yes|no>]
+bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --gemini=<yes|no> --copilot=<yes|no> [--openai=<yes|no>] [--opencode-go=<yes|no>] [--opencode-zen=<yes|no>] [--zai-coding-plan=<yes|no>] [--minimax=<yes|no>]
 ```
 
 **Examples:**
 
-- User has all native subscriptions: `bunx oh-my-openagent install --no-tui --claude=max20 --openai=yes --gemini=yes --copilot=no`
-- User has only Claude: `bunx oh-my-openagent install --no-tui --claude=yes --gemini=no --copilot=no`
-- User has Claude + OpenAI: `bunx oh-my-openagent install --no-tui --claude=yes --openai=yes --gemini=no --copilot=no`
-- User has only GitHub Copilot: `bunx oh-my-openagent install --no-tui --claude=no --gemini=no --copilot=yes`
-- User has Z.ai for Librarian: `bunx oh-my-openagent install --no-tui --claude=yes --gemini=no --copilot=no --zai-coding-plan=yes`
-- User has only OpenCode Zen: `bunx oh-my-openagent install --no-tui --claude=no --gemini=no --copilot=no --opencode-zen=yes`
-- User has OpenCode Go only: `bunx oh-my-openagent install --no-tui --claude=no --openai=no --gemini=no --copilot=no --opencode-go=yes`
-- User has no subscriptions: `bunx oh-my-openagent install --no-tui --claude=no --gemini=no --copilot=no`
+- User has all native subscriptions: `bunx oh-my-opencode install --no-tui --claude=max20 --openai=yes --gemini=yes --copilot=no`
+- User has only Claude: `bunx oh-my-opencode install --no-tui --claude=yes --gemini=no --copilot=no`
+- User has Claude + OpenAI: `bunx oh-my-opencode install --no-tui --claude=yes --openai=yes --gemini=no --copilot=no`
+- User has only GitHub Copilot: `bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=yes`
+- User has Z.ai for Librarian: `bunx oh-my-opencode install --no-tui --claude=yes --gemini=no --copilot=no --zai-coding-plan=yes`
+- User has only OpenCode Zen: `bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no --opencode-zen=yes`
+- User has OpenCode Go only: `bunx oh-my-opencode install --no-tui --claude=no --openai=no --gemini=no --copilot=no --opencode-go=yes`
+- User has only MiniMax: `bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no --minimax=yes`
+- User has no subscriptions: `bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no`
 
 The CLI will:
 

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -32,6 +32,7 @@ program
   .option("--zai-coding-plan <value>", "Z.ai Coding Plan subscription: no, yes (default: no)")
   .option("--kimi-for-coding <value>", "Kimi For Coding subscription: no, yes (default: no)")
   .option("--opencode-go <value>", "OpenCode Go subscription: no, yes (default: no)")
+  .option("--minimax <value>", "MiniMax subscription: no, yes (default: no)")
   .option("--skip-auth", "Skip authentication setup hints")
   .addHelpText("after", `
 Examples:
@@ -47,6 +48,7 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
   OpenCode Zen  opencode/ models (opencode/claude-opus-4-6, etc.)
    Z.ai          zai-coding-plan/glm-5 (visual-engineering fallback)
   Kimi          kimi-for-coding/k2p5 (Sisyphus/Prometheus fallback)
+  MiniMax       minimax/ models (MiniMax-M2.7 for all agents)
 `)
   .action(async (options) => {
     const args: InstallArgs = {
@@ -59,6 +61,7 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
       zaiCodingPlan: options.zaiCodingPlan,
       kimiForCoding: options.kimiForCoding,
       opencodeGo: options.opencodeGo,
+      minimax: options.minimax,
       skipAuth: options.skipAuth ?? false,
     }
     const exitCode = await install(args)

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -40,7 +40,7 @@ Examples:
   $ bunx oh-my-opencode install --no-tui --claude=max20 --openai=yes --gemini=yes --copilot=no
   $ bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=yes --opencode-zen=yes
 
-Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
+Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi > MiniMax):
   Claude        Native anthropic/ models (Opus, Sonnet, Haiku)
   OpenAI        Native openai/ models (GPT-5.4 for Oracle)
   Gemini        Native google/ models (Gemini 3.1 Pro, Flash)
@@ -48,7 +48,7 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
   OpenCode Zen  opencode/ models (opencode/claude-opus-4-6, etc.)
    Z.ai          zai-coding-plan/glm-5 (visual-engineering fallback)
   Kimi          kimi-for-coding/k2p5 (Sisyphus/Prometheus fallback)
-  MiniMax       minimax/ models (MiniMax-M2.7 for all agents)
+  MiniMax       minimax/ models (MiniMax-M2.7, last resort)
 `)
   .action(async (options) => {
     const args: InstallArgs = {

--- a/src/cli/config-manager/detect-current-config.ts
+++ b/src/cli/config-manager/detect-current-config.ts
@@ -11,6 +11,7 @@ function detectProvidersFromOmoConfig(): {
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
   hasOpencodeGo: boolean
+  hasMinimax: boolean
 } {
   const omoConfigPath = getOmoConfigPath()
   if (!existsSync(omoConfigPath)) {
@@ -20,6 +21,7 @@ function detectProvidersFromOmoConfig(): {
       hasZaiCodingPlan: false,
       hasKimiForCoding: false,
       hasOpencodeGo: false,
+      hasMinimax: false,
     }
   }
 
@@ -33,6 +35,7 @@ function detectProvidersFromOmoConfig(): {
         hasZaiCodingPlan: false,
         hasKimiForCoding: false,
         hasOpencodeGo: false,
+        hasMinimax: false,
       }
     }
 
@@ -42,8 +45,9 @@ function detectProvidersFromOmoConfig(): {
     const hasZaiCodingPlan = configStr.includes('"zai-coding-plan/')
     const hasKimiForCoding = configStr.includes('"kimi-for-coding/')
     const hasOpencodeGo = configStr.includes('"opencode-go/')
+    const hasMinimax = configStr.includes('"minimax/')
 
-    return { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo }
+    return { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo, hasMinimax }
   } catch {
     return {
       hasOpenAI: true,
@@ -51,6 +55,7 @@ function detectProvidersFromOmoConfig(): {
       hasZaiCodingPlan: false,
       hasKimiForCoding: false,
       hasOpencodeGo: false,
+      hasMinimax: false,
     }
   }
 }
@@ -72,6 +77,7 @@ export function detectCurrentConfig(): DetectedConfig {
     hasZaiCodingPlan: false,
     hasKimiForCoding: false,
     hasOpencodeGo: false,
+    hasMinimax: false,
   }
 
   const { format, path } = detectConfigFormat()
@@ -95,12 +101,13 @@ export function detectCurrentConfig(): DetectedConfig {
   const providers = openCodeConfig.provider as Record<string, unknown> | undefined
   result.hasGemini = providers ? "google" in providers : false
 
-  const { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo } = detectProvidersFromOmoConfig()
+  const { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo, hasMinimax } = detectProvidersFromOmoConfig()
   result.hasOpenAI = hasOpenAI
   result.hasOpencodeZen = hasOpencodeZen
   result.hasZaiCodingPlan = hasZaiCodingPlan
   result.hasKimiForCoding = hasKimiForCoding
   result.hasOpencodeGo = hasOpencodeGo
+  result.hasMinimax = hasMinimax
 
   return result
 }

--- a/src/cli/install-validators.ts
+++ b/src/cli/install-validators.ts
@@ -40,6 +40,7 @@ export function formatConfigSummary(config: InstallConfig): string {
   lines.push(formatProvider("OpenCode Zen", config.hasOpencodeZen, "opencode/ models"))
   lines.push(formatProvider("Z.ai Coding Plan", config.hasZaiCodingPlan, "Librarian/Multimodal"))
   lines.push(formatProvider("Kimi For Coding", config.hasKimiForCoding, "Sisyphus/Prometheus fallback"))
+  lines.push(formatProvider("MiniMax", config.hasMinimax, "MiniMax-M2.7 for all agents"))
 
   lines.push("")
   lines.push(color.dim("─".repeat(40)))
@@ -153,6 +154,10 @@ export function validateNonTuiArgs(args: InstallArgs): { valid: boolean; errors:
     errors.push(`Invalid --kimi-for-coding value: ${args.kimiForCoding} (expected: no, yes)`)
   }
 
+  if (args.minimax !== undefined && !["no", "yes"].includes(args.minimax)) {
+    errors.push(`Invalid --minimax value: ${args.minimax} (expected: no, yes)`)
+  }
+
   return { valid: errors.length === 0, errors }
 }
 
@@ -165,8 +170,9 @@ export function argsToConfig(args: InstallArgs): InstallConfig {
     hasCopilot: args.copilot === "yes",
     hasOpencodeZen: args.opencodeZen === "yes",
     hasZaiCodingPlan: args.zaiCodingPlan === "yes",
-hasKimiForCoding: args.kimiForCoding === "yes",
+    hasKimiForCoding: args.kimiForCoding === "yes",
     hasOpencodeGo: args.opencodeGo === "yes",
+    hasMinimax: args.minimax === "yes",
   }
 }
 
@@ -177,8 +183,9 @@ export function detectedToInitialValues(detected: DetectedConfig): {
   copilot: BooleanArg
   opencodeZen: BooleanArg
   zaiCodingPlan: BooleanArg
-kimiForCoding: BooleanArg
+  kimiForCoding: BooleanArg
   opencodeGo: BooleanArg
+  minimax: BooleanArg
 } {
   let claude: ClaudeSubscription = "no"
   if (detected.hasClaude) {
@@ -192,7 +199,8 @@ kimiForCoding: BooleanArg
     copilot: detected.hasCopilot ? "yes" : "no",
     opencodeZen: detected.hasOpencodeZen ? "yes" : "no",
     zaiCodingPlan: detected.hasZaiCodingPlan ? "yes" : "no",
-kimiForCoding: detected.hasKimiForCoding ? "yes" : "no",
+    kimiForCoding: detected.hasKimiForCoding ? "yes" : "no",
     opencodeGo: detected.hasOpencodeGo ? "yes" : "no",
+    minimax: detected.hasMinimax ? "yes" : "no",
   }
 }

--- a/src/cli/model-fallback-types.ts
+++ b/src/cli/model-fallback-types.ts
@@ -7,8 +7,9 @@ export interface ProviderAvailability {
 	opencodeZen: boolean
 	copilot: boolean
 	zai: boolean
-kimiForCoding: boolean
+	kimiForCoding: boolean
 	opencodeGo: boolean
+	minimax: boolean
 	isMaxPlan: boolean
 }
 

--- a/src/cli/provider-availability.ts
+++ b/src/cli/provider-availability.ts
@@ -11,8 +11,9 @@ export function toProviderAvailability(config: InstallConfig): ProviderAvailabil
 		opencodeZen: config.hasOpencodeZen,
 		copilot: config.hasCopilot,
 		zai: config.hasZaiCodingPlan,
-kimiForCoding: config.hasKimiForCoding,
+		kimiForCoding: config.hasKimiForCoding,
 		opencodeGo: config.hasOpencodeGo,
+		minimax: config.hasMinimax,
 		isMaxPlan: config.isMax20,
 	}
 }
@@ -25,8 +26,9 @@ export function isProviderAvailable(provider: string, availability: ProviderAvai
 		"github-copilot": availability.copilot,
 		opencode: availability.opencodeZen,
 		"zai-coding-plan": availability.zai,
-"kimi-for-coding": availability.kimiForCoding,
+		"kimi-for-coding": availability.kimiForCoding,
 		"opencode-go": availability.opencodeGo,
+		minimax: availability.minimax,
 	}
 	return mapping[provider] ?? false
 }

--- a/src/cli/tui-install-prompts.ts
+++ b/src/cli/tui-install-prompts.ts
@@ -110,6 +110,16 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
   })
   if (!opencodeGo) return null
 
+  const minimax = await selectOrCancel({
+    message: "Do you have a MiniMax subscription?",
+    options: [
+      { value: "no", label: "No", hint: "Will use other configured providers" },
+      { value: "yes", label: "Yes", hint: "MiniMax-M2.7 for all agents (recommended)" },
+    ],
+    initialValue: initial.minimax,
+  })
+  if (!minimax) return null
+
   return {
     hasClaude: claude !== "no",
     isMax20: claude === "max20",
@@ -120,5 +130,6 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
     hasZaiCodingPlan: zaiCodingPlan === "yes",
     hasKimiForCoding: kimiForCoding === "yes",
     hasOpencodeGo: opencodeGo === "yes",
+    hasMinimax: minimax === "yes",
   }
 }

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -9,8 +9,9 @@ export interface InstallArgs {
   copilot?: BooleanArg
   opencodeZen?: BooleanArg
   zaiCodingPlan?: BooleanArg
-kimiForCoding?: BooleanArg
+  kimiForCoding?: BooleanArg
   opencodeGo?: BooleanArg
+  minimax?: BooleanArg
   skipAuth?: boolean
 }
 
@@ -24,6 +25,7 @@ export interface InstallConfig {
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
   hasOpencodeGo: boolean
+  hasMinimax: boolean
 }
 
 export interface ConfigMergeResult {
@@ -43,4 +45,5 @@ export interface DetectedConfig {
   hasZaiCodingPlan: boolean
   hasKimiForCoding: boolean
   hasOpencodeGo: boolean
+  hasMinimax: boolean
 }

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -15,7 +15,6 @@ export type ModelRequirement = {
 export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   sisyphus: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-opus-4-6",
@@ -37,24 +36,24 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.4", variant: "medium" },
       { providers: ["zai-coding-plan", "opencode"], model: "glm-5" },
       { providers: ["opencode"], model: "big-pickle" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
     requiresAnyModel: true,
   },
   hephaestus: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "venice", "opencode"],
         model: "gpt-5.3-codex",
         variant: "medium",
       },
       { providers: ["github-copilot"], model: "gpt-5.4", variant: "medium" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
     requiresProvider: ["openai", "github-copilot", "venice", "opencode"],
   },
   oracle: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.4",
@@ -71,39 +70,39 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "max",
       },
       { providers: ["opencode-go"], model: "glm-5" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   librarian: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["opencode-go"], model: "minimax-m2.5" },
       { providers: ["opencode"], model: "minimax-m2.5-free" },
       { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
       { providers: ["opencode"], model: "gpt-5-nano" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   explore: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["github-copilot"], model: "grok-code-fast-1" },
       { providers: ["opencode-go"], model: "minimax-m2.5" },
       { providers: ["opencode"], model: "minimax-m2.5-free" },
       { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
       { providers: ["opencode"], model: "gpt-5-nano" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   "multimodal-looker": {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["openai", "opencode"], model: "gpt-5.4", variant: "medium" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
       { providers: ["zai-coding-plan"], model: "glm-4.6v" },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5-nano" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   prometheus: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-opus-4-6",
@@ -119,11 +118,11 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3.1-pro",
       },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   metis: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-opus-4-6",
@@ -136,11 +135,11 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       },
       { providers: ["opencode-go"], model: "glm-5" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   momus: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.4",
@@ -157,11 +156,11 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["opencode-go"], model: "glm-5" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   atlas: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-6" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
       {
@@ -169,11 +168,11 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "gpt-5.4",
         variant: "medium",
       },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   "sisyphus-junior": {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-6" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
       {
@@ -182,6 +181,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "medium",
       },
       { providers: ["opencode"], model: "big-pickle" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
 };
@@ -189,7 +189,6 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
 export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   "visual-engineering": {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3.1-pro",
@@ -203,11 +202,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       },
       { providers: ["opencode-go"], model: "glm-5" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   ultrabrain: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "opencode"],
         model: "gpt-5.4",
@@ -224,11 +223,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "max",
       },
       { providers: ["opencode-go"], model: "glm-5" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   deep: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "opencode"],
         model: "gpt-5.3-codex",
@@ -244,12 +243,12 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "gemini-3.1-pro",
         variant: "high",
       },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
     requiresModel: "gpt-5.3-codex",
   },
   artistry: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3.1-pro",
@@ -261,12 +260,12 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "max",
       },
       { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.4" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
     requiresModel: "gemini-3.1-pro",
   },
   quick: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.4-mini",
@@ -281,11 +280,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       },
       { providers: ["opencode-go"], model: "minimax-m2.5" },
       { providers: ["opencode"], model: "gpt-5-nano" },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   "unspecified-low": {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-sonnet-4-6",
@@ -300,11 +299,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3-flash",
       },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   "unspecified-high": {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-opus-4-6",
@@ -330,11 +329,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         ],
         model: "kimi-k2.5",
       },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
   writing: {
     fallbackChain: [
-      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3-flash",
@@ -344,6 +343,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-sonnet-4-6",
       },
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
   },
 };

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -50,7 +50,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["github-copilot"], model: "gpt-5.4", variant: "medium" },
       { providers: ["minimax"], model: "MiniMax-M2.7" },
     ],
-    requiresProvider: ["openai", "github-copilot", "venice", "opencode"],
+    requiresProvider: ["openai", "github-copilot", "venice", "opencode", "minimax"],
   },
   oracle: {
     fallbackChain: [

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -15,6 +15,7 @@ export type ModelRequirement = {
 export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   sisyphus: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-opus-4-6",
@@ -41,6 +42,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   hephaestus: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "venice", "opencode"],
         model: "gpt-5.3-codex",
@@ -52,6 +54,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   oracle: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.4",
@@ -72,6 +75,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   librarian: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["opencode-go"], model: "minimax-m2.5" },
       { providers: ["opencode"], model: "minimax-m2.5-free" },
       { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
@@ -80,6 +84,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   explore: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["github-copilot"], model: "grok-code-fast-1" },
       { providers: ["opencode-go"], model: "minimax-m2.5" },
       { providers: ["opencode"], model: "minimax-m2.5-free" },
@@ -89,6 +94,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   "multimodal-looker": {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["openai", "opencode"], model: "gpt-5.4", variant: "medium" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
       { providers: ["zai-coding-plan"], model: "glm-4.6v" },
@@ -97,6 +103,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   prometheus: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-opus-4-6",
@@ -116,6 +123,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   metis: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-opus-4-6",
@@ -132,6 +140,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   momus: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.4",
@@ -152,6 +161,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   atlas: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-6" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
       {
@@ -163,6 +173,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   "sisyphus-junior": {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-6" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
       {
@@ -178,6 +189,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
 export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   "visual-engineering": {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3.1-pro",
@@ -195,6 +207,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   ultrabrain: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "opencode"],
         model: "gpt-5.4",
@@ -215,6 +228,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   deep: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "opencode"],
         model: "gpt-5.3-codex",
@@ -235,6 +249,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   artistry: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3.1-pro",
@@ -251,6 +266,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   quick: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["openai", "github-copilot", "opencode"],
         model: "gpt-5.4-mini",
@@ -269,6 +285,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   "unspecified-low": {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-sonnet-4-6",
@@ -287,6 +304,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   "unspecified-high": {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["anthropic", "github-copilot", "opencode"],
         model: "claude-opus-4-6",
@@ -316,6 +334,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   writing: {
     fallbackChain: [
+      { providers: ["minimax"], model: "MiniMax-M2.7" },
       {
         providers: ["google", "github-copilot", "opencode"],
         model: "gemini-3-flash",


### PR DESCRIPTION
## Summary

Add MiniMax as a supported model provider in oh-my-opencode. MiniMax provides the MiniMax-M2.7 model.

## What This Adds

- **CLI Support**: New `--minimax=yes|no` flag for non-TUI installation
- **TUI Prompts**: Interactive prompt asking about MiniMax subscription during setup
- **Fallback Chain**: MiniMax-M2.7 added as last-resort fallback to all agent and category fallback chains
- **Provider Detection**: Config scanner detects `"minimax/"` patterns in existing configs

## Provider Priority

```
Native (anthropic/, openai/, google/) > Kimi for Coding > GitHub Copilot > OpenCode Go > OpenCode Zen > Z.ai Coding Plan > MiniMax
```

MiniMax is positioned as a last-resort option - it will only be used when all other providers are unavailable.

## Files Changed

| File | Change |
|------|--------|
| `src/cli/cli-program.ts` | Added `--minimax` CLI option |
| `src/cli/tui-install-prompts.ts` | Added MiniMax subscription prompt |
| `src/cli/types.ts` | Added `minimax` to types |
| `src/cli/install-validators.ts` | Added `--minimax` validation |
| `src/cli/provider-availability.ts` | Added `minimax` to provider mapping |
| `src/cli/config-manager/detect-current-config.ts` | Added `hasMinimax` detection |
| `src/shared/model-requirements.ts` | Added MiniMax to all fallback chains |
| `docs/guide/installation.md` | Updated with MiniMax subscription option |

## Testing

Tests are enabled. Users with MiniMax subscriptions can authenticate via `opencode auth login` and the system will use MiniMax-M2.7 as a fallback when other providers are unavailable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MiniMax as a supported provider across the CLI, TUI, and model fallback chains. `MiniMax-M2.7` is used only when higher‑priority providers are unavailable, and Hephaestus now activates for MiniMax‑only setups.

- **New Features**
  - CLI: `--minimax=yes|no`; help text and docs (incl. Step 5) list MiniMax at the end of the provider priority chain.
  - TUI: prompt to enable MiniMax during setup.
  - Detection: config scanner flags `"minimax/"` and provider availability exposes `minimax`.
  - Fallbacks: added `minimax/MiniMax-M2.7` as the last fallback in all agent and category chains; included in Hephaestus `requiresProvider` to support MiniMax-only users.

<sup>Written for commit da48d9475b6689f8fe1c1e9244d9e5c000c737e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

