### PR TITLE
Fix empty message recovery when tool calls coexist with empty text parts

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery.ts
@@ -1,6 +1,7 @@
 import {
   findEmptyMessages,
   findEmptyMessageByIndex,
+  findMessagesWithEmptyTextParts,
   injectTextPart,
   replaceEmptyTextParts,
 } from "../session-recovery/storage"
@@ -79,7 +80,9 @@ export async function fixEmptyMessages(params: {
 
   if (!fixed) {
     const emptyMessageIds = findEmptyMessages(params.sessionID)
-    if (emptyMessageIds.length === 0) {
+    const emptyTextPartIds = findMessagesWithEmptyTextParts(params.sessionID)
+    const allIds = [...new Set([...emptyMessageIds, ...emptyTextPartIds])]
+    if (allIds.length === 0) {
       await params.client.tui
         .showToast({
           body: {
@@ -93,7 +96,7 @@ export async function fixEmptyMessages(params: {
       return false
     }
 
-    for (const messageID of emptyMessageIds) {
+    for (const messageID of allIds) {
       const replaced = replaceEmptyTextParts(messageID, PLACEHOLDER_TEXT)
       if (replaced) {
         fixed = true

--- a/src/hooks/anthropic-context-window-limit-recovery/message-builder.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/message-builder.ts
@@ -4,6 +4,7 @@ import { normalizeSDKResponse } from "../../shared"
 import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 import {
   findEmptyMessages,
+  findMessagesWithEmptyTextParts,
   injectTextPart,
   replaceEmptyTextParts,
 } from "../session-recovery/storage"
@@ -114,12 +115,14 @@ export async function sanitizeEmptyMessagesBeforeSummarize(
   }
 
   const emptyMessageIds = findEmptyMessages(sessionID)
-  if (emptyMessageIds.length === 0) {
+  const emptyTextPartIds = findMessagesWithEmptyTextParts(sessionID)
+  const allIds = [...new Set([...emptyMessageIds, ...emptyTextPartIds])]
+  if (allIds.length === 0) {
     return 0
   }
 
   let fixedCount = 0
-  for (const messageID of emptyMessageIds) {
+  for (const messageID of allIds) {
     const replaced = replaceEmptyTextParts(messageID, PLACEHOLDER_TEXT)
     if (replaced) {
       fixedCount++
@@ -135,7 +138,7 @@ export async function sanitizeEmptyMessagesBeforeSummarize(
     log("[auto-compact] pre-summarize sanitization fixed empty messages", {
       sessionID,
       fixedCount,
-      totalEmpty: emptyMessageIds.length,
+      totalEmpty: allIds.length,
     })
   }
 


### PR DESCRIPTION
## Summary

Fixes #2830

The session recovery logic fails to detect and fix a common error case where an assistant message contains both tool call parts and an empty text part. The Anthropic API rejects these messages with:

```
messages: text content blocks must be non-empty
```

The root cause is that `findEmptyMessages()` uses `messageHasContent()` which returns `true` as soon as it sees a tool_use part, skipping over the empty text part entirely. The recovery runs but never identifies the problematic message, leaving the session permanently broken.

The fix is straightforward: `findMessagesWithEmptyTextParts()` already exists in storage.ts and correctly identifies messages containing empty text parts regardless of other content types. It was just never used in the recovery path.

## Changes

- `src/hooks/anthropic-context-window-limit-recovery/empty-content-recovery.ts` -- In the fallback path of `fixEmptyMessages()`, also scan for messages with empty text parts using `findMessagesWithEmptyTextParts()` and merge both result sets before processing
- `src/hooks/anthropic-context-window-limit-recovery/message-builder.ts` -- In `sanitizeEmptyMessagesBeforeSummarize()`, same pattern: combine results from both detection methods to catch all problematic messages before summarization

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [ ] Manual test: create a session where an assistant message has both a tool_use part and an empty text part, verify recovery now detects and fixes it
- [ ] Verify that existing completely-empty message recovery still works as before (no regression)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session recovery for assistant messages that include tool calls plus an empty text part, preventing Anthropic “text content blocks must be non-empty” errors. Sessions now detect and repair these cases instead of getting stuck. Fixes #2830.

- **Bug Fixes**
  - In empty-content recovery, merge results from `findEmptyMessages()` and `findMessagesWithEmptyTextParts()`, de-dupe IDs, and replace empty text parts.
  - In pre-summarize sanitization, apply the same combined detection and update logging to reflect the new total.

<sup>Written for commit b1735d400406e84bc434899578bc0783214c61f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

