### PR TITLE
feat: add managed OpenCode parity workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,157 +1,42 @@
-# oh-my-opencode — O P E N C O D E Plugin
+# AGENTS.md
 
-**Generated:** 2026-03-06 | **Commit:** 7fe44024 | **Branch:** dev
+## Purpose
 
-## OVERVIEW
+Compatibility-first fork of `code-yeongyu/oh-my-openagent`. Phase 1 keeps the upstream package and CLI identity stable while documenting and porting the local OpenCode config and plugin deltas into tracked fork assets.
 
-OpenCode plugin (npm: `oh-my-opencode`) that extends Claude Code (OpenCode fork) with multi-agent orchestration, 48 lifecycle hooks, 26 tools, skill/command/MCP systems, and Claude Code compatibility. 1268 TypeScript files, 160k LOC.
-
-## STRUCTURE
-
-```
-oh-my-opencode/
-├── src/
-│   ├── index.ts              # Plugin entry: loadConfig → createManagers → createTools → createHooks → createPluginInterface
-│   ├── plugin-config.ts      # JSONC multi-level config: user → project → defaults (Zod v4)
-│   ├── agents/               # 11 agents (Sisyphus, Hephaestus, Oracle, Librarian, Explore, Atlas, Prometheus, Metis, Momus, Multimodal-Looker, Sisyphus-Junior)
-│   ├── hooks/                # 48 lifecycle hooks across dedicated modules and standalone files
-│   ├── tools/                # 26 tools across 15 directories
-│   ├── features/             # 19 feature modules (background-agent, skill-loader, tmux, MCP-OAuth, etc.)
-│   ├── shared/               # 95+ utility files in 13 categories
-│   ├── config/               # Zod v4 schema system (24 files)
-│   ├── cli/                  # CLI: install, run, doctor, mcp-oauth (Commander.js)
-│   ├── mcp/                  # 3 built-in remote MCPs (websearch, context7, grep_app)
-│   ├── plugin/               # 8 OpenCode hook handlers + 48 hook composition
-│   └── plugin-handlers/      # 6-phase config loading pipeline
-├── packages/                 # Monorepo: cli-runner, 12 platform binaries
-└── local-ignore/             # Dev-only test fixtures
-```
-
-## INITIALIZATION FLOW
-
-```
-OhMyOpenCodePlugin(ctx)
-  ├─→ loadPluginConfig()         # JSONC parse → project/user merge → Zod validate → migrate
-  ├─→ createManagers()           # TmuxSessionManager, BackgroundManager, SkillMcpManager, ConfigHandler
-  ├─→ createTools()              # SkillContext + AvailableCategories + ToolRegistry (26 tools)
-  ├─→ createHooks()              # 3-tier: Core(39) + Continuation(7) + Skill(2) = 48 hooks
-  └─→ createPluginInterface()    # 8 OpenCode hook handlers → PluginInterface
-```
-
-## 8 OPENCODE HOOK HANDLERS
-
-| Handler | Purpose |
-|---------|---------|
-| `config` | 6-phase: provider → plugin-components → agents → tools → MCPs → commands |
-| `tool` | 26 registered tools |
-| `chat.message` | First-message variant, session setup, keyword detection |
-| `chat.params` | Anthropic effort level adjustment |
-| `chat.headers` | Copilot x-initiator header injection |
-| `event` | Session lifecycle (created, deleted, idle, error) |
-| `tool.execute.before` | Pre-tool hooks (file guard, label truncator, rules injector) |
-| `tool.execute.after` | Post-tool hooks (output truncation, metadata store) |
-| `experimental.chat.messages.transform` | Context injection, thinking block validation |
-
-## WHERE TO LOOK
-
-| Task | Location | Notes |
-|------|----------|-------|
-| Add new agent | `src/agents/` + `src/agents/builtin-agents/` | Follow createXXXAgent factory pattern |
-| Add new hook | `src/hooks/{name}/` + register in `src/plugin/hooks/create-*-hooks.ts` | Match event type to tier |
-| Add new tool | `src/tools/{name}/` + register in `src/plugin/tool-registry.ts` | Follow createXXXTool factory |
-| Add new feature module | `src/features/{name}/` | Standalone module, wire in plugin/ |
-| Add new MCP | `src/mcp/` + register in `createBuiltinMcps()` | Remote HTTP only |
-| Add new skill | `src/features/builtin-skills/skills/` | Implement BuiltinSkill interface |
-| Add new command | `src/features/builtin-commands/` | Template in templates/ |
-| Add new CLI command | `src/cli/cli-program.ts` | Commander.js subcommand |
-| Add new doctor check | `src/cli/doctor/checks/` | Register in checks/index.ts |
-| Modify config schema | `src/config/schema/` + update root schema | Zod v4, add to OhMyOpenCodeConfigSchema |
-| Add new category | `src/tools/delegate-task/constants.ts` | DEFAULT_CATEGORIES + CATEGORY_MODEL_REQUIREMENTS |
-
-## MULTI-LEVEL CONFIG
-
-```
-Project (.opencode/oh-my-opencode.jsonc)  →  User (~/.config/opencode/oh-my-opencode.jsonc)  →  Defaults
-```
-
-- `agents`, `categories`, `claude_code`: deep merged recursively
-- `disabled_*` arrays: Set union (concatenated + deduplicated)
-- All other fields: override replaces base value
-- Zod `safeParse()` fills defaults for omitted fields
-- `migrateConfigFile()` transforms legacy keys automatically
-
-Fields: agents (14 overridable, 21 fields each), categories (8 built-in + custom), disabled_* arrays (agents, hooks, mcps, skills, commands, tools), 19 feature-specific configs.
-
-## THREE-TIER MCP SYSTEM
-
-| Tier | Source | Mechanism |
-|------|--------|-----------|
-| Built-in | `src/mcp/` | 3 remote HTTP: websearch (Exa/Tavily), context7, grep_app |
-| Claude Code | `.mcp.json` | `${VAR}` env expansion via claude-code-mcp-loader |
-| Skill-embedded | SKILL.md YAML | Managed by SkillMcpManager (stdio + HTTP) |
-
-## CONVENTIONS
-
-- **Runtime**: Bun only — never use npm/yarn
-- **TypeScript**: strict mode, ESNext, bundler moduleResolution, `bun-types` (never `@types/node`)
-- **Test pattern**: Bun test (`bun:test`), co-located `*.test.ts`, given/when/then style (nested describe with `#given`/`#when`/`#then` prefixes)
-- **CI test split**: mock-heavy tests run in isolation (separate `bun test` processes), rest in batch
-- **Factory pattern**: `createXXX()` for all tools, hooks, agents
-- **Hook tiers**: Session (23) → Tool-Guard (12) → Transform (4) → Continuation (7) → Skill (2)
-- **Agent modes**: `primary` (respects UI model) vs `subagent` (own fallback chain) vs `all`
-- **Model resolution**: 4-step: override → category-default → provider-fallback → system-default
-- **Config format**: JSONC with comments, Zod v4 validation, snake_case keys
-- **File naming**: kebab-case for all files/directories
-- **Module structure**: index.ts barrel exports, no catch-all files (utils.ts, helpers.ts banned), 200 LOC soft limit
-- **Imports**: relative within module, barrel imports across modules (`import { log } from "./shared"`)
-- **No path aliases**: no `@/` — relative imports only
-
-## ANTI-PATTERNS
-
-- Never use `as any`, `@ts-ignore`, `@ts-expect-error`
-- Never suppress lint/type errors
-- Never add emojis to code/comments unless user explicitly asks
-- Never commit unless explicitly requested
-- Never run `bun publish` directly — use GitHub Actions
-- Never modify `package.json` version locally
-- Test: given/when/then — never use Arrange-Act-Assert comments
-- Comments: avoid AI-generated comment patterns (enforced by comment-checker hook)
-- Never create catch-all files (`utils.ts`, `helpers.ts`, `service.ts`)
-- Empty catch blocks `catch(e) {}` — always handle errors
-- Never use em dashes (—), en dashes (–), or AI filler phrases in generated content
-- index.ts is entry point ONLY — never dump business logic there
-
-## COMMANDS
+## Key commands
 
 ```bash
-bun test                    # Bun test suite
-bun run build              # Build plugin (ESM + declarations + schema)
-bun run build:all          # Build + platform binaries
-bun run typecheck           # tsc --noEmit
-bunx oh-my-opencode install # Interactive setup
-bunx oh-my-opencode doctor  # Health diagnostics
-bunx oh-my-opencode run     # Non-interactive session
+bun test
+bun run build
+tsc --noEmit
+bun run build:all
 ```
 
-## CI/CD
+## Important directories
 
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| ci.yml | push/PR to master/dev | Tests (split: mock-heavy isolated + batch), typecheck, build, schema auto-commit |
-| publish.yml | manual dispatch | Version bump, npm publish, platform binaries, GitHub release, merge to master |
-| publish-platform.yml | called by publish | 12 platform binaries via bun compile (darwin/linux/windows) |
-| sisyphus-agent.yml | @mention / dispatch | AI agent handles issues/PRs |
-| cla.yml | issue_comment/PR | CLA assistant for contributors |
-| lint-workflows.yml | push to .github/ | actionlint + shellcheck on workflow files |
+- `src/` - plugin, CLI, config, shared runtime code
+- `docs/` - upstream docs; fork-specific notes belong under `docs/fork/`
+- `assets/` - managed assets that later tasks will sync into an OpenCode config directory
+- `script/` - build and support scripts
+- `tests/` and `src/**/*.test.ts` - regression coverage
+- `.sisyphus/` - local planning, evidence, and agent rules
 
-## NOTES
+## Validation commands
 
-- Logger writes to `/tmp/oh-my-opencode.log` — check there for debugging
-- Background tasks: 5 concurrent per model/provider (configurable)
-- Plugin load timeout: 10s for Claude Code plugins
-- Model fallback priority: Claude > OpenAI > Gemini > Copilot > OpenCode Zen > Z.ai > Kimi
-- Config migration runs automatically on legacy keys (agent names, hook names, model versions)
-- Build: bun build (ESM) + tsc --emitDeclarationOnly, externals: @ast-grep/napi
-- Test setup: `test-setup.ts` preloaded via bunfig.toml, mock-heavy tests run in isolation in CI
-- 98 barrel export files (index.ts) establish module boundaries
-- Architecture rules enforced via `.sisyphus/rules/modular-code-enforcement.md`
+```bash
+bun test
+tsc --noEmit
+bun run build
+node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); console.log(p.scripts.test, p.scripts.build, p.scripts.typecheck)"
+```
+
+## Gotchas
+
+- Bun-only repo. Do not switch package managers.
+- Preserve npm package and bin identity as `oh-my-opencode` in phase 1.
+- Preserve preferred plugin identity as `oh-my-openagent`.
+- Treat legacy `oh-my-opencode` basename and alias support as compatibility, not drift.
+- Keep OpenCode host config (`opencode.json[c]`) separate from OhMyOpenCode plugin config.
+- Require explicit plugin registration through the OpenCode `plugin` array.
+- Do not rename the compatibility surface in phase 1 unless a verified blocker requires it.

--- a/assets/custom-opencode/oh-my-opencode.json
+++ b/assets/custom-opencode/oh-my-opencode.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "./node_modules/oh-my-openagent/dist/oh-my-opencode.schema.json",
+  "agents": {
+    "sisyphus": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high",
+      "prompt_append": "Before substantive work in any repository, first check whether the root AGENTS.md exists and matches the current project. If it is missing, outdated, or clearly incomplete, create or refresh it immediately before major edits. Keep it concise and factual. Add nested AGENTS.md files only when the repository is large or conventions differ by subtree. Maintain these files as you learn the repo's structure, commands, tests, conventions, and gotchas. If execution begins via /start-work, an approved Prometheus handoff, or an active boulder, treat that as explicit permission to implement. In execution mode, drive the plan to completion, keep delegating and verifying until all planned work is done, and do not stop at interim summaries or partial progress. Return control early only for destructive or irreversible actions, materially missing information, or hard environment blockers that cannot be solved from the repo."
+    },
+    "hephaestus": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high",
+      "prompt_append": "Before substantive work in any repository, first check whether the root AGENTS.md exists and matches the current project. If it is missing, outdated, or clearly incomplete, create or refresh it immediately before major edits. Keep it concise and factual. Add nested AGENTS.md files only when the repository is large or conventions differ by subtree. Maintain these files as you learn the repo's structure, commands, tests, conventions, and gotchas. If execution begins via /start-work, an approved Prometheus handoff, or an active boulder, treat that as explicit permission to implement. In execution mode, drive the plan to completion, keep delegating and verifying until all planned work is done, and do not stop at interim summaries or partial progress. Return control early only for destructive or irreversible actions, materially missing information, or hard environment blockers that cannot be solved from the repo."
+    },
+    "oracle": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "librarian": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "explore": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "multimodal-looker": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "prometheus": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high",
+      "prompt_append": "Before substantive work in any repository, first check whether the root AGENTS.md exists and matches the current project. If it is missing, outdated, or clearly incomplete, create or refresh it immediately before major edits. Keep it concise and factual. Add nested AGENTS.md files only when the repository is large or conventions differ by subtree. Maintain these files as you learn the repo's structure, commands, tests, conventions, and gotchas. You are the planning and negotiation front door. Stay in planning mode, resolve scope and tradeoffs with the user, and finish with a concrete executable plan plus /start-work guidance. Do not execute the plan yourself unless the user explicitly overrides this role."
+    },
+    "metis": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "momus": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "atlas": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high",
+      "prompt_append": "Before substantive work in any repository, first check whether the root AGENTS.md exists and matches the current project. If it is missing, outdated, or clearly incomplete, create or refresh it immediately before major edits. Keep it concise and factual. Add nested AGENTS.md files only when the repository is large or conventions differ by subtree. Maintain these files as you learn the repo's structure, commands, tests, conventions, and gotchas. If execution begins via /start-work, an approved Prometheus handoff, or an active boulder, treat that as explicit permission to implement. In execution mode, drive the plan to completion, keep delegating and verifying until all planned work is done, and do not stop at interim summaries or partial progress. Return control early only for destructive or irreversible actions, materially missing information, or hard environment blockers that cannot be solved from the repo."
+    },
+    "sisyphus-junior": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high",
+      "prompt_append": "Before substantive work in any repository, first check whether the root AGENTS.md exists and matches the current project. If it is missing, outdated, or clearly incomplete, create or refresh it immediately before major edits. Keep it concise and factual. Add nested AGENTS.md files only when the repository is large or conventions differ by subtree. Maintain these files as you learn the repo's structure, commands, tests, conventions, and gotchas. If execution begins via /start-work, an approved Prometheus handoff, or an active boulder, treat that as explicit permission to implement. In execution mode, drive the plan to completion, keep delegating and verifying until all planned work is done, and do not stop at interim summaries or partial progress. Return control early only for destructive or irreversible actions, materially missing information, or hard environment blockers that cannot be solved from the repo."
+    }
+  },
+  "categories": {
+    "visual-engineering": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "ultrabrain": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "deep": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "artistry": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "quick": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "unspecified-low": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "unspecified-high": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    },
+    "writing": {
+      "model": "openai/gpt-5.4",
+      "variant": "xhigh",
+      "textVerbosity": "high"
+    }
+  },
+  "background_task": {
+    "defaultConcurrency": 4,
+    "staleTimeoutMs": 600000,
+    "providerConcurrency": {
+      "openai": 4
+    },
+    "modelConcurrency": {
+      "openai/gpt-5.4": 4
+    }
+  },
+  "hashline_edit": true,
+  "sisyphus": {
+    "tasks": {
+      "storage_path": ".sisyphus/tasks",
+      "claude_code_compat": false
+    }
+  },
+  "sisyphus_agent": {
+    "planner_enabled": true,
+    "replace_plan": true,
+    "default_builder_enabled": false
+  },
+  "babysitting": {
+    "timeout_ms": 300000
+  },
+  "model_capabilities": {
+    "enabled": true,
+    "auto_refresh_on_start": true,
+    "refresh_timeout_ms": 10000
+  },
+  "experimental": {
+    "auto_resume": true,
+    "task_system": false
+  },
+  "notification": {
+    "force_enable": true
+  }
+}

--- a/assets/custom-opencode/opencode.json
+++ b/assets/custom-opencode/opencode.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "default_agent": "prometheus",
+  "plugin": [
+    "./plugins/oh-my-openagent.js"
+  ]
+}

