### PR TITLE
Fix missing load_skills parameter in hook-injected delegate_task examples

### DIFF
--- a/src/hooks/agent-usage-reminder/constants.ts
+++ b/src/hooks/agent-usage-reminder/constants.ts
@@ -34,9 +34,9 @@ RECOMMENDED: Use task with explore/librarian agents for better results:
 
 \`\`\`
 // Parallel exploration - fire multiple agents simultaneously
-task(agent="explore", prompt="Find all files matching pattern X")
-task(agent="explore", prompt="Search for implementation of Y") 
-task(agent="librarian", prompt="Lookup documentation for Z")
+task(subagent_type="explore", load_skills=[], prompt="Find all files matching pattern X")
+task(subagent_type="explore", load_skills=[], prompt="Search for implementation of Y")
+task(subagent_type="librarian", load_skills=[], prompt="Lookup documentation for Z")
 
 // Then continue your work while they run in background
 // System will notify you when each completes

--- a/src/hooks/atlas/system-reminder-templates.ts
+++ b/src/hooks/atlas/system-reminder-templates.ts
@@ -203,6 +203,7 @@ But for any substantial changes, USE \`task\`.
 \`\`\`
 task(
   category="...",
+  load_skills=[],
   prompt="[specific single task with clear acceptance criteria]"
 )
 \`\`\`

--- a/src/hooks/atlas/verification-reminders.ts
+++ b/src/hooks/atlas/verification-reminders.ts
@@ -29,7 +29,7 @@ Your completion will NOT be recorded until you complete ALL of the following:
 
 If anything fails while closing this out, resume the same session immediately:
 \`\`\`typescript
-task(session_id="${sessionId}", prompt="fix: checkbox not recorded correctly")
+task(session_id="${sessionId}", load_skills=[], prompt="fix: checkbox not recorded correctly")
 \`\`\`
 
 **Your completion is NOT tracked until the checkbox is marked in the plan file.**
@@ -47,7 +47,7 @@ ${VERIFICATION_REMINDER}
 
 **If ANY verification fails, use this immediately:**
 \`\`\`
-task(session_id="${sessionId}", prompt="fix: [describe the specific failure]")
+task(session_id="${sessionId}", load_skills=[], prompt="fix: [describe the specific failure]")
 \`\`\`
 
 ${buildReuseHint(sessionId)}`

--- a/src/hooks/task-resume-info/hook.ts
+++ b/src/hooks/task-resume-info/hook.ts
@@ -30,7 +30,7 @@ export function createTaskResumeInfoHook() {
 
     output.output =
       outputText.trimEnd() +
-      `\n\nto continue: task(session_id="${sessionId}", prompt="...")`
+      `\n\nto continue: task(session_id="${sessionId}", load_skills=[], prompt="...")`
   }
 
   return {

--- a/src/hooks/task-resume-info/index.test.ts
+++ b/src/hooks/task-resume-info/index.test.ts
@@ -87,7 +87,7 @@ describe("createTaskResumeInfoHook", () => {
         const output = {
           title: "task",
           output:
-            'Done.\nSession ID: ses_abc123\nto continue: task(session_id="ses_abc123", prompt="...")',
+            'Done.\nSession ID: ses_abc123\nto continue: task(session_id="ses_abc123", load_skills=[], prompt="...")',
           metadata: {},
         }
 


### PR DESCRIPTION
## Summary

Fixes #2803

Three hook files inject `delegate_task()` call examples into the agent context at runtime, but these examples were missing the required `load_skills` parameter. When agents imitate these incomplete examples, they trigger a validation error:

```
Invalid arguments: 'load_skills' parameter is REQUIRED. Pass [] if no skills needed.
```

This was missed during the fix in PR #1663 because that change focused on static prompts and tool schemas, while these hooks generate examples dynamically at runtime.

## Changes

- `src/hooks/agent-usage-reminder/constants.ts` -- Added `load_skills=[]` to all three delegate_task examples, also fixed deprecated `agent=` parameter to `subagent_type=`
- `src/hooks/atlas/index.ts` -- Added `load_skills=[]` to delegate_task examples in the orchestrator delegation template and the verification failure template
- `src/hooks/task-resume-info/index.ts` -- Added `load_skills=[]` to the dynamically generated continuation hint

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] Verified all modified strings contain `load_skills=[]`
- [ ] Manual test: trigger agent-usage-reminder hook by using grep/glob directly in an orchestrator session, confirm the injected example includes load_skills

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing `load_skills=[]` parameter to all hook-injected `task` examples to prevent validation errors when agents copy them (fixes #2803). Also switch deprecated `agent=` to `subagent_type=` in the usage reminder and update the task-resume-info test.

- **Bug Fixes**
  - Add `load_skills=[]` to examples in agent-usage-reminder, atlas system reminder and verification templates, and task-resume-info continuation hint.
  - Replace `agent` with `subagent_type` in usage reminder examples.
  - Update the task-resume-info test to reflect the new continuation hint.

<sup>Written for commit 8bde294978b362e5aa16d154d4fe3482a1961311. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

