### PR TITLE
fix(config): apply git_master defaults when section is missing (fixes #2040)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -969,6 +969,45 @@ describe("GitMasterConfigSchema", () => {
   })
 })
 
+describe("OhMyOpenCodeConfigSchema - git_master defaults (#2040)", () => {
+  test("git_master defaults are applied when section is missing from config", () => {
+    //#given
+    const config = {}
+
+    //#when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    //#then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.git_master).toBeDefined()
+      expect(result.data.git_master.commit_footer).toBe(true)
+      expect(result.data.git_master.include_co_authored_by).toBe(true)
+      expect(result.data.git_master.git_env_prefix).toBe("GIT_MASTER=1")
+    }
+  })
+
+  test("git_master respects explicit false values", () => {
+    //#given
+    const config = {
+      git_master: {
+        commit_footer: false,
+        include_co_authored_by: false,
+      },
+    }
+
+    //#when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    //#then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.git_master.commit_footer).toBe(false)
+      expect(result.data.git_master.include_co_authored_by).toBe(false)
+    }
+  })
+})
+
 describe("skills schema", () => {
   test("accepts skills.sources configuration", () => {
     //#given

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -60,7 +60,11 @@ export const OhMyOpenCodeConfigSchema = z.object({
   model_capabilities: ModelCapabilitiesConfigSchema.optional(),
   openclaw: OpenClawConfigSchema.optional(),
   babysitting: BabysittingConfigSchema.optional(),
-  git_master: GitMasterConfigSchema.optional(),
+  git_master: GitMasterConfigSchema.default({
+    commit_footer: true,
+    include_co_authored_by: true,
+    git_env_prefix: "GIT_MASTER=1",
+  }),
   browser_automation_engine: BrowserAutomationConfigSchema.optional(),
   websearch: WebsearchConfigSchema.optional(),
   tmux: TmuxConfigSchema.optional(),

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -188,9 +188,9 @@ export function loadPluginConfig(
     migrateLegacyConfigFile(projectDetected.path);
   }
 
-  // Load user config first (base)
+  // Load user config first (base). Parse empty config through Zod to apply field defaults.
   let config: OhMyOpenCodeConfig =
-    loadConfigFromPath(userConfigPath, ctx) ?? {};
+    loadConfigFromPath(userConfigPath, ctx) ?? OhMyOpenCodeConfigSchema.parse({});
 
   // Override with project config
   const projectConfig = loadConfigFromPath(projectConfigPath, ctx);


### PR DESCRIPTION
## Summary
- Ensure `git_master` config defaults are always applied even when the section is entirely absent from user config

## Problem
When `git_master` config exists only in the global config file (no project-level config), `pluginConfig.git_master` is `undefined` after Zod parsing because the root schema marks it as `.optional()`. This causes `injectGitMasterConfig()` to use `?? true` fallbacks, ignoring user-specified `commit_footer: false` and `include_co_authored_by: false`.

The root cause: `git_master: GitMasterConfigSchema.optional()` means Zod does NOT apply field-level defaults (inside `GitMasterConfigSchema`) when the entire `git_master` key is missing from the config input.

## Fix
Changed `git_master` from `.optional()` to `.default({...})` in the root schema so Zod always produces a fully-populated `git_master` object with field-level defaults applied. When the user explicitly sets `commit_footer: false`, the value is correctly preserved through the `?? true` fallback in `injectGitMasterConfig`.

## Changes
| File | Change |
|------|--------|
| `src/config/schema/oh-my-opencode-config.ts` | Change `git_master` from `.optional()` to `.default({...})` |
| `src/config/schema.test.ts` | Add tests verifying defaults are applied and explicit `false` values are respected |

Fixes #2040

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `git_master` defaults when the section is missing, and also when the user config file is absent, so settings like `commit_footer` and `include_co_authored_by` are honored. Fixes #2040.

- **Bug Fixes**
  - Set `git_master` in `OhMyOpenCodeConfigSchema` to `.default({ commit_footer: true, include_co_authored_by: true, git_env_prefix: "GIT_MASTER=1" })` and, when no user config is found, fall back to `OhMyOpenCodeConfigSchema.parse({})` to apply Zod defaults.
  - Added tests to confirm defaults are applied and explicit `false` values are preserved.

<sup>Written for commit 2b2b2808958f42a894dc439fa453bcdb6f5cfae2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

