### PR TITLE
fix(tools): register mcp_ prefixed aliases for background tools (fixes #2697)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -48,9 +48,13 @@ export { createHashlineEditTool } from "./hashline-edit"
 export function createBackgroundTools(manager: BackgroundManager, client: OpencodeClient): Record<string, ToolDefinition> {
   const outputManager: BackgroundOutputManager = manager
   const cancelClient: BackgroundCancelClient = client
+  const backgroundOutput = createBackgroundOutput(outputManager, client)
+  const backgroundCancel = createBackgroundCancel(manager, cancelClient)
   return {
-    background_output: createBackgroundOutput(outputManager, client),
-    background_cancel: createBackgroundCancel(manager, cancelClient),
+    background_output: backgroundOutput,
+    background_cancel: backgroundCancel,
+    mcp_background_output: backgroundOutput,
+    mcp_background_cancel: backgroundCancel,
   }
 }
 


### PR DESCRIPTION
## Summary
- Register `mcp_background_output` and `mcp_background_cancel` as aliases for the existing background tools.

## Problem
OpenCode adds the `mcp_` prefix to plugin tool names when presenting them to the model. However, the plugin only registers `background_output` and `background_cancel` in the tool registry. When the model calls `mcp_background_output`, OpenCode can't find a matching tool, causing background task result collection to fail 100% of the time.

## Fix
Register both the original names and `mcp_`-prefixed aliases pointing to the same tool definitions. No duplication -- both names reference the same tool instance.

## Changes
| File | Change |
|------|--------|
| `src/tools/index.ts` | Add `mcp_background_output` and `mcp_background_cancel` aliases |

Fixes #2697

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `mcp_`-prefixed aliases for background tools so OpenCode can resolve them, restoring background task result collection. Fixes #2697.

- **Bug Fixes**
  - Register `mcp_background_output` and `mcp_background_cancel` as aliases to `background_output` and `background_cancel`, reusing the same tool instances.

<sup>Written for commit 5a5b63aa125f3cc7d648628193f7353fd0f1d05d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