--- a/assets/custom-opencode/plugins/heartbeat-status.js
+++ b/assets/custom-opencode/plugins/heartbeat-status.js
@@ -1,0 +1,860 @@
+const HEARTBEAT_INTERVAL_MS = 20_000
+const SILENCE_THRESHOLD_MS = 15_000
+const HEARTBEAT_TOAST_DURATION_MS = 5_000
+const RETRY_TOAST_DURATION_MS = 8_000
+const ERROR_TOAST_DURATION_MS = 10_000
+const STATE_CHANGE_TOAST_DURATION_MS = 4_000
+
+const HARD_PROVIDER_BLOCK_PATTERNS = [
+  /blocked by a gateway or proxy/i,
+  /check your account and provider settings/i,
+  /may not have permission to access this resource/i,
+]
+
+const CLEANUP_KEY = "__opencodeHeartbeatStatusCleanup"
+const WAITING_TOOL_NAMES = new Set(["task"])
+const RESUME_TOOL_NAMES = new Set(["background_output"])
+
+function clone(value) {
+  if (value === undefined) {
+    return undefined
+  }
+
+  return JSON.parse(JSON.stringify(value))
+}
+
+function extractErrorMessage(error) {
+  if (!error) {
+    return ""
+  }
+
+  if (typeof error === "string") {
+    return error
+  }
+
+  if (typeof error?.data?.message === "string") {
+    return error.data.message
+  }
+
+  if (typeof error?.message === "string") {
+    return error.message
+  }
+
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+function extractStatusCode(error) {
+  if (!error || typeof error !== "object") {
+    return undefined
+  }
+
+  return error.statusCode ?? error.status ?? error.data?.statusCode ?? error.error?.statusCode
+}
+
+function isHardProviderBlock(error) {
+  const statusCode = extractStatusCode(error)
+  const message = extractErrorMessage(error)
+
+  return statusCode === 403 && HARD_PROVIDER_BLOCK_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+function pluralizeRu(count, one, few, many) {
+  const mod10 = count % 10
+  const mod100 = count % 100
+
+  if (mod10 === 1 && mod100 !== 11) {
+    return one
+  }
+
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) {
+    return few
+  }
+
+  return many
+}
+
+function formatDuration(ms) {
+  const totalSeconds = Math.max(1, Math.round(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+
+  if (minutes <= 0) {
+    return `${seconds}с`
+  }
+
+  if (minutes < 60) {
+    return `${minutes}м ${seconds}с`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  const restMinutes = minutes % 60
+  return `${hours}ч ${restMinutes}м`
+}
+
+function formatRetryDelay(next) {
+  if (typeof next !== "number" || Number.isNaN(next)) {
+    return "неизвестно"
+  }
+
+  if (next > 1e11) {
+    return formatDuration(Math.max(1000, next - Date.now()))
+  }
+
+  if (next > 1000) {
+    return formatDuration(next)
+  }
+
+  return formatDuration(next * 1000)
+}
+
+function normalizeAgentName(agentName) {
+  if (typeof agentName !== "string") {
+    return "агент не указан"
+  }
+
+  const trimmed = agentName.trim()
+  return trimmed || "агент не указан"
+}
+
+function normalizePercent(percent) {
+  if (typeof percent !== "number" || Number.isNaN(percent)) {
+    return undefined
+  }
+
+  if (percent < 0 || percent > 100) {
+    return undefined
+  }
+
+  return Math.round(percent)
+}
+
+function summarizeTodos(todos) {
+  const list = Array.isArray(todos) ? todos : []
+  const pending = list.filter((todo) => todo?.status === "pending").length
+  const inProgress = list.filter((todo) => todo?.status === "in_progress").length
+  const completed = list.filter((todo) => todo?.status === "completed").length
+
+  return {
+    total: list.length,
+    pending,
+    inProgress,
+    completed,
+  }
+}
+
+function getRemainingSummary(todoSummary) {
+  if (!todoSummary || todoSummary.total === 0) {
+    return "оценка остатка пока недоступна"
+  }
+
+  const remaining = todoSummary.pending + todoSummary.inProgress
+
+  if (remaining <= 0) {
+    return "по текущему плану видимых шагов больше не осталось"
+  }
+
+  return `по текущему плану осталось ещё ${remaining} ${pluralizeRu(remaining, "шаг", "шага", "шагов")}`
+}
+
+function getToolActionSentence(tool) {
+  switch (tool) {
+    case "read":
+      return "Сейчас читает файлы и собирает контекст."
+    case "grep":
+      return "Сейчас ищет нужные места в коде."
+    case "glob":
+      return "Сейчас просматривает структуру файлов."
+    case "bash":
+      return "Сейчас выполняет команду в терминале."
+    case "task":
+      return "Сейчас делегирует часть работы подагенту."
+    case "background_output":
+      return "Сейчас забирает результат фоновой задачи, чтобы возобновить работу."
+    case "webfetch":
+      return "Сейчас читает внешние материалы."
+    case "question":
+      return "Сейчас готовит уточняющий вопрос."
+    case "apply_patch":
+      return "Сейчас вносит правки в файлы."
+    case "lsp_diagnostics":
+      return "Сейчас проверяет диагностику и ошибки."
+    case "lsp_find_references":
+    case "lsp_goto_definition":
+    case "lsp_symbols":
+      return "Сейчас разбирает связи в коде."
+    default:
+      return tool ? `Сейчас работает с инструментом ${tool}.` : "Сейчас выполняет следующий шаг."
+  }
+}
+
+function getToolAfterSentence(tool) {
+  switch (tool) {
+    case "task":
+      return "Сейчас ждёт результат фоновой задачи от подагента."
+    case "background_output":
+      return "Сейчас возобновляет работу после ответа подагента."
+    case "bash":
+    case "read":
+    case "grep":
+    case "glob":
+    case "webfetch":
+      return "Сейчас обрабатывает собранный результат."
+    case "apply_patch":
+      return "Сейчас проверяет внесённые правки."
+    default:
+      return "Сейчас продолжает выполнение плана."
+  }
+}
+
+function getPartActionSentence(part) {
+  switch (part?.type) {
+    case "reasoning":
+    case "thinking":
+      return "Сейчас обдумывает следующий шаг."
+    case "text":
+      return "Сейчас формирует ответ."
+    case "tool":
+    case "tool_use":
+      return "Сейчас работает с инструментами."
+    case "step-start":
+    case "step-finish":
+      return "Сейчас продвигается по шагам плана."
+    case "message update":
+      return "Сейчас обновляет рабочий контекст."
+    case "retry":
+      return "Сейчас пытается восстановиться после ошибки."
+    case "start-work handoff":
+      return "Сейчас передаёт план на исполнение Sisyphus."
+    case "user prompt":
+      return "Сейчас начинает обрабатывать запрос."
+    case "subtask":
+      return "Сейчас формирует задачу для подагента."
+    case "agent":
+      return "Сейчас работает через выбранного агента."
+    default:
+      return "Сейчас выполняет следующий шаг."
+  }
+}
+
+function getStateLabel(state) {
+  switch (state) {
+    case "running":
+      return "в работе"
+    case "waiting_for_subagents":
+      return "ждёт подагентов"
+    case "retrying":
+      return "повторяет попытку"
+    case "completed":
+      return "завершено"
+    case "failed":
+      return "остановлено"
+    default:
+      return "ожидает"
+  }
+}
+
+function getIndeterminateProgressLabel(state) {
+  switch (state.state) {
+    case "waiting_for_subagents":
+      return "Точный процент пока неизвестен: агент ждёт результат подагента."
+    case "retrying":
+      return "Точный процент пока неизвестен: идёт повторная попытка после ошибки."
+    case "failed":
+      return state.hardProviderBlock
+        ? "Точный процент недоступен: выполнение упёрлось в блокировку провайдера."
+        : "Точный процент недоступен: выполнение остановилось из-за ошибки."
+    case "idle":
+      return "Точный процент пока неизвестен: агент ждёт новую задачу."
+    default:
+      return "Точный процент пока неизвестен: текущий этап виден в статусе."
+  }
+}
+
+function resolveProgress(state) {
+  if (state.state === "completed") {
+    return {
+      kind: "determinate",
+      percent: 100,
+      source: "terminal",
+      label: "Выполнение завершено.",
+    }
+  }
+
+  const explicitPercent = normalizePercent(state.progressPercent)
+
+  if (explicitPercent !== undefined) {
+    return {
+      kind: "determinate",
+      percent: explicitPercent,
+      source: "explicit",
+      label: `Получен точный числовой сигнал прогресса: ${explicitPercent}%.`,
+    }
+  }
+
+  if (state.todoSummary && state.todoSummary.total > 0) {
+    return {
+      kind: "determinate",
+      percent: Math.round((state.todoSummary.completed / state.todoSummary.total) * 100),
+      source: "todo",
+      label: `Выполнено ${state.todoSummary.completed} из ${state.todoSummary.total} ${pluralizeRu(state.todoSummary.total, "шага", "шагов", "шагов")}.`,
+    }
+  }
+
+  return {
+    kind: "indeterminate",
+    source: "none",
+    label: getIndeterminateProgressLabel(state),
+  }
+}
+
+export function createSessionState() {
+  return {
+    state: "idle",
+    agentName: "агент не указан",
+    stage: "Ожидает новую задачу.",
+    busySince: undefined,
+    lastActivityAt: undefined,
+    lastToastAt: undefined,
+    lastPartType: undefined,
+    lastRetrySignature: undefined,
+    lastErrorSignature: undefined,
+    retry: undefined,
+    errorMessage: undefined,
+    hardProviderBlock: false,
+    todoSummary: undefined,
+    progressPercent: undefined,
+  }
+}
+
+export function buildHeartbeatSnapshot(state, now = Date.now()) {
+  const currentState = state ?? createSessionState()
+  const progress = resolveProgress(currentState)
+  const agentName = normalizeAgentName(currentState.agentName)
+  const stage = currentState.stage ?? getPartActionSentence({ type: currentState.lastPartType })
+  const statusText = `Агент ${agentName} · ${getStateLabel(currentState.state)} · ${stage}`
+  const detailParts = []
+
+  if (currentState.busySince) {
+    const elapsed = formatDuration(now - currentState.busySince)
+
+    if (currentState.state === "completed" || currentState.state === "failed") {
+      detailParts.push(`Работал ${elapsed}.`)
+    } else if (currentState.state !== "idle") {
+      detailParts.push(`Уже работает ${elapsed}.`)
+    }
+  }
+
+  if (progress.kind === "determinate") {
+    detailParts.push(`Прогресс ${progress.percent}%. ${progress.label}`)
+  } else {
+    detailParts.push(`Прогресс без точного процента. ${progress.label}`)
+  }
+
+  if (currentState.state === "retrying" && currentState.retry) {
+    detailParts.push(`Следующая попытка через ${formatRetryDelay(currentState.retry.next)}.`)
+  }
+
+  if (currentState.state === "failed" && currentState.errorMessage) {
+    if (currentState.hardProviderBlock) {
+      detailParts.push("Продолжение возможно только после исправления настроек провайдера или прокси.")
+    } else {
+      detailParts.push(`Причина: ${currentState.errorMessage}.`)
+    }
+  } else if (currentState.state === "running" || currentState.state === "waiting_for_subagents") {
+    detailParts.push(getRemainingSummary(currentState.todoSummary))
+  }
+
+  return {
+    state: currentState.state,
+    agentName,
+    stage,
+    statusText,
+    detailText: detailParts.join(" "),
+    progress,
+    retry: clone(currentState.retry),
+    errorMessage: currentState.errorMessage,
+    hardProviderBlock: currentState.hardProviderBlock,
+    todoSummary: clone(currentState.todoSummary),
+  }
+}
+
+export function formatHeartbeatStatus(snapshot) {
+  return `${snapshot.statusText}. ${snapshot.detailText}`.trim()
+}
+
+function getToastTitle(snapshot, reason) {
+  switch (reason) {
+    case "start_work":
+      return "Исполнение запущено"
+    case "waiting_for_subagents":
+      return "Ожидание подагентов"
+    case "resume_from_subagents":
+      return "Работа возобновлена"
+    case "completed":
+      return "Выполнение завершено"
+    case "failed":
+      return snapshot.hardProviderBlock ? "Блокировка провайдера" : "Выполнение остановлено"
+    case "retrying":
+      return "Повторная попытка"
+    default:
+      return "Пульс задачи"
+  }
+}
+
+function getToastVariant(snapshot) {
+  switch (snapshot.state) {
+    case "retrying":
+      return "warning"
+    case "failed":
+      return snapshot.hardProviderBlock ? "error" : "warning"
+    default:
+      return "info"
+  }
+}
+
+function getToastDuration(reason) {
+  switch (reason) {
+    case "retrying":
+      return RETRY_TOAST_DURATION_MS
+    case "failed":
+      return ERROR_TOAST_DURATION_MS
+    case "heartbeat":
+      return HEARTBEAT_TOAST_DURATION_MS
+    default:
+      return STATE_CHANGE_TOAST_DURATION_MS
+  }
+}
+
+async function safeToast(client, body) {
+  await client?.tui?.showToast?.({ body }).catch(() => {})
+}
+
+async function safeLog(client, level, message, extra = {}) {
+  await client?.app?.log?.({
+    body: {
+      service: "heartbeat-status",
+      level,
+      message,
+      extra,
+    },
+  }).catch(() => {})
+}
+
+export function createHeartbeatStatusRuntime({
+  client,
+  now = () => Date.now(),
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+} = {}) {
+  let activeSessionID
+  const sessions = new Map()
+
+  const getSessionState = (sessionID) => {
+    let state = sessions.get(sessionID)
+
+    if (!state) {
+      state = createSessionState()
+      sessions.set(sessionID, state)
+    }
+
+    return state
+  }
+
+  const getSessionSnapshot = (sessionID) => buildHeartbeatSnapshot(getSessionState(sessionID), now())
+
+  const markActiveSession = (sessionID) => {
+    if (!sessionID) {
+      return
+    }
+
+    activeSessionID = sessionID
+    getSessionState(sessionID)
+  }
+
+  const touchState = (sessionID, updates = {}) => {
+    const state = getSessionState(sessionID)
+    const currentTime = now()
+
+    state.lastActivityAt = currentTime
+
+    if (updates.agentName !== undefined) {
+      state.agentName = normalizeAgentName(updates.agentName)
+    }
+
+    if (updates.stage !== undefined) {
+      state.stage = updates.stage
+    }
+
+    if (updates.partType !== undefined) {
+      state.lastPartType = updates.partType
+    }
+
+    if (updates.state !== undefined) {
+      state.state = updates.state
+    }
+
+    if (updates.progressPercent !== undefined) {
+      state.progressPercent = normalizePercent(updates.progressPercent)
+    }
+
+    if (state.state !== "idle") {
+      state.busySince ??= currentTime
+    }
+
+    if (updates.clearRetry) {
+      state.retry = undefined
+      state.lastRetrySignature = undefined
+    }
+
+    if (updates.clearFailure) {
+      state.errorMessage = undefined
+      state.hardProviderBlock = false
+      state.lastErrorSignature = undefined
+    }
+
+    return state
+  }
+
+  const publishSnapshot = async (sessionID, reason, level = "info") => {
+    if (!sessionID) {
+      return undefined
+    }
+
+    const snapshot = getSessionSnapshot(sessionID)
+
+    await safeLog(client, level, "Heartbeat state updated", {
+      sessionID,
+      reason,
+      snapshot,
+    })
+
+    if (activeSessionID !== sessionID) {
+      return snapshot
+    }
+
+    await safeToast(client, {
+      title: getToastTitle(snapshot, reason),
+      message: formatHeartbeatStatus(snapshot),
+      variant: getToastVariant(snapshot),
+      duration: getToastDuration(reason),
+    })
+
+    return snapshot
+  }
+
+  const clearSession = (sessionID) => {
+    if (!sessionID) {
+      return
+    }
+
+    sessions.delete(sessionID)
+
+    if (activeSessionID === sessionID) {
+      activeSessionID = undefined
+    }
+  }
+
+  const setRunning = (sessionID, stage, extra = {}) => {
+    const state = touchState(sessionID, {
+      ...extra,
+      state: "running",
+      stage,
+      clearRetry: true,
+      clearFailure: true,
+    })
+
+    return state
+  }
+
+  const setWaitingForSubagents = (sessionID, stage) => {
+    return touchState(sessionID, {
+      state: "waiting_for_subagents",
+      stage,
+      clearRetry: true,
+      clearFailure: true,
+    })
+  }
+
+  const setCompleted = (sessionID) => {
+    const state = getSessionState(sessionID)
+
+    if (state.state === "idle") {
+      state.stage = "Ожидает новую задачу."
+      return state
+    }
+
+    return touchState(sessionID, {
+      state: "completed",
+      stage: "Сейчас завершил текущий этап."
+    })
+  }
+
+  const setFailed = (sessionID, error) => {
+    const hardProviderBlock = isHardProviderBlock(error)
+    const errorMessage = extractErrorMessage(error) || "неизвестная ошибка"
+    const state = touchState(sessionID, {
+      state: "failed",
+      stage: hardProviderBlock
+        ? "Сейчас упёрся в блокировку провайдера."
+        : "Сейчас выполнение остановилось из-за ошибки.",
+    })
+
+    state.errorMessage = errorMessage
+    state.hardProviderBlock = hardProviderBlock
+    state.retry = undefined
+
+    return state
+  }
+
+  const heartbeatInterval = setIntervalFn(() => {
+    if (!activeSessionID) {
+      return
+    }
+
+    const state = sessions.get(activeSessionID)
+
+    if (!state || !state.busySince) {
+      return
+    }
+
+    if (!["running", "waiting_for_subagents", "retrying"].includes(state.state)) {
+      return
+    }
+
+    const currentTime = now()
+    const lastActivityAt = state.lastActivityAt ?? state.busySince
+
+    if (currentTime - lastActivityAt < SILENCE_THRESHOLD_MS) {
+      return
+    }
+
+    if (state.lastToastAt && currentTime - state.lastToastAt < HEARTBEAT_INTERVAL_MS) {
+      return
+    }
+
+    state.lastToastAt = currentTime
+    void publishSnapshot(activeSessionID, "heartbeat")
+  }, HEARTBEAT_INTERVAL_MS)
+
+  return {
+    hooks: {
+      "chat.message": async (input) => {
+        markActiveSession(input.sessionID)
+        setRunning(input.sessionID, "Сейчас начинает обрабатывать запрос.", {
+          agentName: input.agent,
+          partType: "user prompt",
+        })
+      },
+
+      "command.execute.before": async (input) => {
+        markActiveSession(input.sessionID)
+
+        if (input.command.trim().toLowerCase() !== "start-work") {
+          return
+        }
+
+        setRunning(input.sessionID, "Сейчас передаёт план на исполнение Sisyphus.", {
+          partType: "start-work handoff",
+        })
+
+        await publishSnapshot(input.sessionID, "start_work")
+      },
+
+      "tool.execute.before": async (input) => {
+        markActiveSession(input.sessionID)
+
+        if (RESUME_TOOL_NAMES.has(input.tool)) {
+          const previousState = getSessionState(input.sessionID).state
+          setRunning(input.sessionID, getToolActionSentence(input.tool), {
+            partType: "tool_use",
+          })
+
+          if (previousState === "waiting_for_subagents") {
+            await publishSnapshot(input.sessionID, "resume_from_subagents")
+          }
+
+          return
+        }
+
+        setRunning(input.sessionID, getToolActionSentence(input.tool), {
+          partType: "tool_use",
+        })
+      },
+
+      "tool.execute.after": async (input) => {
+        markActiveSession(input.sessionID)
+
+        if (WAITING_TOOL_NAMES.has(input.tool)) {
+          setWaitingForSubagents(input.sessionID, getToolAfterSentence(input.tool))
+          await publishSnapshot(input.sessionID, "waiting_for_subagents")
+          return
+        }
+
+        setRunning(input.sessionID, getToolAfterSentence(input.tool), {
+          partType: "tool",
+        })
+      },
+
+      event: async ({ event }) => {
+        if (event.type === "session.deleted") {
+          clearSession(event.properties?.info?.id)
+          return
+        }
+
+        if (event.type === "todo.updated") {
+          const sessionID = event.properties?.sessionID
+
+          if (!sessionID) {
+            return
+          }
+
+          getSessionState(sessionID).todoSummary = summarizeTodos(event.properties?.todos)
+          return
+        }
+
+        if (event.type === "message.updated") {
+          const sessionID = event.properties?.info?.sessionID
+
+          if (!sessionID) {
+            return
+          }
+
+          setRunning(sessionID, "Сейчас обновляет рабочий контекст.", {
+            partType: "message update",
+          })
+          return
+        }
+
+        if (event.type === "message.part.updated") {
+          const part = event.properties?.part
+          const sessionID = part?.sessionID
+
+          if (!sessionID) {
+            return
+          }
+
+          setRunning(sessionID, getPartActionSentence(part), {
+            partType: part?.type,
+            agentName: part?.type === "agent" ? part?.name : undefined,
+          })
+          return
+        }
+
+        if (event.type === "session.status") {
+          const sessionID = event.properties?.sessionID
+          const status = event.properties?.status
+
+          if (!sessionID || !status) {
+            return
+          }
+
+          markActiveSession(sessionID)
+
+          if (status.type === "busy") {
+            const currentState = getSessionState(sessionID)
+
+            if (currentState.state !== "waiting_for_subagents") {
+              setRunning(sessionID, currentState.stage ?? "Сейчас выполняет следующий шаг.", {
+                partType: currentState.lastPartType,
+              })
+            }
+
+            return
+          }
+
+          if (status.type === "retry") {
+            const state = touchState(sessionID, {
+              state: "retrying",
+              stage: "Сейчас пытается восстановиться после ошибки.",
+              partType: "retry",
+            })
+            const signature = `${status.attempt}:${status.message}:${status.next}`
+
+            state.retry = {
+              attempt: status.attempt,
+              message: status.message,
+              next: status.next,
+            }
+            state.errorMessage = status.message
+            state.hardProviderBlock = false
+
+            if (state.lastRetrySignature === signature) {
+              return
+            }
+
+            state.lastRetrySignature = signature
+            await publishSnapshot(sessionID, "retrying", "warn")
+            return
+          }
+
+          setCompleted(sessionID)
+          await publishSnapshot(sessionID, "completed")
+          return
+        }
+
+        if (event.type === "session.idle") {
+          const sessionID = event.properties?.sessionID
+
+          if (!sessionID) {
+            return
+          }
+
+          markActiveSession(sessionID)
+          setCompleted(sessionID)
+          await publishSnapshot(sessionID, "completed")
+          return
+        }
+
+        if (event.type !== "session.error") {
+          return
+        }
+
+        const sessionID = event.properties?.sessionID
+        const error = event.properties?.error
+
+        if (!sessionID) {
+          return
+        }
+
+        markActiveSession(sessionID)
+
+        const state = setFailed(sessionID, error)
+        const errorSignature = `${extractStatusCode(error) ?? "na"}:${state.errorMessage}`
+
+        if (state.lastErrorSignature === errorSignature) {
+          return
+        }
+
+        state.lastErrorSignature = errorSignature
+        await publishSnapshot(sessionID, "failed", state.hardProviderBlock ? "error" : "warn")
+      },
+    },
+
+    getSessionSnapshot,
+
+    getAllSnapshots() {
+      return Array.from(sessions.entries()).map(([sessionID]) => ({
+        sessionID,
+        snapshot: getSessionSnapshot(sessionID),
+      }))
+    },
+
+    dispose() {
+      clearIntervalFn(heartbeatInterval)
+    },
+  }
+}
+
+export const HeartbeatStatusPlugin = async ({ client }) => {
+  try {
+    globalThis[CLEANUP_KEY]?.()
+  } catch {}
+
+  const runtime = createHeartbeatStatusRuntime({ client })
+  globalThis[CLEANUP_KEY] = () => runtime.dispose()
+  return runtime.hooks
+}

--- a/assets/custom-opencode/plugins/oh-my-openagent.js
+++ b/assets/custom-opencode/plugins/oh-my-openagent.js
@@ -1,0 +1,3 @@
+import OhMyOpenAgent from "oh-my-openagent"
+
+export const OhMyOpenAgentPlugin = OhMyOpenAgent

--- a/assets/custom-opencode/plugins/tls-certificate-retry.js
+++ b/assets/custom-opencode/plugins/tls-certificate-retry.js
@@ -1,0 +1,593 @@
+export const RETRY_DELAY_MS = 60_000
+
+const RETRYABLE_CONNECTIVITY_ERROR_PATTERNS = [
+  /unknown certificate verification error/i,
+  /certificate verification/i,
+  /unable to verify the first certificate/i,
+  /unable to get local issuer certificate/i,
+  /unable to verify leaf signature/i,
+  /unable_to_verify_leaf_signature/i,
+  /self[-_ ]signed certificate/i,
+  /self_signed_cert_in_chain/i,
+  /cert_has_expired/i,
+  /err_tls_cert_altname_invalid/i,
+  /unable to connect/i,
+  /network error/i,
+  /socket hang up/i,
+  /econnreset/i,
+  /econnrefused/i,
+  /timed out/i,
+  /timeout/i,
+]
+
+const HARD_PROVIDER_BLOCK_PATTERNS = [
+  /blocked by a gateway or proxy/i,
+  /check your account and provider settings/i,
+  /may not have permission to access this resource/i,
+]
+
+function clone(value) {
+  if (value === undefined) {
+    return undefined
+  }
+
+  return JSON.parse(JSON.stringify(value))
+}
+
+function createRetrySessionState() {
+  return {
+    state: "idle",
+    attempt: 0,
+    nextRetryAt: undefined,
+    errorMessage: undefined,
+    hardProviderBlock: false,
+  }
+}
+
+function extractErrorMessage(error) {
+  if (!error) {
+    return ""
+  }
+
+  if (typeof error === "string") {
+    return error
+  }
+
+  if (typeof error?.data?.message === "string") {
+    return error.data.message
+  }
+
+  if (typeof error?.message === "string") {
+    return error.message
+  }
+
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+function extractStatusCode(error) {
+  if (!error || typeof error !== "object") {
+    return undefined
+  }
+
+  return error.statusCode ?? error.status ?? error.data?.statusCode ?? error.error?.statusCode
+}
+
+function isRetryableConnectivityError(message) {
+  return RETRYABLE_CONNECTIVITY_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+function isHardProviderBlock(error) {
+  const message = extractErrorMessage(error)
+  const statusCode = extractStatusCode(error)
+
+  return statusCode === 403 && HARD_PROVIDER_BLOCK_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+function toPromptPart(part) {
+  if (!part || typeof part !== "object") {
+    return null
+  }
+
+  if (part.type === "text" && typeof part.text === "string") {
+    const nextPart = { type: "text", text: part.text }
+
+    if (part.synthetic) {
+      nextPart.synthetic = true
+    }
+
+    if (part.ignored) {
+      nextPart.ignored = true
+    }
+
+    return nextPart
+  }
+
+  if (part.type === "file" && typeof part.mime === "string" && typeof part.url === "string") {
+    const nextPart = {
+      type: "file",
+      mime: part.mime,
+      url: part.url,
+    }
+
+    if (typeof part.filename === "string") {
+      nextPart.filename = part.filename
+    }
+
+    if (part.source) {
+      nextPart.source = clone(part.source)
+    }
+
+    return nextPart
+  }
+
+  if (part.type === "agent" && typeof part.name === "string") {
+    const nextPart = { type: "agent", name: part.name }
+
+    if (part.source) {
+      nextPart.source = clone(part.source)
+    }
+
+    return nextPart
+  }
+
+  if (
+    part.type === "subtask" &&
+    typeof part.prompt === "string" &&
+    typeof part.description === "string" &&
+    typeof part.agent === "string"
+  ) {
+    return {
+      type: "subtask",
+      prompt: part.prompt,
+      description: part.description,
+      agent: part.agent,
+    }
+  }
+
+  return null
+}
+
+function buildRetryBody(payload) {
+  const body = {
+    parts: clone(payload.parts) ?? [],
+  }
+
+  if (payload.agent) {
+    body.agent = payload.agent
+  }
+
+  if (payload.model) {
+    body.model = clone(payload.model)
+  }
+
+  if (payload.variant) {
+    body.variant = payload.variant
+  }
+
+  if (payload.system) {
+    body.system = payload.system
+  }
+
+  if (payload.tools) {
+    body.tools = clone(payload.tools)
+  }
+
+  return body
+}
+
+async function safeToast(client, body) {
+  await client?.tui?.showToast?.({ body }).catch(() => {})
+}
+
+async function safeLog(client, level, message, extra = {}) {
+  await client?.app?.log?.({
+    body: {
+      service: "tls-certificate-retry",
+      level,
+      message,
+      extra,
+    },
+  }).catch(() => {})
+}
+
+async function readLastUserPayload(client, directory, sessionID) {
+  const response = await client.session.messages({
+    path: { id: sessionID },
+    query: { directory },
+  })
+
+  const messages = Array.isArray(response?.data) ? response.data : Array.isArray(response) ? response : []
+  const lastUserMessage = [...messages].reverse().find((message) => message?.info?.role === "user")
+
+  if (!lastUserMessage) {
+    return undefined
+  }
+
+  const parts = (lastUserMessage.parts ?? []).map(toPromptPart).filter(Boolean)
+
+  if (parts.length === 0) {
+    return undefined
+  }
+
+  return {
+    agent: lastUserMessage.info.agent,
+    model: clone(lastUserMessage.info.model),
+    system: lastUserMessage.info.system,
+    tools: clone(lastUserMessage.info.tools),
+    parts,
+  }
+}
+
+export function createTlsCertificateRetryRuntime({
+  client,
+  directory,
+  now = () => Date.now(),
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  onStateChange,
+} = {}) {
+  const lastPayloadBySession = new Map()
+  const retryTimerBySession = new Map()
+  const retryAttemptBySession = new Map()
+  const retryDispatchInFlight = new Set()
+  const hardBlockedSessions = new Set()
+  const retryStateBySession = new Map()
+
+  const getRetryState = (sessionID) => {
+    let state = retryStateBySession.get(sessionID)
+
+    if (!state) {
+      state = createRetrySessionState()
+      retryStateBySession.set(sessionID, state)
+    }
+
+    return state
+  }
+
+  const getSessionRetryState = (sessionID) => {
+    const state = getRetryState(sessionID)
+
+    return {
+      state: state.state,
+      attempt: state.attempt,
+      nextRetryAt: state.nextRetryAt,
+      errorMessage: state.errorMessage,
+      hardProviderBlock: state.hardProviderBlock,
+      scheduled: retryTimerBySession.has(sessionID),
+      dispatchInFlight: retryDispatchInFlight.has(sessionID),
+      payloadCached: lastPayloadBySession.has(sessionID),
+    }
+  }
+
+  const safeStateChange = async (sessionID, signal) => {
+    if (typeof onStateChange !== "function") {
+      return
+    }
+
+    try {
+      await onStateChange(sessionID, signal)
+    } catch (error) {
+      await safeLog(client, "warn", "Retry state bridge rejected an update", {
+        sessionID,
+        signal,
+        error: extractErrorMessage(error),
+      })
+    }
+  }
+
+  const clearRetryTimer = (sessionID) => {
+    const timer = retryTimerBySession.get(sessionID)
+
+    if (timer) {
+      clearTimeoutFn(timer)
+      retryTimerBySession.delete(sessionID)
+    }
+  }
+
+  const resetRetryState = (sessionID) => {
+    const state = getRetryState(sessionID)
+    state.state = "idle"
+    state.attempt = 0
+    state.nextRetryAt = undefined
+    state.errorMessage = undefined
+    state.hardProviderBlock = false
+  }
+
+  const clearSessionState = (sessionID) => {
+    clearRetryTimer(sessionID)
+    retryAttemptBySession.delete(sessionID)
+    retryDispatchInFlight.delete(sessionID)
+    hardBlockedSessions.delete(sessionID)
+    lastPayloadBySession.delete(sessionID)
+    retryStateBySession.delete(sessionID)
+  }
+
+  const setRetryingState = async (sessionID, attempt, errorMessage, nextRetryAt) => {
+    const state = getRetryState(sessionID)
+    state.state = "retrying"
+    state.attempt = attempt
+    state.nextRetryAt = nextRetryAt
+    state.errorMessage = errorMessage
+    state.hardProviderBlock = false
+
+    await safeStateChange(sessionID, {
+      state: "retrying",
+      attempt,
+      message: errorMessage,
+      next: nextRetryAt,
+    })
+  }
+
+  const setFailedState = async (sessionID, error, hardProviderBlock) => {
+    const state = getRetryState(sessionID)
+    state.state = "failed"
+    state.nextRetryAt = undefined
+    state.errorMessage = extractErrorMessage(error) || "Unknown session error"
+    state.hardProviderBlock = Boolean(hardProviderBlock)
+
+    await safeStateChange(sessionID, {
+      state: "failed",
+      error,
+      hardProviderBlock: state.hardProviderBlock,
+    })
+  }
+
+  const getRetryPayload = async (sessionID) => {
+    const cachedPayload = lastPayloadBySession.get(sessionID)
+
+    if (cachedPayload) {
+      return clone(cachedPayload)
+    }
+
+    const resolvedPayload = await readLastUserPayload(client, directory, sessionID)
+
+    if (resolvedPayload) {
+      lastPayloadBySession.set(sessionID, clone(resolvedPayload))
+    }
+
+    return resolvedPayload
+  }
+
+  const scheduleRetry = async (sessionID, errorMessage) => {
+    if (!sessionID || hardBlockedSessions.has(sessionID)) {
+      return false
+    }
+
+    if (retryTimerBySession.has(sessionID) || retryDispatchInFlight.has(sessionID)) {
+      return false
+    }
+
+    const nextAttempt = (retryAttemptBySession.get(sessionID) ?? 0) + 1
+    const nextRetryAt = now() + RETRY_DELAY_MS
+    const timer = setTimeoutFn(() => {
+      return dispatchRetry(sessionID)
+    }, RETRY_DELAY_MS)
+
+    retryTimerBySession.set(sessionID, timer)
+    await setRetryingState(sessionID, nextAttempt, errorMessage, nextRetryAt)
+
+    await safeToast(client, {
+      title: "Connection Retry Scheduled",
+      message: `Connection failed. Retrying in 60 seconds (attempt ${nextAttempt}).`,
+      variant: "warning",
+      duration: 7000,
+    })
+
+    await safeLog(client, "warn", "Scheduled automatic retry after connectivity failure", {
+      sessionID,
+      nextAttempt,
+      delayMs: RETRY_DELAY_MS,
+      error: errorMessage,
+    })
+
+    return true
+  }
+
+  const dispatchRetry = async (sessionID) => {
+    if (hardBlockedSessions.has(sessionID)) {
+      clearRetryTimer(sessionID)
+      return
+    }
+
+    clearRetryTimer(sessionID)
+
+    if (retryDispatchInFlight.has(sessionID)) {
+      return
+    }
+
+    retryDispatchInFlight.add(sessionID)
+    let retryableDispatchErrorMessage
+
+    try {
+      const payload = await getRetryPayload(sessionID)
+
+      if (!payload) {
+        await safeLog(client, "warn", "Retry skipped because no user payload could be reconstructed", {
+          sessionID,
+        })
+        return
+      }
+
+      const attempt = (retryAttemptBySession.get(sessionID) ?? 0) + 1
+      retryAttemptBySession.set(sessionID, attempt)
+
+      await safeToast(client, {
+        title: "Connection Retry",
+        message: `Connection failed. Retrying now (attempt ${attempt}).`,
+        variant: "warning",
+        duration: 5000,
+      })
+
+      await safeLog(client, "warn", "Dispatching automatic retry after connectivity failure", {
+        sessionID,
+        attempt,
+        delayMs: RETRY_DELAY_MS,
+      })
+
+      await client.session.promptAsync({
+        path: { id: sessionID },
+        body: buildRetryBody(payload),
+        query: { directory },
+      })
+    } catch (error) {
+      const errorMessage = extractErrorMessage(error)
+
+      await safeLog(client, "error", "Automatic TLS retry dispatch failed", {
+        sessionID,
+        error: errorMessage,
+      })
+
+      if (isHardProviderBlock(error)) {
+        hardBlockedSessions.add(sessionID)
+        await setFailedState(sessionID, error, true)
+
+        await safeToast(client, {
+          title: "Provider Blocked",
+          message: "Execution paused because the provider returned a non-retryable gateway/account block. Fix provider or proxy settings, then resend.",
+          variant: "error",
+          duration: 10000,
+        })
+
+        return
+      }
+
+      if (isRetryableConnectivityError(errorMessage)) {
+        retryableDispatchErrorMessage = errorMessage
+      }
+    } finally {
+      retryDispatchInFlight.delete(sessionID)
+    }
+
+    if (retryableDispatchErrorMessage) {
+      await scheduleRetry(sessionID, retryableDispatchErrorMessage)
+    }
+  }
+
+  return {
+    hooks: {
+      "chat.message": async (input, output) => {
+        const sessionID = input.sessionID
+
+        if (!sessionID || output.message?.role !== "user") {
+          return
+        }
+
+        hardBlockedSessions.delete(sessionID)
+        resetRetryState(sessionID)
+
+        const payload = {
+          agent: input.agent ?? output.message.agent,
+          model: clone(input.model ?? output.message.model),
+          variant: input.variant,
+          system: output.message.system,
+          tools: clone(output.message.tools),
+          parts: (output.parts ?? []).map(toPromptPart).filter(Boolean),
+        }
+
+        if (payload.parts.length > 0) {
+          lastPayloadBySession.set(sessionID, clone(payload))
+        }
+
+        if (retryDispatchInFlight.has(sessionID)) {
+          return
+        }
+
+        if (retryTimerBySession.has(sessionID)) {
+          clearRetryTimer(sessionID)
+          retryAttemptBySession.delete(sessionID)
+
+          await safeLog(client, "info", "Cancelled scheduled TLS retry because a new user message was sent", {
+            sessionID,
+          })
+        }
+      },
+
+      event: async ({ event }) => {
+        if (event.type === "session.deleted") {
+          const sessionID = event.properties?.info?.id
+
+          if (sessionID) {
+            clearSessionState(sessionID)
+          }
+
+          return
+        }
+
+        if (event.type === "session.idle") {
+          const sessionID = event.properties?.sessionID
+
+          if (!sessionID) {
+            return
+          }
+
+          if (!retryTimerBySession.has(sessionID) && !retryDispatchInFlight.has(sessionID)) {
+            retryAttemptBySession.delete(sessionID)
+
+            if (!hardBlockedSessions.has(sessionID)) {
+              resetRetryState(sessionID)
+            }
+          }
+
+          return
+        }
+
+        if (event.type !== "session.error") {
+          return
+        }
+
+        const sessionID = event.properties?.sessionID
+        const rawError = event.properties?.error
+        const errorMessage = extractErrorMessage(rawError)
+
+        if (!sessionID || hardBlockedSessions.has(sessionID)) {
+          return
+        }
+
+        if (isHardProviderBlock(rawError)) {
+          hardBlockedSessions.add(sessionID)
+          clearRetryTimer(sessionID)
+          await setFailedState(sessionID, rawError, true)
+
+          await safeToast(client, {
+            title: "Provider Blocked",
+            message: "The provider returned a non-retryable gateway/account block, so auto-retry is stopped. Fix provider or proxy settings, then resend.",
+            variant: "error",
+            duration: 10000,
+          })
+
+          await safeLog(client, "error", "Detected non-retryable provider block; auto-retry stopped", {
+            sessionID,
+            error: errorMessage,
+            statusCode: extractStatusCode(rawError),
+          })
+
+          return
+        }
+
+        if (!isRetryableConnectivityError(errorMessage)) {
+          return
+        }
+
+        await scheduleRetry(sessionID, errorMessage)
+      },
+    },
+
+    getSessionRetryState,
+
+    getAllSessionRetryStates() {
+      return Array.from(retryStateBySession.keys()).map((sessionID) => ({
+        sessionID,
+        state: getSessionRetryState(sessionID),
+      }))
+    },
+  }
+}
+
+export const TlsCertificateRetryPlugin = async ({ client, directory }) => {
+  const runtime = createTlsCertificateRetryRuntime({ client, directory })
+  return runtime.hooks
+}

--- a/assets/custom-opencode/refresh-omo.ps1
+++ b/assets/custom-opencode/refresh-omo.ps1
@@ -1,0 +1,786 @@
+param(
+  [string]$TargetDir = "C:\Users\RedFox\.config\opencode",
+  [string]$AssetRoot = $PSScriptRoot,
+  [switch]$CheckOnly
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$script:RefreshLogPath = $null
+
+function Write-RefreshLog {
+  param([string]$Message)
+
+  if ($script:RefreshLogPath) {
+    Add-Content -LiteralPath $script:RefreshLogPath -Value $Message -Encoding utf8
+  }
+}
+
+function Write-Step {
+  param([string]$Message)
+
+  Write-Host "==> $Message" -ForegroundColor Cyan
+  Write-RefreshLog "==> $Message"
+}
+
+function Write-Note {
+  param([string]$Message)
+
+  Write-Host $Message
+  Write-RefreshLog $Message
+}
+
+function Resolve-AbsolutePath {
+  param([string]$PathValue)
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    throw "Path value cannot be empty."
+  }
+
+  return [System.IO.Path]::GetFullPath($PathValue)
+}
+
+function Ensure-Directory {
+  param([string]$DirectoryPath)
+
+  if (-not (Test-Path -LiteralPath $DirectoryPath)) {
+    New-Item -ItemType Directory -Path $DirectoryPath -Force | Out-Null
+    return $true
+  }
+
+  return $false
+}
+
+function Get-PortableRelativePath {
+  param(
+    [string]$BasePath,
+    [string]$PathValue
+  )
+
+  $normalizedBasePath = (Resolve-AbsolutePath $BasePath).TrimEnd("\", "/")
+  $normalizedPathValue = (Resolve-AbsolutePath $PathValue).TrimEnd("\", "/")
+
+  if ($normalizedBasePath -ieq $normalizedPathValue) {
+    return "."
+  }
+
+  $baseParts = $normalizedBasePath -split '[\\/]'
+  $pathParts = $normalizedPathValue -split '[\\/]'
+  $maxCommonLength = [Math]::Min($baseParts.Length, $pathParts.Length)
+  $commonLength = 0
+
+  while ($commonLength -lt $maxCommonLength -and $baseParts[$commonLength].Equals($pathParts[$commonLength], [System.StringComparison]::OrdinalIgnoreCase)) {
+    $commonLength += 1
+  }
+
+  if ($commonLength -eq 0 -and $baseParts[0] -match '^[A-Za-z]:$' -and $pathParts[0] -match '^[A-Za-z]:$') {
+    return $normalizedPathValue.Replace("\", "/")
+  }
+
+  $relativeParts = [System.Collections.Generic.List[string]]::new()
+
+  for ($index = $commonLength; $index -lt $baseParts.Length; $index += 1) {
+    $relativeParts.Add("..") | Out-Null
+  }
+
+  for ($index = $commonLength; $index -lt $pathParts.Length; $index += 1) {
+    $relativeParts.Add($pathParts[$index]) | Out-Null
+  }
+
+  if ($relativeParts.Count -eq 0) {
+    return "."
+  }
+
+  return ($relativeParts -join "/")
+}
+
+function Require-Path {
+  param(
+    [string]$PathValue,
+    [string]$Description
+  )
+
+  if (-not (Test-Path -LiteralPath $PathValue)) {
+    throw "$Description was not found: $PathValue"
+  }
+}
+
+function Resolve-CommandPath {
+  param(
+    [string]$Name,
+    [string[]]$FallbackPaths = @()
+  )
+
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  if ($command) {
+    return $command.Source
+  }
+
+  foreach ($fallbackPath in $FallbackPaths) {
+    if ($fallbackPath -and (Test-Path -LiteralPath $fallbackPath)) {
+      return $fallbackPath
+    }
+  }
+
+  throw "Required command '$Name' was not found in PATH or fallback paths."
+}
+
+function Resolve-DoctorCommand {
+  param(
+    [string]$TargetDir,
+    [string]$NodeCommand
+  )
+
+  $shimFallbacks = @(
+    (Join-Path $TargetDir "node_modules\.bin\oh-my-opencode.cmd"),
+    (Join-Path $TargetDir "node_modules\.bin\oh-my-opencode.ps1"),
+    (Join-Path $TargetDir "node_modules\.bin\oh-my-opencode")
+  )
+  $binScriptFallbacks = @(
+    (Join-Path $TargetDir "node_modules\oh-my-openagent\bin\oh-my-opencode.js"),
+    (Join-Path $TargetDir "node_modules\oh-my-opencode\bin\oh-my-opencode.js")
+  )
+
+  foreach ($fallbackPath in $shimFallbacks) {
+    if ($fallbackPath -and (Test-Path -LiteralPath $fallbackPath)) {
+      return [ordered]@{
+        Executable = $fallbackPath
+        Arguments = @()
+        Resolution = "target-local-shim"
+        ResolvedPath = $fallbackPath
+      }
+    }
+  }
+
+  foreach ($fallbackPath in $binScriptFallbacks) {
+    if ($fallbackPath -and (Test-Path -LiteralPath $fallbackPath)) {
+      return [ordered]@{
+        Executable = $NodeCommand
+        Arguments = @($fallbackPath)
+        Resolution = "target-package-bin"
+        ResolvedPath = $fallbackPath
+      }
+    }
+  }
+
+  $command = Get-Command "oh-my-opencode" -ErrorAction SilentlyContinue
+  if ($command) {
+    return [ordered]@{
+      Executable = $command.Source
+      Arguments = @()
+      Resolution = "global-path"
+      ResolvedPath = $command.Source
+    }
+  }
+
+  throw "Required command 'oh-my-opencode' was not found in PATH, local shims, or package bin fallbacks."
+}
+
+function Get-RefreshAdvisoryDoctorIssueTitles {
+  return @(
+    "oh-my-openagent is not registered",
+    "GitHub CLI missing",
+    "Comment checker unavailable"
+  )
+}
+
+function Get-DoctorIssueTitles {
+  param([object]$DoctorResult)
+
+  $issueTitles = [System.Collections.Generic.List[string]]::new()
+
+  foreach ($result in @($DoctorResult.results)) {
+    foreach ($issue in @($result.issues)) {
+      if ($issue.title -and -not [string]::IsNullOrWhiteSpace([string]$issue.title)) {
+        $issueTitles.Add([string]$issue.title) | Out-Null
+      }
+    }
+  }
+
+  return @($issueTitles | Select-Object -Unique)
+}
+
+function Get-WindowsPlatformBinaryPackageCandidates {
+  return @(
+    "oh-my-opencode-windows-x64",
+    "oh-my-opencode-windows-x64-baseline"
+  )
+}
+
+function Ensure-DoctorPlatformBinary {
+  param(
+    [string]$TargetDir,
+    [string]$NpmCommand
+  )
+
+  $candidatePackages = Get-WindowsPlatformBinaryPackageCandidates
+  foreach ($candidatePackage in $candidatePackages) {
+    if (Test-Path -LiteralPath (Join-Path $TargetDir (Join-Path "node_modules" $candidatePackage))) {
+      return
+    }
+  }
+
+  $installedPackagePath = Join-Path $TargetDir "node_modules\oh-my-openagent\package.json"
+  if (-not (Test-Path -LiteralPath $installedPackagePath)) {
+    Write-Note "Skipping platform binary repair because the managed package manifest was not found under node_modules."
+    return
+  }
+
+  $installedPackage = Get-Content -LiteralPath $installedPackagePath -Raw | ConvertFrom-Json
+  $packageVersion = $installedPackage.version
+  if ([string]::IsNullOrWhiteSpace($packageVersion)) {
+    Write-Note "Skipping platform binary repair because the managed package version could not be resolved."
+    return
+  }
+
+  foreach ($candidatePackage in $candidatePackages) {
+    $candidateSpec = "$candidatePackage@$packageVersion"
+
+    try {
+      Invoke-LoggedCommand -Executable $NpmCommand -Arguments @("install", $candidateSpec, "--no-save") -Description "Installing platform binary package $candidateSpec" -WorkingDirectory $TargetDir | Out-Null
+      return
+    }
+    catch {
+      Write-Note "Platform binary install attempt failed for ${candidateSpec}: $($_.Exception.Message)"
+    }
+  }
+
+  throw "Unable to install a local platform binary package for oh-my-opencode. Tried: $($candidatePackages -join ', ')"
+}
+
+function New-RunId {
+  param([string]$Timestamp)
+
+  return ($Timestamp -replace '[:.]', '-')
+}
+
+function Test-FileContentsMatch {
+  param(
+    [string]$SourcePath,
+    [string]$DestinationPath
+  )
+
+  if (-not (Test-Path -LiteralPath $DestinationPath)) {
+    return $false
+  }
+
+  $sourceBytes = [System.IO.File]::ReadAllBytes($SourcePath)
+  $destinationBytes = [System.IO.File]::ReadAllBytes($DestinationPath)
+
+  if ($sourceBytes.Length -ne $destinationBytes.Length) {
+    return $false
+  }
+
+  for ($index = 0; $index -lt $sourceBytes.Length; $index += 1) {
+    if ($sourceBytes[$index] -ne $destinationBytes[$index]) {
+      return $false
+    }
+  }
+
+  return $true
+}
+
+function Copy-DirectoryEntries {
+  param(
+    [string]$SourceDir,
+    [string]$DestinationDir,
+    [string[]]$ExcludeNames = @()
+  )
+
+  Ensure-Directory $DestinationDir | Out-Null
+
+  foreach ($entry in Get-ChildItem -LiteralPath $SourceDir -Force) {
+    if ($ExcludeNames -contains $entry.Name) {
+      continue
+    }
+
+    $destinationPath = Join-Path $DestinationDir $entry.Name
+    Copy-Item -LiteralPath $entry.FullName -Destination $destinationPath -Recurse -Force
+  }
+}
+
+function Clear-DirectoryEntries {
+  param(
+    [string]$DirectoryPath,
+    [string[]]$ExcludeNames = @()
+  )
+
+  foreach ($entry in Get-ChildItem -LiteralPath $DirectoryPath -Force) {
+    if ($ExcludeNames -contains $entry.Name) {
+      continue
+    }
+
+    Remove-Item -LiteralPath $entry.FullName -Recurse -Force
+  }
+}
+
+function Backup-TargetState {
+  param(
+    [string]$SourceDir,
+    [string]$BackupDir
+  )
+
+  Ensure-Directory $BackupDir | Out-Null
+  Copy-DirectoryEntries -SourceDir $SourceDir -DestinationDir $BackupDir -ExcludeNames @("node_modules", ".oh-my-openagent-refresh")
+}
+
+function Restore-TargetState {
+  param(
+    [string]$TargetDir,
+    [string]$BackupDir
+  )
+
+  if (-not (Test-Path -LiteralPath $BackupDir)) {
+    throw "Backup directory was not found: $BackupDir"
+  }
+
+  Clear-DirectoryEntries -DirectoryPath $TargetDir -ExcludeNames @("node_modules", ".oh-my-openagent-refresh")
+  Copy-DirectoryEntries -SourceDir $BackupDir -DestinationDir $TargetDir
+}
+
+function Get-ManagedAssetFiles {
+  param([string]$SourceRoot)
+
+  $managedFiles = [System.Collections.Generic.List[System.IO.FileInfo]]::new()
+
+  foreach ($relativePath in @("opencode.json", "oh-my-opencode.json", "refresh-omo.ps1")) {
+    $fullPath = Join-Path $SourceRoot $relativePath
+    Require-Path $fullPath "Managed asset"
+    $managedFiles.Add((Get-Item -LiteralPath $fullPath))
+  }
+
+  $pluginsDir = Join-Path $SourceRoot "plugins"
+  Require-Path $pluginsDir "Managed plugin directory"
+
+  foreach ($pluginFile in Get-ChildItem -LiteralPath $pluginsDir -Recurse -File | Sort-Object FullName) {
+    $managedFiles.Add($pluginFile)
+  }
+
+  return $managedFiles | Sort-Object { Get-PortableRelativePath -BasePath $SourceRoot -PathValue $_.FullName }
+}
+
+function Invoke-LoggedCommand {
+  param(
+    [string]$Executable,
+    [string[]]$Arguments,
+    [string]$Description,
+    [string]$WorkingDirectory,
+    [hashtable]$EnvironmentOverrides = @{},
+    [switch]$AllowNonZeroExit
+  )
+
+  Write-Step $Description
+  Write-RefreshLog ("$Executable " + ($Arguments -join " "))
+
+  $originalDirectory = Get-Location
+  $captured = @()
+  $previousEnv = @{}
+  $previousErrorActionPreference = $ErrorActionPreference
+
+  try {
+    if ($WorkingDirectory) {
+      Set-Location -LiteralPath $WorkingDirectory
+    }
+
+    foreach ($entry in $EnvironmentOverrides.GetEnumerator()) {
+      $previousEnv[$entry.Key] = [Environment]::GetEnvironmentVariable($entry.Key)
+      [Environment]::SetEnvironmentVariable($entry.Key, [string]$entry.Value)
+    }
+
+    $ErrorActionPreference = "Continue"
+
+    try {
+      $captured = & $Executable @Arguments 2>&1
+      $exitCode = $LASTEXITCODE
+    }
+    finally {
+      $ErrorActionPreference = $previousErrorActionPreference
+    }
+
+    foreach ($line in $captured) {
+      Write-Host $line
+      Write-RefreshLog ([string]$line)
+    }
+
+    if ($AllowNonZeroExit) {
+      return [ordered]@{
+        Output = ($captured | Out-String)
+        ExitCode = $exitCode
+      }
+    }
+
+    if ($exitCode -ne 0) {
+      throw "$Description failed with exit code $exitCode."
+    }
+
+    return ($captured | Out-String)
+  }
+  finally {
+    foreach ($entry in $previousEnv.GetEnumerator()) {
+      [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value)
+    }
+
+    $ErrorActionPreference = $previousErrorActionPreference
+
+    Set-Location $originalDirectory
+  }
+}
+
+function Invoke-DoctorValidation {
+  param(
+    [hashtable]$DoctorCommand,
+    [string]$TargetDir
+  )
+
+  $validationEnv = @{ OPENCODE_CONFIG_DIR = $TargetDir }
+  $doctorArguments = @($DoctorCommand.Arguments + @("doctor", "--json"))
+  $doctorResult = Invoke-LoggedCommand -Executable $DoctorCommand.Executable -Arguments $doctorArguments -Description "Running oh-my-opencode doctor against the synced config" -WorkingDirectory $TargetDir -EnvironmentOverrides $validationEnv -AllowNonZeroExit
+
+  try {
+    $doctorPayload = $doctorResult.Output | ConvertFrom-Json
+  }
+  catch {
+    throw "Doctor output could not be parsed as JSON. Resolution: $($DoctorCommand.Resolution)."
+  }
+
+  $issueTitles = @(Get-DoctorIssueTitles -DoctorResult $doctorPayload)
+  if ($doctorResult.ExitCode -eq 0) {
+    return [ordered]@{
+      AdvisoryOnly = $false
+      IssueTitles = $issueTitles
+      ExitCode = $doctorResult.ExitCode
+    }
+  }
+
+  if ($issueTitles.Count -eq 0) {
+    throw "Doctor failed with exit code $($doctorResult.ExitCode) but returned no parseable issues."
+  }
+
+  $advisoryIssueTitles = @(Get-RefreshAdvisoryDoctorIssueTitles)
+  $nonAdvisoryIssues = @($issueTitles | Where-Object { $advisoryIssueTitles -notcontains $_ })
+  if ($nonAdvisoryIssues.Count -gt 0) {
+    throw "Doctor reported fatal issue(s): $($nonAdvisoryIssues -join ', ')"
+  }
+
+  $advisorySummary = $issueTitles -join ", "
+  Write-Note "Doctor reported advisory issues only; continuing refresh: $advisorySummary"
+  Write-RefreshLog "Doctor exit code $($doctorResult.ExitCode) accepted because only advisory issues were present: $advisorySummary"
+
+  return [ordered]@{
+    AdvisoryOnly = $true
+    IssueTitles = $issueTitles
+    ExitCode = $doctorResult.ExitCode
+  }
+}
+
+function Invoke-PowerShellManagedAssetSync {
+  param(
+    [string]$SourceRoot,
+    [string]$TargetRoot,
+    [string]$Timestamp,
+    [string]$RunId
+  )
+
+  $stateDir = Join-Path $TargetRoot ".oh-my-openagent-sync"
+  $backupDir = Join-Path $stateDir (Join-Path "backups" $RunId)
+  $manifestPath = Join-Path $stateDir "manifest.json"
+  $logPath = Join-Path $stateDir "sync.log"
+  $createdDirectories = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  $fileRecords = [System.Collections.Generic.List[object]]::new()
+
+  foreach ($directoryPath in @($TargetRoot, $stateDir, $backupDir)) {
+    if (Ensure-Directory $directoryPath) {
+      [void]$createdDirectories.Add((Get-PortableRelativePath -BasePath $TargetRoot -PathValue $directoryPath))
+    }
+  }
+
+  foreach ($sourceFile in Get-ManagedAssetFiles -SourceRoot $SourceRoot) {
+    $relativePath = Get-PortableRelativePath -BasePath $SourceRoot -PathValue $sourceFile.FullName
+    $destinationPath = Join-Path $TargetRoot ($relativePath -replace '/', '\\')
+    $destinationDir = Split-Path -Parent $destinationPath
+
+    if (Ensure-Directory $destinationDir) {
+      [void]$createdDirectories.Add((Get-PortableRelativePath -BasePath $TargetRoot -PathValue $destinationDir))
+    }
+
+    $status = "created"
+    $backupPath = $null
+
+    if (Test-Path -LiteralPath $destinationPath) {
+      $destinationItem = Get-Item -LiteralPath $destinationPath
+      if ($destinationItem.PSIsContainer) {
+        throw "Cannot sync file onto non-file path: $destinationPath"
+      }
+
+      if (Test-FileContentsMatch -SourcePath $sourceFile.FullName -DestinationPath $destinationPath) {
+        $status = "unchanged"
+      }
+      else {
+        $backupPath = Join-Path $backupDir ($relativePath -replace '/', '\\')
+        $backupParentDir = Split-Path -Parent $backupPath
+        if (Ensure-Directory $backupParentDir) {
+          [void]$createdDirectories.Add((Get-PortableRelativePath -BasePath $TargetRoot -PathValue $backupParentDir))
+        }
+
+        Copy-Item -LiteralPath $destinationPath -Destination $backupPath -Force
+        $status = "updated"
+      }
+    }
+
+    if ($status -ne "unchanged") {
+      Copy-Item -LiteralPath $sourceFile.FullName -Destination $destinationPath -Force
+    }
+
+    $fileRecords.Add([ordered]@{
+      relativePath = $relativePath
+      sourcePath = $sourceFile.FullName
+      destinationPath = $destinationPath
+      status = $status
+      backupPath = $backupPath
+      bytes = $sourceFile.Length
+    }) | Out-Null
+  }
+
+  $createdCount = @($fileRecords | Where-Object { $_.status -eq "created" }).Count
+  $updatedCount = @($fileRecords | Where-Object { $_.status -eq "updated" }).Count
+  $unchangedCount = @($fileRecords | Where-Object { $_.status -eq "unchanged" }).Count
+  $backupCount = @($fileRecords | Where-Object { $null -ne $_.backupPath }).Count
+  $createdDirectoriesList = @($createdDirectories | Sort-Object)
+
+  $manifest = [ordered]@{
+    timestamp = $Timestamp
+    runId = $RunId
+    assetRoot = $SourceRoot
+    targetDir = $TargetRoot
+    stateDir = $stateDir
+    backupDir = $backupDir
+    manifestPath = $manifestPath
+    logPath = $logPath
+    createdDirectories = $createdDirectoriesList
+    files = @($fileRecords)
+    summary = [ordered]@{
+      created = $createdCount
+      updated = $updatedCount
+      unchanged = $unchangedCount
+      backups = $backupCount
+    }
+  }
+
+  $logLines = [System.Collections.Generic.List[string]]::new()
+  $logLines.Add("Managed custom OpenCode asset sync") | Out-Null
+  $logLines.Add("Timestamp: $Timestamp") | Out-Null
+  $logLines.Add("Target: $TargetRoot") | Out-Null
+  $logLines.Add("Asset root: $SourceRoot") | Out-Null
+  $logLines.Add("Backup dir: $backupDir") | Out-Null
+  $logLines.Add(("Created directories: " + ($(if (@($createdDirectoriesList).Count -gt 0) { @($createdDirectoriesList) -join ", " } else { "(none)" })))) | Out-Null
+  $logLines.Add("") | Out-Null
+
+  foreach ($fileRecord in $fileRecords) {
+    $backupSuffix = if ($null -ne $fileRecord.backupPath) { " | backup: $($fileRecord.backupPath)" } else { "" }
+    $logLines.Add("[$(($fileRecord.status).ToUpperInvariant())] $($fileRecord.relativePath) -> $($fileRecord.destinationPath)$backupSuffix") | Out-Null
+  }
+
+  $manifestJson = $manifest | ConvertTo-Json -Depth 8
+  Set-Content -LiteralPath $manifestPath -Value ($manifestJson + [Environment]::NewLine) -Encoding utf8
+  Set-Content -LiteralPath $logPath -Value (($logLines -join [Environment]::NewLine) + [Environment]::NewLine) -Encoding utf8
+
+  return [ordered]@{
+    manifestPath = $manifestPath
+    logPath = $logPath
+    backupDir = $backupDir
+    summary = $manifest.summary
+    strategy = "powershell"
+  }
+}
+
+function Invoke-ManagedAssetSync {
+  param(
+    [string]$SourceRoot,
+    [string]$TargetRoot,
+    [string]$Timestamp,
+    [string]$RunId,
+    [string]$BunCommand
+  )
+
+  $repoRoot = Resolve-AbsolutePath (Join-Path $SourceRoot "..\..")
+  $repoScriptPath = Join-Path $repoRoot "script\sync-custom-opencode-assets.ts"
+  $repoAssetRoot = Join-Path $repoRoot "assets\custom-opencode"
+  $canUseBunSync = $false
+
+  if ($BunCommand -and (Test-Path -LiteralPath $repoScriptPath) -and (Test-Path -LiteralPath $repoAssetRoot)) {
+    $normalizedRepoAssetRoot = Resolve-AbsolutePath $repoAssetRoot
+    $canUseBunSync = ($normalizedRepoAssetRoot -eq $SourceRoot)
+  }
+
+  if ($canUseBunSync) {
+    $syncOutput = Invoke-LoggedCommand -Executable $BunCommand -Arguments @("run", $repoScriptPath, "--target", $TargetRoot) -Description "Syncing managed OpenCode assets with the repo Bun script" -WorkingDirectory $repoRoot
+    return [ordered]@{
+      manifestPath = Join-Path $TargetRoot ".oh-my-openagent-sync\manifest.json"
+      logPath = Join-Path $TargetRoot ".oh-my-openagent-sync\sync.log"
+      backupDir = Join-Path $TargetRoot (Join-Path ".oh-my-openagent-sync\backups" $RunId)
+      rawOutput = $syncOutput
+      strategy = "bun"
+    }
+  }
+
+  if (-not $BunCommand) {
+    Write-Note "Bun was not found. Using the PowerShell sync fallback that preserves the same .oh-my-openagent-sync manifest and backup layout."
+  }
+  else {
+    Write-Note "A repo-local Bun sync entry point was not available for this AssetRoot. Using the PowerShell sync fallback with the same on-disk contract."
+  }
+
+  return Invoke-PowerShellManagedAssetSync -SourceRoot $SourceRoot -TargetRoot $TargetRoot -Timestamp $Timestamp -RunId $RunId
+}
+
+$TargetDir = Resolve-AbsolutePath $TargetDir
+$AssetRoot = Resolve-AbsolutePath $AssetRoot
+Ensure-Directory $TargetDir | Out-Null
+
+$timestamp = [DateTimeOffset]::UtcNow.ToString("o")
+$runId = New-RunId -Timestamp $timestamp
+$refreshStateDir = Join-Path $TargetDir ".oh-my-openagent-refresh"
+$refreshBackupDir = Join-Path $refreshStateDir (Join-Path "backups" $runId)
+$refreshLogDir = Join-Path $refreshStateDir "logs"
+Ensure-Directory $refreshStateDir | Out-Null
+Ensure-Directory $refreshLogDir | Out-Null
+$script:RefreshLogPath = Join-Path $refreshLogDir "$runId.log"
+
+Set-Content -LiteralPath $script:RefreshLogPath -Value @(
+  "Managed custom OpenCode refresh"
+  "Timestamp: $timestamp"
+  "Target: $TargetDir"
+  "Asset root: $AssetRoot"
+  "Mode: $(if ($CheckOnly) { 'check-only' } else { 'update-and-check' })"
+  ""
+) -Encoding utf8
+
+$packageJsonPath = Join-Path $TargetDir "package.json"
+$opencodeCommand = $null
+$npmCommand = $null
+$nodeCommand = $null
+$doctorCommand = $null
+$bunCommand = $null
+$syncResult = $null
+$restoreAttempted = $false
+
+try {
+  Write-Step "Checking prerequisites"
+
+  Require-Path $packageJsonPath "Managed config package.json"
+  Require-Path (Join-Path $AssetRoot "opencode.json") "Managed host config"
+  Require-Path (Join-Path $AssetRoot "oh-my-opencode.json") "Managed plugin config"
+  Require-Path (Join-Path $AssetRoot "plugins") "Managed plugin directory"
+  Require-Path (Join-Path $AssetRoot "refresh-omo.ps1") "Managed refresh script"
+
+  $nodeCommand = Resolve-CommandPath -Name "node"
+  $npmCommand = Resolve-CommandPath -Name "npm"
+  $opencodeCommand = Resolve-CommandPath -Name "opencode"
+
+  $bunLookup = Get-Command bun -ErrorAction SilentlyContinue
+  if ($bunLookup) {
+    $bunCommand = $bunLookup.Source
+  }
+
+  $nodeVersion = (& $nodeCommand --version).Trim()
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to read Node version."
+  }
+
+  $nodeMajor = [int](($nodeVersion -replace '^[vV]', '').Split('.')[0])
+  if ($nodeMajor -lt 20) {
+    Write-Warning "Node $nodeVersion is installed. Node 20+ is recommended for smoother oh-my-openagent updates."
+    Write-RefreshLog "Warning: Node $nodeVersion is installed. Node 20+ is recommended for smoother oh-my-openagent updates."
+  }
+
+  if ($env:NODE_TLS_REJECT_UNAUTHORIZED -eq "0") {
+    Write-Warning "NODE_TLS_REJECT_UNAUTHORIZED=0 is set in the environment. HTTPS certificate verification is disabled."
+    Write-RefreshLog "Warning: NODE_TLS_REJECT_UNAUTHORIZED=0 is set in the environment. HTTPS certificate verification is disabled."
+  }
+
+  Write-Step "Backing up the current managed config surface"
+  Backup-TargetState -SourceDir $TargetDir -BackupDir $refreshBackupDir
+  Write-Note "Refresh backup: $refreshBackupDir"
+
+  if (-not $CheckOnly) {
+    $npmArguments = if (Test-Path -LiteralPath (Join-Path $TargetDir "node_modules")) {
+      @("update", "oh-my-openagent", "@code-yeongyu/comment-checker")
+    }
+    else {
+      @("install")
+    }
+
+    Invoke-LoggedCommand -Executable $npmCommand -Arguments $npmArguments -Description "Refreshing oh-my-openagent dependencies in the target config directory" -WorkingDirectory $TargetDir | Out-Null
+  }
+  else {
+    Write-Step "Check-only mode, skipping npm refresh"
+  }
+
+  $doctorCommand = Resolve-DoctorCommand -TargetDir $TargetDir -NodeCommand $nodeCommand
+  Write-Note "Doctor command resolution: $($doctorCommand.Resolution) -> $($doctorCommand.ResolvedPath)"
+  Ensure-DoctorPlatformBinary -TargetDir $TargetDir -NpmCommand $npmCommand
+
+  $syncResult = Invoke-ManagedAssetSync -SourceRoot $AssetRoot -TargetRoot $TargetDir -Timestamp $timestamp -RunId $runId -BunCommand $bunCommand
+  Write-Note "Sync strategy: $($syncResult.strategy)"
+  Write-Note "Sync manifest: $($syncResult.manifestPath)"
+  Write-Note "Sync log: $($syncResult.logPath)"
+  Write-Note "Sync backup dir: $($syncResult.backupDir)"
+
+  $validationEnv = @{ OPENCODE_CONFIG_DIR = $TargetDir }
+
+  $opencodeVersion = Invoke-LoggedCommand -Executable $opencodeCommand -Arguments @("--version") -Description "Checking OpenCode version" -WorkingDirectory $TargetDir -EnvironmentOverrides $validationEnv
+  $debugOutput = Invoke-LoggedCommand -Executable $opencodeCommand -Arguments @("debug", "config") -Description "Inspecting the resolved OpenCode config" -WorkingDirectory $TargetDir -EnvironmentOverrides $validationEnv
+
+  if ($debugOutput -notmatch 'prometheus') {
+    throw "Resolved config output does not mention the managed default agent 'prometheus'."
+  }
+
+  Invoke-DoctorValidation -DoctorCommand $doctorCommand -TargetDir $TargetDir | Out-Null
+
+  Write-Host "" 
+  Write-Host "Refresh complete." -ForegroundColor Green
+  Write-RefreshLog "Refresh complete."
+  Write-RefreshLog "OpenCode version : $(($opencodeVersion -split [Environment]::NewLine | Where-Object { $_.Trim() } | Select-Object -Last 1).Trim())"
+  Write-RefreshLog "Node version     : $nodeVersion"
+  Write-RefreshLog "Target dir       : $TargetDir"
+  Write-RefreshLog "Asset root       : $AssetRoot"
+  Write-RefreshLog "Refresh backup   : $refreshBackupDir"
+  Write-RefreshLog "Refresh log      : $script:RefreshLogPath"
+  Write-RefreshLog "Sync manifest    : $($syncResult.manifestPath)"
+  Write-RefreshLog "Mode             : $(if ($CheckOnly) { 'check-only' } else { 'update-and-check' })"
+  Write-Host "OpenCode version : $(($opencodeVersion -split [Environment]::NewLine | Where-Object { $_.Trim() } | Select-Object -Last 1).Trim())"
+  Write-Host "Node version     : $nodeVersion"
+  Write-Host "Target dir       : $TargetDir"
+  Write-Host "Asset root       : $AssetRoot"
+  Write-Host "Refresh backup   : $refreshBackupDir"
+  Write-Host "Refresh log      : $script:RefreshLogPath"
+  Write-Host "Sync manifest    : $($syncResult.manifestPath)"
+  Write-Host "Mode             : $(if ($CheckOnly) { 'check-only' } else { 'update-and-check' })"
+}
+catch {
+  $originalErrorMessage = $_.Exception.Message
+  $restoreMessage = "No backup directory was available for restore."
+
+  if (Test-Path -LiteralPath $refreshBackupDir) {
+    $restoreAttempted = $true
+
+    try {
+      Write-Step "Refresh failed, restoring the previous managed config backup"
+      Restore-TargetState -TargetDir $TargetDir -BackupDir $refreshBackupDir
+      $restoreMessage = "Previous config restored from $refreshBackupDir."
+
+      if ($opencodeCommand) {
+        Invoke-LoggedCommand -Executable $opencodeCommand -Arguments @("debug", "config") -Description "Verifying the restored config" -WorkingDirectory $TargetDir -EnvironmentOverrides @{ OPENCODE_CONFIG_DIR = $TargetDir } | Out-Null
+      }
+    }
+    catch {
+      $restoreMessage = "Restore attempt from $refreshBackupDir failed: $($_.Exception.Message)"
+    }
+  }
+
+  Write-RefreshLog "Original error: $originalErrorMessage"
+  Write-RefreshLog "Restore status: $restoreMessage"
+
+  throw "Managed refresh failed. $restoreMessage Original error: $originalErrorMessage"
+}

--- a/docs/fork/compatibility-contract.md
+++ b/docs/fork/compatibility-contract.md
@@ -1,0 +1,40 @@
+# Fork compatibility contract
+
+## Goal
+
+Freeze the phase-1 compatibility surface for the local parity fork before any runtime migration work starts.
+
+## Frozen identity rules
+
+1. Preserve the npm package identity `oh-my-opencode`.
+2. Preserve the CLI/bin identity `oh-my-opencode`.
+3. Preserve the preferred plugin identity `oh-my-openagent`.
+4. Treat the legacy `oh-my-opencode` basename and alias as supported compatibility behavior.
+5. No phase-1 renaming is allowed unless a verified blocker requires it.
+
+## Frozen config-domain rules
+
+1. Keep OpenCode host config in `opencode.json` or `opencode.jsonc`.
+2. Keep OhMyOpenCode plugin config separate from the host config.
+3. Do not treat host-config keys and plugin-config keys as a single merged namespace.
+4. Require explicit plugin registration through the OpenCode `plugin` array.
+
+## Phase-1 scope guardrails
+
+- This phase scaffolds the fork and documents the contract only.
+- Runtime behavior, tests, config assets, and plugin logic are not renamed in this step.
+- Later migration work must preserve the compatibility rules above unless a blocker is proven and documented.
+
+## Upstream commands frozen from package.json
+
+- `test`: `bun test`
+- `build`: `bun run build`
+- `typecheck`: `tsc --noEmit`
+- `extended build`: `bun run build:all`
+
+## Verification targets for later tasks
+
+- `bun test`
+- `tsc --noEmit`
+- `bun run build`
+- `bun run build:all`

--- a/docs/fork/install-and-refresh.md
+++ b/docs/fork/install-and-refresh.md
@@ -1,0 +1,122 @@
+# Managed install and refresh flow
+
+## Scope
+
+This fork keeps the live OpenCode config under `C:\Users\RedFox\.config\opencode` in sync with the repo-owned assets under `assets/custom-opencode/`.
+
+Run the repo copy of `assets/custom-opencode/refresh-omo.ps1`. That copy owns the managed assets and can use the repo Bun sync entry point when Bun is available.
+
+## Prerequisites
+
+- OpenCode is already installed and `opencode --version` works.
+- The target config directory already exists and has a `package.json`. The current default target is `C:\Users\RedFox\.config\opencode`.
+- `node` and `npm` are on `PATH`.
+- `oh-my-opencode` is installed in the target config directory. The refresh script prefers target-local doctor entry points (`<target>\node_modules\.bin\oh-my-opencode*` first, then the package `bin\oh-my-opencode.js` via Node) and only falls back to a global `oh-my-opencode` on `PATH` if the target-local entry points are unavailable.
+- Bun is optional for the refresh script itself. If Bun is available from the repo checkout, the script runs `script/sync-custom-opencode-assets.ts`. If Bun is missing, the script falls back to a PowerShell sync path that writes the same `.oh-my-openagent-sync` manifest, log, and per-file backups.
+
+## What gets synced
+
+The managed refresh copies these repo-owned assets into the target config directory:
+
+- `opencode.json`
+- `oh-my-opencode.json`
+- `refresh-omo.ps1`
+- `plugins/*.js`
+
+That keeps the host config, the plugin config, the wrapper loader, the custom heartbeat plugin, the TLS retry plugin, and the refresh script itself under version control.
+
+## Run the managed refresh
+
+From the repo root:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\assets\custom-opencode\refresh-omo.ps1"
+```
+
+To point at a different OpenCode config directory:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\assets\custom-opencode\refresh-omo.ps1" -TargetDir "C:\path\to\other\opencode"
+```
+
+For a rollback drill or a temporary asset override, point the script at a different asset tree:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\assets\custom-opencode\refresh-omo.ps1" -AssetRoot "C:\temp\broken-assets" -CheckOnly
+```
+
+`-CheckOnly` keeps the dependency install step out of the way while still exercising sync, validation, and rollback.
+
+## What the script does
+
+1. Verifies `node`, `npm`, and `opencode`, then resolves `oh-my-opencode` from the target config directory first (`node_modules\.bin` shims, then the package `bin\oh-my-opencode.js` via Node) before considering a global `PATH` entry.
+2. Creates a full pre-refresh backup of the target config surface before any managed files are replaced.
+3. Runs `npm install` if the target has no `node_modules`, otherwise runs `npm update oh-my-openagent @code-yeongyu/comment-checker` inside the target config directory.
+4. Repairs the local Windows platform binary package for `oh-my-opencode` when it is missing, so the target-local doctor command can run from the target `node_modules` tree.
+5. Syncs the managed assets into the target directory.
+6. Runs these live checks against the target directory by setting `OPENCODE_CONFIG_DIR` for the command invocation:
+   - `opencode --version`
+   - `opencode debug config`
+   - `oh-my-opencode doctor --json`
+7. Accepts refresh completion when doctor reports only these already-documented advisory caveats: the wrapper-file registration false negative from older installed doctor logic, missing `gh`, and missing `@code-yeongyu/comment-checker`.
+8. If any other post-backup step fails, restores the previous target contents automatically and then re-runs `opencode debug config` against the restored target.
+
+## Where backups, manifests, and logs go
+
+Inside the target config directory:
+
+- `.oh-my-openagent-refresh/backups/<run-id>/` stores the pre-refresh backup used for rollback.
+- `.oh-my-openagent-refresh/logs/<run-id>.log` stores the refresh run log.
+- `.oh-my-openagent-sync/manifest.json` stores the latest managed sync manifest.
+- `.oh-my-openagent-sync/sync.log` stores the latest sync log.
+- `.oh-my-openagent-sync/backups/<run-id>/` stores the per-file backups created by the asset sync when an existing managed file is overwritten.
+
+The refresh backup is broader than the sync backup. It captures the target config surface before the refresh starts. The sync backup is narrower and only stores files that the managed asset copy replaced during that run.
+
+## Manual restore
+
+If you need to restore manually, copy the latest refresh backup back into the target directory and leave `node_modules` in place:
+
+```powershell
+$target = "C:\Users\RedFox\.config\opencode"
+$backup = Get-ChildItem -LiteralPath (Join-Path $target ".oh-my-openagent-refresh\backups") | Sort-Object Name -Descending | Select-Object -First 1
+Get-ChildItem -LiteralPath $target -Force | Where-Object { $_.Name -notin @("node_modules", ".oh-my-openagent-refresh") } | Remove-Item -Recurse -Force
+Get-ChildItem -LiteralPath $backup.FullName -Force | ForEach-Object {
+  Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $target $_.Name) -Recurse -Force
+}
+```
+
+If you want the dependency tree to match the restored `package.json` and `package-lock.json` exactly, run `npm install` inside the target directory after the file restore finishes.
+
+## Validation commands
+
+Run the repo validation first:
+
+```powershell
+bun test
+bun test src/cli/doctor/checks/custom-opencode-assets.test.ts src/cli/doctor/checks/custom-opencode-config.test.ts src/cli/doctor/checks/custom-opencode-refresh.test.ts src/custom-opencode/config-precedence.test.ts src/custom-opencode/alias-compatibility.test.ts src/custom-opencode/plugin-loading.test.ts --bail
+tsc --noEmit
+bun run build
+```
+
+Then run the live managed refresh and inspect the target state:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\assets\custom-opencode\refresh-omo.ps1"
+opencode debug config
+oh-my-opencode doctor --verbose
+```
+
+Current validation caveats:
+
+- `opencode debug config` is the ground-truth check for the managed wrapper flow. It shows whether the synced config and plugin files are actually active.
+- The refresh script now parses `oh-my-opencode doctor --json` and will still complete if the only reported issues are the currently documented advisory caveats: missing `gh`, missing `@code-yeongyu/comment-checker`, or the old wrapper-file registration false negative (`oh-my-openagent is not registered`).
+- Any other doctor failure remains fatal and still triggers rollback.
+
+For a rollback smoke check, copy `assets/custom-opencode/` to a temporary folder, break `oh-my-opencode.json` on purpose, and run:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\assets\custom-opencode\refresh-omo.ps1" -AssetRoot "C:\temp\broken-assets" -CheckOnly
+```
+
+That run should fail, restore the previous target from `.oh-my-openagent-refresh/backups/<run-id>/`, and record the restore in the refresh log.

--- a/docs/fork/local-vs-upstream-delta.md
+++ b/docs/fork/local-vs-upstream-delta.md
@@ -1,0 +1,78 @@
+# Local vs upstream delta review
+
+## Scope and evidence
+
+This document is an inventory-only audit for the local parity fork. It records observed local deltas without normalizing them.
+
+Primary evidence used for this review:
+
+- `C:\Users\RedFox\.config\opencode\opencode.json`
+- `C:\Users\RedFox\.config\opencode\oh-my-opencode.json`
+- `C:\Users\RedFox\.config\opencode\plugins\heartbeat-status.js`
+- `C:\Users\RedFox\.config\opencode\plugins\tls-certificate-retry.js`
+- `C:\Users\RedFox\.config\opencode\node_modules\oh-my-openagent\dist\oh-my-opencode.schema.json`
+- `src/plugin-config.ts`
+- `src/shared/jsonc-parser.ts`
+- `src/cli/config-manager/add-plugin-to-opencode-config.ts`
+- `docs/guide/installation.md`
+- `docs/reference/configuration.md`
+
+The installed schema and repo sources are the compatibility baseline for this audit. The local plugin config still points `$schema` at the remote `dev` URL, but this review does not treat that URL itself as the source of truth.
+
+## Config-only deltas
+
+### Host config delta
+
+- The inspected local OpenCode host config sets `default_agent = prometheus` in `opencode.json`.
+
+### Plugin config deltas
+
+- All configured local agent overrides pin to `openai/gpt-5.4` with `variant = xhigh` and `textVerbosity: high`: `sisyphus`, `hephaestus`, `oracle`, `librarian`, `explore`, `multimodal-looker`, `prometheus`, `metis`, `momus`, `atlas`, and `sisyphus-junior`.
+- All configured local category overrides pin to `openai/gpt-5.4` with `variant = xhigh` and `textVerbosity: high`: `visual-engineering`, `ultrabrain`, `deep`, `artistry`, `quick`, `unspecified-low`, `unspecified-high`, and `writing`.
+- The local config adds `prompt_append` additions for `sisyphus`, `hephaestus`, `prometheus`, `atlas`, and `sisyphus-junior`.
+
+### Supported runtime knob differences
+
+The installed schema explicitly supports the following local runtime knob differences, so they are config deltas rather than immediate drift by themselves:
+
+| Path | Local value | Why it is classified as config-only |
+| --- | --- | --- |
+| `hashline_edit` | `true` | Root schema property exists. |
+| `background_task.staleTimeoutMs` | `600000` | `background_task` schema supports `staleTimeoutMs`. |
+| `babysitting.timeout_ms` | `300000` | `babysitting` schema supports `timeout_ms`. |
+| `model_capabilities.refresh_timeout_ms` | `10000` | `model_capabilities` schema supports `refresh_timeout_ms`. |
+| `experimental.auto_resume` | `true` | `experimental` schema supports `auto_resume`. |
+| `notification.force_enable` | `true` | `notification` schema supports `force_enable`. |
+
+Related local runtime tuning is also present in supported schema space, including `background_task.defaultConcurrency`, `background_task.providerConcurrency.openai`, `background_task.modelConcurrency["openai/gpt-5.4"]`, `model_capabilities.enabled`, `model_capabilities.auto_refresh_on_start`, `experimental.task_system`, and `sisyphus_agent.{planner_enabled,replace_plan,default_builder_enabled}`.
+
+## Plugin/code deltas
+
+- `plugins/heartbeat-status.js` is a local custom plugin that layers heartbeat/status behavior on top of the upstream plugin. The current file tracks tool/message activity, todo summaries, retry/error states, and provider-block handling, then emits status toasts/log entries instead of relying on upstream defaults alone.
+- `plugins/tls-certificate-retry.js` is a local custom plugin that retries retryable certificate/connectivity failures after `RETRY_DELAY_MS = 60_000`, reconstructs the last user payload before retry, and stops automatic retry on hard 403-style provider/account/proxy blocks.
+
+## Intended extension points
+
+- `src/plugin-config.ts` loads user config first, project config second, and deep-merges `agents` and `categories` while unioning the `disabled_*` arrays. That makes the local agent/category pinning and prompt customization a supported extension path.
+- The installed schema explicitly supports agent/category overrides, `prompt_append`, and the runtime knobs called out above, so those keys belong in the supported-extension bucket unless a later task proves a behavior mismatch.
+- `src/cli/config-manager/add-plugin-to-opencode-config.ts` and `docs/guide/installation.md` both show that OpenCode host config is expected to use an explicit `plugin` array entry, with `oh-my-openagent` preferred and legacy `oh-my-opencode` entries normalized during the transition.
+- `src/shared/jsonc-parser.ts`, `docs/reference/configuration.md`, and the compatibility contract all show that legacy `oh-my-opencode` alias/basename support should not be treated as drift. The current loader checks `oh-my-opencode` before `oh-my-openagent`, so legacy file naming remains compatibility behavior in this phase.
+
+## Suspicious runtime drift
+
+### Missing visible plugin registration
+
+The inspected `opencode.json` contains only `$schema` and `default_agent`, so there is missing visible plugin registration in the host config. Because repo docs and config-manager code expect explicit `plugin` array registration, any currently working local plugin load is not explained by the inspected host config alone.
+
+### `sisyphus.tasks.enabled`
+
+- The local `oh-my-opencode.json` sets `sisyphus.tasks.enabled = true`.
+- The installed schema allows `sisyphus.tasks.storage_path`, `sisyphus.tasks.task_list_id`, and `sisyphus.tasks.claude_code_compat`, but it does not allow `sisyphus.tasks.enabled`.
+- No inspected repo file in this task established `sisyphus.tasks.enabled` as a documented merge or schema key, so this should be treated as suspicious runtime drift until a later task proves intentional support.
+
+## Classification summary
+
+- Config-only deltas: `default_agent = prometheus`, full `openai/gpt-5.4` + `xhigh` + `textVerbosity: high` pinning, the five `prompt_append` additions, and the supported runtime knob differences.
+- Plugin/code deltas: the local heartbeat-status and TLS certificate retry plugins.
+- Intended extension points: merge semantics, schema-supported overrides, explicit `plugin` array registration, and legacy `oh-my-opencode` compatibility handling.
+- Suspicious runtime drift: missing visible plugin registration in the inspected host config and `sisyphus.tasks.enabled`.

--- a/script/sync-custom-opencode-assets.ts
+++ b/script/sync-custom-opencode-assets.ts
@@ -1,0 +1,315 @@
+#!/usr/bin/env bun
+
+import { existsSync } from "node:fs"
+import { copyFile, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises"
+import { dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { getOpenCodeConfigDir } from "../src/shared/opencode-config-dir"
+
+export const MANAGED_CUSTOM_OPENCODE_ASSET_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../assets/custom-opencode"
+)
+
+export const SYNC_STATE_DIRNAME = ".oh-my-openagent-sync"
+export const SYNC_MANIFEST_FILENAME = "manifest.json"
+export const SYNC_LOG_FILENAME = "sync.log"
+export const SYNC_BACKUP_DIRNAME = "backups"
+
+export type SyncFileStatus = "created" | "updated" | "unchanged"
+
+export interface SyncedFileRecord {
+  relativePath: string
+  sourcePath: string
+  destinationPath: string
+  status: SyncFileStatus
+  backupPath: string | null
+  bytes: number
+}
+
+export interface SyncManifest {
+  timestamp: string
+  runId: string
+  assetRoot: string
+  targetDir: string
+  stateDir: string
+  backupDir: string
+  manifestPath: string
+  logPath: string
+  createdDirectories: string[]
+  files: SyncedFileRecord[]
+  summary: {
+    created: number
+    updated: number
+    unchanged: number
+    backups: number
+  }
+}
+
+export interface SyncCustomOpenCodeAssetsOptions {
+  assetRoot?: string
+  targetDir?: string
+  timestamp?: string
+}
+
+export interface SyncCustomOpenCodeAssetsResult {
+  manifest: SyncManifest
+  manifestPath: string
+  logPath: string
+  backupDir: string
+}
+
+function toPortableRelativePath(pathValue: string): string {
+  return pathValue.split("\\").join("/")
+}
+
+function createRunId(timestamp: string): string {
+  return timestamp.replace(/[.:]/g, "-")
+}
+
+async function listManagedAssetFiles(rootDir: string): Promise<string[]> {
+  const discovered: string[] = []
+
+  async function walk(currentDir: string): Promise<void> {
+    const entries = await readdir(currentDir, { withFileTypes: true })
+    entries.sort((left, right) => left.name.localeCompare(right.name))
+
+    for (const entry of entries) {
+      const entryPath = join(currentDir, entry.name)
+
+      if (entry.isDirectory()) {
+        await walk(entryPath)
+        continue
+      }
+
+      if (entry.isFile()) {
+        discovered.push(entryPath)
+      }
+    }
+  }
+
+  await walk(rootDir)
+  return discovered.sort((left, right) => left.localeCompare(right))
+}
+
+async function ensureDirectory(directoryPath: string, targetDir: string, createdDirectories: Set<string>): Promise<void> {
+  if (!existsSync(directoryPath)) {
+    await mkdir(directoryPath, { recursive: true })
+    const relativePath = toPortableRelativePath(relative(targetDir, directoryPath))
+    createdDirectories.add(relativePath === "" ? "." : relativePath)
+  }
+}
+
+async function fileContentsMatch(sourcePath: string, destinationPath: string): Promise<boolean> {
+  if (!existsSync(destinationPath)) {
+    return false
+  }
+
+  const [sourceContents, destinationContents] = await Promise.all([
+    readFile(sourcePath),
+    readFile(destinationPath),
+  ])
+
+  return sourceContents.equals(destinationContents)
+}
+
+export function resolveSyncTargetDir(targetDir?: string): string {
+  if (targetDir) {
+    return resolve(targetDir)
+  }
+
+  return getOpenCodeConfigDir({ binary: "opencode" })
+}
+
+export function resolveManagedCustomOpenCodeAssetDir(assetRoot?: string): string {
+  const candidatePaths = [
+    assetRoot ? resolve(assetRoot) : null,
+    MANAGED_CUSTOM_OPENCODE_ASSET_DIR,
+    resolve(process.cwd(), "assets/custom-opencode"),
+  ].filter((candidate): candidate is string => Boolean(candidate))
+
+  for (const candidatePath of candidatePaths) {
+    if (existsSync(candidatePath)) {
+      return candidatePath
+    }
+  }
+
+  throw new Error(`Managed asset directory not found. Tried: ${candidatePaths.join(", ")}`)
+}
+
+export async function syncCustomOpenCodeAssets(
+  options: SyncCustomOpenCodeAssetsOptions = {}
+): Promise<SyncCustomOpenCodeAssetsResult> {
+  const timestamp = options.timestamp ?? new Date().toISOString()
+  const runId = createRunId(timestamp)
+  const assetRoot = resolveManagedCustomOpenCodeAssetDir(options.assetRoot)
+  const targetDir = resolveSyncTargetDir(options.targetDir)
+  const stateDir = join(targetDir, SYNC_STATE_DIRNAME)
+  const backupDir = join(stateDir, SYNC_BACKUP_DIRNAME, runId)
+  const manifestPath = join(stateDir, SYNC_MANIFEST_FILENAME)
+  const logPath = join(stateDir, SYNC_LOG_FILENAME)
+  const createdDirectories = new Set<string>()
+
+  await ensureDirectory(targetDir, targetDir, createdDirectories)
+  await ensureDirectory(stateDir, targetDir, createdDirectories)
+  await ensureDirectory(backupDir, targetDir, createdDirectories)
+
+  const assetFiles = await listManagedAssetFiles(assetRoot)
+  const fileRecords: SyncedFileRecord[] = []
+
+  for (const sourcePath of assetFiles) {
+    const relativePath = toPortableRelativePath(relative(assetRoot, sourcePath))
+    const destinationPath = join(targetDir, relativePath)
+    const destinationDir = dirname(destinationPath)
+
+    await ensureDirectory(destinationDir, targetDir, createdDirectories)
+
+    const destinationExists = existsSync(destinationPath)
+    if (destinationExists) {
+      const destinationStats = await stat(destinationPath)
+      if (!destinationStats.isFile()) {
+        throw new Error(`Cannot sync file onto non-file path: ${destinationPath}`)
+      }
+    }
+
+    const sourceStats = await stat(sourcePath)
+    let backupPath: string | null = null
+    let status: SyncFileStatus = "created"
+
+    if (destinationExists) {
+      const contentsMatch = await fileContentsMatch(sourcePath, destinationPath)
+      if (contentsMatch) {
+        status = "unchanged"
+      } else {
+        backupPath = join(backupDir, relativePath)
+        await ensureDirectory(dirname(backupPath), targetDir, createdDirectories)
+        await copyFile(destinationPath, backupPath)
+        status = "updated"
+      }
+    }
+
+    if (status !== "unchanged") {
+      await copyFile(sourcePath, destinationPath)
+    }
+
+    fileRecords.push({
+      relativePath,
+      sourcePath,
+      destinationPath,
+      status,
+      backupPath,
+      bytes: sourceStats.size,
+    })
+  }
+
+  const manifest: SyncManifest = {
+    timestamp,
+    runId,
+    assetRoot,
+    targetDir,
+    stateDir,
+    backupDir,
+    manifestPath,
+    logPath,
+    createdDirectories: [...createdDirectories].sort((left, right) => left.localeCompare(right)),
+    files: fileRecords,
+    summary: {
+      created: fileRecords.filter((file) => file.status === "created").length,
+      updated: fileRecords.filter((file) => file.status === "updated").length,
+      unchanged: fileRecords.filter((file) => file.status === "unchanged").length,
+      backups: fileRecords.filter((file) => file.backupPath !== null).length,
+    },
+  }
+
+  const logLines = [
+    "Managed custom OpenCode asset sync",
+    `Timestamp: ${timestamp}`,
+    `Target: ${targetDir}`,
+    `Asset root: ${assetRoot}`,
+    `Backup dir: ${backupDir}`,
+    `Created directories: ${manifest.createdDirectories.join(", ") || "(none)"}`,
+    "",
+    ...fileRecords.map((file) => {
+      const backupSuffix = file.backupPath ? ` | backup: ${file.backupPath}` : ""
+      return `[${file.status.toUpperCase()}] ${file.relativePath} -> ${file.destinationPath}${backupSuffix}`
+    }),
+  ]
+
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + "\n")
+  await writeFile(logPath, logLines.join("\n") + "\n")
+
+  return {
+    manifest,
+    manifestPath,
+    logPath,
+    backupDir,
+  }
+}
+
+export function parseSyncCustomOpenCodeAssetArgs(argv: string[]): SyncCustomOpenCodeAssetsOptions & {
+  help: boolean
+} {
+  let targetDir: string | undefined
+  let help = false
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+
+    if (arg === "--help" || arg === "-h") {
+      help = true
+      continue
+    }
+
+    if (arg === "--target") {
+      const nextArg = argv[index + 1]
+      if (!nextArg) {
+        throw new Error("Missing value for --target")
+      }
+
+      targetDir = nextArg
+      index += 1
+      continue
+    }
+
+    if (arg.startsWith("--target=")) {
+      targetDir = arg.slice("--target=".length)
+      continue
+    }
+
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  return { targetDir, help }
+}
+
+function printUsage(): void {
+  console.log("Usage: bun run script/sync-custom-opencode-assets.ts [--target <path>]")
+  console.log("Copies managed custom OpenCode assets into a target config directory with backups and a manifest.")
+}
+
+async function main(): Promise<void> {
+  const args = parseSyncCustomOpenCodeAssetArgs(process.argv.slice(2))
+
+  if (args.help) {
+    printUsage()
+    return
+  }
+
+  const result = await syncCustomOpenCodeAssets({ targetDir: args.targetDir })
+
+  console.log(`Synced managed assets into ${result.manifest.targetDir}`)
+  console.log(`Manifest: ${result.manifestPath}`)
+  console.log(`Log: ${result.logPath}`)
+  console.log(`Backup dir: ${result.backupDir}`)
+  console.log(
+    `Summary: ${result.manifest.summary.created} created, ${result.manifest.summary.updated} updated, ${result.manifest.summary.unchanged} unchanged`
+  )
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}

--- a/src/cli/doctor/checks/custom-opencode-assets.test.ts
+++ b/src/cli/doctor/checks/custom-opencode-assets.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import {
+  MANAGED_CUSTOM_OPENCODE_ASSET_DIR,
+  SYNC_LOG_FILENAME,
+  SYNC_MANIFEST_FILENAME,
+  SYNC_STATE_DIRNAME,
+  syncCustomOpenCodeAssets,
+  type SyncManifest,
+} from "../../../../script/sync-custom-opencode-assets"
+
+const FIXED_TIMESTAMP = "2026-03-30T12:34:56.789Z"
+const tempDirs: string[] = []
+
+function createTempDir(): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "custom-opencode-assets-"))
+  tempDirs.push(tempDir)
+  return tempDir
+}
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+})
+
+describe("custom OpenCode asset sync", () => {
+  it("syncs the managed asset tree into a temporary target with manifest output", async () => {
+    const targetDir = createTempDir()
+
+    const result = await syncCustomOpenCodeAssets({
+      targetDir,
+      timestamp: FIXED_TIMESTAMP,
+    })
+
+    const stateDir = join(targetDir, SYNC_STATE_DIRNAME)
+    const manifestPath = join(stateDir, SYNC_MANIFEST_FILENAME)
+    const logPath = join(stateDir, SYNC_LOG_FILENAME)
+
+    expect(existsSync(join(targetDir, "oh-my-opencode.json"))).toBe(true)
+    expect(existsSync(join(targetDir, "opencode.json"))).toBe(true)
+    expect(existsSync(join(targetDir, "plugins", "heartbeat-status.js"))).toBe(true)
+    expect(existsSync(join(targetDir, "plugins", "oh-my-openagent.js"))).toBe(true)
+    expect(existsSync(join(targetDir, "plugins", "tls-certificate-retry.js"))).toBe(true)
+    expect(existsSync(join(targetDir, "refresh-omo.ps1"))).toBe(true)
+    expect(statSync(join(targetDir, "plugins")).isDirectory()).toBe(true)
+    expect(existsSync(manifestPath)).toBe(true)
+    expect(existsSync(logPath)).toBe(true)
+    expect(existsSync(result.backupDir)).toBe(true)
+
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as SyncManifest
+    expect(manifest.targetDir).toBe(targetDir)
+    expect(manifest.summary).toEqual({
+      created: 6,
+      updated: 0,
+      unchanged: 0,
+      backups: 0,
+    })
+    expect(manifest.files.map((file) => file.relativePath)).toEqual([
+      "oh-my-opencode.json",
+      "opencode.json",
+      "plugins/heartbeat-status.js",
+      "plugins/oh-my-openagent.js",
+      "plugins/tls-certificate-retry.js",
+      "refresh-omo.ps1",
+    ])
+    expect(manifest.createdDirectories).toContain(".oh-my-openagent-sync")
+    expect(manifest.createdDirectories).toContain("plugins")
+
+    const logContents = readFileSync(logPath, "utf-8")
+    expect(logContents).toContain("[CREATED] oh-my-opencode.json")
+    expect(logContents).toContain("[CREATED] opencode.json")
+    expect(logContents).toContain("[CREATED] plugins/heartbeat-status.js")
+    expect(logContents).toContain("[CREATED] plugins/oh-my-openagent.js")
+    expect(logContents).toContain("[CREATED] plugins/tls-certificate-retry.js")
+    expect(logContents).toContain("[CREATED] refresh-omo.ps1")
+  })
+
+  it("backs up an existing target file before overwrite", async () => {
+    const targetDir = createTempDir()
+    const preexistingOpencodeContents = '{\n  "legacy": true\n}\n'
+    const targetOpencodePath = join(targetDir, "opencode.json")
+    const managedOpencodePath = join(MANAGED_CUSTOM_OPENCODE_ASSET_DIR, "opencode.json")
+
+    writeFileSync(targetOpencodePath, preexistingOpencodeContents)
+
+    const result = await syncCustomOpenCodeAssets({
+      targetDir,
+      timestamp: FIXED_TIMESTAMP,
+    })
+
+    const manifestPath = join(targetDir, SYNC_STATE_DIRNAME, SYNC_MANIFEST_FILENAME)
+    const logPath = join(targetDir, SYNC_STATE_DIRNAME, SYNC_LOG_FILENAME)
+    const backupPath = join(result.backupDir, "opencode.json")
+    const managedOpencodeContents = readFileSync(managedOpencodePath, "utf-8")
+    const syncedOpencodeContents = readFileSync(targetOpencodePath, "utf-8")
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as SyncManifest
+    const opencodeRecord = manifest.files.find((file) => file.relativePath === "opencode.json")
+
+    expect(existsSync(backupPath)).toBe(true)
+    expect(readFileSync(backupPath, "utf-8")).toBe(preexistingOpencodeContents)
+    expect(syncedOpencodeContents).toBe(managedOpencodeContents)
+    expect(opencodeRecord?.status).toBe("updated")
+    expect(opencodeRecord?.backupPath).toBe(backupPath)
+    expect(manifest.summary.updated).toBe(1)
+    expect(manifest.summary.backups).toBe(1)
+    expect(readFileSync(logPath, "utf-8")).toContain(`backup: ${backupPath}`)
+  })
+})

--- a/src/cli/doctor/checks/custom-opencode-config.test.ts
+++ b/src/cli/doctor/checks/custom-opencode-config.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const hostConfigPath = new URL("../../../../assets/custom-opencode/opencode.json", import.meta.url)
+const pluginConfigPath = new URL("../../../../assets/custom-opencode/oh-my-opencode.json", import.meta.url)
+const wrapperPluginPath = new URL("../../../../assets/custom-opencode/plugins/oh-my-openagent.js", import.meta.url)
+
+const EXECUTION_PROMPT_APPEND = "Before substantive work in any repository, first check whether the root AGENTS.md exists and matches the current project. If it is missing, outdated, or clearly incomplete, create or refresh it immediately before major edits. Keep it concise and factual. Add nested AGENTS.md files only when the repository is large or conventions differ by subtree. Maintain these files as you learn the repo's structure, commands, tests, conventions, and gotchas. If execution begins via /start-work, an approved Prometheus handoff, or an active boulder, treat that as explicit permission to implement. In execution mode, drive the plan to completion, keep delegating and verifying until all planned work is done, and do not stop at interim summaries or partial progress. Return control early only for destructive or irreversible actions, materially missing information, or hard environment blockers that cannot be solved from the repo."
+const PROMETHEUS_PROMPT_APPEND = "Before substantive work in any repository, first check whether the root AGENTS.md exists and matches the current project. If it is missing, outdated, or clearly incomplete, create or refresh it immediately before major edits. Keep it concise and factual. Add nested AGENTS.md files only when the repository is large or conventions differ by subtree. Maintain these files as you learn the repo's structure, commands, tests, conventions, and gotchas. You are the planning and negotiation front door. Stay in planning mode, resolve scope and tradeoffs with the user, and finish with a concrete executable plan plus /start-work guidance. Do not execute the plan yourself unless the user explicitly overrides this role."
+
+const REQUIRED_AGENTS = [
+  "sisyphus",
+  "hephaestus",
+  "oracle",
+  "librarian",
+  "explore",
+  "multimodal-looker",
+  "prometheus",
+  "metis",
+  "momus",
+  "atlas",
+  "sisyphus-junior",
+] as const
+
+const REQUIRED_CATEGORIES = [
+  "visual-engineering",
+  "ultrabrain",
+  "deep",
+  "artistry",
+  "quick",
+  "unspecified-low",
+  "unspecified-high",
+  "writing",
+] as const
+
+const EXPECTED_MODEL = "openai/gpt-5.4"
+const EXPECTED_VARIANT = "xhigh"
+const EXPECTED_TEXT_VERBOSITY = "high"
+
+const hostConfig = JSON.parse(readFileSync(hostConfigPath, "utf-8")) as {
+  $schema?: string
+  default_agent?: string
+  plugin?: string[]
+}
+
+const pluginConfigContents = readFileSync(pluginConfigPath, "utf-8")
+const pluginConfig = JSON.parse(pluginConfigContents) as {
+  $schema?: string
+  agents?: Record<string, Record<string, unknown>>
+  categories?: Record<string, Record<string, unknown>>
+  background_task?: {
+    staleTimeoutMs?: number
+  }
+  hashline_edit?: boolean
+  sisyphus?: {
+    tasks?: Record<string, unknown>
+  }
+  babysitting?: {
+    timeout_ms?: number
+  }
+  model_capabilities?: {
+    refresh_timeout_ms?: number
+  }
+  experimental?: {
+    auto_resume?: boolean
+  }
+  notification?: {
+    force_enable?: boolean
+  }
+}
+
+const wrapperPluginContents = readFileSync(wrapperPluginPath, "utf-8")
+
+describe("managed custom OpenCode config assets", () => {
+  it("keeps explicit wrapper-plugin registration in the host config", () => {
+    expect(hostConfig.default_agent).toBe("prometheus")
+    expect(hostConfig.plugin).toEqual(["./plugins/oh-my-openagent.js"])
+  })
+
+  it("pins the required agents and categories to the validated model settings", () => {
+    for (const agentName of REQUIRED_AGENTS) {
+      const agentConfig = pluginConfig.agents?.[agentName]
+
+      expect(agentConfig?.model).toBe(EXPECTED_MODEL)
+      expect(agentConfig?.variant).toBe(EXPECTED_VARIANT)
+      expect(agentConfig?.textVerbosity).toBe(EXPECTED_TEXT_VERBOSITY)
+    }
+
+    for (const categoryName of REQUIRED_CATEGORIES) {
+      const categoryConfig = pluginConfig.categories?.[categoryName]
+
+      expect(categoryConfig?.model).toBe(EXPECTED_MODEL)
+      expect(categoryConfig?.variant).toBe(EXPECTED_VARIANT)
+      expect(categoryConfig?.textVerbosity).toBe(EXPECTED_TEXT_VERBOSITY)
+    }
+  })
+
+  it("preserves the audited prompt_append text only for the intended agents", () => {
+    expect(pluginConfig.agents?.sisyphus?.prompt_append).toBe(EXECUTION_PROMPT_APPEND)
+    expect(pluginConfig.agents?.hephaestus?.prompt_append).toBe(EXECUTION_PROMPT_APPEND)
+    expect(pluginConfig.agents?.atlas?.prompt_append).toBe(EXECUTION_PROMPT_APPEND)
+    expect(pluginConfig.agents?.["sisyphus-junior"]?.prompt_append).toBe(EXECUTION_PROMPT_APPEND)
+    expect(pluginConfig.agents?.prometheus?.prompt_append).toBe(PROMETHEUS_PROMPT_APPEND)
+
+    expect(pluginConfig.agents?.oracle?.prompt_append).toBeUndefined()
+    expect(pluginConfig.agents?.librarian?.prompt_append).toBeUndefined()
+    expect(pluginConfig.agents?.explore?.prompt_append).toBeUndefined()
+  })
+
+  it("keeps the intentional runtime knob changes while removing unsupported drift", () => {
+    expect(pluginConfig.$schema).toBe("./node_modules/oh-my-openagent/dist/oh-my-opencode.schema.json")
+    expect(pluginConfigContents).not.toContain("raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json")
+
+    expect(pluginConfig.hashline_edit).toBe(true)
+    expect(pluginConfig.background_task?.staleTimeoutMs).toBe(600000)
+    expect(pluginConfig.babysitting?.timeout_ms).toBe(300000)
+    expect(pluginConfig.model_capabilities?.refresh_timeout_ms).toBe(10000)
+    expect(pluginConfig.experimental?.auto_resume).toBe(true)
+    expect(pluginConfig.notification?.force_enable).toBe(true)
+
+    expect(pluginConfig.sisyphus?.tasks).toEqual({
+      storage_path: ".sisyphus/tasks",
+      claude_code_compat: false,
+    })
+    expect(pluginConfig.sisyphus?.tasks?.enabled).toBeUndefined()
+
+    if (/"tasks"\s*:\s*\{[^}]*"enabled"/s.test(pluginConfigContents)) {
+      throw new Error("Managed config must not reintroduce sisyphus.tasks.enabled.")
+    }
+  })
+
+  it("keeps the wrapper plugin minimal and pointed at the preferred plugin identity", () => {
+    expect(wrapperPluginContents).toContain('import OhMyOpenAgent from "oh-my-openagent"')
+    expect(wrapperPluginContents).toContain("export const OhMyOpenAgentPlugin = OhMyOpenAgent")
+  })
+})

--- a/src/cli/doctor/checks/custom-opencode-refresh.test.ts
+++ b/src/cli/doctor/checks/custom-opencode-refresh.test.ts
@@ -1,0 +1,232 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+const refreshScriptPath = fileURLToPath(new URL("../../../../assets/custom-opencode/refresh-omo.ps1", import.meta.url))
+const assetRootPath = fileURLToPath(new URL("../../../../assets/custom-opencode", import.meta.url))
+const tempDirs: string[] = []
+const isWindows = process.platform === "win32"
+const windowsOnlyIt = isWindows ? it : it.skip
+
+function createTempDir(prefix: string): string {
+  const tempDir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(tempDir)
+  return tempDir
+}
+
+function writeCommandShim(path: string, contents: string): void {
+  writeFileSync(path, contents.replaceAll("\n", "\r\n"))
+}
+
+function createDoctorResultJson(issueTitles: string[]): string {
+  return `${JSON.stringify({
+    results: [
+      {
+        issues: issueTitles.map((title) => ({ title })),
+      },
+    ],
+  }, null, 2)}\n`
+}
+
+function initializeManagedTarget(targetDir: string): void {
+  mkdirSync(join(targetDir, "node_modules", ".bin"), { recursive: true })
+  mkdirSync(join(targetDir, "node_modules", "oh-my-openagent", "bin"), { recursive: true })
+  mkdirSync(join(targetDir, "node_modules", "oh-my-opencode-windows-x64"), { recursive: true })
+
+  writeFileSync(join(targetDir, "package.json"), '{"name":"managed-opencode-config"}\n')
+  writeFileSync(join(targetDir, "node_modules", "oh-my-openagent", "bin", "oh-my-opencode.js"), "process.exit(0)\n")
+}
+
+function writeSupportCommands(commandDir: string): void {
+  writeCommandShim(join(commandDir, "node.cmd"), `@echo off
+if "%~1"=="--version" (
+  echo v20.11.1
+  exit /b 0
+)
+>> "%DOCTOR_INVOCATION_LOG%" echo NODE %*
+if not "%DOCTOR_JSON_PATH%"=="" type "%DOCTOR_JSON_PATH%"
+if "%DOCTOR_EXIT_CODE%"=="" exit /b 0
+exit /b %DOCTOR_EXIT_CODE%
+`)
+
+  writeCommandShim(join(commandDir, "npm.cmd"), `@echo off
+echo npm %*
+exit /b 0
+`)
+
+  writeCommandShim(join(commandDir, "opencode.cmd"), `@echo off
+if "%~1"=="--version" (
+  echo opencode 1.0.200
+  exit /b 0
+)
+if "%~1"=="debug" if "%~2"=="config" (
+  echo default_agent=prometheus
+  exit /b 0
+)
+echo Unexpected opencode args %* 1>&2
+exit /b 1
+`)
+
+  writeCommandShim(join(commandDir, "oh-my-opencode.cmd"), `@echo off
+>> "%DOCTOR_INVOCATION_LOG%" echo GLOBAL %*
+if not "%GLOBAL_DOCTOR_JSON_PATH%"=="" type "%GLOBAL_DOCTOR_JSON_PATH%"
+if "%GLOBAL_DOCTOR_EXIT_CODE%"=="" exit /b 0
+exit /b %GLOBAL_DOCTOR_EXIT_CODE%
+`)
+}
+
+function runRefresh(targetDir: string, commandDir: string, extraEnv: Record<string, string>): ReturnType<typeof spawnSync> {
+  return spawnSync(
+    "powershell",
+    [
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      refreshScriptPath,
+      "-TargetDir",
+      targetDir,
+      "-AssetRoot",
+      assetRootPath,
+      "-CheckOnly",
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${commandDir};${process.env.PATH ?? ""}`,
+        ...extraEnv,
+      },
+    },
+  )
+}
+
+function readLatestRefreshLog(targetDir: string): string {
+  const refreshLogDir = join(targetDir, ".oh-my-openagent-refresh", "logs")
+  const refreshLogName = readdirSync(refreshLogDir).at(-1)
+
+  if (!refreshLogName) {
+    throw new Error(`No refresh log found under ${refreshLogDir}`)
+  }
+
+  return readFileSync(join(refreshLogDir, refreshLogName), "utf-8")
+}
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+})
+
+describe("managed custom OpenCode refresh script", () => {
+  windowsOnlyIt("prefers the target-local shim over a global oh-my-opencode on PATH", () => {
+    const targetDir = createTempDir("custom-opencode-refresh-target-")
+    const commandDir = createTempDir("custom-opencode-refresh-bin-")
+    const invocationLogPath = join(targetDir, "doctor-invocation.log")
+    const doctorJsonPath = join(targetDir, "doctor-success.json")
+
+    initializeManagedTarget(targetDir)
+    writeSupportCommands(commandDir)
+    writeFileSync(doctorJsonPath, createDoctorResultJson([]))
+
+    writeCommandShim(join(targetDir, "node_modules", ".bin", "oh-my-opencode.cmd"), `@echo off
+>> "%DOCTOR_INVOCATION_LOG%" echo LOCAL %*
+type "%DOCTOR_JSON_PATH%"
+exit /b 0
+`)
+
+    const result = runRefresh(targetDir, commandDir, {
+      DOCTOR_INVOCATION_LOG: invocationLogPath,
+      DOCTOR_JSON_PATH: doctorJsonPath,
+      DOCTOR_EXIT_CODE: "0",
+      GLOBAL_DOCTOR_EXIT_CODE: "91",
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe("")
+
+    const invocationLog = readFileSync(invocationLogPath, "utf-8")
+    expect(invocationLog).toContain("LOCAL doctor --json")
+    expect(invocationLog).not.toContain("GLOBAL")
+
+    const refreshLogContents = readLatestRefreshLog(targetDir)
+    expect(refreshLogContents).toContain("Doctor command resolution: target-local-shim")
+    expect(refreshLogContents).toContain(join(targetDir, "node_modules", ".bin", "oh-my-opencode.cmd"))
+  })
+
+  windowsOnlyIt("falls back to the target package bin script before global PATH and accepts advisory-only doctor issues", () => {
+    const targetDir = createTempDir("custom-opencode-refresh-target-")
+    const commandDir = createTempDir("custom-opencode-refresh-bin-")
+    const invocationLogPath = join(targetDir, "doctor-invocation.log")
+    const doctorJsonPath = join(targetDir, "doctor-advisory.json")
+
+    initializeManagedTarget(targetDir)
+    writeSupportCommands(commandDir)
+    writeFileSync(doctorJsonPath, createDoctorResultJson([
+      "oh-my-openagent is not registered",
+      "Comment checker unavailable",
+      "GitHub CLI missing",
+    ]))
+
+    const result = runRefresh(targetDir, commandDir, {
+      DOCTOR_INVOCATION_LOG: invocationLogPath,
+      DOCTOR_JSON_PATH: doctorJsonPath,
+      DOCTOR_EXIT_CODE: "1",
+      GLOBAL_DOCTOR_EXIT_CODE: "92",
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toContain("Refresh complete.")
+    expect(existsSync(join(targetDir, "plugins", "oh-my-openagent.js"))).toBe(true)
+
+    const invocationLog = readFileSync(invocationLogPath, "utf-8")
+    expect(invocationLog).toContain("NODE")
+    expect(invocationLog).toContain(join(targetDir, "node_modules", "oh-my-openagent", "bin", "oh-my-opencode.js"))
+    expect(invocationLog).toContain("doctor --json")
+    expect(invocationLog).not.toContain("GLOBAL")
+
+    const refreshLogContents = readLatestRefreshLog(targetDir)
+    expect(refreshLogContents).toContain("Doctor command resolution: target-package-bin")
+    expect(refreshLogContents).toContain("Doctor exit code 1 accepted because only advisory issues were present")
+  })
+
+  windowsOnlyIt("restores the previous target state when doctor reports a non-advisory failure", () => {
+    const targetDir = createTempDir("custom-opencode-refresh-target-")
+    const commandDir = createTempDir("custom-opencode-refresh-bin-")
+    const invocationLogPath = join(targetDir, "doctor-invocation.log")
+    const doctorJsonPath = join(targetDir, "doctor-fatal.json")
+    const preexistingOpencodeContents = '{\n  "legacy": true\n}\n'
+
+    initializeManagedTarget(targetDir)
+    writeSupportCommands(commandDir)
+    writeFileSync(doctorJsonPath, createDoctorResultJson(["OpenCode binary not found"]))
+    writeFileSync(join(targetDir, "opencode.json"), preexistingOpencodeContents)
+
+    writeCommandShim(join(targetDir, "node_modules", ".bin", "oh-my-opencode.cmd"), `@echo off
+>> "%DOCTOR_INVOCATION_LOG%" echo LOCAL %*
+type "%DOCTOR_JSON_PATH%"
+exit /b %DOCTOR_EXIT_CODE%
+`)
+
+    const result = runRefresh(targetDir, commandDir, {
+      DOCTOR_INVOCATION_LOG: invocationLogPath,
+      DOCTOR_JSON_PATH: doctorJsonPath,
+      DOCTOR_EXIT_CODE: "1",
+      GLOBAL_DOCTOR_EXIT_CODE: "93",
+    })
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain("Managed refresh failed")
+    expect(readFileSync(join(targetDir, "opencode.json"), "utf-8")).toBe(preexistingOpencodeContents)
+
+    const refreshLogContents = readLatestRefreshLog(targetDir)
+    expect(refreshLogContents).toContain("Refresh failed, restoring the previous managed config backup")
+    expect(refreshLogContents).toContain("Original error: Doctor reported fatal issue(s): OpenCode binary not found")
+  })
+})

--- a/src/cli/doctor/checks/local-delta-fixture.test.ts
+++ b/src/cli/doctor/checks/local-delta-fixture.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
+
+type DeltaCategoryName =
+  | "config_only_deltas"
+  | "plugin_code_deltas"
+  | "intended_extension_points"
+  | "suspicious_runtime_drift"
+
+interface DeltaEntry {
+  id: string
+  summary: string
+  evidence?: Record<string, unknown>
+}
+
+interface DeltaFixture {
+  audit_scope: string
+  categories: Record<DeltaCategoryName, DeltaEntry[]>
+}
+
+const fixturePath = new URL("../../../../test/fixtures/local-config-delta/current-local-delta.json", import.meta.url)
+const reportPath = new URL("../../../../docs/fork/local-vs-upstream-delta.md", import.meta.url)
+
+const fixture = JSON.parse(readFileSync(fixturePath, "utf-8")) as DeltaFixture
+const report = readFileSync(reportPath, "utf-8")
+
+const REQUIRED_CATEGORY_IDS: Record<DeltaCategoryName, string[]> = {
+  config_only_deltas: [
+    "host-default-agent-prometheus",
+    "agent-category-model-pinning-openai-gpt-5-4",
+    "prompt-append-additions",
+    "supported-runtime-knob-differences",
+  ],
+  plugin_code_deltas: [
+    "heartbeat-status-plugin",
+    "tls-certificate-retry-plugin",
+  ],
+  intended_extension_points: [
+    "schema-supported-agent-and-runtime-overrides",
+    "config-merge-semantics",
+    "explicit-plugin-array-registration",
+    "legacy-alias-basename-compatibility",
+  ],
+  suspicious_runtime_drift: [
+    "missing-visible-plugin-registration",
+    "unsupported-sisyphus-tasks-enabled",
+  ],
+}
+
+const REQUIRED_REPORT_SNIPPETS = [
+  "## Config-only deltas",
+  "## Plugin/code deltas",
+  "## Intended extension points",
+  "## Suspicious runtime drift",
+  "`default_agent = prometheus`",
+  "`openai/gpt-5.4` with `variant = xhigh` and `textVerbosity: high`",
+  "`prompt_append` additions for `sisyphus`, `hephaestus`, `prometheus`, `atlas`, and `sisyphus-junior`",
+  "`hashline_edit`",
+  "`background_task.staleTimeoutMs`",
+  "`babysitting.timeout_ms`",
+  "`model_capabilities.refresh_timeout_ms`",
+  "`experimental.auto_resume`",
+  "`notification.force_enable`",
+  "missing visible plugin registration",
+  "`sisyphus.tasks.enabled`",
+  "legacy `oh-my-opencode` alias/basename support should not be treated as drift",
+]
+
+function getCategoryEntries(categoryName: DeltaCategoryName): DeltaEntry[] {
+  const entries = fixture.categories[categoryName]
+
+  if (!Array.isArray(entries)) {
+    throw new Error(`Delta fixture is missing the '${categoryName}' category.`)
+  }
+
+  return entries
+}
+
+function getEntry(categoryName: DeltaCategoryName, entryId: string): DeltaEntry {
+  const entry = getCategoryEntries(categoryName).find((item) => item.id === entryId)
+
+  if (!entry) {
+    throw new Error(`Delta fixture category '${categoryName}' is missing required entry '${entryId}'.`)
+  }
+
+  return entry
+}
+
+describe("local delta fixture regression", () => {
+  it("keeps the fixture category contract intact", () => {
+    expect(fixture.audit_scope).toBe("inventory-only")
+
+    for (const [categoryName, requiredIds] of Object.entries(REQUIRED_CATEGORY_IDS) as Array<
+      [DeltaCategoryName, string[]]
+    >) {
+      const categoryEntries = getCategoryEntries(categoryName)
+      const ids = new Set(categoryEntries.map((entry) => entry.id))
+      const missingIds = requiredIds.filter((id) => !ids.has(id))
+
+      if (missingIds.length > 0) {
+        throw new Error(
+          `Delta fixture category '${categoryName}' is missing required ids: ${missingIds.join(", ")}.`
+        )
+      }
+    }
+  })
+
+  it("captures the required config-only facts in machine-readable form", () => {
+    const defaultAgentEntry = getEntry("config_only_deltas", "host-default-agent-prometheus")
+    expect(defaultAgentEntry.evidence?.path).toBe("default_agent")
+    expect(defaultAgentEntry.evidence?.value).toBe("prometheus")
+
+    const modelPinningEntry = getEntry("config_only_deltas", "agent-category-model-pinning-openai-gpt-5-4")
+    expect(modelPinningEntry.evidence?.model).toBe("openai/gpt-5.4")
+    expect(modelPinningEntry.evidence?.variant).toBe("xhigh")
+    expect(modelPinningEntry.evidence?.textVerbosity).toBe("high")
+    expect(modelPinningEntry.evidence?.agents).toEqual([
+      "sisyphus",
+      "hephaestus",
+      "oracle",
+      "librarian",
+      "explore",
+      "multimodal-looker",
+      "prometheus",
+      "metis",
+      "momus",
+      "atlas",
+      "sisyphus-junior",
+    ])
+    expect(modelPinningEntry.evidence?.categories).toEqual([
+      "visual-engineering",
+      "ultrabrain",
+      "deep",
+      "artistry",
+      "quick",
+      "unspecified-low",
+      "unspecified-high",
+      "writing",
+    ])
+
+    const promptAppendEntry = getEntry("config_only_deltas", "prompt-append-additions")
+    expect(promptAppendEntry.evidence?.agents).toEqual([
+      "sisyphus",
+      "hephaestus",
+      "prometheus",
+      "atlas",
+      "sisyphus-junior",
+    ])
+
+    const runtimeKnobEntry = getEntry("config_only_deltas", "supported-runtime-knob-differences")
+    expect(runtimeKnobEntry.evidence?.required_knobs).toEqual([
+      { path: "hashline_edit", value: true },
+      { path: "background_task.staleTimeoutMs", value: 600000 },
+      { path: "babysitting.timeout_ms", value: 300000 },
+      { path: "model_capabilities.refresh_timeout_ms", value: 10000 },
+      { path: "experimental.auto_resume", value: true },
+      { path: "notification.force_enable", value: true },
+    ])
+  })
+
+  it("records the required suspicious drift findings", () => {
+    const missingPluginRegistration = getEntry(
+      "suspicious_runtime_drift",
+      "missing-visible-plugin-registration"
+    )
+    expect(missingPluginRegistration.evidence?.missing_key).toBe("plugin")
+    expect(missingPluginRegistration.evidence?.observed_keys).toEqual(["$schema", "default_agent"])
+
+    const unsupportedSisyphusTasksEnabled = getEntry(
+      "suspicious_runtime_drift",
+      "unsupported-sisyphus-tasks-enabled"
+    )
+    expect(unsupportedSisyphusTasksEnabled.evidence?.unsupported_path).toBe("sisyphus.tasks.enabled")
+    expect(unsupportedSisyphusTasksEnabled.evidence?.allowed_paths).toEqual([
+      "sisyphus.tasks.storage_path",
+      "sisyphus.tasks.task_list_id",
+      "sisyphus.tasks.claude_code_compat",
+    ])
+    expect(unsupportedSisyphusTasksEnabled.evidence?.observed_value).toBe(true)
+  })
+
+  it("keeps the markdown review aligned with the required delta findings", () => {
+    for (const snippet of REQUIRED_REPORT_SNIPPETS) {
+      if (!report.includes(snippet)) {
+        throw new Error(`Delta review is missing required text: ${snippet}`)
+      }
+    }
+  })
+})

--- a/src/cli/doctor/checks/system-plugin.test.ts
+++ b/src/cli/doctor/checks/system-plugin.test.ts
@@ -1,0 +1,64 @@
+/// <reference types="bun-types" />
+
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+
+type SystemPluginModule = typeof import("./system-plugin")
+
+const mockExistsSync = mock((_path: string) => false)
+const mockReadFileSync = mock((_path: string, _encoding: string) => "")
+const mockGetOpenCodeConfigPaths = mock(() => ({
+  configJsonc: "/tmp/opencode.jsonc",
+  configJson: "/tmp/opencode.json",
+}))
+const mockParseJsonc = mock((content: string) => JSON.parse(content) as { plugin?: string[] })
+
+mock.module("node:fs", () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+}))
+
+mock.module("../../../shared", () => ({
+  LEGACY_PLUGIN_NAME: "oh-my-opencode",
+  PLUGIN_NAME: "oh-my-openagent",
+  getOpenCodeConfigPaths: mockGetOpenCodeConfigPaths,
+  parseJsonc: mockParseJsonc,
+}))
+
+async function importFreshSystemPluginModule(): Promise<SystemPluginModule> {
+  return import(`./system-plugin?test=${Date.now()}-${Math.random()}`)
+}
+
+describe("system plugin detection", () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset()
+    mockReadFileSync.mockReset()
+    mockGetOpenCodeConfigPaths.mockReset()
+    mockParseJsonc.mockReset()
+
+    mockExistsSync.mockImplementation((path: string) => path === "/tmp/opencode.json")
+    mockReadFileSync.mockImplementation((_path: string, _encoding: string) => JSON.stringify({
+      plugin: ["./plugins/oh-my-openagent.js"],
+    }))
+    mockGetOpenCodeConfigPaths.mockReturnValue({
+      configJsonc: "/tmp/opencode.jsonc",
+      configJson: "/tmp/opencode.json",
+    })
+    mockParseJsonc.mockImplementation((content: string) => JSON.parse(content) as { plugin?: string[] })
+  })
+
+  it("accepts the managed wrapper file entry as a registered plugin", async () => {
+    const { findPluginEntry, getPluginInfo } = await importFreshSystemPluginModule()
+
+    expect(findPluginEntry(["./plugins/oh-my-openagent.js"]))
+      .toEqual({ entry: "./plugins/oh-my-openagent.js", isLocalDev: false })
+
+    expect(getPluginInfo()).toEqual({
+      registered: true,
+      configPath: "/tmp/opencode.json",
+      entry: "./plugins/oh-my-openagent.js",
+      isPinned: false,
+      pinnedVersion: null,
+      isLocalDev: false,
+    })
+  })
+})

--- a/src/cli/doctor/checks/system-plugin.ts
+++ b/src/cli/doctor/checks/system-plugin.ts
@@ -38,6 +38,15 @@ function parsePluginVersion(entry: string): string | null {
   return null
 }
 
+function isManagedWrapperEntry(entry: string): boolean {
+  const normalizedEntry = entry.replaceAll("\\", "/")
+
+  return normalizedEntry === `${PLUGIN_NAME}.js`
+    || normalizedEntry.endsWith(`/${PLUGIN_NAME}.js`)
+    || normalizedEntry === `${LEGACY_PLUGIN_NAME}.js`
+    || normalizedEntry.endsWith(`/${LEGACY_PLUGIN_NAME}.js`)
+}
+
 function findPluginEntry(entries: string[]): { entry: string; isLocalDev: boolean } | null {
   for (const entry of entries) {
     // Check for current package name
@@ -51,6 +60,10 @@ function findPluginEntry(entries: string[]): { entry: string; isLocalDev: boolea
     // Check for file:// paths that include either name
     if (entry.startsWith("file://") && (entry.includes(PLUGIN_NAME) || entry.includes(LEGACY_PLUGIN_NAME))) {
       return { entry, isLocalDev: true }
+    }
+    // Check for managed wrapper-file paths that point at the preferred plugin entry.
+    if (isManagedWrapperEntry(entry)) {
+      return { entry, isLocalDev: false }
     }
   }
 

--- a/src/custom-opencode/alias-compatibility.test.ts
+++ b/src/custom-opencode/alias-compatibility.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
+
+import { loadPluginConfig } from "../plugin-config"
+import { detectPluginConfigFile } from "../shared/jsonc-parser"
+
+const tempDirs: string[] = []
+
+function makeTempDir(prefix: string) {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  tempDirs.push(dir)
+  return dir
+}
+
+function writeJson(filePath: string, value: unknown) {
+  writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf-8")
+}
+
+function assertLegacyBasename(filePath: string, scope: string) {
+  if (!basename(filePath).startsWith("oh-my-opencode")) {
+    throw new Error(`${scope} must keep legacy oh-my-opencode basename support.`)
+  }
+
+  return filePath
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+
+  delete process.env.OPENCODE_CONFIG_DIR
+})
+
+describe("legacy alias and basename compatibility", () => {
+  it("prefers the legacy basename when both plugin config names exist in the same directory", () => {
+    const configDir = makeTempDir("alias-compat-detect")
+
+    writeJson(join(configDir, "oh-my-openagent.json"), {
+      agents: {
+        prometheus: {
+          model: "google/gemini-3-flash",
+        },
+      },
+    })
+    writeJson(join(configDir, "oh-my-opencode.json"), {
+      agents: {
+        prometheus: {
+          model: "openai/gpt-5.4",
+        },
+      },
+    })
+
+    const detected = detectPluginConfigFile(configDir)
+
+    expect(detected.format).toBe("json")
+    expect(assertLegacyBasename(detected.path, "Plugin config detection")).toBe(
+      join(configDir, "oh-my-opencode.json")
+    )
+  })
+
+  it("loads legacy user and project basenames even when canonical siblings are present", () => {
+    const projectDir = makeTempDir("alias-compat-project")
+    const userConfigDir = makeTempDir("alias-compat-user")
+    const projectConfigDir = join(projectDir, ".opencode")
+
+    mkdirSync(projectConfigDir, { recursive: true })
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+
+    writeJson(join(userConfigDir, "oh-my-opencode.json"), {
+      agents: {
+        prometheus: {
+          model: "openai/gpt-5.4",
+          variant: "high",
+        },
+      },
+    })
+    writeJson(join(userConfigDir, "oh-my-openagent.json"), {
+      agents: {
+        prometheus: {
+          model: "google/gemini-3-flash",
+          variant: "low",
+        },
+      },
+    })
+
+    writeJson(join(projectConfigDir, "oh-my-opencode.json"), {
+      agents: {
+        prometheus: {
+          prompt_append: "Project legacy override stays compatible.",
+        },
+      },
+    })
+    writeJson(join(projectConfigDir, "oh-my-openagent.json"), {
+      agents: {
+        prometheus: {
+          prompt_append: "Canonical sibling should not win while legacy compatibility is enabled.",
+        },
+      },
+    })
+
+    const config = loadPluginConfig(projectDir, {})
+
+    expect(config.agents?.prometheus?.model).toBe("openai/gpt-5.4")
+    expect(config.agents?.prometheus?.variant).toBe("high")
+    expect(config.agents?.prometheus?.prompt_append).toBe(
+      "Project legacy override stays compatible."
+    )
+  })
+
+  it("fails loudly when legacy basename support disappears", () => {
+    expect(() =>
+      assertLegacyBasename("E:/tmp/oh-my-openagent.json", "Plugin config detection")
+    ).toThrow("Plugin config detection must keep legacy oh-my-opencode basename support.")
+  })
+})

--- a/src/custom-opencode/config-precedence.test.ts
+++ b/src/custom-opencode/config-precedence.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { loadPluginConfig } from "../plugin-config"
+
+const managedPluginConfigPath = new URL("../../assets/custom-opencode/oh-my-opencode.json", import.meta.url)
+const tempDirs: string[] = []
+
+function makeTempDir(prefix: string) {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  tempDirs.push(dir)
+  return dir
+}
+
+function writeJson(filePath: string, value: unknown) {
+  writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf-8")
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+
+  delete process.env.OPENCODE_CONFIG_DIR
+})
+
+describe("custom OpenCode config precedence compatibility", () => {
+  it("loads user config first and lets project config override it without breaking merge semantics", () => {
+    const projectDir = makeTempDir("config-precedence-project")
+    const userConfigDir = makeTempDir("config-precedence-user")
+    const projectConfigDir = join(projectDir, ".opencode")
+
+    mkdirSync(projectConfigDir, { recursive: true })
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+
+    writeJson(join(userConfigDir, "oh-my-openagent.json"), {
+      agents: {
+        prometheus: {
+          model: "openai/gpt-5.4",
+          variant: "high",
+          prompt_append: "User config should load first.",
+        },
+      },
+      categories: {
+        quick: {
+          textVerbosity: "low",
+        },
+      },
+      disabled_tools: ["read"],
+      disabled_hooks: ["user-hook"],
+    })
+
+    writeJson(join(projectConfigDir, "oh-my-openagent.json"), {
+      agents: {
+        prometheus: {
+          model: "anthropic/claude-opus-4-6",
+          prompt_append: "Project config must win for overlapping fields.",
+        },
+      },
+      categories: {
+        quick: {
+          model: "anthropic/claude-sonnet-4-6",
+        },
+      },
+      disabled_tools: ["bash", "read"],
+      disabled_hooks: ["project-hook"],
+    })
+
+    const config = loadPluginConfig(projectDir, {})
+
+    expect(config.agents?.prometheus?.model).toBe("anthropic/claude-opus-4-6")
+    expect(config.agents?.prometheus?.variant).toBe("high")
+    expect(config.agents?.prometheus?.prompt_append).toBe(
+      "Project config must win for overlapping fields."
+    )
+    expect(config.categories?.quick?.model).toBe("anthropic/claude-sonnet-4-6")
+    expect(config.categories?.quick?.textVerbosity).toBe("low")
+    expect(config.disabled_tools).toEqual(["read", "bash"])
+    expect(config.disabled_hooks).toEqual(["user-hook", "project-hook"])
+  })
+
+  it("keeps the managed user asset as the base while allowing project-local overrides", () => {
+    const projectDir = makeTempDir("config-precedence-managed-project")
+    const userConfigDir = makeTempDir("config-precedence-managed-user")
+    const projectConfigDir = join(projectDir, ".opencode")
+
+    mkdirSync(projectConfigDir, { recursive: true })
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+
+    const managedUserConfig = JSON.parse(readFileSync(managedPluginConfigPath, "utf-8"))
+    writeJson(join(userConfigDir, "oh-my-openagent.json"), managedUserConfig)
+
+    writeJson(join(projectConfigDir, "oh-my-openagent.json"), {
+      agents: {
+        prometheus: {
+          prompt_append: "Project-local compatibility override.",
+        },
+      },
+      categories: {
+        writing: {
+          model: "anthropic/claude-sonnet-4-6",
+        },
+      },
+      disabled_tools: ["bash"],
+    })
+
+    const config = loadPluginConfig(projectDir, {})
+
+    expect(config.hashline_edit).toBe(true)
+    expect(config.agents?.prometheus?.prompt_append).toBe("Project-local compatibility override.")
+    expect(config.agents?.prometheus?.model).toBe("openai/gpt-5.4")
+    expect(config.categories?.writing?.model).toBe("anthropic/claude-sonnet-4-6")
+    expect(config.categories?.writing?.variant).toBe("xhigh")
+    expect(config.categories?.writing?.textVerbosity).toBe("high")
+    expect(config.disabled_tools).toEqual(["bash"])
+  })
+})

--- a/src/custom-opencode/heartbeat-retry.integration.test.ts
+++ b/src/custom-opencode/heartbeat-retry.integration.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from "bun:test"
+
+import { createHeartbeatStatusRuntime as createHeartbeatStatusRuntimeUntyped } from "../../assets/custom-opencode/plugins/heartbeat-status.js"
+import {
+  createTlsCertificateRetryRuntime as createTlsCertificateRetryRuntimeUntyped,
+} from "../../assets/custom-opencode/plugins/tls-certificate-retry.js"
+
+type HeartbeatHook = (...args: any[]) => Promise<void>
+type RetryHook = (...args: any[]) => Promise<void>
+
+type HeartbeatRuntime = {
+  hooks: Record<string, HeartbeatHook>
+  getSessionSnapshot: (sessionID: string) => any
+}
+
+type RetrySignal =
+  | {
+      state: "retrying"
+      attempt: number
+      message: string
+      next: number
+    }
+  | {
+      state: "failed"
+      error: unknown
+      hardProviderBlock: boolean
+    }
+
+type RetryRuntime = {
+  hooks: Record<string, RetryHook>
+}
+
+type ScheduledTimer = {
+  id: number
+  delay: number
+  callback: () => unknown
+}
+
+const createHeartbeatStatusRuntime = createHeartbeatStatusRuntimeUntyped as (options: Record<string, unknown>) => HeartbeatRuntime
+const createTlsCertificateRetryRuntime = createTlsCertificateRetryRuntimeUntyped as (options: Record<string, unknown>) => RetryRuntime
+
+function createTimerController() {
+  let nextID = 1
+  const activeTimers = new Map<number, ScheduledTimer>()
+  const getActiveTimers = () => Array.from(activeTimers.values())
+
+  return {
+    setTimeoutFn(callback: () => unknown, delay: number) {
+      const timer = {
+        id: nextID++,
+        delay,
+        callback,
+      }
+
+      activeTimers.set(timer.id, timer)
+      return timer.id as unknown as ReturnType<typeof setTimeout>
+    },
+
+    clearTimeoutFn(timerID: ReturnType<typeof setTimeout>) {
+      activeTimers.delete(timerID as unknown as number)
+    },
+
+    getActiveTimers,
+  }
+}
+
+function createMockClient() {
+  const toasts: Array<Record<string, unknown>> = []
+  const logs: Array<Record<string, unknown>> = []
+  const promptCalls: Array<Record<string, unknown>> = []
+
+  return {
+    client: {
+      tui: {
+        showToast: async ({ body }: { body: Record<string, unknown> }) => {
+          toasts.push(body)
+          return true
+        },
+      },
+      app: {
+        log: async ({ body }: { body: Record<string, unknown> }) => {
+          logs.push(body)
+          return true
+        },
+      },
+      session: {
+        messages: async () => ({ data: [] }),
+        promptAsync: async (payload: Record<string, unknown>) => {
+          promptCalls.push(payload)
+          return true
+        },
+      },
+    },
+    logs,
+    promptCalls,
+    toasts,
+  }
+}
+
+function createIntegrationHarness() {
+  const timers = createTimerController()
+  const mock = createMockClient()
+  let currentTime = 25_000
+
+  const heartbeat = createHeartbeatStatusRuntime({
+    client: mock.client,
+    now: () => currentTime,
+    setIntervalFn: () => ({}) as ReturnType<typeof setInterval>,
+    clearIntervalFn: () => {},
+  })
+
+  const retry = createTlsCertificateRetryRuntime({
+    client: mock.client,
+    directory: "E:/projects/ohmyopencode/oh-my-openagent",
+    now: () => currentTime,
+    setTimeoutFn: timers.setTimeoutFn,
+    clearTimeoutFn: timers.clearTimeoutFn,
+    onStateChange: async (sessionID: string, signal: RetrySignal) => {
+      if (signal.state === "retrying") {
+        await heartbeat.hooks.event?.({
+          event: {
+            type: "session.status",
+            properties: {
+              sessionID,
+              status: {
+                type: "retry",
+                attempt: signal.attempt,
+                message: signal.message,
+                next: signal.next,
+              },
+            },
+          },
+        })
+
+        return
+      }
+
+      await heartbeat.hooks.event?.({
+        event: {
+          type: "session.error",
+          properties: {
+            sessionID,
+            error: signal.error,
+          },
+        },
+      })
+    },
+  })
+
+  return {
+    heartbeat,
+    hooks: {
+      heartbeat: heartbeat.hooks,
+      retry: retry.hooks,
+    },
+    promptCalls: mock.promptCalls,
+    setCurrentTime(value: number) {
+      currentTime = value
+    },
+    timers,
+  }
+}
+
+describe("heartbeat and retry integration", () => {
+  it("moves heartbeat from a retryable failure into the retrying state when TLS retry schedules recovery", async () => {
+    const { heartbeat, hooks, setCurrentTime, timers } = createIntegrationHarness()
+    setCurrentTime(25_000)
+
+    await hooks.heartbeat["chat.message"]?.(
+      {
+        sessionID: "ses_retrying",
+        agent: "sisyphus",
+      },
+      {
+        message: { role: "user" },
+        parts: [],
+      },
+    )
+
+    await hooks.retry["chat.message"]?.(
+      {
+        sessionID: "ses_retrying",
+        agent: "sisyphus",
+      },
+      {
+        message: { role: "user" },
+        parts: [{ type: "text", text: "Recover from transient TLS failures only." }],
+      },
+    )
+
+    const retryableError = {
+      message: "unable to verify the first certificate",
+    }
+
+    await hooks.heartbeat.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_retrying",
+          error: retryableError,
+        },
+      },
+    })
+
+    expect(heartbeat.getSessionSnapshot("ses_retrying").state).toBe("failed")
+
+    await hooks.retry.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_retrying",
+          error: retryableError,
+        },
+      },
+    })
+
+    const snapshot = heartbeat.getSessionSnapshot("ses_retrying")
+
+    expect(timers.getActiveTimers()).toHaveLength(1)
+    expect(snapshot.state).toBe("retrying")
+    expect(snapshot.retry).toMatchObject({
+      attempt: 1,
+      message: "unable to verify the first certificate",
+    })
+    expect(snapshot.detailText).toContain("Следующая попытка")
+  })
+
+  it("keeps heartbeat failed and clears pending retry state on a hard provider block", async () => {
+    const { heartbeat, hooks, promptCalls, timers } = createIntegrationHarness()
+
+    await hooks.heartbeat["chat.message"]?.(
+      {
+        sessionID: "ses_failed",
+        agent: "prometheus",
+      },
+      {
+        message: { role: "user" },
+        parts: [],
+      },
+    )
+
+    await hooks.retry["chat.message"]?.(
+      {
+        sessionID: "ses_failed",
+        agent: "prometheus",
+      },
+      {
+        message: { role: "user" },
+        parts: [{ type: "text", text: "Only retry network and certificate issues." }],
+      },
+    )
+
+    const retryableError = {
+      message: "socket hang up",
+    }
+
+    await hooks.retry.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_failed",
+          error: retryableError,
+        },
+      },
+    })
+
+    expect(heartbeat.getSessionSnapshot("ses_failed").state).toBe("retrying")
+    expect(timers.getActiveTimers()).toHaveLength(1)
+
+    const hardProviderBlock = {
+      statusCode: 403,
+      message: "Blocked by a gateway or proxy. Check your account and provider settings.",
+    }
+
+    await hooks.heartbeat.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_failed",
+          error: hardProviderBlock,
+        },
+      },
+    })
+
+    await hooks.retry.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_failed",
+          error: hardProviderBlock,
+        },
+      },
+    })
+
+    const snapshot = heartbeat.getSessionSnapshot("ses_failed")
+
+    expect(timers.getActiveTimers()).toHaveLength(0)
+    expect(promptCalls).toHaveLength(0)
+    expect(snapshot.state).toBe("failed")
+    expect(snapshot.hardProviderBlock).toBe(true)
+    expect(snapshot.detailText).toContain("исправления настроек")
+  })
+})

