### PR TITLE
fix(recovery): ignore empty summary-only assistant messages

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/message-builder.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/message-builder.ts
@@ -158,7 +158,7 @@ export async function getLastAssistant(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   client: any,
   directory: string,
-): Promise<Record<string, unknown> | null> {
+): Promise<{ info: Record<string, unknown>; hasContent: boolean } | null> {
   try {
     const resp = await (client as Client).session.messages({
       path: { id: sessionID },
@@ -175,7 +175,15 @@ export async function getLastAssistant(
       return info?.role === "assistant"
     })
     if (!last) return null
-    return (last as { info?: Record<string, unknown> }).info ?? null
+
+    const message = last as SDKMessage & { info?: Record<string, unknown> }
+    const info = message.info
+    if (!info) return null
+
+    return {
+      info,
+      hasContent: messageHasContentFromSDK(message),
+    }
   } catch {
     return null
   }

--- a/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
@@ -6,8 +6,11 @@ import * as originalLogger from "../../shared/logger"
 
 const executeCompactMock = mock(async () => {})
 const getLastAssistantMock = mock(async () => ({
-  providerID: "anthropic",
-  modelID: "claude-sonnet-4-6",
+  info: {
+    providerID: "anthropic",
+    modelID: "claude-sonnet-4-6",
+  },
+  hasContent: true,
 }))
 const parseAnthropicTokenLimitErrorMock = mock(() => ({
   providerID: "anthropic",
@@ -111,6 +114,45 @@ describe("createAnthropicContextWindowLimitRecoveryHook", () => {
       expect(getClearTimeoutCalls()).toEqual([1 as ReturnType<typeof setTimeout>])
       expect(executeCompactMock).toHaveBeenCalledTimes(1)
       expect(executeCompactMock.mock.calls[0]?.[0]).toBe("session-race")
+    } finally {
+      restore()
+    }
+  })
+
+  test("does not treat empty summary assistant messages as successful compaction", async () => {
+    //#given
+    const { restore, getClearTimeoutCalls } = setupDelayedTimeoutMocks()
+    getLastAssistantMock.mockResolvedValueOnce({
+      info: {
+        summary: true,
+        providerID: "anthropic",
+        modelID: "claude-sonnet-4-6",
+      },
+      hasContent: false,
+    })
+    const { createAnthropicContextWindowLimitRecoveryHook } = await import("./recovery-hook")
+    const hook = createAnthropicContextWindowLimitRecoveryHook(createMockContext())
+
+    try {
+      //#when
+      await hook.event({
+        event: {
+          type: "session.error",
+          properties: { sessionID: "session-empty-summary", error: "prompt is too long" },
+        },
+      })
+
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-empty-summary" },
+        },
+      })
+
+      //#then
+      expect(getClearTimeoutCalls()).toEqual([1 as ReturnType<typeof setTimeout>])
+      expect(executeCompactMock).toHaveBeenCalledTimes(1)
+      expect(executeCompactMock.mock.calls[0]?.[0]).toBe("session-empty-summary")
     } finally {
       restore()
     }

--- a/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.ts
@@ -72,8 +72,9 @@ export function createAnthropicContextWindowLimitRecoveryHook(
         }
 
         const lastAssistant = await getLastAssistant(sessionID, ctx.client, ctx.directory)
-        const providerID = parsed.providerID ?? (lastAssistant?.providerID as string | undefined)
-        const modelID = parsed.modelID ?? (lastAssistant?.modelID as string | undefined)
+        const lastAssistantInfo = lastAssistant?.info
+        const providerID = parsed.providerID ?? (lastAssistantInfo?.providerID as string | undefined)
+        const modelID = parsed.modelID ?? (lastAssistantInfo?.modelID as string | undefined)
 
         await ctx.client.tui
           .showToast({
@@ -136,14 +137,15 @@ export function createAnthropicContextWindowLimitRecoveryHook(
 
       const errorData = autoCompactState.errorDataBySession.get(sessionID)
       const lastAssistant = await getLastAssistant(sessionID, ctx.client, ctx.directory)
+      const lastAssistantInfo = lastAssistant?.info
 
-      if (lastAssistant?.summary === true) {
+      if (lastAssistantInfo?.summary === true && lastAssistant?.hasContent) {
         autoCompactState.pendingCompact.delete(sessionID)
         return
       }
 
-      const providerID = errorData?.providerID ?? (lastAssistant?.providerID as string | undefined)
-      const modelID = errorData?.modelID ?? (lastAssistant?.modelID as string | undefined)
+      const providerID = errorData?.providerID ?? (lastAssistantInfo?.providerID as string | undefined)
+      const modelID = errorData?.modelID ?? (lastAssistantInfo?.modelID as string | undefined)
 
       await ctx.client.tui
         .showToast({


### PR DESCRIPTION
## Summary
- treat summary assistant messages as successful auto-compaction only when they actually contain visible content
- return both assistant info and content-presence metadata from `getLastAssistant()`
- add a regression test for empty summary-only assistant messages

## Why
When the latest assistant message is a summary marker without visible content, the recovery hook currently treats that as a successful compaction and clears the pending recovery state too early. This can skip the follow-up compaction path even though no usable summary content exists.

## Testing
- bun test src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts src/hooks/anthropic-context-window-limit-recovery/message-builder.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the recovery flow so empty summary-only assistant messages are not treated as a successful compaction. This prevents clearing pending recovery too early and ensures follow-up compaction runs when needed.

- **Bug Fixes**
  - `getLastAssistant()` now returns assistant `info` plus a `hasContent` flag.
  - Recovery only marks compaction successful when `summary: true` and `hasContent` is true.
  - Uses `lastAssistant.info` for `providerID` and `modelID` fallbacks.
  - Adds a regression test for empty summary-only assistant messages.

<sup>Written for commit 4e214cba4e4484c4606634a6000228bf93f6821a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

