### PR TITLE
fix(keyword-detector): add logging for silent skip paths (fixes #2058)

### DIFF
--- a/src/hooks/keyword-detector/hook.ts
+++ b/src/hooks/keyword-detector/hook.ts
@@ -57,17 +57,20 @@ export function createKeywordDetectorHook(ctx: PluginInput, _collector?: Context
       let detectedKeywords = detectKeywordsWithType(cleanText, currentAgent, modelID)
 
       if (isPlannerAgent(currentAgent)) {
+        const preFilterCount = detectedKeywords.length
         detectedKeywords = detectedKeywords.filter((k) => k.type !== "ultrawork")
+        if (preFilterCount > detectedKeywords.length) {
+          log(`[keyword-detector] Filtered ultrawork keywords for planner agent`, { sessionID: input.sessionID, agent: currentAgent })
+        }
       }
 
       if (detectedKeywords.length === 0) {
         return
       }
 
-      // Skip keyword detection for background task sessions to prevent mode injection
-      // (e.g., [analyze-mode]) which incorrectly triggers Prometheus restrictions
       const isBackgroundTaskSession = subagentSessions.has(input.sessionID)
       if (isBackgroundTaskSession) {
+        log(`[keyword-detector] Skipping keyword injection for background task session`, { sessionID: input.sessionID })
         return
       }
 


### PR DESCRIPTION
## Summary
- Add logging to keyword-detector silent early return paths for easier debugging

## Problem
The keyword-detector hook has two silent early return paths that make debugging impossible when keyword detection fails:

1. **Planner agent filtering** (line 59-61): When the current agent is a planner (prometheus/plan), ultrawork keywords are silently filtered with no log entry
2. **Background task session skip** (line 69-72): When the session is a background/subagent session, all keyword detection is skipped with no log entry

Users experience keyword detection "not working" with zero diagnostic information in logs, making it impossible to determine why (as reported in #2058).

## Fix
Added `log()` calls to both silent skip paths:

1. **Planner agent filtering**: Logs when ultrawork keywords are filtered due to planner agent, including agent name
2. **Background task session**: Logs when keyword injection is skipped due to background session

## Changes
| File | Change |
|------|--------|
| `src/hooks/keyword-detector/hook.ts` | Add logging for planner agent ultrawork filtering and background session skip |

Fixes #2058

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit logs to the keyword-detector’s silent early returns: when ultrawork keywords are filtered for planner agents and when background/subagent sessions skip keyword injection. This makes “keyword detection not working” diagnosable in logs and fixes #2058.

<sup>Written for commit f030e0d78db1c30529d3b15b379ca04848d6fbca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

