### PR TITLE
fix(tools): add max_tools config to cap registered tools for OpenAI compatibility (fixes #2848)

### DIFF
--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -21,6 +21,8 @@ export const ExperimentalConfigSchema = z.object({
   hashline_edit: z.boolean().optional(),
   /** Append fallback model info to session title when a runtime fallback occurs (default: false) */
   model_fallback_title: z.boolean().optional(),
+  /** Maximum number of tools to register. When set, lower-priority tools are excluded to stay within provider limits (e.g., OpenAI's 128-tool cap). Accounts for ~20 OpenCode built-in tools. */
+  max_tools: z.number().int().min(1).optional(),
 })
 
 export type ExperimentalConfig = z.infer<typeof ExperimentalConfigSchema>

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -150,7 +150,34 @@ export function createToolRegistry(args: {
     normalizeToolArgSchemas(toolDefinition)
   }
 
-  const filteredTools = filterDisabledTools(allTools, pluginConfig.disabled_tools)
+  const filteredTools: ToolsRecord = filterDisabledTools(allTools, pluginConfig.disabled_tools)
+
+  const maxTools = pluginConfig.experimental?.max_tools
+  if (maxTools) {
+    const estimatedBuiltinTools = 20
+    const pluginToolBudget = maxTools - estimatedBuiltinTools
+    const toolEntries = Object.entries(filteredTools)
+    if (pluginToolBudget > 0 && toolEntries.length > pluginToolBudget) {
+      const excess = toolEntries.length - pluginToolBudget
+      log(`[tool-registry] Tool count (${toolEntries.length} plugin + ~${estimatedBuiltinTools} builtin = ~${toolEntries.length + estimatedBuiltinTools}) exceeds max_tools=${maxTools}. Trimming ${excess} lower-priority tools.`)
+      const lowPriorityTools = [
+        "session_list", "session_read", "session_search", "session_info",
+        "call_omo_agent", "interactive_bash", "look_at",
+        "task_create", "task_get", "task_list", "task_update",
+      ]
+      let removed = 0
+      for (const toolName of lowPriorityTools) {
+        if (removed >= excess) break
+        if (filteredTools[toolName]) {
+          delete filteredTools[toolName]
+          removed += 1
+        }
+      }
+      if (removed < excess) {
+        log(`[tool-registry] WARNING: Could not trim enough tools. ${toolEntries.length - removed} plugin tools remain.`)
+      }
+    }
+  }
 
   return {
     filteredTools,


### PR DESCRIPTION
## Summary
- Add `experimental.max_tools` config to automatically trim lower-priority tools when the total exceeds provider limits

## Problem
OpenAI enforces a 128-tool maximum per request. oh-my-opencode registers ~120+ custom tools, which combined with ~20 OpenCode built-in tools totals ~141, exceeding the limit and causing every request to OpenAI models to fail with `Invalid 'tools': array too long`.

## Fix
Added `experimental.max_tools` config option (integer). When set, the tool registry calculates the plugin's tool budget (max_tools minus ~20 estimated built-in tools) and trims excess tools from a predefined low-priority list:
- Session history tools (session_list, session_read, session_search, session_info)
- call_omo_agent (redundant with task tool)
- interactive_bash (niche use case)
- look_at (optional multimodal)
- Task system tools (task_create, task_get, task_list, task_update)

Users can set `"experimental": { "max_tools": 128 }` in their config to fix OpenAI compatibility.

## Changes
| File | Change |
|------|--------|
| `src/config/schema/experimental.ts` | Add `max_tools` field to ExperimentalConfigSchema |
| `src/plugin/tool-registry.ts` | After filtering disabled tools, trim low-priority tools when count exceeds budget |

Fixes #2848

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `experimental.max_tools` to cap registered tools and auto-trim low-priority ones so OpenAI requests stay within the 128-tool limit. Fixes #2848 by preventing "Invalid 'tools': array too long" errors.

- **New Features**
  - New config `experimental.max_tools` (int). Registry computes a plugin budget as max minus ~20 built-ins.
  - If plugin tools exceed the budget, it drops lower-priority tools: `session_*`, `task_*`, `call_omo_agent`, `interactive_bash`, `look_at`.

- **Migration**
  - Set `"experimental": { "max_tools": 128 }` in your config to enable the cap.

<sup>Written for commit 82d89fd5fcfd4c6d28f9870fbfbd84874e7c97d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

