### PR TITLE
fix(context-limit-resolver): check modelContextLimitsCache before Anthropic hardcoded fallback

### DIFF
--- a/src/shared/context-limit-resolver.test.ts
+++ b/src/shared/context-limit-resolver.test.ts
@@ -28,12 +28,12 @@ describe("resolveActualContextLimit", () => {
     resetContextLimitEnv()
   })
 
-  it("returns the default Anthropic limit when 1M mode is disabled despite a cached limit", () => {
+  it("returns the cached limit for Anthropic providers when modelContextLimitsCache has an entry", () => {
     // given
     delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
     delete process.env[VERTEX_CONTEXT_ENV_KEY]
     const modelContextLimitsCache = new Map<string, number>()
-    modelContextLimitsCache.set("anthropic/claude-sonnet-4-5", 123456)
+    modelContextLimitsCache.set("anthropic/claude-sonnet-4-5", 1_000_000)
 
     // when
     const actualLimit = resolveActualContextLimit("anthropic", "claude-sonnet-4-5", {
@@ -42,7 +42,21 @@ describe("resolveActualContextLimit", () => {
     })
 
     // then
-    expect(actualLimit).toBe(200000)
+    expect(actualLimit).toBe(1_000_000)
+  })
+
+  it("falls back to Anthropic default when no cached limit exists and 1M mode is disabled", () => {
+    // given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    // when
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-sonnet-4-5", {
+      anthropicContext1MEnabled: false,
+    })
+
+    // then
+    expect(actualLimit).toBe(200_000)
   })
 
   it("treats Anthropics aliases as Anthropic providers", () => {

--- a/src/shared/context-limit-resolver.ts
+++ b/src/shared/context-limit-resolver.ts
@@ -25,9 +25,12 @@ export function resolveActualContextLimit(
   modelID: string,
   modelCacheState?: ContextLimitModelCacheState,
 ): number | null {
+  const cached = modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`)
+  if (cached) return cached
+
   if (isAnthropicProvider(providerID)) {
     return getAnthropicActualLimit(modelCacheState)
   }
 
-  return modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`) ?? null
+  return null
 }


### PR DESCRIPTION
## Summary

- `resolveActualContextLimit()` now checks `modelContextLimitsCache` first for **all** providers before falling back to provider-specific logic
- Anthropic providers previously skipped the cache entirely, ignoring user-configured context limits from `opencode.json`

Fixes #2836

## Problem

`resolveActualContextLimit()` had an early return for Anthropic providers that bypassed `modelContextLimitsCache`:

```typescript
if (isAnthropicProvider(providerID)) {
  return getAnthropicActualLimit(modelCacheState) // ← cache never checked
}
```

This caused Claude Opus 4.6 (1M context, GA since March 2026) to report as 200K when used behind a proxy that doesn't return the `context-1m` beta header.

## Fix

Check the config-populated cache first, then fall back to provider-specific defaults:

```typescript
const cached = modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`)
if (cached) return cached

if (isAnthropicProvider(providerID)) {
  return getAnthropicActualLimit(modelCacheState)
}
return null
```

## Changes

- `src/shared/context-limit-resolver.ts` — Reorder resolution: cache → provider-specific → null
- `src/shared/context-limit-resolver.test.ts` — Update test to validate cache is respected for Anthropic; add fallback test

## Testing

- Updated existing test: cache entry for Anthropic now returns cached value (was asserting 200K)
- Added new test: no cache entry + 1M disabled → falls back to 200K default
- Existing tests for aliases and non-Anthropic providers pass unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect cached model context limits by checking `modelContextLimitsCache` before provider fallbacks in `resolveActualContextLimit()`. Fixes Anthropic models incorrectly reporting 200K when a cached 1M limit is configured from `opencode.json`.

- **Bug Fixes**
  - Reordered resolution to: cache → provider-specific logic → null (for all providers).
  - Anthropic no longer bypasses the cache; tests updated for cached 1M and default 200K fallback.

<sup>Written for commit af5aaf7a877266235398b93e78d28a79bfb3f0b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