--- a/src/custom-opencode/heartbeat-status.test.ts
+++ b/src/custom-opencode/heartbeat-status.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "bun:test"
+
+import { createHeartbeatStatusRuntime as createHeartbeatStatusRuntimeUntyped } from "../../assets/custom-opencode/plugins/heartbeat-status.js"
+
+type HeartbeatHook = (...args: any[]) => Promise<void>
+
+type HeartbeatRuntime = {
+  hooks: Record<string, HeartbeatHook>
+  getSessionSnapshot: (sessionID: string) => any
+}
+
+const createHeartbeatStatusRuntime = createHeartbeatStatusRuntimeUntyped as (options: Record<string, unknown>) => HeartbeatRuntime
+
+function createMockClient() {
+  const toasts: Array<Record<string, unknown>> = []
+  const logs: Array<Record<string, unknown>> = []
+
+  return {
+    client: {
+      tui: {
+        showToast: async ({ body }: { body: Record<string, unknown> }) => {
+          toasts.push(body)
+          return true
+        },
+      },
+      app: {
+        log: async ({ body }: { body: Record<string, unknown> }) => {
+          logs.push(body)
+          return true
+        },
+      },
+    },
+    logs,
+    toasts,
+  }
+}
+
+function createRuntime() {
+  const mock = createMockClient()
+
+  const runtime = createHeartbeatStatusRuntime({
+    client: mock.client,
+    now: () => 65_000,
+    setIntervalFn: () => ({}) as ReturnType<typeof setInterval>,
+    clearIntervalFn: () => {},
+  })
+
+  return {
+    ...mock,
+    hooks: runtime.hooks,
+    runtime,
+  }
+}
+
+describe("heartbeat status presenter", () => {
+  it("keeps progress indeterminate without todo or percent signals while preserving agent and stage text", async () => {
+    const { hooks, runtime } = createRuntime()
+
+    await hooks["chat.message"]?.(
+      {
+        sessionID: "ses_status",
+        agent: "sisyphus",
+      },
+      {
+        message: { role: "user" },
+        parts: [],
+      },
+    )
+
+    await hooks["tool.execute.before"]?.(
+      {
+        sessionID: "ses_status",
+        callID: "call_read",
+        tool: "read",
+      },
+      {
+        args: { filePath: "README.md" },
+      },
+    )
+
+    const snapshot = runtime.getSessionSnapshot("ses_status")
+
+    expect(snapshot.state).toBe("running")
+    expect(snapshot.progress.kind).toBe("indeterminate")
+    expect(snapshot.progress.source).toBe("none")
+    expect(snapshot.progress.percent).toBeUndefined()
+    expect(snapshot.statusText).toContain("sisyphus")
+    expect(snapshot.statusText).toContain("Сейчас читает файлы и собирает контекст.")
+    expect(snapshot.detailText).toContain("Точный процент пока неизвестен")
+    expect(snapshot.detailText).not.toContain("%")
+  })
+
+  it("uses determinate progress only when todo counts provide a real numeric signal", async () => {
+    const { hooks, runtime } = createRuntime()
+
+    await hooks["chat.message"]?.(
+      {
+        sessionID: "ses_todos",
+        agent: "atlas",
+      },
+      {
+        message: { role: "user" },
+        parts: [],
+      },
+    )
+
+    await hooks.event?.({
+      event: {
+        type: "todo.updated",
+        properties: {
+          sessionID: "ses_todos",
+          todos: [
+            { status: "completed" },
+            { status: "in_progress" },
+            { status: "pending" },
+            { status: "completed" },
+          ],
+        },
+      },
+    })
+
+    const snapshot = runtime.getSessionSnapshot("ses_todos")
+
+    expect(snapshot.progress.kind).toBe("determinate")
+    expect(snapshot.progress.source).toBe("todo")
+    expect(snapshot.progress.percent).toBe(50)
+    expect(snapshot.detailText).toContain("Прогресс 50%")
+    expect(snapshot.detailText).toContain("Выполнено 2 из 4 шагов")
+  })
+
+  it("exposes the named idle, retrying, completed, and failed states", async () => {
+    const { hooks, runtime } = createRuntime()
+
+    expect(runtime.getSessionSnapshot("ses_states").state).toBe("idle")
+
+    await hooks["chat.message"]?.(
+      {
+        sessionID: "ses_states",
+        agent: "prometheus",
+      },
+      {
+        message: { role: "user" },
+        parts: [],
+      },
+    )
+
+    await hooks.event?.({
+      event: {
+        type: "session.status",
+        properties: {
+          sessionID: "ses_states",
+          status: {
+            type: "retry",
+            attempt: 2,
+            message: "network retry",
+            next: 60_000,
+          },
+        },
+      },
+    })
+
+    expect(runtime.getSessionSnapshot("ses_states").state).toBe("retrying")
+
+    await hooks.event?.({
+      event: {
+        type: "session.idle",
+        properties: {
+          sessionID: "ses_states",
+        },
+      },
+    })
+
+    const completedSnapshot = runtime.getSessionSnapshot("ses_states")
+    expect(completedSnapshot.state).toBe("completed")
+    expect(completedSnapshot.progress.kind).toBe("determinate")
+    expect(completedSnapshot.progress.percent).toBe(100)
+
+    await hooks["chat.message"]?.(
+      {
+        sessionID: "ses_states",
+        agent: "prometheus",
+      },
+      {
+        message: { role: "user" },
+        parts: [],
+      },
+    )
+
+    await hooks.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_states",
+          error: {
+            message: "upstream provider failed",
+          },
+        },
+      },
+    })
+
+    const failedSnapshot = runtime.getSessionSnapshot("ses_states")
+    expect(failedSnapshot.state).toBe("failed")
+    expect(failedSnapshot.detailText).toContain("Причина: upstream provider failed.")
+  })
+})

