### PR TITLE
feat: upgrade remaining MiniMax M2.5 fallbacks to M2.7-highspeed

### DIFF
--- a/src/shared/model-requirements.test.ts
+++ b/src/shared/model-requirements.test.ts
@@ -80,7 +80,7 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
 
     const second = librarian.fallbackChain[1]
     expect(second.providers[0]).toBe("opencode")
-    expect(second.model).toBe("minimax-m2.5")
+    expect(second.model).toBe("minimax-m2.7-highspeed")
 
     const tertiary = librarian.fallbackChain[2]
     expect(tertiary.providers).toContain("anthropic")
@@ -106,11 +106,11 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
 
     const secondary = explore.fallbackChain[1]
     expect(secondary.providers).toContain("opencode-go")
-    expect(secondary.model).toBe("minimax-m2.7")
+    expect(secondary.model).toBe("minimax-m2.7-highspeed")
 
     const tertiary = explore.fallbackChain[2]
     expect(tertiary.providers).toContain("opencode")
-    expect(tertiary.model).toBe("minimax-m2.5")
+    expect(tertiary.model).toBe("minimax-m2.7")
 
     const quaternary = explore.fallbackChain[3]
     expect(quaternary.providers).toContain("anthropic")

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -78,7 +78,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   librarian: {
     fallbackChain: [
       { providers: ["opencode-go"], model: "minimax-m2.7" },
-      { providers: ["opencode"], model: "minimax-m2.5" },
+      { providers: ["opencode"], model: "minimax-m2.7-highspeed" },
       { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
       { providers: ["opencode"], model: "gpt-5-nano" },
     ],
@@ -86,8 +86,8 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   explore: {
     fallbackChain: [
       { providers: ["github-copilot", "xai"], model: "grok-code-fast-1" },
-      { providers: ["opencode-go"], model: "minimax-m2.7" },
-      { providers: ["opencode"], model: "minimax-m2.5" },
+      { providers: ["opencode-go"], model: "minimax-m2.7-highspeed" },
+      { providers: ["opencode"], model: "minimax-m2.7" },
       { providers: ["anthropic", "opencode"], model: "claude-haiku-4-5" },
       { providers: ["opencode"], model: "gpt-5-nano" },
     ],


### PR DESCRIPTION
## Summary

- Upgrade the secondary MiniMax fallback entries in `librarian` and `explore` agents from M2.5 to M2.7-highspeed
- Completes the M2.5 → M2.7 migration (primary fallbacks were already upgraded)
- Updates corresponding test assertions

## Changes

### `src/shared/model-requirements.ts`
- **librarian**: 2nd fallback `minimax-m2.5` → `minimax-m2.7-highspeed`
- **explore**: 2nd fallback `minimax-m2.7` → `minimax-m2.7-highspeed`, 3rd fallback `minimax-m2.5` → `minimax-m2.7`

### `src/shared/model-requirements.test.ts`
- Update librarian and explore test assertions to match new M2.7/M2.7-highspeed model IDs

## Why M2.7-highspeed?

MiniMax-M2.7-highspeed is the ultra-fast variant of the M2.7 generation, optimized for latency-sensitive tasks like codebase grep and search — exactly the workload librarian and explore handle.

## Test plan

- [x] `bun test src/shared/model-requirements.test.ts` — 31 tests pass (814 expect() calls)
- [x] No other M2.5 references remain in non-generated source files