### PR TITLE
fix(delegate-task): apply category config temperature/maxTokens/top_p to categoryModel (fixes #2831)

### DIFF
--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -12,7 +12,18 @@ import { buildFallbackChainFromModels, findMostSpecificFallbackEntry } from "../
 import { getAvailableModelsForDelegateTask } from "./available-models"
 import { resolveModelForDelegateTask } from "./model-selection"
 
+import type { CategoryConfig } from "../../config/schema"
 import type { DelegatedModelConfig } from "./types"
+
+function applyCategoryParams(base: DelegatedModelConfig, config: CategoryConfig): DelegatedModelConfig {
+  const result = { ...base }
+  if (config.temperature !== undefined) result.temperature = config.temperature
+  if (config.top_p !== undefined) result.top_p = config.top_p
+  if (config.maxTokens !== undefined) result.maxTokens = config.maxTokens
+  if (config.reasoningEffort !== undefined) result.reasoningEffort = config.reasoningEffort
+  if (config.thinking !== undefined) result.thinking = config.thinking
+  return result
+}
 
 export interface CategoryResolutionResult {
   agentToUse: string
@@ -106,7 +117,7 @@ Available categories: ${allCategoryNames}`,
       const parsedModel = parseModelString(actualModel)
       const variantToUse = userCategories?.[args.category!]?.variant ?? resolved.config.variant
       categoryModel = parsedModel
-        ? (variantToUse ? { ...parsedModel, variant: variantToUse } : parsedModel)
+        ? applyCategoryParams({ ...parsedModel, variant: variantToUse }, resolved.config)
         : undefined
     }
   } else {
@@ -165,7 +176,7 @@ Available categories: ${allCategoryNames}`,
       const parsedModel = parseModelString(actualModel)
       const variantToUse = userCategories?.[args.category!]?.variant ?? resolvedVariant ?? resolved.config.variant
       categoryModel = parsedModel
-        ? (variantToUse ? { ...parsedModel, variant: variantToUse } : parsedModel)
+        ? applyCategoryParams({ ...parsedModel, variant: variantToUse }, resolved.config)
         : undefined
     }
   }

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -234,11 +234,11 @@ Available categories: ${categoryNames.join(", ")}`,
     categoryModel = {
       ...categoryModel,
       variant: userCategories?.[args.category!]?.variant ?? effectiveEntry.variant ?? categoryModel.variant,
-      reasoningEffort: effectiveEntry.reasoningEffort,
-      temperature: effectiveEntry.temperature,
-      top_p: effectiveEntry.top_p,
-      maxTokens: effectiveEntry.maxTokens,
-      thinking: effectiveEntry.thinking,
+      reasoningEffort: effectiveEntry.reasoningEffort ?? categoryModel.reasoningEffort,
+      temperature: effectiveEntry.temperature ?? categoryModel.temperature,
+      top_p: effectiveEntry.top_p ?? categoryModel.top_p,
+      maxTokens: effectiveEntry.maxTokens ?? categoryModel.maxTokens,
+      thinking: effectiveEntry.thinking ?? categoryModel.thinking,
     }
   }
 


### PR DESCRIPTION
## Summary
- Apply category config's temperature, maxTokens, top_p, reasoningEffort, and thinking fields to categoryModel during task delegation

## Problem
When using `task(category="...")`, the category config's `temperature`, `maxTokens`, `top_p`, `reasoningEffort`, and `thinking` fields are silently ignored. Only `model` and `variant` are applied to `categoryModel`. This causes the sisyphus-junior agent's hardcoded defaults (e.g., `temperature: 0.1`) to override category-specified values, breaking Claude models with `variant: "max"` where extended thinking requires `temperature: 1`.

## Fix
Added `applyCategoryParams()` helper that transfers non-undefined category config fields (`temperature`, `top_p`, `maxTokens`, `reasoningEffort`, `thinking`) onto the `DelegatedModelConfig`. Applied at both category model building sites in `category-resolver.ts` (with and without model requirements). Fallback entry params (lines 222-232) still take final precedence for model-specific overrides.

## Changes
| File | Change |
|------|--------|
| `src/tools/delegate-task/category-resolver.ts` | Add `applyCategoryParams()` helper, apply at both `categoryModel` construction sites (L108-110 and L167-169) |

Fixes #2831

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply and preserve category config params during delegate-task resolution so `temperature`, `top_p`, `maxTokens`, `reasoningEffort`, and `thinking` are used in the `categoryModel` for `task(category="...")` and not overwritten by defaults or undefined fallbacks. Fixes #2831.

- **Bug Fixes**
  - Added `applyCategoryParams()` to merge non-undefined category fields into `DelegatedModelConfig`.
  - Applied in both category model build paths in `category-resolver.ts`.
  - Guarded fallback overrides so undefined fields don’t replace category params; defined fallback values still win.

<sup>Written for commit 98572c8dac3f9a6965ef19fafa98e9de5ad2c2d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