--- a/src/custom-opencode/heartbeat-waiting-state.test.ts
+++ b/src/custom-opencode/heartbeat-waiting-state.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "bun:test"
+
+import { createHeartbeatStatusRuntime as createHeartbeatStatusRuntimeUntyped } from "../../assets/custom-opencode/plugins/heartbeat-status.js"
+
+type HeartbeatHook = (...args: any[]) => Promise<void>
+
+type HeartbeatRuntime = {
+  hooks: Record<string, HeartbeatHook>
+  getSessionSnapshot: (sessionID: string) => any
+}
+
+const createHeartbeatStatusRuntime = createHeartbeatStatusRuntimeUntyped as (options: Record<string, unknown>) => HeartbeatRuntime
+
+function createRuntime() {
+  const runtime = createHeartbeatStatusRuntime({
+    client: {
+      tui: {
+        showToast: async () => true,
+      },
+      app: {
+        log: async () => true,
+      },
+    },
+    now: () => 90_000,
+    setIntervalFn: () => ({}) as ReturnType<typeof setInterval>,
+    clearIntervalFn: () => {},
+  })
+
+  return {
+    hooks: runtime.hooks,
+    runtime,
+  }
+}
+
+describe("heartbeat waiting-for-subagents flow", () => {
+  it("transitions running to waiting_for_subagents and back to running on background_output resume", async () => {
+    const { hooks, runtime } = createRuntime()
+
+    await hooks["chat.message"]?.(
+      {
+        sessionID: "ses_waiting",
+        agent: "sisyphus",
+      },
+      {
+        message: { role: "user" },
+        parts: [],
+      },
+    )
+
+    await hooks["tool.execute.before"]?.(
+      {
+        sessionID: "ses_waiting",
+        callID: "call_task_before",
+        tool: "task",
+      },
+      {
+        args: {
+          description: "inspect files",
+        },
+      },
+    )
+
+    expect(runtime.getSessionSnapshot("ses_waiting").state).toBe("running")
+
+    await hooks["tool.execute.after"]?.(
+      {
+        sessionID: "ses_waiting",
+        callID: "call_task_after",
+        tool: "task",
+        args: {
+          description: "inspect files",
+        },
+      },
+      {
+        title: "Delegated",
+        output: "spawned",
+        metadata: {
+          task_id: "task_123",
+        },
+      },
+    )
+
+    const waitingSnapshot = runtime.getSessionSnapshot("ses_waiting")
+
+    expect(waitingSnapshot.state).toBe("waiting_for_subagents")
+    expect(waitingSnapshot.progress.kind).toBe("indeterminate")
+    expect(waitingSnapshot.progress.source).toBe("none")
+    expect(waitingSnapshot.progress.percent).toBeUndefined()
+    expect(waitingSnapshot.statusText).toContain("sisyphus")
+    expect(waitingSnapshot.statusText).toContain("Сейчас ждёт результат фоновой задачи от подагента.")
+    expect(waitingSnapshot.detailText).toContain("агент ждёт результат подагента")
+
+    await hooks["tool.execute.before"]?.(
+      {
+        sessionID: "ses_waiting",
+        callID: "call_background_before",
+        tool: "background_output",
+      },
+      {
+        args: {
+          task_id: "task_123",
+        },
+      },
+    )
+
+    const resumedSnapshot = runtime.getSessionSnapshot("ses_waiting")
+
+    expect(resumedSnapshot.state).toBe("running")
+    expect(resumedSnapshot.progress.kind).toBe("indeterminate")
+    expect(resumedSnapshot.statusText).toContain("Сейчас забирает результат фоновой задачи, чтобы возобновить работу.")
+
+    await hooks["tool.execute.after"]?.(
+      {
+        sessionID: "ses_waiting",
+        callID: "call_background_after",
+        tool: "background_output",
+        args: {
+          task_id: "task_123",
+        },
+      },
+      {
+        title: "Background output",
+        output: "done",
+        metadata: {
+          status: "completed",
+        },
+      },
+    )
+
+    const afterResumeSnapshot = runtime.getSessionSnapshot("ses_waiting")
+
+    expect(afterResumeSnapshot.state).toBe("running")
+    expect(afterResumeSnapshot.statusText).toContain("Сейчас возобновляет работу после ответа подагента.")
+  })
+})

