### PR TITLE
fix: skip effort injection for google-vertex-anthropic provider

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -1,6 +1,9 @@
 import { log, normalizeModelID } from "../../shared"
 
 const OPUS_PATTERN = /claude-.*opus/i
+// Google Vertex Anthropic rejects the `effort-2025-11-24` beta header with a 400.
+// See: https://github.com/code-yeongyu/oh-my-openagent/issues/2940
+const EFFORT_UNSUPPORTED_PROVIDERS = new Set(["google-vertex-anthropic"])
 
 function isClaudeProvider(providerID: string, modelID: string): boolean {
   if (["anthropic", "google-vertex-anthropic", "opencode"].includes(providerID)) return true
@@ -52,6 +55,14 @@ export function createAnthropicEffortHook() {
       if (!model?.modelID || !model?.providerID) return
       if (message.variant !== "max") return
       if (!isClaudeProvider(model.providerID, model.modelID)) return
+      if (EFFORT_UNSUPPORTED_PROVIDERS.has(model.providerID)) {
+        log("anthropic-effort: skipped effort injection (provider does not support effort header)", {
+          sessionID: input.sessionID,
+          provider: model.providerID,
+          model: model.modelID,
+        })
+        return
+      }
       if (output.options.effort !== undefined) return
 
       const opus = isOpusModel(model.modelID)

--- a/src/hooks/anthropic-effort/index.test.ts
+++ b/src/hooks/anthropic-effort/index.test.ts
@@ -130,6 +130,57 @@ describe("createAnthropicEffortHook", () => {
     })
   })
 
+  describe("provider guard", () => {
+    it("skips effort for google-vertex-anthropic provider", async () => {
+      //#given opus on vertex with variant max
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({
+        providerID: "google-vertex-anthropic",
+        modelID: "claude-opus-4-6",
+      })
+
+      //#when chat.params hook is called
+      await hook["chat.params"](input, output)
+
+      //#then effort should not be injected (vertex rejects the beta header)
+      expect(output.options.effort).toBeUndefined()
+      //#and variant should remain unchanged (provider guard returned before clamping)
+      expect(input.message.variant).toBe("max")
+    })
+
+    it("skips effort for non-opus model on google-vertex-anthropic", async () => {
+      //#given sonnet on vertex with variant max
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({
+        providerID: "google-vertex-anthropic",
+        modelID: "claude-sonnet-4-6",
+      })
+
+      //#when chat.params hook is called
+      await hook["chat.params"](input, output)
+
+      //#then effort should not be injected (provider guard fires before model check)
+      expect(output.options.effort).toBeUndefined()
+      //#and variant should remain unchanged (provider guard returned before clamping)
+      expect(input.message.variant).toBe("max")
+    })
+
+    it("still injects effort for direct anthropic provider with opus", async () => {
+      //#given opus on direct anthropic with variant max
+      const hook = createAnthropicEffortHook()
+      const { input, output } = createMockParams({
+        providerID: "anthropic",
+        modelID: "claude-opus-4-6",
+      })
+
+      //#when chat.params hook is called
+      await hook["chat.params"](input, output)
+
+      //#then effort should be injected normally
+      expect(output.options.effort).toBe("max")
+    })
+  })
+
   describe("existing options", () => {
     it("does not overwrite existing effort", async () => {
       const hook = createAnthropicEffortHook()


### PR DESCRIPTION
## Summary

- Add debug log when effort injection is silently skipped for providers that reject the effort beta header
- Add missing test coverage for non-Opus models on `google-vertex-anthropic`

## Changes

- `src/hooks/anthropic-effort/hook.ts`: Log provider and model info when `EFFORT_UNSUPPORTED_PROVIDERS` guard triggers, so users can diagnose why their `variant: "max"` config has no effect
- `src/hooks/anthropic-effort/index.test.ts`: Add test for Sonnet on vertex-anthropic to verify provider guard fires before model-specific logic

## Testing

```bash
bun test src/hooks/anthropic-effort/index.test.ts
```

## Related Issues

Closes #2940

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip effort header injection for `google-vertex-anthropic` and log why, so users see why `variant: "max"` has no effect; relates to #2940.

- **Bug Fixes**
  - Add `EFFORT_UNSUPPORTED_PROVIDERS` guard that returns early and logs `sessionID`, `provider`, and `model` when the effort beta header isn’t supported.
  - Add tests: no effort for Opus/Sonnet on `google-vertex-anthropic`; effort still injected for Opus on `anthropic`.

<sup>Written for commit 5f3388c897e356b3b1743dab2a543dce61a68ecb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

