### PR TITLE
fix(start-work): gracefully handle missing Atlas agent (fixes #2132)

### DIFF
--- a/src/features/claude-code-session-state/state.ts
+++ b/src/features/claude-code-session-state/state.ts
@@ -11,12 +11,23 @@ export function getMainSessionID(): string | undefined {
   return _mainSessionID
 }
 
+const registeredAgentNames = new Set<string>()
+
+export function registerAgentName(name: string): void {
+  registeredAgentNames.add(name.toLowerCase())
+}
+
+export function isAgentRegistered(name: string): boolean {
+  return registeredAgentNames.has(name.toLowerCase())
+}
+
 /** @internal For testing only */
 export function _resetForTesting(): void {
   _mainSessionID = undefined
   subagentSessions.clear()
   syncSubagentSessions.clear()
   sessionAgentMap.clear()
+  registeredAgentNames.clear()
 }
 
 const sessionAgentMap = new Map<string, string>()

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -12,7 +12,7 @@ import {
 } from "../../features/boulder-state"
 import { log } from "../../shared/logger"
 import { getAgentDisplayName } from "../../shared/agent-display-names"
-import { updateSessionAgent } from "../../features/claude-code-session-state"
+import { updateSessionAgent, isAgentRegistered } from "../../features/claude-code-session-state"
 import { detectWorktreePath } from "./worktree-detector"
 import { parseUserRequest } from "./parse-user-request"
 
@@ -80,9 +80,14 @@ export function createStartWorkHook(ctx: PluginInput) {
       if (!promptText.includes("<session-context>")) return
 
       log(`[${HOOK_NAME}] Processing start-work command`, { sessionID: input.sessionID })
-      updateSessionAgent(input.sessionID, "atlas")
-      if (output.message) {
-        output.message["agent"] = getAgentDisplayName("atlas")
+      const atlasDisplayName = getAgentDisplayName("atlas")
+      if (isAgentRegistered("atlas") || isAgentRegistered(atlasDisplayName)) {
+        updateSessionAgent(input.sessionID, "atlas")
+        if (output.message) {
+          output.message["agent"] = atlasDisplayName
+        }
+      } else {
+        log(`[${HOOK_NAME}] Atlas agent not available, continuing with current agent`, { sessionID: input.sessionID })
       }
 
       const existingState = readBoulderState(ctx.directory)

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -4,6 +4,7 @@ import type { OhMyOpenCodeConfig } from "../config";
 import { log, migrateAgentConfig } from "../shared";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { getAgentDisplayName } from "../shared/agent-display-names";
+import { registerAgentName } from "../features/claude-code-session-state";
 import {
   discoverConfigSourceSkills,
   discoverGlobalAgentsSkills,
@@ -292,6 +293,9 @@ export async function applyAgentConfig(params: {
   }
 
   const agentResult = params.config.agent as Record<string, unknown>;
+  for (const name of Object.keys(agentResult)) {
+    registerAgentName(name);
+  }
   log("[config-handler] agents loaded", { agentKeys: Object.keys(agentResult) });
   return agentResult;
 }


### PR DESCRIPTION
## Summary
- Prevent `/start-work` from crashing when Atlas agent is not registered

## Problem
The `/start-work` hook unconditionally sets the session agent to "atlas" via `updateSessionAgent()` and `output.message["agent"]`. When `maybeCreateAtlasConfig()` returns `undefined` (model resolution fails because user's configured providers don't match Atlas's fallback chain), Atlas is never registered but the hook still tries to use it, causing: `Agent not found: "Atlas (Plan Executor)"`.

## Fix
Three changes:

1. **Agent name registry** (`state.ts`): Added `registerAgentName()` and `isAgentRegistered()` functions to track which agents were successfully registered with OpenCode.

2. **Agent registration** (`agent-config-handler.ts`): After all agents are finalized and registered in `params.config.agent`, register each agent name in the registry.

3. **Conditional agent switch** (`start-work-hook.ts`): Check `isAgentRegistered("atlas")` before switching. If Atlas isn't available, log a warning and continue with the current agent. The plan context injection still works regardless.

## Changes
| File | Change |
|------|--------|
| `src/features/claude-code-session-state/state.ts` | Add `registerAgentName()` and `isAgentRegistered()` functions |
| `src/plugin-handlers/agent-config-handler.ts` | Register all finalized agent names after config loading |
| `src/hooks/start-work/start-work-hook.ts` | Check Atlas availability before switching agent |

Fixes #2132

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `/start-work` from crashing when the Atlas agent isn’t registered by only switching to Atlas if it’s available. Continues with the current agent and keeps plan context injection working. Fixes #2132.

- **Bug Fixes**
  - Added agent name registry with `registerAgentName()` and `isAgentRegistered()` in session state.
  - Registered all finalized agent names during config load in `applyAgentConfig`.
  - In `start-work`, switch to Atlas only if registered; otherwise log a warning and leave the agent unchanged.

<sup>Written for commit d09af86ea72683d46db6942316a5869382702828. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

