### PR TITLE
fix: tolerate both category and subagent_type in task() instead of throwing

### DIFF
--- a/src/agents/atlas/default.ts
+++ b/src/agents/atlas/default.ts
@@ -31,7 +31,7 @@ ${buildAntiDuplicationSection()}
 <delegation_system>
 ## How to Delegate
 
-Use \`task()\` with EITHER category OR agent (mutually exclusive):
+Use \`task()\` with category or agent (if both provided, category takes precedence):
 
 \`\`\`typescript
 // Option A: Category + Skills (spawns Sisyphus-Junior with domain config)

--- a/src/agents/atlas/gemini.ts
+++ b/src/agents/atlas/gemini.ts
@@ -58,7 +58,7 @@ ${buildAntiDuplicationSection()}
 <delegation_system>
 ## How to Delegate
 
-Use \`task()\` with EITHER category OR agent (mutually exclusive):
+Use \`task()\` with category or agent (if both provided, category takes precedence):
 
 \`\`\`typescript
 // Category + Skills (spawns Sisyphus-Junior)

--- a/src/agents/atlas/gpt.ts
+++ b/src/agents/atlas/gpt.ts
@@ -68,7 +68,7 @@ ${buildAntiDuplicationSection()}
 <delegation_system>
 ## Delegation API
 
-Use \`task()\` with EITHER category OR agent (mutually exclusive):
+Use \`task()\` with category or agent (if both provided, category takes precedence):
 
 \`\`\`typescript
 // Category + Skills (spawns Sisyphus-Junior)

--- a/src/agents/atlas/prompt-section-builder.ts
+++ b/src/agents/atlas/prompt-section-builder.ts
@@ -100,5 +100,5 @@ export function buildDecisionMatrix(agents: AvailableAgent[], userCategories?: R
 ${categoryRows.join("\n")}
 ${agentRows.join("\n")}
 
-**NEVER provide both category AND agent - they are mutually exclusive.**`
+If both category and agent are provided, category takes precedence.`
 }

--- a/src/hooks/delegate-task-retry/index.test.ts
+++ b/src/hooks/delegate-task-retry/index.test.ts
@@ -15,7 +15,6 @@ describe("sisyphus-task-retry", () => {
       const patternTexts = DELEGATE_TASK_ERROR_PATTERNS.map(p => p.pattern)
       expect(patternTexts).toContain("run_in_background")
       expect(patternTexts).toContain("load_skills")
-      expect(patternTexts).toContain("category OR subagent_type")
       expect(patternTexts).toContain("Unknown category")
       expect(patternTexts).toContain("Unknown agent")
     })
@@ -41,15 +40,6 @@ describe("sisyphus-task-retry", () => {
       
       expect(result).not.toBeNull()
       expect(result?.errorType).toBe("missing_load_skills")
-    })
-
-    it("should detect category/subagent mutual exclusion error", () => {
-      const output = "[ERROR] Invalid arguments: Provide EITHER category OR subagent_type, not both."
-      
-      const result = detectDelegateTaskError(output)
-      
-      expect(result).not.toBeNull()
-      expect(result?.errorType).toBe("mutual_exclusion")
     })
 
     it("should detect unknown category error", () => {

--- a/src/hooks/delegate-task-retry/patterns.ts
+++ b/src/hooks/delegate-task-retry/patterns.ts
@@ -18,12 +18,6 @@ export const DELEGATE_TASK_ERROR_PATTERNS: DelegateTaskErrorPattern[] = [
       "Add load_skills=[] parameter (empty array if no skills needed). Note: Calling Skill tool does NOT populate this.",
   },
   {
-    pattern: "category OR subagent_type",
-    errorType: "mutual_exclusion",
-    fixHint:
-      "Provide ONLY one of: category (e.g., 'general', 'quick') OR subagent_type (e.g., 'oracle', 'explore')",
-  },
-  {
     pattern: "Must provide either category or subagent_type",
     errorType: "missing_category_or_agent",
     fixHint: "Add either category='general' OR subagent_type='explore'",

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -465,7 +465,7 @@ describe("sisyphus-task", () => {
        expect(args.subagent_type).toBe("Sisyphus-Junior")
     }, { timeout: 10000 })
 
-    test("rejects when both category and subagent_type are provided", async () => {
+    test("prefers category and ignores subagent_type when both are provided", async () => {
       //#given
       const { createDelegateTask } = require("./tools")
 
@@ -516,8 +516,11 @@ describe("sisyphus-task", () => {
         load_skills: [],
       }
 
-      //#when + #then
-      await expect(tool.execute(args, toolContext)).rejects.toThrow("mutually exclusive")
+      //#when
+      await tool.execute(args, toolContext)
+
+      //#then — category takes precedence, subagent_type is cleared
+      expect(args.subagent_type).toBeUndefined()
     }, { timeout: 10000 })
 
     test("proceeds without error when systemDefaultModel is undefined", async () => {

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -76,7 +76,7 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
   - category: For task delegation (uses Sisyphus-Junior with category-optimized model)
   - subagent_type: For direct agent invocation (explore, librarian, oracle, etc.)
   
-  **DO NOT provide both.** If category is provided, subagent_type is ignored.
+  If both are provided, category takes precedence and subagent_type is silently ignored.
   
   - load_skills: ALWAYS REQUIRED. Pass [] if no skills needed, or ["skill-1", "skill-2"] for category tasks.
   - category: Use predefined category → Spawns Sisyphus-Junior with category config
@@ -101,8 +101,8 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
       description: tool.schema.string().describe("Short task description (3-5 words)"),
       prompt: tool.schema.string().describe("Full detailed prompt for the agent"),
       run_in_background: tool.schema.boolean().describe("REQUIRED. true=async (returns task_id), false=sync (waits). Use false for task delegation, true ONLY for parallel exploration."),
-      category: tool.schema.string().optional().describe(`REQUIRED if subagent_type not provided. Do NOT provide both category and subagent_type.`),
-      subagent_type: tool.schema.string().optional().describe("REQUIRED if category not provided. Do NOT provide both category and subagent_type. Valid values: explore, librarian, oracle, metis, momus"),
+      category: tool.schema.string().optional().describe(`REQUIRED if subagent_type not provided. If both provided, category takes precedence.`),
+      subagent_type: tool.schema.string().optional().describe("REQUIRED if category not provided. If both provided, category takes precedence and this is ignored. Valid values: explore, librarian, oracle, metis, momus"),
       session_id: tool.schema.string().optional().describe("Existing Task session to continue"),
       command: tool.schema.string().optional().describe("The command that triggered this task"),
     },
@@ -110,13 +110,11 @@ export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefini
       const ctx = toolContext as ToolContextWithMetadata
 
       if (args.category && args.subagent_type) {
-        throw new Error(
-          `Invalid arguments: 'category' and 'subagent_type' are mutually exclusive. Provide EXACTLY ONE.\n` +
-          `  - You provided: category="${args.category}", subagent_type="${args.subagent_type}"\n` +
-          `  - Use category for task delegation (e.g., category="${categoryExamples.split(", ")[0]}")\n` +
-          `  - Use subagent_type for direct agent invocation (e.g., subagent_type="explore")\n` +
-          `  - Valid subagent_type values: explore, librarian, oracle, metis, momus`
-        )
+        log("[task] both category and subagent_type provided — preferring category, ignoring subagent_type", {
+          category: args.category,
+          subagent_type: args.subagent_type,
+        })
+        args.subagent_type = undefined
       }
       if (args.category) {
         args.subagent_type = SISYPHUS_JUNIOR_AGENT


### PR DESCRIPTION
## Summary

When models provide both `category` and `subagent_type` to `task()`, the tool now silently prefers `category` and ignores `subagent_type` instead of throwing a "mutually exclusive" error.

## Problem

Models repeatedly provide both parameters because:
1. The agent prompt associates `category` with `Sisyphus-Junior`, creating a mental link
2. The model reasons "providing both is just being explicit" — logically correct from its perspective
3. The error message doesn't break the loop because the association feels right
4. The tool description said "If category is provided, subagent_type is ignored" but the code actually threw an error — a contradiction

This caused agents to fail delegation back-to-back, wasting tool calls and creating retry loops.

## Changes

- **`tools.ts`**: Replace `throw` with `log` warning + silent `subagent_type` clearing when both provided
- **`tools.ts`**: Update tool description and parameter docs to reflect category-precedence behavior
- **Atlas prompts** (default, gemini, gpt): Remove "mutually exclusive" language, document precedence
- **`prompt-section-builder.ts`**: Update decision matrix to reflect new behavior
- **`patterns.ts`**: Remove `mutual_exclusion` error pattern from delegate-task-retry hook (no longer thrown)
- **Tests**: Update both-provided test to verify tolerant behavior; remove mutual_exclusion detection test

## Refs

- Closes #2847 — `task` tool schema allows `category` + `subagent_type` together
- Relates to #1968 — Kimi K2.5 repeatedly fails to use correct `category` parameter
- Relates to #1948 — crash when task() called without subagent_type
- Relates to #2523 — task() orchestration inconsistency

Thanks to ismeth for surfacing this issue and providing the root cause analysis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`task()` now tolerates both `category` and `subagent_type`; it prefers `category` and ignores `subagent_type` instead of throwing. This stops delegation retry loops and aligns behavior with the docs. Closes #2847.

- **Bug Fixes**
  - `tools.ts`: Replace throw with log; clear `subagent_type` when both are provided; update parameter docs to state precedence.
  - Atlas prompts (`default`, `gemini`, `gpt`) and decision matrix: remove “mutually exclusive” language; document `category` precedence.
  - Delegate-task-retry hook: remove `mutual_exclusion` error pattern and related test.
  - Tests: update to verify tolerant behavior (both provided → `subagent_type` cleared).

<sup>Written for commit 2bb44b9a10f8db47900835b5f7fe46bbbbedb12b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