--- a/src/custom-opencode/plugin-loading.test.ts
+++ b/src/custom-opencode/plugin-loading.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, mock } from "bun:test"
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { addPluginToOpenCodeConfig } from "../cli/config-manager/add-plugin-to-opencode-config"
+import { resetConfigContext } from "../cli/config-manager/config-context"
+
+type DeltaCategoryName = "intended_extension_points" | "suspicious_runtime_drift"
+
+interface DeltaEntry {
+  id: string
+  evidence?: Record<string, unknown>
+}
+
+interface DeltaFixture {
+  categories: Partial<Record<DeltaCategoryName, DeltaEntry[]>>
+}
+
+interface OpenCodeHostConfig {
+  plugin?: string[]
+  [key: string]: unknown
+}
+
+const EXPECTED_WRAPPER_ENTRY = "./plugins/oh-my-openagent.js"
+const EXPECTED_PACKAGE_ENTRY = "oh-my-openagent"
+const hostConfigPath = new URL("../../assets/custom-opencode/opencode.json", import.meta.url)
+const wrapperPluginPath = new URL(
+  "../../assets/custom-opencode/plugins/oh-my-openagent.js",
+  import.meta.url
+)
+const deltaFixturePath = new URL(
+  "../../test/fixtures/local-config-delta/current-local-delta.json",
+  import.meta.url
+)
+const originalFetch = globalThis.fetch
+const tempDirs: string[] = []
+
+function makeTempDir(prefix: string) {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  tempDirs.push(dir)
+  return dir
+}
+
+function writeJson(filePath: string, value: unknown) {
+  writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf-8")
+}
+
+function requirePluginArray(config: OpenCodeHostConfig, scope: string) {
+  if (!Array.isArray(config.plugin) || config.plugin.length === 0) {
+    throw new Error(
+      `${scope} must declare a visible plugin array so plugin loading cannot become implicit again.`
+    )
+  }
+
+  return config.plugin
+}
+
+function getCategoryEntries(fixture: DeltaFixture, categoryName: DeltaCategoryName) {
+  const entries = fixture.categories[categoryName]
+
+  if (!Array.isArray(entries)) {
+    throw new Error(`Delta fixture is missing the '${categoryName}' category.`)
+  }
+
+  return entries
+}
+
+function requireDeltaEntry(
+  fixture: DeltaFixture,
+  categoryName: DeltaCategoryName,
+  entryID: string
+) {
+  const entry = getCategoryEntries(fixture, categoryName).find((candidate) => candidate.id === entryID)
+
+  if (!entry) {
+    throw new Error(
+      `Delta fixture category '${categoryName}' is missing required entry '${entryID}'.`
+    )
+  }
+
+  return entry
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+
+  delete process.env.OPENCODE_CONFIG_DIR
+  resetConfigContext()
+  globalThis.fetch = originalFetch
+})
+
+describe("custom OpenCode plugin loading compatibility", () => {
+  it("keeps wrapper-plugin loading explicit and pointed at the preferred plugin identity", () => {
+    const hostConfig = JSON.parse(readFileSync(hostConfigPath, "utf-8")) as OpenCodeHostConfig
+    const wrapperPluginContents = readFileSync(wrapperPluginPath, "utf-8")
+
+    expect(requirePluginArray(hostConfig, "Managed OpenCode host config")).toEqual([
+      EXPECTED_WRAPPER_ENTRY,
+    ])
+    expect(wrapperPluginContents).toContain('import OhMyOpenAgent from "oh-my-openagent"')
+    expect(wrapperPluginContents).toContain("export const OhMyOpenAgentPlugin = OhMyOpenAgent")
+  })
+
+  it("adds a canonical package entry when host config is missing the plugin array", async () => {
+    const configDir = makeTempDir("plugin-loading-config")
+    const configPath = join(configDir, "opencode.json")
+
+    process.env.OPENCODE_CONFIG_DIR = configDir
+    resetConfigContext()
+    globalThis.fetch = mock(() =>
+      Promise.resolve({
+        ok: false,
+        status: 404,
+      } as Response)
+    ) as unknown as typeof fetch
+
+    writeJson(configPath, {
+      $schema: "https://opencode.ai/config.json",
+      default_agent: "prometheus",
+    })
+
+    const result = await addPluginToOpenCodeConfig("3.14.0")
+    const savedConfig = JSON.parse(readFileSync(configPath, "utf-8")) as OpenCodeHostConfig
+
+    expect(result.success).toBe(true)
+    expect(requirePluginArray(savedConfig, "OpenCode host config after registration")).toEqual([
+      EXPECTED_PACKAGE_ENTRY,
+    ])
+  })
+
+  it("fails loudly when explicit plugin registration disappears from the host config", () => {
+    expect(() => requirePluginArray({ default_agent: "prometheus" }, "Managed OpenCode host config"))
+      .toThrow(
+        "Managed OpenCode host config must declare a visible plugin array so plugin loading cannot become implicit again."
+      )
+  })
+
+  it("keeps the compatibility delta fixture tracking precedence, alias, and explicit plugin loading", () => {
+    const fixture = JSON.parse(readFileSync(deltaFixturePath, "utf-8")) as DeltaFixture
+    const mergeSemantics = requireDeltaEntry(
+      fixture,
+      "intended_extension_points",
+      "config-merge-semantics"
+    )
+    const explicitPluginRegistration = requireDeltaEntry(
+      fixture,
+      "intended_extension_points",
+      "explicit-plugin-array-registration"
+    )
+    const legacyAliasCompatibility = requireDeltaEntry(
+      fixture,
+      "intended_extension_points",
+      "legacy-alias-basename-compatibility"
+    )
+    const missingVisiblePluginRegistration = requireDeltaEntry(
+      fixture,
+      "suspicious_runtime_drift",
+      "missing-visible-plugin-registration"
+    )
+
+    expect(mergeSemantics.evidence?.merge_rules).toEqual([
+      "user config first",
+      "project config overrides second",
+      "agents deepMerge",
+      "categories deepMerge",
+      "disabled_* arrays union",
+    ])
+    expect(explicitPluginRegistration.evidence?.preferred_entry).toBe("oh-my-openagent")
+    expect(explicitPluginRegistration.evidence?.legacy_entry).toBe("oh-my-opencode")
+    expect(legacyAliasCompatibility.evidence?.detection_order).toEqual([
+      "oh-my-opencode",
+      "oh-my-openagent",
+    ])
+    expect(missingVisiblePluginRegistration.evidence?.missing_key).toBe("plugin")
+  })
+
+  it("fails loudly when a tracked compatibility delta category or id disappears", () => {
+    const fixture = JSON.parse(readFileSync(deltaFixturePath, "utf-8")) as DeltaFixture
+    const missingCategory = JSON.parse(JSON.stringify(fixture)) as DeltaFixture
+    const missingEntry = JSON.parse(JSON.stringify(fixture)) as DeltaFixture
+
+    delete missingCategory.categories.intended_extension_points
+    missingEntry.categories.intended_extension_points = getCategoryEntries(
+      missingEntry,
+      "intended_extension_points"
+    ).filter((entry) => entry.id !== "explicit-plugin-array-registration")
+
+    expect(() => getCategoryEntries(missingCategory, "intended_extension_points")).toThrow(
+      "Delta fixture is missing the 'intended_extension_points' category."
+    )
+    expect(() =>
+      requireDeltaEntry(
+        missingEntry,
+        "intended_extension_points",
+        "explicit-plugin-array-registration"
+      )
+    ).toThrow(
+      "Delta fixture category 'intended_extension_points' is missing required entry 'explicit-plugin-array-registration'."
+    )
+  })
+})

