### PR TITLE
fix: use display name in runtime-fallback retry

### DIFF
--- a/src/hooks/runtime-fallback/auto-retry.ts
+++ b/src/hooks/runtime-fallback/auto-retry.ts
@@ -9,6 +9,7 @@ import { SessionCategoryRegistry } from "../../shared/session-category-registry"
 import { buildRetryModelPayload } from "./retry-model-payload"
 import { getLastUserRetryParts } from "./last-user-retry-parts"
 import { extractSessionMessages } from "./session-messages"
+import { getAgentDisplayName } from "../../shared/agent-display-names"
 
 const SESSION_TTL_MS = 30 * 60 * 1000
 
@@ -126,13 +127,14 @@ export function createAutoRetryHelpers(deps: HookDeps) {
         })
 
         const retryAgent = resolvedAgent ?? getSessionAgent(sessionID)
+        const retryAgentDisplayName = retryAgent ? getAgentDisplayName(retryAgent) : undefined
         sessionAwaitingFallbackResult.add(sessionID)
         scheduleSessionFallbackTimeout(sessionID, retryAgent)
 
         await ctx.client.session.promptAsync({
           path: { id: sessionID },
           body: {
-            ...(retryAgent ? { agent: retryAgent } : {}),
+            ...(retryAgentDisplayName ? { agent: retryAgentDisplayName } : {}),
             ...retryModelPayload,
             parts: retryParts,
           },

--- a/src/hooks/runtime-fallback/index.test.ts
+++ b/src/hooks/runtime-fallback/index.test.ts
@@ -2404,7 +2404,7 @@ describe("runtime-fallback", () => {
 
       expect(promptCalls.length).toBe(1)
       const callBody = promptCalls[0]?.body as Record<string, unknown>
-      expect(callBody?.agent).toBe("prometheus")
+      expect(callBody?.agent).toBe("Prometheus (Plan Builder)")
       expect(callBody?.model).toEqual({ providerID: "github-copilot", modelID: "claude-opus-4.6" })
     })
   })


### PR DESCRIPTION
Fixes #2882

When runtime_fallback is enabled and a retryable error occurs, the retry mechanism was using the original agent name (e.g. 'sisyphus') instead of the remapped display name (e.g. 'Sisyphus (Ultraworker)').

This caused the error: "Agent not found: 'sisyphus'. Available agents: Sisyphus (Ultraworker), Atlas (Plan Executor)..."

Changes:
- Import getAgentDisplayName from ../../shared/agent-display-names
- Convert retryAgent to display name before passing to promptAsync
- Update test to expect display name instead of config key

The fix ensures that when retrying with a fallback model, the agent name is properly converted to its display name format before being passed to the API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2882. Use the agent display name during runtime-fallback retries so the API can find the agent and the retry succeeds.

- **Bug Fixes**
  - Convert the retry agent to its display name with `getAgentDisplayName` before calling `promptAsync`.
  - Update the test to expect the display name instead of the config key.

<sup>Written for commit b4d4d30fa84fed20bbe413575913b7d1afd610d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

