### PR TITLE
feat(agent-priority): inject order field for deterministic agent Tab cycling

### DIFF
--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -60,6 +60,7 @@ describe("applyAgentConfig builtin override protection", () => {
     name: "Builtin Sisyphus",
     prompt: "builtin prompt",
     mode: "primary",
+    order: 1,
   }
 
   const builtinOracleConfig: AgentConfig = {

--- a/src/plugin-handlers/agent-priority-order.ts
+++ b/src/plugin-handlers/agent-priority-order.ts
@@ -1,11 +1,21 @@
 import { getAgentDisplayName } from "../shared/agent-display-names";
 
-const CORE_AGENT_ORDER = [
-  getAgentDisplayName("sisyphus"),
-  getAgentDisplayName("hephaestus"),
-  getAgentDisplayName("prometheus"),
-  getAgentDisplayName("atlas"),
-] as const;
+const CORE_AGENT_ORDER: ReadonlyArray<{ displayName: string; order: number }> = [
+  { displayName: getAgentDisplayName("sisyphus"), order: 1 },
+  { displayName: getAgentDisplayName("hephaestus"), order: 2 },
+  { displayName: getAgentDisplayName("prometheus"), order: 3 },
+  { displayName: getAgentDisplayName("atlas"), order: 4 },
+];
+
+function injectOrderField(
+  agentConfig: unknown,
+  order: number,
+): unknown {
+  if (typeof agentConfig === "object" && agentConfig !== null) {
+    return { ...agentConfig, order };
+  }
+  return agentConfig;
+}
 
 export function reorderAgentsByPriority(
   agents: Record<string, unknown>,
@@ -13,10 +23,10 @@ export function reorderAgentsByPriority(
   const ordered: Record<string, unknown> = {};
   const seen = new Set<string>();
 
-  for (const key of CORE_AGENT_ORDER) {
-    if (Object.prototype.hasOwnProperty.call(agents, key)) {
-      ordered[key] = agents[key];
-      seen.add(key);
+  for (const { displayName, order } of CORE_AGENT_ORDER) {
+    if (Object.prototype.hasOwnProperty.call(agents, displayName)) {
+      ordered[displayName] = injectOrderField(agents[displayName], order);
+      seen.add(displayName);
     }
   }
 


### PR DESCRIPTION
## Summary

- Inject explicit `order` field (1-4) into four core agents so Tab cycling order is preserved after OpenCode 1.3.0+ alphabetical sorting
- Pre-empts upstream support: once [anomalyco/opencode#19127](https://github.com/anomalyco/opencode/pull/19127) merges, the order takes effect automatically

## Problem

OpenCode 1.3.0 introduced alphabetical agent sorting ([#18261](https://github.com/anomalyco/opencode/pull/18261)), which overrides oh-my-opencode's intended agent order. Tab cycle changed from `Sisyphus → Hephaestus → Prometheus → Atlas` to `Sisyphus -> Atlas → Hephaestus → Prometheus`.

The existing `reorderAgentsByPriority()` only controlled object insertion order, which OpenCode's `sortBy` ignores.

## Solution

Refactored `reorderAgentsByPriority()` to inject an `order` field into each core agent config:

| Agent | Order |
|-------|-------|
| Sisyphus | 1 |
| Hephaestus | 2 |
| Prometheus | 3 |
| Atlas | 4 |

The `order` field is part of the upstream PR ([anomalyco/opencode#19127](https://github.com/anomalyco/opencode/pull/19127), refs [#7372](https://github.com/anomalyco/opencode/issues/7372)). Until merged, the field is harmlessly ignored by OpenCode.

## Changes

- `src/plugin-handlers/agent-priority-order.ts`: Refactored `CORE_AGENT_ORDER` to carry `order` values, added `injectOrderField()` helper
- `src/plugin-handlers/agent-config-handler.test.ts`: Updated test expectation to include injected `order` field

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit order field to core agents to enforce deterministic Tab cycling despite OpenCode 1.3.0 alphabetical sorting. Prepares for upstream order support so the order applies automatically when available and is a no-op until then.

- **New Features**
  - Assigned order: Sisyphus 1, Hephaestus 2, Prometheus 3, Atlas 4.
  - Refactored `reorderAgentsByPriority()` to inject `order` via `injectOrderField()`.
  - Updated tests to expect `order` on builtin Sisyphus.

<sup>Written for commit 5befb602298aa0597288d6ac4ab2c6fe0d49550f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

