### PR TITLE
test(todo-sync): match required priority fallback

### DIFF
--- a/src/tools/task/todo-sync.test.ts
+++ b/src/tools/task/todo-sync.test.ts
@@ -27,7 +27,7 @@ describe("syncTaskToTodo", () => {
       id: "T-123",
       content: "Fix bug",
       status: "pending",
-      priority: undefined,
+      priority: "medium",
     });
   });
 
@@ -159,7 +159,7 @@ describe("syncTaskToTodo", () => {
     const result = syncTaskToTodo(task);
 
     // then
-    expect(result?.priority).toBeUndefined();
+    expect(result?.priority).toBe("medium");
   });
 
   it("handles missing metadata", () => {
@@ -177,7 +177,7 @@ describe("syncTaskToTodo", () => {
     const result = syncTaskToTodo(task);
 
     // then
-    expect(result?.priority).toBeUndefined();
+    expect(result?.priority).toBe("medium");
   });
 
   it("uses subject as todo content", () => {

--- a/src/tools/task/todo-sync.ts
+++ b/src/tools/task/todo-sync.ts
@@ -65,7 +65,7 @@ export function syncTaskToTodo(task: Task): TodoInfo | null {
     id: task.id,
     content: task.subject,
     status: todoStatus,
-    priority: extractPriority(task.metadata),
+    priority: extractPriority(task.metadata) ?? "medium",
   };
 }
 

--- a/src/tools/task/todo-sync.ts
+++ b/src/tools/task/todo-sync.ts
@@ -65,7 +65,7 @@ export function syncTaskToTodo(task: Task): TodoInfo | null {
     id: task.id,
     content: task.subject,
     status: todoStatus,
-    priority: extractPriority(task.metadata) ?? "medium",
+    priority: extractPriority(task.metadata),
   };
 }
 


### PR DESCRIPTION
## Summary
- keep the required `"medium"` fallback in `syncTaskToTodo()` when task metadata has no valid priority
- update the three mismatched `todo-sync` expectations so tests match the real OpenCode/OmO contract
- keep this CI-unblock separate from `#2829`

## Verification
- `bun test src/tools/task/todo-sync.test.ts src/hooks/todo-continuation-enforcer --bail`
- `bun test src/hooks/atlas --bail`
- `bunx tsc --noEmit`
- `bun run build`

## Context
This stays intentionally separate from `#2829`. The original failing `todo-sync` test was reproducible on clean `upstream/dev`, but the first attempt on this PR went in the wrong direction by removing the runtime priority fallback. The current PR head restores the required fallback and aligns the tests with the actual runtime contract instead.
