### PR TITLE
fix(skill-loader): include directory in skill discovery cache key (fixes #2687)

### DIFF
--- a/src/features/opencode-skill-loader/skill-discovery.ts
+++ b/src/features/opencode-skill-loader/skill-discovery.ts
@@ -10,7 +10,7 @@ export function clearSkillCache(): void {
 }
 
 export async function getAllSkills(options?: SkillResolutionOptions): Promise<LoadedSkill[]> {
-	const cacheKey = options?.browserProvider ?? "playwright"
+	const cacheKey = `${options?.browserProvider ?? "playwright"}:${options?.directory ?? ""}`
 	const hasDisabledSkills = options?.disabledSkills && options.disabledSkills.size > 0
 
 	// Skip cache if disabledSkills is provided (varies between calls)


### PR DESCRIPTION
## Summary
- Include `directory` in skill discovery cache key to prevent stale cached skills from being returned for different project directories.

## Problem
`getAllSkills()` in `skill-discovery.ts` uses only `browserProvider` as the cache key. When a task delegates to a subagent with project-level skills in a different directory, the cached result from a previous call (without that directory) is returned instead of discovering skills from the specified project directory.

## Fix
Changed the cache key from `browserProvider` alone to `browserProvider:directory`, so skills are cached separately per directory context.

## Changes
| File | Change |
|------|--------|
| `src/features/opencode-skill-loader/skill-discovery.ts` | Include `directory` in cache key construction |

Fixes #2687

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the project directory in the skill discovery cache key to prevent stale skills when switching directories. The key changes from browser provider only to provider:directory, scoping results per directory (fixes #2687).

<sup>Written for commit 80396db4c6712b0948435cfaa3d85eb5a9179271. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

