### PR TITLE
fix(shared): check modelContextLimitsCache for all Anthropic models (fixes #2836)

### DIFF
--- a/src/shared/context-limit-resolver.test.ts
+++ b/src/shared/context-limit-resolver.test.ts
@@ -45,7 +45,7 @@ describe("resolveActualContextLimit", () => {
     expect(actualLimit).toBe(1_000_000)
   })
 
-  it("returns default 200K for older Anthropic models even when cached limit is higher", () => {
+  it("returns cached limit for Anthropic models when cache entry exists", () => {
     // given
     delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
     delete process.env[VERTEX_CONTEXT_ENV_KEY]
@@ -58,8 +58,8 @@ describe("resolveActualContextLimit", () => {
       modelContextLimitsCache,
     })
 
-    // then
-    expect(actualLimit).toBe(200_000)
+    // then — cached limit should be respected for all Anthropic models, not just GA ones
+    expect(actualLimit).toBe(500_000)
   })
 
   it("returns default 200K for Anthropic models without cached limit and 1M mode disabled", () => {

--- a/src/shared/context-limit-resolver.ts
+++ b/src/shared/context-limit-resolver.ts
@@ -40,7 +40,7 @@ export function resolveActualContextLimit(
     if (explicit1M === 1_000_000) return explicit1M
 
     const cachedLimit = modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`)
-    if (cachedLimit && isAnthropicNoHeaderGaModel(modelID)) return cachedLimit
+    if (cachedLimit) return cachedLimit
 
     return DEFAULT_ANTHROPIC_ACTUAL_LIMIT
   }


### PR DESCRIPTION
## Summary
- Allow cached model context limits to be used for all Anthropic models, not just GA ones

## Problem
`resolveActualContextLimit()` only checks `modelContextLimitsCache` for Anthropic GA models (claude-opus-4-6, claude-sonnet-4-6) due to the `isAnthropicNoHeaderGaModel()` guard. All other Anthropic models (claude-sonnet-4-5, etc.) fall through to the hardcoded `DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200000`, ignoring any cached context limits from models.dev or user configuration.

## Fix
Removed the `isAnthropicNoHeaderGaModel()` restriction from the cache lookup. Now all Anthropic models check `modelContextLimitsCache` before falling back to the 200K default. The 1M explicit check still takes priority when the beta header or env var is set.

## Changes
| File | Change |
|------|--------|
| `src/shared/context-limit-resolver.ts` | Remove `isAnthropicNoHeaderGaModel` guard from cache lookup (L42-43) |
| `src/shared/context-limit-resolver.test.ts` | Update test to expect cached limit (500K) instead of hardcoded default (200K) |

Fixes #2836

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use cached context limits for all Anthropic models by checking `modelContextLimitsCache` regardless of GA status. Prevents incorrect fallback to 200K when a higher cached limit exists; explicit 1M mode still takes priority. Fixes #2836.

- **Bug Fixes**
  - In `resolveActualContextLimit`, removed the `isAnthropicNoHeaderGaModel()` guard so any Anthropic model uses the cached limit if present.
  - Updated tests to expect 500K from cache for non-GA models; fallback remains 200K when no cache and no 1M mode.

<sup>Written for commit 69ef9fc6401ebd549db287b0f1d69d9dce8a2044. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

