### PR TITLE
fix(cli): add librarian agent fallback when OpenCode Go and Z.ai unavailable (fixes #2658)

### DIFF
--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -74,6 +74,9 @@ exports[`generateModelConfig single native provider uses Claude models when only
     "explore": {
       "model": "anthropic/claude-haiku-4-5",
     },
+    "librarian": {
+      "model": "anthropic/claude-haiku-4-5",
+    },
     "metis": {
       "model": "anthropic/claude-opus-4-6",
       "variant": "max",
@@ -134,6 +137,9 @@ exports[`generateModelConfig single native provider uses Claude models with isMa
       "model": "anthropic/claude-sonnet-4-6",
     },
     "explore": {
+      "model": "anthropic/claude-haiku-4-5",
+    },
+    "librarian": {
       "model": "anthropic/claude-haiku-4-5",
     },
     "metis": {
@@ -493,6 +499,9 @@ exports[`generateModelConfig all native providers uses preferred models from fal
       "model": "openai/gpt-5.4",
       "variant": "medium",
     },
+    "librarian": {
+      "model": "anthropic/claude-haiku-4-5",
+    },
     "metis": {
       "model": "anthropic/claude-opus-4-6",
       "variant": "max",
@@ -567,6 +576,9 @@ exports[`generateModelConfig all native providers uses preferred models with isM
     "hephaestus": {
       "model": "openai/gpt-5.4",
       "variant": "medium",
+    },
+    "librarian": {
+      "model": "anthropic/claude-haiku-4-5",
     },
     "metis": {
       "model": "anthropic/claude-opus-4-6",
@@ -795,6 +807,9 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
       "model": "github-copilot/gpt-5.4",
       "variant": "medium",
     },
+    "librarian": {
+      "model": "github-copilot/gpt-5-mini",
+    },
     "metis": {
       "model": "github-copilot/claude-opus-4.6",
       "variant": "max",
@@ -864,6 +879,9 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
     "hephaestus": {
       "model": "github-copilot/gpt-5.4",
       "variant": "medium",
+    },
+    "librarian": {
+      "model": "github-copilot/gpt-5-mini",
     },
     "metis": {
       "model": "github-copilot/claude-opus-4.6",
@@ -1052,6 +1070,9 @@ exports[`generateModelConfig mixed provider scenarios uses Claude + OpenCode Zen
       "model": "opencode/gpt-5.4",
       "variant": "medium",
     },
+    "librarian": {
+      "model": "anthropic/claude-haiku-4-5",
+    },
     "metis": {
       "model": "anthropic/claude-opus-4-6",
       "variant": "max",
@@ -1126,6 +1147,9 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
     "hephaestus": {
       "model": "openai/gpt-5.4",
       "variant": "medium",
+    },
+    "librarian": {
+      "model": "github-copilot/gpt-5-mini",
     },
     "metis": {
       "model": "github-copilot/claude-opus-4.6",
@@ -1260,6 +1284,9 @@ exports[`generateModelConfig mixed provider scenarios uses Gemini + Claude combi
       "model": "anthropic/claude-sonnet-4-6",
     },
     "explore": {
+      "model": "anthropic/claude-haiku-4-5",
+    },
+    "librarian": {
       "model": "anthropic/claude-haiku-4-5",
     },
     "metis": {

--- a/src/cli/model-fallback.test.ts
+++ b/src/cli/model-fallback.test.ts
@@ -537,15 +537,15 @@ describe("generateModelConfig", () => {
       expect(result.agents?.librarian?.model).toBe("zai-coding-plan/glm-4.7")
     })
 
-    test("librarian is omitted when no librarian provider matches", () => {
+    test("librarian falls back to Claude when no dedicated provider matches", () => {
       // #given only Claude is available (no opencode-go or ZAI)
       const config = createConfig({ hasClaude: true })
 
       // #when generateModelConfig is called
       const result = generateModelConfig(config)
 
-      // #then librarian should be omitted when its dedicated providers are unavailable
-      expect(result.agents?.librarian).toBeUndefined()
+      // #then librarian should fall back to claude-haiku
+      expect(result.agents?.librarian?.model).toBe("anthropic/claude-haiku-4-5")
     })
   })
 

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -58,6 +58,12 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
         agents[role] = { model: "opencode-go/minimax-m2.7" }
       } else if (avail.zai) {
         agents[role] = { model: ZAI_MODEL }
+      } else if (avail.native.claude) {
+        agents[role] = { model: "anthropic/claude-haiku-4-5" }
+      } else if (avail.copilot) {
+        agents[role] = { model: "github-copilot/gpt-5-mini" }
+      } else if (avail.native.openai) {
+        agents[role] = { model: "openai/gpt-5.4-mini" }
       }
       continue
     }


### PR DESCRIPTION
## Summary
- Add fallback model assignment for the librarian agent when neither OpenCode Go nor Z.ai providers are available.

## Problem
The CLI install logic for the librarian agent only assigns a model when OpenCode Go or Z.ai is available. If both are unavailable, the librarian agent is silently omitted from the config, causing it to fall through to the hardcoded fallback chain starting with `opencode-go/minimax-m2.5` which requires OpenCode billing.

Every other agent (explore, oracle, etc.) has a full fallback chain. Librarian was the only one silently dropped.

## Fix
Added fallback providers for librarian matching the pattern used by other agents: Claude -> Copilot -> OpenAI.

## Changes
| File | Change |
|------|--------|
| `src/cli/model-fallback.ts` | Add Claude/Copilot/OpenAI fallback for librarian |
| `src/cli/model-fallback.test.ts` | Update test: librarian now falls back to claude-haiku instead of being omitted |

Fixes #2658

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a proper fallback for the librarian CLI agent when OpenCode Go and Z.ai are unavailable, preventing the agent from being dropped during install. The librarian now falls back to `anthropic/claude-haiku-4-5` → `github-copilot/gpt-5-mini` → `openai/gpt-5.4-mini`.

- **Bug Fixes**
  - Added fallback logic in `src/cli/model-fallback.ts` to align librarian with other agents.
  - Updated unit tests and snapshots to expect `anthropic/claude-haiku-4-5` when only Claude is available.

<sup>Written for commit bbfec58017fe89538c8f85210ef6a0c9ceef6285. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

