### PR TITLE
fix(anthropic-effort): restrict effort injection to models that support it

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -1,6 +1,14 @@
 import { log, normalizeModelID } from "../../shared"
 
-const OPUS_PATTERN = /claude-.*opus/i
+type ClaudeFamily = "opus" | "sonnet" | "haiku"
+
+interface ClaudeModelVersion {
+  family: ClaudeFamily
+  major: number
+  minor: number
+}
+
+const VERSION_PATTERN = /claude-(opus|sonnet|haiku)-(\d+)(?:-(\d+))?/i
 
 function isClaudeProvider(providerID: string, modelID: string): boolean {
   if (["anthropic", "google-vertex-anthropic", "opencode"].includes(providerID)) return true
@@ -8,9 +16,63 @@ function isClaudeProvider(providerID: string, modelID: string): boolean {
   return false
 }
 
-function isOpusModel(modelID: string): boolean {
-  const normalized = normalizeModelID(modelID)
-  return OPUS_PATTERN.test(normalized)
+/**
+ * Parse a Claude model ID into family + semver-ish version.
+ *
+ * Handles normalised IDs like `claude-opus-4-6`, `claude-sonnet-4-6-20260301`,
+ * and `claude-sonnet-4-20250514`.  A captured "minor" value > 99 is a date
+ * suffix and is treated as minor 0 (e.g. `sonnet-4-20250514` → version 4.0).
+ */
+function parseClaudeModelVersion(modelID: string): ClaudeModelVersion | undefined {
+  const normalized = normalizeModelID(modelID).toLowerCase()
+  const match = normalized.match(VERSION_PATTERN)
+  if (!match) return undefined
+
+  const major = Number(match[2])
+  const minorRaw = match[3] ? Number(match[3]) : 0
+  // Date suffixes like 20250514 are not minor versions — treat as x.0
+  const minor = minorRaw > 99 ? 0 : minorRaw
+
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) return undefined
+
+  return { family: match[1].toLowerCase() as ClaudeFamily, major, minor }
+}
+
+/**
+ * Determine the correct effort level for a Claude model when variant is "max".
+ *
+ * Returns undefined when the model does not support the effort parameter at all
+ * (Haiku, Sonnet 4.0, non-Claude), signalling that the hook should bail out.
+ *
+ * Supported models (per Anthropic docs):
+ *  - Opus 4.6+  → effort "max"
+ *  - Opus 4.5   → effort "high" (max is Opus 4.6-exclusive)
+ *  - Sonnet 4.6+ (minor > 0) → effort "high"
+ *  - Haiku (any) → NOT supported
+ *  - Sonnet 4.0  → NOT supported
+ */
+function resolveEffortForVariantMax(
+  modelID: string,
+): { effort: "max" | "high"; variant: "max" | "high" } | undefined {
+  const parsed = parseClaudeModelVersion(modelID)
+  if (!parsed) return undefined
+
+  const aboveMajor4 = parsed.major > 4
+
+  if (parsed.family === "opus") {
+    const supportsMax = aboveMajor4 || (parsed.major === 4 && parsed.minor >= 6)
+    return supportsMax
+      ? { effort: "max", variant: "max" }
+      : { effort: "high", variant: "high" }
+  }
+
+  if (parsed.family === "sonnet") {
+    const supportsEffort = aboveMajor4 || (parsed.major === 4 && parsed.minor > 0)
+    return supportsEffort ? { effort: "high", variant: "high" } : undefined
+  }
+
+  // Haiku and anything else — effort not supported
+  return undefined
 }
 
 interface ChatParamsInput {
@@ -28,25 +90,11 @@ interface ChatParamsOutput {
   options: Record<string, unknown>
 }
 
-/**
- * Valid thinking budget levels per model tier.
- * Opus supports "max"; all other Claude models cap at "high".
- */
-const MAX_VARIANT_BY_TIER: Record<string, string> = {
-  opus: "max",
-  default: "high",
-}
-
-function clampVariant(variant: string, isOpus: boolean): string {
-  if (variant !== "max") return variant
-  return isOpus ? MAX_VARIANT_BY_TIER.opus : MAX_VARIANT_BY_TIER.default
-}
-
 export function createAnthropicEffortHook() {
   return {
     "chat.params": async (
       input: ChatParamsInput,
-      output: ChatParamsOutput
+      output: ChatParamsOutput,
     ): Promise<void> => {
       const { model, message } = input
       if (!model?.modelID || !model?.providerID) return
@@ -54,14 +102,14 @@ export function createAnthropicEffortHook() {
       if (!isClaudeProvider(model.providerID, model.modelID)) return
       if (output.options.effort !== undefined) return
 
-      const opus = isOpusModel(model.modelID)
-      const clamped = clampVariant(message.variant, opus)
-      output.options.effort = clamped
+      const resolved = resolveEffortForVariantMax(model.modelID)
+      if (!resolved) return
 
-      if (!opus) {
-        // Override the variant so OpenCode doesn't pass "max" to the API
-        ;(message as { variant?: string }).variant = clamped
-        log("anthropic-effort: clamped variant max→high for non-Opus model", {
+      output.options.effort = resolved.effort
+
+      if (resolved.variant !== "max") {
+        ;(message as { variant?: string }).variant = resolved.variant
+        log("anthropic-effort: clamped variant max→" + resolved.variant + " for non-Opus-4.6+ model", {
           sessionID: input.sessionID,
           provider: model.providerID,
           model: model.modelID,

--- a/src/hooks/anthropic-effort/index.test.ts
+++ b/src/hooks/anthropic-effort/index.test.ts
@@ -45,7 +45,7 @@ function createMockParams(overrides: {
 }
 
 describe("createAnthropicEffortHook", () => {
-  describe("opus family with variant max", () => {
+  describe("opus 4.6+ — should inject effort max", () => {
     it("injects effort max for anthropic opus-4-6", async () => {
       const hook = createAnthropicEffortHook()
       const { input, output } = createMockParams({})
@@ -53,39 +53,132 @@ describe("createAnthropicEffortHook", () => {
       await hook["chat.params"](input, output)
 
       expect(output.options.effort).toBe("max")
+      expect(input.message.variant).toBe("max")
     })
 
-    it("injects effort max for another opus family model such as opus-4-5", async () => {
-      const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({ modelID: "claude-opus-4-5" })
-
-      await hook["chat.params"](input, output)
-
-      expect(output.options.effort).toBe("max")
-    })
-
-    it("injects effort max for dotted opus ids", async () => {
+    it("injects effort max for dotted opus-4.6", async () => {
       const hook = createAnthropicEffortHook()
       const { input, output } = createMockParams({ modelID: "claude-opus-4.6" })
 
       await hook["chat.params"](input, output)
 
       expect(output.options.effort).toBe("max")
+      expect(input.message.variant).toBe("max")
     })
 
-    it("should preserve max for other opus model IDs such as opus-4-5", async () => {
-      //#given another opus model id that is not 4.6
+    it("injects effort max for opus-4-6 with date suffix", async () => {
       const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({
-        modelID: "claude-opus-4-5",
-      })
+      const { input, output } = createMockParams({ modelID: "claude-opus-4-6-20260301" })
 
-      //#when chat.params hook is called
       await hook["chat.params"](input, output)
 
-      //#then max should still be treated as valid for opus family
       expect(output.options.effort).toBe("max")
       expect(input.message.variant).toBe("max")
+    })
+
+    it("injects effort max for future opus-5-0", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ modelID: "claude-opus-5-0" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBe("max")
+      expect(input.message.variant).toBe("max")
+    })
+  })
+
+  describe("opus < 4.6 — should inject effort high", () => {
+    it("clamps to high for opus-4-5", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ modelID: "claude-opus-4-5" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBe("high")
+      expect(input.message.variant).toBe("high")
+    })
+
+    it("clamps to high for opus-4-5 with date suffix", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ modelID: "claude-opus-4-5-20251101" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBe("high")
+      expect(input.message.variant).toBe("high")
+    })
+  })
+
+  describe("sonnet 4.6+ — should inject effort high", () => {
+    it("injects effort high for sonnet-4-6", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ modelID: "claude-sonnet-4-6" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBe("high")
+      expect(input.message.variant).toBe("high")
+    })
+
+    it("injects effort high for sonnet-4-6 with date suffix", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ modelID: "claude-sonnet-4-6-20260501" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBe("high")
+      expect(input.message.variant).toBe("high")
+    })
+
+    it("injects effort high for future sonnet-5-0", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ modelID: "claude-sonnet-5-0" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBe("high")
+      expect(input.message.variant).toBe("high")
+    })
+  })
+
+  describe("unsupported models — should NOT inject effort", () => {
+    it("skips haiku-4-5", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ modelID: "claude-haiku-4-5" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBeUndefined()
+      expect(input.message.variant).toBe("max")
+    })
+
+    it("skips haiku-4-5 with date suffix", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ modelID: "claude-haiku-4-5-20251001" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBeUndefined()
+      expect(input.message.variant).toBe("max")
+    })
+
+    it("skips sonnet-4 (date suffix, no real minor version)", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ modelID: "claude-sonnet-4-20250514" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBeUndefined()
+      expect(input.message.variant).toBe("max")
+    })
+
+    it("skips non-claude models", async () => {
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({ providerID: "openai", modelID: "gpt-5.4" })
+
+      await hook["chat.params"](input, output)
+
+      expect(output.options.effort).toBeUndefined()
     })
   })
 
@@ -102,27 +195,6 @@ describe("createAnthropicEffortHook", () => {
     it("does nothing when variant is undefined", async () => {
       const hook = createAnthropicEffortHook()
       const { input, output } = createMockParams({ variant: undefined })
-
-      await hook["chat.params"](input, output)
-
-      expect(output.options.effort).toBeUndefined()
-    })
-
-    it("should clamp effort to high for non-opus claude model with variant max", async () => {
-      //#given claude-sonnet-4-6 (not opus) with variant max
-      const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({ modelID: "claude-sonnet-4-6" })
-
-      await hook["chat.params"](input, output)
-
-      //#then effort should be clamped to high (not max)
-      expect(output.options.effort).toBe("high")
-      expect(input.message.variant).toBe("high")
-    })
-
-    it("does nothing for non-claude providers/models", async () => {
-      const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({ providerID: "openai", modelID: "gpt-5.4" })
 
       await hook["chat.params"](input, output)
 


### PR DESCRIPTION
## Summary

The `anthropic-effort` hook currently injects `output_config.effort` for **all** Claude models when `variant=max`. However, only certain Claude models support the effort parameter ([Anthropic docs](https://platform.claude.com/docs/en/build-with-claude/effort)). Sending it to unsupported models causes `AI_APICallError` from the Anthropic API.

**Concrete impact**: OpenCode session title generation uses Claude Haiku 4.5 as the small model. The hook injects `effort: "high"` → Anthropic API rejects → `result.text` fails with "No output generated" → titles never get set.

## Root Cause

PR #2643 (v3.13.1) widened the hook from Opus 4.6-only to all Claude models, removing the `isOpus46()` guard. Non-Opus models now get `effort: "high"` (clamped from "max"), but Haiku and Sonnet 4 don't support effort at all.

## Fix

Replace the blanket Claude model check with a version-aware guard that respects Anthropic's per-model effort support:

| Model | Effort injected | Variant |
|---|---|---|
| **Opus 4.6+** | `max` | stays `max` |
| **Opus < 4.6** (e.g. 4.5) | `high` | clamped to `high` |
| **Sonnet > 4.0** (e.g. 4.6+) | `high` | clamped to `high` |
| **Sonnet 4.0** | *(none)* | unchanged |
| **Haiku** (any) | *(none)* | unchanged |
| **Non-Claude** | *(none)* | unchanged |

Date suffixes in model IDs (e.g. `claude-sonnet-4-20250514`, `claude-opus-4-6-20260301`) are correctly handled — values > 99 are recognized as dates and treated as minor version 0.

## Changes

- `src/hooks/anthropic-effort/hook.ts` — Added `parseClaudeModelVersion()` and `resolveEffortForVariantMax()` to version-gate effort injection
- `src/hooks/anthropic-effort/index.test.ts` — 16 test cases covering all model families, date suffixes, future versions, and skip conditions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the `anthropic-effort` hook to inject `output_config.effort` only for Claude models that support it, preventing Anthropic API errors and restoring OpenCode session title generation. Adds version-aware model parsing and clamps `variant` when needed.

- Bug Fixes
  - Opus 4.6+: effort=max; Opus 4.5: effort=high; Sonnet 4.6+: effort=high; Sonnet 4.0/Haiku/non-Claude: no effort.
  - Version parser handles `claude-<family>-<major>-<minor>` and date suffixes; dates (>99) are treated as minor 0.
  - When clamped, also set `message.variant` to "high" to avoid sending "max" to unsupported models.
  - Expanded tests cover model families, date suffixes, future versions, and skip conditions.

<sup>Written for commit 78a76c0e47260005e4e5955927e66d9a67fcc38f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

