### PR TITLE
fix: add model_not_supported to retryable error patterns

### DIFF
--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -45,6 +45,7 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /(?:^|\s)429(?:\s|$)/,
   /(?:^|\s)503(?:\s|$)/,
   /(?:^|\s)529(?:\s|$)/,
+  /model.?not.?supported/i,
 ]
 
 /**

--- a/src/shared/model-error-classifier.ts
+++ b/src/shared/model-error-classifier.ts
@@ -67,6 +67,9 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   "504",
   "429",
   "529",
+  "model_not_supported",
+  "model is not supported",
+  "model not supported",
 ]
 
 const AUTO_RETRY_GATE_PATTERNS = [


### PR DESCRIPTION
Fixes #2885

Problem: When a subagent is assigned a model that returns a `model_not_supported` error, the error is not recognized as retryable. This causes the subagent to silently fail.

Changes:
- Added `model_not_supported`, `model is not supported`, and `model not supported` to `RETRYABLE_MESSAGE_PATTERNS` in `src/shared/model-error-classifier.ts`
- Added regex pattern `/model.?not.?supported/i` to `RETRYABLE_ERROR_PATTERNS` in `src/hooks/runtime-fallback/constants.ts`

These patterns will now trigger the fallback mechanism when a model is not supported, allowing the subagent to retry with an alternative model instead of silently failing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add model-not-supported errors to retryable error patterns so the runtime fallback kicks in for unsupported models. Subagents now retry with an alternative model instead of failing silently when providers return `model_not_supported` or similar messages.

<sup>Written for commit a8bfd900bbf4e87d2784811e03f0008de6208ee7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

