### PR TITLE
fix(rules-injector): respect claude_code config for user rule loading

### DIFF
--- a/src/hooks/rules-injector/constants.ts
+++ b/src/hooks/rules-injector/constants.ts
@@ -26,4 +26,6 @@ export const GITHUB_INSTRUCTIONS_PATTERN = /\.instructions\.md$/;
 
 export const USER_RULE_DIR = ".claude/rules";
 
+export const OPENCODE_USER_RULE_DIRS = [".sisyphus/rules", ".opencode/rules"];
+
 export const RULE_EXTENSIONS = [".md", ".mdc"];

--- a/src/hooks/rules-injector/finder.ts
+++ b/src/hooks/rules-injector/finder.ts
@@ -1,3 +1,3 @@
 export { findProjectRoot } from "./project-root-finder";
 export { calculateDistance } from "./rule-distance";
-export { findRuleFiles } from "./rule-file-finder";
+export { findRuleFiles, type FindRuleFilesOptions } from "./rule-file-finder";

--- a/src/hooks/rules-injector/hook.ts
+++ b/src/hooks/rules-injector/hook.ts
@@ -32,6 +32,7 @@ const TRACKED_TOOLS = ["read", "write", "edit", "multiedit"];
 export function createRulesInjectorHook(
   ctx: PluginInput,
   modelCacheState?: { anthropicContext1MEnabled: boolean },
+  options?: { skipClaudeUserRules?: boolean },
 ) {
   const truncator = createDynamicTruncator(ctx, modelCacheState);
   const { getSessionCache, clearSessionCache } = createSessionCacheStore();
@@ -39,6 +40,9 @@ export function createRulesInjectorHook(
     workspaceDirectory: ctx.directory,
     truncator,
     getSessionCache,
+    ruleFinderOptions: options?.skipClaudeUserRules
+      ? { skipClaudeUserRules: true }
+      : undefined,
   });
 
   const toolExecuteAfter = async (

--- a/src/hooks/rules-injector/injector.ts
+++ b/src/hooks/rules-injector/injector.ts
@@ -2,6 +2,7 @@ import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { relative, resolve } from "node:path";
 import { findProjectRoot, findRuleFiles } from "./finder";
+import type { FindRuleFilesOptions } from "./rule-file-finder";
 import {
   createContentHash,
   isDuplicateByContentHash,
@@ -82,6 +83,7 @@ export function createRuleInjectionProcessor(deps: {
   workspaceDirectory: string;
   truncator: DynamicTruncator;
   getSessionCache: (sessionID: string) => SessionInjectedRulesCache;
+  ruleFinderOptions?: FindRuleFilesOptions;
 }): {
   processFilePathForInjection: (
     filePath: string,
@@ -89,7 +91,7 @@ export function createRuleInjectionProcessor(deps: {
     output: ToolExecuteOutput
   ) => Promise<void>;
 } {
-  const { workspaceDirectory, truncator, getSessionCache } = deps;
+  const { workspaceDirectory, truncator, getSessionCache, ruleFinderOptions } = deps;
 
   async function processFilePathForInjection(
     filePath: string,
@@ -103,7 +105,7 @@ export function createRuleInjectionProcessor(deps: {
     const cache = getSessionCache(sessionID);
     const home = homedir();
 
-    const ruleFileCandidates = findRuleFiles(projectRoot, home, resolved);
+    const ruleFileCandidates = findRuleFiles(projectRoot, home, resolved, ruleFinderOptions);
     const toInject: RuleToInject[] = [];
     let dirty = false;
 

--- a/src/hooks/rules-injector/rule-file-finder.ts
+++ b/src/hooks/rules-injector/rule-file-finder.ts
@@ -4,9 +4,19 @@ import {
   PROJECT_RULE_FILES,
   PROJECT_RULE_SUBDIRS,
   USER_RULE_DIR,
+  OPENCODE_USER_RULE_DIRS,
 } from "./constants";
 import type { RuleFileCandidate } from "./types";
 import { findRuleFilesRecursive, safeRealpathSync } from "./rule-file-scanner";
+
+export interface FindRuleFilesOptions {
+  /**
+   * When true, skip loading rules from ~/.claude/rules/.
+   * Use when claude_code integration is disabled to prevent
+   * Claude Code-specific instructions from leaking into non-Claude agents.
+   */
+  skipClaudeUserRules?: boolean;
+}
 
 /**
  * Find all rule files for a given context.
@@ -25,6 +35,7 @@ export function findRuleFiles(
   projectRoot: string | null,
   homeDir: string,
   currentFile: string,
+  options?: FindRuleFilesOptions,
 ): RuleFileCandidate[] {
   const candidates: RuleFileCandidate[] = [];
   const seenRealPaths = new Set<string>();
@@ -89,22 +100,31 @@ export function findRuleFiles(
     }
   }
 
-  // Search user-level rule directory (~/.claude/rules)
-  const userRuleDir = join(homeDir, USER_RULE_DIR);
-  const userFiles: string[] = [];
-  findRuleFilesRecursive(userRuleDir, userFiles);
+  // Search user-level rule directories
+  // Always search OpenCode-native dirs (~/.sisyphus/rules, ~/.opencode/rules)
+  const userRuleDirs: string[] = OPENCODE_USER_RULE_DIRS.map((dir) => join(homeDir, dir));
 
-  for (const filePath of userFiles) {
-    const realPath = safeRealpathSync(filePath);
-    if (seenRealPaths.has(realPath)) continue;
-    seenRealPaths.add(realPath);
+  // Only search ~/.claude/rules when claude_code integration is not disabled
+  if (!options?.skipClaudeUserRules) {
+    userRuleDirs.push(join(homeDir, USER_RULE_DIR));
+  }
 
-    candidates.push({
-      path: filePath,
-      realPath,
-      isGlobal: true,
-      distance: 9999, // Global rules always have max distance
-    });
+  for (const userRuleDir of userRuleDirs) {
+    const userFiles: string[] = [];
+    findRuleFilesRecursive(userRuleDir, userFiles);
+
+    for (const filePath of userFiles) {
+      const realPath = safeRealpathSync(filePath);
+      if (seenRealPaths.has(realPath)) continue;
+      seenRealPaths.add(realPath);
+
+      candidates.push({
+        path: filePath,
+        realPath,
+        isGlobal: true,
+        distance: 9999, // Global rules always have max distance
+      });
+    }
   }
 
   // Sort by distance (closest first, then global rules last)

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -91,10 +91,11 @@ export function createToolGuardHooks(args: {
     ? safeHook("empty-task-response-detector", () => createEmptyTaskResponseDetectorHook(ctx))
     : null
 
-  const claudeCodeDisabled = pluginConfig.claude_code
-    && !pluginConfig.claude_code.hooks
-    && !pluginConfig.claude_code.skills
-    && !pluginConfig.claude_code.agents
+  const cc = pluginConfig.claude_code
+  const claudeCodeDisabled = cc != null
+    && cc.hooks === false
+    && cc.skills === false
+    && cc.agents === false
   const rulesInjector = isHookEnabled("rules-injector")
     ? safeHook("rules-injector", () =>
         createRulesInjectorHook(ctx, modelCacheState, {

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -91,9 +91,15 @@ export function createToolGuardHooks(args: {
     ? safeHook("empty-task-response-detector", () => createEmptyTaskResponseDetectorHook(ctx))
     : null
 
+  const claudeCodeDisabled = pluginConfig.claude_code
+    && !pluginConfig.claude_code.hooks
+    && !pluginConfig.claude_code.skills
+    && !pluginConfig.claude_code.agents
   const rulesInjector = isHookEnabled("rules-injector")
     ? safeHook("rules-injector", () =>
-        createRulesInjectorHook(ctx, modelCacheState))
+        createRulesInjectorHook(ctx, modelCacheState, {
+          skipClaudeUserRules: claudeCodeDisabled ?? false,
+        }))
     : null
 
   const tasksTodowriteDisabler = isHookEnabled("tasks-todowrite-disabler")


### PR DESCRIPTION
## Summary

- Gate `~/.claude/rules/` loading behind `claude_code` config — when all integration flags are `false`, skip loading Claude Code-specific user rules
- Add `~/.sisyphus/rules/` and `~/.opencode/rules/` as OpenCode-native user rule directories (always searched)
- Thread `skipClaudeUserRules` option from hook creation through injector to file finder

## Problem

The rules-injector unconditionally loads `~/.claude/rules/` into all agent contexts. When users have Claude Code-specific instructions there (tool references, OMC agent naming conventions), these leak into non-Claude agents like GPT-5.4 (Sisyphus), causing hallucinated tool calls:

```
task(subagent_type="oh-my-claudecode:planner")  // hallucinated — doesn't exist in OpenCode
```

The `claude_code: { hooks: false, skills: false, agents: false }` config correctly gates skill/agent discovery but the rules-injector bypasses it entirely.

## Changes

| File | Change |
|---|---|
| `constants.ts` | Add `OPENCODE_USER_RULE_DIRS` for native user rule paths |
| `rule-file-finder.ts` | Accept `FindRuleFilesOptions`, conditionally skip `~/.claude/rules/`, always search OpenCode-native dirs |
| `finder.ts` | Re-export `FindRuleFilesOptions` type |
| `injector.ts` | Pass through `ruleFinderOptions` |
| `hook.ts` | Accept `skipClaudeUserRules` option |
| `create-tool-guard-hooks.ts` | Check `claude_code` config and pass flag to hook |

## Backward Compatibility

Default behavior is **unchanged** — `~/.claude/rules/` is still loaded unless `claude_code` integration is explicitly disabled. The new OpenCode-native dirs (`~/.sisyphus/rules/`, `~/.opencode/rules/`) are additive.

## Test

All 40 existing rules-injector tests pass (`bun test src/hooks/rules-injector/`).

Fixes #2920

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip loading `~/.claude/rules/` only when `claude_code` is explicitly disabled to prevent Claude-specific rules from leaking into other agents, and add OpenCode-native user rule directories. Fixes #2920.

- **Bug Fixes**
  - Gate `~/.claude/rules/` behind `claude_code`; skip only when `hooks`, `skills`, and `agents` are all set to `false` (uses strict equality).
  - Pass `skipClaudeUserRules` from hook creation through the injector to the file finder.

- **New Features**
  - Always search `~/.sisyphus/rules/` and `~/.opencode/rules/` for user rules.

<sup>Written for commit 738b045e9b495ff5d5473abfa6fcbcb8497331fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

