### PR TITLE
fix(delegate-task): honor user model override in category-resolver cold cache (fixes #2712)

### DIFF
--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -133,6 +133,16 @@ Available categories: ${allCategoryNames}`,
 
     if (resolution && "skipped" in resolution) {
       isModelResolutionSkipped = true
+      const userModelOverride = explicitCategoryModel ?? overrideModel
+      if (userModelOverride) {
+        actualModel = userModelOverride
+        const parsedModel = parseModelString(actualModel)
+        const variantToUse = userCategories?.[args.category!]?.variant ?? resolved.config.variant
+        categoryModel = parsedModel
+          ? applyCategoryParams({ ...parsedModel, variant: variantToUse }, resolved.config)
+          : undefined
+        modelInfo = { model: actualModel, type: "user-defined", source: "override" }
+      }
     } else if (resolution) {
       const {
         model: resolvedModel,


### PR DESCRIPTION
## Summary
- Fix category-resolver to honor user-configured model when provider cache is cold

## Problem
The partial fix in commit a8ec9274 addressed the cold-cache model override issue in `subagent-resolver.ts` but **not** in `category-resolver.ts`. When using `category` parameter (e.g., `task(category="quick")`), the model resolution goes through `category-resolver.ts` which still ignores the user override when `resolveModelForDelegateTask()` returns `{ skipped: true }` (cold cache).

This causes:
1. User-configured category model is ignored on first run (cold cache)
2. Falls through with `categoryModel = undefined`
3. May use wrong provider/model or fail entirely

## Fix
Added cold-cache user override handling in `category-resolver.ts` that mirrors the existing fix in `subagent-resolver.ts`. When resolution is skipped (cold cache) but the user has explicitly configured a model (`explicitCategoryModel` or `overrideModel`), the user override is applied directly instead of falling through.

## Changes
| File | Change |
|------|--------|
| `src/tools/delegate-task/category-resolver.ts` | Add user model override handling when resolution returns `{ skipped: true }` |

Fixes #2712

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor user model overrides in `category-resolver` when the provider cache is cold. If resolution is skipped, we apply the explicit or override model (with the right variant), matching `subagent-resolver` and preventing wrong model selection on first run (fixes #2712).

<sup>Written for commit 5d5eb46f19e539bf02e86624ae2bf76c64375ab3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

