### PR TITLE
fix(anthropic-effort): skip effort=max for internal agent messages (fixes #2632)

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -1,4 +1,5 @@
 import { log, normalizeModelID } from "../../shared"
+import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker"
 
 const OPUS_PATTERN = /claude-.*opus/i
 const INTERNAL_SKIP_AGENTS = new Set(["title", "summary", "compaction"])
@@ -25,6 +26,26 @@ interface ChatParamsInput {
   model: { providerID: string; modelID: string }
   provider: { id: string }
   message: { variant?: string }
+  rawMessage?: Record<string, unknown>
+}
+
+function isInternalAgentMessage(rawMessage: Record<string, unknown> | undefined): boolean {
+  if (!rawMessage) return false
+  const content = rawMessage.content
+  if (typeof content === "string") {
+    return content.includes(OMO_INTERNAL_INITIATOR_MARKER)
+  }
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (typeof part === "object" && part !== null && "text" in part) {
+        const textPart = part as Record<string, unknown>
+        if (typeof textPart.text === "string" && textPart.text.includes(OMO_INTERNAL_INITIATOR_MARKER)) {
+          return true
+        }
+      }
+    }
+  }
+  return false
 }
 
 interface ChatParamsOutput {
@@ -54,11 +75,12 @@ export function createAnthropicEffortHook() {
       input: ChatParamsInput,
       output: ChatParamsOutput
     ): Promise<void> => {
-      const { agent, model, message } = input
+      const { agent, model, message, rawMessage } = input
       if (!model?.modelID || !model?.providerID) return
       if (message.variant !== "max") return
       if (!isClaudeProvider(model.providerID, model.modelID)) return
       if (shouldSkipForInternalAgent(agent?.name)) return
+      if (isInternalAgentMessage(rawMessage)) return
       if (output.options.effort !== undefined) return
 
       const opus = isOpusModel(model.modelID)


### PR DESCRIPTION
## Summary
- Skip applying `effort=max` for internal agent-originated messages to prevent unnecessary Copilot premium request consumption.

## Problem
The `anthropic-effort` hook applies `effort=max` to all Claude Opus messages with `variant="max"`, without checking whether the message was initiated by the user or by an internal agent (e.g., Prometheus delegating to Momus via `task()`). Internal agent prompts are marked with `OMO_INTERNAL_INITIATOR_MARKER` but the hook never checks for it. This causes internal orchestration messages to consume Copilot premium requests.

## Fix
Added `isInternalAgentMessage()` check that inspects `rawMessage.content` for the `OMO_INTERNAL_INITIATOR_MARKER`. This follows the same pattern used in `chat-headers.ts` for detecting internal messages. The `rawMessage` is already passed through `ChatParamsHookInput` from `chat-params.ts`.

## Changes
| File | Change |
|------|--------|
| `src/hooks/anthropic-effort/hook.ts` | Import marker, add `rawMessage` to interface, add `isInternalAgentMessage()` guard |

Fixes #2632

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip applying effort=max to internal agent-originated Claude requests to avoid using Copilot premium on orchestration prompts. Detects internal messages via an initiator marker so effort is only set for user-initiated messages.

- **Bug Fixes**
  - Added isInternalAgentMessage(rawMessage) that checks for OMO_INTERNAL_INITIATOR_MARKER in string and array content.
  - Early-return in the effort hook for internal messages, keeping existing provider/model/agent guards intact.

<sup>Written for commit 231bc99d5b049597ab7b474908572b4e3d99b099. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

