### PR TITLE
feat(atlas): support plugin tools with metadata.sessionId in orchestration hook

### DIFF
--- a/src/hooks/atlas/subagent-session-id.test.ts
+++ b/src/hooks/atlas/subagent-session-id.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { extractSessionIdFromOutput } from "./subagent-session-id"
+import { extractSessionIdFromMetadata, extractSessionIdFromOutput } from "./subagent-session-id"
 
 describe("extractSessionIdFromOutput", () => {
   test("extracts Session ID blocks from background output", () => {
@@ -75,5 +75,46 @@ debug log: session_id: ses_wrong_body_789`
 
     // then
     expect(result).toBe("ses_real_metadata_456")
+  })
+})
+
+describe("extractSessionIdFromMetadata", () => {
+  test("extracts sessionId from tool metadata object", () => {
+    // given
+    const metadata = { sessionId: "ses_plugin_abc123" }
+
+    // when
+    const result = extractSessionIdFromMetadata(metadata)
+
+    // then
+    expect(result).toBe("ses_plugin_abc123")
+  })
+
+  test("returns undefined for metadata without sessionId", () => {
+    // given
+    const metadata = { title: "some task" }
+
+    // when
+    const result = extractSessionIdFromMetadata(metadata)
+
+    // then
+    expect(result).toBeUndefined()
+  })
+
+  test("returns undefined for non-object metadata", () => {
+    expect(extractSessionIdFromMetadata(null)).toBeUndefined()
+    expect(extractSessionIdFromMetadata(undefined)).toBeUndefined()
+    expect(extractSessionIdFromMetadata("string")).toBeUndefined()
+  })
+
+  test("rejects sessionId values that don't start with ses_", () => {
+    // given
+    const metadata = { sessionId: "not-a-session-id" }
+
+    // when
+    const result = extractSessionIdFromMetadata(metadata)
+
+    // then
+    expect(result).toBeUndefined()
   })
 })

--- a/src/hooks/atlas/subagent-session-id.ts
+++ b/src/hooks/atlas/subagent-session-id.ts
@@ -3,6 +3,16 @@ import { log } from "../../shared/logger"
 import { isSessionInBoulderLineage } from "./boulder-session-lineage"
 import { HOOK_NAME } from "./hook-name"
 
+export function extractSessionIdFromMetadata(metadata: unknown): string | undefined {
+  if (metadata && typeof metadata === "object" && "sessionId" in metadata) {
+    const value = (metadata as Record<string, unknown>).sessionId
+    if (typeof value === "string" && value.startsWith("ses_")) {
+      return value
+    }
+  }
+  return undefined
+}
+
 export function extractSessionIdFromOutput(output: string): string | undefined {
   const taskMetadataBlocks = [...output.matchAll(/<task_metadata>([\s\S]*?)<\/task_metadata>/gi)]
   const lastTaskMetadataBlock = taskMetadataBlocks.at(-1)?.[1]

--- a/src/hooks/atlas/tool-execute-after.ts
+++ b/src/hooks/atlas/tool-execute-after.ts
@@ -14,7 +14,7 @@ import { shouldPauseForFinalWaveApproval } from "./final-wave-approval-gate"
 import { HOOK_NAME } from "./hook-name"
 import { DIRECT_WORK_REMINDER } from "./system-reminder-templates"
 import { isSisyphusPath } from "./sisyphus-path"
-import { extractSessionIdFromOutput, validateSubagentSessionId } from "./subagent-session-id"
+import { extractSessionIdFromMetadata, extractSessionIdFromOutput, validateSubagentSessionId } from "./subagent-session-id"
 import {
   buildCompletionGate,
   buildFinalWaveApprovalReminder,
@@ -105,7 +105,9 @@ export function createToolExecuteAfterHandler(input: {
       return
     }
 
-    if (toolInput.tool !== "task") {
+    const metadataSessionId = extractSessionIdFromMetadata(toolOutput.metadata)
+    const isPluginToolWithSession = toolInput.tool !== "task" && !!metadataSessionId
+    if (toolInput.tool !== "task" && !isPluginToolWithSession) {
       return
     }
 
@@ -115,6 +117,7 @@ export function createToolExecuteAfterHandler(input: {
       pendingTaskRefs.delete(toolInput.callID)
     }
     const isBackgroundLaunch = outputStr.includes("Background task launched") || outputStr.includes("Background task continued")
+      || outputStr.includes("Background delegate launched")
     if (isBackgroundLaunch) {
       return
     }
@@ -125,7 +128,7 @@ export function createToolExecuteAfterHandler(input: {
       const verificationDirectory = worktreePath ? worktreePath : ctx.directory
       const gitStats = collectGitDiffStats(verificationDirectory)
       const fileChanges = formatFileChanges(gitStats)
-      const extractedSessionId = extractSessionIdFromOutput(toolOutput.output)
+      const extractedSessionId = metadataSessionId ?? extractSessionIdFromOutput(toolOutput.output)
 
       if (boulderState) {
         const progress = getPlanProgress(boulderState.active_plan)


### PR DESCRIPTION
## Problem

The atlas `tool-execute-after` hook only processes the built-in `task` tool (line 108: `if (toolInput.tool !== "task") return`). Plugin tools that create child sessions and set `context.metadata({ metadata: { sessionId } })` are completely ignored by atlas orchestration — no boulder tracking, no verification reminders, no session ID extraction.

This means custom plugin tools like [custom-agent-bridge](https://github.com/OsomePteLtd/dev/blob/main/.opencode/plugins/custom-agent-bridge.ts) that delegate work to child sessions don't participate in the orchestration flow, even though they follow the same `metadata.sessionId` pattern as the built-in task tool.

## Fix

### 1. Add `extractSessionIdFromMetadata()` (`subagent-session-id.ts`)

Reads `sessionId` directly from tool metadata object, preferred over text-based extraction. Validates the value starts with `ses_` to avoid false positives.

### 2. Extend `tool-execute-after` guard (`tool-execute-after.ts`)

Instead of `if (toolInput.tool !== "task") return`, now also allows any tool where `toolOutput.metadata.sessionId` is set:

```typescript
const metadataSessionId = extractSessionIdFromMetadata(toolOutput.metadata)
const isPluginToolWithSession = toolInput.tool !== "task" && !!metadataSessionId
if (toolInput.tool !== "task" && !isPluginToolWithSession) {
  return
}
```

Also recognizes `"Background delegate launched"` as a background launch string alongside the existing task patterns.

When extracting the session ID, metadata is preferred over text parsing:
```typescript
const extractedSessionId = metadataSessionId ?? extractSessionIdFromOutput(toolOutput.output)
```

## Changes

- `src/hooks/atlas/subagent-session-id.ts` — Add `extractSessionIdFromMetadata()` function
- `src/hooks/atlas/tool-execute-after.ts` — Extend guard to process plugin tools with `metadata.sessionId`
- `src/hooks/atlas/subagent-session-id.test.ts` — Add 4 test cases for metadata extraction

## Plugin Tool Pattern

Plugin tools that create child sessions should set metadata matching the built-in task tool pattern:

```typescript
context.metadata({
  title: description,
  metadata: { sessionId: childSessionId },
})
```

After this change, they'll automatically participate in atlas orchestration (boulder tracking, verification reminders, system-reminder injection).

## Note on TUI Navigation

This PR enables **atlas orchestration** for plugin tools. TUI clickability (navigating to child sessions by clicking on tool calls) is controlled by OpenCode's Go TUI binary, which currently only checks `toolCall.Name == agent.AgentToolName`. A separate OpenCode PR would be needed to also check tool metadata for session navigation.

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun test src/hooks/atlas/subagent-session-id.test.ts` passes (10/10)
- [x] No version changes in `package.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable atlas orchestration for plugin tools that create child sessions by reading `metadata.sessionId` in the `tool-execute-after` hook. This extends boulder tracking and verification reminders beyond the built-in `task` tool.

- **New Features**
  - Added `extractSessionIdFromMetadata()` to read `ses_` IDs from tool metadata (preferred over output parsing).
  - Process non-`task` tools when `toolOutput.metadata.sessionId` is present.
  - Recognize "Background delegate launched" as a background launch to skip orchestration.
  - Added tests for metadata-based session ID extraction.

<sup>Written for commit 6e700e000af2df3f614b1657fcc65ee9c2e03a46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

