### PR TITLE
fix(recovery): detect empty text parts alongside tool calls in fixEmptyMessages (fixes #2830)

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.ts
@@ -1,4 +1,4 @@
-import { replaceEmptyTextPartsAsync } from "../session-recovery/storage/empty-text"
+import { replaceEmptyTextPartsAsync, findMessagesWithEmptyTextPartsFromSDK } from "../session-recovery/storage/empty-text"
 import { injectTextPartAsync } from "../session-recovery/storage/text-part-injector"
 import type { Client } from "./client"
 
@@ -157,11 +157,19 @@ export async function fixEmptyMessagesWithSDK(params: {
   }
 
   const emptyMessageIds = await findEmptyMessagesFromSDK(params.client, params.sessionID)
-  if (emptyMessageIds.length === 0) {
+
+  // Also find messages with empty text parts alongside non-empty content (e.g., tool calls).
+  // messageHasContentFromSDK returns true for these since they have tool parts,
+  // but the API still rejects the empty text block.
+  const emptyTextPartIds = await findMessagesWithEmptyTextPartsFromSDK(params.client, params.sessionID)
+  const additionalIds = emptyTextPartIds.filter((id) => !emptyMessageIds.includes(id))
+  const allTargetIds = [...emptyMessageIds, ...additionalIds]
+
+  if (allTargetIds.length === 0) {
     return { fixed: false, fixedMessageIds: [], scannedEmptyCount: 0 }
   }
 
-  for (const messageID of emptyMessageIds) {
+  for (const messageID of allTargetIds) {
     const replaced = await replaceEmptyTextPartsAsync(
       params.client,
       params.sessionID,
@@ -187,5 +195,5 @@ export async function fixEmptyMessagesWithSDK(params: {
     }
   }
 
-  return { fixed, fixedMessageIds, scannedEmptyCount: emptyMessageIds.length }
+  return { fixed, fixedMessageIds, scannedEmptyCount: allTargetIds.length }
 }


### PR DESCRIPTION
## Summary
- Fix empty message recovery to detect empty text parts in messages that also contain tool call parts

## Problem
When an assistant message contains both tool call parts and an empty text part `{"type": "text", "text": ""}`, `messageHasContentFromSDK()` returns `true` because it finds tool-type parts. This causes `findEmptyMessagesFromSDK()` to skip the message entirely. But the Anthropic API still rejects it because of the empty text block, causing sessions to become permanently broken.

## Fix
Added a second scan pass in `fixEmptyMessagesWithSDK` using the existing `findMessagesWithEmptyTextPartsFromSDK()` function (already in `session-recovery/storage/empty-text.ts`). This catches messages that have empty text parts alongside non-empty content (tool calls). The existing `replaceEmptyTextPartsAsync` correctly handles replacing only the empty text parts within such messages.

## Changes
| File | Change |
|------|--------|
| `src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery-sdk.ts` | Import `findMessagesWithEmptyTextPartsFromSDK`, add second scan pass after `findEmptyMessagesFromSDK`, merge results with deduplication |

Fixes #2830

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes recovery for assistant messages that have empty text blocks alongside tool calls, preventing Anthropic API rejections and stuck sessions. Adds a second scan to detect and replace only the empty text parts. Fixes #2830.

- **Bug Fixes**
  - Also scan with findMessagesWithEmptyTextPartsFromSDK, in addition to findEmptyMessagesFromSDK.
  - Merge and dedupe target message IDs; process all with replaceEmptyTextPartsAsync.
  - Update scannedEmptyCount to reflect all processed messages.

<sup>Written for commit 404390efda7ce2d5f6012d8537270ecb7f24e002. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

