### PR TITLE
fix(session-recovery): fallback to fetching messageID from session messages (fixes #2046)

### DIFF
--- a/src/hooks/session-recovery/hook.ts
+++ b/src/hooks/session-recovery/hook.ts
@@ -54,9 +54,25 @@ export function createSessionRecoveryHook(ctx: PluginInput, options?: SessionRec
     if (!errorType) return false
 
     const sessionID = info.sessionID
-    const assistantMsgID = info.id
+    let assistantMsgID = info.id
 
-    if (!sessionID || !assistantMsgID) return false
+    if (!sessionID) return false
+
+    if (!assistantMsgID) {
+      try {
+        const messagesResp = await ctx.client.session.messages({
+          path: { id: sessionID },
+          query: { directory: ctx.directory },
+        })
+        const msgs = (messagesResp as { data?: MessageData[] }).data
+        const lastAssistant = msgs?.findLast((m) => m.info?.role === "assistant" && m.info?.error)
+        assistantMsgID = lastAssistant?.info?.id
+      } catch {
+        log("[session-recovery] Failed to fetch messages for messageID fallback", { sessionID })
+      }
+    }
+
+    if (!assistantMsgID) return false
     if (processingErrors.has(assistantMsgID)) return false
     processingErrors.add(assistantMsgID)
 


### PR DESCRIPTION
## Summary
- Fix session-recovery hook to work around OpenCode's missing messageID in session.error events

## Problem
OpenCode's `session.error` event does not include `messageID` in its payload:
```javascript
BusEvent.define("session.error", zod_default.object({
  sessionID: zod_default.string().optional(),
  error: MessageV2.Assistant.shape.error
  // No messageID field
}))
```

The session-recovery hook extracts `messageID` from `props?.messageID` (line 533 in event.ts), which is always `undefined`. The recovery function then returns `false` on `if (!assistantMsgID) return false`, silently failing to recover from tool_result_missing, thinking_block_order, and other recoverable errors.

## Fix
When `messageID` is not provided in the event payload, the hook now falls back to fetching the session messages and finding the last assistant message with an error. This provides the `assistantMsgID` needed for the recovery flow to proceed.

## Changes
| File | Change |
|------|--------|
| `src/hooks/session-recovery/hook.ts` | Add messageID fallback: fetch session messages and find last errored assistant message |

Fixes #2046

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix session recovery when OpenCode `session.error` events omit `messageID` by falling back to fetch session messages and use the last errored assistant message’s id. Restores recovery for `tool_result_missing`, `thinking_block_order`, and similar errors.

- **Bug Fixes**
  - If `info.id` is missing, fetch messages for the `sessionID` and derive `assistantMsgID` from the last assistant message with an error.
  - Return early only if `sessionID` is missing or no errored assistant message is found; log a single fallback failure.

<sup>Written for commit fee60d2defa3d8e1ce662df76fd25215d57c7fc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

