### PR TITLE
fix: preserve nested async skill names in discovery

### DIFF
--- a/src/features/opencode-skill-loader/async-loader.test.ts
+++ b/src/features/opencode-skill-loader/async-loader.test.ts
@@ -107,6 +107,30 @@ Direct skill.
       expect(skills[0].name).toBe("direct-skill")
     })
 
+    it("preserves nested skill path names during recursive discovery", async () => {
+      // given
+      const nestedSkillDir = join(SKILLS_DIR, "superpowers", "brainstorming")
+      mkdirSync(nestedSkillDir, { recursive: true })
+      writeFileSync(
+        join(nestedSkillDir, "SKILL.md"),
+        `---
+name: brainstorming
+description: Nested brainstorming skill
+---
+Nested skill.
+`
+      )
+
+      // when
+      const { discoverSkillsInDirAsync } = await import("./async-loader")
+      const skills = await discoverSkillsInDirAsync(SKILLS_DIR)
+
+      // then
+      expect(skills).toHaveLength(1)
+      expect(skills[0]?.name).toBe("superpowers/brainstorming")
+      expect(skills[0]?.definition.name).toBe("superpowers/brainstorming")
+    })
+
     it("skips entries starting with dot", async () => {
       // given
       const validContent = `---

--- a/src/features/opencode-skill-loader/async-loader.test.ts
+++ b/src/features/opencode-skill-loader/async-loader.test.ts
@@ -131,6 +131,54 @@ Nested skill.
       expect(skills[0]?.definition.name).toBe("superpowers/brainstorming")
     })
 
+    it("preserves nested skill path names for nested {dirName}.md discovery", async () => {
+      // given
+      const nestedSkillDir = join(SKILLS_DIR, "superpowers", "brainstorming")
+      mkdirSync(nestedSkillDir, { recursive: true })
+      writeFileSync(
+        join(nestedSkillDir, "brainstorming.md"),
+        `---
+name: brainstorming
+description: Nested brainstorming skill
+---
+Nested skill.
+`
+      )
+
+      // when
+      const { discoverSkillsInDirAsync } = await import("./async-loader")
+      const skills = await discoverSkillsInDirAsync(SKILLS_DIR)
+
+      // then
+      expect(skills).toHaveLength(1)
+      expect(skills[0]?.name).toBe("superpowers/brainstorming")
+      expect(skills[0]?.definition.name).toBe("superpowers/brainstorming")
+    })
+
+    it("preserves nested skill path names for nested direct markdown discovery", async () => {
+      // given
+      const nestedSkillDir = join(SKILLS_DIR, "superpowers")
+      mkdirSync(nestedSkillDir, { recursive: true })
+      writeFileSync(
+        join(nestedSkillDir, "brainstorming.md"),
+        `---
+name: brainstorming
+description: Nested brainstorming skill
+---
+Nested skill.
+`
+      )
+
+      // when
+      const { discoverSkillsInDirAsync } = await import("./async-loader")
+      const skills = await discoverSkillsInDirAsync(SKILLS_DIR)
+
+      // then
+      expect(skills).toHaveLength(1)
+      expect(skills[0]?.name).toBe("superpowers/brainstorming")
+      expect(skills[0]?.definition.name).toBe("superpowers/brainstorming")
+    })
+
     it("skips entries starting with dot", async () => {
       // given
       const validContent = `---

--- a/src/features/opencode-skill-loader/async-loader.ts
+++ b/src/features/opencode-skill-loader/async-loader.ts
@@ -75,7 +75,8 @@ export async function loadSkillFromPathAsync(
   skillPath: string,
   resolvedPath: string,
   defaultName: string,
-  scope: SkillScope
+  scope: SkillScope,
+  namePrefix = ""
 ): Promise<LoadedSkill | null> {
   try {
     const content = await readFile(skillPath, "utf-8")
@@ -86,7 +87,8 @@ export async function loadSkillFromPathAsync(
     const mcpJsonMcp = await loadMcpJsonFromDirAsync(resolvedPath)
     const mcpConfig = mcpJsonMcp || frontmatterMcp
 
-    const skillName = data.name || defaultName
+    const baseName = data.name || defaultName
+    const skillName = namePrefix ? `${namePrefix}/${baseName}` : baseName
     const originalDescription = data.description || ""
     const isOpencodeSource = scope === "opencode" || scope === "opencode-project"
     const formattedDescription = `(${scope} - Skill) ${originalDescription}`
@@ -142,11 +144,17 @@ function parseAllowedTools(allowedTools: string | string[] | undefined): string[
   return allowedTools.split(/\s+/).filter(Boolean)
 }
 
-export async function discoverSkillsInDirAsync(skillsDir: string): Promise<LoadedSkill[]> {
+export async function discoverSkillsInDirAsync(
+  skillsDir: string,
+  scope: SkillScope = "opencode-project",
+  namePrefix = "",
+  depth = 0,
+  maxDepth = 2
+): Promise<LoadedSkill[]> {
   try {
     const entries = await readdir(skillsDir, { withFileTypes: true })
     
-    const processEntry = async (entry: Dirent): Promise<LoadedSkill | null> => {
+    const processEntry = async (entry: Dirent): Promise<LoadedSkill | LoadedSkill[] | null> => {
       if (entry.name.startsWith(".")) return null
 
       const entryPath = join(skillsDir, entry.name)
@@ -158,28 +166,44 @@ export async function discoverSkillsInDirAsync(skillsDir: string): Promise<Loade
         const skillMdPath = join(resolvedPath, "SKILL.md")
         try {
           await readFile(skillMdPath, "utf-8")
-          return await loadSkillFromPathAsync(skillMdPath, resolvedPath, dirName, "opencode-project")
+          return await loadSkillFromPathAsync(skillMdPath, resolvedPath, dirName, scope, namePrefix)
         } catch {
           const namedSkillMdPath = join(resolvedPath, `${dirName}.md`)
           try {
             await readFile(namedSkillMdPath, "utf-8")
-            return await loadSkillFromPathAsync(namedSkillMdPath, resolvedPath, dirName, "opencode-project")
+            return await loadSkillFromPathAsync(namedSkillMdPath, resolvedPath, dirName, scope, namePrefix)
           } catch {
-            return null
+            if (depth >= maxDepth) {
+              return null
+            }
+
+            const nestedPrefix = namePrefix ? `${namePrefix}/${dirName}` : dirName
+            const nestedSkills = await discoverSkillsInDirAsync(
+              resolvedPath,
+              scope,
+              nestedPrefix,
+              depth + 1,
+              maxDepth
+            )
+
+            return nestedSkills.length > 0 ? nestedSkills : null
           }
         }
       }
 
       if (isMarkdownFile(entry)) {
         const skillName = basename(entry.name, ".md")
-        return await loadSkillFromPathAsync(entryPath, skillsDir, skillName, "opencode-project")
+        return await loadSkillFromPathAsync(entryPath, skillsDir, skillName, scope, namePrefix)
       }
 
       return null
     }
 
     const skillPromises = await mapWithConcurrency(entries, processEntry, 16)
-    return skillPromises.filter((skill): skill is LoadedSkill => skill !== null)
+    return skillPromises.flatMap((skill): LoadedSkill[] => {
+      if (skill === null) return []
+      return Array.isArray(skill) ? skill : [skill]
+    })
   } catch (error: unknown) {
     if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
       return []


### PR DESCRIPTION
## Summary
- preserve nested skill path prefixes in the async skill discovery path so prompt-visible skill names match tool resolution
- add a regression test covering nested discovery for `superpowers/brainstorming`

## Testing
- `npx tsc --noEmit --pretty false`
- `npx --yes bun test src/features/opencode-skill-loader/async-loader.test.ts`
- manual reproduction via `npx --yes tsx` confirmed `discoverSkillsInDirAsync()` returns `superpowers/brainstorming`

Closes #2696.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes async skill discovery to keep full nested skill paths (e.g., superpowers/brainstorming) so prompt-visible names match tool resolution. Closes #2696.

- **Bug Fixes**
  - Preserve nested path names by passing a `namePrefix` through `discoverSkillsInDirAsync` and `loadSkillFromPathAsync`.
  - Recurse into subfolders with a depth cap (default 2), flatten results, and handle nested `SKILL.md`, `{dirName}.md`, and parent-folder markdown.
  - Add tests for all three nested cases; existing calls keep working via safe defaults.

<sup>Written for commit e27f183b65660de96a2c374b5e2b09eccc72152a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

