### PR TITLE
fix(delegate-task): reject when both category and subagent_type provided (fixes #2847)

### DIFF
--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -465,7 +465,7 @@ describe("sisyphus-task", () => {
        expect(args.subagent_type).toBe("Sisyphus-Junior")
     }, { timeout: 10000 })
 
-    test("category overrides subagent_type and still maps to sisyphus-junior", async () => {
+    test("rejects when both category and subagent_type are provided", async () => {
       //#given
       const { createDelegateTask } = require("./tools")
 
@@ -507,14 +507,7 @@ describe("sisyphus-task", () => {
         abort: new AbortController().signal,
       }
 
-      const args: {
-        description: string
-        prompt: string
-        category: string
-        subagent_type: string
-        run_in_background: boolean
-        load_skills: string[]
-      } = {
+      const args = {
         description: "Override test",
         prompt: "Do something",
         category: "quick",
@@ -523,12 +516,8 @@ describe("sisyphus-task", () => {
         load_skills: [],
       }
 
-      //#when
-      const result = await tool.execute(args, toolContext)
-
-      //#then
-      expect(args.subagent_type).toBe("Sisyphus-Junior")
-      expect(result).toContain("Background task launched")
+      //#when + #then
+      await expect(tool.execute(args, toolContext)).rejects.toThrow("mutually exclusive")
     }, { timeout: 10000 })
 
     test("proceeds without error when systemDefaultModel is undefined", async () => {

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -102,20 +102,23 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
       prompt: tool.schema.string().describe("Full detailed prompt for the agent"),
       run_in_background: tool.schema.boolean().describe("REQUIRED. true=async (returns task_id), false=sync (waits). Use false for task delegation, true ONLY for parallel exploration."),
       category: tool.schema.string().optional().describe(`REQUIRED if subagent_type not provided. Do NOT provide both category and subagent_type.`),
-      subagent_type: tool.schema.string().optional().describe("REQUIRED if category not provided. Do NOT provide both category and subagent_type."),
+      subagent_type: tool.schema.string().optional().describe("REQUIRED if category not provided. Do NOT provide both category and subagent_type. Valid values: explore, librarian, oracle, metis, momus"),
       session_id: tool.schema.string().optional().describe("Existing Task session to continue"),
       command: tool.schema.string().optional().describe("The command that triggered this task"),
     },
     async execute(args: DelegateTaskArgs, toolContext) {
       const ctx = toolContext as ToolContextWithMetadata
 
+      if (args.category && args.subagent_type) {
+        throw new Error(
+          `Invalid arguments: 'category' and 'subagent_type' are mutually exclusive. Provide EXACTLY ONE.\n` +
+          `  - You provided: category="${args.category}", subagent_type="${args.subagent_type}"\n` +
+          `  - Use category for task delegation (e.g., category="${categoryExamples.split(", ")[0]}")\n` +
+          `  - Use subagent_type for direct agent invocation (e.g., subagent_type="explore")\n` +
+          `  - Valid subagent_type values: explore, librarian, oracle, metis, momus`
+        )
+      }
       if (args.category) {
-        if (args.subagent_type && args.subagent_type !== SISYPHUS_JUNIOR_AGENT) {
-          log("[task] category provided - overriding subagent_type to sisyphus-junior", {
-            category: args.category,
-            subagent_type: args.subagent_type,
-          })
-        }
         args.subagent_type = SISYPHUS_JUNIOR_AGENT
       }
       await ctx.metadata?.({


### PR DESCRIPTION
## Summary
- Enforce mutual exclusion between category and subagent_type parameters in the task tool

## Problem
The task tool JSON schema allows both `category` and `subagent_type` to be present simultaneously. Models confabulate invalid values (e.g., `subagent_type: "Sisyphus-Junior"`) when both fields are provided, leading to wasted retries. The constraint is documented in prose but not enforced by the schema or runtime validation.

## Fix
1. **Runtime validation**: Added an explicit error when both `category` and `subagent_type` are provided. The error message names the violation and lists valid `subagent_type` values to guide the model toward correct usage.
2. **Schema hint**: Added valid values enum hint to `subagent_type` description (`explore, librarian, oracle, metis, momus`) so models can see the allowed values directly in the schema.
3. **Removed silent override**: Previously, providing both fields would silently ignore `subagent_type` and use the category. Now it produces a clear structured error instead.

## Changes
| File | Change |
|------|--------|
| `src/tools/delegate-task/tools.ts` | Add mutual exclusion validation (throws on both), enumerate valid subagent_type values in schema description |

Fixes #2847

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects tasks that pass both `category` and `subagent_type` in the delegate-task tool to enforce mutual exclusivity and avoid wasted retries. Fixes #2847 and lists valid `subagent_type` values in the schema for clearer guidance.

- **Bug Fixes**
  - Throws a clear error when both fields are provided; message shows inputs and valid `subagent_type` values: explore, librarian, oracle, metis, momus.
  - Adds the allowed values to the `subagent_type` schema description.
  - Removes the silent override that ignored `subagent_type` when `category` was set.
  - Updates tests to expect the mutual-exclusion error when both fields are provided.

<sup>Written for commit 8136679b1cc10ea24d5a535594cda18a53044781. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

