### PR TITLE
fix: use getAgentDisplayName in injectBoulderContinuation

### DIFF
--- a/src/hooks/atlas/boulder-continuation-injector.ts
+++ b/src/hooks/atlas/boulder-continuation-injector.ts
@@ -2,6 +2,7 @@ import type { PluginInput } from "@opencode-ai/plugin"
 import type { BackgroundManager } from "../../features/background-agent"
 import { log } from "../../shared/logger"
 import { createInternalAgentTextPart, resolveInheritedPromptTools } from "../../shared"
+import { getAgentDisplayName } from "../../shared/agent-display-names"
 import { HOOK_NAME } from "./hook-name"
 import { BOULDER_CONTINUATION_PROMPT } from "./system-reminder-templates"
 import { resolveRecentPromptContextForSession } from "./recent-model-resolver"
@@ -62,7 +63,7 @@ export async function injectBoulderContinuation(input: {
     await ctx.client.session.promptAsync({
       path: { id: sessionID },
       body: {
-        agent: agent ?? "atlas",
+        agent: getAgentDisplayName(agent ?? "atlas"),
         ...(promptContext.model !== undefined ? { model: promptContext.model } : {}),
         ...(inheritedTools ? { tools: inheritedTools } : {}),
         parts: [createInternalAgentTextPart(prompt)],


### PR DESCRIPTION
## Summary
- Fixed "Agent not found: 'atlas'" error in `injectBoulderContinuation`
- Added `getAgentDisplayName()` call to convert config key to display name

## Root Cause
`injectBoulderContinuation` was passing raw agent config key `"atlas"` to `session.promptAsync`, but the SDK's agent matching logic compares against display names registered in the system (`"Atlas (Plan Executor)"`).

## Fix
```typescript
// Before
agent: agent ?? "atlas",

// After  
agent: getAgentDisplayName(agent ?? "atlas"),
```

## Test Plan
- [ ] Run auto-compact with atlas agent configured
- [ ] Verify no "Agent not found" errors in logs
- [ ] Confirm atlas agent executes properly

Fixes issue where auto-compact continuation would fail with "Agent not found: 'atlas'" error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "Agent not found: 'atlas'" during boulder continuation by mapping the agent config key to the SDK’s expected display name. Ensures the atlas agent runs correctly in auto-compact.

- **Bug Fixes**
  - Use `getAgentDisplayName(agent ?? "atlas")` when setting `agent` in `injectBoulderContinuation`, so `session.promptAsync` receives the correct display name (e.g., "Atlas (Plan Executor)").

<sup>Written for commit a3b84ec5f91a601c698903dbe25d0606ef703779. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