--- a/src/custom-opencode/tls-certificate-retry.test.ts
+++ b/src/custom-opencode/tls-certificate-retry.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from "bun:test"
+
+import {
+  RETRY_DELAY_MS,
+  createTlsCertificateRetryRuntime as createTlsCertificateRetryRuntimeUntyped,
+} from "../../assets/custom-opencode/plugins/tls-certificate-retry.js"
+
+type RetryHook = (...args: any[]) => Promise<void>
+
+type RetrySignal =
+  | {
+      state: "retrying"
+      attempt: number
+      message: string
+      next: number
+    }
+  | {
+      state: "failed"
+      error: unknown
+      hardProviderBlock: boolean
+    }
+
+type RetryRuntime = {
+  hooks: Record<string, RetryHook>
+  getSessionRetryState: (sessionID: string) => any
+}
+
+type ScheduledTimer = {
+  id: number
+  delay: number
+  callback: () => unknown
+}
+
+const createTlsCertificateRetryRuntime = createTlsCertificateRetryRuntimeUntyped as (options: Record<string, unknown>) => RetryRuntime
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+
+  return {
+    promise,
+    resolve,
+    reject,
+  }
+}
+
+function createTimerController() {
+  let nextID = 1
+  const activeTimers = new Map<number, ScheduledTimer>()
+  const getActiveTimers = () => Array.from(activeTimers.values())
+
+  return {
+    setTimeoutFn(callback: () => unknown, delay: number) {
+      const timer = {
+        id: nextID++,
+        delay,
+        callback,
+      }
+
+      activeTimers.set(timer.id, timer)
+      return timer.id as unknown as ReturnType<typeof setTimeout>
+    },
+
+    clearTimeoutFn(timerID: ReturnType<typeof setTimeout>) {
+      activeTimers.delete(timerID as unknown as number)
+    },
+
+    getActiveTimers,
+
+    runNext() {
+      const timer = getActiveTimers()[0]
+
+      if (!timer) {
+        throw new Error("No active timer to run")
+      }
+
+      activeTimers.delete(timer.id)
+      return Promise.resolve(timer.callback())
+    },
+  }
+}
+
+function createMockClient({
+  promptAsyncImpl,
+  sessionMessages,
+}: {
+  promptAsyncImpl?: (payload: Record<string, unknown>) => Promise<unknown>
+  sessionMessages?: unknown[]
+} = {}) {
+  const toasts: Array<Record<string, unknown>> = []
+  const logs: Array<Record<string, unknown>> = []
+  const promptCalls: Array<Record<string, unknown>> = []
+
+  return {
+    client: {
+      tui: {
+        showToast: async ({ body }: { body: Record<string, unknown> }) => {
+          toasts.push(body)
+          return true
+        },
+      },
+      app: {
+        log: async ({ body }: { body: Record<string, unknown> }) => {
+          logs.push(body)
+          return true
+        },
+      },
+      session: {
+        messages: async () => ({
+          data: sessionMessages ?? [],
+        }),
+        promptAsync: async (payload: Record<string, unknown>) => {
+          promptCalls.push(payload)
+
+          if (promptAsyncImpl) {
+            return promptAsyncImpl(payload)
+          }
+
+          return true
+        },
+      },
+    },
+    logs,
+    promptCalls,
+    toasts,
+  }
+}
+
+function createRuntime(options: {
+  now?: () => number
+  onStateChange?: (sessionID: string, signal: RetrySignal) => Promise<void>
+  promptAsyncImpl?: (payload: Record<string, unknown>) => Promise<unknown>
+  sessionMessages?: unknown[]
+} = {}) {
+  const timers = createTimerController()
+  const mock = createMockClient({
+    promptAsyncImpl: options.promptAsyncImpl,
+    sessionMessages: options.sessionMessages,
+  })
+
+  const runtime = createTlsCertificateRetryRuntime({
+    client: mock.client,
+    directory: "E:/projects/ohmyopencode/oh-my-openagent",
+    now: options.now ?? (() => 10_000),
+    onStateChange: options.onStateChange,
+    setTimeoutFn: timers.setTimeoutFn,
+    clearTimeoutFn: timers.clearTimeoutFn,
+  })
+
+  return {
+    ...mock,
+    hooks: runtime.hooks,
+    runtime,
+    timers,
+  }
+}
+
+describe("tls certificate retry plugin", () => {
+  it("schedules one retry for retryable TLS failures and re-dispatches the last user payload", async () => {
+    const signals: RetrySignal[] = []
+    const { hooks, promptCalls, runtime, timers } = createRuntime({
+      onStateChange: async (_sessionID, signal) => {
+        signals.push(signal)
+      },
+    })
+
+    await hooks["chat.message"]?.(
+      {
+        sessionID: "ses_tls",
+        agent: "atlas",
+        variant: "xhigh",
+        model: {
+          providerID: "openai",
+          modelID: "gpt-5.4",
+        },
+      },
+      {
+        message: {
+          role: "user",
+          system: "Focus on retry behavior.",
+          tools: [{ id: "read" }],
+        },
+        parts: [{ type: "text", text: "Retry this request if TLS fails." }],
+      },
+    )
+
+    await hooks.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_tls",
+          error: {
+            message: "unknown certificate verification error",
+          },
+        },
+      },
+    })
+
+    expect(timers.getActiveTimers()).toHaveLength(1)
+    expect(timers.getActiveTimers()[0]?.delay).toBe(RETRY_DELAY_MS)
+    expect(runtime.getSessionRetryState("ses_tls")).toMatchObject({
+      state: "retrying",
+      attempt: 1,
+      scheduled: true,
+      payloadCached: true,
+    })
+    expect(signals).toEqual([
+      {
+        state: "retrying",
+        attempt: 1,
+        message: "unknown certificate verification error",
+        next: 10_000 + RETRY_DELAY_MS,
+      },
+    ])
+
+    await timers.runNext()
+
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0]).toMatchObject({
+      path: { id: "ses_tls" },
+      query: { directory: "E:/projects/ohmyopencode/oh-my-openagent" },
+      body: {
+        agent: "atlas",
+        variant: "xhigh",
+        system: "Focus on retry behavior.",
+        tools: [{ id: "read" }],
+        model: {
+          providerID: "openai",
+          modelID: "gpt-5.4",
+        },
+        parts: [{ type: "text", text: "Retry this request if TLS fails." }],
+      },
+    })
+    expect(runtime.getSessionRetryState("ses_tls")).toMatchObject({
+      state: "retrying",
+      attempt: 1,
+      scheduled: false,
+      dispatchInFlight: false,
+    })
+  })
+
+  it("prevents duplicate timer scheduling and duplicate dispatch on repeated connectivity errors", async () => {
+    const signals: RetrySignal[] = []
+    const dispatchDeferred = createDeferred<unknown>()
+    const { hooks, promptCalls, timers } = createRuntime({
+      onStateChange: async (_sessionID, signal) => {
+        signals.push(signal)
+      },
+      promptAsyncImpl: async () => dispatchDeferred.promise,
+    })
+
+    await hooks["chat.message"]?.(
+      {
+        sessionID: "ses_dedupe",
+        agent: "sisyphus",
+      },
+      {
+        message: { role: "user" },
+        parts: [{ type: "text", text: "Keep my last payload cached." }],
+      },
+    )
+
+    const retryableErrorEvent = {
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_dedupe",
+          error: {
+            message: "socket hang up",
+          },
+        },
+      },
+    }
+
+    await hooks.event?.(retryableErrorEvent)
+    await hooks.event?.(retryableErrorEvent)
+
+    expect(timers.getActiveTimers()).toHaveLength(1)
+    expect(signals.filter((signal) => signal.state === "retrying")).toHaveLength(1)
+
+    const retryDispatch = timers.runNext()
+
+    expect(promptCalls).toHaveLength(1)
+
+    await hooks.event?.(retryableErrorEvent)
+
+    expect(timers.getActiveTimers()).toHaveLength(0)
+    expect(promptCalls).toHaveLength(1)
+
+    dispatchDeferred.resolve(true)
+    await retryDispatch
+
+    expect(promptCalls).toHaveLength(1)
+  })
+
+  it("stops automatic retry immediately on a hard provider block", async () => {
+    const signals: RetrySignal[] = []
+    const { hooks, promptCalls, runtime, timers } = createRuntime({
+      onStateChange: async (_sessionID, signal) => {
+        signals.push(signal)
+      },
+    })
+
+    await hooks["chat.message"]?.(
+      {
+        sessionID: "ses_blocked",
+        agent: "prometheus",
+      },
+      {
+        message: { role: "user" },
+        parts: [{ type: "text", text: "Retry only if the network is flaky." }],
+      },
+    )
+
+    await hooks.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_blocked",
+          error: {
+            message: "network error: unable to connect",
+          },
+        },
+      },
+    })
+
+    expect(timers.getActiveTimers()).toHaveLength(1)
+
+    await hooks.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_blocked",
+          error: {
+            statusCode: 403,
+            message: "Blocked by a gateway or proxy. Check your account and provider settings.",
+          },
+        },
+      },
+    })
+
+    expect(timers.getActiveTimers()).toHaveLength(0)
+    expect(promptCalls).toHaveLength(0)
+    expect(runtime.getSessionRetryState("ses_blocked")).toMatchObject({
+      state: "failed",
+      hardProviderBlock: true,
+      scheduled: false,
+    })
+    expect(signals.at(-1)).toMatchObject({
+      state: "failed",
+      hardProviderBlock: true,
+    })
+
+    await hooks.event?.({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID: "ses_blocked",
+          error: {
+            message: "socket hang up",
+          },
+        },
+      },
+    })
+
+    expect(timers.getActiveTimers()).toHaveLength(0)
+    expect(promptCalls).toHaveLength(0)
+  })
+})

