### PR TITLE
fix(publish): restore version commit-back to dev after npm release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,6 +216,19 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
+      - name: Commit version bump
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add package.json packages/*/package.json
+          git diff --cached --quiet || git commit -m "release: v${{ steps.version.outputs.version }}"
+          git tag -f "v${{ steps.version.outputs.version }}"
+          git push origin --tags --force
+          git push origin HEAD
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check if oh-my-openagent already published
         id: check-openagent
         run: |


### PR DESCRIPTION
The dual-publish commit `e244403` (March 8) replaced the old "Git commit and tag" step with the openagent publish logic. The version bump that was being committed back to dev got dropped as collateral.

Since then, `package.json` has been stuck at `3.11.0` while npm is at `3.13.1`. Anything reading the version from source (doctor, auto-update, binary embed, `/get-unpublished-changes`) gets the wrong number.

This re-adds the commit-back step between the oh-my-opencode publish and the openagent publish, which is where it needs to sit so the `git checkout -- package.json` at the end only reverts the name mutation, not the version bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the missing commit-back of the version bump in the publish workflow so the repo’s `package.json` stays in sync with the npm release, fixing stale version reads across tools.

- **Bug Fixes**
  - Add a “Commit version bump” step that commits root and package `package.json` changes, tags `v{version}`, and pushes branch and tags.
  - Place the step between the two publish phases to avoid reverting the version bump during cleanup.
  - Guard with the existing skip check to avoid unnecessary commits.

<sup>Written for commit fb837db90d7727c3510e389e681ad3b8f08781e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