--- a/src/features/mcp-oauth/discovery.ts
+++ b/src/features/mcp-oauth/discovery.ts
@@ -5,6 +5,10 @@ export interface OAuthServerMetadata {
   resource: string
 }
 
+type MetadataFetchResult =
+  | { ok: true; json: Record<string, unknown> }
+  | { ok: false; status: number }
+
 const discoveryCache = new Map<string, OAuthServerMetadata>()
 const pendingDiscovery = new Map<string, Promise<OAuthServerMetadata>>()
 
@@ -24,7 +28,7 @@ function readStringField(source: Record<string, unknown>, field: string): string
   return value
 }
 
-async function fetchMetadata(url: string): Promise<{ ok: true; json: Record<string, unknown> } | { ok: false; status: number }> {
+async function fetchMetadata(url: string): Promise<MetadataFetchResult> {
   const response = await fetch(url, { headers: { accept: "application/json" } })
   if (!response.ok) {
     return { ok: false, status: response.status }
@@ -65,7 +69,7 @@ async function fetchAuthorizationServerMetadata(issuer: string, resource: string
   const metadataUrl = new URL(`/.well-known/oauth-authorization-server${issuerPath}`, issuerUrl).toString()
   const metadata = await fetchMetadata(metadataUrl)
 
-  if (!metadata.ok) {
+  if (metadata.ok === false) {
     if (metadata.status === 404 && issuerPath !== "") {
       const rootMetadataUrl = new URL("/.well-known/oauth-authorization-server", issuerUrl).toString()
       const rootMetadata = await fetchMetadata(rootMetadataUrl)
@@ -110,7 +114,7 @@ export async function discoverOAuthServerMetadata(resource: string): Promise<OAu
       return fetchAuthorizationServerMetadata(authServers[0], resource)
     }
 
-    if (prmResponse.status !== 404) {
+    if (prmResponse.ok === false && prmResponse.status !== 404) {
       throw new Error(`OAuth protected resource metadata fetch failed (${prmResponse.status})`)
     }
 

--- a/test/fixtures/local-config-delta/current-local-delta.json
+++ b/test/fixtures/local-config-delta/current-local-delta.json
@@ -1,0 +1,243 @@
+{
+  "audit_scope": "inventory-only",
+  "evidence": {
+    "local_host_config": "C:\\Users\\RedFox\\.config\\opencode\\opencode.json",
+    "local_plugin_config": "C:\\Users\\RedFox\\.config\\opencode\\oh-my-opencode.json",
+    "local_plugins": [
+      "C:\\Users\\RedFox\\.config\\opencode\\plugins\\heartbeat-status.js",
+      "C:\\Users\\RedFox\\.config\\opencode\\plugins\\tls-certificate-retry.js"
+    ],
+    "installed_schema": "C:\\Users\\RedFox\\.config\\opencode\\node_modules\\oh-my-openagent\\dist\\oh-my-opencode.schema.json",
+    "repo_references": [
+      "src/plugin-config.ts",
+      "src/shared/jsonc-parser.ts",
+      "src/cli/config-manager/add-plugin-to-opencode-config.ts",
+      "docs/guide/installation.md",
+      "docs/reference/configuration.md"
+    ]
+  },
+  "categories": {
+    "config_only_deltas": [
+      {
+        "id": "host-default-agent-prometheus",
+        "summary": "Local OpenCode host config sets default_agent = prometheus.",
+        "evidence": {
+          "file": "C:\\Users\\RedFox\\.config\\opencode\\opencode.json",
+          "path": "default_agent",
+          "value": "prometheus"
+        }
+      },
+      {
+        "id": "agent-category-model-pinning-openai-gpt-5-4",
+        "summary": "Configured local agents and categories pin to openai/gpt-5.4 with variant xhigh and textVerbosity high.",
+        "evidence": {
+          "file": "C:\\Users\\RedFox\\.config\\opencode\\oh-my-opencode.json",
+          "model": "openai/gpt-5.4",
+          "variant": "xhigh",
+          "textVerbosity": "high",
+          "agents": [
+            "sisyphus",
+            "hephaestus",
+            "oracle",
+            "librarian",
+            "explore",
+            "multimodal-looker",
+            "prometheus",
+            "metis",
+            "momus",
+            "atlas",
+            "sisyphus-junior"
+          ],
+          "categories": [
+            "visual-engineering",
+            "ultrabrain",
+            "deep",
+            "artistry",
+            "quick",
+            "unspecified-low",
+            "unspecified-high",
+            "writing"
+          ]
+        }
+      },
+      {
+        "id": "prompt-append-additions",
+        "summary": "Local config adds custom prompt_append text for selected execution/planning agents.",
+        "evidence": {
+          "file": "C:\\Users\\RedFox\\.config\\opencode\\oh-my-opencode.json",
+          "agents": [
+            "sisyphus",
+            "hephaestus",
+            "prometheus",
+            "atlas",
+            "sisyphus-junior"
+          ]
+        }
+      },
+      {
+        "id": "supported-runtime-knob-differences",
+        "summary": "Local config changes supported runtime knobs beyond the upstream baseline.",
+        "evidence": {
+          "file": "C:\\Users\\RedFox\\.config\\opencode\\oh-my-opencode.json",
+          "required_knobs": [
+            {
+              "path": "hashline_edit",
+              "value": true
+            },
+            {
+              "path": "background_task.staleTimeoutMs",
+              "value": 600000
+            },
+            {
+              "path": "babysitting.timeout_ms",
+              "value": 300000
+            },
+            {
+              "path": "model_capabilities.refresh_timeout_ms",
+              "value": 10000
+            },
+            {
+              "path": "experimental.auto_resume",
+              "value": true
+            },
+            {
+              "path": "notification.force_enable",
+              "value": true
+            }
+          ],
+          "adjacent_supported_keys": [
+            "background_task.defaultConcurrency",
+            "background_task.providerConcurrency.openai",
+            "background_task.modelConcurrency.openai/gpt-5.4",
+            "model_capabilities.enabled",
+            "model_capabilities.auto_refresh_on_start",
+            "experimental.task_system",
+            "sisyphus_agent.planner_enabled",
+            "sisyphus_agent.replace_plan",
+            "sisyphus_agent.default_builder_enabled"
+          ]
+        }
+      }
+    ],
+    "plugin_code_deltas": [
+      {
+        "id": "heartbeat-status-plugin",
+        "summary": "Custom heartbeat plugin tracks tool/message activity, todo summaries, retry/error state, and provider blocks before emitting status toasts/logs.",
+        "evidence": {
+          "file": "C:\\Users\\RedFox\\.config\\opencode\\plugins\\heartbeat-status.js",
+          "status_modes": [
+            "busy",
+            "retry",
+            "idle"
+          ],
+          "notable_signals": [
+            "tool activity",
+            "message updates",
+            "todo.updated",
+            "session.error hard-block detection"
+          ]
+        }
+      },
+      {
+        "id": "tls-certificate-retry-plugin",
+        "summary": "Custom TLS retry plugin reconstructs the last user payload, retries retryable certificate/connectivity failures after 60 seconds, and stops on hard provider blocks.",
+        "evidence": {
+          "file": "C:\\Users\\RedFox\\.config\\opencode\\plugins\\tls-certificate-retry.js",
+          "retry_delay_ms": 60000,
+          "guardrails": [
+            "retryable certificate/connectivity patterns only",
+            "single scheduled retry timer per session",
+            "hard 403 provider/account/proxy blocks stop auto-retry"
+          ]
+        }
+      }
+    ],
+    "intended_extension_points": [
+      {
+        "id": "schema-supported-agent-and-runtime-overrides",
+        "summary": "Installed schema supports agent/category overrides, prompt_append, and the audited runtime knobs.",
+        "evidence": {
+          "file": "C:\\Users\\RedFox\\.config\\opencode\\node_modules\\oh-my-openagent\\dist\\oh-my-opencode.schema.json",
+          "supported_paths": [
+            "agents.*.model",
+            "agents.*.variant",
+            "agents.*.textVerbosity",
+            "agents.*.prompt_append",
+            "categories.*.model",
+            "categories.*.variant",
+            "categories.*.textVerbosity",
+            "hashline_edit",
+            "background_task.staleTimeoutMs",
+            "babysitting.timeout_ms",
+            "model_capabilities.refresh_timeout_ms",
+            "experimental.auto_resume",
+            "notification.force_enable"
+          ]
+        }
+      },
+      {
+        "id": "config-merge-semantics",
+        "summary": "User config loads before project config; agents/categories deep-merge and disabled arrays union.",
+        "evidence": {
+          "file": "src/plugin-config.ts",
+          "merge_rules": [
+            "user config first",
+            "project config overrides second",
+            "agents deepMerge",
+            "categories deepMerge",
+            "disabled_* arrays union"
+          ]
+        }
+      },
+      {
+        "id": "explicit-plugin-array-registration",
+        "summary": "OpenCode host config expects explicit plugin array registration and normalizes canonical versus legacy entries.",
+        "evidence": {
+          "file": "src/cli/config-manager/add-plugin-to-opencode-config.ts",
+          "preferred_entry": "oh-my-openagent",
+          "legacy_entry": "oh-my-opencode"
+        }
+      },
+      {
+        "id": "legacy-alias-basename-compatibility",
+        "summary": "Legacy oh-my-opencode alias/basename handling remains compatibility behavior and should not be treated as drift.",
+        "evidence": {
+          "file": "src/shared/jsonc-parser.ts",
+          "detection_order": [
+            "oh-my-opencode",
+            "oh-my-openagent"
+          ]
+        }
+      }
+    ],
+    "suspicious_runtime_drift": [
+      {
+        "id": "missing-visible-plugin-registration",
+        "summary": "The inspected local opencode.json has no plugin array entry, so the active plugin load path is not visible in the host config.",
+        "evidence": {
+          "file": "C:\\Users\\RedFox\\.config\\opencode\\opencode.json",
+          "observed_keys": [
+            "$schema",
+            "default_agent"
+          ],
+          "missing_key": "plugin"
+        }
+      },
+      {
+        "id": "unsupported-sisyphus-tasks-enabled",
+        "summary": "Local config sets sisyphus.tasks.enabled even though the installed schema does not allow that property.",
+        "evidence": {
+          "config_file": "C:\\Users\\RedFox\\.config\\opencode\\oh-my-opencode.json",
+          "schema_file": "C:\\Users\\RedFox\\.config\\opencode\\node_modules\\oh-my-openagent\\dist\\oh-my-opencode.schema.json",
+          "unsupported_path": "sisyphus.tasks.enabled",
+          "allowed_paths": [
+            "sisyphus.tasks.storage_path",
+            "sisyphus.tasks.task_list_id",
+            "sisyphus.tasks.claude_code_compat"
+          ],
+          "observed_value": true
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a managed custom OpenCode layer for local parity, including repo-owned config assets, sync/refresh workflow, and fork-specific operator docs
- port the local heartbeat progress and guarded TLS retry plugins into versioned assets with focused regression coverage
- tighten doctor and compatibility checks so wrapper-file plugin registration, refresh verification, and managed config drift are explicitly tested

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a managed OpenCode local-parity workflow with repo-owned config assets and a refresh/sync process to keep `~/.config/opencode` in sync. Ports heartbeat progress and TLS certificate retry plugins with tests, and tightens doctor checks and fork docs for phase‑1 compatibility.

- **New Features**
  - Repo-managed asset tree under `assets/custom-opencode` with host config (`opencode.json`), plugin config (`oh-my-opencode.json`), and wrapper plugin (`plugins/oh-my-openagent.js`).
  - Refresh script (`refresh-omo.ps1`) to install/sync assets to the user config dir with backups, logs, and verification; Bun sync entry point (`script/sync-custom-opencode-assets.ts`).
  - Ported `heartbeat-status` and `tls-certificate-retry` plugins into versioned assets with focused unit and integration tests.
  - Doctor suite adds checks for managed assets, refresh verification, wrapper-file registration, config precedence, and alias compatibility.
  - Fork docs for phase‑1 compatibility contract, install/refresh steps, and local vs upstream delta audit.

- **Bug Fixes**
  - Doctor now accepts wrapper-file plugin registration that points to `oh-my-openagent`/`oh-my-opencode` in the OpenCode `plugin` array.

<sup>Written for commit b86a8c5f724628d61096994263d552b7cb4f366c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

