### PR TITLE
fix: finish u49 canonical contract and y87 OMO stabilization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,39 +40,44 @@ OhMyOpenCodePlugin(ctx)
 
 ## 8 OPENCODE HOOK HANDLERS
 
-| Handler | Purpose |
-|---------|---------|
-| `config` | 6-phase: provider → plugin-components → agents → tools → MCPs → commands |
-| `tool` | 26 registered tools |
-| `chat.message` | First-message variant, session setup, keyword detection |
-| `chat.params` | Anthropic effort level adjustment |
-| `chat.headers` | Copilot x-initiator header injection |
-| `event` | Session lifecycle (created, deleted, idle, error) |
-| `tool.execute.before` | Pre-tool hooks (file guard, label truncator, rules injector) |
-| `tool.execute.after` | Post-tool hooks (output truncation, metadata store) |
-| `experimental.chat.messages.transform` | Context injection, thinking block validation |
+| Handler                                | Purpose                                                                  |
+| -------------------------------------- | ------------------------------------------------------------------------ |
+| `config`                               | 6-phase: provider → plugin-components → agents → tools → MCPs → commands |
+| `tool`                                 | 26 registered tools                                                      |
+| `chat.message`                         | First-message variant, session setup, keyword detection                  |
+| `chat.params`                          | Anthropic effort level adjustment                                        |
+| `chat.headers`                         | Copilot x-initiator header injection                                     |
+| `event`                                | Session lifecycle (created, deleted, idle, error)                        |
+| `tool.execute.before`                  | Pre-tool hooks (file guard, label truncator, rules injector)             |
+| `tool.execute.after`                   | Post-tool hooks (output truncation, metadata store)                      |
+| `experimental.chat.messages.transform` | Context injection, thinking block validation                             |
 
 ## WHERE TO LOOK
 
-| Task | Location | Notes |
-|------|----------|-------|
-| Add new agent | `src/agents/` + `src/agents/builtin-agents/` | Follow createXXXAgent factory pattern |
-| Add new hook | `src/hooks/{name}/` + register in `src/plugin/hooks/create-*-hooks.ts` | Match event type to tier |
-| Add new tool | `src/tools/{name}/` + register in `src/plugin/tool-registry.ts` | Follow createXXXTool factory |
-| Add new feature module | `src/features/{name}/` | Standalone module, wire in plugin/ |
-| Add new MCP | `src/mcp/` + register in `createBuiltinMcps()` | Remote HTTP only |
-| Add new skill | `src/features/builtin-skills/skills/` | Implement BuiltinSkill interface |
-| Add new command | `src/features/builtin-commands/` | Template in templates/ |
-| Add new CLI command | `src/cli/cli-program.ts` | Commander.js subcommand |
-| Add new doctor check | `src/cli/doctor/checks/` | Register in checks/index.ts |
-| Modify config schema | `src/config/schema/` + update root schema | Zod v4, add to OhMyOpenCodeConfigSchema |
-| Add new category | `src/tools/delegate-task/constants.ts` | DEFAULT_CATEGORIES + CATEGORY_MODEL_REQUIREMENTS |
+| Task                   | Location                                                               | Notes                                            |
+| ---------------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| Add new agent          | `src/agents/` + `src/agents/builtin-agents/`                           | Follow createXXXAgent factory pattern            |
+| Add new hook           | `src/hooks/{name}/` + register in `src/plugin/hooks/create-*-hooks.ts` | Match event type to tier                         |
+| Add new tool           | `src/tools/{name}/` + register in `src/plugin/tool-registry.ts`        | Follow createXXXTool factory                     |
+| Add new feature module | `src/features/{name}/`                                                 | Standalone module, wire in plugin/               |
+| Add new MCP            | `src/mcp/` + register in `createBuiltinMcps()`                         | Remote HTTP only                                 |
+| Add new skill          | `src/features/builtin-skills/skills/`                                  | Implement BuiltinSkill interface                 |
+| Add new command        | `src/features/builtin-commands/`                                       | Template in templates/                           |
+| Add new CLI command    | `src/cli/cli-program.ts`                                               | Commander.js subcommand                          |
+| Add new doctor check   | `src/cli/doctor/checks/`                                               | Register in checks/index.ts                      |
+| Modify config schema   | `src/config/schema/` + update root schema                              | Zod v4, add to OhMyOpenCodeConfigSchema          |
+| Add new category       | `src/tools/delegate-task/constants.ts`                                 | DEFAULT_CATEGORIES + CATEGORY_MODEL_REQUIREMENTS |
 
 ## MULTI-LEVEL CONFIG
 
 ```
-Project (.opencode/oh-my-opencode.jsonc)  →  User (~/.config/opencode/oh-my-opencode.jsonc)  →  Defaults
+Project (.opencode/oh-my-openagent.jsonc or legacy .opencode/oh-my-opencode.jsonc)
+  → User (~/.config/opencode/oh-my-openagent.jsonc or legacy ~/.config/opencode/oh-my-opencode.jsonc)
+  → Defaults
 ```
+
+- Per-directory precedence: `oh-my-openagent.jsonc` → `oh-my-openagent.json` → `oh-my-opencode.jsonc` → `oh-my-opencode.json`
+- Project config overrides user config after each layer resolves its winning file
 
 - `agents`, `categories`, `claude_code`: deep merged recursively
 - `disabled_*` arrays: Set union (concatenated + deduplicated)
@@ -80,15 +85,15 @@ Project (.opencode/oh-my-opencode.jsonc)  →  User (~/.config/opencode/oh-my-op
 - Zod `safeParse()` fills defaults for omitted fields
 - `migrateConfigFile()` transforms legacy keys automatically
 
-Fields: agents (14 overridable, 21 fields each), categories (8 built-in + custom), disabled_* arrays (agents, hooks, mcps, skills, commands, tools), 19 feature-specific configs.
+Fields: agents (14 overridable, 21 fields each), categories (8 built-in + custom), disabled\_\* arrays (agents, hooks, mcps, skills, commands, tools), 19 feature-specific configs.
 
 ## THREE-TIER MCP SYSTEM
 
-| Tier | Source | Mechanism |
-|------|--------|-----------|
-| Built-in | `src/mcp/` | 3 remote HTTP: websearch (Exa/Tavily), context7, grep_app |
-| Claude Code | `.mcp.json` | `${VAR}` env expansion via claude-code-mcp-loader |
-| Skill-embedded | SKILL.md YAML | Managed by SkillMcpManager (stdio + HTTP) |
+| Tier           | Source        | Mechanism                                                 |
+| -------------- | ------------- | --------------------------------------------------------- |
+| Built-in       | `src/mcp/`    | 3 remote HTTP: websearch (Exa/Tavily), context7, grep_app |
+| Claude Code    | `.mcp.json`   | `${VAR}` env expansion via claude-code-mcp-loader         |
+| Skill-embedded | SKILL.md YAML | Managed by SkillMcpManager (stdio + HTTP)                 |
 
 ## CONVENTIONS
 
@@ -135,14 +140,14 @@ bunx oh-my-opencode run     # Non-interactive session
 
 ## CI/CD
 
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| ci.yml | push/PR to master/dev | Tests (split: mock-heavy isolated + batch), typecheck, build, schema auto-commit |
-| publish.yml | manual dispatch | Version bump, npm publish, platform binaries, GitHub release, merge to master |
-| publish-platform.yml | called by publish | 12 platform binaries via bun compile (darwin/linux/windows) |
-| sisyphus-agent.yml | @mention / dispatch | AI agent handles issues/PRs |
-| cla.yml | issue_comment/PR | CLA assistant for contributors |
-| lint-workflows.yml | push to .github/ | actionlint + shellcheck on workflow files |
+| Workflow             | Trigger               | Purpose                                                                          |
+| -------------------- | --------------------- | -------------------------------------------------------------------------------- |
+| ci.yml               | push/PR to master/dev | Tests (split: mock-heavy isolated + batch), typecheck, build, schema auto-commit |
+| publish.yml          | manual dispatch       | Version bump, npm publish, platform binaries, GitHub release, merge to master    |
+| publish-platform.yml | called by publish     | 12 platform binaries via bun compile (darwin/linux/windows)                      |
+| sisyphus-agent.yml   | @mention / dispatch   | AI agent handles issues/PRs                                                      |
+| cla.yml              | issue_comment/PR      | CLA assistant for contributors                                                   |
+| lint-workflows.yml   | push to .github/      | actionlint + shellcheck on workflow files                                        |
 
 ## NOTES
 

--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -4885,6 +4885,11 @@
       "additionalProperties": false
     },
     "git_master": {
+      "default": {
+        "commit_footer": true,
+        "include_co_authored_by": true,
+        "git_env_prefix": "GIT_MASTER=1"
+      },
       "type": "object",
       "properties": {
         "commit_footer": {
@@ -5035,5 +5040,6 @@
       }
     }
   },
+  "required": [],
   "additionalProperties": false
 }

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -26,7 +26,7 @@ Follow the prompts to configure your Claude, ChatGPT, and Gemini subscriptions. 
 
 After you install it, you can read this [overview guide](./overview.md) to understand more.
 
-The published package and local binary are still `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`, while legacy `oh-my-opencode` entries still load with a warning. Plugin config loading recognizes both `oh-my-openagent.json[c]` and `oh-my-opencode.json[c]` during the transition. If you see a "Using legacy package name" warning from `bunx oh-my-opencode doctor`, update your `opencode.json` plugin entry from `"oh-my-opencode"` to `"oh-my-openagent"`.
+The published package and local binary are still `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`, while legacy `oh-my-opencode` entries still load with a warning. The canonical plugin config filename is now `oh-my-openagent.jsonc`; legacy `oh-my-opencode.json[c]` files remain readable for compatibility, but they no longer win when a canonical file exists. If you see a "Using legacy package name" warning from `bunx oh-my-opencode doctor`, update your `opencode.json` plugin entry from `"oh-my-opencode"` to `"oh-my-openagent"`.
 
 ## For LLM Agents
 
@@ -115,6 +115,7 @@ bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --gemini=<yes|no> -
 The CLI will:
 
 - Register the plugin in `opencode.json`
+- Write or update the canonical OMO config file at `~/.config/opencode/oh-my-openagent.jsonc` (or the equivalent `OPENCODE_CONFIG_DIR` location)
 - Configure agent models based on subscription flags
 - Show which auth steps are needed
 
@@ -124,6 +125,7 @@ The CLI will:
 opencode --version  # Should be 1.0.150 or higher
 cat ~/.config/opencode/opencode.json  # Should contain "oh-my-openagent" in plugin array, or the legacy "oh-my-opencode" entry while you are still migrating
 ```
+
 #### Run Doctor Verification
 
 After installation, verify everything is working correctly:
@@ -167,7 +169,7 @@ Read the [opencode-antigravity-auth documentation](https://github.com/NoeFabris/
 
 ##### Plugin config model override
 
-The `opencode-antigravity-auth` plugin uses different model names than the built-in Google auth. Override the agent models in your plugin config file. Existing installs still commonly use `oh-my-opencode.json` or `.opencode/oh-my-opencode.json`, while the compatibility layer also recognizes `oh-my-openagent.json[c]`.
+The `opencode-antigravity-auth` plugin uses different model names than the built-in Google auth. Override the agent models in your plugin config file. Use the canonical config filename `oh-my-openagent.jsonc`; legacy `oh-my-opencode.json[c]` files are still recognized for compatibility during migration.
 
 ```json
 {
@@ -214,12 +216,12 @@ GitHub Copilot is supported as a **fallback provider** when native providers are
 
 When GitHub Copilot is the best available provider, install-time defaults are agent-specific. Common examples are:
 
-| Agent         | Model                              |
-| ------------- | ---------------------------------- |
-| **Sisyphus**  | `github-copilot/claude-opus-4.6`   |
-| **Oracle**    | `github-copilot/gpt-5.4`           |
-| **Explore**   | `github-copilot/gpt-5-mini`        |
-| **Atlas**     | `github-copilot/claude-sonnet-4.6` |
+| Agent        | Model                              |
+| ------------ | ---------------------------------- |
+| **Sisyphus** | `github-copilot/claude-opus-4.6`   |
+| **Oracle**   | `github-copilot/gpt-5.4`           |
+| **Explore**  | `github-copilot/gpt-5-mini`        |
+| **Atlas**    | `github-copilot/claude-sonnet-4.6` |
 
 GitHub Copilot acts as a proxy provider, routing requests to underlying models based on your subscription. Some agents, like Librarian, are not installed from Copilot alone and instead rely on other configured providers or runtime fallback behavior.
 
@@ -242,11 +244,11 @@ OpenCode Zen provides access to `opencode/` prefixed models including `opencode/
 
 When OpenCode Zen is the best available provider, these are the most relevant source-backed examples:
 
-| Agent         | Model                                                |
-| ------------- | ---------------------------------------------------- |
-| **Sisyphus**  | `opencode/claude-opus-4-6`                           |
-| **Oracle**    | `opencode/gpt-5.4`                                   |
-| **Explore**   | `opencode/claude-haiku-4-5`                          |
+| Agent        | Model                       |
+| ------------ | --------------------------- |
+| **Sisyphus** | `opencode/claude-opus-4-6`  |
+| **Oracle**   | `opencode/gpt-5.4`          |
+| **Explore**  | `opencode/claude-haiku-4-5` |
 
 ##### Setup
 
@@ -293,29 +295,29 @@ Not all models behave the same way. Understanding which models are "similar" hel
 
 **GPT Models** (explicit reasoning, principle-driven):
 
-| Model             | Provider(s)                      | Notes                                             |
-| ----------------- | -------------------------------- | ------------------------------------------------- |
+| Model             | Provider(s)                      | Notes                                                                             |
+| ----------------- | -------------------------------- | --------------------------------------------------------------------------------- |
 | **GPT-5.3-codex** | openai, github-copilot, opencode | Deep coding powerhouse. Still available for deep category and explicit overrides. |
-| **GPT-5.4**       | openai, github-copilot, opencode | High intelligence. Default for Oracle.            |
-| **GPT-5.4 Mini**  | openai, github-copilot, opencode | Fast + strong reasoning. Default for quick category.     |
-| **GPT-5-Nano**    | opencode                         | Ultra-cheap, fast. Good for simple utility tasks. |
+| **GPT-5.4**       | openai, github-copilot, opencode | High intelligence. Default for Oracle.                                            |
+| **GPT-5.4 Mini**  | openai, github-copilot, opencode | Fast + strong reasoning. Default for quick category.                              |
+| **GPT-5-Nano**    | opencode                         | Ultra-cheap, fast. Good for simple utility tasks.                                 |
 
 **Different-Behavior Models**:
 
-| Model                 | Provider(s)                      | Notes                                                       |
-| --------------------- | -------------------------------- | ----------------------------------------------------------- |
-| **Gemini 3.1 Pro**    | google, github-copilot, opencode | Excels at visual/frontend tasks. Different reasoning style. |
-| **Gemini 3 Flash**    | google, github-copilot, opencode | Fast, good for doc search and light tasks.                  |
-| **MiniMax M2.7**      | venice, opencode-go              | Fast and smart. Good for utility tasks where the provider catalog exposes M2.7. |
-| **MiniMax M2.5**      | opencode                         | Legacy OpenCode catalog entry still used in some fallback chains for compatibility. |
+| Model              | Provider(s)                      | Notes                                                                               |
+| ------------------ | -------------------------------- | ----------------------------------------------------------------------------------- |
+| **Gemini 3.1 Pro** | google, github-copilot, opencode | Excels at visual/frontend tasks. Different reasoning style.                         |
+| **Gemini 3 Flash** | google, github-copilot, opencode | Fast, good for doc search and light tasks.                                          |
+| **MiniMax M2.7**   | venice, opencode-go              | Fast and smart. Good for utility tasks where the provider catalog exposes M2.7.     |
+| **MiniMax M2.5**   | opencode                         | Legacy OpenCode catalog entry still used in some fallback chains for compatibility. |
 
 **Speed-Focused Models**:
 
-| Model                   | Provider(s)            | Speed          | Notes                                                                                                                                         |
-| ----------------------- | ---------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Grok Code Fast 1**    | github-copilot, venice | Very fast      | Optimized for code grep/search. Default for Explore.                                                                                          |
-| **Claude Haiku 4.5**    | anthropic, opencode    | Fast           | Good balance of speed and intelligence.                                                                                                       |
-| **MiniMax M2.5**          | opencode            | Very fast      | Legacy OpenCode catalog entry that still appears in some utility fallback chains.                                                            |
+| Model                   | Provider(s)            | Speed          | Notes                                                                                                                                          |
+| ----------------------- | ---------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Grok Code Fast 1**    | github-copilot, venice | Very fast      | Optimized for code grep/search. Default for Explore.                                                                                           |
+| **Claude Haiku 4.5**    | anthropic, opencode    | Fast           | Good balance of speed and intelligence.                                                                                                        |
+| **MiniMax M2.5**        | opencode               | Very fast      | Legacy OpenCode catalog entry that still appears in some utility fallback chains.                                                              |
 | **GPT-5.3-codex-spark** | openai                 | Extremely fast | Blazing fast but compacts so aggressively that oh-my-openagent's context management doesn't work well with it. Not recommended for omo agents. |
 
 #### What Each Agent Does and Which Model It Got
@@ -324,10 +326,10 @@ Based on your subscriptions, here's how the agents were configured:
 
 **Claude-Optimized Agents** (prompts tuned for Claude-family models):
 
-| Agent        | Role             | Default Chain                                   | What It Does                                                                             |
-| ------------ | ---------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Agent        | Role             | Default Chain                                                                                 | What It Does                                                                                                                          |
+| ------------ | ---------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | **Sisyphus** | Main ultraworker | Opus (max) → OpenCode Go Kimi K2.5 → K2P5 → Kimi K2.5 → GPT-5.4 (medium) → GLM 5 → Big Pickle | Primary coding agent. Orchestrates everything. Claude-family models are still preferred, but GPT-5.4 now has a dedicated prompt path. |
-| **Metis**    | Plan review      | Opus (max) → GPT-5.4 (high) → GLM 5 → K2P5 | Reviews Prometheus plans for gaps.                                                       |
+| **Metis**    | Plan review      | Opus (max) → GPT-5.4 (high) → GLM 5 → K2P5                                                    | Reviews Prometheus plans for gaps.                                                                                                    |
 
 **Dual-Prompt Agents** (auto-switch between Claude and GPT prompts):
 
@@ -335,28 +337,28 @@ These agents detect your model family at runtime and switch to the appropriate p
 
 Priority: **Claude > GPT > Claude-like models**
 
-| Agent          | Role              | Default Chain                                              | GPT Prompt?                                                      |
-| -------------- | ----------------- | ---------------------------------------------------------- | ---------------------------------------------------------------- |
-| **Prometheus** | Strategic planner | Opus (max) → **GPT-5.4 (high)** → GLM 5 → Gemini 3.1 Pro | Yes — XML-tagged, principle-driven (~300 lines vs ~1,100 Claude) |
+| Agent          | Role              | Default Chain                                                       | GPT Prompt?                                                      |
+| -------------- | ----------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **Prometheus** | Strategic planner | Opus (max) → **GPT-5.4 (high)** → GLM 5 → Gemini 3.1 Pro            | Yes — XML-tagged, principle-driven (~300 lines vs ~1,100 Claude) |
 | **Atlas**      | Todo orchestrator | **Claude Sonnet 4.6** → Kimi K2.5 → GPT-5.4 (medium) → MiniMax M2.7 | Yes - GPT-optimized todo management                              |
 
 **GPT-Native Agents** (built for GPT, don't override to Claude):
 
-| Agent          | Role                   | Default Chain                          | Notes                                                  |
-| -------------- | ---------------------- | -------------------------------------- | ------------------------------------------------------ |
-| **Hephaestus** | Deep autonomous worker | GPT-5.4 (medium) only                  | "Codex on steroids." No fallback. Requires GPT access. |
-| **Oracle**     | Architecture/debugging | GPT-5.4 (high) → Gemini 3.1 Pro (high) → Opus (max) → GLM 5 | High-IQ strategic backup. GPT preferred.               |
+| Agent          | Role                   | Default Chain                                                | Notes                                                  |
+| -------------- | ---------------------- | ------------------------------------------------------------ | ------------------------------------------------------ |
+| **Hephaestus** | Deep autonomous worker | GPT-5.4 (medium) only                                        | "Codex on steroids." No fallback. Requires GPT access. |
+| **Oracle**     | Architecture/debugging | GPT-5.4 (high) → Gemini 3.1 Pro (high) → Opus (max) → GLM 5  | High-IQ strategic backup. GPT preferred.               |
 | **Momus**      | High-accuracy reviewer | GPT-5.4 (xhigh) → Opus (max) → Gemini 3.1 Pro (high) → GLM 5 | Verification agent. GPT preferred.                     |
 
 **Utility Agents** (speed over intelligence):
 
 These agents do search, grep, and retrieval. They intentionally use fast, cheap models. **Don't "upgrade" them to Opus — it wastes tokens on simple tasks.**
 
-| Agent                 | Role               | Default Chain                                                          | Design Rationale                                               |
-| --------------------- | ------------------ | ---------------------------------------------------------------------- | -------------------------------------------------------------- |
-| **Explore**           | Fast codebase grep | Grok Code Fast → OpenCode Go MiniMax M2.7 → OpenCode MiniMax M2.5 → Haiku → GPT-5-Nano | Speed is everything. Grok is blazing fast for grep.            |
-| **Librarian**         | Docs/code search   | OpenCode Go MiniMax M2.7 → OpenCode MiniMax M2.5 → Haiku → GPT-5-Nano                   | Doc retrieval doesn't need deep reasoning. MiniMax is fast where the provider catalog supports it.    |
-| **Multimodal Looker** | Vision/screenshots | GPT-5.4 (medium) → Kimi K2.5 → GLM-4.6v → GPT-5-Nano | GPT-5.4 now leads the default vision path when available. |
+| Agent                 | Role               | Default Chain                                                                          | Design Rationale                                                                                   |
+| --------------------- | ------------------ | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **Explore**           | Fast codebase grep | Grok Code Fast → OpenCode Go MiniMax M2.7 → OpenCode MiniMax M2.5 → Haiku → GPT-5-Nano | Speed is everything. Grok is blazing fast for grep.                                                |
+| **Librarian**         | Docs/code search   | OpenCode Go MiniMax M2.7 → OpenCode MiniMax M2.5 → Haiku → GPT-5-Nano                  | Doc retrieval doesn't need deep reasoning. MiniMax is fast where the provider catalog supports it. |
+| **Multimodal Looker** | Vision/screenshots | GPT-5.4 (medium) → Kimi K2.5 → GLM-4.6v → GPT-5-Nano                                   | GPT-5.4 now leads the default vision path when available.                                          |
 
 #### Why Different Models Need Different Prompts
 
@@ -375,7 +377,7 @@ This is why Prometheus and Atlas ship separate prompts per model family — they
 
 #### Custom Model Configuration
 
-If the user wants to override which model an agent uses, you can customize in your plugin config file. Existing installs still commonly use `oh-my-opencode.json`, while the compatibility layer also recognizes `oh-my-openagent.json[c]`.
+If the user wants to override which model an agent uses, customize the canonical plugin config file `oh-my-openagent.jsonc`. Legacy `oh-my-opencode.json[c]` files remain readable during migration, but canonical files are now authoritative.
 
 ```jsonc
 {

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -115,7 +115,7 @@ bunx oh-my-opencode install --no-tui --claude=<yes|no|max20> --gemini=<yes|no> -
 The CLI will:
 
 - Register the plugin in `opencode.json`
-- Write or update the canonical OMO config file at `~/.config/opencode/oh-my-openagent.jsonc` (or the equivalent `OPENCODE_CONFIG_DIR` location)
+- Write or update the canonical OMO config using the `oh-my-openagent` basename, preferring `oh-my-openagent.jsonc` for new installs and preserving an existing canonical `.json` file during migration
 - Configure agent models based on subscription flags
 - Show which auth steps are needed
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -324,11 +324,11 @@ bunx oh-my-opencode refresh-model-capabilities
 
 ### Options
 
-| Option               | Description                                          |
-| -------------------- | ---------------------------------------------------- |
-| `-d, --directory`    | Working directory to read oh-my-opencode config from |
-| `--source-url <url>` | Override the models.dev source URL                   |
-| `--json`             | Output refresh summary as JSON                       |
+| Option               | Description                                  |
+| -------------------- | -------------------------------------------- |
+| `-d, --directory`    | Working directory to read plugin config from |
+| `--source-url <url>` | Override the models.dev source URL           |
+| `--json`             | Output refresh summary as JSON               |
 
 ### Configuration
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,15 +14,15 @@ npx oh-my-opencode
 
 ## Commands
 
-| Command                       | Description                                            |
-| ----------------------------- | ------------------------------------------------------ |
-| `install`                     | Interactive setup wizard                               |
-| `doctor`                      | Environment diagnostics and health checks              |
-| `run`                         | OpenCode session runner with task completion enforcement |
-| `get-local-version`           | Display local version information and update check     |
-| `refresh-model-capabilities`  | Refresh the cached models.dev-based model capabilities |
-| `version`                     | Show version information                               |
-| `mcp oauth`                   | MCP OAuth authentication management                    |
+| Command                      | Description                                              |
+| ---------------------------- | -------------------------------------------------------- |
+| `install`                    | Interactive setup wizard                                 |
+| `doctor`                     | Environment diagnostics and health checks                |
+| `run`                        | OpenCode session runner with task completion enforcement |
+| `get-local-version`          | Display local version information and update check       |
+| `refresh-model-capabilities` | Refresh the cached models.dev-based model capabilities   |
+| `version`                    | Show version information                                 |
+| `mcp oauth`                  | MCP OAuth authentication management                      |
 
 ---
 
@@ -40,23 +40,23 @@ bunx oh-my-opencode install
 
 1. **Subscription Selection**: Choose which providers and subscriptions you actually have
 2. **Plugin Registration**: Registers `oh-my-openagent` in OpenCode settings, or upgrades a legacy `oh-my-opencode` entry during the compatibility window
-3. **Configuration File Creation**: Writes the generated OmO config to `oh-my-opencode.json` in the active OpenCode config directory
+3. **Configuration File Creation**: Writes the generated OmO config to the canonical `oh-my-openagent.jsonc` path in the active OpenCode config directory (or preserves an existing canonical `.json` file)
 4. **Authentication Hints**: Shows the `opencode auth login` steps for the providers you selected, unless `--skip-auth` is set
 
 ### Options
 
-| Option | Description |
-| ------ | ----------- |
-| `--no-tui` | Run in non-interactive mode without TUI |
-| `--claude <no\|yes\|max20>` | Claude subscription mode |
-| `--openai <no\|yes>` | OpenAI / ChatGPT subscription |
-| `--gemini <no\|yes>` | Gemini integration |
-| `--copilot <no\|yes>` | GitHub Copilot subscription |
-| `--opencode-zen <no\|yes>` | OpenCode Zen access |
-| `--zai-coding-plan <no\|yes>` | Z.ai Coding Plan subscription |
-| `--kimi-for-coding <no\|yes>` | Kimi for Coding subscription |
-| `--opencode-go <no\|yes>` | OpenCode Go subscription |
-| `--skip-auth` | Skip authentication setup hints |
+| Option                        | Description                             |
+| ----------------------------- | --------------------------------------- |
+| `--no-tui`                    | Run in non-interactive mode without TUI |
+| `--claude <no\|yes\|max20>`   | Claude subscription mode                |
+| `--openai <no\|yes>`          | OpenAI / ChatGPT subscription           |
+| `--gemini <no\|yes>`          | Gemini integration                      |
+| `--copilot <no\|yes>`         | GitHub Copilot subscription             |
+| `--opencode-zen <no\|yes>`    | OpenCode Zen access                     |
+| `--zai-coding-plan <no\|yes>` | Z.ai Coding Plan subscription           |
+| `--kimi-for-coding <no\|yes>` | Kimi for Coding subscription            |
+| `--opencode-go <no\|yes>`     | OpenCode Go subscription                |
+| `--skip-auth`                 | Skip authentication setup hints         |
 
 ---
 
@@ -65,10 +65,12 @@ bunx oh-my-opencode install
 Diagnoses your environment to ensure Oh My OpenCode is functioning correctly. The current checks are grouped into system, config, tools, and models.
 
 The doctor command detects common issues including:
+
 - Legacy plugin entry references in `opencode.json` (warns when `oh-my-opencode` is still used instead of `oh-my-openagent`)
 - Configuration file validity and JSONC parsing errors
 - Model resolution and fallback chain verification
 - Missing or misconfigured MCP servers
+
 ### Usage
 
 ```bash
@@ -77,20 +79,20 @@ bunx oh-my-opencode doctor
 
 ### Diagnostic Categories
 
-| Category          | Check Items                                                                          |
-| ----------------- | ------------------------------------------------------------------------------------ |
-| **System**        | OpenCode binary, version (>= 1.0.150), plugin registration, legacy package name warning |
-| **Config**        | Configuration file validity, JSONC parsing, Zod schema validation                    |
-| **Tools**         | AST-Grep, LSP servers, GitHub CLI, MCP servers                                       |
-| **Models**        | Model capabilities cache, model resolution, agent/category overrides, availability   |
+| Category   | Check Items                                                                             |
+| ---------- | --------------------------------------------------------------------------------------- |
+| **System** | OpenCode binary, version (>= 1.0.150), plugin registration, legacy package name warning |
+| **Config** | Configuration file validity, JSONC parsing, Zod schema validation                       |
+| **Tools**  | AST-Grep, LSP servers, GitHub CLI, MCP servers                                          |
+| **Models** | Model capabilities cache, model resolution, agent/category overrides, availability      |
 
 ### Options
 
-| Option       | Description                               |
-| ------------ | ----------------------------------------- |
-| `--status`   | Show compact system dashboard             |
-| `--verbose`  | Show detailed diagnostic information      |
-| `--json`     | Output results in JSON format             |
+| Option      | Description                          |
+| ----------- | ------------------------------------ |
+| `--status`  | Show compact system dashboard        |
+| `--verbose` | Show detailed diagnostic information |
+| `--json`    | Output results in JSON format        |
 
 ### Example Output
 
@@ -106,7 +108,7 @@ System
   ✓ Plugin registered in opencode.json
 
 Config
-  ✓ oh-my-opencode.jsonc is valid
+  ✓ oh-my-openagent.jsonc is valid
   ✓ Model resolution: all agents have valid fallback chains
   ⚠ categories.visual-engineering: using default model
 
@@ -120,6 +122,7 @@ Models
 
 Summary: 10 passed, 1 warning, 0 failed
 ```
+
 ---
 
 ## run
@@ -134,18 +137,18 @@ bunx oh-my-opencode run <message>
 
 ### Options
 
-| Option                | Description                                                         |
-| --------------------- | ------------------------------------------------------------------- |
-| `-a, --agent <name>`  | Agent to use (default: from CLI/env/config, fallback: Sisyphus)     |
-| `-m, --model <provider/model>` | Model override (e.g., anthropic/claude-sonnet-4)             |
-| `-d, --directory <path>` | Working directory                                                |
-| `-p, --port <port>`  | Server port (attaches if port already in use)                       |
-| `--attach <url>`      | Attach to existing opencode server URL                              |
-| `--on-complete <command>` | Shell command to run after completion                          |
-| `--json`              | Output structured JSON result to stdout                             |
-| `--no-timestamp`      | Disable timestamp prefix in run output                              |
-| `--verbose`           | Show full event stream (default: messages/tools only)               |
-| `--session-id <id>`   | Resume existing session instead of creating new one                 |
+| Option                         | Description                                                     |
+| ------------------------------ | --------------------------------------------------------------- |
+| `-a, --agent <name>`           | Agent to use (default: from CLI/env/config, fallback: Sisyphus) |
+| `-m, --model <provider/model>` | Model override (e.g., anthropic/claude-sonnet-4)                |
+| `-d, --directory <path>`       | Working directory                                               |
+| `-p, --port <port>`            | Server port (attaches if port already in use)                   |
+| `--attach <url>`               | Attach to existing opencode server URL                          |
+| `--on-complete <command>`      | Shell command to run after completion                           |
+| `--json`                       | Output structured JSON result to stdout                         |
+| `--no-timestamp`               | Disable timestamp prefix in run output                          |
+| `--verbose`                    | Show full event stream (default: messages/tools only)           |
+| `--session-id <id>`            | Resume existing session instead of creating new one             |
 
 ---
 
@@ -161,14 +164,15 @@ bunx oh-my-opencode get-local-version
 
 ### Options
 
-| Option            | Description                                    |
-| ----------------- | ---------------------------------------------- |
-| `-d, --directory` | Working directory to check config from         |
-| `--json`          | Output in JSON format for scripting            |
+| Option            | Description                            |
+| ----------------- | -------------------------------------- |
+| `-d, --directory` | Working directory to check config from |
+| `--json`          | Output in JSON format for scripting    |
 
 ### Output
 
 Shows:
+
 - Current installed version
 - Latest available version on npm
 - Whether you're up to date
@@ -231,11 +235,12 @@ The runtime loads user config as the base config, then merges project config on 
 1. **Project Level**: `.opencode/oh-my-openagent.jsonc`, `.opencode/oh-my-openagent.json`, `.opencode/oh-my-opencode.jsonc`, or `.opencode/oh-my-opencode.json`
 2. **User Level**: `~/.config/opencode/oh-my-openagent.jsonc`, `~/.config/opencode/oh-my-openagent.json`, `~/.config/opencode/oh-my-opencode.jsonc`, or `~/.config/opencode/oh-my-opencode.json`
 
-**Naming Note**: The published package and binary are still `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`. Plugin config loading recognizes both `oh-my-openagent.*` and legacy `oh-my-opencode.*` basenames. If both basenames exist in the same directory, the legacy `oh-my-opencode.*` file currently wins.
+**Naming Note**: The published package and binary are still `oh-my-opencode`. Inside `opencode.json`, the compatibility layer now prefers the plugin entry `oh-my-openagent`. Plugin config loading recognizes both `oh-my-openagent.*` and legacy `oh-my-opencode.*` basenames. If both basenames exist in the same directory, the canonical `oh-my-openagent.*` file wins.
 
 ### Filename Compatibility
 
 Both `.jsonc` and `.json` extensions are supported. JSONC (JSON with Comments) is preferred as it allows:
+
 - Comments (both `//` and `/* */` styles)
 - Trailing commas in arrays and objects
 
@@ -304,6 +309,7 @@ The doctor warns if it finds the legacy plugin entry `oh-my-opencode` in `openco
 jq '.plugin = (.plugin // [] | map(if . == "oh-my-opencode" then "oh-my-openagent" else . end))' \
   ~/.config/opencode/opencode.json > /tmp/opencode.json && mv /tmp/opencode.json ~/.config/opencode/opencode.json
 ```
+
 ---
 
 ## refresh-model-capabilities
@@ -318,11 +324,11 @@ bunx oh-my-opencode refresh-model-capabilities
 
 ### Options
 
-| Option            | Description                                         |
-| ----------------- | --------------------------------------------------- |
-| `-d, --directory` | Working directory to read oh-my-opencode config from |
-| `--source-url <url>` | Override the models.dev source URL               |
-| `--json`          | Output refresh summary as JSON                      |
+| Option               | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| `-d, --directory`    | Working directory to read oh-my-opencode config from |
+| `--source-url <url>` | Override the models.dev source URL                   |
+| `--json`             | Output refresh summary as JSON                       |
 
 ### Configuration
 
@@ -334,8 +340,8 @@ Configure automatic refresh behavior in your plugin config:
     "enabled": true,
     "auto_refresh_on_start": true,
     "refresh_timeout_ms": 5000,
-    "source_url": "https://models.dev/api.json"
-  }
+    "source_url": "https://models.dev/api.json",
+  },
 }
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -43,17 +43,24 @@ Complete reference for Oh My OpenCode plugin configuration. During the rename tr
 
 ### File Locations
 
-User config is loaded first, then project config overrides it. In each directory, the compatibility layer recognizes both the renamed and legacy basenames.
+User config is loaded first, then project config overrides it. In each directory, the compatibility layer recognizes both the canonical and legacy basenames.
 
 1. Project config: `.opencode/oh-my-openagent.json[c]` or `.opencode/oh-my-opencode.json[c]`
 2. User config (`.jsonc` preferred over `.json`):
 
-| Platform    | Path candidates |
-| ----------- | --------------- |
+| Platform    | Path candidates                                                                           |
+| ----------- | ----------------------------------------------------------------------------------------- |
 | macOS/Linux | `~/.config/opencode/oh-my-openagent.json[c]`, `~/.config/opencode/oh-my-opencode.json[c]` |
 | Windows     | `%APPDATA%\opencode\oh-my-openagent.json[c]`, `%APPDATA%\opencode\oh-my-opencode.json[c]` |
 
-**Rename compatibility:** The published package and CLI binary remain `oh-my-opencode`. OpenCode plugin registration prefers `oh-my-openagent`, while legacy `oh-my-opencode` entries and config basenames still load during the transition. Config detection checks `oh-my-opencode` before `oh-my-openagent`, so if both plugin config basenames exist in the same directory, the legacy `oh-my-opencode.*` file currently wins.
+**Canonical contract:** The published package and CLI binary remain `oh-my-opencode`, but the canonical plugin config filename is `oh-my-openagent.jsonc`.
+
+- Per directory precedence is `oh-my-openagent.jsonc` → `oh-my-openagent.json` → `oh-my-opencode.jsonc` → `oh-my-opencode.json`
+- If canonical and legacy config files coexist, the canonical file wins
+- Legacy `oh-my-opencode.*` files and plain `.json` files remain compatibility inputs during the transition
+- Project config still overrides user config after each layer resolves its winning file
+
+If you run `bunx oh-my-opencode install`, the installer writes the canonical config path and keeps legacy files readable for compatibility.
 JSONC supports `// line comments`, `/* block comments */`, and trailing commas.
 
 Enable schema autocomplete:
@@ -163,26 +170,26 @@ Core agents receive an injected runtime `order` field for deterministic Tab cycl
 
 #### Agent Options
 
-| Option            | Type           | Description                                                     |
-| ----------------- | -------------- | --------------------------------------------------------------- |
-| `model`           | string         | Model override (`provider/model`)                               |
-| `fallback_models` | string\|array  | Fallback models on API errors. Supports strings or mixed arrays of strings and object entries with per-model settings |
-| `temperature`     | number         | Sampling temperature                                            |
-| `top_p`           | number         | Top-p sampling                                                  |
-| `prompt`          | string         | Replace system prompt. Supports `file://` URIs                  |
-| `prompt_append`   | string         | Append to system prompt. Supports `file://` URIs                |
-| `tools`           | array         | Allowed tools list                                     |
-| `disable`         | boolean       | Disable this agent                                     |
-| `mode`            | string        | Agent mode                                             |
-| `color`           | string        | UI color                                               |
-| `permission`      | object        | Per-tool permissions (see below)                       |
-| `category`        | string        | Inherit model from category                            |
-| `variant`         | string        | Model variant: `max`, `high`, `medium`, `low`, `xhigh`. Normalized to supported values |
-| `maxTokens`       | number        | Max response tokens                                    |
-| `thinking`        | object        | Anthropic extended thinking                            |
-| `reasoningEffort` | string        | OpenAI reasoning: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`. Normalized to supported values |
-| `textVerbosity`   | string        | Text verbosity: `low`, `medium`, `high`                |
-| `providerOptions` | object        | Provider-specific options                              |
+| Option            | Type          | Description                                                                                                           |
+| ----------------- | ------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `model`           | string        | Model override (`provider/model`)                                                                                     |
+| `fallback_models` | string\|array | Fallback models on API errors. Supports strings or mixed arrays of strings and object entries with per-model settings |
+| `temperature`     | number        | Sampling temperature                                                                                                  |
+| `top_p`           | number        | Top-p sampling                                                                                                        |
+| `prompt`          | string        | Replace system prompt. Supports `file://` URIs                                                                        |
+| `prompt_append`   | string        | Append to system prompt. Supports `file://` URIs                                                                      |
+| `tools`           | array         | Allowed tools list                                                                                                    |
+| `disable`         | boolean       | Disable this agent                                                                                                    |
+| `mode`            | string        | Agent mode                                                                                                            |
+| `color`           | string        | UI color                                                                                                              |
+| `permission`      | object        | Per-tool permissions (see below)                                                                                      |
+| `category`        | string        | Inherit model from category                                                                                           |
+| `variant`         | string        | Model variant: `max`, `high`, `medium`, `low`, `xhigh`. Normalized to supported values                                |
+| `maxTokens`       | number        | Max response tokens                                                                                                   |
+| `thinking`        | object        | Anthropic extended thinking                                                                                           |
+| `reasoningEffort` | string        | OpenAI reasoning: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`. Normalized to supported values                 |
+| `textVerbosity`   | string        | Text verbosity: `low`, `medium`, `high`                                                                               |
+| `providerOptions` | object        | Provider-specific options                                                                                             |
 
 #### Anthropic Extended Thinking
 
@@ -220,7 +227,6 @@ Control what tools an agent can use:
 | `doom_loop`          | `ask` / `allow` / `deny`                                                    |
 | `external_directory` | `ask` / `allow` / `deny`                                                    |
 
-
 #### Fallback Models with Per-Model Settings
 
 `fallback_models` accepts either a single model string or an array. Array entries can be plain strings or objects with individual model settings:
@@ -237,15 +243,15 @@ Control what tools an agent can use:
         {
           "model": "google/gemini-3.1-pro",
           "variant": "high",
-          "temperature": 0.2
+          "temperature": 0.2,
         },
         {
           "model": "anthropic/claude-sonnet-4-6",
-          "thinking": { "type": "enabled", "budgetTokens": 64000 }
-        }
-      ]
-    }
-  }
+          "thinking": { "type": "enabled", "budgetTokens": 64000 },
+        },
+      ],
+    },
+  },
 }
 ```
 
@@ -259,21 +265,21 @@ Both `prompt` and `prompt_append` support loading content from files via `file:/
 {
   "agents": {
     "sisyphus": {
-      "prompt_append": "file:///absolute/path/to/prompt.txt"
+      "prompt_append": "file:///absolute/path/to/prompt.txt",
     },
     "oracle": {
-      "prompt": "file://./relative/to/project/prompt.md"
+      "prompt": "file://./relative/to/project/prompt.md",
     },
     "explore": {
-      "prompt_append": "file://~/home/dir/prompt.txt"
-    }
+      "prompt_append": "file://~/home/dir/prompt.txt",
+    },
   },
   "categories": {
     "custom": {
       "model": "anthropic/claude-sonnet-4-6",
-      "prompt_append": "file://./category-context.md"
-    }
-  }
+      "prompt_append": "file://./category-context.md",
+    },
+  },
 }
 ```
 
@@ -285,36 +291,36 @@ Domain-specific model delegation used by the `task()` tool. When Sisyphus delega
 
 #### Built-in Categories
 
-| Category             | Default Model                   | Description                                    |
-| -------------------- | ------------------------------- | ---------------------------------------------- |
-| `visual-engineering` | `google/gemini-3.1-pro` (high)  | Frontend, UI/UX, design, animation             |
-| `ultrabrain`         | `openai/gpt-5.4` (xhigh)        | Deep logical reasoning, complex architecture   |
-| `deep`               | `openai/gpt-5.3-codex` (medium) | Autonomous problem-solving, thorough research  |
-| `artistry`           | `google/gemini-3.1-pro` (high)  | Creative/unconventional approaches             |
-| `quick`              | `openai/gpt-5.4-mini`           | Trivial tasks, typo fixes, single-file changes |
-| `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | General tasks, low effort                      |
-| `unspecified-high`   | `anthropic/claude-opus-4-6` (max) | General tasks, high effort                   |
-| `writing`            | `google/gemini-3-flash`         | Documentation, prose, technical writing        |
+| Category             | Default Model                     | Description                                    |
+| -------------------- | --------------------------------- | ---------------------------------------------- |
+| `visual-engineering` | `google/gemini-3.1-pro` (high)    | Frontend, UI/UX, design, animation             |
+| `ultrabrain`         | `openai/gpt-5.4` (xhigh)          | Deep logical reasoning, complex architecture   |
+| `deep`               | `openai/gpt-5.3-codex` (medium)   | Autonomous problem-solving, thorough research  |
+| `artistry`           | `google/gemini-3.1-pro` (high)    | Creative/unconventional approaches             |
+| `quick`              | `openai/gpt-5.4-mini`             | Trivial tasks, typo fixes, single-file changes |
+| `unspecified-low`    | `anthropic/claude-sonnet-4-6`     | General tasks, low effort                      |
+| `unspecified-high`   | `anthropic/claude-opus-4-6` (max) | General tasks, high effort                     |
+| `writing`            | `google/gemini-3-flash`           | Documentation, prose, technical writing        |
 
 > **Note**: Built-in defaults only apply if the category is present in your config. Otherwise the system default model is used.
 
 #### Category Options
 
-| Option              | Type          | Default | Description                                                         |
-| ------------------- | ------------- | ------- | ------------------------------------------------------------------- |
-| `model`             | string        | -       | Model override                                                      |
+| Option              | Type          | Default | Description                                                                                                           |
+| ------------------- | ------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `model`             | string        | -       | Model override                                                                                                        |
 | `fallback_models`   | string\|array | -       | Fallback models on API errors. Supports strings or mixed arrays of strings and object entries with per-model settings |
-| `temperature`       | number        | -       | Sampling temperature                                                |
-| `top_p`             | number        | -       | Top-p sampling                                                      |
-| `maxTokens`         | number        | -       | Max response tokens                                                 |
-| `thinking`          | object        | -       | Anthropic extended thinking                                         |
-| `reasoningEffort`   | string        | -       | OpenAI reasoning effort. Unsupported values are normalized          |
-| `textVerbosity`     | string        | -       | Text verbosity                                                      |
-| `tools`             | array         | -       | Allowed tools                                                       |
-| `prompt_append`     | string        | -       | Append to system prompt                                             |
-| `variant`           | string        | -       | Model variant. Unsupported values are normalized                    |
-| `description`       | string        | -       | Shown in `task()` tool prompt                                       |
-| `is_unstable_agent` | boolean       | `false` | Force background mode + monitoring. Auto-enabled for Gemini models. |
+| `temperature`       | number        | -       | Sampling temperature                                                                                                  |
+| `top_p`             | number        | -       | Top-p sampling                                                                                                        |
+| `maxTokens`         | number        | -       | Max response tokens                                                                                                   |
+| `thinking`          | object        | -       | Anthropic extended thinking                                                                                           |
+| `reasoningEffort`   | string        | -       | OpenAI reasoning effort. Unsupported values are normalized                                                            |
+| `textVerbosity`     | string        | -       | Text verbosity                                                                                                        |
+| `tools`             | array         | -       | Allowed tools                                                                                                         |
+| `prompt_append`     | string        | -       | Append to system prompt                                                                                               |
+| `variant`           | string        | -       | Model variant. Unsupported values are normalized                                                                      |
+| `description`       | string        | -       | Shown in `task()` tool prompt                                                                                         |
+| `is_unstable_agent` | boolean       | `false` | Force background mode + monitoring. Auto-enabled for Gemini models.                                                   |
 
 Disable categories: `{ "disabled_categories": ["ultrabrain"] }`
 
@@ -343,6 +349,7 @@ Normalized fields:
 - `thinking` - removed if the target model does not support thinking
 
 Examples:
+
 - Claude models do not support `reasoningEffort` - it is removed automatically
 - GPT-4.1 does not support reasoning - `reasoningEffort` is removed
 - o-series models support `none` through `high` - `xhigh` is downgraded to `high`
@@ -350,34 +357,33 @@ Examples:
 
 Capability data comes from provider runtime metadata first. OmO also ships bundled models.dev-backed capability data, supports a refreshable local models.dev cache, and falls back to heuristic family detection plus alias rules when exact metadata is unavailable. `bunx oh-my-opencode doctor` surfaces capability diagnostics and warns when a configured model relies on compatibility fallback.
 
-
 #### Agent Provider Chains
 
-| Agent                 | Default Model       | Provider Priority                                                            |
-| --------------------- | ------------------- | ---------------------------------------------------------------------------- |
+| Agent                 | Default Model       | Provider Priority                                                                                                    |
+| --------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | **Sisyphus**          | `claude-opus-4-6`   | `claude-opus-4-6 (max)` → `kimi-k2.5` via OpenCode Go / Kimi providers → `gpt-5.4 (medium)` → `glm-5` → `big-pickle` |
-| **Hephaestus**        | `gpt-5.4`           | `gpt-5.4 (medium)`                                                           |
-| **oracle**            | `gpt-5.4`           | `gpt-5.4 (high)` → `gemini-3.1-pro (high)` → `claude-opus-4-6 (max)` → `glm-5` |
-| **librarian**         | `minimax-m2.7`      | `opencode-go/minimax-m2.7` → `opencode/minimax-m2.5` → `claude-haiku-4-5` → `gpt-5-nano` |
-| **explore**           | `grok-code-fast-1`  | `grok-code-fast-1` → `opencode-go/minimax-m2.7` → `opencode/minimax-m2.5` → `claude-haiku-4-5` → `gpt-5-nano` |
-| **multimodal-looker** | `gpt-5.4`           | `gpt-5.4 (medium)` → `kimi-k2.5` → `glm-4.6v` → `gpt-5-nano`                |
-| **Prometheus**        | `claude-opus-4-6`   | `claude-opus-4-6 (max)` → `gpt-5.4 (high)` → `glm-5` → `gemini-3.1-pro`     |
-| **Metis**             | `claude-opus-4-6`   | `claude-opus-4-6 (max)` → `gpt-5.4 (high)` → `glm-5` → `k2p5`               |
-| **Momus**             | `gpt-5.4`           | `gpt-5.4 (xhigh)` → `claude-opus-4-6 (max)` → `gemini-3.1-pro (high)` → `glm-5` |
-| **Atlas**             | `claude-sonnet-4-6` | `claude-sonnet-4-6` → `kimi-k2.5` → `gpt-5.4 (medium)` → `minimax-m2.7`     |
+| **Hephaestus**        | `gpt-5.4`           | `gpt-5.4 (medium)`                                                                                                   |
+| **oracle**            | `gpt-5.4`           | `gpt-5.4 (high)` → `gemini-3.1-pro (high)` → `claude-opus-4-6 (max)` → `glm-5`                                       |
+| **librarian**         | `minimax-m2.7`      | `opencode-go/minimax-m2.7` → `opencode/minimax-m2.5` → `claude-haiku-4-5` → `gpt-5-nano`                             |
+| **explore**           | `grok-code-fast-1`  | `grok-code-fast-1` → `opencode-go/minimax-m2.7` → `opencode/minimax-m2.5` → `claude-haiku-4-5` → `gpt-5-nano`        |
+| **multimodal-looker** | `gpt-5.4`           | `gpt-5.4 (medium)` → `kimi-k2.5` → `glm-4.6v` → `gpt-5-nano`                                                         |
+| **Prometheus**        | `claude-opus-4-6`   | `claude-opus-4-6 (max)` → `gpt-5.4 (high)` → `glm-5` → `gemini-3.1-pro`                                              |
+| **Metis**             | `claude-opus-4-6`   | `claude-opus-4-6 (max)` → `gpt-5.4 (high)` → `glm-5` → `k2p5`                                                        |
+| **Momus**             | `gpt-5.4`           | `gpt-5.4 (xhigh)` → `claude-opus-4-6 (max)` → `gemini-3.1-pro (high)` → `glm-5`                                      |
+| **Atlas**             | `claude-sonnet-4-6` | `claude-sonnet-4-6` → `kimi-k2.5` → `gpt-5.4 (medium)` → `minimax-m2.7`                                              |
 
 #### Category Provider Chains
 
-| Category               | Default Model       | Provider Priority                                              |
-| ---------------------- | ------------------- | -------------------------------------------------------------- |
-| **visual-engineering** | `gemini-3.1-pro`    | `gemini-3.1-pro` → `glm-5` → `claude-opus-4-6`                 |
-| **ultrabrain**         | `gpt-5.4`           | `gpt-5.4` → `gemini-3.1-pro` → `claude-opus-4-6`               |
-| **deep**               | `gpt-5.3-codex`     | `gpt-5.3-codex` → `claude-opus-4-6` → `gemini-3.1-pro`         |
-| **artistry**           | `gemini-3.1-pro`    | `gemini-3.1-pro` → `claude-opus-4-6` → `gpt-5.4`               |
-| **quick**              | `gpt-5.4-mini`    | `gpt-5.4-mini` → `claude-haiku-4-5` → `gemini-3-flash` → `minimax-m2.7` → `gpt-5-nano` |
-| **unspecified-low**    | `claude-sonnet-4-6` | `claude-sonnet-4-6` → `gpt-5.3-codex` → `gemini-3-flash` → `minimax-m2.7` |
-| **unspecified-high**   | `claude-opus-4-6`   | `claude-opus-4-6` → `gpt-5.4 (high)` → `glm-5` → `k2p5` → `kimi-k2.5` |
-| **writing**            | `gemini-3-flash`    | `gemini-3-flash` → `claude-sonnet-4-6` → `minimax-m2.7`        |
+| Category               | Default Model       | Provider Priority                                                                      |
+| ---------------------- | ------------------- | -------------------------------------------------------------------------------------- |
+| **visual-engineering** | `gemini-3.1-pro`    | `gemini-3.1-pro` → `glm-5` → `claude-opus-4-6`                                         |
+| **ultrabrain**         | `gpt-5.4`           | `gpt-5.4` → `gemini-3.1-pro` → `claude-opus-4-6`                                       |
+| **deep**               | `gpt-5.3-codex`     | `gpt-5.3-codex` → `claude-opus-4-6` → `gemini-3.1-pro`                                 |
+| **artistry**           | `gemini-3.1-pro`    | `gemini-3.1-pro` → `claude-opus-4-6` → `gpt-5.4`                                       |
+| **quick**              | `gpt-5.4-mini`      | `gpt-5.4-mini` → `claude-haiku-4-5` → `gemini-3-flash` → `minimax-m2.7` → `gpt-5-nano` |
+| **unspecified-low**    | `claude-sonnet-4-6` | `claude-sonnet-4-6` → `gpt-5.3-codex` → `gemini-3-flash` → `minimax-m2.7`              |
+| **unspecified-high**   | `claude-opus-4-6`   | `claude-opus-4-6` → `gpt-5.4 (high)` → `glm-5` → `k2p5` → `kimi-k2.5`                  |
+| **writing**            | `gemini-3-flash`    | `gemini-3-flash` → `claude-sonnet-4-6` → `minimax-m2.7`                                |
 
 Run `bunx oh-my-opencode doctor --verbose` to see effective model resolution for your config.
 
@@ -472,10 +478,7 @@ Disable built-in skills: `{ "disabled_skills": ["playwright"] }`
 ```json
 {
   "skills": {
-    "sources": [
-      { "path": "./my-skills", "recursive": true },
-      "https://example.com/skill.yaml"
-    ],
+    "sources": [{ "path": "./my-skills", "recursive": true }, "https://example.com/skill.yaml"],
     "enable": ["my-skill"],
     "disable": ["other-skill"],
     "my-skill": {
@@ -724,23 +727,23 @@ Mixed arrays are allowed, so string entries and object entries can appear togeth
 
 Object entries use the following shape:
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `model` | string | Fallback model ID. Provider prefix is optional when OmO can inherit the current/default provider. |
-| `variant` | string | Explicit variant override for this fallback entry. |
-| `reasoningEffort` | string | OpenAI reasoning effort override for this fallback entry. |
-| `temperature` | number | Temperature applied if this fallback model becomes active. |
-| `top_p` | number | Top-p applied if this fallback model becomes active. |
-| `maxTokens` | number | Max response tokens applied if this fallback model becomes active. |
-| `thinking` | object | Anthropic thinking config applied if this fallback model becomes active. |
+| Field             | Type   | Description                                                                                       |
+| ----------------- | ------ | ------------------------------------------------------------------------------------------------- |
+| `model`           | string | Fallback model ID. Provider prefix is optional when OmO can inherit the current/default provider. |
+| `variant`         | string | Explicit variant override for this fallback entry.                                                |
+| `reasoningEffort` | string | OpenAI reasoning effort override for this fallback entry.                                         |
+| `temperature`     | number | Temperature applied if this fallback model becomes active.                                        |
+| `top_p`           | number | Top-p applied if this fallback model becomes active.                                              |
+| `maxTokens`       | number | Max response tokens applied if this fallback model becomes active.                                |
+| `thinking`        | object | Anthropic thinking config applied if this fallback model becomes active.                          |
 
 Per-model settings are **fallback-only**. They are promoted only when that specific fallback model is actually selected, so they do not override your primary model settings when the primary model resolves successfully.
 
 `thinking` uses the same shape as the normal agent/category option:
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `type` | string | `enabled` or `disabled` |
+| Field          | Type   | Description                        |
+| -------------- | ------ | ---------------------------------- |
+| `type`         | string | `enabled` or `disabled`            |
 | `budgetTokens` | number | Optional Anthropic thinking budget |
 
 Object entries can also omit the provider prefix when OmO can infer it from the current/default provider. If you provide both inline variant syntax in `model` and an explicit `variant` field, the explicit `variant` field wins.
@@ -756,11 +759,7 @@ Use strings when you only need an ordered fallback chain:
   "agents": {
     "atlas": {
       "model": "anthropic/claude-sonnet-4-6",
-      "fallback_models": [
-        "anthropic/claude-haiku-4-5",
-        "openai/gpt-5.4",
-        "google/gemini-3.1-pro"
-      ]
+      "fallback_models": ["anthropic/claude-haiku-4-5", "openai/gpt-5.4", "google/gemini-3.1-pro"]
     }
   }
 }
@@ -888,17 +887,17 @@ OmO can refresh a local models.dev capability snapshot on startup. This cache is
     "enabled": true,
     "auto_refresh_on_start": true,
     "refresh_timeout_ms": 5000,
-    "source_url": "https://models.dev/api.json"
-  }
+    "source_url": "https://models.dev/api.json",
+  },
 }
 ```
 
-| Option | Default behavior | Description |
-| ------ | ---------------- | ----------- |
-| `enabled` | enabled unless explicitly set to `false` | Master switch for model capability refresh behavior |
+| Option                  | Default behavior                                    | Description                                              |
+| ----------------------- | --------------------------------------------------- | -------------------------------------------------------- |
+| `enabled`               | enabled unless explicitly set to `false`            | Master switch for model capability refresh behavior      |
 | `auto_refresh_on_start` | refresh on startup unless explicitly set to `false` | Refresh the local models.dev cache during startup checks |
-| `refresh_timeout_ms` | `5000` | Timeout for the startup refresh attempt |
-| `source_url` | `https://models.dev/api.json` | Override the models.dev source URL |
+| `refresh_timeout_ms`    | `5000`                                              | Timeout for the startup refresh attempt                  |
+| `source_url`            | `https://models.dev/api.json`                       | Override the models.dev source URL                       |
 
 Notes:
 

--- a/docs/reference/features.md
+++ b/docs/reference/features.md
@@ -8,14 +8,15 @@ Oh-My-OpenAgent provides 11 specialized AI agents. Each has distinct expertise, 
 
 Core-agent tab cycling is deterministic via injected runtime order field. The fixed priority order is Sisyphus (order: 1), Hephaestus (order: 2), Prometheus (order: 3), and Atlas (order: 4). Remaining agents follow after that stable core ordering.
 
-| Agent                 | Model              | Purpose                                                                                                                                                                                                                                                                                                                                                          |
-| --------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Sisyphus**          | `claude-opus-4-6`  | The default orchestrator. Plans, delegates, and executes complex tasks using specialized subagents with aggressive parallel execution. Todo-driven workflow with extended thinking (32k budget). Fallback: `glm-5` → `big-pickle`.                                                                                                                                 |
+| Agent                 | Model              | Purpose                                                                                                                                                                                                                                                                                                                   |
+| --------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Sisyphus**          | `claude-opus-4-6`  | The default orchestrator. Plans, delegates, and executes complex tasks using specialized subagents with aggressive parallel execution. Todo-driven workflow with extended thinking (32k budget). Fallback: `glm-5` → `big-pickle`.                                                                                        |
 | **Hephaestus**        | `gpt-5.4`          | The Legitimate Craftsman. Autonomous deep worker inspired by AmpCode's deep mode. Goal-oriented execution with thorough research before action. Explores codebase patterns, completes tasks end-to-end without premature stopping. Named after the Greek god of forge and craftsmanship. Requires a GPT-capable provider. |
-| **Oracle**            | `gpt-5.4`          | Architecture decisions, code review, debugging. Read-only consultation with stellar logical reasoning and deep analysis. Inspired by AmpCode. Fallback: `gemini-3.1-pro` → `claude-opus-4-6`.                                                                                                                                                                    |
-| **Librarian**         | `minimax-m2.7`     | Multi-repo analysis, documentation lookup, OSS implementation examples. Deep codebase understanding with evidence-based answers. Primary OpenCode Go path uses MiniMax M2.7. Other provider catalogs may still fall back to MiniMax M2.5, then `claude-haiku-4-5` and `gpt-5-nano`.                                                                                  |
-| **Explore**           | `grok-code-fast-1` | Fast codebase exploration and contextual grep. Primary path stays on Grok Code Fast 1. MiniMax M2.7 is now used where provider catalogs expose it, while some OpenCode fallback paths still use MiniMax M2.5 for catalog compatibility.                                                                                                                          |
-| **Multimodal-Looker** | `gpt-5.4`          | Visual content specialist. Analyzes PDFs, images, diagrams to extract information. Fallback: `k2p5` → `glm-4.6v` → `gpt-5-nano`.                                                                                                                                                                                                                                  |
+| **Oracle**            | `gpt-5.4`          | Architecture decisions, code review, debugging. Read-only consultation with stellar logical reasoning and deep analysis. Inspired by AmpCode. Fallback: `gemini-3.1-pro` → `claude-opus-4-6`.                                                                                                                             |
+| **Librarian**         | `minimax-m2.7`     | Multi-repo analysis, documentation lookup, OSS implementation examples. Deep codebase understanding with evidence-based answers. Primary OpenCode Go path uses MiniMax M2.7. Other provider catalogs may still fall back to MiniMax M2.5, then `claude-haiku-4-5` and `gpt-5-nano`.                                       |
+| **Explore**           | `grok-code-fast-1` | Fast codebase exploration and contextual grep. Primary path stays on Grok Code Fast 1. MiniMax M2.7 is now used where provider catalogs expose it, while some OpenCode fallback paths still use MiniMax M2.5 for catalog compatibility.                                                                                   |
+| **Multimodal-Looker** | `gpt-5.4`          | Visual content specialist. Analyzes PDFs, images, diagrams to extract information. Fallback: `k2p5` → `glm-4.6v` → `gpt-5-nano`.                                                                                                                                                                                          |
+
 ### Planning Agents
 
 | Agent          | Model             | Purpose                                                                                                                                            |
@@ -92,7 +93,7 @@ When running inside tmux:
 - Auto-cleanup when agents complete
 - **Stable agent ordering**: core-agent tab cycling is deterministic via injected runtime order field (Sisyphus: 1, Hephaestus: 2, Prometheus: 3, Atlas: 4)
 
-Customize agent models, prompts, and permissions in `oh-my-opencode.jsonc`.
+Customize agent models, prompts, and permissions in the canonical `oh-my-openagent.jsonc` config file.
 
 ## Category System
 
@@ -107,16 +108,16 @@ By combining these two concepts, you can generate optimal agents through `task`.
 
 ### Built-in Categories
 
-| Category             | Default Model                   | Use Cases                                                                                                                   |
-| -------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `visual-engineering` | `google/gemini-3.1-pro`         | Frontend, UI/UX, design, styling, animation                                                                                 |
-| `ultrabrain`         | `openai/gpt-5.4` (xhigh)        | Deep logical reasoning, complex architecture decisions requiring extensive analysis                                         |
-| `deep`               | `openai/gpt-5.3-codex` (medium) | Goal-oriented autonomous problem-solving. Thorough research before action. For hairy problems requiring deep understanding. |
-| `artistry`           | `google/gemini-3.1-pro` (high)  | Highly creative/artistic tasks, novel ideas                                                                                 |
-| `quick`              | `openai/gpt-5.4-mini`           | Trivial tasks - single file changes, typo fixes, simple modifications                                                       |
-| `unspecified-low`    | `anthropic/claude-sonnet-4-6`   | Tasks that don't fit other categories, low effort required                                                                  |
-| `unspecified-high`   | `anthropic/claude-opus-4-6` (max) | Tasks that don't fit other categories, high effort required                                                               |
-| `writing`            | `google/gemini-3-flash`         | Documentation, prose, technical writing                                                                                     |
+| Category             | Default Model                     | Use Cases                                                                                                                   |
+| -------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `visual-engineering` | `google/gemini-3.1-pro`           | Frontend, UI/UX, design, styling, animation                                                                                 |
+| `ultrabrain`         | `openai/gpt-5.4` (xhigh)          | Deep logical reasoning, complex architecture decisions requiring extensive analysis                                         |
+| `deep`               | `openai/gpt-5.3-codex` (medium)   | Goal-oriented autonomous problem-solving. Thorough research before action. For hairy problems requiring deep understanding. |
+| `artistry`           | `google/gemini-3.1-pro` (high)    | Highly creative/artistic tasks, novel ideas                                                                                 |
+| `quick`              | `openai/gpt-5.4-mini`             | Trivial tasks - single file changes, typo fixes, simple modifications                                                       |
+| `unspecified-low`    | `anthropic/claude-sonnet-4-6`     | Tasks that don't fit other categories, low effort required                                                                  |
+| `unspecified-high`   | `anthropic/claude-opus-4-6` (max) | Tasks that don't fit other categories, high effort required                                                                 |
+| `writing`            | `google/gemini-3-flash`           | Documentation, prose, technical writing                                                                                     |
 
 ### Usage
 
@@ -207,10 +208,13 @@ Configure per-agent fallback chains with arrays that can mix plain model strings
       "fallback_models": [
         "opencode/glm-5",
         { "model": "openai/gpt-5.4", "variant": "high" },
-        { "model": "anthropic/claude-sonnet-4-6", "thinking": { "type": "enabled", "budgetTokens": 64000 } }
-      ]
-    }
-  }
+        {
+          "model": "anthropic/claude-sonnet-4-6",
+          "thinking": { "type": "enabled", "budgetTokens": 64000 },
+        },
+      ],
+    },
+  },
 }
 ```
 
@@ -224,23 +228,24 @@ Load agent system prompts from external files using `file://` URLs in the `promp
 {
   "agents": {
     "sisyphus": {
-      "prompt": "file:///path/to/custom-prompt.md"
+      "prompt": "file:///path/to/custom-prompt.md",
     },
     "oracle": {
-      "prompt_append": "file:///path/to/additional-context.md"
-    }
+      "prompt_append": "file:///path/to/additional-context.md",
+    },
   },
   "categories": {
     "deep": {
-      "prompt_append": "file:///path/to/deep-category-append.md"
-    }
-  }
+      "prompt_append": "file:///path/to/deep-category-append.md",
+    },
+  },
 }
 ```
 
 Supports `~` expansion for home directory and relative `file://` paths.
 
 Useful for:
+
 - Version controlling prompts separately from config
 - Sharing prompts across projects
 - Keeping configuration files concise
@@ -259,6 +264,7 @@ The system automatically recovers from common session failures without user inte
 - **JSON parse errors**: Recovers from malformed tool outputs
 
 Recovery happens transparently during agent execution. You see the result, not the failure.
+
 ## Skills
 
 Skills provide specialized workflows with embedded MCP servers and detailed instructions. A Skill is a mechanism that injects **specialized knowledge (Context)** and **tools (MCP)** for specific domains into agents.
@@ -938,14 +944,15 @@ Configure automatic refresh at startup:
     "enabled": true,
     "auto_refresh_on_start": true,
     "refresh_timeout_ms": 5000,
-    "source_url": "https://models.dev/api.json"
-  }
+    "source_url": "https://models.dev/api.json",
+  },
 }
 ```
 
 ### Capability Diagnostics
 
 Run `bunx oh-my-opencode doctor` to see capability diagnostics including:
+
 - effective model resolution for agents and categories
 - warnings when configured models rely on compatibility fallback
 - override compatibility details alongside model resolution output

--- a/script/build-schema-document.ts
+++ b/script/build-schema-document.ts
@@ -1,17 +1,22 @@
-import * as z from "zod"
-import { OhMyOpenCodeConfigSchema } from "../src/config/schema"
+import * as z from "zod";
+import { OhMyOpenCodeConfigSchema } from "../src/config/schema";
 
 export function createOhMyOpenCodeJsonSchema(): Record<string, unknown> {
-  const jsonSchema = z.toJSONSchema(OhMyOpenCodeConfigSchema, {
-    target: "draft-7",
-    unrepresentable: "any",
-  })
+	const jsonSchema = z.toJSONSchema(OhMyOpenCodeConfigSchema, {
+		target: "draft-7",
+		unrepresentable: "any",
+	});
 
-  return {
-    $schema: "http://json-schema.org/draft-07/schema#",
-    $id: "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
-    title: "Oh My OpenCode Configuration",
-    description: "Configuration schema for oh-my-opencode plugin",
-    ...jsonSchema,
-  }
+	const required = Array.isArray(jsonSchema.required)
+		? jsonSchema.required.filter((name) => name !== "git_master")
+		: undefined;
+
+	return {
+		$schema: "http://json-schema.org/draft-07/schema#",
+		$id: "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
+		title: "Oh My OpenCode Configuration",
+		description: "Configuration schema for oh-my-opencode plugin",
+		...jsonSchema,
+		...(required !== undefined ? { required } : {}),
+	};
 }

--- a/script/build-schema.test.ts
+++ b/script/build-schema.test.ts
@@ -1,18 +1,26 @@
-import { describe, expect, test } from "bun:test"
-import { createOhMyOpenCodeJsonSchema } from "./build-schema-document"
+import { describe, expect, test } from "bun:test";
+import { createOhMyOpenCodeJsonSchema } from "./build-schema-document";
 
 describe("build-schema-document", () => {
-  test("generates schema with skills property", () => {
-    // given
-    const expectedDraft = "http://json-schema.org/draft-07/schema#"
+	test("generates schema with skills property", () => {
+		// given
+		const expectedDraft = "http://json-schema.org/draft-07/schema#";
 
-    // when
-    const schema = createOhMyOpenCodeJsonSchema()
+		// when
+		const schema = createOhMyOpenCodeJsonSchema();
 
-    // then
-    expect(schema.$schema).toBe(expectedDraft)
-    expect(schema.title).toBe("Oh My OpenCode Configuration")
-    expect(schema.properties).toBeDefined()
-    expect(schema.properties.skills).toBeDefined()
-  })
-})
+		// then
+		expect(schema.$schema).toBe(expectedDraft);
+		expect(schema.title).toBe("Oh My OpenCode Configuration");
+		expect(schema.properties).toBeDefined();
+		expect(schema.properties.skills).toBeDefined();
+	});
+
+	test("does not require git_master at the schema root when runtime supplies defaults", () => {
+		const schema = createOhMyOpenCodeJsonSchema();
+
+		expect(Array.isArray(schema.required) ? schema.required : []).not.toContain(
+			"git_master",
+		);
+	});
+});

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -8,24 +8,26 @@ Entry point `index.ts` orchestrates 5-step initialization: loadConfig → create
 
 ## KEY FILES
 
-| File | Purpose |
-|------|---------|
-| `index.ts` | Plugin entry, exports `OhMyOpenCodePlugin` |
-| `plugin-config.ts` | JSONC parse, multi-level merge, Zod v4 validation |
-| `create-managers.ts` | TmuxSessionManager, BackgroundManager, SkillMcpManager, ConfigHandler |
-| `create-tools.ts` | SkillContext + AvailableCategories + ToolRegistry (26 tools) |
-| `create-hooks.ts` | 3-tier: Core(39) + Continuation(7) + Skill(2) = 48 hooks |
+| File                  | Purpose                                                                                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `index.ts`            | Plugin entry, exports `OhMyOpenCodePlugin`                                                                                      |
+| `plugin-config.ts`    | JSONC parse, multi-level merge, Zod v4 validation                                                                               |
+| `create-managers.ts`  | TmuxSessionManager, BackgroundManager, SkillMcpManager, ConfigHandler                                                           |
+| `create-tools.ts`     | SkillContext + AvailableCategories + ToolRegistry (26 tools)                                                                    |
+| `create-hooks.ts`     | 3-tier: Core(39) + Continuation(7) + Skill(2) = 48 hooks                                                                        |
 | `plugin-interface.ts` | 8 OpenCode hook handlers: config, tool, chat.message, chat.params, chat.headers, event, tool.execute.before, tool.execute.after |
 
 ## CONFIG LOADING
 
 ```
 loadPluginConfig(directory, ctx)
-  1. User: ~/.config/opencode/oh-my-opencode.jsonc
-  2. Project: .opencode/oh-my-opencode.jsonc
+  1. User: canonical-first search in ~/.config/opencode/
+     (oh-my-openagent.jsonc → oh-my-openagent.json → oh-my-opencode.jsonc → oh-my-opencode.json)
+  2. Project: canonical-first search in .opencode/
+     (oh-my-openagent.jsonc → oh-my-openagent.json → oh-my-opencode.jsonc → oh-my-opencode.json)
   3. mergeConfigs(user, project) → deepMerge for agents/categories, Set union for disabled_*
   4. Zod safeParse → defaults for omitted fields
-  5. migrateConfigFile() → legacy key transformation
+  5. migrateConfigFile() → legacy key transformation when a legacy basename is loaded
 ```
 
 ## HOOK COMPOSITION

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -1,40 +1,59 @@
-import { Command } from "commander"
-import { install } from "./install"
-import { run } from "./run"
-import { getLocalVersion } from "./get-local-version"
-import { doctor } from "./doctor"
-import { refreshModelCapabilities } from "./refresh-model-capabilities"
-import { createMcpOAuthCommand } from "./mcp-oauth"
-import type { InstallArgs } from "./types"
-import type { RunOptions } from "./run"
-import type { GetLocalVersionOptions } from "./get-local-version/types"
-import type { DoctorOptions } from "./doctor"
-import packageJson from "../../package.json" with { type: "json" }
+import { Command } from "commander";
+import packageJson from "../../package.json" with { type: "json" };
+import type { DoctorOptions } from "./doctor";
+import { doctor } from "./doctor";
+import { getLocalVersion } from "./get-local-version";
+import type { GetLocalVersionOptions } from "./get-local-version/types";
+import { install } from "./install";
+import { createMcpOAuthCommand } from "./mcp-oauth";
+import { refreshModelCapabilities } from "./refresh-model-capabilities";
+import type { RunOptions } from "./run";
+import { run } from "./run";
+import type { InstallArgs } from "./types";
 
-const VERSION = packageJson.version
+const VERSION = packageJson.version;
 
-const program = new Command()
-
-program
-  .name("oh-my-opencode")
-  .description("The ultimate OpenCode plugin - multi-model orchestration, LSP tools, and more")
-  .version(VERSION, "-v, --version", "Show version number")
-  .enablePositionalOptions()
+const program = new Command();
 
 program
-  .command("install")
-  .description("Install and configure oh-my-opencode with interactive setup")
-  .option("--no-tui", "Run in non-interactive mode (requires all options)")
-  .option("--claude <value>", "Claude subscription: no, yes, max20")
-  .option("--openai <value>", "OpenAI/ChatGPT subscription: no, yes (default: no)")
-  .option("--gemini <value>", "Gemini integration: no, yes")
-  .option("--copilot <value>", "GitHub Copilot subscription: no, yes")
-  .option("--opencode-zen <value>", "OpenCode Zen access: no, yes (default: no)")
-  .option("--zai-coding-plan <value>", "Z.ai Coding Plan subscription: no, yes (default: no)")
-  .option("--kimi-for-coding <value>", "Kimi For Coding subscription: no, yes (default: no)")
-  .option("--opencode-go <value>", "OpenCode Go subscription: no, yes (default: no)")
-  .option("--skip-auth", "Skip authentication setup hints")
-  .addHelpText("after", `
+	.name("oh-my-opencode")
+	.description(
+		"The ultimate OpenCode plugin - multi-model orchestration, LSP tools, and more",
+	)
+	.version(VERSION, "-v, --version", "Show version number")
+	.enablePositionalOptions();
+
+program
+	.command("install")
+	.description("Install and configure oh-my-opencode with interactive setup")
+	.option("--no-tui", "Run in non-interactive mode (requires all options)")
+	.option("--claude <value>", "Claude subscription: no, yes, max20")
+	.option(
+		"--openai <value>",
+		"OpenAI/ChatGPT subscription: no, yes (default: no)",
+	)
+	.option("--gemini <value>", "Gemini integration: no, yes")
+	.option("--copilot <value>", "GitHub Copilot subscription: no, yes")
+	.option(
+		"--opencode-zen <value>",
+		"OpenCode Zen access: no, yes (default: no)",
+	)
+	.option(
+		"--zai-coding-plan <value>",
+		"Z.ai Coding Plan subscription: no, yes (default: no)",
+	)
+	.option(
+		"--kimi-for-coding <value>",
+		"Kimi For Coding subscription: no, yes (default: no)",
+	)
+	.option(
+		"--opencode-go <value>",
+		"OpenCode Go subscription: no, yes (default: no)",
+	)
+	.option("--skip-auth", "Skip authentication setup hints")
+	.addHelpText(
+		"after",
+		`
 Examples:
   $ bunx oh-my-opencode install
   $ bunx oh-my-opencode install --no-tui --claude=max20 --openai=yes --gemini=yes --copilot=no
@@ -48,40 +67,56 @@ Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi):
   OpenCode Zen  opencode/ models (opencode/claude-opus-4-6, etc.)
    Z.ai          zai-coding-plan/glm-5 (visual-engineering fallback)
   Kimi          kimi-for-coding/k2p5 (Sisyphus/Prometheus fallback)
-`)
-  .action(async (options) => {
-    const args: InstallArgs = {
-      tui: options.tui !== false,
-      claude: options.claude,
-      openai: options.openai,
-      gemini: options.gemini,
-      copilot: options.copilot,
-      opencodeZen: options.opencodeZen,
-      zaiCodingPlan: options.zaiCodingPlan,
-      kimiForCoding: options.kimiForCoding,
-      opencodeGo: options.opencodeGo,
-      skipAuth: options.skipAuth ?? false,
-    }
-    const exitCode = await install(args)
-    process.exit(exitCode)
-  })
+`,
+	)
+	.action(async (options) => {
+		const args: InstallArgs = {
+			tui: options.tui !== false,
+			claude: options.claude,
+			openai: options.openai,
+			gemini: options.gemini,
+			copilot: options.copilot,
+			opencodeZen: options.opencodeZen,
+			zaiCodingPlan: options.zaiCodingPlan,
+			kimiForCoding: options.kimiForCoding,
+			opencodeGo: options.opencodeGo,
+			skipAuth: options.skipAuth ?? false,
+		};
+		const exitCode = await install(args);
+		process.exit(exitCode);
+	});
 
 program
-   .command("run <message>")
-   .allowUnknownOption()
-   .passThroughOptions()
-  .description("Run opencode with todo/background task completion enforcement")
-  .option("-a, --agent <name>", "Agent to use (default: from CLI/env/config, fallback: Sisyphus)")
-  .option("-m, --model <provider/model>", "Model override (e.g., anthropic/claude-sonnet-4)")
-  .option("-d, --directory <path>", "Working directory")
-  .option("-p, --port <port>", "Server port (attaches if port already in use)", parseInt)
-  .option("--attach <url>", "Attach to existing opencode server URL")
-  .option("--on-complete <command>", "Shell command to run after completion")
-  .option("--json", "Output structured JSON result to stdout")
-  .option("--no-timestamp", "Disable timestamp prefix in run output")
-  .option("--verbose", "Show full event stream (default: messages/tools only)")
-  .option("--session-id <id>", "Resume existing session instead of creating new one")
-  .addHelpText("after", `
+	.command("run <message>")
+	.allowUnknownOption()
+	.passThroughOptions()
+	.description("Run opencode with todo/background task completion enforcement")
+	.option(
+		"-a, --agent <name>",
+		"Agent to use (default: from CLI/env/config, fallback: Sisyphus)",
+	)
+	.option(
+		"-m, --model <provider/model>",
+		"Model override (e.g., anthropic/claude-sonnet-4)",
+	)
+	.option("-d, --directory <path>", "Working directory")
+	.option(
+		"-p, --port <port>",
+		"Server port (attaches if port already in use)",
+		parseInt,
+	)
+	.option("--attach <url>", "Attach to existing opencode server URL")
+	.option("--on-complete <command>", "Shell command to run after completion")
+	.option("--json", "Output structured JSON result to stdout")
+	.option("--no-timestamp", "Disable timestamp prefix in run output")
+	.option("--verbose", "Show full event stream (default: messages/tools only)")
+	.option(
+		"--session-id <id>",
+		"Resume existing session instead of creating new one",
+	)
+	.addHelpText(
+		"after",
+		`
 Examples:
   $ bunx oh-my-opencode run "Fix the bug in index.ts"
   $ bunx oh-my-opencode run --agent Sisyphus "Implement feature X"
@@ -96,7 +131,7 @@ Examples:
 Agent resolution order:
   1) --agent flag
   2) OPENCODE_DEFAULT_AGENT
-  3) oh-my-opencode.json "default_run_agent"
+  3) oh-my-openagent.json[c] "default_run_agent"
   4) Sisyphus (fallback)
 
 Available core agents:
@@ -105,35 +140,38 @@ Available core agents:
 Unlike 'opencode run', this command waits until:
   - All todos are completed or cancelled
   - All child sessions (background tasks) are idle
-`)
-  .action(async (message: string, options) => {
-    if (options.port && options.attach) {
-      console.error("Error: --port and --attach are mutually exclusive")
-      process.exit(1)
-    }
-    const runOptions: RunOptions = {
-      message,
-      agent: options.agent,
-      model: options.model,
-      directory: options.directory,
-      port: options.port,
-      attach: options.attach,
-      onComplete: options.onComplete,
-      json: options.json ?? false,
-      timestamp: options.timestamp ?? true,
-      verbose: options.verbose ?? false,
-      sessionId: options.sessionId,
-    }
-    const exitCode = await run(runOptions)
-    process.exit(exitCode)
-  })
+`,
+	)
+	.action(async (message: string, options) => {
+		if (options.port && options.attach) {
+			console.error("Error: --port and --attach are mutually exclusive");
+			process.exit(1);
+		}
+		const runOptions: RunOptions = {
+			message,
+			agent: options.agent,
+			model: options.model,
+			directory: options.directory,
+			port: options.port,
+			attach: options.attach,
+			onComplete: options.onComplete,
+			json: options.json ?? false,
+			timestamp: options.timestamp ?? true,
+			verbose: options.verbose ?? false,
+			sessionId: options.sessionId,
+		};
+		const exitCode = await run(runOptions);
+		process.exit(exitCode);
+	});
 
 program
-  .command("get-local-version")
-  .description("Show current installed version and check for updates")
-  .option("-d, --directory <path>", "Working directory to check config from")
-  .option("--json", "Output in JSON format for scripting")
-  .addHelpText("after", `
+	.command("get-local-version")
+	.description("Show current installed version and check for updates")
+	.option("-d, --directory <path>", "Working directory to check config from")
+	.option("--json", "Output in JSON format for scripting")
+	.addHelpText(
+		"after",
+		`
 Examples:
   $ bunx oh-my-opencode get-local-version
   $ bunx oh-my-opencode get-local-version --json
@@ -144,63 +182,76 @@ This command shows:
   - Latest available version on npm
   - Whether you're up to date
   - Special modes (local dev, pinned version)
-`)
-  .action(async (options) => {
-    const versionOptions: GetLocalVersionOptions = {
-      directory: options.directory,
-      json: options.json ?? false,
-    }
-    const exitCode = await getLocalVersion(versionOptions)
-    process.exit(exitCode)
-  })
+`,
+	)
+	.action(async (options) => {
+		const versionOptions: GetLocalVersionOptions = {
+			directory: options.directory,
+			json: options.json ?? false,
+		};
+		const exitCode = await getLocalVersion(versionOptions);
+		process.exit(exitCode);
+	});
 
 program
-  .command("doctor")
-  .description("Check oh-my-opencode installation health and diagnose issues")
-  .option("--status", "Show compact system dashboard")
-  .option("--verbose", "Show detailed diagnostic information")
-  .option("--json", "Output results in JSON format")
-  .addHelpText("after", `
+	.command("doctor")
+	.description("Check oh-my-opencode installation health and diagnose issues")
+	.option("--status", "Show compact system dashboard")
+	.option("--verbose", "Show detailed diagnostic information")
+	.option("--json", "Output results in JSON format")
+	.addHelpText(
+		"after",
+		`
 Examples:
   $ bunx oh-my-opencode doctor            # Show problems only
   $ bunx oh-my-opencode doctor --status   # Compact dashboard
   $ bunx oh-my-opencode doctor --verbose  # Deep diagnostics
   $ bunx oh-my-opencode doctor --json     # JSON output
-`)
-  .action(async (options) => {
-    const mode = options.status ? "status" : options.verbose ? "verbose" : "default"
-    const doctorOptions: DoctorOptions = {
-      mode,
-      json: options.json ?? false,
-    }
-    const exitCode = await doctor(doctorOptions)
-    process.exit(exitCode)
-  })
+`,
+	)
+	.action(async (options) => {
+		const mode = options.status
+			? "status"
+			: options.verbose
+				? "verbose"
+				: "default";
+		const doctorOptions: DoctorOptions = {
+			mode,
+			json: options.json ?? false,
+		};
+		const exitCode = await doctor(doctorOptions);
+		process.exit(exitCode);
+	});
 
 program
-  .command("refresh-model-capabilities")
-  .description("Refresh the cached models.dev-based model capabilities snapshot")
-  .option("-d, --directory <path>", "Working directory to read oh-my-opencode config from")
-  .option("--source-url <url>", "Override the models.dev source URL")
-  .option("--json", "Output refresh summary as JSON")
-  .action(async (options) => {
-    const exitCode = await refreshModelCapabilities({
-      directory: options.directory,
-      sourceUrl: options.sourceUrl,
-      json: options.json ?? false,
-    })
-    process.exit(exitCode)
-  })
+	.command("refresh-model-capabilities")
+	.description(
+		"Refresh the cached models.dev-based model capabilities snapshot",
+	)
+	.option(
+		"-d, --directory <path>",
+		"Working directory to read oh-my-opencode config from",
+	)
+	.option("--source-url <url>", "Override the models.dev source URL")
+	.option("--json", "Output refresh summary as JSON")
+	.action(async (options) => {
+		const exitCode = await refreshModelCapabilities({
+			directory: options.directory,
+			sourceUrl: options.sourceUrl,
+			json: options.json ?? false,
+		});
+		process.exit(exitCode);
+	});
 
 program
-  .command("version")
-  .description("Show version information")
-  .action(() => {
-    console.log(`oh-my-opencode v${VERSION}`)
-  })
+	.command("version")
+	.description("Show version information")
+	.action(() => {
+		console.log(`oh-my-opencode v${VERSION}`);
+	});
 
-program.addCommand(createMcpOAuthCommand())
+program.addCommand(createMcpOAuthCommand());
 
 export function runCli(): void {
-  program.parse()
+	program.parse();
 }

--- a/src/cli/config-manager/AGENTS.md
+++ b/src/cli/config-manager/AGENTS.md
@@ -8,26 +8,26 @@
 
 ## FILE CATALOG
 
-| File | Purpose |
-|------|---------|
-| `add-plugin-to-opencode-config.ts` | Register `oh-my-opencode` in `.opencode/opencode.json` plugin array |
-| `add-provider-config.ts` | Add provider API key to OpenCode config (user-level) |
-| `antigravity-provider-configuration.ts` | Handle Antigravity provider setup (special case) |
-| `auth-plugins.ts` | Detect auth plugin requirements per provider (oauth vs key) |
-| `bun-install.ts` | Run `bun install` / `npm install` for plugin setup |
-| `config-context.ts` | `ConfigContext` — shared config state across install steps |
-| `deep-merge-record.ts` | Deep merge utility for JSONC config objects |
-| `detect-current-config.ts` | Read existing OpenCode config, detect installed plugins |
-| `ensure-config-directory-exists.ts` | Create `.opencode/` dir if missing |
-| `format-error-with-suggestion.ts` | Format errors with actionable suggestions |
-| `generate-omo-config.ts` | Generate `oh-my-opencode.jsonc` from install selections |
-| `jsonc-provider-editor.ts` | Read/write JSONC files with comment preservation |
-| `npm-dist-tags.ts` | Fetch latest version from npm registry (dist-tags) |
-| `opencode-binary.ts` | Detect OpenCode binary location, verify it's installed |
-| `opencode-config-format.ts` | OpenCode config format constants and type guards |
-| `parse-opencode-config-file.ts` | Parse opencode.json/opencode.jsonc with fallback |
-| `plugin-name-with-version.ts` | Resolve `oh-my-opencode@X.Y.Z` for installation |
-| `write-omo-config.ts` | Write generated config to `.opencode/oh-my-opencode.jsonc` |
+| File                                    | Purpose                                                                                              |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `add-plugin-to-opencode-config.ts`      | Register `oh-my-opencode` in `.opencode/opencode.json` plugin array                                  |
+| `add-provider-config.ts`                | Add provider API key to OpenCode config (user-level)                                                 |
+| `antigravity-provider-configuration.ts` | Handle Antigravity provider setup (special case)                                                     |
+| `auth-plugins.ts`                       | Detect auth plugin requirements per provider (oauth vs key)                                          |
+| `bun-install.ts`                        | Run `bun install` / `npm install` for plugin setup                                                   |
+| `config-context.ts`                     | `ConfigContext` — shared config state across install steps                                           |
+| `deep-merge-record.ts`                  | Deep merge utility for JSONC config objects                                                          |
+| `detect-current-config.ts`              | Read existing OpenCode config, detect installed plugins                                              |
+| `ensure-config-directory-exists.ts`     | Create `.opencode/` dir if missing                                                                   |
+| `format-error-with-suggestion.ts`       | Format errors with actionable suggestions                                                            |
+| `generate-omo-config.ts`                | Generate OMO config content for canonical `oh-my-openagent.json[c]` targets                          |
+| `jsonc-provider-editor.ts`              | Read/write JSONC files with comment preservation                                                     |
+| `npm-dist-tags.ts`                      | Fetch latest version from npm registry (dist-tags)                                                   |
+| `opencode-binary.ts`                    | Detect OpenCode binary location, verify it's installed                                               |
+| `opencode-config-format.ts`             | OpenCode config format constants and type guards                                                     |
+| `parse-opencode-config-file.ts`         | Parse opencode.json/opencode.jsonc with fallback                                                     |
+| `plugin-name-with-version.ts`           | Resolve `oh-my-opencode@X.Y.Z` for installation                                                      |
+| `write-omo-config.ts`                   | Write generated config to canonical `oh-my-openagent.jsonc` (or preserve existing canonical `.json`) |
 
 ## USAGE PATTERN
 

--- a/src/cli/config-manager/detect-current-config.ts
+++ b/src/cli/config-manager/detect-current-config.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import {
-	detectPluginConfigFile,
+	getPluginConfigFileCandidates,
 	LEGACY_PLUGIN_NAME,
 	PLUGIN_NAME,
 	parseJsonc,
@@ -17,53 +17,40 @@ function detectProvidersFromOmoConfig(): {
 	hasKimiForCoding: boolean;
 	hasOpencodeGo: boolean;
 } {
-	const detectedConfig = detectPluginConfigFile(getConfigDir());
-	if (detectedConfig.format === "none" || !existsSync(detectedConfig.path)) {
-		return {
-			hasOpenAI: true,
-			hasOpencodeZen: true,
-			hasZaiCodingPlan: false,
-			hasKimiForCoding: false,
-			hasOpencodeGo: false,
-		};
-	}
+	for (const candidatePath of getPluginConfigFileCandidates(getConfigDir())) {
+		if (!existsSync(candidatePath)) continue;
 
-	try {
-		const content = readFileSync(detectedConfig.path, "utf-8");
-		const omoConfig = parseJsonc<Record<string, unknown>>(content);
-		if (!omoConfig || typeof omoConfig !== "object") {
+		try {
+			const content = readFileSync(candidatePath, "utf-8");
+			const omoConfig = parseJsonc<Record<string, unknown>>(content);
+			if (!omoConfig || typeof omoConfig !== "object") {
+				continue;
+			}
+
+			const configStr = JSON.stringify(omoConfig);
+			const hasOpenAI = configStr.includes('"openai/');
+			const hasOpencodeZen = configStr.includes('"opencode/');
+			const hasZaiCodingPlan = configStr.includes('"zai-coding-plan/');
+			const hasKimiForCoding = configStr.includes('"kimi-for-coding/');
+			const hasOpencodeGo = configStr.includes('"opencode-go/');
+
 			return {
-				hasOpenAI: true,
-				hasOpencodeZen: true,
-				hasZaiCodingPlan: false,
-				hasKimiForCoding: false,
-				hasOpencodeGo: false,
+				hasOpenAI,
+				hasOpencodeZen,
+				hasZaiCodingPlan,
+				hasKimiForCoding,
+				hasOpencodeGo,
 			};
-		}
-
-		const configStr = JSON.stringify(omoConfig);
-		const hasOpenAI = configStr.includes('"openai/');
-		const hasOpencodeZen = configStr.includes('"opencode/');
-		const hasZaiCodingPlan = configStr.includes('"zai-coding-plan/');
-		const hasKimiForCoding = configStr.includes('"kimi-for-coding/');
-		const hasOpencodeGo = configStr.includes('"opencode-go/');
-
-		return {
-			hasOpenAI,
-			hasOpencodeZen,
-			hasZaiCodingPlan,
-			hasKimiForCoding,
-			hasOpencodeGo,
-		};
-	} catch {
-		return {
-			hasOpenAI: true,
-			hasOpencodeZen: true,
-			hasZaiCodingPlan: false,
-			hasKimiForCoding: false,
-			hasOpencodeGo: false,
-		};
+		} catch {}
 	}
+
+	return {
+		hasOpenAI: true,
+		hasOpencodeZen: true,
+		hasZaiCodingPlan: false,
+		hasKimiForCoding: false,
+		hasOpencodeGo: false,
+	};
 }
 
 function isOurPlugin(plugin: string): boolean {

--- a/src/cli/config-manager/detect-current-config.ts
+++ b/src/cli/config-manager/detect-current-config.ts
@@ -1,106 +1,129 @@
-import { existsSync, readFileSync } from "node:fs"
-import { parseJsonc, LEGACY_PLUGIN_NAME, PLUGIN_NAME } from "../../shared"
-import type { DetectedConfig } from "../types"
-import { getOmoConfigPath } from "./config-context"
-import { detectConfigFormat } from "./opencode-config-format"
-import { parseOpenCodeConfigFileWithError } from "./parse-opencode-config-file"
+import { existsSync, readFileSync } from "node:fs";
+import {
+	detectPluginConfigFile,
+	LEGACY_PLUGIN_NAME,
+	PLUGIN_NAME,
+	parseJsonc,
+} from "../../shared";
+import type { DetectedConfig } from "../types";
+import { getConfigDir } from "./config-context";
+import { detectConfigFormat } from "./opencode-config-format";
+import { parseOpenCodeConfigFileWithError } from "./parse-opencode-config-file";
 
 function detectProvidersFromOmoConfig(): {
-  hasOpenAI: boolean
-  hasOpencodeZen: boolean
-  hasZaiCodingPlan: boolean
-  hasKimiForCoding: boolean
-  hasOpencodeGo: boolean
+	hasOpenAI: boolean;
+	hasOpencodeZen: boolean;
+	hasZaiCodingPlan: boolean;
+	hasKimiForCoding: boolean;
+	hasOpencodeGo: boolean;
 } {
-  const omoConfigPath = getOmoConfigPath()
-  if (!existsSync(omoConfigPath)) {
-    return {
-      hasOpenAI: true,
-      hasOpencodeZen: true,
-      hasZaiCodingPlan: false,
-      hasKimiForCoding: false,
-      hasOpencodeGo: false,
-    }
-  }
+	const detectedConfig = detectPluginConfigFile(getConfigDir());
+	if (detectedConfig.format === "none" || !existsSync(detectedConfig.path)) {
+		return {
+			hasOpenAI: true,
+			hasOpencodeZen: true,
+			hasZaiCodingPlan: false,
+			hasKimiForCoding: false,
+			hasOpencodeGo: false,
+		};
+	}
 
-  try {
-    const content = readFileSync(omoConfigPath, "utf-8")
-    const omoConfig = parseJsonc<Record<string, unknown>>(content)
-    if (!omoConfig || typeof omoConfig !== "object") {
-      return {
-        hasOpenAI: true,
-        hasOpencodeZen: true,
-        hasZaiCodingPlan: false,
-        hasKimiForCoding: false,
-        hasOpencodeGo: false,
-      }
-    }
+	try {
+		const content = readFileSync(detectedConfig.path, "utf-8");
+		const omoConfig = parseJsonc<Record<string, unknown>>(content);
+		if (!omoConfig || typeof omoConfig !== "object") {
+			return {
+				hasOpenAI: true,
+				hasOpencodeZen: true,
+				hasZaiCodingPlan: false,
+				hasKimiForCoding: false,
+				hasOpencodeGo: false,
+			};
+		}
 
-    const configStr = JSON.stringify(omoConfig)
-    const hasOpenAI = configStr.includes('"openai/')
-    const hasOpencodeZen = configStr.includes('"opencode/')
-    const hasZaiCodingPlan = configStr.includes('"zai-coding-plan/')
-    const hasKimiForCoding = configStr.includes('"kimi-for-coding/')
-    const hasOpencodeGo = configStr.includes('"opencode-go/')
+		const configStr = JSON.stringify(omoConfig);
+		const hasOpenAI = configStr.includes('"openai/');
+		const hasOpencodeZen = configStr.includes('"opencode/');
+		const hasZaiCodingPlan = configStr.includes('"zai-coding-plan/');
+		const hasKimiForCoding = configStr.includes('"kimi-for-coding/');
+		const hasOpencodeGo = configStr.includes('"opencode-go/');
 
-    return { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo }
-  } catch {
-    return {
-      hasOpenAI: true,
-      hasOpencodeZen: true,
-      hasZaiCodingPlan: false,
-      hasKimiForCoding: false,
-      hasOpencodeGo: false,
-    }
-  }
+		return {
+			hasOpenAI,
+			hasOpencodeZen,
+			hasZaiCodingPlan,
+			hasKimiForCoding,
+			hasOpencodeGo,
+		};
+	} catch {
+		return {
+			hasOpenAI: true,
+			hasOpencodeZen: true,
+			hasZaiCodingPlan: false,
+			hasKimiForCoding: false,
+			hasOpencodeGo: false,
+		};
+	}
 }
 
 function isOurPlugin(plugin: string): boolean {
-  return plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`) ||
-         plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+	return (
+		plugin === PLUGIN_NAME ||
+		plugin.startsWith(`${PLUGIN_NAME}@`) ||
+		plugin === LEGACY_PLUGIN_NAME ||
+		plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+	);
 }
 
 export function detectCurrentConfig(): DetectedConfig {
-  const result: DetectedConfig = {
-    isInstalled: false,
-    hasClaude: true,
-    isMax20: true,
-    hasOpenAI: true,
-    hasGemini: false,
-    hasCopilot: false,
-    hasOpencodeZen: true,
-    hasZaiCodingPlan: false,
-    hasKimiForCoding: false,
-    hasOpencodeGo: false,
-  }
+	const result: DetectedConfig = {
+		isInstalled: false,
+		hasClaude: true,
+		isMax20: true,
+		hasOpenAI: true,
+		hasGemini: false,
+		hasCopilot: false,
+		hasOpencodeZen: true,
+		hasZaiCodingPlan: false,
+		hasKimiForCoding: false,
+		hasOpencodeGo: false,
+	};
 
-  const { format, path } = detectConfigFormat()
-  if (format === "none") {
-    return result
-  }
+	const { format, path } = detectConfigFormat();
+	if (format === "none") {
+		return result;
+	}
 
-  const parseResult = parseOpenCodeConfigFileWithError(path)
-  if (!parseResult.config) {
-    return result
-  }
+	const parseResult = parseOpenCodeConfigFileWithError(path);
+	if (!parseResult.config) {
+		return result;
+	}
 
-  const openCodeConfig = parseResult.config
-  const plugins = openCodeConfig.plugin ?? []
-  result.isInstalled = plugins.some(isOurPlugin)
+	const openCodeConfig = parseResult.config;
+	const plugins = openCodeConfig.plugin ?? [];
+	result.isInstalled = plugins.some(isOurPlugin);
 
-  if (!result.isInstalled) {
-    return result
-  }
+	if (!result.isInstalled) {
+		return result;
+	}
 
-  const providers = openCodeConfig.provider as Record<string, unknown> | undefined
-  result.hasGemini = providers ? "google" in providers : false
+	const providers = openCodeConfig.provider as
+		| Record<string, unknown>
+		| undefined;
+	result.hasGemini = providers ? "google" in providers : false;
 
-  const { hasOpenAI, hasOpencodeZen, hasZaiCodingPlan, hasKimiForCoding, hasOpencodeGo } = detectProvidersFromOmoConfig()
-  result.hasOpenAI = hasOpenAI
-  result.hasOpencodeZen = hasOpencodeZen
-  result.hasZaiCodingPlan = hasZaiCodingPlan
-  result.hasKimiForCoding = hasKimiForCoding
-  result.hasOpencodeGo = hasOpencodeGo
+	const {
+		hasOpenAI,
+		hasOpencodeZen,
+		hasZaiCodingPlan,
+		hasKimiForCoding,
+		hasOpencodeGo,
+	} = detectProvidersFromOmoConfig();
+	result.hasOpenAI = hasOpenAI;
+	result.hasOpencodeZen = hasOpencodeZen;
+	result.hasZaiCodingPlan = hasZaiCodingPlan;
+	result.hasKimiForCoding = hasKimiForCoding;
+	result.hasOpencodeGo = hasOpencodeGo;
 
-  return result
+	return result;
 }

--- a/src/cli/config-manager/plugin-detection.test.ts
+++ b/src/cli/config-manager/plugin-detection.test.ts
@@ -149,6 +149,31 @@ describe("detectCurrentConfig - single package detection", () => {
 		expect(result.hasOpenAI).toBe(true);
 		expect(result.hasOpencodeGo).toBe(false);
 	});
+
+	it("falls back to legacy omo config when canonical config is malformed", () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify({ plugin: ["oh-my-openagent"] }, null, 2) + "\n",
+			"utf-8",
+		);
+		writeFileSync(canonicalOmoConfigPath, "{ invalid jsonc", "utf-8");
+		writeFileSync(
+			legacyOmoConfigPath,
+			JSON.stringify(
+				{ agents: { atlas: { model: "opencode-go/kimi-k2.5" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+
+		// when
+		const result = detectCurrentConfig();
+
+		// then
+		expect(result.hasOpencodeGo).toBe(true);
+	});
 });
 
 describe("addPluginToOpenCodeConfig - single package writes", () => {

--- a/src/cli/config-manager/plugin-detection.test.ts
+++ b/src/cli/config-manager/plugin-detection.test.ts
@@ -1,165 +1,281 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-
-import { resetConfigContext } from "./config-context"
-import { detectCurrentConfig } from "./detect-current-config"
-import { addPluginToOpenCodeConfig } from "./add-plugin-to-opencode-config"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { addPluginToOpenCodeConfig } from "./add-plugin-to-opencode-config";
+import { resetConfigContext } from "./config-context";
+import { detectCurrentConfig } from "./detect-current-config";
 
 describe("detectCurrentConfig - single package detection", () => {
-  let testConfigDir = ""
-  let testConfigPath = ""
-  let testOmoConfigPath = ""
+	let testConfigDir = "";
+	let testConfigPath = "";
+	let legacyOmoConfigPath = "";
+	let canonicalOmoConfigPath = "";
 
-  beforeEach(() => {
-    testConfigDir = join(tmpdir(), `omo-detect-config-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    testConfigPath = join(testConfigDir, "opencode.json")
-    testOmoConfigPath = join(testConfigDir, "oh-my-opencode.json")
+	beforeEach(() => {
+		testConfigDir = join(
+			tmpdir(),
+			`omo-detect-config-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		testConfigPath = join(testConfigDir, "opencode.json");
+		legacyOmoConfigPath = join(testConfigDir, "oh-my-opencode.json");
+		canonicalOmoConfigPath = join(testConfigDir, "oh-my-openagent.jsonc");
 
-    mkdirSync(testConfigDir, { recursive: true })
-    process.env.OPENCODE_CONFIG_DIR = testConfigDir
-    resetConfigContext()
-  })
+		mkdirSync(testConfigDir, { recursive: true });
+		process.env.OPENCODE_CONFIG_DIR = testConfigDir;
+		resetConfigContext();
+	});
 
-  afterEach(() => {
-    rmSync(testConfigDir, { recursive: true, force: true })
-    resetConfigContext()
-    delete process.env.OPENCODE_CONFIG_DIR
-  })
+	afterEach(() => {
+		rmSync(testConfigDir, { recursive: true, force: true });
+		resetConfigContext();
+		delete process.env.OPENCODE_CONFIG_DIR;
+	});
 
-  it("detects both legacy and canonical plugin entries", () => {
-    // given
-    writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-opencode", "oh-my-openagent@3.11.0"] }, null, 2) + "\n", "utf-8")
+	it("detects both legacy and canonical plugin entries", () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify(
+				{ plugin: ["oh-my-opencode", "oh-my-openagent@3.11.0"] },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
 
-    // when
-    const result = detectCurrentConfig()
+		// when
+		const result = detectCurrentConfig();
 
-    // then
-    expect(result.isInstalled).toBe(true)
-  })
+		// then
+		expect(result.isInstalled).toBe(true);
+	});
 
-  it("returns false when plugin not present with similar name", () => {
-    // given
-    writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-openagent-extra"] }, null, 2) + "\n", "utf-8")
+	it("returns false when plugin not present with similar name", () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify({ plugin: ["oh-my-openagent-extra"] }, null, 2) + "\n",
+			"utf-8",
+		);
 
-    // when
-    const result = detectCurrentConfig()
+		// when
+		const result = detectCurrentConfig();
 
-    // then
-    expect(result.isInstalled).toBe(false)
-  })
+		// then
+		expect(result.isInstalled).toBe(false);
+	});
 
-  it("detects OpenCode Go from the existing omo config", () => {
-    // given
-    writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2) + "\n", "utf-8")
-    writeFileSync(testOmoConfigPath, JSON.stringify({ agents: { atlas: { model: "opencode-go/kimi-k2.5" } } }, null, 2) + "\n", "utf-8")
+	it("detects OpenCode Go from the existing omo config", () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2) + "\n",
+			"utf-8",
+		);
+		writeFileSync(
+			legacyOmoConfigPath,
+			JSON.stringify(
+				{ agents: { atlas: { model: "opencode-go/kimi-k2.5" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
 
-    // when
-    const result = detectCurrentConfig()
+		// when
+		const result = detectCurrentConfig();
 
-    // then
-    expect(result.isInstalled).toBe(true)
-    expect(result.hasOpencodeGo).toBe(true)
-  })
-})
+		// then
+		expect(result.isInstalled).toBe(true);
+		expect(result.hasOpencodeGo).toBe(true);
+	});
+
+	it("detects providers from canonical omo config", () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify({ plugin: ["oh-my-openagent"] }, null, 2) + "\n",
+			"utf-8",
+		);
+		writeFileSync(
+			canonicalOmoConfigPath,
+			JSON.stringify(
+				{ agents: { atlas: { model: "opencode-go/kimi-k2.5" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+
+		// when
+		const result = detectCurrentConfig();
+
+		// then
+		expect(result.isInstalled).toBe(true);
+		expect(result.hasOpencodeGo).toBe(true);
+	});
+
+	it("prefers canonical omo config over legacy omo config when both exist", () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify({ plugin: ["oh-my-openagent"] }, null, 2) + "\n",
+			"utf-8",
+		);
+		writeFileSync(
+			legacyOmoConfigPath,
+			JSON.stringify(
+				{ agents: { atlas: { model: "opencode-go/kimi-k2.5" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+		writeFileSync(
+			canonicalOmoConfigPath,
+			JSON.stringify(
+				{ agents: { atlas: { model: "openai/gpt-5.4" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+
+		// when
+		const result = detectCurrentConfig();
+
+		// then
+		expect(result.hasOpenAI).toBe(true);
+		expect(result.hasOpencodeGo).toBe(false);
+	});
+});
 
 describe("addPluginToOpenCodeConfig - single package writes", () => {
-  let testConfigDir = ""
-  let testConfigPath = ""
+	let testConfigDir = "";
+	let testConfigPath = "";
 
-  beforeEach(() => {
-    testConfigDir = join(tmpdir(), `omo-add-plugin-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    testConfigPath = join(testConfigDir, "opencode.json")
+	beforeEach(() => {
+		testConfigDir = join(
+			tmpdir(),
+			`omo-add-plugin-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		testConfigPath = join(testConfigDir, "opencode.json");
 
-    mkdirSync(testConfigDir, { recursive: true })
-    process.env.OPENCODE_CONFIG_DIR = testConfigDir
-    resetConfigContext()
-  })
+		mkdirSync(testConfigDir, { recursive: true });
+		process.env.OPENCODE_CONFIG_DIR = testConfigDir;
+		resetConfigContext();
+	});
 
-  afterEach(() => {
-    rmSync(testConfigDir, { recursive: true, force: true })
-    resetConfigContext()
-    delete process.env.OPENCODE_CONFIG_DIR
-  })
+	afterEach(() => {
+		rmSync(testConfigDir, { recursive: true, force: true });
+		resetConfigContext();
+		delete process.env.OPENCODE_CONFIG_DIR;
+	});
 
-  it("writes canonical plugin entry for new installs", async () => {
-    // given
-    writeFileSync(testConfigPath, JSON.stringify({}, null, 2) + "\n", "utf-8")
+	it("writes canonical plugin entry for new installs", async () => {
+		// given
+		writeFileSync(testConfigPath, JSON.stringify({}, null, 2) + "\n", "utf-8");
 
-    // when
-    const result = await addPluginToOpenCodeConfig("3.11.0")
+		// when
+		const result = await addPluginToOpenCodeConfig("3.11.0");
 
-    // then
-    expect(result.success).toBe(true)
-    const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
-  })
+		// then
+		expect(result.success).toBe(true);
+		const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"));
+		expect(savedConfig.plugin).toEqual(["oh-my-openagent"]);
+	});
 
-  it("upgrades a bare legacy plugin entry to canonical", async () => {
-    // given
-    writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2) + "\n", "utf-8")
+	it("upgrades a bare legacy plugin entry to canonical", async () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2) + "\n",
+			"utf-8",
+		);
 
-    // when
-    const result = await addPluginToOpenCodeConfig("3.11.0")
+		// when
+		const result = await addPluginToOpenCodeConfig("3.11.0");
 
-    // then
-    expect(result.success).toBe(true)
-    const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
-  })
+		// then
+		expect(result.success).toBe(true);
+		const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"));
+		expect(savedConfig.plugin).toEqual(["oh-my-openagent"]);
+	});
 
-  it("upgrades a version-pinned legacy entry to canonical", async () => {
-    // given
-    writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-opencode@3.10.0"] }, null, 2) + "\n", "utf-8")
+	it("upgrades a version-pinned legacy entry to canonical", async () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify({ plugin: ["oh-my-opencode@3.10.0"] }, null, 2) + "\n",
+			"utf-8",
+		);
 
-    // when
-    const result = await addPluginToOpenCodeConfig("3.11.0")
+		// when
+		const result = await addPluginToOpenCodeConfig("3.11.0");
 
-    // then
-    expect(result.success).toBe(true)
-    const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.10.0"])
-  })
+		// then
+		expect(result.success).toBe(true);
+		const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"));
+		expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.10.0"]);
+	});
 
-  it("removes stale legacy entry when canonical and legacy entries both exist", async () => {
-    // given
-    writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-openagent", "oh-my-opencode"] }, null, 2) + "\n", "utf-8")
+	it("removes stale legacy entry when canonical and legacy entries both exist", async () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify(
+				{ plugin: ["oh-my-openagent", "oh-my-opencode"] },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
 
-    // when
-    const result = await addPluginToOpenCodeConfig("3.11.0")
+		// when
+		const result = await addPluginToOpenCodeConfig("3.11.0");
 
-    // then
-    expect(result.success).toBe(true)
-    const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
-  })
+		// then
+		expect(result.success).toBe(true);
+		const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"));
+		expect(savedConfig.plugin).toEqual(["oh-my-openagent"]);
+	});
 
-  it("preserves a canonical entry when it already exists", async () => {
-    // given
-    writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-openagent@3.10.0"] }, null, 2) + "\n", "utf-8")
+	it("preserves a canonical entry when it already exists", async () => {
+		// given
+		writeFileSync(
+			testConfigPath,
+			JSON.stringify({ plugin: ["oh-my-openagent@3.10.0"] }, null, 2) + "\n",
+			"utf-8",
+		);
 
-    // when
-    const result = await addPluginToOpenCodeConfig("3.11.0")
+		// when
+		const result = await addPluginToOpenCodeConfig("3.11.0");
 
-    // then
-    expect(result.success).toBe(true)
-    const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
-    expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.10.0"])
-  })
+		// then
+		expect(result.success).toBe(true);
+		const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"));
+		expect(savedConfig.plugin).toEqual(["oh-my-openagent@3.10.0"]);
+	});
 
-  it("rewrites quoted jsonc plugin field in place", async () => {
-    // given
-    testConfigPath = join(testConfigDir, "opencode.jsonc")
-    writeFileSync(testConfigPath, '{\n  "plugin": ["oh-my-opencode"]\n}\n', "utf-8")
+	it("rewrites quoted jsonc plugin field in place", async () => {
+		// given
+		testConfigPath = join(testConfigDir, "opencode.jsonc");
+		writeFileSync(
+			testConfigPath,
+			'{\n  "plugin": ["oh-my-opencode"]\n}\n',
+			"utf-8",
+		);
 
-    // when
-    const result = await addPluginToOpenCodeConfig("3.11.0")
+		// when
+		const result = await addPluginToOpenCodeConfig("3.11.0");
 
-    // then
-    expect(result.success).toBe(true)
-    const savedContent = readFileSync(testConfigPath, "utf-8")
-    expect(savedContent.includes('"plugin": [\n    "oh-my-openagent"\n  ]')).toBe(true)
-    expect(savedContent.includes("oh-my-opencode")).toBe(false)
-  })
-})
+		// then
+		expect(result.success).toBe(true);
+		const savedContent = readFileSync(testConfigPath, "utf-8");
+		expect(
+			savedContent.includes('"plugin": [\n    "oh-my-openagent"\n  ]'),
+		).toBe(true);
+		expect(savedContent.includes("oh-my-opencode")).toBe(false);
+	});
+});

--- a/src/cli/config-manager/write-omo-config.test.ts
+++ b/src/cli/config-manager/write-omo-config.test.ts
@@ -1,80 +1,142 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { parseJsonc } from "../../shared/jsonc-parser"
-import type { InstallConfig } from "../types"
-import { resetConfigContext } from "./config-context"
-import { generateOmoConfig } from "./generate-omo-config"
-import { writeOmoConfig } from "./write-omo-config"
+import { parseJsonc } from "../../shared/jsonc-parser";
+import type { InstallConfig } from "../types";
+import { resetConfigContext } from "./config-context";
+import { generateOmoConfig } from "./generate-omo-config";
+import { writeOmoConfig } from "./write-omo-config";
 
 const installConfig: InstallConfig = {
-  hasClaude: true,
-  isMax20: true,
-  hasOpenAI: true,
-  hasGemini: true,
-  hasCopilot: false,
-  hasOpencodeZen: false,
-  hasZaiCodingPlan: false,
-  hasKimiForCoding: false,
-}
+	hasClaude: true,
+	isMax20: true,
+	hasOpenAI: true,
+	hasGemini: true,
+	hasCopilot: false,
+	hasOpencodeZen: false,
+	hasZaiCodingPlan: false,
+	hasKimiForCoding: false,
+};
 
 function getRecord(value: unknown): Record<string, unknown> {
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    return value as Record<string, unknown>
-  }
+	if (value && typeof value === "object" && !Array.isArray(value)) {
+		return value as Record<string, unknown>;
+	}
 
-  return {}
+	return {};
 }
 
 describe("writeOmoConfig", () => {
-  let testConfigDir = ""
-  let testConfigPath = ""
+	let testConfigDir = "";
+	let legacyConfigPath = "";
+	let canonicalConfigPath = "";
 
-  beforeEach(() => {
-    testConfigDir = join(tmpdir(), `omo-write-config-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    testConfigPath = join(testConfigDir, "oh-my-opencode.json")
+	beforeEach(() => {
+		testConfigDir = join(
+			tmpdir(),
+			`omo-write-config-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		legacyConfigPath = join(testConfigDir, "oh-my-opencode.json");
+		canonicalConfigPath = join(testConfigDir, "oh-my-openagent.jsonc");
 
-    mkdirSync(testConfigDir, { recursive: true })
-    process.env.OPENCODE_CONFIG_DIR = testConfigDir
-    resetConfigContext()
-  })
+		mkdirSync(testConfigDir, { recursive: true });
+		process.env.OPENCODE_CONFIG_DIR = testConfigDir;
+		resetConfigContext();
+	});
 
-  afterEach(() => {
-    rmSync(testConfigDir, { recursive: true, force: true })
-    resetConfigContext()
-    delete process.env.OPENCODE_CONFIG_DIR
-  })
+	afterEach(() => {
+		rmSync(testConfigDir, { recursive: true, force: true });
+		resetConfigContext();
+		delete process.env.OPENCODE_CONFIG_DIR;
+	});
 
-  it("preserves existing user values while adding new defaults", () => {
-    // given
-    const existingConfig = {
-      agents: {
-        sisyphus: {
-          model: "custom/provider-model",
-        },
-      },
-      disabled_hooks: ["comment-checker"],
-    }
-    writeFileSync(testConfigPath, JSON.stringify(existingConfig, null, 2) + "\n", "utf-8")
+	it("writes the canonical jsonc path for new installs", () => {
+		// when
+		const result = writeOmoConfig(installConfig);
 
-    const generatedDefaults = generateOmoConfig(installConfig)
+		// then
+		expect(result.success).toBe(true);
+		expect(result.configPath).toBe(canonicalConfigPath);
+		expect(existsSync(canonicalConfigPath)).toBe(true);
+	});
 
-    // when
-    const result = writeOmoConfig(installConfig)
+	it("preserves legacy user values while writing merged config to the canonical path", () => {
+		// given
+		const existingConfig = {
+			agents: {
+				sisyphus: {
+					model: "custom/provider-model",
+				},
+			},
+			disabled_hooks: ["comment-checker"],
+		};
+		writeFileSync(
+			legacyConfigPath,
+			JSON.stringify(existingConfig, null, 2) + "\n",
+			"utf-8",
+		);
 
-    // then
-    expect(result.success).toBe(true)
+		const generatedDefaults = generateOmoConfig(installConfig);
 
-    const savedConfig = parseJsonc<Record<string, unknown>>(readFileSync(testConfigPath, "utf-8"))
-    const savedAgents = getRecord(savedConfig.agents)
-    const savedSisyphus = getRecord(savedAgents.sisyphus)
-    expect(savedSisyphus.model).toBe("custom/provider-model")
-    expect(savedConfig.disabled_hooks).toEqual(["comment-checker"])
+		// when
+		const result = writeOmoConfig(installConfig);
 
-    for (const defaultKey of Object.keys(generatedDefaults)) {
-      expect(savedConfig).toHaveProperty(defaultKey)
-    }
-  })
-})
+		// then
+		expect(result.success).toBe(true);
+		expect(result.configPath).toBe(canonicalConfigPath);
+
+		const savedConfig = parseJsonc<Record<string, unknown>>(
+			readFileSync(canonicalConfigPath, "utf-8"),
+		);
+		const savedAgents = getRecord(savedConfig.agents);
+		const savedSisyphus = getRecord(savedAgents.sisyphus);
+		expect(savedSisyphus.model).toBe("custom/provider-model");
+		expect(savedConfig.disabled_hooks).toEqual(["comment-checker"]);
+
+		for (const defaultKey of Object.keys(generatedDefaults)) {
+			expect(savedConfig).toHaveProperty(defaultKey);
+		}
+	});
+
+	it("prefers canonical config as the merge source when canonical and legacy configs coexist", () => {
+		// given
+		writeFileSync(
+			legacyConfigPath,
+			JSON.stringify(
+				{ agents: { sisyphus: { model: "legacy/provider-model" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+		writeFileSync(
+			canonicalConfigPath,
+			JSON.stringify(
+				{ agents: { sisyphus: { model: "canonical/provider-model" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+
+		// when
+		const result = writeOmoConfig(installConfig);
+
+		// then
+		expect(result.success).toBe(true);
+		const savedConfig = parseJsonc<Record<string, unknown>>(
+			readFileSync(canonicalConfigPath, "utf-8"),
+		);
+		const savedAgents = getRecord(savedConfig.agents);
+		const savedSisyphus = getRecord(savedAgents.sisyphus);
+		expect(savedSisyphus.model).toBe("canonical/provider-model");
+	});
+});

--- a/src/cli/config-manager/write-omo-config.test.ts
+++ b/src/cli/config-manager/write-omo-config.test.ts
@@ -139,4 +139,53 @@ describe("writeOmoConfig", () => {
 		const savedSisyphus = getRecord(savedAgents.sisyphus);
 		expect(savedSisyphus.model).toBe("canonical/provider-model");
 	});
+
+	it("updates an existing canonical json file in place instead of creating a second canonical file", () => {
+		const canonicalJsonPath = join(testConfigDir, "oh-my-openagent.json");
+		writeFileSync(
+			canonicalJsonPath,
+			JSON.stringify(
+				{ agents: { sisyphus: { model: "canonical-json/provider-model" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+
+		const result = writeOmoConfig(installConfig);
+
+		expect(result.success).toBe(true);
+		expect(result.configPath).toBe(canonicalJsonPath);
+		expect(existsSync(canonicalConfigPath)).toBe(false);
+
+		const savedConfig = parseJsonc<Record<string, unknown>>(
+			readFileSync(canonicalJsonPath, "utf-8"),
+		);
+		const savedAgents = getRecord(savedConfig.agents);
+		const savedSisyphus = getRecord(savedAgents.sisyphus);
+		expect(savedSisyphus.model).toBe("canonical-json/provider-model");
+	});
+
+	it("falls back to legacy config when canonical config is malformed", () => {
+		writeFileSync(canonicalConfigPath, "{ invalid jsonc", "utf-8");
+		writeFileSync(
+			legacyConfigPath,
+			JSON.stringify(
+				{ agents: { sisyphus: { model: "legacy-fallback/provider-model" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+
+		const result = writeOmoConfig(installConfig);
+
+		expect(result.success).toBe(true);
+		const savedConfig = parseJsonc<Record<string, unknown>>(
+			readFileSync(canonicalConfigPath, "utf-8"),
+		);
+		const savedAgents = getRecord(savedConfig.agents);
+		const savedSisyphus = getRecord(savedAgents.sisyphus);
+		expect(savedSisyphus.model).toBe("legacy-fallback/provider-model");
+	});
 });

--- a/src/cli/config-manager/write-omo-config.ts
+++ b/src/cli/config-manager/write-omo-config.ts
@@ -1,67 +1,85 @@
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs"
-import { parseJsonc } from "../../shared"
-import type { ConfigMergeResult, InstallConfig } from "../types"
-import { getConfigDir, getOmoConfigPath } from "./config-context"
-import { deepMergeRecord } from "./deep-merge-record"
-import { ensureConfigDirectoryExists } from "./ensure-config-directory-exists"
-import { formatErrorWithSuggestion } from "./format-error-with-suggestion"
-import { generateOmoConfig } from "./generate-omo-config"
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { detectPluginConfigFile, parseJsonc } from "../../shared";
+import type { ConfigMergeResult, InstallConfig } from "../types";
+import { getConfigDir, getOmoConfigPath } from "./config-context";
+import { deepMergeRecord } from "./deep-merge-record";
+import { ensureConfigDirectoryExists } from "./ensure-config-directory-exists";
+import { formatErrorWithSuggestion } from "./format-error-with-suggestion";
+import { generateOmoConfig } from "./generate-omo-config";
 
 function isEmptyOrWhitespace(content: string): boolean {
-  return content.trim().length === 0
+	return content.trim().length === 0;
 }
 
-export function writeOmoConfig(installConfig: InstallConfig): ConfigMergeResult {
-  try {
-    ensureConfigDirectoryExists()
-  } catch (err) {
-    return {
-      success: false,
-      configPath: getConfigDir(),
-      error: formatErrorWithSuggestion(err, "create config directory"),
-    }
-  }
+export function writeOmoConfig(
+	installConfig: InstallConfig,
+): ConfigMergeResult {
+	try {
+		ensureConfigDirectoryExists();
+	} catch (err) {
+		return {
+			success: false,
+			configPath: getConfigDir(),
+			error: formatErrorWithSuggestion(err, "create config directory"),
+		};
+	}
 
-  const omoConfigPath = getOmoConfigPath()
+	const omoConfigPath = getOmoConfigPath();
+	const detectedConfig = detectPluginConfigFile(getConfigDir());
+	const sourceConfigPath =
+		detectedConfig.format !== "none" ? detectedConfig.path : omoConfigPath;
 
-  try {
-    const newConfig = generateOmoConfig(installConfig)
+	try {
+		const newConfig = generateOmoConfig(installConfig);
 
-    if (existsSync(omoConfigPath)) {
-      try {
-        const stat = statSync(omoConfigPath)
-        const content = readFileSync(omoConfigPath, "utf-8")
+		if (existsSync(sourceConfigPath)) {
+			try {
+				const stat = statSync(sourceConfigPath);
+				const content = readFileSync(sourceConfigPath, "utf-8");
 
-        if (stat.size === 0 || isEmptyOrWhitespace(content)) {
-          writeFileSync(omoConfigPath, JSON.stringify(newConfig, null, 2) + "\n")
-          return { success: true, configPath: omoConfigPath }
-        }
+				if (stat.size === 0 || isEmptyOrWhitespace(content)) {
+					writeFileSync(
+						omoConfigPath,
+						JSON.stringify(newConfig, null, 2) + "\n",
+					);
+					return { success: true, configPath: omoConfigPath };
+				}
 
-        const existing = parseJsonc<Record<string, unknown>>(content)
-        if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
-          writeFileSync(omoConfigPath, JSON.stringify(newConfig, null, 2) + "\n")
-          return { success: true, configPath: omoConfigPath }
-        }
+				const existing = parseJsonc<Record<string, unknown>>(content);
+				if (
+					!existing ||
+					typeof existing !== "object" ||
+					Array.isArray(existing)
+				) {
+					writeFileSync(
+						omoConfigPath,
+						JSON.stringify(newConfig, null, 2) + "\n",
+					);
+					return { success: true, configPath: omoConfigPath };
+				}
 
-        const merged = deepMergeRecord(newConfig, existing)
-        writeFileSync(omoConfigPath, JSON.stringify(merged, null, 2) + "\n")
-      } catch (parseErr) {
-        if (parseErr instanceof SyntaxError) {
-          writeFileSync(omoConfigPath, JSON.stringify(newConfig, null, 2) + "\n")
-          return { success: true, configPath: omoConfigPath }
-        }
-        throw parseErr
-      }
-    } else {
-      writeFileSync(omoConfigPath, JSON.stringify(newConfig, null, 2) + "\n")
-    }
+				const merged = deepMergeRecord(newConfig, existing);
+				writeFileSync(omoConfigPath, JSON.stringify(merged, null, 2) + "\n");
+			} catch (parseErr) {
+				if (parseErr instanceof SyntaxError) {
+					writeFileSync(
+						omoConfigPath,
+						JSON.stringify(newConfig, null, 2) + "\n",
+					);
+					return { success: true, configPath: omoConfigPath };
+				}
+				throw parseErr;
+			}
+		} else {
+			writeFileSync(omoConfigPath, JSON.stringify(newConfig, null, 2) + "\n");
+		}
 
-    return { success: true, configPath: omoConfigPath }
-  } catch (err) {
-    return {
-      success: false,
-      configPath: omoConfigPath,
-      error: formatErrorWithSuggestion(err, "write oh-my-opencode config"),
-    }
-  }
+		return { success: true, configPath: omoConfigPath };
+	} catch (err) {
+		return {
+			success: false,
+			configPath: omoConfigPath,
+			error: formatErrorWithSuggestion(err, "write oh-my-opencode config"),
+		};
+	}
 }

--- a/src/cli/config-manager/write-omo-config.ts
+++ b/src/cli/config-manager/write-omo-config.ts
@@ -1,7 +1,12 @@
 import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { detectPluginConfigFile, parseJsonc } from "../../shared";
+import { join } from "node:path";
+import {
+	CONFIG_BASENAME,
+	getPluginConfigFileCandidates,
+	parseJsonc,
+} from "../../shared";
 import type { ConfigMergeResult, InstallConfig } from "../types";
-import { getConfigDir, getOmoConfigPath } from "./config-context";
+import { getConfigDir } from "./config-context";
 import { deepMergeRecord } from "./deep-merge-record";
 import { ensureConfigDirectoryExists } from "./ensure-config-directory-exists";
 import { formatErrorWithSuggestion } from "./format-error-with-suggestion";
@@ -9,6 +14,57 @@ import { generateOmoConfig } from "./generate-omo-config";
 
 function isEmptyOrWhitespace(content: string): boolean {
 	return content.trim().length === 0;
+}
+
+function getWritableOmoConfigPath(configDir: string): string {
+	const canonicalJsoncPath = join(configDir, `${CONFIG_BASENAME}.jsonc`);
+	const canonicalJsonPath = join(configDir, `${CONFIG_BASENAME}.json`);
+
+	if (existsSync(canonicalJsoncPath)) {
+		return canonicalJsoncPath;
+	}
+
+	if (existsSync(canonicalJsonPath)) {
+		return canonicalJsonPath;
+	}
+
+	return canonicalJsoncPath;
+}
+
+function readFirstValidExistingConfig(
+	configDir: string,
+): Record<string, unknown> | null {
+	for (const candidatePath of getPluginConfigFileCandidates(configDir)) {
+		if (!existsSync(candidatePath)) continue;
+
+		try {
+			const stat = statSync(candidatePath);
+			const content = readFileSync(candidatePath, "utf-8");
+
+			if (stat.size === 0 || isEmptyOrWhitespace(content)) {
+				continue;
+			}
+
+			const existing = parseJsonc<Record<string, unknown>>(content);
+			if (
+				!existing ||
+				typeof existing !== "object" ||
+				Array.isArray(existing)
+			) {
+				continue;
+			}
+
+			return existing;
+		} catch (parseErr) {
+			if (parseErr instanceof SyntaxError) {
+				continue;
+			}
+
+			throw parseErr;
+		}
+	}
+
+	return null;
 }
 
 export function writeOmoConfig(
@@ -24,55 +80,14 @@ export function writeOmoConfig(
 		};
 	}
 
-	const omoConfigPath = getOmoConfigPath();
-	const detectedConfig = detectPluginConfigFile(getConfigDir());
-	const sourceConfigPath =
-		detectedConfig.format !== "none" ? detectedConfig.path : omoConfigPath;
+	const configDir = getConfigDir();
+	const omoConfigPath = getWritableOmoConfigPath(configDir);
 
 	try {
 		const newConfig = generateOmoConfig(installConfig);
-
-		if (existsSync(sourceConfigPath)) {
-			try {
-				const stat = statSync(sourceConfigPath);
-				const content = readFileSync(sourceConfigPath, "utf-8");
-
-				if (stat.size === 0 || isEmptyOrWhitespace(content)) {
-					writeFileSync(
-						omoConfigPath,
-						JSON.stringify(newConfig, null, 2) + "\n",
-					);
-					return { success: true, configPath: omoConfigPath };
-				}
-
-				const existing = parseJsonc<Record<string, unknown>>(content);
-				if (
-					!existing ||
-					typeof existing !== "object" ||
-					Array.isArray(existing)
-				) {
-					writeFileSync(
-						omoConfigPath,
-						JSON.stringify(newConfig, null, 2) + "\n",
-					);
-					return { success: true, configPath: omoConfigPath };
-				}
-
-				const merged = deepMergeRecord(newConfig, existing);
-				writeFileSync(omoConfigPath, JSON.stringify(merged, null, 2) + "\n");
-			} catch (parseErr) {
-				if (parseErr instanceof SyntaxError) {
-					writeFileSync(
-						omoConfigPath,
-						JSON.stringify(newConfig, null, 2) + "\n",
-					);
-					return { success: true, configPath: omoConfigPath };
-				}
-				throw parseErr;
-			}
-		} else {
-			writeFileSync(omoConfigPath, JSON.stringify(newConfig, null, 2) + "\n");
-		}
+		const existing = readFirstValidExistingConfig(configDir);
+		const merged = existing ? deepMergeRecord(newConfig, existing) : newConfig;
+		writeFileSync(omoConfigPath, JSON.stringify(merged, null, 2) + "\n");
 
 		return { success: true, configPath: omoConfigPath };
 	} catch (err) {

--- a/src/cli/doctor/checks/config.test.ts
+++ b/src/cli/doctor/checks/config.test.ts
@@ -77,5 +77,140 @@ describe("config check", () => {
 				rmSync(tempProject, { recursive: true, force: true });
 			}
 		});
+
+		it("fails when the only plugin config is malformed", async () => {
+			const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+			const originalCwd = process.cwd();
+			const tempBase = join(
+				tmpdir(),
+				`omo-doctor-config-broken-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+			const tempProject = join(
+				tmpdir(),
+				`omo-doctor-config-broken-project-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+
+			try {
+				mkdirSync(tempBase, { recursive: true });
+				mkdirSync(tempProject, { recursive: true });
+				process.env.OPENCODE_CONFIG_DIR = tempBase;
+				process.chdir(tempProject);
+
+				const brokenPath = join(tempBase, "oh-my-openagent.jsonc");
+				writeFileSync(brokenPath, "{ invalid jsonc", "utf-8");
+
+				const freshConfig = await import(
+					`./config?test=${Date.now()}-${Math.random()}`
+				);
+				const result = await freshConfig.checkConfig();
+
+				expect(result.status).toBe("fail");
+				expect(result.details).toContain(`Path: ${brokenPath}`);
+				expect(
+					result.issues.some(
+						(issue) => issue.title === "Invalid configuration",
+					),
+				).toBe(true);
+			} finally {
+				if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+				else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+				process.chdir(originalCwd);
+				rmSync(tempBase, { recursive: true, force: true });
+				rmSync(tempProject, { recursive: true, force: true });
+			}
+		});
+
+		it("fails when only the project plugin config is malformed", async () => {
+			const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+			const originalCwd = process.cwd();
+			const tempBase = join(
+				tmpdir(),
+				`omo-doctor-config-empty-user-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+			const tempProject = join(
+				tmpdir(),
+				`omo-doctor-config-broken-project-only-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+
+			try {
+				mkdirSync(tempBase, { recursive: true });
+				mkdirSync(join(tempProject, ".opencode"), { recursive: true });
+				process.env.OPENCODE_CONFIG_DIR = tempBase;
+				process.chdir(tempProject);
+
+				const brokenPath = join(
+					tempProject,
+					".opencode",
+					"oh-my-openagent.jsonc",
+				);
+				writeFileSync(brokenPath, "{ invalid jsonc", "utf-8");
+
+				const freshConfig = await import(
+					`./config?test=${Date.now()}-${Math.random()}`
+				);
+				const result = await freshConfig.checkConfig();
+
+				expect(result.status).toBe("fail");
+				expect(result.details).toContain(`Path: ${brokenPath}`);
+			} finally {
+				if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+				else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+				process.chdir(originalCwd);
+				rmSync(tempBase, { recursive: true, force: true });
+				rmSync(tempProject, { recursive: true, force: true });
+			}
+		});
+
+		it("applies legacy agent-name migrations before collecting config warnings", async () => {
+			const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+			const originalCwd = process.cwd();
+			const tempBase = join(
+				tmpdir(),
+				`omo-doctor-config-migrate-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+			const tempProject = join(
+				tmpdir(),
+				`omo-doctor-config-migrate-project-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+
+			try {
+				mkdirSync(tempBase, { recursive: true });
+				mkdirSync(tempProject, { recursive: true });
+				process.env.OPENCODE_CONFIG_DIR = tempBase;
+				process.chdir(tempProject);
+
+				writeFileSync(
+					join(tempBase, "oh-my-opencode.jsonc"),
+					JSON.stringify(
+						{
+							agents: {
+								omo: { model: "not-a-provider-model" },
+							},
+						},
+						null,
+						2,
+					) + "\n",
+					"utf-8",
+				);
+
+				const freshConfig = await import(
+					`./config?test=${Date.now()}-${Math.random()}`
+				);
+				const result = await freshConfig.checkConfig();
+
+				expect(result.status).toBe("warn");
+				expect(
+					result.issues.some(
+						(issue) => issue.title === "Invalid agent override: sisyphus",
+					),
+				).toBe(true);
+			} finally {
+				if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+				else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+				process.chdir(originalCwd);
+				rmSync(tempBase, { recursive: true, force: true });
+				rmSync(tempProject, { recursive: true, force: true });
+			}
+		});
 	});
 });

--- a/src/cli/doctor/checks/config.test.ts
+++ b/src/cli/doctor/checks/config.test.ts
@@ -1,27 +1,81 @@
-import { describe, it, expect } from "bun:test"
-import * as config from "./config"
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as config from "./config";
 
 describe("config check", () => {
-  describe("checkConfig", () => {
-    it("returns a valid CheckResult", async () => {
-      //#given config check is available
-      //#when running the consolidated config check
-      const result = await config.checkConfig()
+	describe("checkConfig", () => {
+		it("returns a valid CheckResult", async () => {
+			//#given config check is available
+			//#when running the consolidated config check
+			const result = await config.checkConfig();
 
-      //#then should return a properly shaped CheckResult
-      expect(result.name).toBe("Configuration")
-      expect(["pass", "fail", "warn", "skip"]).toContain(result.status)
-      expect(typeof result.message).toBe("string")
-      expect(Array.isArray(result.issues)).toBe(true)
-    })
+			//#then should return a properly shaped CheckResult
+			expect(result.name).toBe("Configuration");
+			expect(["pass", "fail", "warn", "skip"]).toContain(result.status);
+			expect(typeof result.message).toBe("string");
+			expect(Array.isArray(result.issues)).toBe(true);
+		});
 
-    it("includes issues array even when config is valid", async () => {
-      //#given a normal environment
-      //#when running config check
-      const result = await config.checkConfig()
+		it("includes issues array even when config is valid", async () => {
+			//#given a normal environment
+			//#when running config check
+			const result = await config.checkConfig();
 
-      //#then issues should be an array (possibly empty)
-      expect(Array.isArray(result.issues)).toBe(true)
-    })
-  })
-})
+			//#then issues should be an array (possibly empty)
+			expect(Array.isArray(result.issues)).toBe(true);
+		});
+
+		it("falls back to legacy config when canonical config is malformed", async () => {
+			const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+			const originalCwd = process.cwd();
+			const tempBase = join(
+				tmpdir(),
+				`omo-doctor-config-user-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+			const tempProject = join(
+				tmpdir(),
+				`omo-doctor-config-project-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+			);
+
+			try {
+				mkdirSync(tempBase, { recursive: true });
+				mkdirSync(tempProject, { recursive: true });
+				process.env.OPENCODE_CONFIG_DIR = tempBase;
+				process.chdir(tempProject);
+
+				writeFileSync(
+					join(tempBase, "oh-my-openagent.jsonc"),
+					"{ invalid jsonc",
+					"utf-8",
+				);
+				writeFileSync(
+					join(tempBase, "oh-my-opencode.jsonc"),
+					JSON.stringify(
+						{ disabled_hooks: ["legacy-fallback-hook"] },
+						null,
+						2,
+					) + "\n",
+					"utf-8",
+				);
+
+				const freshConfig = await import(
+					`./config?test=${Date.now()}-${Math.random()}`
+				);
+				const result = await freshConfig.checkConfig();
+
+				expect(result.status).toBe("pass");
+				expect(result.details).toContain(
+					`Path: ${join(tempBase, "oh-my-opencode.jsonc")}`,
+				);
+			} finally {
+				if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+				else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+				process.chdir(originalCwd);
+				rmSync(tempBase, { recursive: true, force: true });
+				rmSync(tempProject, { recursive: true, force: true });
+			}
+		});
+	});
+});

--- a/src/cli/doctor/checks/config.ts
+++ b/src/cli/doctor/checks/config.ts
@@ -1,9 +1,12 @@
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { OhMyOpenCodeConfigSchema } from "../../../config";
 import {
 	getOpenCodeConfigDir,
-	readFirstValidPluginConfigFile,
+	getPluginConfigFileCandidates,
+	migrateConfigFile,
+	parseJsonc,
 } from "../../../shared";
 import { CHECK_IDS, CHECK_NAMES } from "../constants";
 import type { CheckResult, DoctorIssue } from "../types";
@@ -11,8 +14,13 @@ import { getModelResolutionInfoWithOverrides } from "./model-resolution";
 import { loadAvailableModelsFromCache } from "./model-resolution-cache";
 import type { OmoConfig } from "./model-resolution-types";
 
-const USER_CONFIG_DIR = getOpenCodeConfigDir({ binary: "opencode" });
-const PROJECT_CONFIG_DIR = join(process.cwd(), ".opencode");
+function getUserConfigDir(): string {
+	return getOpenCodeConfigDir({ binary: "opencode" });
+}
+
+function getProjectConfigDir(): string {
+	return join(process.cwd(), ".opencode");
+}
 
 interface ConfigValidationResult {
 	exists: boolean;
@@ -20,63 +28,97 @@ interface ConfigValidationResult {
 	valid: boolean;
 	config: OmoConfig | null;
 	errors: string[];
+	terminal: boolean;
 }
 
-function findValidConfig(): { path: string; config: OmoConfig } | null {
-	const projectConfig =
-		readFirstValidPluginConfigFile<OmoConfig>(PROJECT_CONFIG_DIR);
-	if (projectConfig.format !== "none" && projectConfig.data) {
-		return { path: projectConfig.path, config: projectConfig.data };
-	}
+function inspectConfigDir(directory: string): ConfigValidationResult {
+	let firstExistingPath: string | null = null;
+	let fallbackError: string | null = null;
 
-	const userConfig = readFirstValidPluginConfigFile<OmoConfig>(USER_CONFIG_DIR);
-	if (userConfig.format !== "none" && userConfig.data) {
-		return { path: userConfig.path, config: userConfig.data };
-	}
+	for (const candidatePath of getPluginConfigFileCandidates(directory)) {
+		if (!existsSync(candidatePath)) continue;
+		firstExistingPath ??= candidatePath;
 
-	return null;
-}
+		let rawConfig: unknown;
+		try {
+			rawConfig = parseJsonc<unknown>(readFileSync(candidatePath, "utf-8"));
+		} catch (error) {
+			fallbackError ??=
+				error instanceof Error ? error.message : "Failed to parse config";
+			continue;
+		}
 
-function validateConfig(): ConfigValidationResult {
-	const validConfig = findValidConfig();
-	if (!validConfig) {
-		return { exists: false, path: null, valid: true, config: null, errors: [] };
-	}
+		if (
+			!rawConfig ||
+			typeof rawConfig !== "object" ||
+			Array.isArray(rawConfig)
+		) {
+			fallbackError ??= "Plugin config root must be an object";
+			continue;
+		}
 
-	try {
-		const rawConfig = validConfig.config;
+		migrateConfigFile(candidatePath, rawConfig as Record<string, unknown>, {
+			persist: false,
+		});
+
 		const schemaResult = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
-
 		if (!schemaResult.success) {
 			return {
 				exists: true,
-				path: validConfig.path,
+				path: candidatePath,
 				valid: false,
-				config: rawConfig,
+				config: rawConfig as OmoConfig,
 				errors: schemaResult.error.issues.map(
 					(issue) => `${issue.path.join(".")}: ${issue.message}`,
 				),
+				terminal: true,
 			};
 		}
 
 		return {
 			exists: true,
-			path: validConfig.path,
+			path: candidatePath,
 			valid: true,
-			config: rawConfig,
+			config: rawConfig as OmoConfig,
 			errors: [],
-		};
-	} catch (error) {
-		return {
-			exists: true,
-			path: validConfig.path,
-			valid: false,
-			config: null,
-			errors: [
-				error instanceof Error ? error.message : "Failed to parse config",
-			],
+			terminal: false,
 		};
 	}
+
+	if (firstExistingPath) {
+		return {
+			exists: true,
+			path: firstExistingPath,
+			valid: false,
+			config: null,
+			errors: [fallbackError ?? "Failed to parse config"],
+			terminal: false,
+		};
+	}
+
+	return {
+		exists: false,
+		path: null,
+		valid: true,
+		config: null,
+		errors: [],
+		terminal: false,
+	};
+}
+
+function validateConfig(): ConfigValidationResult {
+	const projectConfig = inspectConfigDir(getProjectConfigDir());
+	if ((projectConfig.exists && projectConfig.valid) || projectConfig.terminal) {
+		return projectConfig;
+	}
+
+	const userConfig = inspectConfigDir(getUserConfigDir());
+	if (userConfig.exists && userConfig.valid) {
+		return userConfig;
+	}
+
+	if (projectConfig.exists) return projectConfig;
+	return userConfig;
 }
 
 function collectModelResolutionIssues(config: OmoConfig): DoctorIssue[] {

--- a/src/cli/doctor/checks/config.ts
+++ b/src/cli/doctor/checks/config.ts
@@ -1,164 +1,183 @@
-import { readFileSync } from "node:fs"
-import { join } from "node:path"
+import { join } from "node:path";
 
-import { OhMyOpenCodeConfigSchema } from "../../../config"
-import { detectPluginConfigFile, getOpenCodeConfigDir, parseJsonc } from "../../../shared"
-import { CHECK_IDS, CHECK_NAMES, PACKAGE_NAME } from "../constants"
-import type { CheckResult, DoctorIssue } from "../types"
-import { loadAvailableModelsFromCache } from "./model-resolution-cache"
-import { getModelResolutionInfoWithOverrides } from "./model-resolution"
-import type { OmoConfig } from "./model-resolution-types"
+import { OhMyOpenCodeConfigSchema } from "../../../config";
+import {
+	getOpenCodeConfigDir,
+	readFirstValidPluginConfigFile,
+} from "../../../shared";
+import { CHECK_IDS, CHECK_NAMES } from "../constants";
+import type { CheckResult, DoctorIssue } from "../types";
+import { getModelResolutionInfoWithOverrides } from "./model-resolution";
+import { loadAvailableModelsFromCache } from "./model-resolution-cache";
+import type { OmoConfig } from "./model-resolution-types";
 
-const USER_CONFIG_DIR = getOpenCodeConfigDir({ binary: "opencode" })
-const PROJECT_CONFIG_DIR = join(process.cwd(), ".opencode")
+const USER_CONFIG_DIR = getOpenCodeConfigDir({ binary: "opencode" });
+const PROJECT_CONFIG_DIR = join(process.cwd(), ".opencode");
 
 interface ConfigValidationResult {
-  exists: boolean
-  path: string | null
-  valid: boolean
-  config: OmoConfig | null
-  errors: string[]
+	exists: boolean;
+	path: string | null;
+	valid: boolean;
+	config: OmoConfig | null;
+	errors: string[];
 }
 
-function findConfigPath(): string | null {
-  const projectConfig = detectPluginConfigFile(PROJECT_CONFIG_DIR)
-  if (projectConfig.format !== "none") return projectConfig.path
+function findValidConfig(): { path: string; config: OmoConfig } | null {
+	const projectConfig =
+		readFirstValidPluginConfigFile<OmoConfig>(PROJECT_CONFIG_DIR);
+	if (projectConfig.format !== "none" && projectConfig.data) {
+		return { path: projectConfig.path, config: projectConfig.data };
+	}
 
-  const userConfig = detectPluginConfigFile(USER_CONFIG_DIR)
-  if (userConfig.format !== "none") return userConfig.path
+	const userConfig = readFirstValidPluginConfigFile<OmoConfig>(USER_CONFIG_DIR);
+	if (userConfig.format !== "none" && userConfig.data) {
+		return { path: userConfig.path, config: userConfig.data };
+	}
 
-  return null
+	return null;
 }
 
 function validateConfig(): ConfigValidationResult {
-  const configPath = findConfigPath()
-  if (!configPath) {
-    return { exists: false, path: null, valid: true, config: null, errors: [] }
-  }
+	const validConfig = findValidConfig();
+	if (!validConfig) {
+		return { exists: false, path: null, valid: true, config: null, errors: [] };
+	}
 
-  try {
-    const content = readFileSync(configPath, "utf-8")
-    const rawConfig = parseJsonc<OmoConfig>(content)
-    const schemaResult = OhMyOpenCodeConfigSchema.safeParse(rawConfig)
+	try {
+		const rawConfig = validConfig.config;
+		const schemaResult = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
 
-    if (!schemaResult.success) {
-      return {
-        exists: true,
-        path: configPath,
-        valid: false,
-        config: rawConfig,
-        errors: schemaResult.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`),
-      }
-    }
+		if (!schemaResult.success) {
+			return {
+				exists: true,
+				path: validConfig.path,
+				valid: false,
+				config: rawConfig,
+				errors: schemaResult.error.issues.map(
+					(issue) => `${issue.path.join(".")}: ${issue.message}`,
+				),
+			};
+		}
 
-    return { exists: true, path: configPath, valid: true, config: rawConfig, errors: [] }
-  } catch (error) {
-    return {
-      exists: true,
-      path: configPath,
-      valid: false,
-      config: null,
-      errors: [error instanceof Error ? error.message : "Failed to parse config"],
-    }
-  }
+		return {
+			exists: true,
+			path: validConfig.path,
+			valid: true,
+			config: rawConfig,
+			errors: [],
+		};
+	} catch (error) {
+		return {
+			exists: true,
+			path: validConfig.path,
+			valid: false,
+			config: null,
+			errors: [
+				error instanceof Error ? error.message : "Failed to parse config",
+			],
+		};
+	}
 }
 
 function collectModelResolutionIssues(config: OmoConfig): DoctorIssue[] {
-  const issues: DoctorIssue[] = []
-  const availableModels = loadAvailableModelsFromCache()
-  const resolution = getModelResolutionInfoWithOverrides(config)
+	const issues: DoctorIssue[] = [];
+	const availableModels = loadAvailableModelsFromCache();
+	const resolution = getModelResolutionInfoWithOverrides(config);
 
-  const invalidAgentOverrides = resolution.agents.filter(
-    (agent) => agent.userOverride && !agent.userOverride.includes("/")
-  )
-  const invalidCategoryOverrides = resolution.categories.filter(
-    (category) => category.userOverride && !category.userOverride.includes("/")
-  )
+	const invalidAgentOverrides = resolution.agents.filter(
+		(agent) => agent.userOverride && !agent.userOverride.includes("/"),
+	);
+	const invalidCategoryOverrides = resolution.categories.filter(
+		(category) => category.userOverride && !category.userOverride.includes("/"),
+	);
 
-  for (const invalidAgent of invalidAgentOverrides) {
-    issues.push({
-      title: `Invalid agent override: ${invalidAgent.name}`,
-      description: `Override '${invalidAgent.userOverride}' must be in provider/model format.`,
-      severity: "warning",
-      affects: [invalidAgent.name],
-    })
-  }
+	for (const invalidAgent of invalidAgentOverrides) {
+		issues.push({
+			title: `Invalid agent override: ${invalidAgent.name}`,
+			description: `Override '${invalidAgent.userOverride}' must be in provider/model format.`,
+			severity: "warning",
+			affects: [invalidAgent.name],
+		});
+	}
 
-  for (const invalidCategory of invalidCategoryOverrides) {
-    issues.push({
-      title: `Invalid category override: ${invalidCategory.name}`,
-      description: `Override '${invalidCategory.userOverride}' must be in provider/model format.`,
-      severity: "warning",
-      affects: [invalidCategory.name],
-    })
-  }
+	for (const invalidCategory of invalidCategoryOverrides) {
+		issues.push({
+			title: `Invalid category override: ${invalidCategory.name}`,
+			description: `Override '${invalidCategory.userOverride}' must be in provider/model format.`,
+			severity: "warning",
+			affects: [invalidCategory.name],
+		});
+	}
 
-  if (availableModels.cacheExists) {
-    const providerSet = new Set(availableModels.providers)
-    const unknownProviders = [
-      ...resolution.agents.map((agent) => agent.userOverride),
-      ...resolution.categories.map((category) => category.userOverride),
-    ]
-      .filter((value): value is string => Boolean(value))
-      .map((value) => value.split("/")[0])
-      .filter((provider) => provider.length > 0 && !providerSet.has(provider))
+	if (availableModels.cacheExists) {
+		const providerSet = new Set(availableModels.providers);
+		const unknownProviders = [
+			...resolution.agents.map((agent) => agent.userOverride),
+			...resolution.categories.map((category) => category.userOverride),
+		]
+			.filter((value): value is string => Boolean(value))
+			.map((value) => value.split("/")[0])
+			.filter((provider) => provider.length > 0 && !providerSet.has(provider));
 
-    if (unknownProviders.length > 0) {
-      const uniqueProviders = [...new Set(unknownProviders)]
-      issues.push({
-        title: "Model override uses unavailable provider",
-        description: `Provider(s) not found in OpenCode model cache: ${uniqueProviders.join(", ")}`,
-        severity: "warning",
-        affects: ["model resolution"],
-      })
-    }
-  }
+		if (unknownProviders.length > 0) {
+			const uniqueProviders = [...new Set(unknownProviders)];
+			issues.push({
+				title: "Model override uses unavailable provider",
+				description: `Provider(s) not found in OpenCode model cache: ${uniqueProviders.join(", ")}`,
+				severity: "warning",
+				affects: ["model resolution"],
+			});
+		}
+	}
 
-  return issues
+	return issues;
 }
 
 export async function checkConfig(): Promise<CheckResult> {
-  const validation = validateConfig()
-  const issues: DoctorIssue[] = []
+	const validation = validateConfig();
+	const issues: DoctorIssue[] = [];
 
-  if (!validation.exists) {
-    return {
-      name: CHECK_NAMES[CHECK_IDS.CONFIG],
-      status: "pass",
-      message: "No custom config found; defaults are used",
-      details: undefined,
-      issues,
-    }
-  }
+	if (!validation.exists) {
+		return {
+			name: CHECK_NAMES[CHECK_IDS.CONFIG],
+			status: "pass",
+			message: "No custom config found; defaults are used",
+			details: undefined,
+			issues,
+		};
+	}
 
-  if (!validation.valid) {
-    issues.push(
-      ...validation.errors.map((error) => ({
-        title: "Invalid configuration",
-        description: error,
-        severity: "error" as const,
-        affects: ["plugin startup"],
-      }))
-    )
+	if (!validation.valid) {
+		issues.push(
+			...validation.errors.map((error) => ({
+				title: "Invalid configuration",
+				description: error,
+				severity: "error" as const,
+				affects: ["plugin startup"],
+			})),
+		);
 
-    return {
-      name: CHECK_NAMES[CHECK_IDS.CONFIG],
-      status: "fail",
-      message: `Configuration invalid (${issues.length} issue${issues.length > 1 ? "s" : ""})`,
-      details: validation.path ? [`Path: ${validation.path}`] : undefined,
-      issues,
-    }
-  }
+		return {
+			name: CHECK_NAMES[CHECK_IDS.CONFIG],
+			status: "fail",
+			message: `Configuration invalid (${issues.length} issue${issues.length > 1 ? "s" : ""})`,
+			details: validation.path ? [`Path: ${validation.path}`] : undefined,
+			issues,
+		};
+	}
 
-  if (validation.config) {
-    issues.push(...collectModelResolutionIssues(validation.config))
-  }
+	if (validation.config) {
+		issues.push(...collectModelResolutionIssues(validation.config));
+	}
 
-  return {
-    name: CHECK_NAMES[CHECK_IDS.CONFIG],
-    status: issues.length > 0 ? "warn" : "pass",
-    message: issues.length > 0 ? `${issues.length} configuration warning(s)` : "Configuration is valid",
-    details: validation.path ? [`Path: ${validation.path}`] : undefined,
-    issues,
-  }
+	return {
+		name: CHECK_NAMES[CHECK_IDS.CONFIG],
+		status: issues.length > 0 ? "warn" : "pass",
+		message:
+			issues.length > 0
+				? `${issues.length} configuration warning(s)`
+				: "Configuration is valid",
+		details: validation.path ? [`Path: ${validation.path}`] : undefined,
+		issues,
+	};
 }

--- a/src/cli/doctor/checks/model-resolution-config.test.ts
+++ b/src/cli/doctor/checks/model-resolution-config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("model-resolution-config", () => {
+	it("merges user config with project override using runtime precedence", async () => {
+		const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+		const originalCwd = process.cwd();
+		const tempBase = join(
+			tmpdir(),
+			`omo-model-resolution-user-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		const tempProject = join(
+			tmpdir(),
+			`omo-model-resolution-project-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+
+		try {
+			mkdirSync(tempBase, { recursive: true });
+			mkdirSync(join(tempProject, ".opencode"), { recursive: true });
+			process.env.OPENCODE_CONFIG_DIR = tempBase;
+			process.chdir(tempProject);
+
+			writeFileSync(
+				join(tempBase, "oh-my-openagent.jsonc"),
+				JSON.stringify(
+					{
+						agents: {
+							oracle: { model: "openai/gpt-5.4" },
+						},
+					},
+					null,
+					2,
+				) + "\n",
+				"utf-8",
+			);
+			writeFileSync(
+				join(tempProject, ".opencode", "oh-my-openagent.jsonc"),
+				JSON.stringify(
+					{
+						categories: {
+							"visual-engineering": { model: "google/gemini-3-flash-preview" },
+						},
+					},
+					null,
+					2,
+				) + "\n",
+				"utf-8",
+			);
+
+			const { loadOmoConfig } = await import(
+				`./model-resolution-config?test=${Date.now()}-${Math.random()}`
+			);
+			const result = loadOmoConfig();
+
+			expect(result?.agents?.oracle?.model).toBe("openai/gpt-5.4");
+			expect(result?.categories?.["visual-engineering"]?.model).toBe(
+				"google/gemini-3-flash-preview",
+			);
+		} finally {
+			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+			else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+			process.chdir(originalCwd);
+			rmSync(tempBase, { recursive: true, force: true });
+			rmSync(tempProject, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/cli/doctor/checks/model-resolution-config.test.ts
+++ b/src/cli/doctor/checks/model-resolution-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -58,6 +58,56 @@ describe("model-resolution-config", () => {
 			expect(result?.categories?.["visual-engineering"]?.model).toBe(
 				"google/gemini-3-flash-preview",
 			);
+		} finally {
+			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+			else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+			process.chdir(originalCwd);
+			rmSync(tempBase, { recursive: true, force: true });
+			rmSync(tempProject, { recursive: true, force: true });
+		}
+	});
+
+	it("loads legacy-only config without creating a canonical copy during diagnostics", async () => {
+		const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+		const originalCwd = process.cwd();
+		const tempBase = join(
+			tmpdir(),
+			`omo-model-resolution-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		const tempProject = join(
+			tmpdir(),
+			`omo-model-resolution-legacy-project-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+
+		try {
+			mkdirSync(tempBase, { recursive: true });
+			mkdirSync(tempProject, { recursive: true });
+			process.env.OPENCODE_CONFIG_DIR = tempBase;
+			process.chdir(tempProject);
+
+			const legacyPath = join(tempBase, "oh-my-opencode.jsonc");
+			const canonicalPath = join(tempBase, "oh-my-openagent.jsonc");
+			writeFileSync(
+				legacyPath,
+				JSON.stringify(
+					{
+						agents: {
+							oracle: { model: "anthropic/claude-opus-4-6" },
+						},
+					},
+					null,
+					2,
+				) + "\n",
+				"utf-8",
+			);
+
+			const { loadOmoConfig } = await import(
+				`./model-resolution-config?test=${Date.now()}-${Math.random()}`
+			);
+			const result = loadOmoConfig();
+
+			expect(result?.agents?.oracle?.model).toBe("anthropic/claude-opus-4-6");
+			expect(existsSync(canonicalPath)).toBe(false);
 		} finally {
 			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
 			else process.env.OPENCODE_CONFIG_DIR = originalEnv;

--- a/src/cli/doctor/checks/model-resolution-config.ts
+++ b/src/cli/doctor/checks/model-resolution-config.ts
@@ -1,55 +1,51 @@
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { loadPluginConfig } from "../../../plugin-config";
+import {
+	type OhMyOpenCodeConfig,
+	OhMyOpenCodeConfigSchema,
+} from "../../../config";
+import { loadConfigFromPath, mergeConfigs } from "../../../plugin-config";
 import {
 	getOpenCodeConfigPaths,
 	getPluginConfigFileCandidates,
-	readFirstValidPluginConfigFile,
 } from "../../../shared";
 import type { OmoConfig } from "./model-resolution-types";
 
-const USER_CONFIG_DIR = getOpenCodeConfigPaths({
-	binary: "opencode",
-	version: null,
-}).configDir;
-const PROJECT_CONFIG_DIR = join(process.cwd(), ".opencode");
+function getUserConfigDir(): string {
+	return getOpenCodeConfigPaths({
+		binary: "opencode",
+		version: null,
+	}).configDir;
+}
+
+function getProjectConfigDir(): string {
+	return join(process.cwd(), ".opencode");
+}
+
+function loadFirstRuntimeLikeConfig(
+	directory: string,
+): OhMyOpenCodeConfig | null {
+	for (const candidatePath of getPluginConfigFileCandidates(directory)) {
+		const loadedConfig = loadConfigFromPath(
+			candidatePath,
+			{},
+			{ migrate: true, persistMigration: false },
+		);
+		if (loadedConfig) return loadedConfig;
+	}
+
+	return null;
+}
 
 export function loadOmoConfig(): OmoConfig | null {
-	const hasAnyConfig =
-		getPluginConfigFileCandidates(PROJECT_CONFIG_DIR).some((path) => {
-			try {
-				readFileSync(path, "utf-8");
-				return true;
-			} catch {
-				return false;
-			}
-		}) ||
-		getPluginConfigFileCandidates(USER_CONFIG_DIR).some((path) => {
-			try {
-				readFileSync(path, "utf-8");
-				return true;
-			} catch {
-				return false;
-			}
-		});
+	const userConfig = loadFirstRuntimeLikeConfig(getUserConfigDir());
+	const projectConfig = loadFirstRuntimeLikeConfig(getProjectConfigDir());
 
-	if (!hasAnyConfig) return null;
+	if (!userConfig && !projectConfig) return null;
 
-	try {
-		return loadPluginConfig(process.cwd(), {});
-	} catch {
-		const projectDetected =
-			readFirstValidPluginConfigFile<OmoConfig>(PROJECT_CONFIG_DIR);
-		if (projectDetected.format !== "none") {
-			return projectDetected.data;
-		}
-
-		const userDetected =
-			readFirstValidPluginConfigFile<OmoConfig>(USER_CONFIG_DIR);
-		if (userDetected.format !== "none") {
-			return userDetected.data;
-		}
-
-		return null;
+	let config = userConfig ?? OhMyOpenCodeConfigSchema.parse({});
+	if (projectConfig) {
+		config = mergeConfigs(config, projectConfig);
 	}
+
+	return config;
 }

--- a/src/cli/doctor/checks/model-resolution-config.ts
+++ b/src/cli/doctor/checks/model-resolution-config.ts
@@ -1,31 +1,55 @@
-import { readFileSync } from "node:fs"
-import { join } from "node:path"
-import { detectPluginConfigFile, getOpenCodeConfigPaths, parseJsonc } from "../../../shared"
-import type { OmoConfig } from "./model-resolution-types"
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { loadPluginConfig } from "../../../plugin-config";
+import {
+	getOpenCodeConfigPaths,
+	getPluginConfigFileCandidates,
+	readFirstValidPluginConfigFile,
+} from "../../../shared";
+import type { OmoConfig } from "./model-resolution-types";
 
-const USER_CONFIG_DIR = getOpenCodeConfigPaths({ binary: "opencode", version: null }).configDir
-const PROJECT_CONFIG_DIR = join(process.cwd(), ".opencode")
+const USER_CONFIG_DIR = getOpenCodeConfigPaths({
+	binary: "opencode",
+	version: null,
+}).configDir;
+const PROJECT_CONFIG_DIR = join(process.cwd(), ".opencode");
 
 export function loadOmoConfig(): OmoConfig | null {
-  const projectDetected = detectPluginConfigFile(PROJECT_CONFIG_DIR)
-  if (projectDetected.format !== "none") {
-    try {
-      const content = readFileSync(projectDetected.path, "utf-8")
-      return parseJsonc<OmoConfig>(content)
-    } catch {
-      return null
-    }
-  }
+	const hasAnyConfig =
+		getPluginConfigFileCandidates(PROJECT_CONFIG_DIR).some((path) => {
+			try {
+				readFileSync(path, "utf-8");
+				return true;
+			} catch {
+				return false;
+			}
+		}) ||
+		getPluginConfigFileCandidates(USER_CONFIG_DIR).some((path) => {
+			try {
+				readFileSync(path, "utf-8");
+				return true;
+			} catch {
+				return false;
+			}
+		});
 
-  const userDetected = detectPluginConfigFile(USER_CONFIG_DIR)
-  if (userDetected.format !== "none") {
-    try {
-      const content = readFileSync(userDetected.path, "utf-8")
-      return parseJsonc<OmoConfig>(content)
-    } catch {
-      return null
-    }
-  }
+	if (!hasAnyConfig) return null;
 
-  return null
+	try {
+		return loadPluginConfig(process.cwd(), {});
+	} catch {
+		const projectDetected =
+			readFirstValidPluginConfigFile<OmoConfig>(PROJECT_CONFIG_DIR);
+		if (projectDetected.format !== "none") {
+			return projectDetected.data;
+		}
+
+		const userDetected =
+			readFirstValidPluginConfigFile<OmoConfig>(USER_CONFIG_DIR);
+		if (userDetected.format !== "none") {
+			return userDetected.data;
+		}
+
+		return null;
+	}
 }

--- a/src/cli/doctor/checks/system-plugin.ts
+++ b/src/cli/doctor/checks/system-plugin.ts
@@ -26,11 +26,13 @@ interface OpenCodeConfigShape {
 export interface PluginConfigFileState {
 	canonicalJsoncPath: string;
 	canonicalJsonPath: string;
+	canonicalPaths: string[];
 	canonicalPath: string | null;
 	legacyJsoncPath: string;
 	legacyJsonPath: string;
 	legacyPaths: string[];
 	hasCanonical: boolean;
+	hasMultipleCanonical: boolean;
 	hasLegacy: boolean;
 }
 
@@ -56,6 +58,9 @@ export function getPluginConfigFileState(): PluginConfigFileState {
 		: existsSync(canonicalJsonPath)
 			? canonicalJsonPath
 			: null;
+	const canonicalPaths = [canonicalJsoncPath, canonicalJsonPath].filter(
+		(path) => existsSync(path),
+	);
 
 	const legacyPaths = [legacyJsoncPath, legacyJsonPath].filter((path) =>
 		existsSync(path),
@@ -64,11 +69,13 @@ export function getPluginConfigFileState(): PluginConfigFileState {
 	return {
 		canonicalJsoncPath,
 		canonicalJsonPath,
+		canonicalPaths,
 		canonicalPath,
 		legacyJsoncPath,
 		legacyJsonPath,
 		legacyPaths,
 		hasCanonical: canonicalPath !== null,
+		hasMultipleCanonical: canonicalPaths.length > 1,
 		hasLegacy: legacyPaths.length > 0,
 	};
 }

--- a/src/cli/doctor/checks/system-plugin.ts
+++ b/src/cli/doctor/checks/system-plugin.ts
@@ -1,109 +1,169 @@
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
-import { LEGACY_PLUGIN_NAME, PLUGIN_NAME, getOpenCodeConfigPaths, parseJsonc } from "../../../shared"
+import {
+	CONFIG_BASENAME,
+	getOpenCodeConfigPaths,
+	LEGACY_CONFIG_BASENAME,
+	LEGACY_PLUGIN_NAME,
+	PLUGIN_NAME,
+	parseJsonc,
+} from "../../../shared";
 
 export interface PluginInfo {
-  registered: boolean
-  configPath: string | null
-  entry: string | null
-  isPinned: boolean
-  pinnedVersion: string | null
-  isLocalDev: boolean
+	registered: boolean;
+	configPath: string | null;
+	entry: string | null;
+	isPinned: boolean;
+	pinnedVersion: string | null;
+	isLocalDev: boolean;
 }
 
 interface OpenCodeConfigShape {
-  plugin?: string[]
+	plugin?: string[];
+}
+
+export interface PluginConfigFileState {
+	canonicalJsoncPath: string;
+	canonicalJsonPath: string;
+	canonicalPath: string | null;
+	legacyJsoncPath: string;
+	legacyJsonPath: string;
+	legacyPaths: string[];
+	hasCanonical: boolean;
+	hasLegacy: boolean;
 }
 
 function detectConfigPath(): string | null {
-  const paths = getOpenCodeConfigPaths({ binary: "opencode", version: null })
-  if (existsSync(paths.configJsonc)) return paths.configJsonc
-  if (existsSync(paths.configJson)) return paths.configJson
-  return null
+	const paths = getOpenCodeConfigPaths({ binary: "opencode", version: null });
+	if (existsSync(paths.configJsonc)) return paths.configJsonc;
+	if (existsSync(paths.configJson)) return paths.configJson;
+	return null;
+}
+
+export function getPluginConfigFileState(): PluginConfigFileState {
+	const { configDir } = getOpenCodeConfigPaths({
+		binary: "opencode",
+		version: null,
+	});
+	const canonicalJsoncPath = join(configDir, `${CONFIG_BASENAME}.jsonc`);
+	const canonicalJsonPath = join(configDir, `${CONFIG_BASENAME}.json`);
+	const legacyJsoncPath = join(configDir, `${LEGACY_CONFIG_BASENAME}.jsonc`);
+	const legacyJsonPath = join(configDir, `${LEGACY_CONFIG_BASENAME}.json`);
+
+	const canonicalPath = existsSync(canonicalJsoncPath)
+		? canonicalJsoncPath
+		: existsSync(canonicalJsonPath)
+			? canonicalJsonPath
+			: null;
+
+	const legacyPaths = [legacyJsoncPath, legacyJsonPath].filter((path) =>
+		existsSync(path),
+	);
+
+	return {
+		canonicalJsoncPath,
+		canonicalJsonPath,
+		canonicalPath,
+		legacyJsoncPath,
+		legacyJsonPath,
+		legacyPaths,
+		hasCanonical: canonicalPath !== null,
+		hasLegacy: legacyPaths.length > 0,
+	};
 }
 
 function parsePluginVersion(entry: string): string | null {
-  // Check for current package name
-  if (entry.startsWith(`${PLUGIN_NAME}@`)) {
-    const value = entry.slice(PLUGIN_NAME.length + 1)
-    if (!value || value === "latest") return null
-    return value
-  }
-  // Check for legacy package name
-  if (entry.startsWith(`${LEGACY_PLUGIN_NAME}@`)) {
-    const value = entry.slice(LEGACY_PLUGIN_NAME.length + 1)
-    if (!value || value === "latest") return null
-    return value
-  }
-  return null
+	// Check for current package name
+	if (entry.startsWith(`${PLUGIN_NAME}@`)) {
+		const value = entry.slice(PLUGIN_NAME.length + 1);
+		if (!value || value === "latest") return null;
+		return value;
+	}
+	// Check for legacy package name
+	if (entry.startsWith(`${LEGACY_PLUGIN_NAME}@`)) {
+		const value = entry.slice(LEGACY_PLUGIN_NAME.length + 1);
+		if (!value || value === "latest") return null;
+		return value;
+	}
+	return null;
 }
 
-function findPluginEntry(entries: string[]): { entry: string; isLocalDev: boolean } | null {
-  for (const entry of entries) {
-    // Check for current package name
-    if (entry === PLUGIN_NAME || entry.startsWith(`${PLUGIN_NAME}@`)) {
-      return { entry, isLocalDev: false }
-    }
-    // Check for legacy package name
-    if (entry === LEGACY_PLUGIN_NAME || entry.startsWith(`${LEGACY_PLUGIN_NAME}@`)) {
-      return { entry, isLocalDev: false }
-    }
-    // Check for file:// paths that include either name
-    if (entry.startsWith("file://") && (entry.includes(PLUGIN_NAME) || entry.includes(LEGACY_PLUGIN_NAME))) {
-      return { entry, isLocalDev: true }
-    }
-  }
+function findPluginEntry(
+	entries: string[],
+): { entry: string; isLocalDev: boolean } | null {
+	for (const entry of entries) {
+		// Check for current package name
+		if (entry === PLUGIN_NAME || entry.startsWith(`${PLUGIN_NAME}@`)) {
+			return { entry, isLocalDev: false };
+		}
+		// Check for legacy package name
+		if (
+			entry === LEGACY_PLUGIN_NAME ||
+			entry.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+		) {
+			return { entry, isLocalDev: false };
+		}
+		// Check for file:// paths that include either name
+		if (
+			entry.startsWith("file://") &&
+			(entry.includes(PLUGIN_NAME) || entry.includes(LEGACY_PLUGIN_NAME))
+		) {
+			return { entry, isLocalDev: true };
+		}
+	}
 
-  return null
+	return null;
 }
 
 export function getPluginInfo(): PluginInfo {
-  const configPath = detectConfigPath()
-  if (!configPath) {
-    return {
-      registered: false,
-      configPath: null,
-      entry: null,
-      isPinned: false,
-      pinnedVersion: null,
-      isLocalDev: false,
-    }
-  }
+	const configPath = detectConfigPath();
+	if (!configPath) {
+		return {
+			registered: false,
+			configPath: null,
+			entry: null,
+			isPinned: false,
+			pinnedVersion: null,
+			isLocalDev: false,
+		};
+	}
 
-  try {
-    const content = readFileSync(configPath, "utf-8")
-    const parsedConfig = parseJsonc<OpenCodeConfigShape>(content)
-    const pluginEntry = findPluginEntry(parsedConfig.plugin ?? [])
-    if (!pluginEntry) {
-      return {
-        registered: false,
-        configPath,
-        entry: null,
-        isPinned: false,
-        pinnedVersion: null,
-        isLocalDev: false,
-      }
-    }
+	try {
+		const content = readFileSync(configPath, "utf-8");
+		const parsedConfig = parseJsonc<OpenCodeConfigShape>(content);
+		const pluginEntry = findPluginEntry(parsedConfig.plugin ?? []);
+		if (!pluginEntry) {
+			return {
+				registered: false,
+				configPath,
+				entry: null,
+				isPinned: false,
+				pinnedVersion: null,
+				isLocalDev: false,
+			};
+		}
 
-    const pinnedVersion = parsePluginVersion(pluginEntry.entry)
-    return {
-      registered: true,
-      configPath,
-      entry: pluginEntry.entry,
-      isPinned: pinnedVersion !== null && /^\d+\.\d+\.\d+/.test(pinnedVersion ?? ""),
-      pinnedVersion,
-      isLocalDev: pluginEntry.isLocalDev,
-    }
-  } catch {
-    return {
-      registered: false,
-      configPath,
-      entry: null,
-      isPinned: false,
-      pinnedVersion: null,
-      isLocalDev: false,
-    }
-  }
+		const pinnedVersion = parsePluginVersion(pluginEntry.entry);
+		return {
+			registered: true,
+			configPath,
+			entry: pluginEntry.entry,
+			isPinned:
+				pinnedVersion !== null && /^\d+\.\d+\.\d+/.test(pinnedVersion ?? ""),
+			pinnedVersion,
+			isLocalDev: pluginEntry.isLocalDev,
+		};
+	} catch {
+		return {
+			registered: false,
+			configPath,
+			entry: null,
+			isPinned: false,
+			pinnedVersion: null,
+			isLocalDev: false,
+		};
+	}
 }
 
-export { detectConfigPath, findPluginEntry }
+export { detectConfigPath, findPluginEntry };

--- a/src/cli/doctor/checks/system.test.ts
+++ b/src/cli/doctor/checks/system.test.ts
@@ -1,207 +1,375 @@
 /// <reference types="bun-types" />
 
-import { beforeEach, describe, expect, it, mock } from "bun:test"
-import { PLUGIN_NAME } from "../../../shared"
-import type { PluginInfo } from "./system-plugin"
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { PLUGIN_NAME } from "../../../shared";
+import type { PluginInfo } from "./system-plugin";
 
-type SystemModule = typeof import("./system")
+type SystemModule = typeof import("./system");
 
 async function importFreshSystemModule(): Promise<SystemModule> {
-  return import(`./system?test=${Date.now()}-${Math.random()}`)
+	return import(`./system?test=${Date.now()}-${Math.random()}`);
 }
 
-const mockFindOpenCodeBinary = mock(async () => ({ path: "/usr/local/bin/opencode" }))
-const mockGetOpenCodeVersion = mock(async () => "1.0.200")
-const mockCompareVersions = mock((_leftVersion?: string, _rightVersion?: string) => true)
-const mockGetPluginInfo = mock((): PluginInfo => ({
-  registered: true,
-  entry: "oh-my-opencode",
-  isPinned: false,
-  pinnedVersion: null,
-  configPath: null,
-  isLocalDev: false,
-}))
+const mockFindOpenCodeBinary = mock(async () => ({
+	path: "/usr/local/bin/opencode",
+}));
+const mockGetOpenCodeVersion = mock(async () => "1.0.200");
+const mockCompareVersions = mock(
+	(_leftVersion?: string, _rightVersion?: string) => true,
+);
+const mockGetPluginInfo = mock(
+	(): PluginInfo => ({
+		registered: true,
+		entry: "oh-my-opencode",
+		isPinned: false,
+		pinnedVersion: null,
+		configPath: null,
+		isLocalDev: false,
+	}),
+);
 const mockGetLoadedPluginVersion = mock(() => ({
-  cacheDir: "/Users/test/Library/Caches/opencode with spaces",
-  cachePackagePath: "/tmp/package.json",
-  installedPackagePath: "/tmp/node_modules/oh-my-opencode/package.json",
-  expectedVersion: "3.0.0",
-  loadedVersion: "3.1.0",
-}))
-const mockGetLatestPluginVersion = mock(async (_currentVersion: string | null) => null as string | null)
-const mockGetSuggestedInstallTag = mock(() => "latest")
+	cacheDir: "/Users/test/Library/Caches/opencode with spaces",
+	cachePackagePath: "/tmp/package.json",
+	installedPackagePath: "/tmp/node_modules/oh-my-opencode/package.json",
+	expectedVersion: "3.0.0",
+	loadedVersion: "3.1.0",
+}));
+const mockGetLatestPluginVersion = mock(
+	async (_currentVersion: string | null) => null as string | null,
+);
+const mockGetSuggestedInstallTag = mock(() => "latest");
+const mockGetPluginConfigFileState = mock(() => ({
+	canonicalJsoncPath: "/Users/test/.config/opencode/oh-my-openagent.jsonc",
+	canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+	canonicalPath: null as string | null,
+	legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
+	legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
+	legacyPaths: [] as string[],
+	hasCanonical: false,
+	hasLegacy: false,
+}));
 
 mock.module("./system-binary", () => ({
-  findOpenCodeBinary: mockFindOpenCodeBinary,
-  getOpenCodeVersion: mockGetOpenCodeVersion,
-  compareVersions: mockCompareVersions,
-}))
+	findOpenCodeBinary: mockFindOpenCodeBinary,
+	getOpenCodeVersion: mockGetOpenCodeVersion,
+	compareVersions: mockCompareVersions,
+}));
 
 mock.module("./system-plugin", () => ({
-  getPluginInfo: mockGetPluginInfo,
-}))
+	getPluginInfo: mockGetPluginInfo,
+	getPluginConfigFileState: mockGetPluginConfigFileState,
+}));
 
 mock.module("./system-loaded-version", () => ({
-  getLoadedPluginVersion: mockGetLoadedPluginVersion,
-  getLatestPluginVersion: mockGetLatestPluginVersion,
-  getSuggestedInstallTag: mockGetSuggestedInstallTag,
-}))
+	getLoadedPluginVersion: mockGetLoadedPluginVersion,
+	getLatestPluginVersion: mockGetLatestPluginVersion,
+	getSuggestedInstallTag: mockGetSuggestedInstallTag,
+}));
 
 describe("system check", () => {
-  beforeEach(() => {
-    mockFindOpenCodeBinary.mockReset()
-    mockGetOpenCodeVersion.mockReset()
-    mockCompareVersions.mockReset()
-    mockGetPluginInfo.mockReset()
-    mockGetLoadedPluginVersion.mockReset()
-    mockGetLatestPluginVersion.mockReset()
-    mockGetSuggestedInstallTag.mockReset()
+	beforeEach(() => {
+		mockFindOpenCodeBinary.mockReset();
+		mockGetOpenCodeVersion.mockReset();
+		mockCompareVersions.mockReset();
+		mockGetPluginInfo.mockReset();
+		mockGetPluginConfigFileState.mockReset();
+		mockGetLoadedPluginVersion.mockReset();
+		mockGetLatestPluginVersion.mockReset();
+		mockGetSuggestedInstallTag.mockReset();
 
-    mockFindOpenCodeBinary.mockResolvedValue({ path: "/usr/local/bin/opencode" })
-    mockGetOpenCodeVersion.mockResolvedValue("1.0.200")
-    mockCompareVersions.mockReturnValue(true)
-    mockGetPluginInfo.mockReturnValue({
-      registered: true,
-      entry: "oh-my-opencode",
-      isPinned: false,
-      pinnedVersion: null,
-      configPath: null,
-      isLocalDev: false,
-    })
-    mockGetLoadedPluginVersion.mockReturnValue({
-      cacheDir: "/Users/test/Library/Caches/opencode with spaces",
-      cachePackagePath: "/tmp/package.json",
-      installedPackagePath: "/tmp/node_modules/oh-my-opencode/package.json",
-      expectedVersion: "3.0.0",
-      loadedVersion: "3.1.0",
-    })
-    mockGetLatestPluginVersion.mockResolvedValue(null)
-    mockGetSuggestedInstallTag.mockReturnValue("latest")
-  })
+		mockFindOpenCodeBinary.mockResolvedValue({
+			path: "/usr/local/bin/opencode",
+		});
+		mockGetOpenCodeVersion.mockResolvedValue("1.0.200");
+		mockCompareVersions.mockReturnValue(true);
+		mockGetPluginInfo.mockReturnValue({
+			registered: true,
+			entry: "oh-my-opencode",
+			isPinned: false,
+			pinnedVersion: null,
+			configPath: null,
+			isLocalDev: false,
+		});
+		mockGetPluginConfigFileState.mockReturnValue({
+			canonicalJsoncPath: "/Users/test/.config/opencode/oh-my-openagent.jsonc",
+			canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+			canonicalPath: null,
+			legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
+			legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
+			legacyPaths: [],
+			hasCanonical: false,
+			hasLegacy: false,
+		});
+		mockGetLoadedPluginVersion.mockReturnValue({
+			cacheDir: "/Users/test/Library/Caches/opencode with spaces",
+			cachePackagePath: "/tmp/package.json",
+			installedPackagePath: "/tmp/node_modules/oh-my-opencode/package.json",
+			expectedVersion: "3.0.0",
+			loadedVersion: "3.1.0",
+		});
+		mockGetLatestPluginVersion.mockResolvedValue(null);
+		mockGetSuggestedInstallTag.mockReturnValue("latest");
+	});
 
-  describe("#given cache directory contains spaces", () => {
-    it("uses a quoted cache directory in mismatch fix command", async () => {
-      //#given
-      const { checkSystem } = await importFreshSystemModule()
+	describe("#given cache directory contains spaces", () => {
+		it("uses a quoted cache directory in mismatch fix command", async () => {
+			//#given
+			const { checkSystem } = await importFreshSystemModule();
 
-      //#when
-      const result = await checkSystem()
+			//#when
+			const result = await checkSystem();
 
-      //#then
-      const mismatchIssue = result.issues.find((issue) => issue.title === "Loaded plugin version mismatch")
-      expect(mismatchIssue?.fix).toBe('Reinstall: cd "/Users/test/Library/Caches/opencode with spaces" && bun install')
-    })
+			//#then
+			const mismatchIssue = result.issues.find(
+				(issue) => issue.title === "Loaded plugin version mismatch",
+			);
+			expect(mismatchIssue?.fix).toBe(
+				'Reinstall: cd "/Users/test/Library/Caches/opencode with spaces" && bun install',
+			);
+		});
 
-    it("uses the loaded version channel for update fix command", async () => {
-      //#given
-      mockGetLoadedPluginVersion.mockReturnValue({
-        cacheDir: "/Users/test/Library/Caches/opencode with spaces",
-        cachePackagePath: "/tmp/package.json",
-        installedPackagePath: "/tmp/node_modules/oh-my-opencode/package.json",
-        expectedVersion: "3.0.0-canary.1",
-        loadedVersion: "3.0.0-canary.1",
-      })
-      mockGetLatestPluginVersion.mockResolvedValue("3.0.0-canary.2")
-      mockGetSuggestedInstallTag.mockReturnValue("canary")
-      mockCompareVersions.mockImplementation((leftVersion?: string, rightVersion?: string) => {
-        return !(leftVersion === "3.0.0-canary.1" && rightVersion === "3.0.0-canary.2")
-      })
-      const { checkSystem } = await importFreshSystemModule()
+		it("uses the loaded version channel for update fix command", async () => {
+			//#given
+			mockGetLoadedPluginVersion.mockReturnValue({
+				cacheDir: "/Users/test/Library/Caches/opencode with spaces",
+				cachePackagePath: "/tmp/package.json",
+				installedPackagePath: "/tmp/node_modules/oh-my-opencode/package.json",
+				expectedVersion: "3.0.0-canary.1",
+				loadedVersion: "3.0.0-canary.1",
+			});
+			mockGetLatestPluginVersion.mockResolvedValue("3.0.0-canary.2");
+			mockGetSuggestedInstallTag.mockReturnValue("canary");
+			mockCompareVersions.mockImplementation(
+				(leftVersion?: string, rightVersion?: string) => {
+					return !(
+						leftVersion === "3.0.0-canary.1" &&
+						rightVersion === "3.0.0-canary.2"
+					);
+				},
+			);
+			const { checkSystem } = await importFreshSystemModule();
 
-      //#when
-      const result = await checkSystem()
+			//#when
+			const result = await checkSystem();
 
-      //#then
-      const outdatedIssue = result.issues.find((issue) => issue.title === "Loaded plugin is outdated")
-      expect(outdatedIssue?.fix).toBe(
-        `Update: cd "/Users/test/Library/Caches/opencode with spaces" && bun add ${PLUGIN_NAME}@canary`
-      )
-    })
-  })
+			//#then
+			const outdatedIssue = result.issues.find(
+				(issue) => issue.title === "Loaded plugin is outdated",
+			);
+			expect(outdatedIssue?.fix).toBe(
+				`Update: cd "/Users/test/Library/Caches/opencode with spaces" && bun add ${PLUGIN_NAME}@canary`,
+			);
+		});
+	});
 
-  describe("#given OpenCode plugin entry uses legacy package name", () => {
-    it("adds a warning for a bare legacy entry", async () => {
-      //#given
-      mockGetPluginInfo.mockReturnValue({
-        registered: true,
-        entry: "oh-my-opencode",
-        isPinned: false,
-        pinnedVersion: null,
-        configPath: null,
-        isLocalDev: false,
-      })
-      const { checkSystem } = await importFreshSystemModule()
+	describe("#given OpenCode plugin entry uses legacy package name", () => {
+		it("adds a warning for a bare legacy entry", async () => {
+			//#given
+			mockGetPluginInfo.mockReturnValue({
+				registered: true,
+				entry: "oh-my-opencode",
+				isPinned: false,
+				pinnedVersion: null,
+				configPath: null,
+				isLocalDev: false,
+			});
+			const { checkSystem } = await importFreshSystemModule();
 
-      //#when
-      const result = await checkSystem()
+			//#when
+			const result = await checkSystem();
 
-      //#then
-      const legacyEntryIssue = result.issues.find((issue) => issue.title === "Using legacy package name")
-      expect(legacyEntryIssue?.severity).toBe("warning")
-      expect(legacyEntryIssue?.fix).toBe(
-        'Update your opencode.json plugin entry: "oh-my-opencode" → "oh-my-openagent"'
-      )
-    })
+			//#then
+			const legacyEntryIssue = result.issues.find(
+				(issue) => issue.title === "Using legacy package name",
+			);
+			expect(legacyEntryIssue?.severity).toBe("warning");
+			expect(legacyEntryIssue?.fix).toBe(
+				'Update your opencode.json plugin entry: "oh-my-opencode" → "oh-my-openagent"',
+			);
+		});
 
-    it("adds a warning for a version-pinned legacy entry", async () => {
-      //#given
-      mockGetPluginInfo.mockReturnValue({
-        registered: true,
-        entry: "oh-my-opencode@3.0.0",
-        isPinned: true,
-        pinnedVersion: "3.0.0",
-        configPath: null,
-        isLocalDev: false,
-      })
-      const { checkSystem } = await importFreshSystemModule()
+		it("adds a warning for a version-pinned legacy entry", async () => {
+			//#given
+			mockGetPluginInfo.mockReturnValue({
+				registered: true,
+				entry: "oh-my-opencode@3.0.0",
+				isPinned: true,
+				pinnedVersion: "3.0.0",
+				configPath: null,
+				isLocalDev: false,
+			});
+			const { checkSystem } = await importFreshSystemModule();
 
-      //#when
-      const result = await checkSystem()
+			//#when
+			const result = await checkSystem();
 
-      //#then
-      const legacyEntryIssue = result.issues.find((issue) => issue.title === "Using legacy package name")
-      expect(legacyEntryIssue?.severity).toBe("warning")
-      expect(legacyEntryIssue?.fix).toBe(
-        'Update your opencode.json plugin entry: "oh-my-opencode@3.0.0" → "oh-my-openagent@3.0.0"'
-      )
-    })
+			//#then
+			const legacyEntryIssue = result.issues.find(
+				(issue) => issue.title === "Using legacy package name",
+			);
+			expect(legacyEntryIssue?.severity).toBe("warning");
+			expect(legacyEntryIssue?.fix).toBe(
+				'Update your opencode.json plugin entry: "oh-my-opencode@3.0.0" → "oh-my-openagent@3.0.0"',
+			);
+		});
 
-    it("does not warn for a canonical plugin entry", async () => {
-      //#given
-      mockGetPluginInfo.mockReturnValue({
-        registered: true,
-        entry: PLUGIN_NAME,
-        isPinned: false,
-        pinnedVersion: null,
-        configPath: null,
-        isLocalDev: false,
-      })
-      const { checkSystem } = await importFreshSystemModule()
+		it("does not warn for a canonical plugin entry", async () => {
+			//#given
+			mockGetPluginInfo.mockReturnValue({
+				registered: true,
+				entry: PLUGIN_NAME,
+				isPinned: false,
+				pinnedVersion: null,
+				configPath: null,
+				isLocalDev: false,
+			});
+			const { checkSystem } = await importFreshSystemModule();
 
-      //#when
-      const result = await checkSystem()
+			//#when
+			const result = await checkSystem();
 
-      //#then
-      expect(result.issues.some((issue) => issue.title === "Using legacy package name")).toBe(false)
-    })
+			//#then
+			expect(
+				result.issues.some(
+					(issue) => issue.title === "Using legacy package name",
+				),
+			).toBe(false);
+		});
 
-    it("does not warn for a local-dev legacy entry", async () => {
-      //#given
-      mockGetPluginInfo.mockReturnValue({
-        registered: true,
-        entry: "oh-my-opencode",
-        isPinned: false,
-        pinnedVersion: null,
-        configPath: null,
-        isLocalDev: true,
-      })
-      const { checkSystem } = await importFreshSystemModule()
+		it("does not warn for a local-dev legacy entry", async () => {
+			//#given
+			mockGetPluginInfo.mockReturnValue({
+				registered: true,
+				entry: "oh-my-opencode",
+				isPinned: false,
+				pinnedVersion: null,
+				configPath: null,
+				isLocalDev: true,
+			});
+			const { checkSystem } = await importFreshSystemModule();
 
-      //#when
-      const result = await checkSystem()
+			//#when
+			const result = await checkSystem();
 
-      //#then
-      expect(result.issues.some((issue) => issue.title === "Using legacy package name")).toBe(false)
-    })
-  })
-})
+			//#then
+			expect(
+				result.issues.some(
+					(issue) => issue.title === "Using legacy package name",
+				),
+			).toBe(false);
+		});
+	});
+
+	describe("#given plugin config filenames are in a migration state", () => {
+		it("adds a warning when only a legacy config filename exists", async () => {
+			//#given
+			mockGetPluginInfo.mockReturnValue({
+				registered: true,
+				entry: PLUGIN_NAME,
+				isPinned: false,
+				pinnedVersion: null,
+				configPath: null,
+				isLocalDev: false,
+			});
+			mockGetPluginConfigFileState.mockReturnValue({
+				canonicalJsoncPath:
+					"/Users/test/.config/opencode/oh-my-openagent.jsonc",
+				canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+				canonicalPath: null,
+				legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
+				legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
+				legacyPaths: ["/Users/test/.config/opencode/oh-my-opencode.jsonc"],
+				hasCanonical: false,
+				hasLegacy: true,
+			});
+			const { checkSystem } = await importFreshSystemModule();
+
+			//#when
+			const result = await checkSystem();
+
+			//#then
+			const legacyConfigIssue = result.issues.find(
+				(issue) => issue.title === "Using legacy config filename",
+			);
+			expect(legacyConfigIssue?.severity).toBe("warning");
+			expect(legacyConfigIssue?.description).toContain("oh-my-opencode.jsonc");
+			expect(legacyConfigIssue?.fix).toContain("oh-my-openagent.jsonc");
+		});
+
+		it("adds a warning when canonical and legacy config files coexist", async () => {
+			//#given
+			mockGetPluginInfo.mockReturnValue({
+				registered: true,
+				entry: PLUGIN_NAME,
+				isPinned: false,
+				pinnedVersion: null,
+				configPath: null,
+				isLocalDev: false,
+			});
+			mockGetPluginConfigFileState.mockReturnValue({
+				canonicalJsoncPath:
+					"/Users/test/.config/opencode/oh-my-openagent.jsonc",
+				canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+				canonicalPath: "/Users/test/.config/opencode/oh-my-openagent.jsonc",
+				legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
+				legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
+				legacyPaths: ["/Users/test/.config/opencode/oh-my-opencode.jsonc"],
+				hasCanonical: true,
+				hasLegacy: true,
+			});
+			const { checkSystem } = await importFreshSystemModule();
+
+			//#when
+			const result = await checkSystem();
+
+			//#then
+			const coexistIssue = result.issues.find(
+				(issue) => issue.title === "Canonical and legacy config files coexist",
+			);
+			expect(coexistIssue?.severity).toBe("warning");
+			expect(coexistIssue?.description).toContain("oh-my-openagent.jsonc");
+			expect(coexistIssue?.description).toContain("oh-my-opencode.jsonc");
+			expect(coexistIssue?.fix).toContain("remove legacy");
+		});
+
+		it("does not add config filename warnings when only canonical config exists", async () => {
+			//#given
+			mockGetPluginInfo.mockReturnValue({
+				registered: true,
+				entry: PLUGIN_NAME,
+				isPinned: false,
+				pinnedVersion: null,
+				configPath: null,
+				isLocalDev: false,
+			});
+			mockGetPluginConfigFileState.mockReturnValue({
+				canonicalJsoncPath:
+					"/Users/test/.config/opencode/oh-my-openagent.jsonc",
+				canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+				canonicalPath: "/Users/test/.config/opencode/oh-my-openagent.jsonc",
+				legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
+				legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
+				legacyPaths: [],
+				hasCanonical: true,
+				hasLegacy: false,
+			});
+			const { checkSystem } = await importFreshSystemModule();
+
+			//#when
+			const result = await checkSystem();
+
+			//#then
+			expect(
+				result.issues.some(
+					(issue) => issue.title === "Using legacy config filename",
+				),
+			).toBe(false);
+			expect(
+				result.issues.some(
+					(issue) =>
+						issue.title === "Canonical and legacy config files coexist",
+				),
+			).toBe(false);
+		});
+	});
+});

--- a/src/cli/doctor/checks/system.test.ts
+++ b/src/cli/doctor/checks/system.test.ts
@@ -41,11 +41,13 @@ const mockGetSuggestedInstallTag = mock(() => "latest");
 const mockGetPluginConfigFileState = mock(() => ({
 	canonicalJsoncPath: "/Users/test/.config/opencode/oh-my-openagent.jsonc",
 	canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+	canonicalPaths: [] as string[],
 	canonicalPath: null as string | null,
 	legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
 	legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
 	legacyPaths: [] as string[],
 	hasCanonical: false,
+	hasMultipleCanonical: false,
 	hasLegacy: false,
 }));
 
@@ -93,11 +95,13 @@ describe("system check", () => {
 		mockGetPluginConfigFileState.mockReturnValue({
 			canonicalJsoncPath: "/Users/test/.config/opencode/oh-my-openagent.jsonc",
 			canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+			canonicalPaths: [],
 			canonicalPath: null,
 			legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
 			legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
 			legacyPaths: [],
 			hasCanonical: false,
+			hasMultipleCanonical: false,
 			hasLegacy: false,
 		});
 		mockGetLoadedPluginVersion.mockReturnValue({
@@ -275,11 +279,13 @@ describe("system check", () => {
 				canonicalJsoncPath:
 					"/Users/test/.config/opencode/oh-my-openagent.jsonc",
 				canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+				canonicalPaths: [],
 				canonicalPath: null,
 				legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
 				legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
 				legacyPaths: ["/Users/test/.config/opencode/oh-my-opencode.jsonc"],
 				hasCanonical: false,
+				hasMultipleCanonical: false,
 				hasLegacy: true,
 			});
 			const { checkSystem } = await importFreshSystemModule();
@@ -310,11 +316,13 @@ describe("system check", () => {
 				canonicalJsoncPath:
 					"/Users/test/.config/opencode/oh-my-openagent.jsonc",
 				canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+				canonicalPaths: ["/Users/test/.config/opencode/oh-my-openagent.jsonc"],
 				canonicalPath: "/Users/test/.config/opencode/oh-my-openagent.jsonc",
 				legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
 				legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
 				legacyPaths: ["/Users/test/.config/opencode/oh-my-opencode.jsonc"],
 				hasCanonical: true,
+				hasMultipleCanonical: false,
 				hasLegacy: true,
 			});
 			const { checkSystem } = await importFreshSystemModule();
@@ -346,11 +354,13 @@ describe("system check", () => {
 				canonicalJsoncPath:
 					"/Users/test/.config/opencode/oh-my-openagent.jsonc",
 				canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+				canonicalPaths: ["/Users/test/.config/opencode/oh-my-openagent.jsonc"],
 				canonicalPath: "/Users/test/.config/opencode/oh-my-openagent.jsonc",
 				legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
 				legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
 				legacyPaths: [],
 				hasCanonical: true,
+				hasMultipleCanonical: false,
 				hasLegacy: false,
 			});
 			const { checkSystem } = await importFreshSystemModule();
@@ -370,6 +380,46 @@ describe("system check", () => {
 						issue.title === "Canonical and legacy config files coexist",
 				),
 			).toBe(false);
+		});
+
+		it("adds a warning when canonical json and jsonc files coexist", async () => {
+			//#given
+			mockGetPluginInfo.mockReturnValue({
+				registered: true,
+				entry: PLUGIN_NAME,
+				isPinned: false,
+				pinnedVersion: null,
+				configPath: null,
+				isLocalDev: false,
+			});
+			mockGetPluginConfigFileState.mockReturnValue({
+				canonicalJsoncPath:
+					"/Users/test/.config/opencode/oh-my-openagent.jsonc",
+				canonicalJsonPath: "/Users/test/.config/opencode/oh-my-openagent.json",
+				canonicalPaths: [
+					"/Users/test/.config/opencode/oh-my-openagent.jsonc",
+					"/Users/test/.config/opencode/oh-my-openagent.json",
+				],
+				canonicalPath: "/Users/test/.config/opencode/oh-my-openagent.jsonc",
+				legacyJsoncPath: "/Users/test/.config/opencode/oh-my-opencode.jsonc",
+				legacyJsonPath: "/Users/test/.config/opencode/oh-my-opencode.json",
+				legacyPaths: [],
+				hasCanonical: true,
+				hasMultipleCanonical: true,
+				hasLegacy: false,
+			});
+			const { checkSystem } = await importFreshSystemModule();
+
+			//#when
+			const result = await checkSystem();
+
+			//#then
+			const canonicalIssue = result.issues.find(
+				(issue) => issue.title === "Multiple canonical config files coexist",
+			);
+			expect(canonicalIssue?.severity).toBe("warning");
+			expect(canonicalIssue?.description).toContain("oh-my-openagent.jsonc");
+			expect(canonicalIssue?.description).toContain("oh-my-openagent.json");
 		});
 	});
 });

--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -137,6 +137,16 @@ export async function checkSystem(): Promise<CheckResult> {
 		}
 	}
 
+	if (pluginConfigFileState.hasMultipleCanonical) {
+		issues.push({
+			title: "Multiple canonical config files coexist",
+			description: `Detected multiple canonical OMO config files: ${pluginConfigFileState.canonicalPaths.join(", ")}. The runtime prefers "${pluginConfigFileState.canonicalJsoncPath}", but keeping both canonical files can make edits land in the wrong file.`,
+			fix: `Keep only one canonical config file, preferably "${pluginConfigFileState.canonicalJsoncPath}", and remove the extra canonical file(s): ${pluginConfigFileState.canonicalPaths.filter((path) => path !== pluginConfigFileState.canonicalJsoncPath).join(", ")}`,
+			severity: "warning",
+			affects: ["plugin loading", "doctor"],
+		});
+	}
+
 	if (pluginConfigFileState.hasCanonical && pluginConfigFileState.hasLegacy) {
 		issues.push({
 			title: "Canonical and legacy config files coexist",
@@ -145,10 +155,9 @@ export async function checkSystem(): Promise<CheckResult> {
 			severity: "warning",
 			affects: ["plugin loading", "doctor"],
 		});
-	} else if (
-		!pluginConfigFileState.hasCanonical &&
-		pluginConfigFileState.hasLegacy
-	) {
+	}
+
+	if (!pluginConfigFileState.hasCanonical && pluginConfigFileState.hasLegacy) {
 		issues.push({
 			title: "Using legacy config filename",
 			description: `Detected legacy OMO config file(s): ${pluginConfigFileState.legacyPaths.join(", ")}. Legacy files still load for compatibility, but the canonical config path is "${pluginConfigFileState.canonicalJsoncPath}".`,

--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -1,147 +1,204 @@
-import { existsSync, readFileSync } from "node:fs"
-
-import { MIN_OPENCODE_VERSION, CHECK_IDS, CHECK_NAMES } from "../constants"
-import type { CheckResult, DoctorIssue, SystemInfo } from "../types"
-import { findOpenCodeBinary, getOpenCodeVersion, compareVersions } from "./system-binary"
-import { getPluginInfo } from "./system-plugin"
-import { getLatestPluginVersion, getLoadedPluginVersion, getSuggestedInstallTag } from "./system-loaded-version"
-import { parseJsonc } from "../../../shared"
-import { PLUGIN_NAME, LEGACY_PLUGIN_NAME } from "../../../shared/plugin-identity"
+import { existsSync, readFileSync } from "node:fs";
+import { parseJsonc } from "../../../shared";
+import {
+	LEGACY_PLUGIN_NAME,
+	PLUGIN_NAME,
+} from "../../../shared/plugin-identity";
+import { CHECK_IDS, CHECK_NAMES, MIN_OPENCODE_VERSION } from "../constants";
+import type { CheckResult, DoctorIssue, SystemInfo } from "../types";
+import {
+	compareVersions,
+	findOpenCodeBinary,
+	getOpenCodeVersion,
+} from "./system-binary";
+import {
+	getLatestPluginVersion,
+	getLoadedPluginVersion,
+	getSuggestedInstallTag,
+} from "./system-loaded-version";
+import { getPluginConfigFileState, getPluginInfo } from "./system-plugin";
 
 function isConfigValid(configPath: string | null): boolean {
-  if (!configPath) return true
-  if (!existsSync(configPath)) return false
+	if (!configPath) return true;
+	if (!existsSync(configPath)) return false;
 
-  try {
-    parseJsonc<Record<string, unknown>>(readFileSync(configPath, "utf-8"))
-    return true
-  } catch {
-    return false
-  }
+	try {
+		parseJsonc<Record<string, unknown>>(readFileSync(configPath, "utf-8"));
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 function getResultStatus(issues: DoctorIssue[]): CheckResult["status"] {
-  if (issues.some((issue) => issue.severity === "error")) return "fail"
-  if (issues.some((issue) => issue.severity === "warning")) return "warn"
-  return "pass"
+	if (issues.some((issue) => issue.severity === "error")) return "fail";
+	if (issues.some((issue) => issue.severity === "warning")) return "warn";
+	return "pass";
 }
 
-function buildMessage(status: CheckResult["status"], issues: DoctorIssue[]): string {
-  if (status === "pass") return "System checks passed"
-  if (status === "fail") return `${issues.length} system issue(s) detected`
-  return `${issues.length} system warning(s) detected`
+function buildMessage(
+	status: CheckResult["status"],
+	issues: DoctorIssue[],
+): string {
+	if (status === "pass") return "System checks passed";
+	if (status === "fail") return `${issues.length} system issue(s) detected`;
+	return `${issues.length} system warning(s) detected`;
 }
 
 export async function gatherSystemInfo(): Promise<SystemInfo> {
-  const [binaryInfo, pluginInfo] = await Promise.all([findOpenCodeBinary(), Promise.resolve(getPluginInfo())])
-  const loadedInfo = getLoadedPluginVersion()
+	const [binaryInfo, pluginInfo] = await Promise.all([
+		findOpenCodeBinary(),
+		Promise.resolve(getPluginInfo()),
+	]);
+	const loadedInfo = getLoadedPluginVersion();
 
-  const opencodeVersion = binaryInfo ? await getOpenCodeVersion(binaryInfo.path) : null
-  const pluginVersion = pluginInfo.pinnedVersion ?? loadedInfo.expectedVersion ?? loadedInfo.loadedVersion
+	const opencodeVersion = binaryInfo
+		? await getOpenCodeVersion(binaryInfo.path)
+		: null;
+	const pluginVersion =
+		pluginInfo.pinnedVersion ??
+		loadedInfo.expectedVersion ??
+		loadedInfo.loadedVersion;
 
-  return {
-    opencodeVersion,
-    opencodePath: binaryInfo?.path ?? null,
-    pluginVersion,
-    loadedVersion: loadedInfo.loadedVersion,
-    bunVersion: Bun.version,
-    configPath: pluginInfo.configPath,
-    configValid: isConfigValid(pluginInfo.configPath),
-    isLocalDev: pluginInfo.isLocalDev,
-  }
+	return {
+		opencodeVersion,
+		opencodePath: binaryInfo?.path ?? null,
+		pluginVersion,
+		loadedVersion: loadedInfo.loadedVersion,
+		bunVersion: Bun.version,
+		configPath: pluginInfo.configPath,
+		configValid: isConfigValid(pluginInfo.configPath),
+		isLocalDev: pluginInfo.isLocalDev,
+	};
 }
 
 export async function checkSystem(): Promise<CheckResult> {
-  const [systemInfo, pluginInfo] = await Promise.all([gatherSystemInfo(), Promise.resolve(getPluginInfo())])
-  const loadedInfo = getLoadedPluginVersion()
-  const latestVersion = await getLatestPluginVersion(systemInfo.loadedVersion)
-  const installTag = getSuggestedInstallTag(systemInfo.loadedVersion)
-  const issues: DoctorIssue[] = []
+	const [systemInfo, pluginInfo] = await Promise.all([
+		gatherSystemInfo(),
+		Promise.resolve(getPluginInfo()),
+	]);
+	const loadedInfo = getLoadedPluginVersion();
+	const pluginConfigFileState = getPluginConfigFileState();
+	const latestVersion = await getLatestPluginVersion(systemInfo.loadedVersion);
+	const installTag = getSuggestedInstallTag(systemInfo.loadedVersion);
+	const issues: DoctorIssue[] = [];
 
-  if (!systemInfo.opencodePath) {
-    issues.push({
-      title: "OpenCode binary not found",
-      description: "Install OpenCode CLI or desktop and ensure the binary is available.",
-      fix: "Install from https://opencode.ai/docs",
-      severity: "error",
-      affects: ["doctor", "run"],
-    })
-  }
+	if (!systemInfo.opencodePath) {
+		issues.push({
+			title: "OpenCode binary not found",
+			description:
+				"Install OpenCode CLI or desktop and ensure the binary is available.",
+			fix: "Install from https://opencode.ai/docs",
+			severity: "error",
+			affects: ["doctor", "run"],
+		});
+	}
 
-  if (
-    systemInfo.opencodeVersion &&
-    !compareVersions(systemInfo.opencodeVersion, MIN_OPENCODE_VERSION)
-  ) {
-    issues.push({
-      title: "OpenCode version below minimum",
-      description: `Detected ${systemInfo.opencodeVersion}; required >= ${MIN_OPENCODE_VERSION}.`,
-      fix: "Update OpenCode to the latest stable release",
-      severity: "warning",
-      affects: ["tooling", "doctor"],
-    })
-  }
+	if (
+		systemInfo.opencodeVersion &&
+		!compareVersions(systemInfo.opencodeVersion, MIN_OPENCODE_VERSION)
+	) {
+		issues.push({
+			title: "OpenCode version below minimum",
+			description: `Detected ${systemInfo.opencodeVersion}; required >= ${MIN_OPENCODE_VERSION}.`,
+			fix: "Update OpenCode to the latest stable release",
+			severity: "warning",
+			affects: ["tooling", "doctor"],
+		});
+	}
 
-  if (!pluginInfo.registered) {
-    issues.push({
-      title: `${PLUGIN_NAME} is not registered`,
-      description: "Plugin entry is missing from OpenCode configuration.",
-      fix: `Run: bunx ${PLUGIN_NAME} install`,
-      severity: "error",
-      affects: ["all agents"],
-    })
-  }
+	if (!pluginInfo.registered) {
+		issues.push({
+			title: `${PLUGIN_NAME} is not registered`,
+			description: "Plugin entry is missing from OpenCode configuration.",
+			fix: `Run: bunx ${PLUGIN_NAME} install`,
+			severity: "error",
+			affects: ["all agents"],
+		});
+	}
 
-  if (pluginInfo.entry && !pluginInfo.isLocalDev) {
-    const isLegacyName = pluginInfo.entry === LEGACY_PLUGIN_NAME
-      || pluginInfo.entry.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+	if (pluginInfo.entry && !pluginInfo.isLocalDev) {
+		const isLegacyName =
+			pluginInfo.entry === LEGACY_PLUGIN_NAME ||
+			pluginInfo.entry.startsWith(`${LEGACY_PLUGIN_NAME}@`);
 
-    if (isLegacyName) {
-      const suggestedEntry = pluginInfo.entry.replace(LEGACY_PLUGIN_NAME, PLUGIN_NAME)
-      issues.push({
-        title: "Using legacy package name",
-        description: `Your opencode.json references "${LEGACY_PLUGIN_NAME}" which has been renamed to "${PLUGIN_NAME}". The old name may stop working in a future release.`,
-        fix: `Update your opencode.json plugin entry: "${pluginInfo.entry}" → "${suggestedEntry}"`,
-        severity: "warning",
-        affects: ["plugin loading"],
-      })
-    }
-  }
+		if (isLegacyName) {
+			const suggestedEntry = pluginInfo.entry.replace(
+				LEGACY_PLUGIN_NAME,
+				PLUGIN_NAME,
+			);
+			issues.push({
+				title: "Using legacy package name",
+				description: `Your opencode.json references "${LEGACY_PLUGIN_NAME}" which has been renamed to "${PLUGIN_NAME}". The old name may stop working in a future release.`,
+				fix: `Update your opencode.json plugin entry: "${pluginInfo.entry}" → "${suggestedEntry}"`,
+				severity: "warning",
+				affects: ["plugin loading"],
+			});
+		}
+	}
 
-  if (loadedInfo.expectedVersion && loadedInfo.loadedVersion && loadedInfo.expectedVersion !== loadedInfo.loadedVersion) {
-    issues.push({
-      title: "Loaded plugin version mismatch",
-      description: `Cache expects ${loadedInfo.expectedVersion} but loaded ${loadedInfo.loadedVersion}.`,
-      fix: `Reinstall: cd "${loadedInfo.cacheDir}" && bun install`,
-      severity: "warning",
-      affects: ["plugin loading"],
-    })
-  }
+	if (pluginConfigFileState.hasCanonical && pluginConfigFileState.hasLegacy) {
+		issues.push({
+			title: "Canonical and legacy config files coexist",
+			description: `Detected canonical config "${pluginConfigFileState.canonicalPath}" and legacy config file(s): ${pluginConfigFileState.legacyPaths.join(", ")}. The canonical file wins, but keeping both files can cause confusion during migration.`,
+			fix: `Review both files, keep "${pluginConfigFileState.canonicalPath}" as the source of truth, and remove legacy file(s): ${pluginConfigFileState.legacyPaths.join(", ")}`,
+			severity: "warning",
+			affects: ["plugin loading", "doctor"],
+		});
+	} else if (
+		!pluginConfigFileState.hasCanonical &&
+		pluginConfigFileState.hasLegacy
+	) {
+		issues.push({
+			title: "Using legacy config filename",
+			description: `Detected legacy OMO config file(s): ${pluginConfigFileState.legacyPaths.join(", ")}. Legacy files still load for compatibility, but the canonical config path is "${pluginConfigFileState.canonicalJsoncPath}".`,
+			fix: `Move or copy your OMO config to "${pluginConfigFileState.canonicalJsoncPath}" and remove legacy file(s) once verified.`,
+			severity: "warning",
+			affects: ["plugin loading", "doctor"],
+		});
+	}
 
-  if (
-    systemInfo.loadedVersion &&
-    latestVersion &&
-    !compareVersions(systemInfo.loadedVersion, latestVersion)
-  ) {
-    issues.push({
-      title: "Loaded plugin is outdated",
-      description: `Loaded ${systemInfo.loadedVersion}, latest ${latestVersion}.`,
-      fix: `Update: cd "${loadedInfo.cacheDir}" && bun add ${PLUGIN_NAME}@${installTag}`,
-      severity: "warning",
-      affects: ["plugin features"],
-    })
-  }
+	if (
+		loadedInfo.expectedVersion &&
+		loadedInfo.loadedVersion &&
+		loadedInfo.expectedVersion !== loadedInfo.loadedVersion
+	) {
+		issues.push({
+			title: "Loaded plugin version mismatch",
+			description: `Cache expects ${loadedInfo.expectedVersion} but loaded ${loadedInfo.loadedVersion}.`,
+			fix: `Reinstall: cd "${loadedInfo.cacheDir}" && bun install`,
+			severity: "warning",
+			affects: ["plugin loading"],
+		});
+	}
 
-  const status = getResultStatus(issues)
-  return {
-    name: CHECK_NAMES[CHECK_IDS.SYSTEM],
-    status,
-    message: buildMessage(status, issues),
-    details: [
-      systemInfo.opencodeVersion ? `OpenCode: ${systemInfo.opencodeVersion}` : "OpenCode: not detected",
-      `Plugin expected: ${systemInfo.pluginVersion ?? "unknown"}`,
-      `Plugin loaded: ${systemInfo.loadedVersion ?? "unknown"}`,
-      `Bun: ${systemInfo.bunVersion ?? "unknown"}`,
-    ],
-    issues,
-  }
+	if (
+		systemInfo.loadedVersion &&
+		latestVersion &&
+		!compareVersions(systemInfo.loadedVersion, latestVersion)
+	) {
+		issues.push({
+			title: "Loaded plugin is outdated",
+			description: `Loaded ${systemInfo.loadedVersion}, latest ${latestVersion}.`,
+			fix: `Update: cd "${loadedInfo.cacheDir}" && bun add ${PLUGIN_NAME}@${installTag}`,
+			severity: "warning",
+			affects: ["plugin features"],
+		});
+	}
+
+	const status = getResultStatus(issues);
+	return {
+		name: CHECK_NAMES[CHECK_IDS.SYSTEM],
+		status,
+		message: buildMessage(status, issues),
+		details: [
+			systemInfo.opencodeVersion
+				? `OpenCode: ${systemInfo.opencodeVersion}`
+				: "OpenCode: not detected",
+			`Plugin expected: ${systemInfo.pluginVersion ?? "unknown"}`,
+			`Plugin loaded: ${systemInfo.loadedVersion ?? "unknown"}`,
+			`Bun: ${systemInfo.bunVersion ?? "unknown"}`,
+		],
+		issues,
+	};
 }

--- a/src/cli/run/opencode-binary-resolver.test.ts
+++ b/src/cli/run/opencode-binary-resolver.test.ts
@@ -1,102 +1,120 @@
-import { describe, expect, it } from "bun:test"
-import { delimiter, join } from "node:path"
+import { describe, expect, it } from "bun:test";
+import { delimiter, join } from "node:path";
 import {
-  buildPathWithBinaryFirst,
-  collectCandidateBinaryPaths,
-  findWorkingOpencodeBinary,
-  withWorkingOpencodePath,
-} from "./opencode-binary-resolver"
+	buildPathWithBinaryFirst,
+	collectCandidateBinaryPaths,
+	findWorkingOpencodeBinary,
+	withWorkingOpencodePath,
+} from "./opencode-binary-resolver";
 
 describe("collectCandidateBinaryPaths", () => {
-  it("includes Bun.which results first and removes duplicates", () => {
-    // given
-    const pathEnv = ["/bad", "/good"].join(delimiter)
-    const which = (command: string): string | undefined => {
-      if (command === "opencode") return "/bad/opencode"
-      return undefined
-    }
+	it("includes Bun.which results first and removes duplicates", () => {
+		// given
+		const pathEnv = "/bad:/good";
+		const which = (command: string): string | undefined => {
+			if (command === "opencode") return "/bad/opencode";
+			return undefined;
+		};
 
-    // when
-    const candidates = collectCandidateBinaryPaths(pathEnv, which, "darwin")
+		// when
+		const candidates = collectCandidateBinaryPaths(pathEnv, which, "darwin");
 
-    // then
-    expect(candidates[0]).toBe("/bad/opencode")
-    expect(candidates).toContain("/good/opencode")
-    expect(candidates.filter((candidate) => candidate === "/bad/opencode")).toHaveLength(1)
-  })
-})
+		// then
+		expect(candidates[0]).toBe("/bad/opencode");
+		expect(candidates).toContain("/good/opencode");
+		expect(
+			candidates.filter((candidate) => candidate === "/bad/opencode"),
+		).toHaveLength(1);
+	});
+
+	it("uses the requested platform delimiter when expanding PATH entries", () => {
+		// given
+		const posixPathEnv = "/bad:/good";
+
+		// when
+		const candidates = collectCandidateBinaryPaths(
+			posixPathEnv,
+			() => undefined,
+			"darwin",
+		);
+
+		// then
+		expect(candidates).toContain("/good/opencode");
+		expect(candidates).not.toContain("/bad:/good/opencode");
+	});
+});
 
 describe("findWorkingOpencodeBinary", () => {
-  it("returns the first runnable candidate", async () => {
-    // given
-    const pathEnv = ["/bad", "/good"].join(delimiter)
-    const which = (command: string): string | undefined => {
-      if (command === "opencode") return "/bad/opencode"
-      return undefined
-    }
-    const probe = async (binaryPath: string): Promise<boolean> =>
-      binaryPath === "/good/opencode"
+	it("returns the first runnable candidate", async () => {
+		// given
+		const pathEnv = "/bad:/good";
+		const which = (command: string): string | undefined => {
+			if (command === "opencode") return "/bad/opencode";
+			return undefined;
+		};
+		const probe = async (binaryPath: string): Promise<boolean> =>
+			binaryPath === "/good/opencode";
 
-    // when
-    const resolved = await findWorkingOpencodeBinary(pathEnv, probe, which, "darwin")
+		// when
+		const resolved = await findWorkingOpencodeBinary(
+			pathEnv,
+			probe,
+			which,
+			"darwin",
+		);
 
-    // then
-    expect(resolved).toBe("/good/opencode")
-  })
-})
+		// then
+		expect(resolved).toBe("/good/opencode");
+	});
+});
 
 describe("buildPathWithBinaryFirst", () => {
-  it("prepends the binary directory and avoids duplicate entries", () => {
-    // given
-    const binaryPath = "/good/opencode"
-    const pathEnv = ["/bad", "/good", "/other"].join(delimiter)
+	it("prepends the binary directory and avoids duplicate entries", () => {
+		// given
+		const binaryPath = "/good/opencode";
+		const pathEnv = ["/bad", "/good", "/other"].join(delimiter);
 
-    // when
-    const updated = buildPathWithBinaryFirst(pathEnv, binaryPath)
+		// when
+		const updated = buildPathWithBinaryFirst(pathEnv, binaryPath);
 
-    // then
-    expect(updated).toBe(["/good", "/bad", "/other"].join(delimiter))
-  })
-})
+		// then
+		expect(updated).toBe(["/good", "/bad", "/other"].join(delimiter));
+	});
+});
 
 describe("withWorkingOpencodePath", () => {
-  it("temporarily updates PATH while starting the server", async () => {
-    // given
-    const originalPath = process.env.PATH
-    process.env.PATH = ["/bad", "/other"].join(delimiter)
-    const finder = async (): Promise<string | null> => "/good/opencode"
-    let observedPath = ""
+	it("temporarily updates PATH while starting the server", async () => {
+		// given
+		const originalPath = process.env.PATH;
+		process.env.PATH = ["/bad", "/other"].join(delimiter);
+		const finder = async (): Promise<string | null> => "/good/opencode";
+		let observedPath = "";
 
-    // when
-    await withWorkingOpencodePath(
-      async () => {
-        observedPath = process.env.PATH ?? ""
-      },
-      finder,
-    )
+		// when
+		await withWorkingOpencodePath(async () => {
+			observedPath = process.env.PATH ?? "";
+		}, finder);
 
-    // then
-    expect(observedPath).toBe(["/good", "/bad", "/other"].join(delimiter))
-    expect(process.env.PATH).toBe(["/bad", "/other"].join(delimiter))
-    process.env.PATH = originalPath
-  })
+		// then
+		expect(observedPath).toBe(["/good", "/bad", "/other"].join(delimiter));
+		expect(process.env.PATH).toBe(["/bad", "/other"].join(delimiter));
+		process.env.PATH = originalPath;
+	});
 
-  it("restores PATH when server startup fails", async () => {
-    // given
-    const originalPath = process.env.PATH
-    process.env.PATH = ["/bad", "/other"].join(delimiter)
-    const finder = async (): Promise<string | null> => join("/good", "opencode")
+	it("restores PATH when server startup fails", async () => {
+		// given
+		const originalPath = process.env.PATH;
+		process.env.PATH = ["/bad", "/other"].join(delimiter);
+		const finder = async (): Promise<string | null> =>
+			join("/good", "opencode");
 
-    // when & then
-    await expect(
-      withWorkingOpencodePath(
-        async () => {
-          throw new Error("boom")
-        },
-        finder,
-      ),
-    ).rejects.toThrow("boom")
-    expect(process.env.PATH).toBe(["/bad", "/other"].join(delimiter))
-    process.env.PATH = originalPath
-  })
-})
+		// when & then
+		await expect(
+			withWorkingOpencodePath(async () => {
+				throw new Error("boom");
+			}, finder),
+		).rejects.toThrow("boom");
+		expect(process.env.PATH).toBe(["/bad", "/other"].join(delimiter));
+		process.env.PATH = originalPath;
+	});
+});

--- a/src/cli/run/opencode-binary-resolver.ts
+++ b/src/cli/run/opencode-binary-resolver.ts
@@ -1,96 +1,105 @@
-import { delimiter, dirname, join } from "node:path"
-import { spawnWithWindowsHide } from "../../shared/spawn-with-windows-hide"
+import { delimiter, dirname, posix, win32 } from "node:path";
+import { spawnWithWindowsHide } from "../../shared/spawn-with-windows-hide";
 
-const OPENCODE_COMMANDS = ["opencode", "opencode-desktop"] as const
-const WINDOWS_SUFFIXES = ["", ".exe", ".cmd", ".bat", ".ps1"] as const
+const OPENCODE_COMMANDS = ["opencode", "opencode-desktop"] as const;
+const WINDOWS_SUFFIXES = ["", ".exe", ".cmd", ".bat", ".ps1"] as const;
 
 function getCommandCandidates(platform: NodeJS.Platform): string[] {
-  if (platform !== "win32") return [...OPENCODE_COMMANDS]
+	if (platform !== "win32") return [...OPENCODE_COMMANDS];
 
-  return OPENCODE_COMMANDS.flatMap((command) =>
-    WINDOWS_SUFFIXES.map((suffix) => `${command}${suffix}`),
-  )
+	return OPENCODE_COMMANDS.flatMap((command) =>
+		WINDOWS_SUFFIXES.map((suffix) => `${command}${suffix}`),
+	);
 }
 
 export function collectCandidateBinaryPaths(
-  pathEnv: string | undefined,
-  which: (command: string) => string | null | undefined = Bun.which,
-  platform: NodeJS.Platform = process.platform,
+	pathEnv: string | undefined,
+	which: (command: string) => string | null | undefined = Bun.which,
+	platform: NodeJS.Platform = process.platform,
 ): string[] {
-  const seen = new Set<string>()
-  const candidates: string[] = []
-  const commandCandidates = getCommandCandidates(platform)
+	const seen = new Set<string>();
+	const candidates: string[] = [];
+	const commandCandidates = getCommandCandidates(platform);
 
-  const addCandidate = (binaryPath: string | undefined | null): void => {
-    if (!binaryPath || seen.has(binaryPath)) return
-    seen.add(binaryPath)
-    candidates.push(binaryPath)
-  }
+	const addCandidate = (binaryPath: string | undefined | null): void => {
+		if (!binaryPath || seen.has(binaryPath)) return;
+		seen.add(binaryPath);
+		candidates.push(binaryPath);
+	};
 
-  for (const command of commandCandidates) {
-    addCandidate(which(command))
-  }
+	for (const command of commandCandidates) {
+		addCandidate(which(command));
+	}
 
-  for (const entry of (pathEnv ?? "").split(delimiter).filter(Boolean)) {
-    for (const command of commandCandidates) {
-      addCandidate(join(entry, command))
-    }
-  }
+	const pathDelimiter =
+		platform === "win32" ? win32.delimiter : posix.delimiter;
+	const joinForPlatform = platform === "win32" ? win32.join : posix.join;
 
-  return candidates
+	for (const entry of (pathEnv ?? "").split(pathDelimiter).filter(Boolean)) {
+		for (const command of commandCandidates) {
+			addCandidate(joinForPlatform(entry, command));
+		}
+	}
+
+	return candidates;
 }
 
 export async function canExecuteBinary(binaryPath: string): Promise<boolean> {
-  try {
-    const proc = spawnWithWindowsHide([binaryPath, "--version"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-    await proc.exited
-    return proc.exitCode === 0
-  } catch {
-    return false
-  }
+	try {
+		const proc = spawnWithWindowsHide([binaryPath, "--version"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		await proc.exited;
+		return proc.exitCode === 0;
+	} catch {
+		return false;
+	}
 }
 
 export async function findWorkingOpencodeBinary(
-  pathEnv: string | undefined = process.env.PATH,
-  probe: (binaryPath: string) => Promise<boolean> = canExecuteBinary,
-  which: (command: string) => string | null | undefined = Bun.which,
-  platform: NodeJS.Platform = process.platform,
+	pathEnv: string | undefined = process.env.PATH,
+	probe: (binaryPath: string) => Promise<boolean> = canExecuteBinary,
+	which: (command: string) => string | null | undefined = Bun.which,
+	platform: NodeJS.Platform = process.platform,
 ): Promise<string | null> {
-  const candidates = collectCandidateBinaryPaths(pathEnv, which, platform)
-  for (const candidate of candidates) {
-    if (await probe(candidate)) {
-      return candidate
-    }
-  }
-  return null
+	const candidates = collectCandidateBinaryPaths(pathEnv, which, platform);
+	for (const candidate of candidates) {
+		if (await probe(candidate)) {
+			return candidate;
+		}
+	}
+	return null;
 }
 
-export function buildPathWithBinaryFirst(pathEnv: string | undefined, binaryPath: string): string {
-  const preferredDir = dirname(binaryPath)
-  const existing = (pathEnv ?? "").split(delimiter).filter(
-    (entry) => entry.length > 0 && entry !== preferredDir,
-  )
-  return [preferredDir, ...existing].join(delimiter)
+export function buildPathWithBinaryFirst(
+	pathEnv: string | undefined,
+	binaryPath: string,
+): string {
+	const preferredDir = dirname(binaryPath);
+	const existing = (pathEnv ?? "")
+		.split(delimiter)
+		.filter((entry) => entry.length > 0 && entry !== preferredDir);
+	return [preferredDir, ...existing].join(delimiter);
 }
 
 export async function withWorkingOpencodePath<T>(
-  startServer: () => Promise<T>,
-  finder: (pathEnv: string | undefined) => Promise<string | null> = findWorkingOpencodeBinary,
+	startServer: () => Promise<T>,
+	finder: (
+		pathEnv: string | undefined,
+	) => Promise<string | null> = findWorkingOpencodeBinary,
 ): Promise<T> {
-  const originalPath = process.env.PATH
-  const binaryPath = await finder(originalPath)
+	const originalPath = process.env.PATH;
+	const binaryPath = await finder(originalPath);
 
-  if (!binaryPath) {
-    return startServer()
-  }
+	if (!binaryPath) {
+		return startServer();
+	}
 
-  process.env.PATH = buildPathWithBinaryFirst(originalPath, binaryPath)
-  try {
-    return await startServer()
-  } finally {
-    process.env.PATH = originalPath
-  }
+	process.env.PATH = buildPathWithBinaryFirst(originalPath, binaryPath);
+	try {
+		return await startServer();
+	} finally {
+		process.env.PATH = originalPath;
+	}
 }

--- a/src/cli/run/runner.test.ts
+++ b/src/cli/run/runner.test.ts
@@ -1,193 +1,197 @@
 /// <reference types="bun-types" />
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "bun:test"
-import type { OhMyOpenCodeConfig } from "../../config"
-import { resolveRunAgent, waitForEventProcessorShutdown } from "./runner"
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { OhMyOpenCodeConfig } from "../../config";
+import { resolveRunAgent, waitForEventProcessorShutdown } from "./runner";
 
-const createConfig = (overrides: Partial<OhMyOpenCodeConfig> = {}): OhMyOpenCodeConfig => ({
-  ...overrides,
-})
+const createConfig = (
+	overrides: Partial<OhMyOpenCodeConfig> = {},
+): OhMyOpenCodeConfig => ({
+	...overrides,
+});
 
 describe("resolveRunAgent", () => {
-  it("uses CLI agent over env and config", () => {
-    // given
-    const config = createConfig({ default_run_agent: "prometheus" })
-    const env = { OPENCODE_DEFAULT_AGENT: "Atlas" }
+	it("uses CLI agent over env and config", () => {
+		// given
+		const config = createConfig({ default_run_agent: "prometheus" });
+		const env = { OPENCODE_DEFAULT_AGENT: "Atlas" };
 
-    // when
-    const agent = resolveRunAgent(
-      { message: "test", agent: "Hephaestus" },
-      config,
-      env
-    )
+		// when
+		const agent = resolveRunAgent(
+			{ message: "test", agent: "Hephaestus" },
+			config,
+			env,
+		);
 
-    // then
-    expect(agent).toBe("Hephaestus (Deep Agent)")
-  })
+		// then
+		expect(agent).toBe("Hephaestus (Deep Agent)");
+	});
 
-  it("uses env agent over config", () => {
-    // given
-    const config = createConfig({ default_run_agent: "prometheus" })
-    const env = { OPENCODE_DEFAULT_AGENT: "Atlas" }
+	it("uses env agent over config", () => {
+		// given
+		const config = createConfig({ default_run_agent: "prometheus" });
+		const env = { OPENCODE_DEFAULT_AGENT: "Atlas" };
 
-    // when
-    const agent = resolveRunAgent({ message: "test" }, config, env)
+		// when
+		const agent = resolveRunAgent({ message: "test" }, config, env);
 
-    // then
-    expect(agent).toBe("Atlas (Plan Executor)")
-  })
+		// then
+		expect(agent).toBe("Atlas (Plan Executor)");
+	});
 
-  it("uses config agent over default", () => {
-    // given
-    const config = createConfig({ default_run_agent: "Prometheus" })
+	it("uses config agent over default", () => {
+		// given
+		const config = createConfig({ default_run_agent: "Prometheus" });
 
-    // when
-    const agent = resolveRunAgent({ message: "test" }, config, {})
+		// when
+		const agent = resolveRunAgent({ message: "test" }, config, {});
 
-    // then
-    expect(agent).toBe("Prometheus (Plan Builder)")
-  })
+		// then
+		expect(agent).toBe("Prometheus (Plan Builder)");
+	});
 
-  it("falls back to sisyphus when none set", () => {
-    // given
-    const config = createConfig()
+	it("falls back to sisyphus when none set", () => {
+		// given
+		const config = createConfig();
 
-    // when
-    const agent = resolveRunAgent({ message: "test" }, config, {})
+		// when
+		const agent = resolveRunAgent({ message: "test" }, config, {});
 
-    // then
-    expect(agent).toBe("Sisyphus (Ultraworker)")
-  })
+		// then
+		expect(agent).toBe("Sisyphus (Ultraworker)");
+	});
 
-  it("skips disabled sisyphus for next available core agent", () => {
-    // given
-    const config = createConfig({ disabled_agents: ["sisyphus"] })
+	it("skips disabled sisyphus for next available core agent", () => {
+		// given
+		const config = createConfig({ disabled_agents: ["sisyphus"] });
 
-    // when
-    const agent = resolveRunAgent({ message: "test" }, config, {})
+		// when
+		const agent = resolveRunAgent({ message: "test" }, config, {});
 
-    // then
-    expect(agent).toBe("Hephaestus (Deep Agent)")
-  })
+		// then
+		expect(agent).toBe("Hephaestus (Deep Agent)");
+	});
 
-  it("maps display-name style default_run_agent values to canonical display names", () => {
-    // given
-    const config = createConfig({ default_run_agent: "Sisyphus (Ultraworker)" })
+	it("maps display-name style default_run_agent values to canonical display names", () => {
+		// given
+		const config = createConfig({
+			default_run_agent: "Sisyphus (Ultraworker)",
+		});
 
-    // when
-    const agent = resolveRunAgent({ message: "test" }, config, {})
+		// when
+		const agent = resolveRunAgent({ message: "test" }, config, {});
 
-    // then
-    expect(agent).toBe("Sisyphus (Ultraworker)")
-  })
-})
+		// then
+		expect(agent).toBe("Sisyphus (Ultraworker)");
+	});
+});
 
 describe("waitForEventProcessorShutdown", () => {
-  it("returns quickly when event processor completes", async () => {
-    //#given
-    const eventProcessor = new Promise<void>((resolve) => {
-      setTimeout(() => {
-        resolve()
-      }, 25)
-    })
-    const start = performance.now()
+	it("returns quickly when event processor completes", async () => {
+		//#given
+		const eventProcessor = new Promise<void>((resolve) => {
+			setTimeout(() => {
+				resolve();
+			}, 25);
+		});
+		const start = performance.now();
 
-    //#when
-    await waitForEventProcessorShutdown(eventProcessor, 200)
+		//#when
+		await waitForEventProcessorShutdown(eventProcessor, 200);
 
-    //#then
-    const elapsed = performance.now() - start
-    expect(elapsed).toBeLessThan(200)
-  })
+		//#then
+		const elapsed = performance.now() - start;
+		expect(elapsed).toBeLessThan(200);
+	});
 
-  it("times out and continues when event processor does not complete", async () => {
-    //#given
-    const eventProcessor = new Promise<void>(() => {})
-    const timeoutMs = 200
-    const start = performance.now()
+	it("times out and continues when event processor does not complete", async () => {
+		//#given
+		const eventProcessor = new Promise<void>(() => {});
+		const timeoutMs = 200;
+		const start = performance.now();
 
-    //#when
-    await waitForEventProcessorShutdown(eventProcessor, timeoutMs)
+		//#when
+		await waitForEventProcessorShutdown(eventProcessor, timeoutMs);
 
-    //#then
-    const elapsed = performance.now() - start
-    expect(elapsed).toBeGreaterThanOrEqual(timeoutMs - 10)
-  })
-})
+		//#then
+		const elapsed = performance.now() - start;
+		expect(elapsed).toBeGreaterThanOrEqual(timeoutMs - 10);
+	});
+});
 
 describe("run environment setup", () => {
-  let originalClient: string | undefined
-  let originalRunMode: string | undefined
+	let originalClient: string | undefined;
+	let originalRunMode: string | undefined;
 
-  beforeEach(() => {
-    originalClient = process.env.OPENCODE_CLIENT
-    originalRunMode = process.env.OPENCODE_CLI_RUN_MODE
-  })
+	beforeEach(() => {
+		originalClient = process.env.OPENCODE_CLIENT;
+		originalRunMode = process.env.OPENCODE_CLI_RUN_MODE;
+	});
 
-  afterEach(() => {
-    if (originalClient === undefined) {
-      delete process.env.OPENCODE_CLIENT
-    } else {
-      process.env.OPENCODE_CLIENT = originalClient
-    }
-    if (originalRunMode === undefined) {
-      delete process.env.OPENCODE_CLI_RUN_MODE
-    } else {
-      process.env.OPENCODE_CLI_RUN_MODE = originalRunMode
-    }
-  })
+	afterEach(() => {
+		if (originalClient === undefined) {
+			delete process.env.OPENCODE_CLIENT;
+		} else {
+			process.env.OPENCODE_CLIENT = originalClient;
+		}
+		if (originalRunMode === undefined) {
+			delete process.env.OPENCODE_CLI_RUN_MODE;
+		} else {
+			process.env.OPENCODE_CLI_RUN_MODE = originalRunMode;
+		}
+	});
 
-  it("sets OPENCODE_CLIENT to 'run' to exclude question tool from registry", async () => {
-    //#given
-    delete process.env.OPENCODE_CLIENT
+	it("sets OPENCODE_CLIENT to 'run' to exclude question tool from registry", async () => {
+		//#given
+		delete process.env.OPENCODE_CLIENT;
 
-    //#when - run() sets env vars synchronously before any async work
-    const { run } = await import(`./runner?env-setup-${Date.now()}`)
-    run({ message: "test" }).catch(() => {})
+		//#when - run() sets env vars synchronously before any async work
+		const { run } = await import(`./runner?env-setup-${Date.now()}`);
+		run({ message: "test" }).catch(() => {});
 
-    //#then
-    expect(String(process.env.OPENCODE_CLIENT)).toBe("run")
-    expect(String(process.env.OPENCODE_CLI_RUN_MODE)).toBe("true")
-  })
-})
+		//#then
+		expect(String(process.env.OPENCODE_CLIENT)).toBe("run");
+		expect(String(process.env.OPENCODE_CLI_RUN_MODE)).toBe("true");
+	});
+});
 
 describe("run with invalid model", () => {
-  it("given invalid --model value, when run, then returns exit code 1 with error message", async () => {
-    // given
-    const originalExit = process.exit
-    const originalError = console.error
-    const errorMessages: string[] = []
-    const exitCodes: number[] = []
+	it("given invalid --model value, when run, then returns exit code 1 with error message", async () => {
+		// given
+		const originalExit = process.exit;
+		const originalError = console.error;
+		const errorMessages: string[] = [];
+		const exitCodes: number[] = [];
 
-    console.error = (...args: unknown[]) => {
-      errorMessages.push(args.map(String).join(" "))
-    }
-    process.exit = ((code?: number) => {
-      exitCodes.push(code ?? 0)
-      throw new Error("exit")
-    }) as typeof process.exit
+		console.error = (...args: unknown[]) => {
+			errorMessages.push(args.map(String).join(" "));
+		};
+		process.exit = ((code?: number) => {
+			exitCodes.push(code ?? 0);
+			throw new Error("exit");
+		}) as typeof process.exit;
 
-    try {
-      // when
-      // Note: This will actually try to run - but the issue is that resolveRunModel
-      // is called BEFORE the try block, so it throws an unhandled exception
-      // We're testing the runner's error handling
-      const { run } = await import("./runner")
+		try {
+			// when
+			// Note: This will actually try to run - but the issue is that resolveRunModel
+			// is called BEFORE the try block, so it throws an unhandled exception
+			// We're testing the runner's error handling
+			const { run } = await import("./runner");
 
-      // This will throw because model "invalid" is invalid format
-      try {
-        await run({
-          message: "test",
-          model: "invalid",
-        })
-      } catch {
-        // Expected to potentially throw due to unhandled model resolution error
-      }
-    } finally {
-      // then - verify error handling
-      // Currently this will fail because the error is not caught properly
-      console.error = originalError
-      process.exit = originalExit
-    }
-  })
-})
+			// This will throw because model "invalid" is invalid format
+			try {
+				await run({
+					message: "test",
+					model: "invalid",
+				});
+			} catch {
+				// Expected to potentially throw due to unhandled model resolution error
+			}
+		} finally {
+			// then - verify error handling
+			// Currently this will fail because the error is not caught properly
+			console.error = originalError;
+			process.exit = originalExit;
+		}
+	});
+});

--- a/src/features/background-agent/task-poller.ts
+++ b/src/features/background-agent/task-poller.ts
@@ -1,196 +1,221 @@
-import { log } from "../../shared"
-
-import type { BackgroundTaskConfig } from "../../config/schema"
-import type { BackgroundTask } from "./types"
-import type { ConcurrencyManager } from "./concurrency"
-import type { OpencodeClient } from "./opencode-client"
-
+import type { BackgroundTaskConfig } from "../../config/schema";
+import { log } from "../../shared";
+import type { ConcurrencyManager } from "./concurrency";
 import {
-  DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS,
-  DEFAULT_SESSION_GONE_TIMEOUT_MS,
-  DEFAULT_STALE_TIMEOUT_MS,
-  MIN_RUNTIME_BEFORE_STALE_MS,
-  TERMINAL_TASK_TTL_MS,
-  TASK_TTL_MS,
-} from "./constants"
-import { removeTaskToastTracking } from "./remove-task-toast-tracking"
+	DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS,
+	DEFAULT_SESSION_GONE_TIMEOUT_MS,
+	DEFAULT_STALE_TIMEOUT_MS,
+	MIN_RUNTIME_BEFORE_STALE_MS,
+	TASK_TTL_MS,
+	TERMINAL_TASK_TTL_MS,
+} from "./constants";
+import type { OpencodeClient } from "./opencode-client";
+import { removeTaskToastTracking } from "./remove-task-toast-tracking";
+import { isActiveSessionStatus } from "./session-status-classifier";
+import type { BackgroundTask } from "./types";
 
-import { isActiveSessionStatus } from "./session-status-classifier"
 const TERMINAL_TASK_STATUSES = new Set<BackgroundTask["status"]>([
-  "completed",
-  "error",
-  "cancelled",
-  "interrupt",
-])
+	"completed",
+	"error",
+	"cancelled",
+	"interrupt",
+]);
 
 export function pruneStaleTasksAndNotifications(args: {
-  tasks: Map<string, BackgroundTask>
-  notifications: Map<string, BackgroundTask[]>
-  onTaskPruned: (taskId: string, task: BackgroundTask, errorMessage: string) => void
-  taskTtlMs?: number
+	tasks: Map<string, BackgroundTask>;
+	notifications: Map<string, BackgroundTask[]>;
+	onTaskPruned: (
+		taskId: string,
+		task: BackgroundTask,
+		errorMessage: string,
+	) => void;
+	taskTtlMs?: number;
 }): void {
-  const { tasks, notifications, onTaskPruned } = args
-  const effectiveTtl = args.taskTtlMs ?? TASK_TTL_MS
-  const now = Date.now()
-  const tasksWithPendingNotifications = new Set<string>()
+	const { tasks, notifications, onTaskPruned } = args;
+	const effectiveTtl = args.taskTtlMs ?? TASK_TTL_MS;
+	const now = Date.now();
+	const tasksWithPendingNotifications = new Set<string>();
 
-  for (const queued of notifications.values()) {
-    for (const task of queued) {
-      tasksWithPendingNotifications.add(task.id)
-    }
-  }
+	for (const queued of notifications.values()) {
+		for (const task of queued) {
+			tasksWithPendingNotifications.add(task.id);
+		}
+	}
 
-  for (const [taskId, task] of tasks.entries()) {
-    if (TERMINAL_TASK_STATUSES.has(task.status)) {
-      if (tasksWithPendingNotifications.has(taskId)) continue
+	for (const [taskId, task] of tasks.entries()) {
+		if (TERMINAL_TASK_STATUSES.has(task.status)) {
+			if (tasksWithPendingNotifications.has(taskId)) continue;
 
-      const completedAt = task.completedAt?.getTime()
-      if (!completedAt) continue
+			const completedAt = task.completedAt?.getTime();
+			if (!completedAt) continue;
 
-      const age = now - completedAt
-      if (age <= TERMINAL_TASK_TTL_MS) continue
+			const age = now - completedAt;
+			if (age <= TERMINAL_TASK_TTL_MS) continue;
 
-      removeTaskToastTracking(taskId)
-      tasks.delete(taskId)
-      continue
-    }
+			removeTaskToastTracking(taskId);
+			tasks.delete(taskId);
+			continue;
+		}
 
-    const lastActivity = task.status === "running" && task.progress?.lastUpdate
-      ? task.progress.lastUpdate.getTime()
-      : undefined
-    const timestamp = task.status === "pending"
-      ? task.queuedAt?.getTime()
-      : (lastActivity ?? task.startedAt?.getTime())
+		const lastActivity =
+			task.status === "running" && task.progress?.lastUpdate
+				? task.progress.lastUpdate.getTime()
+				: undefined;
+		const timestamp =
+			task.status === "pending"
+				? task.queuedAt?.getTime()
+				: (lastActivity ?? task.startedAt?.getTime());
 
-    if (!timestamp) continue
+		if (!timestamp) continue;
 
-    const age = now - timestamp
-    if (age <= effectiveTtl) continue
+		const age = now - timestamp;
+		if (age <= effectiveTtl) continue;
 
-    const ttlMinutes = Math.round(effectiveTtl / 60000)
-    const errorMessage = task.status === "pending"
-      ? `Task timed out while queued (${ttlMinutes} minutes)`
-      : `Task timed out after ${ttlMinutes} minutes of inactivity`
+		const ttlMinutes = Math.round(effectiveTtl / 60000);
+		const errorMessage =
+			task.status === "pending"
+				? `Task timed out while queued (${ttlMinutes} minutes)`
+				: `Task timed out after ${ttlMinutes} minutes of inactivity`;
 
-    onTaskPruned(taskId, task, errorMessage)
-  }
+		onTaskPruned(taskId, task, errorMessage);
+	}
 
-  for (const [sessionID, queued] of notifications.entries()) {
-    if (queued.length === 0) {
-      notifications.delete(sessionID)
-      continue
-    }
+	for (const [sessionID, queued] of notifications.entries()) {
+		if (queued.length === 0) {
+			notifications.delete(sessionID);
+			continue;
+		}
 
-    const validNotifications = queued.filter((task) => {
-      if (!task.startedAt) return false
-      const age = now - task.startedAt.getTime()
-      return age <= effectiveTtl
-    })
+		const validNotifications = queued.filter((task) => {
+			if (!task.startedAt) return false;
+			const age = now - task.startedAt.getTime();
+			return age <= effectiveTtl;
+		});
 
-    if (validNotifications.length === 0) {
-      notifications.delete(sessionID)
-    } else if (validNotifications.length !== queued.length) {
-      notifications.set(sessionID, validNotifications)
-    }
-  }
+		if (validNotifications.length === 0) {
+			notifications.delete(sessionID);
+		} else if (validNotifications.length !== queued.length) {
+			notifications.set(sessionID, validNotifications);
+		}
+	}
 }
 
-export type SessionStatusMap = Record<string, { type: string }>
+export type SessionStatusMap = Record<string, { type: string }>;
 
 export async function checkAndInterruptStaleTasks(args: {
-  tasks: Iterable<BackgroundTask>
-  client: OpencodeClient
-  config: BackgroundTaskConfig | undefined
-  concurrencyManager: ConcurrencyManager
-  notifyParentSession: (task: BackgroundTask) => Promise<void>
-  sessionStatuses?: SessionStatusMap
-  onTaskInterrupted?: (task: BackgroundTask) => void
+	tasks: Iterable<BackgroundTask>;
+	client: OpencodeClient;
+	config: BackgroundTaskConfig | undefined;
+	concurrencyManager: ConcurrencyManager;
+	notifyParentSession: (task: BackgroundTask) => Promise<void>;
+	sessionStatuses?: SessionStatusMap;
+	onTaskInterrupted?: (task: BackgroundTask) => void;
 }): Promise<void> {
-  const {
-    tasks,
-    client,
-    config,
-    concurrencyManager,
-    notifyParentSession,
-    sessionStatuses,
-    onTaskInterrupted = (task) => removeTaskToastTracking(task.id),
-  } = args
-  const staleTimeoutMs = config?.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS
-  const sessionGoneTimeoutMs = config?.sessionGoneTimeoutMs ?? DEFAULT_SESSION_GONE_TIMEOUT_MS
-  const now = Date.now()
+	const {
+		tasks,
+		client,
+		config,
+		concurrencyManager,
+		notifyParentSession,
+		sessionStatuses,
+		onTaskInterrupted = (task) => removeTaskToastTracking(task.id),
+	} = args;
+	const staleTimeoutMs = config?.staleTimeoutMs ?? DEFAULT_STALE_TIMEOUT_MS;
+	const sessionGoneTimeoutMs =
+		config?.sessionGoneTimeoutMs ?? DEFAULT_SESSION_GONE_TIMEOUT_MS;
+	const now = Date.now();
 
-  const messageStalenessMs = config?.messageStalenessTimeoutMs ?? DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS
+	const messageStalenessMs =
+		config?.messageStalenessTimeoutMs ?? DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS;
 
-  for (const task of tasks) {
-    if (task.status !== "running") continue
+	for (const task of tasks) {
+		if (task.status !== "running") continue;
 
-    const startedAt = task.startedAt
-    const sessionID = task.sessionID
-    if (!startedAt || !sessionID) continue
+		const startedAt = task.startedAt;
+		const sessionID = task.sessionID;
+		if (!startedAt || !sessionID) continue;
 
-    const sessionStatus = sessionStatuses?.[sessionID]?.type
-    const sessionIsRunning = sessionStatus !== undefined && isActiveSessionStatus(sessionStatus)
-    const sessionGone = sessionStatuses !== undefined && sessionStatus === undefined
-    const runtime = now - startedAt.getTime()
+		const sessionStatus = sessionStatuses?.[sessionID]?.type;
+		const sessionIsRunning =
+			sessionStatus !== undefined && isActiveSessionStatus(sessionStatus);
+		const sessionGone =
+			sessionStatuses !== undefined && sessionStatus === undefined;
+		const runtime = now - startedAt.getTime();
 
-    if (!task.progress?.lastUpdate) {
-      if (sessionIsRunning) continue
-      const effectiveTimeout = sessionGone ? sessionGoneTimeoutMs : messageStalenessMs
-      if (runtime <= effectiveTimeout) continue
+		if (!task.progress?.lastUpdate) {
+			if (sessionIsRunning) continue;
+			const effectiveTimeout = sessionGone
+				? sessionGoneTimeoutMs
+				: messageStalenessMs;
+			if (runtime <= effectiveTimeout) continue;
 
-      const staleMinutes = Math.round(runtime / 60000)
-      const reason = sessionGone ? "session gone from status registry" : "no activity"
-      task.status = "cancelled"
-      task.error = `Stale timeout (${reason} for ${staleMinutes}min since start). This is a FINAL cancellation - do NOT create a replacement task. If the timeout is too short, increase 'background_task.${sessionGone ? "sessionGoneTimeoutMs" : "staleTimeoutMs"}' in .opencode/oh-my-opencode.json.`
-      task.completedAt = new Date()
+			const staleMinutes = Math.round(runtime / 60000);
+			const reason = sessionGone
+				? "session gone from status registry"
+				: "no activity";
+			task.status = "cancelled";
+			task.error = `Stale timeout (${reason} for ${staleMinutes}min since start). This is a FINAL cancellation - do NOT create a replacement task. If the timeout is too short, increase 'background_task.${sessionGone ? "sessionGoneTimeoutMs" : "staleTimeoutMs"}' in .opencode/oh-my-openagent.jsonc.`;
+			task.completedAt = new Date();
 
-      if (task.concurrencyKey) {
-        concurrencyManager.release(task.concurrencyKey)
-        task.concurrencyKey = undefined
-      }
+			if (task.concurrencyKey) {
+				concurrencyManager.release(task.concurrencyKey);
+				task.concurrencyKey = undefined;
+			}
 
-      onTaskInterrupted(task)
+			onTaskInterrupted(task);
 
-      client.session.abort({ path: { id: sessionID } }).catch(() => {})
-      log(`[background-agent] Task ${task.id} interrupted: no progress since start`)
+			client.session.abort({ path: { id: sessionID } }).catch(() => {});
+			log(
+				`[background-agent] Task ${task.id} interrupted: no progress since start`,
+			);
 
-      try {
-        await notifyParentSession(task)
-      } catch (err) {
-        log("[background-agent] Error in notifyParentSession for stale task:", { taskId: task.id, error: err })
-      }
-      continue
-    }
+			try {
+				await notifyParentSession(task);
+			} catch (err) {
+				log("[background-agent] Error in notifyParentSession for stale task:", {
+					taskId: task.id,
+					error: err,
+				});
+			}
+			continue;
+		}
 
-    if (sessionIsRunning) continue
+		if (sessionIsRunning) continue;
 
-    if (runtime < MIN_RUNTIME_BEFORE_STALE_MS) continue
+		if (runtime < MIN_RUNTIME_BEFORE_STALE_MS) continue;
 
-    const timeSinceLastUpdate = now - task.progress.lastUpdate.getTime()
-    const effectiveStaleTimeout = sessionGone ? sessionGoneTimeoutMs : staleTimeoutMs
-    if (timeSinceLastUpdate <= effectiveStaleTimeout) continue
-    if (task.status !== "running") continue
+		const timeSinceLastUpdate = now - task.progress.lastUpdate.getTime();
+		const effectiveStaleTimeout = sessionGone
+			? sessionGoneTimeoutMs
+			: staleTimeoutMs;
+		if (timeSinceLastUpdate <= effectiveStaleTimeout) continue;
+		if (task.status !== "running") continue;
 
-     const staleMinutes = Math.round(timeSinceLastUpdate / 60000)
-     const reason = sessionGone ? "session gone from status registry" : "no activity"
-     task.status = "cancelled"
-     task.error = `Stale timeout (${reason} for ${staleMinutes}min). This is a FINAL cancellation - do NOT create a replacement task. If the timeout is too short, increase 'background_task.${sessionGone ? "sessionGoneTimeoutMs" : "staleTimeoutMs"}' in .opencode/oh-my-opencode.json.`
-     task.completedAt = new Date()
+		const staleMinutes = Math.round(timeSinceLastUpdate / 60000);
+		const reason = sessionGone
+			? "session gone from status registry"
+			: "no activity";
+		task.status = "cancelled";
+		task.error = `Stale timeout (${reason} for ${staleMinutes}min). This is a FINAL cancellation - do NOT create a replacement task. If the timeout is too short, increase 'background_task.${sessionGone ? "sessionGoneTimeoutMs" : "staleTimeoutMs"}' in .opencode/oh-my-openagent.jsonc.`;
+		task.completedAt = new Date();
 
-    if (task.concurrencyKey) {
-      concurrencyManager.release(task.concurrencyKey)
-      task.concurrencyKey = undefined
-    }
+		if (task.concurrencyKey) {
+			concurrencyManager.release(task.concurrencyKey);
+			task.concurrencyKey = undefined;
+		}
 
-    onTaskInterrupted(task)
+		onTaskInterrupted(task);
 
-    client.session.abort({ path: { id: sessionID } }).catch(() => {})
-    log(`[background-agent] Task ${task.id} interrupted: stale timeout`)
+		client.session.abort({ path: { id: sessionID } }).catch(() => {});
+		log(`[background-agent] Task ${task.id} interrupted: stale timeout`);
 
-    try {
-      await notifyParentSession(task)
-    } catch (err) {
-      log("[background-agent] Error in notifyParentSession for stale task:", { taskId: task.id, error: err })
-    }
-  }
+		try {
+			await notifyParentSession(task);
+		} catch (err) {
+			log("[background-agent] Error in notifyParentSession for stale task:", {
+				taskId: task.id,
+				error: err,
+			});
+		}
+	}
 }

--- a/src/features/claude-code-command-loader/loader.test.ts
+++ b/src/features/claude-code-command-loader/loader.test.ts
@@ -1,125 +1,177 @@
-import { execFileSync } from "node:child_process"
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { loadOpencodeGlobalCommands, loadOpencodeProjectCommands } from "./loader"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	loadOpencodeGlobalCommands,
+	loadOpencodeProjectCommands,
+} from "./loader";
 
-const TEST_DIR = join(tmpdir(), `claude-code-command-loader-${Date.now()}`)
-
-function writeCommand(directory: string, name: string, description: string): void {
-  mkdirSync(directory, { recursive: true })
-  writeFileSync(
-    join(directory, `${name}.md`),
-    `---\ndescription: ${description}\n---\nRun ${name}.\n`,
-  )
+function writeCommand(
+	directory: string,
+	name: string,
+	description: string,
+): void {
+	mkdirSync(directory, { recursive: true });
+	writeFileSync(
+		join(directory, `${name}.md`),
+		`---\ndescription: ${description}\n---\nRun ${name}.\n`,
+	);
 }
 
 describe("claude-code command loader", () => {
-  let originalOpencodeConfigDir: string | undefined
+	let testDir: string;
+	let originalOpencodeConfigDir: string | undefined;
 
-  beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
-    originalOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR
-  })
+	beforeEach(() => {
+		testDir = mkdtempSync(join(tmpdir(), "claude-code-command-loader-"));
+		originalOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
+	});
 
-  afterEach(() => {
-    if (originalOpencodeConfigDir === undefined) {
-      delete process.env.OPENCODE_CONFIG_DIR
-    } else {
-      process.env.OPENCODE_CONFIG_DIR = originalOpencodeConfigDir
-    }
-    rmSync(TEST_DIR, { recursive: true, force: true })
-  })
+	afterEach(() => {
+		if (originalOpencodeConfigDir === undefined) {
+			delete process.env.OPENCODE_CONFIG_DIR;
+		} else {
+			process.env.OPENCODE_CONFIG_DIR = originalOpencodeConfigDir;
+		}
+		rmSync(testDir, { recursive: true, force: true });
+	});
 
-  it("#given a parent .opencode/commands directory #when loadOpencodeProjectCommands is called from child directory #then it loads the ancestor command", async () => {
-    // given
-    const projectDir = join(TEST_DIR, "project")
-    const childDir = join(projectDir, "apps", "desktop")
-    writeCommand(join(projectDir, ".opencode", "commands"), "ancestor", "Ancestor command")
+	it("#given a parent .opencode/commands directory #when loadOpencodeProjectCommands is called from child directory #then it loads the ancestor command", async () => {
+		// given
+		const projectDir = join(testDir, "project");
+		const childDir = join(projectDir, "apps", "desktop");
+		writeCommand(
+			join(projectDir, ".opencode", "commands"),
+			"ancestor",
+			"Ancestor command",
+		);
 
-    // when
-    const commands = await loadOpencodeProjectCommands(childDir)
+		// when
+		const commands = await loadOpencodeProjectCommands(childDir);
 
-    // then
-    expect(commands.ancestor?.description).toBe("(opencode-project) Ancestor command")
-  })
+		// then
+		expect(commands.ancestor?.description).toBe(
+			"(opencode-project) Ancestor command",
+		);
+	});
 
-  it("#given a .opencode/command directory #when loadOpencodeProjectCommands is called #then it loads the singular alias directory", async () => {
-    // given
-    writeCommand(join(TEST_DIR, ".opencode", "command"), "singular", "Singular command")
+	it("#given a .opencode/command directory #when loadOpencodeProjectCommands is called #then it loads the singular alias directory", async () => {
+		// given
+		writeCommand(
+			join(testDir, ".opencode", "command"),
+			"singular",
+			"Singular command",
+		);
 
-    // when
-    const commands = await loadOpencodeProjectCommands(TEST_DIR)
+		// when
+		const commands = await loadOpencodeProjectCommands(testDir);
 
-    // then
-    expect(commands.singular?.description).toBe("(opencode-project) Singular command")
-  })
+		// then
+		expect(commands.singular?.description).toBe(
+			"(opencode-project) Singular command",
+		);
+	});
 
-  it("#given duplicate project command names across ancestors #when loadOpencodeProjectCommands is called #then the nearest directory wins", async () => {
-    // given
-    const projectRoot = join(TEST_DIR, "project")
-    const childDir = join(projectRoot, "apps", "desktop")
-    const ancestorDir = join(TEST_DIR, ".opencode", "commands")
-    const projectDir = join(projectRoot, ".opencode", "commands")
-    writeCommand(ancestorDir, "duplicate", "Ancestor command")
-    writeCommand(projectDir, "duplicate", "Nearest command")
+	it("#given duplicate project command names across ancestors #when loadOpencodeProjectCommands is called #then the nearest directory wins", async () => {
+		// given
+		const projectRoot = join(testDir, "project");
+		const childDir = join(projectRoot, "apps", "desktop");
+		const ancestorDir = join(testDir, ".opencode", "commands");
+		const projectDir = join(projectRoot, ".opencode", "commands");
+		writeCommand(ancestorDir, "duplicate", "Ancestor command");
+		writeCommand(projectDir, "duplicate", "Nearest command");
 
-    // when
-    const commands = await loadOpencodeProjectCommands(childDir)
+		// when
+		const commands = await loadOpencodeProjectCommands(childDir);
 
-    // then
-    expect(commands.duplicate?.description).toBe("(opencode-project) Nearest command")
-  })
+		// then
+		expect(commands.duplicate?.description).toBe(
+			"(opencode-project) Nearest command",
+		);
+	});
 
-  it("#given a global .opencode/commands directory #when loadOpencodeGlobalCommands is called #then it loads the plural alias directory", async () => {
-    // given
-    const opencodeConfigDir = join(TEST_DIR, "opencode-config")
-    process.env.OPENCODE_CONFIG_DIR = opencodeConfigDir
-    writeCommand(join(opencodeConfigDir, "commands"), "global-plural", "Global plural command")
+	it("#given a global .opencode/commands directory #when loadOpencodeGlobalCommands is called #then it loads the plural alias directory", async () => {
+		// given
+		const opencodeConfigDir = join(testDir, "opencode-config");
+		process.env.OPENCODE_CONFIG_DIR = opencodeConfigDir;
+		writeCommand(
+			join(opencodeConfigDir, "commands"),
+			"global-plural",
+			"Global plural command",
+		);
 
-    // when
-    const commands = await loadOpencodeGlobalCommands()
+		// when
+		const commands = await loadOpencodeGlobalCommands();
 
-    // then
-    expect(commands["global-plural"]?.description).toBe("(opencode) Global plural command")
-  })
+		// then
+		expect(commands["global-plural"]?.description).toBe(
+			"(opencode) Global plural command",
+		);
+	});
 
-  it("#given duplicate global command names across profile and parent dirs #when loadOpencodeGlobalCommands is called #then the profile dir wins", async () => {
-    // given
-    const opencodeRootDir = join(TEST_DIR, "opencode-root")
-    const profileConfigDir = join(opencodeRootDir, "profiles", "codex")
-    process.env.OPENCODE_CONFIG_DIR = profileConfigDir
-    writeCommand(join(opencodeRootDir, "commands"), "duplicate-global", "Parent global command")
-    writeCommand(join(profileConfigDir, "commands"), "duplicate-global", "Profile global command")
+	it("#given duplicate global command names across profile and parent dirs #when loadOpencodeGlobalCommands is called #then the profile dir wins", async () => {
+		// given
+		const opencodeRootDir = join(testDir, "opencode-root");
+		const profileConfigDir = join(opencodeRootDir, "profiles", "codex");
+		process.env.OPENCODE_CONFIG_DIR = profileConfigDir;
+		writeCommand(
+			join(opencodeRootDir, "commands"),
+			"duplicate-global",
+			"Parent global command",
+		);
+		writeCommand(
+			join(profileConfigDir, "commands"),
+			"duplicate-global",
+			"Profile global command",
+		);
 
-    // when
-    const commands = await loadOpencodeGlobalCommands()
+		// when
+		const commands = await loadOpencodeGlobalCommands();
 
-    // then
-    expect(commands["duplicate-global"]?.description).toBe("(opencode) Profile global command")
-  })
+		// then
+		expect(commands["duplicate-global"]?.description).toBe(
+			"(opencode) Profile global command",
+		);
+	});
 
-  it("#given nested project opencode commands in a worktree #when loadOpencodeProjectCommands is called #then it preserves slash names and stops at the worktree root", async () => {
-    // given
-    const repositoryDir = join(TEST_DIR, "repo")
-    const nestedDirectory = join(repositoryDir, "packages", "app", "src")
-    mkdirSync(nestedDirectory, { recursive: true })
-    execFileSync("git", ["init"], {
-      cwd: repositoryDir,
-      stdio: ["ignore", "ignore", "ignore"],
-    })
-    writeCommand(join(repositoryDir, ".opencode", "commands", "deploy"), "staging", "Deploy staging")
-    writeCommand(join(repositoryDir, ".opencode", "command"), "release", "Release command")
-    writeCommand(join(TEST_DIR, ".opencode", "commands"), "outside", "Outside command")
+	it("#given nested project opencode commands in a worktree #when loadOpencodeProjectCommands is called #then it preserves slash names and stops at the worktree root", async () => {
+		// given
+		const repositoryDir = join(testDir, "repo");
+		const nestedDirectory = join(repositoryDir, "packages", "app", "src");
+		mkdirSync(nestedDirectory, { recursive: true });
+		execFileSync("git", ["init"], {
+			cwd: repositoryDir,
+			stdio: ["ignore", "ignore", "ignore"],
+		});
+		writeCommand(
+			join(repositoryDir, ".opencode", "commands", "deploy"),
+			"staging",
+			"Deploy staging",
+		);
+		writeCommand(
+			join(repositoryDir, ".opencode", "command"),
+			"release",
+			"Release command",
+		);
+		writeCommand(
+			join(testDir, ".opencode", "commands"),
+			"outside",
+			"Outside command",
+		);
 
-    // when
-    const commands = await loadOpencodeProjectCommands(nestedDirectory)
+		// when
+		const commands = await loadOpencodeProjectCommands(nestedDirectory);
 
-    // then
-    expect(commands["deploy/staging"]?.description).toBe("(opencode-project) Deploy staging")
-    expect(commands.release?.description).toBe("(opencode-project) Release command")
-    expect(commands.outside).toBeUndefined()
-    expect(commands["deploy:staging"]).toBeUndefined()
-  })
-})
+		// then
+		expect(commands["deploy/staging"]?.description).toBe(
+			"(opencode-project) Deploy staging",
+		);
+		expect(commands.release?.description).toBe(
+			"(opencode-project) Release command",
+		);
+		expect(commands.outside).toBeUndefined();
+		expect(commands["deploy:staging"]).toBeUndefined();
+	});
+});

--- a/src/features/claude-code-command-loader/loader.ts
+++ b/src/features/claude-code-command-loader/loader.ts
@@ -1,169 +1,208 @@
-import { promises as fs, type Dirent } from "fs"
-import { join, basename } from "path"
-import { parseFrontmatter } from "../../shared/frontmatter"
-import { sanitizeModelField } from "../../shared/model-sanitizer"
-import { isMarkdownFile } from "../../shared/file-utils"
-import {
-  findProjectOpencodeCommandDirs,
-  getClaudeConfigDir,
-  getOpenCodeCommandDirs,
-} from "../../shared"
-import { log } from "../../shared/logger"
-import type { CommandScope, CommandDefinition, CommandFrontmatter, LoadedCommand } from "./types"
+import { type Dirent, promises as fs } from "fs";
+import { basename, join } from "path";
+import { getClaudeConfigDir } from "../../shared/claude-config-dir";
+import { isMarkdownFile } from "../../shared/file-utils";
+import { parseFrontmatter } from "../../shared/frontmatter";
+import { log } from "../../shared/logger";
+import { sanitizeModelField } from "../../shared/model-sanitizer";
+import { getOpenCodeCommandDirs } from "../../shared/opencode-command-dirs";
+import { findProjectOpencodeCommandDirs } from "../../shared/project-discovery-dirs";
+import type {
+	CommandDefinition,
+	CommandFrontmatter,
+	CommandScope,
+	LoadedCommand,
+} from "./types";
 
 async function loadCommandsFromDir(
-  commandsDir: string,
-  scope: CommandScope,
-  visited: Set<string> = new Set(),
-  prefix: string = ""
+	commandsDir: string,
+	scope: CommandScope,
+	visited: Set<string> = new Set(),
+	prefix: string = "",
 ): Promise<LoadedCommand[]> {
-  try {
-    await fs.access(commandsDir)
-  } catch {
-    return []
-  }
+	try {
+		await fs.access(commandsDir);
+	} catch {
+		return [];
+	}
 
-  let realPath: string
-  try {
-    realPath = await fs.realpath(commandsDir)
-  } catch (error) {
-    log(`Failed to resolve command directory: ${commandsDir}`, error)
-    return []
-  }
+	let realPath: string;
+	try {
+		realPath = await fs.realpath(commandsDir);
+	} catch (error) {
+		log(`Failed to resolve command directory: ${commandsDir}`, error);
+		return [];
+	}
 
-  if (visited.has(realPath)) {
-    return []
-  }
-  visited.add(realPath)
+	if (visited.has(realPath)) {
+		return [];
+	}
+	visited.add(realPath);
 
-  let entries: Dirent[]
-  try {
-    entries = await fs.readdir(commandsDir, { withFileTypes: true })
-  } catch (error) {
-    log(`Failed to read command directory: ${commandsDir}`, error)
-    return []
-  }
+	let entries: Dirent[];
+	try {
+		entries = await fs.readdir(commandsDir, { withFileTypes: true });
+	} catch (error) {
+		log(`Failed to read command directory: ${commandsDir}`, error);
+		return [];
+	}
 
-  const commands: LoadedCommand[] = []
+	const commands: LoadedCommand[] = [];
 
-  for (const entry of entries) {
-    if (entry.isDirectory()) {
-      if (entry.name.startsWith(".")) continue
-      const subDirPath = join(commandsDir, entry.name)
-      const subPrefix = prefix ? `${prefix}/${entry.name}` : entry.name
-      const subCommands = await loadCommandsFromDir(subDirPath, scope, visited, subPrefix)
-      commands.push(...subCommands)
-      continue
-    }
+	for (const entry of entries) {
+		if (entry.isDirectory()) {
+			if (entry.name.startsWith(".")) continue;
+			const subDirPath = join(commandsDir, entry.name);
+			const subPrefix = prefix ? `${prefix}/${entry.name}` : entry.name;
+			const subCommands = await loadCommandsFromDir(
+				subDirPath,
+				scope,
+				visited,
+				subPrefix,
+			);
+			commands.push(...subCommands);
+			continue;
+		}
 
-    if (!isMarkdownFile(entry)) continue
+		if (!isMarkdownFile(entry)) continue;
 
-    const commandPath = join(commandsDir, entry.name)
-    const baseCommandName = basename(entry.name, ".md")
-    const commandName = prefix ? `${prefix}/${baseCommandName}` : baseCommandName
+		const commandPath = join(commandsDir, entry.name);
+		const baseCommandName = basename(entry.name, ".md");
+		const commandName = prefix
+			? `${prefix}/${baseCommandName}`
+			: baseCommandName;
 
-    try {
-      const content = await fs.readFile(commandPath, "utf-8")
-      const { data, body } = parseFrontmatter<CommandFrontmatter>(content)
+		try {
+			const content = await fs.readFile(commandPath, "utf-8");
+			const { data, body } = parseFrontmatter<CommandFrontmatter>(content);
 
-      const wrappedTemplate = `<command-instruction>
+			const wrappedTemplate = `<command-instruction>
 ${body.trim()}
 </command-instruction>
 
 <user-request>
 $ARGUMENTS
-</user-request>`
+</user-request>`;
 
-      const formattedDescription = `(${scope}) ${data.description || ""}`
+			const formattedDescription = `(${scope}) ${data.description || ""}`;
 
-      const isOpencodeSource = scope === "opencode" || scope === "opencode-project"
-      const definition: CommandDefinition = {
-        name: commandName,
-        description: formattedDescription,
-        template: wrappedTemplate,
-        agent: data.agent,
-        model: sanitizeModelField(data.model, isOpencodeSource ? "opencode" : "claude-code"),
-        subtask: data.subtask,
-        argumentHint: data["argument-hint"],
-        handoffs: data.handoffs,
-      }
+			const isOpencodeSource =
+				scope === "opencode" || scope === "opencode-project";
+			const definition: CommandDefinition = {
+				name: commandName,
+				description: formattedDescription,
+				template: wrappedTemplate,
+				agent: data.agent,
+				model: sanitizeModelField(
+					data.model,
+					isOpencodeSource ? "opencode" : "claude-code",
+				),
+				subtask: data.subtask,
+				argumentHint: data["argument-hint"],
+				handoffs: data.handoffs,
+			};
 
-      commands.push({
-        name: commandName,
-        path: commandPath,
-        definition,
-        scope,
-      })
-    } catch (error) {
-      log(`Failed to parse command: ${commandPath}`, error)
-      continue
-    }
-  }
+			commands.push({
+				name: commandName,
+				path: commandPath,
+				definition,
+				scope,
+			});
+		} catch (error) {
+			log(`Failed to parse command: ${commandPath}`, error);
+		}
+	}
 
-  return commands
+	return commands;
 }
 
-function deduplicateLoadedCommandsByName(commands: LoadedCommand[]): LoadedCommand[] {
-  const seen = new Set<string>()
-  const deduplicatedCommands: LoadedCommand[] = []
+function deduplicateLoadedCommandsByName(
+	commands: LoadedCommand[],
+): LoadedCommand[] {
+	const seen = new Set<string>();
+	const deduplicatedCommands: LoadedCommand[] = [];
 
-  for (const command of commands) {
-    if (seen.has(command.name)) {
-      continue
-    }
+	for (const command of commands) {
+		if (seen.has(command.name)) {
+			continue;
+		}
 
-    seen.add(command.name)
-    deduplicatedCommands.push(command)
-  }
+		seen.add(command.name);
+		deduplicatedCommands.push(command);
+	}
 
-  return deduplicatedCommands
+	return deduplicatedCommands;
 }
 
-function commandsToRecord(commands: LoadedCommand[]): Record<string, CommandDefinition> {
-  const result: Record<string, CommandDefinition> = {}
-  for (const cmd of deduplicateLoadedCommandsByName(commands)) {
-    const { name: _name, argumentHint: _argumentHint, ...openCodeCompatible } = cmd.definition
-    result[cmd.name] = openCodeCompatible as CommandDefinition
-  }
-  return result
+function commandsToRecord(
+	commands: LoadedCommand[],
+): Record<string, CommandDefinition> {
+	const result: Record<string, CommandDefinition> = {};
+	for (const cmd of deduplicateLoadedCommandsByName(commands)) {
+		const {
+			name: _name,
+			argumentHint: _argumentHint,
+			...openCodeCompatible
+		} = cmd.definition;
+		result[cmd.name] = openCodeCompatible as CommandDefinition;
+	}
+	return result;
 }
 
-export async function loadUserCommands(): Promise<Record<string, CommandDefinition>> {
-  const userCommandsDir = join(getClaudeConfigDir(), "commands")
-  const commands = await loadCommandsFromDir(userCommandsDir, "user")
-  return commandsToRecord(commands)
+export async function loadUserCommands(): Promise<
+	Record<string, CommandDefinition>
+> {
+	const userCommandsDir = join(getClaudeConfigDir(), "commands");
+	const commands = await loadCommandsFromDir(userCommandsDir, "user");
+	return commandsToRecord(commands);
 }
 
-export async function loadProjectCommands(directory?: string): Promise<Record<string, CommandDefinition>> {
-  const projectCommandsDir = join(directory ?? process.cwd(), ".claude", "commands")
-  const commands = await loadCommandsFromDir(projectCommandsDir, "project")
-  return commandsToRecord(commands)
+export async function loadProjectCommands(
+	directory?: string,
+): Promise<Record<string, CommandDefinition>> {
+	const projectCommandsDir = join(
+		directory ?? process.cwd(),
+		".claude",
+		"commands",
+	);
+	const commands = await loadCommandsFromDir(projectCommandsDir, "project");
+	return commandsToRecord(commands);
 }
 
-export async function loadOpencodeGlobalCommands(): Promise<Record<string, CommandDefinition>> {
-  const opencodeCommandDirs = getOpenCodeCommandDirs({ binary: "opencode" })
-  const allCommands = await Promise.all(
-    opencodeCommandDirs.map((commandsDir) => loadCommandsFromDir(commandsDir, "opencode")),
-  )
-  return commandsToRecord(allCommands.flat())
+export async function loadOpencodeGlobalCommands(): Promise<
+	Record<string, CommandDefinition>
+> {
+	const opencodeCommandDirs = getOpenCodeCommandDirs({ binary: "opencode" });
+	const allCommands = await Promise.all(
+		opencodeCommandDirs.map((commandsDir) =>
+			loadCommandsFromDir(commandsDir, "opencode"),
+		),
+	);
+	return commandsToRecord(allCommands.flat());
 }
 
-export async function loadOpencodeProjectCommands(directory?: string): Promise<Record<string, CommandDefinition>> {
-  const opencodeProjectDirs = findProjectOpencodeCommandDirs(directory ?? process.cwd())
-  const allCommands = await Promise.all(
-    opencodeProjectDirs.map((commandsDir) =>
-      loadCommandsFromDir(commandsDir, "opencode-project"),
-    ),
-  )
-  return commandsToRecord(allCommands.flat())
+export async function loadOpencodeProjectCommands(
+	directory?: string,
+): Promise<Record<string, CommandDefinition>> {
+	const opencodeProjectDirs = findProjectOpencodeCommandDirs(
+		directory ?? process.cwd(),
+	);
+	const allCommands = await Promise.all(
+		opencodeProjectDirs.map((commandsDir) =>
+			loadCommandsFromDir(commandsDir, "opencode-project"),
+		),
+	);
+	return commandsToRecord(allCommands.flat());
 }
 
-export async function loadAllCommands(directory?: string): Promise<Record<string, CommandDefinition>> {
-  const [user, project, global, projectOpencode] = await Promise.all([
-    loadUserCommands(),
-    loadProjectCommands(directory),
-    loadOpencodeGlobalCommands(),
-    loadOpencodeProjectCommands(directory),
-  ])
-  return { ...projectOpencode, ...global, ...project, ...user }
+export async function loadAllCommands(
+	directory?: string,
+): Promise<Record<string, CommandDefinition>> {
+	const [user, project, global, projectOpencode] = await Promise.all([
+		loadUserCommands(),
+		loadProjectCommands(directory),
+		loadOpencodeGlobalCommands(),
+		loadOpencodeProjectCommands(directory),
+	]);
+	return { ...projectOpencode, ...global, ...project, ...user };
 }

--- a/src/features/claude-tasks/session-storage.test.ts
+++ b/src/features/claude-tasks/session-storage.test.ts
@@ -1,204 +1,208 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { existsSync, mkdirSync, rmSync, writeFileSync, readdirSync } from "fs"
-import { join } from "path"
-import type { OhMyOpenCodeConfig } from "../../config/schema"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { OhMyOpenCodeConfig } from "../../config/schema";
 import {
-  getSessionTaskDir,
-  listSessionTaskFiles,
-  listAllSessionDirs,
-  findTaskAcrossSessions,
-} from "./session-storage"
+	findTaskAcrossSessions,
+	getSessionTaskDir,
+	listAllSessionDirs,
+	listSessionTaskFiles,
+} from "./session-storage";
 
-const TEST_DIR = ".test-session-storage"
-const TEST_DIR_ABS = join(process.cwd(), TEST_DIR)
+const TEST_DIR = ".test-session-storage";
+const TEST_DIR_ABS = join(process.cwd(), TEST_DIR);
 
 function makeConfig(storagePath: string): Partial<OhMyOpenCodeConfig> {
-  return {
-    sisyphus: {
-      tasks: { storage_path: storagePath, claude_code_compat: false },
-    },
-  }
+	return {
+		sisyphus: {
+			tasks: { storage_path: storagePath, claude_code_compat: false },
+		},
+	};
 }
 
 describe("getSessionTaskDir", () => {
-  test("returns session-scoped subdirectory under base task dir", () => {
-    //#given
-    const config = makeConfig("/tmp/tasks")
-    const sessionID = "ses_abc123"
+	test("returns session-scoped subdirectory under base task dir", () => {
+		//#given
+		const config = makeConfig("/tmp/tasks");
+		const sessionID = "ses_abc123";
 
-    //#when
-    const result = getSessionTaskDir(config, sessionID)
+		//#when
+		const result = getSessionTaskDir(config, sessionID);
 
-    //#then
-    expect(result).toBe("/tmp/tasks/ses_abc123")
-  })
+		//#then
+		expect(result).toBe(join("/tmp/tasks", "ses_abc123"));
+	});
 
-  test("uses relative storage path joined with cwd", () => {
-    //#given
-    const config = makeConfig(TEST_DIR)
-    const sessionID = "ses_xyz"
+	test("uses relative storage path joined with cwd", () => {
+		//#given
+		const config = makeConfig(TEST_DIR);
+		const sessionID = "ses_xyz";
 
-    //#when
-    const result = getSessionTaskDir(config, sessionID)
+		//#when
+		const result = getSessionTaskDir(config, sessionID);
 
-    //#then
-    expect(result).toBe(join(TEST_DIR_ABS, "ses_xyz"))
-  })
-})
+		//#then
+		expect(result).toBe(join(TEST_DIR_ABS, "ses_xyz"));
+	});
+});
 
 describe("listSessionTaskFiles", () => {
-  beforeEach(() => {
-    if (existsSync(TEST_DIR_ABS)) {
-      rmSync(TEST_DIR_ABS, { recursive: true, force: true })
-    }
-  })
+	beforeEach(() => {
+		if (existsSync(TEST_DIR_ABS)) {
+			rmSync(TEST_DIR_ABS, { recursive: true, force: true });
+		}
+	});
 
-  afterEach(() => {
-    if (existsSync(TEST_DIR_ABS)) {
-      rmSync(TEST_DIR_ABS, { recursive: true, force: true })
-    }
-  })
+	afterEach(() => {
+		if (existsSync(TEST_DIR_ABS)) {
+			rmSync(TEST_DIR_ABS, { recursive: true, force: true });
+		}
+	});
 
-  test("returns empty array when session directory does not exist", () => {
-    //#given
-    const config = makeConfig(TEST_DIR)
+	test("returns empty array when session directory does not exist", () => {
+		//#given
+		const config = makeConfig(TEST_DIR);
 
-    //#when
-    const result = listSessionTaskFiles(config, "nonexistent-session")
+		//#when
+		const result = listSessionTaskFiles(config, "nonexistent-session");
 
-    //#then
-    expect(result).toEqual([])
-  })
+		//#then
+		expect(result).toEqual([]);
+	});
 
-  test("lists only T-*.json files in the session directory", () => {
-    //#given
-    const config = makeConfig(TEST_DIR)
-    const sessionDir = join(TEST_DIR_ABS, "ses_001")
-    mkdirSync(sessionDir, { recursive: true })
-    writeFileSync(join(sessionDir, "T-aaa.json"), "{}", "utf-8")
-    writeFileSync(join(sessionDir, "T-bbb.json"), "{}", "utf-8")
-    writeFileSync(join(sessionDir, "other.txt"), "nope", "utf-8")
+	test("lists only T-*.json files in the session directory", () => {
+		//#given
+		const config = makeConfig(TEST_DIR);
+		const sessionDir = join(TEST_DIR_ABS, "ses_001");
+		mkdirSync(sessionDir, { recursive: true });
+		writeFileSync(join(sessionDir, "T-aaa.json"), "{}", "utf-8");
+		writeFileSync(join(sessionDir, "T-bbb.json"), "{}", "utf-8");
+		writeFileSync(join(sessionDir, "other.txt"), "nope", "utf-8");
 
-    //#when
-    const result = listSessionTaskFiles(config, "ses_001")
+		//#when
+		const result = listSessionTaskFiles(config, "ses_001");
 
-    //#then
-    expect(result).toHaveLength(2)
-    expect(result).toContain("T-aaa")
-    expect(result).toContain("T-bbb")
-  })
+		//#then
+		expect(result).toHaveLength(2);
+		expect(result).toContain("T-aaa");
+		expect(result).toContain("T-bbb");
+	});
 
-  test("does not list tasks from other sessions", () => {
-    //#given
-    const config = makeConfig(TEST_DIR)
-    const session1Dir = join(TEST_DIR_ABS, "ses_001")
-    const session2Dir = join(TEST_DIR_ABS, "ses_002")
-    mkdirSync(session1Dir, { recursive: true })
-    mkdirSync(session2Dir, { recursive: true })
-    writeFileSync(join(session1Dir, "T-from-s1.json"), "{}", "utf-8")
-    writeFileSync(join(session2Dir, "T-from-s2.json"), "{}", "utf-8")
+	test("does not list tasks from other sessions", () => {
+		//#given
+		const config = makeConfig(TEST_DIR);
+		const session1Dir = join(TEST_DIR_ABS, "ses_001");
+		const session2Dir = join(TEST_DIR_ABS, "ses_002");
+		mkdirSync(session1Dir, { recursive: true });
+		mkdirSync(session2Dir, { recursive: true });
+		writeFileSync(join(session1Dir, "T-from-s1.json"), "{}", "utf-8");
+		writeFileSync(join(session2Dir, "T-from-s2.json"), "{}", "utf-8");
 
-    //#when
-    const result = listSessionTaskFiles(config, "ses_001")
+		//#when
+		const result = listSessionTaskFiles(config, "ses_001");
 
-    //#then
-    expect(result).toEqual(["T-from-s1"])
-  })
-})
+		//#then
+		expect(result).toEqual(["T-from-s1"]);
+	});
+});
 
 describe("listAllSessionDirs", () => {
-  beforeEach(() => {
-    if (existsSync(TEST_DIR_ABS)) {
-      rmSync(TEST_DIR_ABS, { recursive: true, force: true })
-    }
-  })
+	beforeEach(() => {
+		if (existsSync(TEST_DIR_ABS)) {
+			rmSync(TEST_DIR_ABS, { recursive: true, force: true });
+		}
+	});
 
-  afterEach(() => {
-    if (existsSync(TEST_DIR_ABS)) {
-      rmSync(TEST_DIR_ABS, { recursive: true, force: true })
-    }
-  })
+	afterEach(() => {
+		if (existsSync(TEST_DIR_ABS)) {
+			rmSync(TEST_DIR_ABS, { recursive: true, force: true });
+		}
+	});
 
-  test("returns empty array when base directory does not exist", () => {
-    //#given
-    const config = makeConfig(TEST_DIR)
+	test("returns empty array when base directory does not exist", () => {
+		//#given
+		const config = makeConfig(TEST_DIR);
 
-    //#when
-    const result = listAllSessionDirs(config)
+		//#when
+		const result = listAllSessionDirs(config);
 
-    //#then
-    expect(result).toEqual([])
-  })
+		//#then
+		expect(result).toEqual([]);
+	});
 
-  test("returns only directory entries (not files)", () => {
-    //#given
-    const config = makeConfig(TEST_DIR)
-    mkdirSync(TEST_DIR_ABS, { recursive: true })
-    mkdirSync(join(TEST_DIR_ABS, "ses_001"), { recursive: true })
-    mkdirSync(join(TEST_DIR_ABS, "ses_002"), { recursive: true })
-    writeFileSync(join(TEST_DIR_ABS, ".lock"), "{}", "utf-8")
-    writeFileSync(join(TEST_DIR_ABS, "T-legacy.json"), "{}", "utf-8")
+	test("returns only directory entries (not files)", () => {
+		//#given
+		const config = makeConfig(TEST_DIR);
+		mkdirSync(TEST_DIR_ABS, { recursive: true });
+		mkdirSync(join(TEST_DIR_ABS, "ses_001"), { recursive: true });
+		mkdirSync(join(TEST_DIR_ABS, "ses_002"), { recursive: true });
+		writeFileSync(join(TEST_DIR_ABS, ".lock"), "{}", "utf-8");
+		writeFileSync(join(TEST_DIR_ABS, "T-legacy.json"), "{}", "utf-8");
 
-    //#when
-    const result = listAllSessionDirs(config)
+		//#when
+		const result = listAllSessionDirs(config);
 
-    //#then
-    expect(result).toHaveLength(2)
-    expect(result).toContain("ses_001")
-    expect(result).toContain("ses_002")
-  })
-})
+		//#then
+		expect(result).toHaveLength(2);
+		expect(result).toContain("ses_001");
+		expect(result).toContain("ses_002");
+	});
+});
 
 describe("findTaskAcrossSessions", () => {
-  beforeEach(() => {
-    if (existsSync(TEST_DIR_ABS)) {
-      rmSync(TEST_DIR_ABS, { recursive: true, force: true })
-    }
-  })
+	beforeEach(() => {
+		if (existsSync(TEST_DIR_ABS)) {
+			rmSync(TEST_DIR_ABS, { recursive: true, force: true });
+		}
+	});
 
-  afterEach(() => {
-    if (existsSync(TEST_DIR_ABS)) {
-      rmSync(TEST_DIR_ABS, { recursive: true, force: true })
-    }
-  })
+	afterEach(() => {
+		if (existsSync(TEST_DIR_ABS)) {
+			rmSync(TEST_DIR_ABS, { recursive: true, force: true });
+		}
+	});
 
-  test("returns null when task does not exist in any session", () => {
-    //#given
-    const config = makeConfig(TEST_DIR)
-    mkdirSync(join(TEST_DIR_ABS, "ses_001"), { recursive: true })
+	test("returns null when task does not exist in any session", () => {
+		//#given
+		const config = makeConfig(TEST_DIR);
+		mkdirSync(join(TEST_DIR_ABS, "ses_001"), { recursive: true });
 
-    //#when
-    const result = findTaskAcrossSessions(config, "T-nonexistent")
+		//#when
+		const result = findTaskAcrossSessions(config, "T-nonexistent");
 
-    //#then
-    expect(result).toBeNull()
-  })
+		//#then
+		expect(result).toBeNull();
+	});
 
-  test("finds task in the correct session directory", () => {
-    //#given
-    const config = makeConfig(TEST_DIR)
-    const session2Dir = join(TEST_DIR_ABS, "ses_002")
-    mkdirSync(join(TEST_DIR_ABS, "ses_001"), { recursive: true })
-    mkdirSync(session2Dir, { recursive: true })
-    writeFileSync(join(session2Dir, "T-target.json"), '{"id":"T-target"}', "utf-8")
+	test("finds task in the correct session directory", () => {
+		//#given
+		const config = makeConfig(TEST_DIR);
+		const session2Dir = join(TEST_DIR_ABS, "ses_002");
+		mkdirSync(join(TEST_DIR_ABS, "ses_001"), { recursive: true });
+		mkdirSync(session2Dir, { recursive: true });
+		writeFileSync(
+			join(session2Dir, "T-target.json"),
+			'{"id":"T-target"}',
+			"utf-8",
+		);
 
-    //#when
-    const result = findTaskAcrossSessions(config, "T-target")
+		//#when
+		const result = findTaskAcrossSessions(config, "T-target");
 
-    //#then
-    expect(result).not.toBeNull()
-    expect(result!.sessionID).toBe("ses_002")
-    expect(result!.path).toBe(join(session2Dir, "T-target.json"))
-  })
+		//#then
+		expect(result).not.toBeNull();
+		expect(result!.sessionID).toBe("ses_002");
+		expect(result!.path).toBe(join(session2Dir, "T-target.json"));
+	});
 
-  test("returns null when base directory does not exist", () => {
-    //#given
-    const config = makeConfig(TEST_DIR)
+	test("returns null when base directory does not exist", () => {
+		//#given
+		const config = makeConfig(TEST_DIR);
 
-    //#when
-    const result = findTaskAcrossSessions(config, "T-any")
+		//#when
+		const result = findTaskAcrossSessions(config, "T-any");
 
-    //#then
-    expect(result).toBeNull()
-  })
-})
+		//#then
+		expect(result).toBeNull();
+	});
+});

--- a/src/features/mcp-oauth/storage.test.ts
+++ b/src/features/mcp-oauth/storage.test.ts
@@ -1,136 +1,152 @@
-import { describe, expect, test, beforeEach, afterEach } from "bun:test"
-import { existsSync, mkdirSync, rmSync, readFileSync, statSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
-import { tmpdir } from "node:os"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
-  deleteToken,
-  getMcpOauthStoragePath,
-  listAllTokens,
-  listTokensByHost,
-  loadToken,
-  saveToken,
-} from "./storage"
-import type { OAuthTokenData } from "./storage"
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { OAuthTokenData } from "./storage";
+import {
+	deleteToken,
+	getMcpOauthStoragePath,
+	listTokensByHost,
+	loadToken,
+	saveToken,
+} from "./storage";
 
 describe("mcp-oauth storage", () => {
-  const TEST_CONFIG_DIR = join(tmpdir(), "mcp-oauth-test-" + Date.now())
-  let originalConfigDir: string | undefined
+	const TEST_CONFIG_DIR = join(tmpdir(), "mcp-oauth-test-" + Date.now());
+	let originalConfigDir: string | undefined;
 
-  beforeEach(() => {
-    originalConfigDir = process.env.OPENCODE_CONFIG_DIR
-    process.env.OPENCODE_CONFIG_DIR = TEST_CONFIG_DIR
-    if (!existsSync(TEST_CONFIG_DIR)) {
-      mkdirSync(TEST_CONFIG_DIR, { recursive: true })
-    }
-  })
+	beforeEach(() => {
+		originalConfigDir = process.env.OPENCODE_CONFIG_DIR;
+		process.env.OPENCODE_CONFIG_DIR = TEST_CONFIG_DIR;
+		if (!existsSync(TEST_CONFIG_DIR)) {
+			mkdirSync(TEST_CONFIG_DIR, { recursive: true });
+		}
+	});
 
-  afterEach(() => {
-    if (originalConfigDir === undefined) {
-      delete process.env.OPENCODE_CONFIG_DIR
-    } else {
-      process.env.OPENCODE_CONFIG_DIR = originalConfigDir
-    }
-    if (existsSync(TEST_CONFIG_DIR)) {
-      rmSync(TEST_CONFIG_DIR, { recursive: true, force: true })
-    }
-  })
+	afterEach(() => {
+		if (originalConfigDir === undefined) {
+			delete process.env.OPENCODE_CONFIG_DIR;
+		} else {
+			process.env.OPENCODE_CONFIG_DIR = originalConfigDir;
+		}
+		if (existsSync(TEST_CONFIG_DIR)) {
+			rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+		}
+	});
 
-  test("should save tokens with {host}/{resource} key and set 0600 permissions", () => {
-    // given
-    const token: OAuthTokenData = {
-      accessToken: "access-1",
-      refreshToken: "refresh-1",
-      expiresAt: 1710000000,
-      clientInfo: { clientId: "client-1", clientSecret: "secret-1" },
-    }
+	test("should save tokens with {host}/{resource} key and set 0600 permissions", () => {
+		// given
+		const token: OAuthTokenData = {
+			accessToken: "access-1",
+			refreshToken: "refresh-1",
+			expiresAt: 1710000000,
+			clientInfo: { clientId: "client-1", clientSecret: "secret-1" },
+		};
 
-    // when
-    const success = saveToken("https://example.com:443", "mcp/v1", token)
-    const storagePath = getMcpOauthStoragePath()
-    const parsed = JSON.parse(readFileSync(storagePath, "utf-8")) as Record<string, OAuthTokenData>
-    const mode = statSync(storagePath).mode & 0o777
+		// when
+		const success = saveToken("https://example.com:443", "mcp/v1", token);
+		const storagePath = getMcpOauthStoragePath();
+		const parsed = JSON.parse(readFileSync(storagePath, "utf-8")) as Record<
+			string,
+			OAuthTokenData
+		>;
+		const mode = statSync(storagePath).mode & 0o777;
 
-    // then
-    expect(success).toBe(true)
-    expect(Object.keys(parsed)).toEqual(["example.com/mcp/v1"])
-    expect(parsed["example.com/mcp/v1"].accessToken).toBe("access-1")
-    expect(mode).toBe(0o600)
-  })
+		// then
+		expect(success).toBe(true);
+		expect(Object.keys(parsed)).toEqual(["example.com/mcp/v1"]);
+		expect(parsed["example.com/mcp/v1"].accessToken).toBe("access-1");
+		if (process.platform === "win32") {
+			expect(mode & 0o400).toBe(0o400);
+		} else {
+			expect(mode).toBe(0o600);
+		}
+	});
 
-  test("should load a saved token", () => {
-    // given
-    const token: OAuthTokenData = { accessToken: "access-2", refreshToken: "refresh-2" }
-    saveToken("api.example.com", "resource-a", token)
+	test("should load a saved token", () => {
+		// given
+		const token: OAuthTokenData = {
+			accessToken: "access-2",
+			refreshToken: "refresh-2",
+		};
+		saveToken("api.example.com", "resource-a", token);
 
-    // when
-    const loaded = loadToken("api.example.com:8443", "resource-a")
+		// when
+		const loaded = loadToken("api.example.com:8443", "resource-a");
 
-    // then
-    expect(loaded).toEqual(token)
-  })
+		// then
+		expect(loaded).toEqual(token);
+	});
 
-  test("should delete a token", () => {
-    // given
-    const token: OAuthTokenData = { accessToken: "access-3" }
-    saveToken("api.example.com", "resource-b", token)
+	test("should delete a token", () => {
+		// given
+		const token: OAuthTokenData = { accessToken: "access-3" };
+		saveToken("api.example.com", "resource-b", token);
 
-    // when
-    const success = deleteToken("api.example.com", "resource-b")
-    const loaded = loadToken("api.example.com", "resource-b")
+		// when
+		const success = deleteToken("api.example.com", "resource-b");
+		const loaded = loadToken("api.example.com", "resource-b");
 
-    // then
-    expect(success).toBe(true)
-    expect(loaded).toBeNull()
-  })
+		// then
+		expect(success).toBe(true);
+		expect(loaded).toBeNull();
+	});
 
-  test("should list tokens by host", () => {
-    // given
-    saveToken("api.example.com", "resource-a", { accessToken: "access-a" })
-    saveToken("api.example.com", "resource-b", { accessToken: "access-b" })
-    saveToken("other.example.com", "resource-c", { accessToken: "access-c" })
+	test("should list tokens by host", () => {
+		// given
+		saveToken("api.example.com", "resource-a", { accessToken: "access-a" });
+		saveToken("api.example.com", "resource-b", { accessToken: "access-b" });
+		saveToken("other.example.com", "resource-c", { accessToken: "access-c" });
 
-    // when
-    const entries = listTokensByHost("api.example.com:5555")
+		// when
+		const entries = listTokensByHost("api.example.com:5555");
 
-    // then
-    expect(Object.keys(entries).sort()).toEqual([
-      "api.example.com/resource-a",
-      "api.example.com/resource-b",
-    ])
-    expect(entries["api.example.com/resource-a"].accessToken).toBe("access-a")
-  })
+		// then
+		expect(Object.keys(entries).sort()).toEqual([
+			"api.example.com/resource-a",
+			"api.example.com/resource-b",
+		]);
+		expect(entries["api.example.com/resource-a"].accessToken).toBe("access-a");
+	});
 
-  test("should handle missing storage file", () => {
-    // given
-    const storagePath = getMcpOauthStoragePath()
-    if (existsSync(storagePath)) {
-      rmSync(storagePath, { force: true })
-    }
+	test("should handle missing storage file", () => {
+		// given
+		const storagePath = getMcpOauthStoragePath();
+		if (existsSync(storagePath)) {
+			rmSync(storagePath, { force: true });
+		}
 
-    // when
-    const loaded = loadToken("api.example.com", "resource-a")
-    const entries = listTokensByHost("api.example.com")
+		// when
+		const loaded = loadToken("api.example.com", "resource-a");
+		const entries = listTokensByHost("api.example.com");
 
-    // then
-    expect(loaded).toBeNull()
-    expect(entries).toEqual({})
-  })
+		// then
+		expect(loaded).toBeNull();
+		expect(entries).toEqual({});
+	});
 
-  test("should handle invalid JSON", () => {
-    // given
-    const storagePath = getMcpOauthStoragePath()
-    const dir = join(storagePath, "..")
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
-    }
-    writeFileSync(storagePath, "{not-valid-json", "utf-8")
+	test("should handle invalid JSON", () => {
+		// given
+		const storagePath = getMcpOauthStoragePath();
+		const dir = join(storagePath, "..");
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true });
+		}
+		writeFileSync(storagePath, "{not-valid-json", "utf-8");
 
-    // when
-    const loaded = loadToken("api.example.com", "resource-a")
-    const entries = listTokensByHost("api.example.com")
+		// when
+		const loaded = loadToken("api.example.com", "resource-a");
+		const entries = listTokensByHost("api.example.com");
 
-    // then
-    expect(loaded).toBeNull()
-    expect(entries).toEqual({})
-  })
-})
+		// then
+		expect(loaded).toBeNull();
+		expect(entries).toEqual({});
+	});
+});

--- a/src/features/skill-mcp-manager/connection-race.test.ts
+++ b/src/features/skill-mcp-manager/connection-race.test.ts
@@ -1,291 +1,407 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-import type { ClaudeCodeMcpServer } from "../claude-code-mcp-loader/types"
-import type { SkillMcpClientInfo, SkillMcpManagerState } from "./types"
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import type { ClaudeCodeMcpServer } from "../claude-code-mcp-loader/types";
+import type { SkillMcpClientInfo, SkillMcpManagerState } from "./types";
 
 type Deferred<TValue> = {
-  promise: Promise<TValue>
-  resolve: (value: TValue) => void
-  reject: (error: Error) => void
-}
+	promise: Promise<TValue>;
+	resolve: (value: TValue) => void;
+	reject: (error: Error) => void;
+};
 
-const pendingConnects: Deferred<void>[] = []
-const trackedStates: SkillMcpManagerState[] = []
-const createdClients: MockClient[] = []
-const createdTransports: MockStdioClientTransport[] = []
+const pendingConnects: Deferred<void>[] = [];
+const trackedStates: SkillMcpManagerState[] = [];
+const createdClients: MockClient[] = [];
+const createdTransports: MockStdioClientTransport[] = [];
 
 class MockClient {
-  readonly close = mock(async () => {})
+	readonly close = mock(async () => {});
 
-  constructor(
-    _clientInfo: { name: string; version: string },
-    _options: { capabilities: Record<string, never> }
-  ) {
-    createdClients.push(this)
-  }
+	constructor(
+		_clientInfo: { name: string; version: string },
+		_options: { capabilities: Record<string, never> },
+	) {
+		createdClients.push(this);
+	}
 
-  async connect(_transport: MockStdioClientTransport): Promise<void> {
-    const pendingConnect = pendingConnects.shift()
-    if (pendingConnect) {
-      await pendingConnect.promise
-    }
-  }
+	async connect(_transport: MockStdioClientTransport): Promise<void> {
+		const pendingConnect = pendingConnects.shift();
+		if (pendingConnect) {
+			await pendingConnect.promise;
+		}
+	}
 }
 
 class MockStdioClientTransport {
-  readonly close = mock(async () => {})
+	readonly close = mock(async () => {});
 
-  constructor(_options: { command: string; args?: string[]; env?: Record<string, string>; stderr?: string }) {
-    createdTransports.push(this)
-  }
+	constructor(_options: {
+		command: string;
+		args?: string[];
+		env?: Record<string, string>;
+		stderr?: string;
+	}) {
+		createdTransports.push(this);
+	}
 }
 
-mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
-  Client: MockClient,
-}))
+let disconnectAll: typeof import("./cleanup").disconnectAll;
+let disconnectSession: typeof import("./cleanup").disconnectSession;
+let getOrCreateClient: typeof import("./connection").getOrCreateClient;
+let createStdioClientSpy: ReturnType<typeof spyOn>;
 
-mock.module("@modelcontextprotocol/sdk/client/stdio.js", () => ({
-  StdioClientTransport: MockStdioClientTransport,
-}))
+async function importRaceModules(): Promise<void> {
+	const stdioClientModule = await import("./stdio-client");
+	createStdioClientSpy = spyOn(
+		stdioClientModule,
+		"createStdioClient",
+	).mockImplementation(async ({ state, clientKey, info }) => {
+		const client = new MockClient(
+			{
+				name: `skill-mcp-${info.skillName}-${info.serverName}`,
+				version: "1.0.0",
+			},
+			{ capabilities: {} },
+		);
+		const transport = new MockStdioClientTransport({
+			command: "mock-mcp-server",
+		});
 
-const { disconnectAll, disconnectSession } = await import("./cleanup")
-const { getOrCreateClient } = await import("./connection")
+		const pendingConnect = pendingConnects.shift();
+		if (pendingConnect) {
+			await pendingConnect.promise;
+		}
+
+		state.clients.set(clientKey, {
+			client: client as never,
+			transport: transport as never,
+			skillName: info.skillName,
+			lastUsedAt: Date.now(),
+			connectionType: "stdio",
+		});
+
+		return client as never;
+	});
+
+	const suffix = `race-${Date.now()}-${Math.random()}`;
+	({ disconnectAll, disconnectSession } = await import(`./cleanup?${suffix}`));
+	({ getOrCreateClient } = await import(`./connection?${suffix}`));
+}
 
 function createDeferred<TValue>(): Deferred<TValue> {
-  let resolvePromise: ((value: TValue) => void) | null = null
-  let rejectPromise: ((error: Error) => void) | null = null
-  const promise = new Promise<TValue>((resolve, reject) => {
-    resolvePromise = resolve
-    rejectPromise = reject
-  })
+	let resolvePromise: ((value: TValue) => void) | null = null;
+	let rejectPromise: ((error: Error) => void) | null = null;
+	const promise = new Promise<TValue>((resolve, reject) => {
+		resolvePromise = resolve;
+		rejectPromise = reject;
+	});
 
-  if (!resolvePromise || !rejectPromise) {
-    throw new Error("Failed to create deferred promise")
-  }
+	if (!resolvePromise || !rejectPromise) {
+		throw new Error("Failed to create deferred promise");
+	}
 
-  return {
-    promise,
-    resolve: resolvePromise,
-    reject: rejectPromise,
-  }
+	return {
+		promise,
+		resolve: resolvePromise,
+		reject: rejectPromise,
+	};
 }
 
 function createState(): SkillMcpManagerState {
-  const state: SkillMcpManagerState = {
-    clients: new Map(),
-    pendingConnections: new Map(),
-    disconnectedSessions: new Map(),
-    authProviders: new Map(),
-    cleanupRegistered: false,
-    cleanupInterval: null,
-    cleanupHandlers: [],
-    idleTimeoutMs: 5 * 60 * 1000,
-    shutdownGeneration: 0,
-    inFlightConnections: new Map(),
-    disposed: false,
-  }
+	const state: SkillMcpManagerState = {
+		clients: new Map(),
+		pendingConnections: new Map(),
+		disconnectedSessions: new Map(),
+		authProviders: new Map(),
+		cleanupRegistered: false,
+		cleanupInterval: null,
+		cleanupHandlers: [],
+		idleTimeoutMs: 5 * 60 * 1000,
+		shutdownGeneration: 0,
+		inFlightConnections: new Map(),
+		disposed: false,
+	};
 
-  trackedStates.push(state)
-  return state
+	trackedStates.push(state);
+	return state;
 }
 
 function createClientInfo(sessionID: string): SkillMcpClientInfo {
-  return {
-    serverName: "race-server",
-    skillName: "race-skill",
-    sessionID,
-  }
+	return {
+		serverName: "race-server",
+		skillName: "race-skill",
+		sessionID,
+	};
 }
 
 function createClientKey(info: SkillMcpClientInfo): string {
-  return `${info.sessionID}:${info.skillName}:${info.serverName}`
+	return `${info.sessionID}:${info.skillName}:${info.serverName}`;
 }
 
 const stdioConfig: ClaudeCodeMcpServer = {
-  command: "mock-mcp-server",
-}
+	command: "mock-mcp-server",
+};
 
-beforeEach(() => {
-  pendingConnects.length = 0
-  createdClients.length = 0
-  createdTransports.length = 0
-})
+beforeEach(async () => {
+	pendingConnects.length = 0;
+	createdClients.length = 0;
+	createdTransports.length = 0;
+	mock.restore();
+	await importRaceModules();
+});
 
 afterEach(async () => {
-  for (const state of trackedStates) {
-    await disconnectAll(state)
-  }
+	for (const state of trackedStates) {
+		await disconnectAll(state);
+	}
 
-  trackedStates.length = 0
-  pendingConnects.length = 0
-  createdClients.length = 0
-  createdTransports.length = 0
-})
+	trackedStates.length = 0;
+	pendingConnects.length = 0;
+	createdClients.length = 0;
+	createdTransports.length = 0;
+	createStdioClientSpy?.mockRestore();
+	mock.restore();
+});
 
 describe("getOrCreateClient disconnect race", () => {
-  it("#given pending connection for session A #when disconnectSession(A) is called before connection completes #then completed client is not added to state.clients", async () => {
-    const state = createState()
-    const info = createClientInfo("session-a")
-    const clientKey = createClientKey(info)
-    const pendingConnect = createDeferred<void>()
-    pendingConnects.push(pendingConnect)
+	it("#given pending connection for session A #when disconnectSession(A) is called before connection completes #then completed client is not added to state.clients", async () => {
+		const state = createState();
+		const info = createClientInfo("session-a");
+		const clientKey = createClientKey(info);
+		const pendingConnect = createDeferred<void>();
+		pendingConnects.push(pendingConnect);
 
-    const clientPromise = getOrCreateClient({ state, clientKey, info, config: stdioConfig })
-    expect(state.pendingConnections.has(clientKey)).toBe(true)
+		const clientPromise = getOrCreateClient({
+			state,
+			clientKey,
+			info,
+			config: stdioConfig,
+		});
+		expect(state.pendingConnections.has(clientKey)).toBe(true);
 
-    await disconnectSession(state, info.sessionID)
-    pendingConnect.resolve(undefined)
+		await disconnectSession(state, info.sessionID);
+		pendingConnect.resolve(undefined);
 
-    await expect(clientPromise).rejects.toThrow(/disconnected during MCP connection setup/)
-    expect(state.clients.has(clientKey)).toBe(false)
-    expect(state.pendingConnections.has(clientKey)).toBe(false)
-    expect(state.disconnectedSessions.has(info.sessionID)).toBe(false)
-    expect(createdClients).toHaveLength(1)
-    expect(createdClients[0]?.close).toHaveBeenCalledTimes(1)
-    expect(createdTransports[0]?.close).toHaveBeenCalledTimes(1)
-  })
+		await expect(clientPromise).rejects.toThrow(
+			/disconnected during MCP connection setup/,
+		);
+		expect(state.clients.has(clientKey)).toBe(false);
+		expect(state.pendingConnections.has(clientKey)).toBe(false);
+		expect(state.disconnectedSessions.has(info.sessionID)).toBe(false);
+		expect(createdClients).toHaveLength(1);
+		expect(createdClients[0]?.close).toHaveBeenCalledTimes(1);
+		expect(createdTransports[0]?.close).toHaveBeenCalledTimes(1);
+	});
 
-  it("#given session A in disconnectedSessions #when new connection completes with no remaining pending #then disconnectedSessions entry is cleaned up", async () => {
-    const state = createState()
-    const info = createClientInfo("session-a")
-    const clientKey = createClientKey(info)
-    state.disconnectedSessions.set(info.sessionID, 1)
+	it("#given session A in disconnectedSessions #when new connection completes with no remaining pending #then disconnectedSessions entry is cleaned up", async () => {
+		const state = createState();
+		const info = createClientInfo("session-a");
+		const clientKey = createClientKey(info);
+		state.disconnectedSessions.set(info.sessionID, 1);
 
-    const client = await getOrCreateClient({ state, clientKey, info, config: stdioConfig })
+		const client = await getOrCreateClient({
+			state,
+			clientKey,
+			info,
+			config: stdioConfig,
+		});
 
-    expect(state.disconnectedSessions.has(info.sessionID)).toBe(false)
-    expect(state.clients.get(clientKey)?.client).toBe(client)
-    expect(createdClients[0]?.close).not.toHaveBeenCalled()
-  })
+		expect(state.disconnectedSessions.has(info.sessionID)).toBe(false);
+		expect(state.clients.get(clientKey)?.client).toBe(client);
+		expect(createdClients[0]?.close).not.toHaveBeenCalled();
+	});
 
-  it("#given no pending connections #when disconnectSession is called #then no errors occur and session is not added to disconnectedSessions", async () => {
-    const state = createState()
+	it("#given no pending connections #when disconnectSession is called #then no errors occur and session is not added to disconnectedSessions", async () => {
+		const state = createState();
 
-    await expect(disconnectSession(state, "session-a")).resolves.toBeUndefined()
-    expect(state.disconnectedSessions.has("session-a")).toBe(false)
-    expect(state.pendingConnections.size).toBe(0)
-    expect(state.clients.size).toBe(0)
-  })
-})
+		await expect(
+			disconnectSession(state, "session-a"),
+		).resolves.toBeUndefined();
+		expect(state.disconnectedSessions.has("session-a")).toBe(false);
+		expect(state.pendingConnections.size).toBe(0);
+		expect(state.clients.size).toBe(0);
+	});
+});
 
 describe("getOrCreateClient disconnectAll race", () => {
-  it("#given pending connection #when disconnectAll() is called before connection completes #then client is not added to state.clients", async () => {
-    const state = createState()
-    const info = createClientInfo("session-a")
-    const clientKey = createClientKey(info)
-    const pendingConnect = createDeferred<void>()
-    pendingConnects.push(pendingConnect)
+	it("#given pending connection #when disconnectAll() is called before connection completes #then client is not added to state.clients", async () => {
+		const state = createState();
+		const info = createClientInfo("session-a");
+		const clientKey = createClientKey(info);
+		const pendingConnect = createDeferred<void>();
+		pendingConnects.push(pendingConnect);
 
-    const clientPromise = getOrCreateClient({ state, clientKey, info, config: stdioConfig })
-    expect(state.pendingConnections.has(clientKey)).toBe(true)
+		const clientPromise = getOrCreateClient({
+			state,
+			clientKey,
+			info,
+			config: stdioConfig,
+		});
+		expect(state.pendingConnections.has(clientKey)).toBe(true);
 
-    await disconnectAll(state)
-    pendingConnect.resolve(undefined)
+		await disconnectAll(state);
+		pendingConnect.resolve(undefined);
 
-    await expect(clientPromise).rejects.toThrow(/connection completed after shutdown/)
-    expect(state.clients.has(clientKey)).toBe(false)
-  })
+		await expect(clientPromise).rejects.toThrow(
+			/Shutdown occurred during MCP connection/,
+		);
+		expect(state.clients.has(clientKey)).toBe(false);
+	});
 
-  it("#given state after disconnectAll() completed #when getOrCreateClient() is called #then it throws shut down error and registers nothing", async () => {
-    const state = createState()
-    const info = createClientInfo("session-b")
-    const clientKey = createClientKey(info)
+	it("#given state after disconnectAll() completed #when getOrCreateClient() is called #then it throws shut down error and registers nothing", async () => {
+		const state = createState();
+		const info = createClientInfo("session-b");
+		const clientKey = createClientKey(info);
 
-    await disconnectAll(state)
+		await disconnectAll(state);
 
-    await expect(getOrCreateClient({ state, clientKey, info, config: stdioConfig })).rejects.toThrow(/has been shut down/)
-    expect(state.clients.size).toBe(0)
-    expect(state.pendingConnections.size).toBe(0)
-    expect(state.inFlightConnections.size).toBe(0)
-    expect(state.disposed).toBe(true)
-    expect(createdClients).toHaveLength(0)
-    expect(createdTransports).toHaveLength(0)
-  })
-})
+		await expect(
+			getOrCreateClient({ state, clientKey, info, config: stdioConfig }),
+		).rejects.toThrow(/has been shut down/);
+		expect(state.clients.size).toBe(0);
+		expect(state.pendingConnections.size).toBe(0);
+		expect(state.inFlightConnections.size).toBe(0);
+		expect(state.disposed).toBe(true);
+		expect(createdClients).toHaveLength(0);
+		expect(createdTransports).toHaveLength(0);
+	});
+});
 
 describe("getOrCreateClient multi-key disconnect race", () => {
-  it("#given 2 pending connections for session A #when disconnectSession(A) before both complete #then both old connections are rejected", async () => {
-    const state = createState()
-    const infoKey1 = createClientInfo("session-a")
-    const infoKey2 = { ...createClientInfo("session-a"), serverName: "server-2" }
-    const clientKey1 = createClientKey(infoKey1)
-    const clientKey2 = `${infoKey2.sessionID}:${infoKey2.skillName}:${infoKey2.serverName}`
-    const pendingConnect1 = createDeferred<void>()
-    const pendingConnect2 = createDeferred<void>()
-    pendingConnects.push(pendingConnect1)
-    pendingConnects.push(pendingConnect2)
+	it("#given 2 pending connections for session A #when disconnectSession(A) before both complete #then both old connections are rejected", async () => {
+		const state = createState();
+		const infoKey1 = createClientInfo("session-a");
+		const infoKey2 = {
+			...createClientInfo("session-a"),
+			serverName: "server-2",
+		};
+		const clientKey1 = createClientKey(infoKey1);
+		const clientKey2 = `${infoKey2.sessionID}:${infoKey2.skillName}:${infoKey2.serverName}`;
+		const pendingConnect1 = createDeferred<void>();
+		const pendingConnect2 = createDeferred<void>();
+		pendingConnects.push(pendingConnect1);
+		pendingConnects.push(pendingConnect2);
 
-    const promise1 = getOrCreateClient({ state, clientKey: clientKey1, info: infoKey1, config: stdioConfig })
-    const promise2 = getOrCreateClient({ state, clientKey: clientKey2, info: infoKey2, config: stdioConfig })
-    expect(state.pendingConnections.size).toBe(2)
+		const promise1 = getOrCreateClient({
+			state,
+			clientKey: clientKey1,
+			info: infoKey1,
+			config: stdioConfig,
+		});
+		const promise2 = getOrCreateClient({
+			state,
+			clientKey: clientKey2,
+			info: infoKey2,
+			config: stdioConfig,
+		});
+		expect(state.pendingConnections.size).toBe(2);
 
-    await disconnectSession(state, "session-a")
+		await disconnectSession(state, "session-a");
 
-    pendingConnect1.resolve(undefined)
-    await expect(promise1).rejects.toThrow(/disconnected during MCP connection setup/)
+		pendingConnect1.resolve(undefined);
+		await expect(promise1).rejects.toThrow(
+			/disconnected during MCP connection setup/,
+		);
 
-    pendingConnect2.resolve(undefined)
-    await expect(promise2).rejects.toThrow(/disconnected during MCP connection setup/)
+		pendingConnect2.resolve(undefined);
+		await expect(promise2).rejects.toThrow(
+			/disconnected during MCP connection setup/,
+		);
 
-    expect(state.clients.has(clientKey1)).toBe(false)
-    expect(state.clients.has(clientKey2)).toBe(false)
-    expect(state.disconnectedSessions.has("session-a")).toBe(false)
-  })
+		expect(state.clients.has(clientKey1)).toBe(false);
+		expect(state.clients.has(clientKey2)).toBe(false);
+		expect(state.disconnectedSessions.has("session-a")).toBe(false);
+	});
 
-  it("#given a superseded pending connection #when the old connection completes #then the stale client is removed from state.clients", async () => {
-    const state = createState()
-    const info = createClientInfo("session-a")
-    const clientKey = createClientKey(info)
-    const pendingConnect = createDeferred<void>()
-    const supersedingConnection = createDeferred<Awaited<ReturnType<typeof getOrCreateClient>>>()
-    pendingConnects.push(pendingConnect)
+	it("#given a superseded pending connection #when the old connection completes #then the stale client is removed from state.clients", async () => {
+		const state = createState();
+		const info = createClientInfo("session-a");
+		const clientKey = createClientKey(info);
+		const pendingConnect = createDeferred<void>();
+		const supersedingConnection =
+			createDeferred<Awaited<ReturnType<typeof getOrCreateClient>>>();
+		pendingConnects.push(pendingConnect);
 
-    const clientPromise = getOrCreateClient({ state, clientKey, info, config: stdioConfig })
-    state.pendingConnections.set(clientKey, supersedingConnection.promise)
+		const clientPromise = getOrCreateClient({
+			state,
+			clientKey,
+			info,
+			config: stdioConfig,
+		});
+		state.pendingConnections.set(clientKey, supersedingConnection.promise);
 
-    pendingConnect.resolve(undefined)
+		pendingConnect.resolve(undefined);
 
-    await expect(clientPromise).rejects.toThrow(/superseded by a newer connection attempt/)
-    expect(state.clients.has(clientKey)).toBe(false)
-    expect(createdClients[0]?.close).toHaveBeenCalledTimes(1)
-  })
+		await expect(clientPromise).rejects.toThrow(
+			/superseded by a newer connection attempt/,
+		);
+		expect(state.clients.has(clientKey)).toBe(false);
+		expect(createdClients[0]?.close).toHaveBeenCalledTimes(1);
+	});
 
-  it("#given a superseded pending connection #when a newer client already replaced the map entry #then the stale cleanup does not delete the newer client", async () => {
-    const state = createState()
-    const info = createClientInfo("session-a")
-    const clientKey = createClientKey(info)
-    const pendingConnect = createDeferred<void>()
-    const supersedingConnection = createDeferred<Awaited<ReturnType<typeof getOrCreateClient>>>()
-    pendingConnects.push(pendingConnect)
+	it("#given a superseded pending connection #when a newer client already replaced the map entry #then the stale cleanup does not delete the newer client", async () => {
+		const state = createState();
+		const info = createClientInfo("session-a");
+		const clientKey = createClientKey(info);
+		const pendingConnect = createDeferred<void>();
+		const supersedingConnection =
+			createDeferred<Awaited<ReturnType<typeof getOrCreateClient>>>();
+		pendingConnects.push(pendingConnect);
 
-    const newerClient = new MockClient(
-      { name: "newer-client", version: "1.0.0" },
-      { capabilities: {} },
-    )
-    const newerTransport = new MockStdioClientTransport({ command: "mock-mcp-server" })
-    let replacedEntry = false
-    const originalSet = state.clients.set.bind(state.clients)
-    Reflect.set(state.clients, "set", (key: string, value: SkillMcpManagerState["clients"] extends Map<string, infer TValue> ? TValue : never) => {
-      originalSet(key, value)
-      if (!replacedEntry && key === clientKey) {
-        replacedEntry = true
-        originalSet(key, {
-          client: newerClient as never,
-          transport: newerTransport as never,
-          skillName: info.skillName,
-          lastUsedAt: Date.now(),
-          connectionType: "stdio",
-        })
-      }
-      return state.clients
-    })
+		const newerClient = new MockClient(
+			{ name: "newer-client", version: "1.0.0" },
+			{ capabilities: {} },
+		);
+		const newerTransport = new MockStdioClientTransport({
+			command: "mock-mcp-server",
+		});
+		let replacedEntry = false;
+		const originalSet = state.clients.set.bind(state.clients);
+		Reflect.set(
+			state.clients,
+			"set",
+			(
+				key: string,
+				value: SkillMcpManagerState["clients"] extends Map<string, infer TValue>
+					? TValue
+					: never,
+			) => {
+				originalSet(key, value);
+				if (!replacedEntry && key === clientKey) {
+					replacedEntry = true;
+					originalSet(key, {
+						client: newerClient as never,
+						transport: newerTransport as never,
+						skillName: info.skillName,
+						lastUsedAt: Date.now(),
+						connectionType: "stdio",
+					});
+				}
+				return state.clients;
+			},
+		);
 
-    const clientPromise = getOrCreateClient({ state, clientKey, info, config: stdioConfig })
-    state.pendingConnections.set(clientKey, supersedingConnection.promise)
+		const clientPromise = getOrCreateClient({
+			state,
+			clientKey,
+			info,
+			config: stdioConfig,
+		});
+		state.pendingConnections.set(clientKey, supersedingConnection.promise);
 
-    pendingConnect.resolve(undefined)
+		pendingConnect.resolve(undefined);
 
-    await expect(clientPromise).rejects.toThrow(/superseded by a newer connection attempt/)
-    expect(state.clients.get(clientKey)?.client.close).toBe(newerClient.close)
-    expect(newerClient.close).not.toHaveBeenCalled()
-  })
-})
+		await expect(clientPromise).rejects.toThrow(
+			/superseded by a newer connection attempt/,
+		);
+		expect(state.clients.get(clientKey)?.client.close).toBe(newerClient.close);
+		expect(newerClient.close).not.toHaveBeenCalled();
+	});
+});

--- a/src/features/skill-mcp-manager/manager.test.ts
+++ b/src/features/skill-mcp-manager/manager.test.ts
@@ -1,836 +1,931 @@
-import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test"
-import { SkillMcpManager } from "./manager"
-import type { SkillMcpClientInfo, SkillMcpServerContext } from "./types"
-import type { ClaudeCodeMcpServer } from "../claude-code-mcp-loader/types"
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import type { ClaudeCodeMcpServer } from "../claude-code-mcp-loader/types";
+import { SkillMcpManager } from "./manager";
+import type { SkillMcpClientInfo, SkillMcpServerContext } from "./types";
 
-// Mock the MCP SDK transports to avoid network calls
-const mockHttpConnect = mock(() => Promise.reject(new Error("Mocked HTTP connection failure")))
-const mockHttpClose = mock(() => Promise.resolve())
-let lastTransportInstance: { url?: URL; options?: { requestInit?: RequestInit } } = {}
+// Mock the MCP SDK client/transports to avoid network calls and cross-file mock contamination
+const mockHttpConnect = mock(() =>
+	Promise.reject(new Error("Mocked HTTP connection failure")),
+);
+const mockHttpClose = mock(() => Promise.resolve());
+const mockStdioConnect = mock(() =>
+	Promise.reject(new Error("Mocked stdio connection failure")),
+);
+const mockStdioClose = mock(() => Promise.resolve());
+let lastTransportInstance: {
+	url?: URL;
+	options?: { requestInit?: RequestInit };
+} = {};
+
+mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
+	Client: class MockClient {
+		constructor(
+			public clientInfo: { name: string; version: string },
+			public options: { capabilities: Record<string, never> },
+		) {}
+
+		async connect(transport: { start?: () => Promise<void> }) {
+			await transport.start?.();
+		}
+
+		async close() {
+			return Promise.resolve();
+		}
+	},
+}));
 
 mock.module("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
-  StreamableHTTPClientTransport: class MockStreamableHTTPClientTransport {
-    constructor(public url: URL, public options?: { requestInit?: RequestInit }) {
-      lastTransportInstance = { url, options }
-    }
-    async start() {
-      await mockHttpConnect()
-    }
-    async close() {
-      await mockHttpClose()
-    }
-  },
-}))
+	StreamableHTTPClientTransport: class MockStreamableHTTPClientTransport {
+		constructor(
+			public url: URL,
+			public options?: { requestInit?: RequestInit },
+		) {
+			lastTransportInstance = { url, options };
+		}
+		async start() {
+			await mockHttpConnect();
+		}
+		async close() {
+			await mockHttpClose();
+		}
+	},
+}));
 
-const mockTokens = mock(() => null as { accessToken: string; refreshToken?: string; expiresAt?: number } | null)
-const mockLogin = mock(() => Promise.resolve({ accessToken: "new-token" }))
+mock.module("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+	StdioClientTransport: class MockStdioClientTransport {
+		constructor(
+			public options: {
+				command: string;
+				args?: string[];
+				env?: Record<string, string>;
+				stderr?: string;
+			},
+		) {}
+
+		async start() {
+			await mockStdioConnect();
+		}
+
+		async close() {
+			await mockStdioClose();
+		}
+	},
+}));
+
+const mockTokens = mock(
+	() =>
+		null as {
+			accessToken: string;
+			refreshToken?: string;
+			expiresAt?: number;
+		} | null,
+);
+const mockLogin = mock(() => Promise.resolve({ accessToken: "new-token" }));
 
 mock.module("../mcp-oauth/provider", () => ({
-  McpOAuthProvider: class MockMcpOAuthProvider {
-    constructor(public options: { serverUrl: string; clientId?: string; scopes?: string[] }) {}
-    tokens() {
-      return mockTokens()
-    }
-    async login() {
-      return mockLogin()
-    }
-  },
-}))
-
-
-
-
-
-
-
-
-
-
-
-
-
+	McpOAuthProvider: class MockMcpOAuthProvider {
+		constructor(
+			public options: {
+				serverUrl: string;
+				clientId?: string;
+				scopes?: string[];
+			},
+		) {}
+		tokens() {
+			return mockTokens();
+		}
+		async login() {
+			return mockLogin();
+		}
+	},
+}));
 
 describe("SkillMcpManager", () => {
-  let manager: SkillMcpManager
-
-  beforeEach(() => {
-    manager = new SkillMcpManager()
-    mockHttpConnect.mockClear()
-    mockHttpClose.mockClear()
-  })
-
-  afterEach(async () => {
-    await manager.disconnectAll()
-  })
-
-  describe("getOrCreateClient", () => {
-    describe("configuration validation", () => {
-      it("throws error when neither url nor command is provided", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "test-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {}
-
-        // when / #then
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /no valid connection configuration/
-        )
-      })
-
-      it("includes both HTTP and stdio examples in error message", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "my-mcp",
-          skillName: "data-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {}
-
-        // when / #then
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /HTTP[\s\S]*Stdio/
-        )
-      })
-
-      it("includes server and skill names in error message", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "custom-server",
-          skillName: "custom-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {}
-
-        // when / #then
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /custom-server[\s\S]*custom-skill/
-        )
-      })
-    })
-
-    describe("connection type detection", () => {
-      it("detects HTTP connection from explicit type='http'", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "http-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          type: "http",
-          url: "https://example.com/mcp",
-        }
-
-        // when / #then - should fail at connection, not config validation
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /Failed to connect/
-        )
-      })
-
-      it("detects HTTP connection from explicit type='sse'", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "sse-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          type: "sse",
-          url: "https://example.com/mcp",
-        }
-
-        // when / #then - should fail at connection, not config validation
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /Failed to connect/
-        )
-      })
-
-      it("detects HTTP connection from url field when type is not specified", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "inferred-http",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          url: "https://example.com/mcp",
-        }
-
-        // when / #then - should fail at connection, not config validation
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /Failed to connect[\s\S]*URL/
-        )
-      })
-
-      it("detects stdio connection from explicit type='stdio'", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "stdio-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          type: "stdio",
-          command: "node",
-          args: ["-e", "process.exit(0)"],
-        }
-
-        // when / #then - should fail at connection, not config validation
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /Failed to connect[\s\S]*Command/
-        )
-      })
-
-      it("detects stdio connection from command field when type is not specified", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "inferred-stdio",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          command: "node",
-          args: ["-e", "process.exit(0)"],
-        }
-
-        // when / #then - should fail at connection, not config validation
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /Failed to connect[\s\S]*Command/
-        )
-      })
-
-      it("prefers explicit type over inferred type", async () => {
-        // given - has both url and command, but type is explicitly stdio
-        const info: SkillMcpClientInfo = {
-          serverName: "mixed-config",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          type: "stdio",
-          url: "https://example.com/mcp", // should be ignored
-          command: "node",
-          args: ["-e", "process.exit(0)"],
-        }
-
-        // when / #then - should use stdio (show Command in error, not URL)
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /Command: node/
-        )
-      })
-    })
-
-    describe("HTTP connection", () => {
-      it("throws error for invalid URL", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "bad-url-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          type: "http",
-          url: "not-a-valid-url",
-        }
-
-        // when / #then
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /invalid URL/
-        )
-      })
-
-      it("includes URL in HTTP connection error", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "http-error-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          url: "https://nonexistent.example.com/mcp",
-        }
-
-        // when / #then
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /https:\/\/nonexistent\.example\.com\/mcp/
-        )
-      })
-
-      it("includes helpful hints for HTTP connection failures", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "hint-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          url: "https://nonexistent.example.com/mcp",
-        }
-
-        // when / #then
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /Hints[\s\S]*Verify the URL[\s\S]*authentication headers[\s\S]*MCP over HTTP/
-        )
-      })
-
-      it("calls mocked transport connect for HTTP connections", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "mock-test-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          url: "https://example.com/mcp",
-        }
-
-        // when
-        try {
-          await manager.getOrCreateClient(info, config)
-        } catch {
-          // Expected to fail
-        }
-
-        // then - verify mock was called (transport was instantiated)
-        // The connection attempt happens through the Client.connect() which
-        // internally calls transport.start()
-        expect(mockHttpConnect).toHaveBeenCalled()
-      })
-    })
-
-    describe("stdio connection (backward compatibility)", () => {
-      it("throws error when command is missing for stdio type", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "missing-command",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          type: "stdio",
-          // command is missing
-        }
-
-        // when / #then
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /missing 'command' field/
-        )
-      })
-
-      it("includes command in stdio connection error", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "test-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          command: "nonexistent-command-xyz",
-          args: ["--foo"],
-        }
-
-        // when / #then
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /nonexistent-command-xyz --foo/
-        )
-      })
-
-      it("includes helpful hints for stdio connection failures", async () => {
-        // given
-        const info: SkillMcpClientInfo = {
-          serverName: "test-server",
-          skillName: "test-skill",
-          sessionID: "session-1",
-        }
-        const config: ClaudeCodeMcpServer = {
-          command: "nonexistent-command",
-        }
-
-        // when / #then
-        await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-          /Hints[\s\S]*PATH[\s\S]*package exists/
-        )
-      })
-    })
-  })
-
-  describe("disconnectSession", () => {
-    it("removes all clients for a specific session", async () => {
-      // given
-      const session1Info: SkillMcpClientInfo = {
-        serverName: "server1",
-        skillName: "skill1",
-        sessionID: "session-1",
-      }
-      const session2Info: SkillMcpClientInfo = {
-        serverName: "server1",
-        skillName: "skill1",
-        sessionID: "session-2",
-      }
-
-      // when
-      await manager.disconnectSession("session-1")
-
-      // then
-      expect(manager.isConnected(session1Info)).toBe(false)
-      expect(manager.isConnected(session2Info)).toBe(false)
-    })
-
-    it("does not throw when session has no clients", async () => {
-      // given / #when / #then
-      await expect(manager.disconnectSession("nonexistent")).resolves.toBeUndefined()
-    })
-  })
-
-  describe("disconnectAll", () => {
-    it("clears all clients", async () => {
-      // given - no actual clients connected (would require real MCP server)
-
-      // when
-      await manager.disconnectAll()
-
-      // then
-      expect(manager.getConnectedServers()).toEqual([])
-    })
-
-    it("unregisters signal handlers after disconnectAll", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "signal-server",
-        skillName: "signal-skill",
-        sessionID: "session-1",
-      }
-      const config: ClaudeCodeMcpServer = {
-        url: "https://example.com/mcp",
-      }
-
-      const before = process.listenerCount("SIGINT")
-
-      // when
-      try {
-        await manager.getOrCreateClient(info, config)
-      } catch {
-        // Expected to fail connection, still registers cleanup handlers
-      }
-      const afterRegister = process.listenerCount("SIGINT")
-
-      await manager.disconnectAll()
-      const afterDisconnect = process.listenerCount("SIGINT")
-
-      // then
-      expect(afterRegister).toBe(before + 1)
-      expect(afterDisconnect).toBe(before)
-    })
-  })
-
-  describe("isConnected", () => {
-    it("returns false for unconnected server", () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "unknown",
-        skillName: "test",
-        sessionID: "session-1",
-      }
-
-      // when / #then
-      expect(manager.isConnected(info)).toBe(false)
-    })
-  })
-
-  describe("getConnectedServers", () => {
-    it("returns empty array when no servers connected", () => {
-      // given / #when / #then
-      expect(manager.getConnectedServers()).toEqual([])
-    })
-  })
-
-  describe("environment variable handling", () => {
-    it("always inherits process.env even when config.env is undefined", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "test-server",
-        skillName: "test-skill",
-        sessionID: "session-1",
-      }
-      const configWithoutEnv: ClaudeCodeMcpServer = {
-        command: "node",
-        args: ["-e", "process.exit(0)"],
-      }
-
-      // when - attempt connection (will fail but exercises env merging code path)
-      // then - should not throw "undefined" related errors for env
-      try {
-        await manager.getOrCreateClient(info, configWithoutEnv)
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        expect(message).not.toContain("env")
-        expect(message).not.toContain("undefined")
-      }
-    })
-
-    it("overlays config.env on top of inherited process.env", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "test-server",
-        skillName: "test-skill",
-        sessionID: "session-2",
-      }
-      const configWithEnv: ClaudeCodeMcpServer = {
-        command: "node",
-        args: ["-e", "process.exit(0)"],
-        env: {
-          CUSTOM_VAR: "custom_value",
-        },
-      }
-
-      // when - attempt connection
-      // then - should not throw, env merging should work
-      try {
-        await manager.getOrCreateClient(info, configWithEnv)
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        expect(message).toContain("Failed to connect")
-      }
-    })
-  })
-
-  describe("HTTP headers handling", () => {
-    it("accepts configuration with headers", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "auth-server",
-        skillName: "test-skill",
-        sessionID: "session-1",
-      }
-      const config: ClaudeCodeMcpServer = {
-        url: "https://example.com/mcp",
-        headers: {
-          Authorization: "Bearer test-token",
-          "X-Custom-Header": "custom-value",
-        },
-      }
-
-      // when / #then - should fail at connection, not config validation
-      // Headers are passed through to the transport
-      await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-        /Failed to connect/
-      )
-
-      // Verify headers were forwarded to transport
-      expect(lastTransportInstance.options?.requestInit?.headers).toEqual({
-        Authorization: "Bearer test-token",
-        "X-Custom-Header": "custom-value",
-      })
-    })
-
-    it("works without headers (optional)", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "no-auth-server",
-        skillName: "test-skill",
-        sessionID: "session-1",
-      }
-      const config: ClaudeCodeMcpServer = {
-        url: "https://example.com/mcp",
-        // no headers
-      }
-
-      // when / #then - should fail at connection, not config validation
-      await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
-        /Failed to connect/
-      )
-    })
-  })
-
-  describe("operation retry logic", () => {
-    it("should retry operation when 'Not connected' error occurs", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "retry-server",
-        skillName: "retry-skill",
-        sessionID: "session-retry-1",
-      }
-      const context: SkillMcpServerContext = {
-        config: {
-          url: "https://example.com/mcp",
-        },
-        skillName: "retry-skill",
-      }
-
-      let callCount = 0
-      const mockClient = {
-        callTool: mock(async () => {
-          callCount++
-          if (callCount === 1) {
-            throw new Error("Not connected")
-          }
-          return { content: [{ type: "text", text: "success" }] }
-        }),
-        close: mock(() => Promise.resolve()),
-      }
-
-      const getOrCreateSpy = spyOn(manager as any, "getOrCreateClientWithRetry")
-      getOrCreateSpy.mockResolvedValue(mockClient)
-
-      // when
-      const result = await manager.callTool(info, context, "test-tool", {})
-
-      // then
-      expect(callCount).toBe(2)
-      expect(result).toEqual([{ type: "text", text: "success" }])
-      expect(getOrCreateSpy).toHaveBeenCalledTimes(2)
-    })
-
-    it("should fail after 3 retry attempts", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "fail-server",
-        skillName: "fail-skill",
-        sessionID: "session-fail-1",
-      }
-      const context: SkillMcpServerContext = {
-        config: {
-          url: "https://example.com/mcp",
-        },
-        skillName: "fail-skill",
-      }
-
-      const mockClient = {
-        callTool: mock(async () => {
-          throw new Error("Not connected")
-        }),
-        close: mock(() => Promise.resolve()),
-      }
-
-      const getOrCreateSpy = spyOn(manager as any, "getOrCreateClientWithRetry")
-      getOrCreateSpy.mockResolvedValue(mockClient)
-
-      // when / #then
-      await expect(manager.callTool(info, context, "test-tool", {})).rejects.toThrow(
-        /Failed after 3 reconnection attempts/
-      )
-      expect(getOrCreateSpy).toHaveBeenCalledTimes(3)
-    })
-
-    it("should not retry on non-connection errors", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "error-server",
-        skillName: "error-skill",
-        sessionID: "session-error-1",
-      }
-      const context: SkillMcpServerContext = {
-        config: {
-          url: "https://example.com/mcp",
-        },
-        skillName: "error-skill",
-      }
-
-      const mockClient = {
-        callTool: mock(async () => {
-          throw new Error("Tool not found")
-        }),
-        close: mock(() => Promise.resolve()),
-      }
-
-      const getOrCreateSpy = spyOn(manager as any, "getOrCreateClientWithRetry")
-      getOrCreateSpy.mockResolvedValue(mockClient)
-
-      // when / #then
-      await expect(manager.callTool(info, context, "test-tool", {})).rejects.toThrow(
-        "Tool not found"
-      )
-      expect(getOrCreateSpy).toHaveBeenCalledTimes(1)
-    })
-  })
-
-  describe("OAuth integration", () => {
-    beforeEach(() => {
-      mockTokens.mockClear()
-      mockLogin.mockClear()
-    })
-
-    it("injects Authorization header when oauth config has stored tokens", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "oauth-server",
-        skillName: "oauth-skill",
-        sessionID: "session-oauth-1",
-      }
-      const config: ClaudeCodeMcpServer = {
-        url: "https://mcp.example.com/mcp",
-        oauth: {
-          clientId: "my-client",
-          scopes: ["read", "write"],
-        },
-      }
-      mockTokens.mockReturnValue({ accessToken: "stored-access-token" })
-
-      // when
-      try {
-        await manager.getOrCreateClient(info, config)
-      } catch { /* connection fails in test */ }
-
-      // then
-      const headers = lastTransportInstance.options?.requestInit?.headers as Record<string, string> | undefined
-      expect(headers?.Authorization).toBe("Bearer stored-access-token")
-    })
-
-    it("does not inject Authorization header when no stored tokens exist and login fails", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "oauth-no-token",
-        skillName: "oauth-skill",
-        sessionID: "session-oauth-2",
-      }
-      const config: ClaudeCodeMcpServer = {
-        url: "https://mcp.example.com/mcp",
-        oauth: {
-          clientId: "my-client",
-        },
-      }
-      mockTokens.mockReturnValue(null)
-      mockLogin.mockRejectedValue(new Error("Login failed"))
-
-      // when
-      try {
-        await manager.getOrCreateClient(info, config)
-      } catch { /* connection fails in test */ }
-
-      // then
-      const headers = lastTransportInstance.options?.requestInit?.headers as Record<string, string> | undefined
-      expect(headers?.Authorization).toBeUndefined()
-    })
-
-    it("preserves existing static headers alongside OAuth token", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "oauth-with-headers",
-        skillName: "oauth-skill",
-        sessionID: "session-oauth-3",
-      }
-      const config: ClaudeCodeMcpServer = {
-        url: "https://mcp.example.com/mcp",
-        headers: {
-          "X-Custom": "custom-value",
-        },
-        oauth: {
-          clientId: "my-client",
-        },
-      }
-      mockTokens.mockReturnValue({ accessToken: "oauth-token" })
-
-      // when
-      try {
-        await manager.getOrCreateClient(info, config)
-      } catch { /* connection fails in test */ }
-
-      // then
-      const headers = lastTransportInstance.options?.requestInit?.headers as Record<string, string> | undefined
-      expect(headers?.["X-Custom"]).toBe("custom-value")
-      expect(headers?.Authorization).toBe("Bearer oauth-token")
-    })
-
-    it("does not create auth provider when oauth config is absent", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "no-oauth-server",
-        skillName: "test-skill",
-        sessionID: "session-no-oauth",
-      }
-      const config: ClaudeCodeMcpServer = {
-        url: "https://mcp.example.com/mcp",
-        headers: {
-          Authorization: "Bearer static-token",
-        },
-      }
-
-      // when
-      try {
-        await manager.getOrCreateClient(info, config)
-      } catch { /* connection fails in test */ }
-
-      // then
-      const headers = lastTransportInstance.options?.requestInit?.headers as Record<string, string> | undefined
-      expect(headers?.Authorization).toBe("Bearer static-token")
-      expect(mockTokens).not.toHaveBeenCalled()
-    })
-
-    it("handles step-up auth by triggering re-login on 403 with scope", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "stepup-server",
-        skillName: "stepup-skill",
-        sessionID: "session-stepup-1",
-      }
-      const config: ClaudeCodeMcpServer = {
-        url: "https://mcp.example.com/mcp",
-        oauth: {
-          clientId: "my-client",
-          scopes: ["read"],
-        },
-      }
-      const context: SkillMcpServerContext = {
-        config,
-        skillName: "stepup-skill",
-      }
-
-      mockTokens.mockReturnValue({ accessToken: "initial-token" })
-      mockLogin.mockResolvedValue({ accessToken: "upgraded-token" })
-
-      let callCount = 0
-      const mockClient = {
-        callTool: mock(async () => {
-          callCount++
-          if (callCount === 1) {
-            throw new Error('403 WWW-Authenticate: Bearer scope="admin write"')
-          }
-          return { content: [{ type: "text", text: "success" }] }
-        }),
-        close: mock(() => Promise.resolve()),
-      }
-
-      const getOrCreateSpy = spyOn(manager as any, "getOrCreateClientWithRetry")
-      getOrCreateSpy.mockResolvedValue(mockClient)
-
-      // when
-      const result = await manager.callTool(info, context, "test-tool", {})
-
-      // then
-      expect(result).toEqual([{ type: "text", text: "success" }])
-      expect(mockLogin).toHaveBeenCalled()
-    })
-
-    it("does not attempt step-up when oauth config is absent", async () => {
-      // given
-      const info: SkillMcpClientInfo = {
-        serverName: "no-stepup-server",
-        skillName: "no-stepup-skill",
-        sessionID: "session-no-stepup",
-      }
-      const context: SkillMcpServerContext = {
-        config: {
-          url: "https://mcp.example.com/mcp",
-        },
-        skillName: "no-stepup-skill",
-      }
-
-      const mockClient = {
-        callTool: mock(async () => {
-          throw new Error('403 WWW-Authenticate: Bearer scope="admin"')
-        }),
-        close: mock(() => Promise.resolve()),
-      }
-
-      const getOrCreateSpy = spyOn(manager as any, "getOrCreateClientWithRetry")
-      getOrCreateSpy.mockResolvedValue(mockClient)
-
-      // when / #then
-      await expect(manager.callTool(info, context, "test-tool", {})).rejects.toThrow(/403/)
-      expect(mockLogin).not.toHaveBeenCalled()
-    })
-  })
-})
+	let manager: SkillMcpManager;
+
+	beforeEach(() => {
+		manager = new SkillMcpManager();
+		mockHttpConnect.mockClear();
+		mockHttpClose.mockClear();
+		mockStdioConnect.mockClear();
+		mockStdioClose.mockClear();
+	});
+
+	afterEach(async () => {
+		await manager.disconnectAll();
+	});
+
+	describe("getOrCreateClient", () => {
+		describe("configuration validation", () => {
+			it("throws error when neither url nor command is provided", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "test-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {};
+
+				// when / #then
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/no valid connection configuration/,
+				);
+			});
+
+			it("includes both HTTP and stdio examples in error message", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "my-mcp",
+					skillName: "data-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {};
+
+				// when / #then
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/HTTP[\s\S]*Stdio/,
+				);
+			});
+
+			it("includes server and skill names in error message", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "custom-server",
+					skillName: "custom-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {};
+
+				// when / #then
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/custom-server[\s\S]*custom-skill/,
+				);
+			});
+		});
+
+		describe("connection type detection", () => {
+			it("detects HTTP connection from explicit type='http'", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "http-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					type: "http",
+					url: "https://example.com/mcp",
+				};
+
+				// when / #then - should fail at connection, not config validation
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/Failed to connect/,
+				);
+			});
+
+			it("detects HTTP connection from explicit type='sse'", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "sse-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					type: "sse",
+					url: "https://example.com/mcp",
+				};
+
+				// when / #then - should fail at connection, not config validation
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/Failed to connect/,
+				);
+			});
+
+			it("detects HTTP connection from url field when type is not specified", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "inferred-http",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					url: "https://example.com/mcp",
+				};
+
+				// when / #then - should fail at connection, not config validation
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/Failed to connect[\s\S]*URL/,
+				);
+			});
+
+			it("detects stdio connection from explicit type='stdio'", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "stdio-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					type: "stdio",
+					command: "node",
+					args: ["-e", "process.exit(0)"],
+				};
+
+				// when / #then - should fail at connection, not config validation
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/Failed to connect[\s\S]*Command/,
+				);
+			});
+
+			it("detects stdio connection from command field when type is not specified", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "inferred-stdio",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					command: "node",
+					args: ["-e", "process.exit(0)"],
+				};
+
+				// when / #then - should fail at connection, not config validation
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/Failed to connect[\s\S]*Command/,
+				);
+			});
+
+			it("prefers explicit type over inferred type", async () => {
+				// given - has both url and command, but type is explicitly stdio
+				const info: SkillMcpClientInfo = {
+					serverName: "mixed-config",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					type: "stdio",
+					url: "https://example.com/mcp", // should be ignored
+					command: "node",
+					args: ["-e", "process.exit(0)"],
+				};
+
+				// when / #then - should use stdio (show Command in error, not URL)
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/Command: node/,
+				);
+			});
+		});
+
+		describe("HTTP connection", () => {
+			it("throws error for invalid URL", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "bad-url-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					type: "http",
+					url: "not-a-valid-url",
+				};
+
+				// when / #then
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/invalid URL/,
+				);
+			});
+
+			it("includes URL in HTTP connection error", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "http-error-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					url: "https://nonexistent.example.com/mcp",
+				};
+
+				// when / #then
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/https:\/\/nonexistent\.example\.com\/mcp/,
+				);
+			});
+
+			it("includes helpful hints for HTTP connection failures", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "hint-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					url: "https://nonexistent.example.com/mcp",
+				};
+
+				// when / #then
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/Hints[\s\S]*Verify the URL[\s\S]*authentication headers[\s\S]*MCP over HTTP/,
+				);
+			});
+
+			it("calls mocked transport connect for HTTP connections", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "mock-test-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					url: "https://example.com/mcp",
+				};
+
+				// when
+				try {
+					await manager.getOrCreateClient(info, config);
+				} catch {
+					// Expected to fail
+				}
+
+				// then - verify mock was called (transport was instantiated)
+				// The connection attempt happens through the Client.connect() which
+				// internally calls transport.start()
+				expect(mockHttpConnect).toHaveBeenCalled();
+			});
+		});
+
+		describe("stdio connection (backward compatibility)", () => {
+			it("throws error when command is missing for stdio type", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "missing-command",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					type: "stdio",
+					// command is missing
+				};
+
+				// when / #then
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/missing 'command' field/,
+				);
+			});
+
+			it("includes command in stdio connection error", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "test-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					command: "nonexistent-command-xyz",
+					args: ["--foo"],
+				};
+
+				// when / #then
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/nonexistent-command-xyz --foo/,
+				);
+			});
+
+			it("includes helpful hints for stdio connection failures", async () => {
+				// given
+				const info: SkillMcpClientInfo = {
+					serverName: "test-server",
+					skillName: "test-skill",
+					sessionID: "session-1",
+				};
+				const config: ClaudeCodeMcpServer = {
+					command: "nonexistent-command",
+				};
+
+				// when / #then
+				await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+					/Hints[\s\S]*PATH[\s\S]*package exists/,
+				);
+			});
+		});
+	});
+
+	describe("disconnectSession", () => {
+		it("removes all clients for a specific session", async () => {
+			// given
+			const session1Info: SkillMcpClientInfo = {
+				serverName: "server1",
+				skillName: "skill1",
+				sessionID: "session-1",
+			};
+			const session2Info: SkillMcpClientInfo = {
+				serverName: "server1",
+				skillName: "skill1",
+				sessionID: "session-2",
+			};
+
+			// when
+			await manager.disconnectSession("session-1");
+
+			// then
+			expect(manager.isConnected(session1Info)).toBe(false);
+			expect(manager.isConnected(session2Info)).toBe(false);
+		});
+
+		it("does not throw when session has no clients", async () => {
+			// given / #when / #then
+			await expect(
+				manager.disconnectSession("nonexistent"),
+			).resolves.toBeUndefined();
+		});
+	});
+
+	describe("disconnectAll", () => {
+		it("clears all clients", async () => {
+			// given - no actual clients connected (would require real MCP server)
+
+			// when
+			await manager.disconnectAll();
+
+			// then
+			expect(manager.getConnectedServers()).toEqual([]);
+		});
+
+		it("unregisters signal handlers after disconnectAll", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "signal-server",
+				skillName: "signal-skill",
+				sessionID: "session-1",
+			};
+			const config: ClaudeCodeMcpServer = {
+				url: "https://example.com/mcp",
+			};
+
+			const before = process.listenerCount("SIGINT");
+
+			// when
+			try {
+				await manager.getOrCreateClient(info, config);
+			} catch {
+				// Expected to fail connection, still registers cleanup handlers
+			}
+			const afterRegister = process.listenerCount("SIGINT");
+
+			await manager.disconnectAll();
+			const afterDisconnect = process.listenerCount("SIGINT");
+
+			// then
+			expect(afterRegister).toBe(before + 1);
+			expect(afterDisconnect).toBe(before);
+		});
+	});
+
+	describe("isConnected", () => {
+		it("returns false for unconnected server", () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "unknown",
+				skillName: "test",
+				sessionID: "session-1",
+			};
+
+			// when / #then
+			expect(manager.isConnected(info)).toBe(false);
+		});
+	});
+
+	describe("getConnectedServers", () => {
+		it("returns empty array when no servers connected", () => {
+			// given / #when / #then
+			expect(manager.getConnectedServers()).toEqual([]);
+		});
+	});
+
+	describe("environment variable handling", () => {
+		it("always inherits process.env even when config.env is undefined", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "test-server",
+				skillName: "test-skill",
+				sessionID: "session-1",
+			};
+			const configWithoutEnv: ClaudeCodeMcpServer = {
+				command: "node",
+				args: ["-e", "process.exit(0)"],
+			};
+
+			// when - attempt connection (will fail but exercises env merging code path)
+			// then - should not throw "undefined" related errors for env
+			try {
+				await manager.getOrCreateClient(info, configWithoutEnv);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				expect(message).not.toContain("env");
+				expect(message).not.toContain("undefined");
+			}
+		});
+
+		it("overlays config.env on top of inherited process.env", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "test-server",
+				skillName: "test-skill",
+				sessionID: "session-2",
+			};
+			const configWithEnv: ClaudeCodeMcpServer = {
+				command: "node",
+				args: ["-e", "process.exit(0)"],
+				env: {
+					CUSTOM_VAR: "custom_value",
+				},
+			};
+
+			// when - attempt connection
+			// then - should not throw, env merging should work
+			try {
+				await manager.getOrCreateClient(info, configWithEnv);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				expect(message).toContain("Failed to connect");
+			}
+		});
+	});
+
+	describe("HTTP headers handling", () => {
+		it("accepts configuration with headers", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "auth-server",
+				skillName: "test-skill",
+				sessionID: "session-1",
+			};
+			const config: ClaudeCodeMcpServer = {
+				url: "https://example.com/mcp",
+				headers: {
+					Authorization: "Bearer test-token",
+					"X-Custom-Header": "custom-value",
+				},
+			};
+
+			// when / #then - should fail at connection, not config validation
+			// Headers are passed through to the transport
+			await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+				/Failed to connect/,
+			);
+
+			// Verify headers were forwarded to transport
+			expect(lastTransportInstance.options?.requestInit?.headers).toEqual({
+				Authorization: "Bearer test-token",
+				"X-Custom-Header": "custom-value",
+			});
+		});
+
+		it("works without headers (optional)", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "no-auth-server",
+				skillName: "test-skill",
+				sessionID: "session-1",
+			};
+			const config: ClaudeCodeMcpServer = {
+				url: "https://example.com/mcp",
+				// no headers
+			};
+
+			// when / #then - should fail at connection, not config validation
+			await expect(manager.getOrCreateClient(info, config)).rejects.toThrow(
+				/Failed to connect/,
+			);
+		});
+	});
+
+	describe("operation retry logic", () => {
+		it("should retry operation when 'Not connected' error occurs", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "retry-server",
+				skillName: "retry-skill",
+				sessionID: "session-retry-1",
+			};
+			const context: SkillMcpServerContext = {
+				config: {
+					url: "https://example.com/mcp",
+				},
+				skillName: "retry-skill",
+			};
+
+			let callCount = 0;
+			const mockClient = {
+				callTool: mock(async () => {
+					callCount++;
+					if (callCount === 1) {
+						throw new Error("Not connected");
+					}
+					return { content: [{ type: "text", text: "success" }] };
+				}),
+				close: mock(() => Promise.resolve()),
+			};
+
+			const getOrCreateSpy = spyOn(
+				manager as any,
+				"getOrCreateClientWithRetry",
+			);
+			getOrCreateSpy.mockResolvedValue(mockClient);
+
+			// when
+			const result = await manager.callTool(info, context, "test-tool", {});
+
+			// then
+			expect(callCount).toBe(2);
+			expect(result).toEqual([{ type: "text", text: "success" }]);
+			expect(getOrCreateSpy).toHaveBeenCalledTimes(2);
+		});
+
+		it("should fail after 3 retry attempts", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "fail-server",
+				skillName: "fail-skill",
+				sessionID: "session-fail-1",
+			};
+			const context: SkillMcpServerContext = {
+				config: {
+					url: "https://example.com/mcp",
+				},
+				skillName: "fail-skill",
+			};
+
+			const mockClient = {
+				callTool: mock(async () => {
+					throw new Error("Not connected");
+				}),
+				close: mock(() => Promise.resolve()),
+			};
+
+			const getOrCreateSpy = spyOn(
+				manager as any,
+				"getOrCreateClientWithRetry",
+			);
+			getOrCreateSpy.mockResolvedValue(mockClient);
+
+			// when / #then
+			await expect(
+				manager.callTool(info, context, "test-tool", {}),
+			).rejects.toThrow(/Failed after 3 reconnection attempts/);
+			expect(getOrCreateSpy).toHaveBeenCalledTimes(3);
+		});
+
+		it("should not retry on non-connection errors", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "error-server",
+				skillName: "error-skill",
+				sessionID: "session-error-1",
+			};
+			const context: SkillMcpServerContext = {
+				config: {
+					url: "https://example.com/mcp",
+				},
+				skillName: "error-skill",
+			};
+
+			const mockClient = {
+				callTool: mock(async () => {
+					throw new Error("Tool not found");
+				}),
+				close: mock(() => Promise.resolve()),
+			};
+
+			const getOrCreateSpy = spyOn(
+				manager as any,
+				"getOrCreateClientWithRetry",
+			);
+			getOrCreateSpy.mockResolvedValue(mockClient);
+
+			// when / #then
+			await expect(
+				manager.callTool(info, context, "test-tool", {}),
+			).rejects.toThrow("Tool not found");
+			expect(getOrCreateSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("OAuth integration", () => {
+		beforeEach(() => {
+			mockTokens.mockClear();
+			mockLogin.mockClear();
+		});
+
+		it("injects Authorization header when oauth config has stored tokens", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "oauth-server",
+				skillName: "oauth-skill",
+				sessionID: "session-oauth-1",
+			};
+			const config: ClaudeCodeMcpServer = {
+				url: "https://mcp.example.com/mcp",
+				oauth: {
+					clientId: "my-client",
+					scopes: ["read", "write"],
+				},
+			};
+			mockTokens.mockReturnValue({ accessToken: "stored-access-token" });
+
+			// when
+			try {
+				await manager.getOrCreateClient(info, config);
+			} catch {
+				/* connection fails in test */
+			}
+
+			// then
+			const headers = lastTransportInstance.options?.requestInit?.headers as
+				| Record<string, string>
+				| undefined;
+			expect(headers?.Authorization).toBe("Bearer stored-access-token");
+		});
+
+		it("does not inject Authorization header when no stored tokens exist and login fails", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "oauth-no-token",
+				skillName: "oauth-skill",
+				sessionID: "session-oauth-2",
+			};
+			const config: ClaudeCodeMcpServer = {
+				url: "https://mcp.example.com/mcp",
+				oauth: {
+					clientId: "my-client",
+				},
+			};
+			mockTokens.mockReturnValue(null);
+			mockLogin.mockRejectedValue(new Error("Login failed"));
+
+			// when
+			try {
+				await manager.getOrCreateClient(info, config);
+			} catch {
+				/* connection fails in test */
+			}
+
+			// then
+			const headers = lastTransportInstance.options?.requestInit?.headers as
+				| Record<string, string>
+				| undefined;
+			expect(headers?.Authorization).toBeUndefined();
+		});
+
+		it("preserves existing static headers alongside OAuth token", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "oauth-with-headers",
+				skillName: "oauth-skill",
+				sessionID: "session-oauth-3",
+			};
+			const config: ClaudeCodeMcpServer = {
+				url: "https://mcp.example.com/mcp",
+				headers: {
+					"X-Custom": "custom-value",
+				},
+				oauth: {
+					clientId: "my-client",
+				},
+			};
+			mockTokens.mockReturnValue({ accessToken: "oauth-token" });
+
+			// when
+			try {
+				await manager.getOrCreateClient(info, config);
+			} catch {
+				/* connection fails in test */
+			}
+
+			// then
+			const headers = lastTransportInstance.options?.requestInit?.headers as
+				| Record<string, string>
+				| undefined;
+			expect(headers?.["X-Custom"]).toBe("custom-value");
+			expect(headers?.Authorization).toBe("Bearer oauth-token");
+		});
+
+		it("does not create auth provider when oauth config is absent", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "no-oauth-server",
+				skillName: "test-skill",
+				sessionID: "session-no-oauth",
+			};
+			const config: ClaudeCodeMcpServer = {
+				url: "https://mcp.example.com/mcp",
+				headers: {
+					Authorization: "Bearer static-token",
+				},
+			};
+
+			// when
+			try {
+				await manager.getOrCreateClient(info, config);
+			} catch {
+				/* connection fails in test */
+			}
+
+			// then
+			const headers = lastTransportInstance.options?.requestInit?.headers as
+				| Record<string, string>
+				| undefined;
+			expect(headers?.Authorization).toBe("Bearer static-token");
+			expect(mockTokens).not.toHaveBeenCalled();
+		});
+
+		it("handles step-up auth by triggering re-login on 403 with scope", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "stepup-server",
+				skillName: "stepup-skill",
+				sessionID: "session-stepup-1",
+			};
+			const config: ClaudeCodeMcpServer = {
+				url: "https://mcp.example.com/mcp",
+				oauth: {
+					clientId: "my-client",
+					scopes: ["read"],
+				},
+			};
+			const context: SkillMcpServerContext = {
+				config,
+				skillName: "stepup-skill",
+			};
+
+			mockTokens.mockReturnValue({ accessToken: "initial-token" });
+			mockLogin.mockResolvedValue({ accessToken: "upgraded-token" });
+
+			let callCount = 0;
+			const mockClient = {
+				callTool: mock(async () => {
+					callCount++;
+					if (callCount === 1) {
+						throw new Error('403 WWW-Authenticate: Bearer scope="admin write"');
+					}
+					return { content: [{ type: "text", text: "success" }] };
+				}),
+				close: mock(() => Promise.resolve()),
+			};
+
+			const getOrCreateSpy = spyOn(
+				manager as any,
+				"getOrCreateClientWithRetry",
+			);
+			getOrCreateSpy.mockResolvedValue(mockClient);
+
+			// when
+			const result = await manager.callTool(info, context, "test-tool", {});
+
+			// then
+			expect(result).toEqual([{ type: "text", text: "success" }]);
+			expect(mockLogin).toHaveBeenCalled();
+		});
+
+		it("does not attempt step-up when oauth config is absent", async () => {
+			// given
+			const info: SkillMcpClientInfo = {
+				serverName: "no-stepup-server",
+				skillName: "no-stepup-skill",
+				sessionID: "session-no-stepup",
+			};
+			const context: SkillMcpServerContext = {
+				config: {
+					url: "https://mcp.example.com/mcp",
+				},
+				skillName: "no-stepup-skill",
+			};
+
+			const mockClient = {
+				callTool: mock(async () => {
+					throw new Error('403 WWW-Authenticate: Bearer scope="admin"');
+				}),
+				close: mock(() => Promise.resolve()),
+			};
+
+			const getOrCreateSpy = spyOn(
+				manager as any,
+				"getOrCreateClientWithRetry",
+			);
+			getOrCreateSpy.mockResolvedValue(mockClient);
+
+			// when / #then
+			await expect(
+				manager.callTool(info, context, "test-tool", {}),
+			).rejects.toThrow(/403/);
+			expect(mockLogin).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/hooks/anthropic-context-window-limit-recovery/parser.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/parser.test.ts
@@ -1,97 +1,104 @@
 /// <reference types="bun-types" />
-import { describe, expect, it } from "bun:test"
-import { parseAnthropicTokenLimitError } from "./parser"
+import { beforeEach, describe, expect, it } from "bun:test";
+
+let parseAnthropicTokenLimitError: typeof import("./parser").parseAnthropicTokenLimitError;
+
+beforeEach(async () => {
+	({ parseAnthropicTokenLimitError } = await import(
+		`./parser?parser-${Date.now()}-${Math.random()}`
+	));
+});
 
 describe("parseAnthropicTokenLimitError", () => {
-  it("#given a standard token limit error string #when parsing #then extracts tokens", () => {
-    //#given
-    const error = "prompt is too long: 250000 tokens > 200000 maximum"
+	it("#given a standard token limit error string #when parsing #then extracts tokens", () => {
+		//#given
+		const error = "prompt is too long: 250000 tokens > 200000 maximum";
 
-    //#when
-    const result = parseAnthropicTokenLimitError(error)
+		//#when
+		const result = parseAnthropicTokenLimitError(error);
 
-    //#then
-    expect(result).not.toBeNull()
-    expect(result!.currentTokens).toBe(250000)
-    expect(result!.maxTokens).toBe(200000)
-  })
+		//#then
+		expect(result).not.toBeNull();
+		expect(result!.currentTokens).toBe(250000);
+		expect(result!.maxTokens).toBe(200000);
+	});
 
-  it("#given a non-token-limit error #when parsing #then returns null", () => {
-    //#given
-    const error = { message: "internal server error" }
+	it("#given a non-token-limit error #when parsing #then returns null", () => {
+		//#given
+		const error = { message: "internal server error" };
 
-    //#when
-    const result = parseAnthropicTokenLimitError(error)
+		//#when
+		const result = parseAnthropicTokenLimitError(error);
 
-    //#then
-    expect(result).toBeNull()
-  })
+		//#then
+		expect(result).toBeNull();
+	});
 
-  it("#given null input #when parsing #then returns null", () => {
-    //#given
-    const error = null
+	it("#given null input #when parsing #then returns null", () => {
+		//#given
+		const error = null;
 
-    //#when
-    const result = parseAnthropicTokenLimitError(error)
+		//#when
+		const result = parseAnthropicTokenLimitError(error);
 
-    //#then
-    expect(result).toBeNull()
-  })
+		//#then
+		expect(result).toBeNull();
+	});
 
-  it("#given a proxy error with non-standard structure #when parsing #then returns null without crashing", () => {
-    //#given
-    const proxyError = {
-      data: [1, 2, 3],
-      error: "string-not-object",
-      message: "Failed to process error response",
-    }
+	it("#given a proxy error with non-standard structure #when parsing #then returns null without crashing", () => {
+		//#given
+		const proxyError = {
+			data: [1, 2, 3],
+			error: "string-not-object",
+			message: "Failed to process error response",
+		};
 
-    //#when
-    const result = parseAnthropicTokenLimitError(proxyError)
+		//#when
+		const result = parseAnthropicTokenLimitError(proxyError);
 
-    //#then
-    expect(result).toBeNull()
-  })
+		//#then
+		expect(result).toBeNull();
+	});
 
-  it("#given a circular reference error #when parsing #then returns null without crashing", () => {
-    //#given
-    const circular: Record<string, unknown> = { message: "prompt is too long" }
-    circular.self = circular
+	it("#given a circular reference error #when parsing #then returns null without crashing", () => {
+		//#given
+		const circular: Record<string, unknown> = { message: "prompt is too long" };
+		circular.self = circular;
 
-    //#when
-    const result = parseAnthropicTokenLimitError(circular)
+		//#when
+		const result = parseAnthropicTokenLimitError(circular);
 
-    //#then
-    expect(result).not.toBeNull()
-  })
+		//#then
+		expect(result).not.toBeNull();
+	});
 
-  it("#given an error where data.responseBody has invalid JSON #when parsing #then handles gracefully", () => {
-    //#given
-    const error = {
-      data: { responseBody: "not valid json {{{" },
-      message: "prompt is too long with 300000 tokens exceeds 200000",
-    }
+	it("#given an error where data.responseBody has invalid JSON #when parsing #then handles gracefully", () => {
+		//#given
+		const error = {
+			data: { responseBody: "not valid json {{{" },
+			message: "prompt is too long with 300000 tokens exceeds 200000",
+		};
 
-    //#when
-    const result = parseAnthropicTokenLimitError(error)
+		//#when
+		const result = parseAnthropicTokenLimitError(error);
 
-    //#then
-    expect(result).not.toBeNull()
-    expect(result!.currentTokens).toBe(300000)
-    expect(result!.maxTokens).toBe(200000)
-  })
+		//#then
+		expect(result).not.toBeNull();
+		expect(result!.currentTokens).toBe(300000);
+		expect(result!.maxTokens).toBe(200000);
+	});
 
-  it("#given an error with data as a string (not object) #when parsing #then does not crash", () => {
-    //#given
-    const error = {
-      data: "some-string-data",
-      message: "token limit exceeded",
-    }
+	it("#given an error with data as a string (not object) #when parsing #then does not crash", () => {
+		//#given
+		const error = {
+			data: "some-string-data",
+			message: "token limit exceeded",
+		};
 
-    //#when
-    const result = parseAnthropicTokenLimitError(error)
+		//#when
+		const result = parseAnthropicTokenLimitError(error);
 
-    //#then
-    expect(result).not.toBeNull()
-  })
-})
+		//#then
+		expect(result).not.toBeNull();
+	});
+});

--- a/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
@@ -1,118 +1,139 @@
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
-import type { PluginInput } from "@opencode-ai/plugin"
-import * as originalExecutor from "./executor"
-import * as originalParser from "./parser"
-import * as originalLogger from "../../shared/logger"
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	spyOn,
+	test,
+} from "bun:test";
+import type { PluginInput } from "@opencode-ai/plugin";
+import * as loggerModule from "../../shared/logger";
+import * as executorModule from "./executor";
+import * as parserModule from "./parser";
 
-const executeCompactMock = mock(async () => {})
+const executeCompactMock = mock(async () => {});
 const getLastAssistantMock = mock(async () => ({
-  providerID: "anthropic",
-  modelID: "claude-sonnet-4-6",
-}))
+	providerID: "anthropic",
+	modelID: "claude-sonnet-4-6",
+}));
 const parseAnthropicTokenLimitErrorMock = mock(() => ({
-  providerID: "anthropic",
-  modelID: "claude-sonnet-4-6",
-}))
+	providerID: "anthropic",
+	modelID: "claude-sonnet-4-6",
+}));
 
-mock.module("./executor", () => ({
-  executeCompact: executeCompactMock,
-  getLastAssistant: getLastAssistantMock,
-}))
+let createAnthropicContextWindowLimitRecoveryHook: typeof import("./recovery-hook").createAnthropicContextWindowLimitRecoveryHook;
 
-mock.module("./parser", () => ({
-  parseAnthropicTokenLimitError: parseAnthropicTokenLimitErrorMock,
-}))
+async function importRecoveryHookFactory(): Promise<void> {
+	mock &&
+		spyOn(executorModule, "executeCompact").mockImplementation(
+			executeCompactMock,
+		);
+	mock &&
+		spyOn(executorModule, "getLastAssistant").mockImplementation(
+			getLastAssistantMock,
+		);
+	mock &&
+		spyOn(parserModule, "parseAnthropicTokenLimitError").mockImplementation(
+			parseAnthropicTokenLimitErrorMock,
+		);
+	spyOn(loggerModule, "log").mockImplementation(() => {});
 
-mock.module("../../shared/logger", () => ({
-  log: () => {},
-}))
-
-afterAll(() => {
-  mock.module("./executor", () => originalExecutor)
-  mock.module("./parser", () => originalParser)
-  mock.module("../../shared/logger", () => originalLogger)
-})
+	const recoveryHookModule = await import(
+		`./recovery-hook?recovery-${Date.now()}-${Math.random()}`
+	);
+	createAnthropicContextWindowLimitRecoveryHook =
+		recoveryHookModule.createAnthropicContextWindowLimitRecoveryHook;
+}
 
 function createMockContext(): PluginInput {
-  return {
-    client: {
-      session: {
-        messages: mock(() => Promise.resolve({ data: [] })),
-      },
-      tui: {
-        showToast: mock(() => Promise.resolve()),
-      },
-    },
-    directory: "/tmp",
-  } as PluginInput
+	return {
+		client: {
+			session: {
+				messages: mock(() => Promise.resolve({ data: [] })),
+			},
+			tui: {
+				showToast: mock(() => Promise.resolve()),
+			},
+		},
+		directory: "/tmp",
+	} as PluginInput;
 }
 
 function setupDelayedTimeoutMocks(): {
-  restore: () => void
-  getClearTimeoutCalls: () => Array<ReturnType<typeof setTimeout>>
+	restore: () => void;
+	getClearTimeoutCalls: () => Array<ReturnType<typeof setTimeout>>;
 } {
-  const originalSetTimeout = globalThis.setTimeout
-  const originalClearTimeout = globalThis.clearTimeout
-  const clearTimeoutCalls: Array<ReturnType<typeof setTimeout>> = []
-  let timeoutCounter = 0
+	const originalSetTimeout = globalThis.setTimeout;
+	const originalClearTimeout = globalThis.clearTimeout;
+	const clearTimeoutCalls: Array<ReturnType<typeof setTimeout>> = [];
+	let timeoutCounter = 0;
 
-  globalThis.setTimeout = ((_: () => void, _delay?: number) => {
-    timeoutCounter += 1
-    return timeoutCounter as ReturnType<typeof setTimeout>
-  }) as typeof setTimeout
+	globalThis.setTimeout = ((_: () => void, _delay?: number) => {
+		timeoutCounter += 1;
+		return timeoutCounter as ReturnType<typeof setTimeout>;
+	}) as typeof setTimeout;
 
-  globalThis.clearTimeout = ((timeoutID: ReturnType<typeof setTimeout>) => {
-    clearTimeoutCalls.push(timeoutID)
-  }) as typeof clearTimeout
+	globalThis.clearTimeout = ((timeoutID: ReturnType<typeof setTimeout>) => {
+		clearTimeoutCalls.push(timeoutID);
+	}) as typeof clearTimeout;
 
-  return {
-    restore: () => {
-      globalThis.setTimeout = originalSetTimeout
-      globalThis.clearTimeout = originalClearTimeout
-    },
-    getClearTimeoutCalls: () => clearTimeoutCalls,
-  }
+	return {
+		restore: () => {
+			globalThis.setTimeout = originalSetTimeout;
+			globalThis.clearTimeout = originalClearTimeout;
+		},
+		getClearTimeoutCalls: () => clearTimeoutCalls,
+	};
 }
 
 describe("createAnthropicContextWindowLimitRecoveryHook", () => {
-  beforeEach(() => {
-    executeCompactMock.mockClear()
-    getLastAssistantMock.mockClear()
-    parseAnthropicTokenLimitErrorMock.mockClear()
-  })
+	beforeEach(async () => {
+		mock.restore();
+		executeCompactMock.mockClear();
+		getLastAssistantMock.mockClear();
+		parseAnthropicTokenLimitErrorMock.mockClear();
+		await importRecoveryHookFactory();
+	});
 
-  afterEach(() => {
-    mock.restore()
-  })
+	afterEach(() => {
+		mock.restore();
+	});
 
-  test("cancels pending timer when session.idle handles compaction first", async () => {
-    //#given
-    const { restore, getClearTimeoutCalls } = setupDelayedTimeoutMocks()
-    const { createAnthropicContextWindowLimitRecoveryHook } = await import("./recovery-hook")
-    const hook = createAnthropicContextWindowLimitRecoveryHook(createMockContext())
+	test("cancels pending timer when session.idle handles compaction first", async () => {
+		//#given
+		const { restore, getClearTimeoutCalls } = setupDelayedTimeoutMocks();
+		const hook = createAnthropicContextWindowLimitRecoveryHook(
+			createMockContext(),
+		);
 
-    try {
-      //#when
-      await hook.event({
-        event: {
-          type: "session.error",
-          properties: { sessionID: "session-race", error: "prompt is too long" },
-        },
-      })
+		try {
+			//#when
+			await hook.event({
+				event: {
+					type: "session.error",
+					properties: {
+						sessionID: "session-race",
+						error: "prompt is too long",
+					},
+				},
+			});
 
-      await hook.event({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: "session-race" },
-        },
-      })
+			await hook.event({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: "session-race" },
+				},
+			});
 
-      //#then
-      expect(getClearTimeoutCalls()).toEqual([1 as ReturnType<typeof setTimeout>])
-      expect(executeCompactMock).toHaveBeenCalledTimes(1)
-      expect(executeCompactMock.mock.calls[0]?.[0]).toBe("session-race")
-    } finally {
-      restore()
-    }
-  })
-})
+			//#then
+			expect(getClearTimeoutCalls()).toEqual([
+				1 as ReturnType<typeof setTimeout>,
+			]);
+			expect(executeCompactMock).toHaveBeenCalledTimes(1);
+			expect(executeCompactMock.mock.calls[0]?.[0]).toBe("session-race");
+		} finally {
+			restore();
+		}
+	});
+});

--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -1,2267 +1,2484 @@
-import { describe, expect, test, beforeEach, afterEach, mock } from "bun:test"
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
-import { tmpdir } from "node:os"
-import { randomUUID } from "node:crypto"
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BoulderState } from "../../features/boulder-state";
 import {
-  writeBoulderState,
-  clearBoulderState,
-  readBoulderState,
-} from "../../features/boulder-state"
-import type { BoulderState } from "../../features/boulder-state"
-import { _resetForTesting, subagentSessions, updateSessionAgent } from "../../features/claude-code-session-state"
-import type { PendingTaskRef } from "./types"
+	clearBoulderState,
+	readBoulderState,
+	writeBoulderState,
+} from "../../features/boulder-state";
+import {
+	_resetForTesting,
+	subagentSessions,
+	updateSessionAgent,
+} from "../../features/claude-code-session-state";
+import { getAgentDisplayName } from "../../shared/agent-display-names";
+import type { PendingTaskRef } from "./types";
 
-const TEST_STORAGE_ROOT = join(tmpdir(), `atlas-message-storage-${randomUUID()}`)
-const TEST_MESSAGE_STORAGE = join(TEST_STORAGE_ROOT, "message")
-const TEST_PART_STORAGE = join(TEST_STORAGE_ROOT, "part")
+const TEST_STORAGE_ROOT = join(
+	tmpdir(),
+	`atlas-message-storage-${randomUUID()}`,
+);
+const TEST_MESSAGE_STORAGE = join(TEST_STORAGE_ROOT, "message");
+const TEST_PART_STORAGE = join(TEST_STORAGE_ROOT, "part");
 
 mock.module("../../features/hook-message-injector/constants", () => ({
-  OPENCODE_STORAGE: TEST_STORAGE_ROOT,
-  MESSAGE_STORAGE: TEST_MESSAGE_STORAGE,
-  PART_STORAGE: TEST_PART_STORAGE,
-}))
+	OPENCODE_STORAGE: TEST_STORAGE_ROOT,
+	MESSAGE_STORAGE: TEST_MESSAGE_STORAGE,
+	PART_STORAGE: TEST_PART_STORAGE,
+}));
 
 mock.module("../../shared/opencode-message-dir", () => ({
-  getMessageDir: (sessionID: string) => {
-    const dir = join(TEST_MESSAGE_STORAGE, sessionID)
-    return existsSync(dir) ? dir : null
-  },
-}))
+	getMessageDir: (sessionID: string) => {
+		const dir = join(TEST_MESSAGE_STORAGE, sessionID);
+		return existsSync(dir) ? dir : null;
+	},
+}));
 
 mock.module("../../shared/opencode-storage-detection", () => ({
-  isSqliteBackend: () => false,
-}))
+	isSqliteBackend: () => false,
+}));
 
-const { createAtlasHook } = await import("./index")
-const { createToolExecuteAfterHandler } = await import("./tool-execute-after")
-const { createToolExecuteBeforeHandler } = await import("./tool-execute-before")
-const { MESSAGE_STORAGE } = await import("../../features/hook-message-injector")
+const { createAtlasHook } = await import("./index");
+const { createToolExecuteAfterHandler } = await import("./tool-execute-after");
+const { createToolExecuteBeforeHandler } = await import(
+	"./tool-execute-before"
+);
+const { MESSAGE_STORAGE } = await import(
+	"../../features/hook-message-injector"
+);
 
 describe("atlas hook", () => {
-  let TEST_DIR: string
-  let SISYPHUS_DIR: string
+	let TEST_DIR: string;
+	let SISYPHUS_DIR: string;
 
-  function createMockPluginInput(overrides?: {
-    promptMock?: ReturnType<typeof mock>
-    sessionGetMock?: ReturnType<typeof mock>
-  }) {
-    const promptMock = overrides?.promptMock ?? mock(() => Promise.resolve())
-    const sessionGetMock = overrides?.sessionGetMock ?? mock(async ({ path }: { path: { id: string } }) => ({
-      data: {
-        id: path.id,
-        parentID: path.id.startsWith("ses_") ? "session-1" : "main-session-123",
-      },
-    }))
-    return {
-      directory: TEST_DIR,
-      client: {
-        session: {
-          get: sessionGetMock,
-          prompt: promptMock,
-          promptAsync: promptMock,
-        },
-      },
-      _promptMock: promptMock,
-      _sessionGetMock: sessionGetMock,
-    } as unknown as Parameters<typeof createAtlasHook>[0] & {
-      _promptMock: ReturnType<typeof mock>
-      _sessionGetMock: ReturnType<typeof mock>
-    }
-  }
+	function createMockPluginInput(overrides?: {
+		promptMock?: ReturnType<typeof mock>;
+		sessionGetMock?: ReturnType<typeof mock>;
+	}) {
+		const promptMock = overrides?.promptMock ?? mock(() => Promise.resolve());
+		const sessionGetMock =
+			overrides?.sessionGetMock ??
+			mock(async ({ path }: { path: { id: string } }) => ({
+				data: {
+					id: path.id,
+					parentID: path.id.startsWith("ses_")
+						? "session-1"
+						: "main-session-123",
+				},
+			}));
+		return {
+			directory: TEST_DIR,
+			client: {
+				session: {
+					get: sessionGetMock,
+					prompt: promptMock,
+					promptAsync: promptMock,
+				},
+			},
+			_promptMock: promptMock,
+			_sessionGetMock: sessionGetMock,
+		} as unknown as Parameters<typeof createAtlasHook>[0] & {
+			_promptMock: ReturnType<typeof mock>;
+			_sessionGetMock: ReturnType<typeof mock>;
+		};
+	}
 
-  function setupMessageStorage(sessionID: string, agent: string): void {
-    const messageDir = join(MESSAGE_STORAGE, sessionID)
-    if (!existsSync(messageDir)) {
-      mkdirSync(messageDir, { recursive: true })
-    }
-    const messageData = {
-      agent,
-      model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
-    }
-    writeFileSync(join(messageDir, "msg_test001.json"), JSON.stringify(messageData))
-  }
+	function setupMessageStorage(sessionID: string, agent: string): void {
+		const messageDir = join(MESSAGE_STORAGE, sessionID);
+		if (!existsSync(messageDir)) {
+			mkdirSync(messageDir, { recursive: true });
+		}
+		const messageData = {
+			agent,
+			model: { providerID: "anthropic", modelID: "claude-opus-4-6" },
+		};
+		writeFileSync(
+			join(messageDir, "msg_test001.json"),
+			JSON.stringify(messageData),
+		);
+	}
 
-  function cleanupMessageStorage(sessionID: string): void {
-    const messageDir = join(MESSAGE_STORAGE, sessionID)
-    if (existsSync(messageDir)) {
-      rmSync(messageDir, { recursive: true, force: true })
-    }
-  }
+	function cleanupMessageStorage(sessionID: string): void {
+		const messageDir = join(MESSAGE_STORAGE, sessionID);
+		if (existsSync(messageDir)) {
+			rmSync(messageDir, { recursive: true, force: true });
+		}
+	}
 
-  beforeEach(() => {
-    TEST_DIR = join(tmpdir(), `atlas-test-${randomUUID()}`)
-    SISYPHUS_DIR = join(TEST_DIR, ".sisyphus")
-    if (!existsSync(TEST_DIR)) {
-      mkdirSync(TEST_DIR, { recursive: true })
-    }
-    if (!existsSync(SISYPHUS_DIR)) {
-      mkdirSync(SISYPHUS_DIR, { recursive: true })
-    }
-    clearBoulderState(TEST_DIR)
-  })
+	beforeEach(() => {
+		TEST_DIR = join(tmpdir(), `atlas-test-${randomUUID()}`);
+		SISYPHUS_DIR = join(TEST_DIR, ".sisyphus");
+		if (!existsSync(TEST_DIR)) {
+			mkdirSync(TEST_DIR, { recursive: true });
+		}
+		if (!existsSync(SISYPHUS_DIR)) {
+			mkdirSync(SISYPHUS_DIR, { recursive: true });
+		}
+		clearBoulderState(TEST_DIR);
+	});
 
-  afterEach(() => {
-    clearBoulderState(TEST_DIR)
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true, force: true })
-    }
-  })
+	afterEach(() => {
+		clearBoulderState(TEST_DIR);
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
 
-  describe("tool.execute.after handler", () => {
-    test("should handle undefined output gracefully (issue #1035)", async () => {
-      // given - hook and undefined output (e.g., from /review command)
-      const hook = createAtlasHook(createMockPluginInput())
+	describe("tool.execute.after handler", () => {
+		test("should handle undefined output gracefully (issue #1035)", async () => {
+			// given - hook and undefined output (e.g., from /review command)
+			const hook = createAtlasHook(createMockPluginInput());
 
-      // when - calling with undefined output
-      const result = await hook["tool.execute.after"](
-        { tool: "task", sessionID: "session-123" },
-        undefined as unknown as { title: string; output: string; metadata: Record<string, unknown> }
-      )
+			// when - calling with undefined output
+			const result = await hook["tool.execute.after"](
+				{ tool: "task", sessionID: "session-123" },
+				undefined as unknown as {
+					title: string;
+					output: string;
+					metadata: Record<string, unknown>;
+				},
+			);
 
-      // then - returns undefined without throwing
-      expect(result).toBeUndefined()
-    })
+			// then - returns undefined without throwing
+			expect(result).toBeUndefined();
+		});
 
-    test("should ignore non-task tools", async () => {
-      // given - hook and non-task tool
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Test Tool",
-        output: "Original output",
-        metadata: {},
-      }
+		test("should ignore non-task tools", async () => {
+			// given - hook and non-task tool
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Test Tool",
+				output: "Original output",
+				metadata: {},
+			};
 
-      // when
-      await hook["tool.execute.after"](
-        { tool: "other_tool", sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["tool.execute.after"](
+				{ tool: "other_tool", sessionID: "session-123" },
+				output,
+			);
 
-      // then - output unchanged
-      expect(output.output).toBe("Original output")
-    })
+			// then - output unchanged
+			expect(output.output).toBe("Original output");
+		});
 
-     test("should not transform when caller is not Atlas", async () => {
-       // given - boulder state exists but caller agent in message storage is not Atlas
-       const sessionID = "session-non-orchestrator-test"
-       setupMessageStorage(sessionID, "other-agent")
-      
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
+		test("should not transform when caller is not Atlas", async () => {
+			// given - boulder state exists but caller agent in message storage is not Atlas
+			const sessionID = "session-non-orchestrator-test";
+			setupMessageStorage(sessionID, "other-agent");
 
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
 
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: "Task completed successfully",
-        metadata: {},
-      }
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
 
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: "Task completed successfully",
+				metadata: {},
+			};
 
-      // then - output unchanged because caller is not orchestrator
-      expect(output.output).toBe("Task completed successfully")
-      
-      cleanupMessageStorage(sessionID)
-    })
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
 
-     test("should append standalone verification when no boulder state but caller is Atlas", async () => {
-       // given - no boulder state, but caller is Atlas
-       const sessionID = "session-no-boulder-test"
-       setupMessageStorage(sessionID, "atlas")
-      
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: "Task completed successfully",
-        metadata: {},
-      }
+			// then - output unchanged because caller is not orchestrator
+			expect(output.output).toBe("Task completed successfully");
 
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
+			cleanupMessageStorage(sessionID);
+		});
 
-      // then - standalone verification reminder appended
-      expect(output.output).toContain("Task completed successfully")
-      expect(output.output).toContain("LYING")
-      expect(output.output).toContain("PHASE 1")
-      
-      cleanupMessageStorage(sessionID)
-    })
+		test("should append standalone verification when no boulder state but caller is Atlas", async () => {
+			// given - no boulder state, but caller is Atlas
+			const sessionID = "session-no-boulder-test";
+			setupMessageStorage(sessionID, "atlas");
 
-     test("should transform output when caller is Atlas with boulder state", async () => {
-       // given - Atlas caller with boulder state
-       const sessionID = "session-transform-test"
-       setupMessageStorage(sessionID, "atlas")
-      
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2")
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: "Task completed successfully",
+				metadata: {},
+			};
 
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
 
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: "Task completed successfully",
-        metadata: {},
-      }
+			// then - standalone verification reminder appended
+			expect(output.output).toContain("Task completed successfully");
+			expect(output.output).toContain("LYING");
+			expect(output.output).toContain("PHASE 1");
 
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
+			cleanupMessageStorage(sessionID);
+		});
 
-      // then - output should be transformed (original output preserved for debugging)
-      expect(output.output).toContain("Task completed successfully")
-      expect(output.output).toContain("SUBAGENT WORK COMPLETED")
-      expect(output.output).toContain("test-plan")
-      expect(output.output).toContain("LYING")
-      expect(output.output).toContain("PHASE 1")
-      
-      cleanupMessageStorage(sessionID)
-    })
+		test("should transform output when caller is Atlas with boulder state", async () => {
+			// given - Atlas caller with boulder state
+			const sessionID = "session-transform-test";
+			setupMessageStorage(sessionID, "atlas");
 
-     test("should still transform when plan is complete (shows progress)", async () => {
-       // given - boulder state with complete plan, Atlas caller
-       const sessionID = "session-complete-plan-test"
-       setupMessageStorage(sessionID, "atlas")
-      
-      const planPath = join(TEST_DIR, "complete-plan.md")
-      writeFileSync(planPath, "# Plan\n- [x] Task 1\n- [x] Task 2")
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2");
 
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "complete-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
 
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: "Original output",
-        metadata: {},
-      }
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: "Task completed successfully",
+				metadata: {},
+			};
 
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
 
-      // then - output transformed even when complete (shows 2/2 done)
-      expect(output.output).toContain("SUBAGENT WORK COMPLETED")
-      expect(output.output).toContain("2/2 done")
-      expect(output.output).toContain("0 remaining")
-      
-      cleanupMessageStorage(sessionID)
-    })
+			// then - output should be transformed (original output preserved for debugging)
+			expect(output.output).toContain("Task completed successfully");
+			expect(output.output).toContain("SUBAGENT WORK COMPLETED");
+			expect(output.output).toContain("test-plan");
+			expect(output.output).toContain("LYING");
+			expect(output.output).toContain("PHASE 1");
 
-     test("should append session ID to boulder state if not present", async () => {
-       // given - boulder state without session-append-test, Atlas caller
-       const sessionID = "session-append-test"
-       setupMessageStorage(sessionID, "atlas")
-      
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
+			cleanupMessageStorage(sessionID);
+		});
 
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
+		test("should still transform when plan is complete (shows progress)", async () => {
+			// given - boulder state with complete plan, Atlas caller
+			const sessionID = "session-complete-plan-test";
+			setupMessageStorage(sessionID, "atlas");
 
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: "Task output",
-        metadata: {},
-      }
+			const planPath = join(TEST_DIR, "complete-plan.md");
+			writeFileSync(planPath, "# Plan\n- [x] Task 1\n- [x] Task 2");
 
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "complete-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
 
-      // then - sessionID should be appended
-      const updatedState = readBoulderState(TEST_DIR)
-      expect(updatedState?.session_ids).toContain(sessionID)
-      
-      cleanupMessageStorage(sessionID)
-    })
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: "Original output",
+				metadata: {},
+			};
 
-     test("should not duplicate existing session ID", async () => {
-       // given - boulder state already has session-dup-test, Atlas caller
-       const sessionID = "session-dup-test"
-       setupMessageStorage(sessionID, "atlas")
-      
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
 
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [sessionID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
+			// then - output transformed even when complete (shows 2/2 done)
+			expect(output.output).toContain("SUBAGENT WORK COMPLETED");
+			expect(output.output).toContain("2/2 done");
+			expect(output.output).toContain("0 remaining");
 
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: "Task output",
-        metadata: {},
-      }
+			cleanupMessageStorage(sessionID);
+		});
 
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
+		test("should append session ID to boulder state if not present", async () => {
+			// given - boulder state without session-append-test, Atlas caller
+			const sessionID = "session-append-test";
+			setupMessageStorage(sessionID, "atlas");
 
-      // then - should still have only one sessionID
-      const updatedState = readBoulderState(TEST_DIR)
-      const count = updatedState?.session_ids.filter((id) => id === sessionID).length
-      expect(count).toBe(1)
-      
-      cleanupMessageStorage(sessionID)
-    })
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
 
-     test("should include boulder.json path and notepad path in transformed output", async () => {
-       // given - boulder state, Atlas caller
-       const sessionID = "session-path-test"
-       setupMessageStorage(sessionID, "atlas")
-      
-      const planPath = join(TEST_DIR, "my-feature.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2\n- [x] Task 3")
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
 
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "my-feature",
-      }
-      writeBoulderState(TEST_DIR, state)
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: "Task output",
+				metadata: {},
+			};
 
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: "Task completed",
-        metadata: {},
-      }
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
 
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
+			// then - sessionID should be appended
+			const updatedState = readBoulderState(TEST_DIR);
+			expect(updatedState?.session_ids).toContain(sessionID);
 
-      // then - output should contain plan name and progress
-      expect(output.output).toContain("my-feature")
-      expect(output.output).toContain("1/3 done")
-      expect(output.output).toContain("2 remaining")
-      
-      cleanupMessageStorage(sessionID)
-    })
+			cleanupMessageStorage(sessionID);
+		});
 
-     test("should include session_id and checkbox instructions in reminder", async () => {
-       // given - boulder state, Atlas caller
-       const sessionID = "session-resume-test"
-       setupMessageStorage(sessionID, "atlas")
-      
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
+		test("should not duplicate existing session ID", async () => {
+			// given - boulder state already has session-dup-test, Atlas caller
+			const sessionID = "session-dup-test";
+			setupMessageStorage(sessionID, "atlas");
 
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
 
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: "Task completed",
-        metadata: {},
-      }
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [sessionID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
 
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: "Task output",
+				metadata: {},
+			};
 
-      // then - should include verification instructions
-      expect(output.output).toContain("LYING")
-     expect(output.output).toContain("PHASE 1")
-     expect(output.output).toContain("PHASE 2")
-      
-      cleanupMessageStorage(sessionID)
-    })
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
 
-    test("should clean pending task refs when a task returns background launch output", async () => {
-      // given - direct handlers with shared pending maps
-      const sessionID = "session-bg-launch-cleanup-test"
-      setupMessageStorage(sessionID, "atlas")
+			// then - should still have only one sessionID
+			const updatedState = readBoulderState(TEST_DIR);
+			const count = updatedState?.session_ids.filter(
+				(id) => id === sessionID,
+			).length;
+			expect(count).toBe(1);
 
-      const planPath = join(TEST_DIR, "background-cleanup-plan.md")
-      writeFileSync(planPath, `# Plan
+			cleanupMessageStorage(sessionID);
+		});
+
+		test("should include boulder.json path and notepad path in transformed output", async () => {
+			// given - boulder state, Atlas caller
+			const sessionID = "session-path-test";
+			setupMessageStorage(sessionID, "atlas");
+
+			const planPath = join(TEST_DIR, "my-feature.md");
+			writeFileSync(
+				planPath,
+				"# Plan\n- [ ] Task 1\n- [ ] Task 2\n- [x] Task 3",
+			);
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "my-feature",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: "Task completed",
+				metadata: {},
+			};
+
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
+
+			// then - output should contain plan name and progress
+			expect(output.output).toContain("my-feature");
+			expect(output.output).toContain("1/3 done");
+			expect(output.output).toContain("2 remaining");
+
+			cleanupMessageStorage(sessionID);
+		});
+
+		test("should include session_id and checkbox instructions in reminder", async () => {
+			// given - boulder state, Atlas caller
+			const sessionID = "session-resume-test";
+			setupMessageStorage(sessionID, "atlas");
+
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: "Task completed",
+				metadata: {},
+			};
+
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
+
+			// then - should include verification instructions
+			expect(output.output).toContain("LYING");
+			expect(output.output).toContain("PHASE 1");
+			expect(output.output).toContain("PHASE 2");
+
+			cleanupMessageStorage(sessionID);
+		});
+
+		test("should clean pending task refs when a task returns background launch output", async () => {
+			// given - direct handlers with shared pending maps
+			const sessionID = "session-bg-launch-cleanup-test";
+			setupMessageStorage(sessionID, "atlas");
+
+			const planPath = join(TEST_DIR, "background-cleanup-plan.md");
+			writeFileSync(
+				planPath,
+				`# Plan
 
 ## TODOs
 - [ ] 1. Implement auth flow
-`)
-      writeBoulderState(TEST_DIR, {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "background-cleanup-plan",
-      })
+`,
+			);
+			writeBoulderState(TEST_DIR, {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "background-cleanup-plan",
+			});
 
-      const pendingFilePaths = new Map<string, string>()
-      const pendingTaskRefs = new Map<string, PendingTaskRef>()
-      const beforeHandler = createToolExecuteBeforeHandler({
-        ctx: createMockPluginInput(),
-        pendingFilePaths,
-        pendingTaskRefs,
-      })
-      const afterHandler = createToolExecuteAfterHandler({
-        ctx: createMockPluginInput(),
-        pendingFilePaths,
-        pendingTaskRefs,
-        autoCommit: true,
-        getState: () => ({ promptFailureCount: 0 }),
-      })
+			const pendingFilePaths = new Map<string, string>();
+			const pendingTaskRefs = new Map<string, PendingTaskRef>();
+			const beforeHandler = createToolExecuteBeforeHandler({
+				ctx: createMockPluginInput(),
+				pendingFilePaths,
+				pendingTaskRefs,
+			});
+			const afterHandler = createToolExecuteAfterHandler({
+				ctx: createMockPluginInput(),
+				pendingFilePaths,
+				pendingTaskRefs,
+				autoCommit: true,
+				getState: () => ({ promptFailureCount: 0 }),
+			});
 
-      // when - the task is captured before execution
-      await beforeHandler(
-        { tool: "task", sessionID, callID: "call-bg-launch" },
-        { args: { prompt: "Implement auth flow" } }
-      )
-      expect(pendingTaskRefs.size).toBe(1)
+			// when - the task is captured before execution
+			await beforeHandler(
+				{ tool: "task", sessionID, callID: "call-bg-launch" },
+				{ args: { prompt: "Implement auth flow" } },
+			);
+			expect(pendingTaskRefs.size).toBe(1);
 
-      // and the task returns a background launch result
-      await afterHandler(
-        { tool: "task", sessionID, callID: "call-bg-launch" },
-        {
-          title: "Sisyphus Task",
-          output: "Background task launched.\n\nSession ID: ses_bg_12345",
-          metadata: {},
-        }
-      )
+			// and the task returns a background launch result
+			await afterHandler(
+				{ tool: "task", sessionID, callID: "call-bg-launch" },
+				{
+					title: "Sisyphus Task",
+					output: "Background task launched.\n\nSession ID: ses_bg_12345",
+					metadata: {},
+				},
+			);
 
-      // then - the pending task ref is still cleaned up
-      expect(pendingTaskRefs.size).toBe(0)
+			// then - the pending task ref is still cleaned up
+			expect(pendingTaskRefs.size).toBe(0);
 
-      cleanupMessageStorage(sessionID)
-    })
+			cleanupMessageStorage(sessionID);
+		});
 
-     test("should persist preferred subagent session for the current top-level task", async () => {
-       // given - boulder state with a current top-level task, Atlas caller
-       const sessionID = "session-task-session-track-test"
-       setupMessageStorage(sessionID, "atlas")
+		test("should persist preferred subagent session for the current top-level task", async () => {
+			// given - boulder state with a current top-level task, Atlas caller
+			const sessionID = "session-task-session-track-test";
+			setupMessageStorage(sessionID, "atlas");
 
-      const planPath = join(TEST_DIR, "task-session-plan.md")
-      writeFileSync(planPath, `# Plan
+			const planPath = join(TEST_DIR, "task-session-plan.md");
+			writeFileSync(
+				planPath,
+				`# Plan
 
 ## TODOs
 - [ ] 1. Implement auth flow
   - [ ] nested acceptance checkbox
-`)
+`,
+			);
 
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "task-session-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "task-session-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
 
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: `Task completed successfully
-
-<task_metadata>
-session_id: ses_auth_flow_123
-</task_metadata>`,
-        metadata: {
-          agent: "sisyphus-junior",
-          category: "deep",
-        },
-      }
-
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
-
-      // then
-     const updatedState = readBoulderState(TEST_DIR)
-      expect(updatedState?.task_sessions?.["todo:1"]?.session_id).toBe("ses_auth_flow_123")
-      expect(updatedState?.task_sessions?.["todo:1"]?.task_title).toBe("Implement auth flow")
-      expect(updatedState?.task_sessions?.["todo:1"]?.agent).toBe("sisyphus-junior")
-      expect(updatedState?.task_sessions?.["todo:1"]?.category).toBe("deep")
-
-      cleanupMessageStorage(sessionID)
-    })
-
-     test("should preserve the delegated task key even after the plan advances to the next task", async () => {
-       // given - Atlas caller starts task 1, then the plan advances before task output is processed
-       const sessionID = "session-stable-task-key-test"
-       setupMessageStorage(sessionID, "atlas")
-
-      const planPath = join(TEST_DIR, "stable-task-key-plan.md")
-      writeFileSync(planPath, `# Plan
-
-## TODOs
-- [ ] 1. Implement auth flow
-- [ ] 2. Add API validation
-`)
-
-      writeBoulderState(TEST_DIR, {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "stable-task-key-plan",
-      })
-
-      const hook = createAtlasHook(createMockPluginInput())
-
-      // when - Atlas delegates task 1
-      await hook["tool.execute.before"](
-        { tool: "task", sessionID, callID: "call-task-1" },
-        { args: { prompt: "Implement auth flow" } }
-      )
-
-      // and the plan is advanced before the task output is processed
-      writeFileSync(planPath, `# Plan
-
-## TODOs
-- [x] 1. Implement auth flow
-- [ ] 2. Add API validation
-`)
-
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID, callID: "call-task-1" },
-        {
-          title: "Sisyphus Task",
-          output: `Task completed successfully
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: `Task completed successfully
 
 <task_metadata>
 session_id: ses_auth_flow_123
 </task_metadata>`,
-          metadata: {
-            agent: "sisyphus-junior",
-            category: "deep",
-          },
-        }
-      )
+				metadata: {
+					agent: "sisyphus-junior",
+					category: "deep",
+				},
+			};
 
-      // then - the completed task session is still recorded against task 1, not task 2
-     const updatedState = readBoulderState(TEST_DIR)
-      expect(updatedState?.task_sessions?.["todo:1"]?.session_id).toBe("ses_auth_flow_123")
-      expect(updatedState?.task_sessions?.["todo:2"]).toBeUndefined()
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
 
-      cleanupMessageStorage(sessionID)
-    })
+			// then
+			const updatedState = readBoulderState(TEST_DIR);
+			expect(updatedState?.task_sessions?.["todo:1"]?.session_id).toBe(
+				"ses_auth_flow_123",
+			);
+			expect(updatedState?.task_sessions?.["todo:1"]?.task_title).toBe(
+				"Implement auth flow",
+			);
+			expect(updatedState?.task_sessions?.["todo:1"]?.agent).toBe(
+				"sisyphus-junior",
+			);
+			expect(updatedState?.task_sessions?.["todo:1"]?.category).toBe("deep");
 
-     test("should not overwrite the current task mapping when task() explicitly resumes an older session", async () => {
-       // given - current plan is on task 2, but Atlas explicitly resumes an older session for a previous task
-       const sessionID = "session-cross-task-resume-test"
-       setupMessageStorage(sessionID, "atlas")
+			cleanupMessageStorage(sessionID);
+		});
 
-      const planPath = join(TEST_DIR, "cross-task-resume-plan.md")
-      writeFileSync(planPath, `# Plan
+		test("should preserve the delegated task key even after the plan advances to the next task", async () => {
+			// given - Atlas caller starts task 1, then the plan advances before task output is processed
+			const sessionID = "session-stable-task-key-test";
+			setupMessageStorage(sessionID, "atlas");
 
-## TODOs
-- [x] 1. Implement auth flow
-- [ ] 2. Add API validation
-`)
-
-      writeBoulderState(TEST_DIR, {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "cross-task-resume-plan",
-      })
-
-      const hook = createAtlasHook(createMockPluginInput())
-
-      // when - Atlas resumes an explicit prior session
-      await hook["tool.execute.before"](
-        { tool: "task", sessionID, callID: "call-resume-old-task" },
-        { args: { prompt: "Follow up on previous task", session_id: "ses_old_task_111" } }
-      )
-
-      const output = {
-        title: "Sisyphus Task",
-        output: `Task continued successfully
-
-<task_metadata>
-session_id: ses_old_task_111
-</task_metadata>`,
-        metadata: {
-          agent: "sisyphus-junior",
-          category: "deep",
-        },
-      }
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID, callID: "call-resume-old-task" },
-        output
-      )
-
-      // then - Atlas does not poison task 2's preferred session mapping
-      const updatedState = readBoulderState(TEST_DIR)
-      expect(updatedState?.task_sessions?.["todo:2"]).toBeUndefined()
-      expect(output.output).not.toContain('task(session_id="ses_old_task_111"')
-
-      cleanupMessageStorage(sessionID)
-    })
-
-    test("should not reuse an explicitly resumed session id in completion reminders", async () => {
-      // given - current plan is on task 2 with an existing tracked session
-      const sessionID = "session-explicit-resume-reminder-test"
-      setupMessageStorage(sessionID, "atlas")
-
-      const planPath = join(TEST_DIR, "explicit-resume-reminder-plan.md")
-      writeFileSync(planPath, `# Plan
-
-## TODOs
-- [x] 1. Implement auth flow
-- [ ] 2. Add API validation
-`)
-
-      writeBoulderState(TEST_DIR, {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "explicit-resume-reminder-plan",
-        task_sessions: {
-          "todo:2": {
-            task_key: "todo:2",
-            task_label: "2",
-            task_title: "Add API validation",
-            session_id: "ses_tracked_current_task",
-            updated_at: "2026-01-02T10:00:00Z",
-          },
-        },
-      })
-
-      const hook = createAtlasHook(createMockPluginInput())
-      const output = {
-        title: "Sisyphus Task",
-        output: `Task continued successfully
-
-<task_metadata>
-session_id: ses_old_task_111
-</task_metadata>`,
-        metadata: {},
-      }
-
-      // when
-      await hook["tool.execute.before"](
-        { tool: "task", sessionID, callID: "call-explicit-resume-reminder" },
-        { args: { prompt: "Follow up on previous task", session_id: "ses_old_task_111" } }
-      )
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID, callID: "call-explicit-resume-reminder" },
-        output
-      )
-
-      // then
-      expect(output.output).not.toContain('task(session_id="ses_old_task_111"')
-      expect(output.output).toContain("ses_tracked_current_task")
-
-      cleanupMessageStorage(sessionID)
-    })
-
-    test("should skip persistence when multiple in-flight task calls claim the same top-level task", async () => {
-      // given
-      const sessionID = "session-parallel-task-collision-test"
-      setupMessageStorage(sessionID, "atlas")
-
-      const planPath = join(TEST_DIR, "parallel-task-collision-plan.md")
-      writeFileSync(planPath, `# Plan
+			const planPath = join(TEST_DIR, "stable-task-key-plan.md");
+			writeFileSync(
+				planPath,
+				`# Plan
 
 ## TODOs
 - [ ] 1. Implement auth flow
 - [ ] 2. Add API validation
-`)
+`,
+			);
 
-      writeBoulderState(TEST_DIR, {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "parallel-task-collision-plan",
-      })
+			writeBoulderState(TEST_DIR, {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "stable-task-key-plan",
+			});
 
-      const pendingFilePaths = new Map<string, string>()
-      const pendingTaskRefs = new Map<string, PendingTaskRef>()
-      const beforeHandler = createToolExecuteBeforeHandler({
-        ctx: createMockPluginInput(),
-        pendingFilePaths,
-        pendingTaskRefs,
-      })
-      const afterHandler = createToolExecuteAfterHandler({
-        ctx: createMockPluginInput(),
-        pendingFilePaths,
-        pendingTaskRefs,
-        autoCommit: true,
-        getState: () => ({ promptFailureCount: 0 }),
-      })
+			const hook = createAtlasHook(createMockPluginInput());
 
-      // when - two task() calls start before either one completes
-      await beforeHandler(
-        { tool: "task", sessionID, callID: "call-task-first" },
-        { args: { prompt: "Implement auth flow part 1" } }
-      )
-      await beforeHandler(
-        { tool: "task", sessionID, callID: "call-task-second" },
-        { args: { prompt: "Implement auth flow part 2" } }
-      )
+			// when - Atlas delegates task 1
+			await hook["tool.execute.before"](
+				{ tool: "task", sessionID, callID: "call-task-1" },
+				{ args: { prompt: "Implement auth flow" } },
+			);
 
-      const secondPendingTaskRef = pendingTaskRefs.get("call-task-second")
+			// and the plan is advanced before the task output is processed
+			writeFileSync(
+				planPath,
+				`# Plan
 
-      await afterHandler(
-        { tool: "task", sessionID, callID: "call-task-second" },
-        {
-          title: "Sisyphus Task",
-          output: `Task completed successfully
+## TODOs
+- [x] 1. Implement auth flow
+- [ ] 2. Add API validation
+`,
+			);
+
+			await hook["tool.execute.after"](
+				{ tool: "task", sessionID, callID: "call-task-1" },
+				{
+					title: "Sisyphus Task",
+					output: `Task completed successfully
+
+<task_metadata>
+session_id: ses_auth_flow_123
+</task_metadata>`,
+					metadata: {
+						agent: "sisyphus-junior",
+						category: "deep",
+					},
+				},
+			);
+
+			// then - the completed task session is still recorded against task 1, not task 2
+			const updatedState = readBoulderState(TEST_DIR);
+			expect(updatedState?.task_sessions?.["todo:1"]?.session_id).toBe(
+				"ses_auth_flow_123",
+			);
+			expect(updatedState?.task_sessions?.["todo:2"]).toBeUndefined();
+
+			cleanupMessageStorage(sessionID);
+		});
+
+		test("should not overwrite the current task mapping when task() explicitly resumes an older session", async () => {
+			// given - current plan is on task 2, but Atlas explicitly resumes an older session for a previous task
+			const sessionID = "session-cross-task-resume-test";
+			setupMessageStorage(sessionID, "atlas");
+
+			const planPath = join(TEST_DIR, "cross-task-resume-plan.md");
+			writeFileSync(
+				planPath,
+				`# Plan
+
+## TODOs
+- [x] 1. Implement auth flow
+- [ ] 2. Add API validation
+`,
+			);
+
+			writeBoulderState(TEST_DIR, {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "cross-task-resume-plan",
+			});
+
+			const hook = createAtlasHook(createMockPluginInput());
+
+			// when - Atlas resumes an explicit prior session
+			await hook["tool.execute.before"](
+				{ tool: "task", sessionID, callID: "call-resume-old-task" },
+				{
+					args: {
+						prompt: "Follow up on previous task",
+						session_id: "ses_old_task_111",
+					},
+				},
+			);
+
+			const output = {
+				title: "Sisyphus Task",
+				output: `Task continued successfully
+
+<task_metadata>
+session_id: ses_old_task_111
+</task_metadata>`,
+				metadata: {
+					agent: "sisyphus-junior",
+					category: "deep",
+				},
+			};
+			await hook["tool.execute.after"](
+				{ tool: "task", sessionID, callID: "call-resume-old-task" },
+				output,
+			);
+
+			// then - Atlas does not poison task 2's preferred session mapping
+			const updatedState = readBoulderState(TEST_DIR);
+			expect(updatedState?.task_sessions?.["todo:2"]).toBeUndefined();
+			expect(output.output).not.toContain('task(session_id="ses_old_task_111"');
+
+			cleanupMessageStorage(sessionID);
+		});
+
+		test("should not reuse an explicitly resumed session id in completion reminders", async () => {
+			// given - current plan is on task 2 with an existing tracked session
+			const sessionID = "session-explicit-resume-reminder-test";
+			setupMessageStorage(sessionID, "atlas");
+
+			const planPath = join(TEST_DIR, "explicit-resume-reminder-plan.md");
+			writeFileSync(
+				planPath,
+				`# Plan
+
+## TODOs
+- [x] 1. Implement auth flow
+- [ ] 2. Add API validation
+`,
+			);
+
+			writeBoulderState(TEST_DIR, {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "explicit-resume-reminder-plan",
+				task_sessions: {
+					"todo:2": {
+						task_key: "todo:2",
+						task_label: "2",
+						task_title: "Add API validation",
+						session_id: "ses_tracked_current_task",
+						updated_at: "2026-01-02T10:00:00Z",
+					},
+				},
+			});
+
+			const hook = createAtlasHook(createMockPluginInput());
+			const output = {
+				title: "Sisyphus Task",
+				output: `Task continued successfully
+
+<task_metadata>
+session_id: ses_old_task_111
+</task_metadata>`,
+				metadata: {},
+			};
+
+			// when
+			await hook["tool.execute.before"](
+				{ tool: "task", sessionID, callID: "call-explicit-resume-reminder" },
+				{
+					args: {
+						prompt: "Follow up on previous task",
+						session_id: "ses_old_task_111",
+					},
+				},
+			);
+			await hook["tool.execute.after"](
+				{ tool: "task", sessionID, callID: "call-explicit-resume-reminder" },
+				output,
+			);
+
+			// then
+			expect(output.output).not.toContain('task(session_id="ses_old_task_111"');
+			expect(output.output).toContain("ses_tracked_current_task");
+
+			cleanupMessageStorage(sessionID);
+		});
+
+		test("should skip persistence when multiple in-flight task calls claim the same top-level task", async () => {
+			// given
+			const sessionID = "session-parallel-task-collision-test";
+			setupMessageStorage(sessionID, "atlas");
+
+			const planPath = join(TEST_DIR, "parallel-task-collision-plan.md");
+			writeFileSync(
+				planPath,
+				`# Plan
+
+## TODOs
+- [ ] 1. Implement auth flow
+- [ ] 2. Add API validation
+`,
+			);
+
+			writeBoulderState(TEST_DIR, {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "parallel-task-collision-plan",
+			});
+
+			const pendingFilePaths = new Map<string, string>();
+			const pendingTaskRefs = new Map<string, PendingTaskRef>();
+			const beforeHandler = createToolExecuteBeforeHandler({
+				ctx: createMockPluginInput(),
+				pendingFilePaths,
+				pendingTaskRefs,
+			});
+			const afterHandler = createToolExecuteAfterHandler({
+				ctx: createMockPluginInput(),
+				pendingFilePaths,
+				pendingTaskRefs,
+				autoCommit: true,
+				getState: () => ({ promptFailureCount: 0 }),
+			});
+
+			// when - two task() calls start before either one completes
+			await beforeHandler(
+				{ tool: "task", sessionID, callID: "call-task-first" },
+				{ args: { prompt: "Implement auth flow part 1" } },
+			);
+			await beforeHandler(
+				{ tool: "task", sessionID, callID: "call-task-second" },
+				{ args: { prompt: "Implement auth flow part 2" } },
+			);
+
+			const secondPendingTaskRef = pendingTaskRefs.get("call-task-second");
+
+			await afterHandler(
+				{ tool: "task", sessionID, callID: "call-task-second" },
+				{
+					title: "Sisyphus Task",
+					output: `Task completed successfully
 
 <task_metadata>
 session_id: ses_parallel_collision_222
 </task_metadata>`,
-          metadata: {},
-        }
-      )
+					metadata: {},
+				},
+			);
 
-      // then
-      expect(secondPendingTaskRef).toEqual({
-        kind: "skip",
-        reason: "ambiguous_task_key",
-        task: {
-          key: "todo:1",
-          label: "1",
-          title: "Implement auth flow",
-        },
-      })
-      const updatedState = readBoulderState(TEST_DIR)
-      expect(updatedState?.task_sessions?.["todo:1"]).toBeUndefined()
+			// then
+			expect(secondPendingTaskRef).toEqual({
+				kind: "skip",
+				reason: "ambiguous_task_key",
+				task: {
+					key: "todo:1",
+					label: "1",
+					title: "Implement auth flow",
+				},
+			});
+			const updatedState = readBoulderState(TEST_DIR);
+			expect(updatedState?.task_sessions?.["todo:1"]).toBeUndefined();
 
-      cleanupMessageStorage(sessionID)
-    })
+			cleanupMessageStorage(sessionID);
+		});
 
-    test("should ignore extracted session ids that are outside the active boulder lineage", async () => {
-      // given
-      const sessionID = "session-untrusted-session-id-test"
-      setupMessageStorage(sessionID, "atlas")
+		test("should ignore extracted session ids that are outside the active boulder lineage", async () => {
+			// given
+			const sessionID = "session-untrusted-session-id-test";
+			setupMessageStorage(sessionID, "atlas");
 
-      const planPath = join(TEST_DIR, "untrusted-session-id-plan.md")
-      writeFileSync(planPath, `# Plan
+			const planPath = join(TEST_DIR, "untrusted-session-id-plan.md");
+			writeFileSync(
+				planPath,
+				`# Plan
 
 ## TODOs
 - [ ] 1. Implement auth flow
-`)
+`,
+			);
 
-      writeBoulderState(TEST_DIR, {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "untrusted-session-id-plan",
-      })
+			writeBoulderState(TEST_DIR, {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "untrusted-session-id-plan",
+			});
 
-      const hook = createAtlasHook(createMockPluginInput({
-        sessionGetMock: mock(async ({ path }: { path: { id: string } }) => ({
-          data: {
-            id: path.id,
-            parentID: path.id === "ses_untrusted_999" ? "session-outside-lineage" : "main-session-123",
-          },
-        })),
-      }))
-      const output = {
-        title: "Sisyphus Task",
-        output: `Task completed successfully
+			const hook = createAtlasHook(
+				createMockPluginInput({
+					sessionGetMock: mock(async ({ path }: { path: { id: string } }) => ({
+						data: {
+							id: path.id,
+							parentID:
+								path.id === "ses_untrusted_999"
+									? "session-outside-lineage"
+									: "main-session-123",
+						},
+					})),
+				}),
+			);
+			const output = {
+				title: "Sisyphus Task",
+				output: `Task completed successfully
 
 <task_metadata>
 session_id: ses_untrusted_999
 </task_metadata>`,
-        metadata: {},
-      }
-
-      // when
-      await hook["tool.execute.after"](
-        { tool: "task", sessionID },
-        output
-      )
-
-      // then
-      const updatedState = readBoulderState(TEST_DIR)
-      expect(updatedState?.task_sessions?.["todo:1"]).toBeUndefined()
-      expect(output.output).not.toContain('task(session_id="ses_untrusted_999"')
-      expect(output.output).toContain('task(session_id="<session_id>"')
-
-      cleanupMessageStorage(sessionID)
-    })
-
-    describe("completion gate output ordering", () => {
-      const COMPLETION_GATE_SESSION = "completion-gate-order-test"
-
-      beforeEach(() => {
-        setupMessageStorage(COMPLETION_GATE_SESSION, "atlas")
-      })
-
-      afterEach(() => {
-        cleanupMessageStorage(COMPLETION_GATE_SESSION)
-      })
-
-      test("should include completion gate before Subagent Response in transformed boulder output", async () => {
-        // given - Atlas caller with boulder state
-        const planPath = join(TEST_DIR, "test-plan.md")
-        writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2")
-
-        const state: BoulderState = {
-          active_plan: planPath,
-          started_at: "2026-01-02T10:00:00Z",
-          session_ids: ["session-1"],
-          plan_name: "test-plan",
-        }
-        writeBoulderState(TEST_DIR, state)
-
-        const hook = createAtlasHook(createMockPluginInput())
-        const output = {
-          title: "Sisyphus Task",
-          output: "Task completed successfully",
-          metadata: {},
-        }
-
-        // when
-        await hook["tool.execute.after"](
-          { tool: "task", sessionID: COMPLETION_GATE_SESSION },
-          output
-        )
-
-        // then - completion gate should appear BEFORE Subagent Response
-        const subagentResponseIndex = output.output.indexOf("**Subagent Response:**")
-        const completionGateIndex = output.output.indexOf("COMPLETION GATE")
-
-        expect(completionGateIndex).toBeGreaterThanOrEqual(0)
-        expect(subagentResponseIndex).toBeGreaterThanOrEqual(0)
-        expect(completionGateIndex).toBeLessThan(subagentResponseIndex)
-      })
-
-      test("should include completion gate before verification phase text", async () => {
-        // given - Atlas caller with boulder state
-        const planPath = join(TEST_DIR, "test-plan.md")
-        writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2")
-
-        const state: BoulderState = {
-          active_plan: planPath,
-          started_at: "2026-01-02T10:00:00Z",
-          session_ids: ["session-1"],
-          plan_name: "test-plan",
-        }
-        writeBoulderState(TEST_DIR, state)
-
-        const hook = createAtlasHook(createMockPluginInput())
-        const output = {
-          title: "Sisyphus Task",
-          output: "Task completed successfully",
-          metadata: {},
-        }
-
-        // when
-        await hook["tool.execute.after"](
-          { tool: "task", sessionID: COMPLETION_GATE_SESSION },
-          output
-        )
-
-        // then - completion gate should appear BEFORE verification phase text
-        const completionGateIndex = output.output.indexOf("COMPLETION GATE")
-        const lyingIndex = output.output.indexOf("LYING")
-        const phase1Index = output.output.indexOf("PHASE 1")
-
-        expect(completionGateIndex).toBeGreaterThanOrEqual(0)
-        expect(lyingIndex).toBeGreaterThanOrEqual(0)
-        expect(completionGateIndex).toBeLessThan(lyingIndex)
-        if (phase1Index !== -1) {
-          expect(completionGateIndex).toBeLessThan(phase1Index)
-        }
-      })
-
-      test("should not contain old STEP 7 MARK COMPLETION IN PLAN FILE text", async () => {
-        // given - Atlas caller with boulder state
-        const planPath = join(TEST_DIR, "test-plan.md")
-        writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2")
-
-        const state: BoulderState = {
-          active_plan: planPath,
-          started_at: "2026-01-02T10:00:00Z",
-          session_ids: ["session-1"],
-          plan_name: "test-plan",
-        }
-        writeBoulderState(TEST_DIR, state)
-
-        const hook = createAtlasHook(createMockPluginInput())
-        const output = {
-          title: "Sisyphus Task",
-          output: "Task completed successfully",
-          metadata: {},
-        }
-
-        // when
-        await hook["tool.execute.after"](
-          { tool: "task", sessionID: COMPLETION_GATE_SESSION },
-          output
-        )
-
-        // then - old STEP 7 MARK COMPLETION IN PLAN FILE should be absent
-        expect(output.output).not.toContain("STEP 7: MARK COMPLETION IN PLAN FILE")
-        expect(output.output).not.toContain("MARK COMPLETION IN PLAN FILE")
-      })
-    })
-
-    describe("Write/Edit tool direct work reminder", () => {
-      const ORCHESTRATOR_SESSION = "orchestrator-write-test"
-
-       beforeEach(() => {
-         setupMessageStorage(ORCHESTRATOR_SESSION, "atlas")
-       })
-
-      afterEach(() => {
-        cleanupMessageStorage(ORCHESTRATOR_SESSION)
-      })
-
-      test("should append delegation reminder when orchestrator writes outside .sisyphus/", async () => {
-        // given
-        const hook = createAtlasHook(createMockPluginInput())
-        const output = {
-          title: "Write",
-          output: "File written successfully",
-          metadata: { filePath: "/path/to/code.ts" },
-        }
-
-        // when
-        await hook["tool.execute.after"](
-          { tool: "Write", sessionID: ORCHESTRATOR_SESSION },
-          output
-        )
-
-        // then
-        expect(output.output).toContain("ORCHESTRATOR, not an IMPLEMENTER")
-        expect(output.output).toContain("task")
-        expect(output.output).toContain("task")
-      })
-
-      test("should append delegation reminder when orchestrator edits outside .sisyphus/", async () => {
-        // given
-        const hook = createAtlasHook(createMockPluginInput())
-        const output = {
-          title: "Edit",
-          output: "File edited successfully",
-          metadata: { filePath: "/src/components/button.tsx" },
-        }
-
-        // when
-        await hook["tool.execute.after"](
-          { tool: "Edit", sessionID: ORCHESTRATOR_SESSION },
-          output
-        )
-
-        // then
-        expect(output.output).toContain("ORCHESTRATOR, not an IMPLEMENTER")
-      })
-
-      test("should NOT append reminder when orchestrator writes inside .sisyphus/", async () => {
-        // given
-        const hook = createAtlasHook(createMockPluginInput())
-        const originalOutput = "File written successfully"
-        const output = {
-          title: "Write",
-          output: originalOutput,
-          metadata: { filePath: "/project/.sisyphus/plans/work-plan.md" },
-        }
-
-        // when
-        await hook["tool.execute.after"](
-          { tool: "Write", sessionID: ORCHESTRATOR_SESSION },
-          output
-        )
-
-        // then
-        expect(output.output).toBe(originalOutput)
-        expect(output.output).not.toContain("ORCHESTRATOR, not an IMPLEMENTER")
-      })
-
-      test("should NOT append reminder when non-orchestrator writes outside .sisyphus/", async () => {
-        // given
-        const nonOrchestratorSession = "non-orchestrator-session"
-        setupMessageStorage(nonOrchestratorSession, "sisyphus-junior")
-        
-        const hook = createAtlasHook(createMockPluginInput())
-        const originalOutput = "File written successfully"
-        const output = {
-          title: "Write",
-          output: originalOutput,
-          metadata: { filePath: "/path/to/code.ts" },
-        }
-
-        // when
-        await hook["tool.execute.after"](
-          { tool: "Write", sessionID: nonOrchestratorSession },
-          output
-        )
-
-        // then
-        expect(output.output).toBe(originalOutput)
-        expect(output.output).not.toContain("ORCHESTRATOR, not an IMPLEMENTER")
-        
-        cleanupMessageStorage(nonOrchestratorSession)
-      })
-
-      test("should NOT append reminder for read-only tools", async () => {
-        // given
-        const hook = createAtlasHook(createMockPluginInput())
-        const originalOutput = "File content"
-        const output = {
-          title: "Read",
-          output: originalOutput,
-          metadata: { filePath: "/path/to/code.ts" },
-        }
-
-        // when
-        await hook["tool.execute.after"](
-          { tool: "Read", sessionID: ORCHESTRATOR_SESSION },
-          output
-        )
-
-        // then
-        expect(output.output).toBe(originalOutput)
-      })
-
-      test("should handle missing filePath gracefully", async () => {
-        // given
-        const hook = createAtlasHook(createMockPluginInput())
-        const originalOutput = "File written successfully"
-        const output = {
-          title: "Write",
-          output: originalOutput,
-          metadata: {},
-        }
-
-        // when
-        await hook["tool.execute.after"](
-          { tool: "Write", sessionID: ORCHESTRATOR_SESSION },
-          output
-        )
-
-        // then
-        expect(output.output).toBe(originalOutput)
-      })
-
-      describe("cross-platform path validation (Windows support)", () => {
-        test("should NOT append reminder when orchestrator writes inside .sisyphus\\ (Windows backslash)", async () => {
-          // given
-          const hook = createAtlasHook(createMockPluginInput())
-          const originalOutput = "File written successfully"
-          const output = {
-            title: "Write",
-            output: originalOutput,
-            metadata: { filePath: ".sisyphus\\plans\\work-plan.md" },
-          }
-
-          // when
-          await hook["tool.execute.after"](
-            { tool: "Write", sessionID: ORCHESTRATOR_SESSION },
-            output
-          )
-
-          // then
-          expect(output.output).toBe(originalOutput)
-          expect(output.output).not.toContain("ORCHESTRATOR, not an IMPLEMENTER")
-        })
-
-        test("should NOT append reminder when orchestrator writes inside .sisyphus with mixed separators", async () => {
-          // given
-          const hook = createAtlasHook(createMockPluginInput())
-          const originalOutput = "File written successfully"
-          const output = {
-            title: "Write",
-            output: originalOutput,
-            metadata: { filePath: ".sisyphus\\plans/work-plan.md" },
-          }
-
-          // when
-          await hook["tool.execute.after"](
-            { tool: "Write", sessionID: ORCHESTRATOR_SESSION },
-            output
-          )
-
-          // then
-          expect(output.output).toBe(originalOutput)
-          expect(output.output).not.toContain("ORCHESTRATOR, not an IMPLEMENTER")
-        })
-
-        test("should NOT append reminder for absolute Windows path inside .sisyphus\\", async () => {
-          // given
-          const hook = createAtlasHook(createMockPluginInput())
-          const originalOutput = "File written successfully"
-          const output = {
-            title: "Write",
-            output: originalOutput,
-            metadata: { filePath: "C:\\Users\\test\\project\\.sisyphus\\plans\\x.md" },
-          }
-
-          // when
-          await hook["tool.execute.after"](
-            { tool: "Write", sessionID: ORCHESTRATOR_SESSION },
-            output
-          )
-
-          // then
-          expect(output.output).toBe(originalOutput)
-          expect(output.output).not.toContain("ORCHESTRATOR, not an IMPLEMENTER")
-        })
-
-        test("should append reminder for Windows path outside .sisyphus\\", async () => {
-          // given
-          const hook = createAtlasHook(createMockPluginInput())
-          const output = {
-            title: "Write",
-            output: "File written successfully",
-            metadata: { filePath: "C:\\Users\\test\\project\\src\\code.ts" },
-          }
-
-          // when
-          await hook["tool.execute.after"](
-            { tool: "Write", sessionID: ORCHESTRATOR_SESSION },
-            output
-          )
-
-          // then
-          expect(output.output).toContain("ORCHESTRATOR, not an IMPLEMENTER")
-        })
-      })
-    })
-  })
-
-  describe("session.idle handler (boulder continuation)", () => {
-    const MAIN_SESSION_ID = "main-session-123"
-
-    async function flushMicrotasks(): Promise<void> {
-      await Promise.resolve()
-      await Promise.resolve()
-    }
-
-     beforeEach(() => {
-       _resetForTesting()
-       subagentSessions.clear()
-       setupMessageStorage(MAIN_SESSION_ID, "atlas")
-     })
-
-    afterEach(() => {
-      cleanupMessageStorage(MAIN_SESSION_ID)
-      _resetForTesting()
-    })
-
-    test("should inject continuation when boulder has incomplete tasks", async () => {
-      // given - boulder state with incomplete plan
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2\n- [ ] Task 3")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should call prompt with continuation
-      expect(mockInput._promptMock).toHaveBeenCalled()
-      const callArgs = mockInput._promptMock.mock.calls[0][0]
-      expect(callArgs.path.id).toBe(MAIN_SESSION_ID)
-      expect(callArgs.body.parts[0].text).toContain("incomplete tasks")
-      expect(callArgs.body.parts[0].text).toContain("2 remaining")
-    })
-
-    test("should not inject when no boulder state exists", async () => {
-      // given - no boulder state
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should not call prompt
-      expect(mockInput._promptMock).not.toHaveBeenCalled()
-    })
-
-    test("should not inject when main session is not in boulder session_ids", async () => {
-      // given - boulder state exists but current (main) session is NOT in session_ids
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["some-other-session-id"],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when - main session fires idle but is NOT in boulder's session_ids
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should NOT call prompt because session is not part of this boulder
-      expect(mockInput._promptMock).not.toHaveBeenCalled()
-    })
-
-    test("should append subagent session to boulder before injecting continuation", async () => {
-      // given - active boulder plan with another registered session and current session tracked as subagent
-      const subagentSessionID = "subagent-session-456"
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-      subagentSessions.add(subagentSessionID)
-      updateSessionAgent(subagentSessionID, "atlas")
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when - subagent session goes idle before parent task output appends it
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: subagentSessionID },
-        },
-      })
-
-      // then - session is registered into boulder and continuation is injected
-      expect(readBoulderState(TEST_DIR)?.session_ids).toContain(subagentSessionID)
-      expect(mockInput._promptMock).toHaveBeenCalled()
-      const callArgs = mockInput._promptMock.mock.calls[0][0]
-      expect(callArgs.path.id).toBe(subagentSessionID)
-    })
-
-    test("should inject when registered boulder session has incomplete tasks even if last agent differs", async () => {
-      cleanupMessageStorage(MAIN_SESSION_ID)
-      setupMessageStorage(MAIN_SESSION_ID, "hephaestus")
-
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-        agent: "atlas",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      expect(mockInput._promptMock).toHaveBeenCalled()
-      const callArgs = mockInput._promptMock.mock.calls[0][0]
-      expect(callArgs.path.id).toBe(MAIN_SESSION_ID)
-      expect(callArgs.body.parts[0].text).toContain("2 remaining")
-    })
-
-    test("should not inject when boulder plan is complete", async () => {
-      // given - boulder state with complete plan
-      const planPath = join(TEST_DIR, "complete-plan.md")
-      writeFileSync(planPath, "# Plan\n- [x] Task 1\n- [x] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "complete-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should not call prompt
-      expect(mockInput._promptMock).not.toHaveBeenCalled()
-    })
-
-    test("should skip when abort error occurred before idle", async () => {
-      // given - boulder state with incomplete plan
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when - send abort error then idle
-      await hook.handler({
-        event: {
-          type: "session.error",
-          properties: {
-            sessionID: MAIN_SESSION_ID,
-            error: { name: "AbortError", message: "aborted" },
-          },
-        },
-      })
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should not call prompt
-      expect(mockInput._promptMock).not.toHaveBeenCalled()
-    })
-
-     test("should skip when background tasks are running", async () => {
-       // given - boulder state with incomplete plan
-       const planPath = join(TEST_DIR, "test-plan.md")
-       writeFileSync(planPath, "# Plan\n- [ ] Task 1")
-
-       const state: BoulderState = {
-         active_plan: planPath,
-         started_at: "2026-01-02T10:00:00Z",
-         session_ids: [MAIN_SESSION_ID],
-         plan_name: "test-plan",
-       }
-       writeBoulderState(TEST_DIR, state)
-
-       const mockBackgroundManager = {
-         getTasksByParentSession: () => [{ status: "running" }],
-       }
-
-       const mockInput = createMockPluginInput()
-       const hook = createAtlasHook(mockInput, {
-         directory: TEST_DIR,
-         backgroundManager: mockBackgroundManager as any,
-       })
-
-       // when
-       await hook.handler({
-         event: {
-           type: "session.idle",
-           properties: { sessionID: MAIN_SESSION_ID },
-         },
-       })
-
-       // then - should not call prompt
-       expect(mockInput._promptMock).not.toHaveBeenCalled()
-     })
-
-     test("should skip when continuation is stopped via isContinuationStopped", async () => {
-       // given - boulder state with incomplete plan
-       const planPath = join(TEST_DIR, "test-plan.md")
-       writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-       const state: BoulderState = {
-         active_plan: planPath,
-         started_at: "2026-01-02T10:00:00Z",
-         session_ids: [MAIN_SESSION_ID],
-         plan_name: "test-plan",
-       }
-       writeBoulderState(TEST_DIR, state)
-
-       const mockInput = createMockPluginInput()
-       const hook = createAtlasHook(mockInput, {
-         directory: TEST_DIR,
-         isContinuationStopped: (sessionID: string) => sessionID === MAIN_SESSION_ID,
-       })
-
-       // when
-       await hook.handler({
-         event: {
-           type: "session.idle",
-           properties: { sessionID: MAIN_SESSION_ID },
-         },
-       })
-
-       // then - should not call prompt because continuation is stopped
-       expect(mockInput._promptMock).not.toHaveBeenCalled()
-     })
-
-    test("should clear abort state on message.updated", async () => {
-      // given - boulder with incomplete plan
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when - abort error, then message update, then idle
-      await hook.handler({
-        event: {
-          type: "session.error",
-          properties: {
-            sessionID: MAIN_SESSION_ID,
-            error: { name: "AbortError" },
-          },
-        },
-      })
-      await hook.handler({
-        event: {
-          type: "message.updated",
-          properties: { info: { sessionID: MAIN_SESSION_ID, role: "user" } },
-        },
-      })
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should call prompt because abort state was cleared
-      expect(mockInput._promptMock).toHaveBeenCalled()
-    })
-
-    test("should include plan progress in continuation prompt", async () => {
-      // given - boulder state with specific progress
-      const planPath = join(TEST_DIR, "progress-plan.md")
-      writeFileSync(planPath, "# Plan\n- [x] Task 1\n- [x] Task 2\n- [ ] Task 3\n- [ ] Task 4")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "progress-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should include progress
-      const callArgs = mockInput._promptMock.mock.calls[0][0]
-      expect(callArgs.body.parts[0].text).toContain("2/4 completed")
-      expect(callArgs.body.parts[0].text).toContain("2 remaining")
-    })
-
-    test("should include preferred reuse session in continuation prompt for current top-level task", async () => {
-      // given - boulder state with tracked preferred session
-      const planPath = join(TEST_DIR, "preferred-session-plan.md")
-      writeFileSync(planPath, `# Plan
+				metadata: {},
+			};
+
+			// when
+			await hook["tool.execute.after"]({ tool: "task", sessionID }, output);
+
+			// then
+			const updatedState = readBoulderState(TEST_DIR);
+			expect(updatedState?.task_sessions?.["todo:1"]).toBeUndefined();
+			expect(output.output).not.toContain(
+				'task(session_id="ses_untrusted_999"',
+			);
+			expect(output.output).toContain('task(session_id="<session_id>"');
+
+			cleanupMessageStorage(sessionID);
+		});
+
+		describe("completion gate output ordering", () => {
+			const COMPLETION_GATE_SESSION = "completion-gate-order-test";
+
+			beforeEach(() => {
+				setupMessageStorage(COMPLETION_GATE_SESSION, "atlas");
+			});
+
+			afterEach(() => {
+				cleanupMessageStorage(COMPLETION_GATE_SESSION);
+			});
+
+			test("should include completion gate before Subagent Response in transformed boulder output", async () => {
+				// given - Atlas caller with boulder state
+				const planPath = join(TEST_DIR, "test-plan.md");
+				writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2");
+
+				const state: BoulderState = {
+					active_plan: planPath,
+					started_at: "2026-01-02T10:00:00Z",
+					session_ids: ["session-1"],
+					plan_name: "test-plan",
+				};
+				writeBoulderState(TEST_DIR, state);
+
+				const hook = createAtlasHook(createMockPluginInput());
+				const output = {
+					title: "Sisyphus Task",
+					output: "Task completed successfully",
+					metadata: {},
+				};
+
+				// when
+				await hook["tool.execute.after"](
+					{ tool: "task", sessionID: COMPLETION_GATE_SESSION },
+					output,
+				);
+
+				// then - completion gate should appear BEFORE Subagent Response
+				const subagentResponseIndex = output.output.indexOf(
+					"**Subagent Response:**",
+				);
+				const completionGateIndex = output.output.indexOf("COMPLETION GATE");
+
+				expect(completionGateIndex).toBeGreaterThanOrEqual(0);
+				expect(subagentResponseIndex).toBeGreaterThanOrEqual(0);
+				expect(completionGateIndex).toBeLessThan(subagentResponseIndex);
+			});
+
+			test("should include completion gate before verification phase text", async () => {
+				// given - Atlas caller with boulder state
+				const planPath = join(TEST_DIR, "test-plan.md");
+				writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2");
+
+				const state: BoulderState = {
+					active_plan: planPath,
+					started_at: "2026-01-02T10:00:00Z",
+					session_ids: ["session-1"],
+					plan_name: "test-plan",
+				};
+				writeBoulderState(TEST_DIR, state);
+
+				const hook = createAtlasHook(createMockPluginInput());
+				const output = {
+					title: "Sisyphus Task",
+					output: "Task completed successfully",
+					metadata: {},
+				};
+
+				// when
+				await hook["tool.execute.after"](
+					{ tool: "task", sessionID: COMPLETION_GATE_SESSION },
+					output,
+				);
+
+				// then - completion gate should appear BEFORE verification phase text
+				const completionGateIndex = output.output.indexOf("COMPLETION GATE");
+				const lyingIndex = output.output.indexOf("LYING");
+				const phase1Index = output.output.indexOf("PHASE 1");
+
+				expect(completionGateIndex).toBeGreaterThanOrEqual(0);
+				expect(lyingIndex).toBeGreaterThanOrEqual(0);
+				expect(completionGateIndex).toBeLessThan(lyingIndex);
+				if (phase1Index !== -1) {
+					expect(completionGateIndex).toBeLessThan(phase1Index);
+				}
+			});
+
+			test("should not contain old STEP 7 MARK COMPLETION IN PLAN FILE text", async () => {
+				// given - Atlas caller with boulder state
+				const planPath = join(TEST_DIR, "test-plan.md");
+				writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2");
+
+				const state: BoulderState = {
+					active_plan: planPath,
+					started_at: "2026-01-02T10:00:00Z",
+					session_ids: ["session-1"],
+					plan_name: "test-plan",
+				};
+				writeBoulderState(TEST_DIR, state);
+
+				const hook = createAtlasHook(createMockPluginInput());
+				const output = {
+					title: "Sisyphus Task",
+					output: "Task completed successfully",
+					metadata: {},
+				};
+
+				// when
+				await hook["tool.execute.after"](
+					{ tool: "task", sessionID: COMPLETION_GATE_SESSION },
+					output,
+				);
+
+				// then - old STEP 7 MARK COMPLETION IN PLAN FILE should be absent
+				expect(output.output).not.toContain(
+					"STEP 7: MARK COMPLETION IN PLAN FILE",
+				);
+				expect(output.output).not.toContain("MARK COMPLETION IN PLAN FILE");
+			});
+		});
+
+		describe("Write/Edit tool direct work reminder", () => {
+			const ORCHESTRATOR_SESSION = "orchestrator-write-test";
+
+			beforeEach(() => {
+				setupMessageStorage(ORCHESTRATOR_SESSION, "atlas");
+			});
+
+			afterEach(() => {
+				cleanupMessageStorage(ORCHESTRATOR_SESSION);
+			});
+
+			test("should append delegation reminder when orchestrator writes outside .sisyphus/", async () => {
+				// given
+				const hook = createAtlasHook(createMockPluginInput());
+				const output = {
+					title: "Write",
+					output: "File written successfully",
+					metadata: { filePath: "/path/to/code.ts" },
+				};
+
+				// when
+				await hook["tool.execute.after"](
+					{ tool: "Write", sessionID: ORCHESTRATOR_SESSION },
+					output,
+				);
+
+				// then
+				expect(output.output).toContain("ORCHESTRATOR, not an IMPLEMENTER");
+				expect(output.output).toContain("task");
+				expect(output.output).toContain("task");
+			});
+
+			test("should append delegation reminder when orchestrator edits outside .sisyphus/", async () => {
+				// given
+				const hook = createAtlasHook(createMockPluginInput());
+				const output = {
+					title: "Edit",
+					output: "File edited successfully",
+					metadata: { filePath: "/src/components/button.tsx" },
+				};
+
+				// when
+				await hook["tool.execute.after"](
+					{ tool: "Edit", sessionID: ORCHESTRATOR_SESSION },
+					output,
+				);
+
+				// then
+				expect(output.output).toContain("ORCHESTRATOR, not an IMPLEMENTER");
+			});
+
+			test("should NOT append reminder when orchestrator writes inside .sisyphus/", async () => {
+				// given
+				const hook = createAtlasHook(createMockPluginInput());
+				const originalOutput = "File written successfully";
+				const output = {
+					title: "Write",
+					output: originalOutput,
+					metadata: { filePath: "/project/.sisyphus/plans/work-plan.md" },
+				};
+
+				// when
+				await hook["tool.execute.after"](
+					{ tool: "Write", sessionID: ORCHESTRATOR_SESSION },
+					output,
+				);
+
+				// then
+				expect(output.output).toBe(originalOutput);
+				expect(output.output).not.toContain("ORCHESTRATOR, not an IMPLEMENTER");
+			});
+
+			test("should NOT append reminder when non-orchestrator writes outside .sisyphus/", async () => {
+				// given
+				const nonOrchestratorSession = "non-orchestrator-session";
+				setupMessageStorage(nonOrchestratorSession, "sisyphus-junior");
+
+				const hook = createAtlasHook(createMockPluginInput());
+				const originalOutput = "File written successfully";
+				const output = {
+					title: "Write",
+					output: originalOutput,
+					metadata: { filePath: "/path/to/code.ts" },
+				};
+
+				// when
+				await hook["tool.execute.after"](
+					{ tool: "Write", sessionID: nonOrchestratorSession },
+					output,
+				);
+
+				// then
+				expect(output.output).toBe(originalOutput);
+				expect(output.output).not.toContain("ORCHESTRATOR, not an IMPLEMENTER");
+
+				cleanupMessageStorage(nonOrchestratorSession);
+			});
+
+			test("should NOT append reminder for read-only tools", async () => {
+				// given
+				const hook = createAtlasHook(createMockPluginInput());
+				const originalOutput = "File content";
+				const output = {
+					title: "Read",
+					output: originalOutput,
+					metadata: { filePath: "/path/to/code.ts" },
+				};
+
+				// when
+				await hook["tool.execute.after"](
+					{ tool: "Read", sessionID: ORCHESTRATOR_SESSION },
+					output,
+				);
+
+				// then
+				expect(output.output).toBe(originalOutput);
+			});
+
+			test("should handle missing filePath gracefully", async () => {
+				// given
+				const hook = createAtlasHook(createMockPluginInput());
+				const originalOutput = "File written successfully";
+				const output = {
+					title: "Write",
+					output: originalOutput,
+					metadata: {},
+				};
+
+				// when
+				await hook["tool.execute.after"](
+					{ tool: "Write", sessionID: ORCHESTRATOR_SESSION },
+					output,
+				);
+
+				// then
+				expect(output.output).toBe(originalOutput);
+			});
+
+			describe("cross-platform path validation (Windows support)", () => {
+				test("should NOT append reminder when orchestrator writes inside .sisyphus\\ (Windows backslash)", async () => {
+					// given
+					const hook = createAtlasHook(createMockPluginInput());
+					const originalOutput = "File written successfully";
+					const output = {
+						title: "Write",
+						output: originalOutput,
+						metadata: { filePath: ".sisyphus\\plans\\work-plan.md" },
+					};
+
+					// when
+					await hook["tool.execute.after"](
+						{ tool: "Write", sessionID: ORCHESTRATOR_SESSION },
+						output,
+					);
+
+					// then
+					expect(output.output).toBe(originalOutput);
+					expect(output.output).not.toContain(
+						"ORCHESTRATOR, not an IMPLEMENTER",
+					);
+				});
+
+				test("should NOT append reminder when orchestrator writes inside .sisyphus with mixed separators", async () => {
+					// given
+					const hook = createAtlasHook(createMockPluginInput());
+					const originalOutput = "File written successfully";
+					const output = {
+						title: "Write",
+						output: originalOutput,
+						metadata: { filePath: ".sisyphus\\plans/work-plan.md" },
+					};
+
+					// when
+					await hook["tool.execute.after"](
+						{ tool: "Write", sessionID: ORCHESTRATOR_SESSION },
+						output,
+					);
+
+					// then
+					expect(output.output).toBe(originalOutput);
+					expect(output.output).not.toContain(
+						"ORCHESTRATOR, not an IMPLEMENTER",
+					);
+				});
+
+				test("should NOT append reminder for absolute Windows path inside .sisyphus\\", async () => {
+					// given
+					const hook = createAtlasHook(createMockPluginInput());
+					const originalOutput = "File written successfully";
+					const output = {
+						title: "Write",
+						output: originalOutput,
+						metadata: {
+							filePath: "C:\\Users\\test\\project\\.sisyphus\\plans\\x.md",
+						},
+					};
+
+					// when
+					await hook["tool.execute.after"](
+						{ tool: "Write", sessionID: ORCHESTRATOR_SESSION },
+						output,
+					);
+
+					// then
+					expect(output.output).toBe(originalOutput);
+					expect(output.output).not.toContain(
+						"ORCHESTRATOR, not an IMPLEMENTER",
+					);
+				});
+
+				test("should append reminder for Windows path outside .sisyphus\\", async () => {
+					// given
+					const hook = createAtlasHook(createMockPluginInput());
+					const output = {
+						title: "Write",
+						output: "File written successfully",
+						metadata: { filePath: "C:\\Users\\test\\project\\src\\code.ts" },
+					};
+
+					// when
+					await hook["tool.execute.after"](
+						{ tool: "Write", sessionID: ORCHESTRATOR_SESSION },
+						output,
+					);
+
+					// then
+					expect(output.output).toContain("ORCHESTRATOR, not an IMPLEMENTER");
+				});
+			});
+		});
+	});
+
+	describe("session.idle handler (boulder continuation)", () => {
+		const MAIN_SESSION_ID = "main-session-123";
+
+		async function flushMicrotasks(): Promise<void> {
+			await Promise.resolve();
+			await Promise.resolve();
+		}
+
+		beforeEach(() => {
+			_resetForTesting();
+			subagentSessions.clear();
+			setupMessageStorage(MAIN_SESSION_ID, "atlas");
+		});
+
+		afterEach(() => {
+			cleanupMessageStorage(MAIN_SESSION_ID);
+			_resetForTesting();
+		});
+
+		test("should inject continuation when boulder has incomplete tasks", async () => {
+			// given - boulder state with incomplete plan
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(
+				planPath,
+				"# Plan\n- [ ] Task 1\n- [x] Task 2\n- [ ] Task 3",
+			);
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should call prompt with continuation
+			expect(mockInput._promptMock).toHaveBeenCalled();
+			const callArgs = mockInput._promptMock.mock.calls[0][0];
+			expect(callArgs.path.id).toBe(MAIN_SESSION_ID);
+			expect(callArgs.body.parts[0].text).toContain("incomplete tasks");
+			expect(callArgs.body.parts[0].text).toContain("2 remaining");
+		});
+
+		test("should not inject when no boulder state exists", async () => {
+			// given - no boulder state
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should not call prompt
+			expect(mockInput._promptMock).not.toHaveBeenCalled();
+		});
+
+		test("should not inject when main session is not in boulder session_ids", async () => {
+			// given - boulder state exists but current (main) session is NOT in session_ids
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["some-other-session-id"],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when - main session fires idle but is NOT in boulder's session_ids
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should NOT call prompt because session is not part of this boulder
+			expect(mockInput._promptMock).not.toHaveBeenCalled();
+		});
+
+		test("should append subagent session to boulder before injecting continuation", async () => {
+			// given - active boulder plan with another registered session and current session tracked as subagent
+			const subagentSessionID = "subagent-session-456";
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+			subagentSessions.add(subagentSessionID);
+			updateSessionAgent(subagentSessionID, "atlas");
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when - subagent session goes idle before parent task output appends it
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: subagentSessionID },
+				},
+			});
+
+			// then - session is registered into boulder and continuation is injected
+			expect(readBoulderState(TEST_DIR)?.session_ids).toContain(
+				subagentSessionID,
+			);
+			expect(mockInput._promptMock).toHaveBeenCalled();
+			const callArgs = mockInput._promptMock.mock.calls[0][0];
+			expect(callArgs.path.id).toBe(subagentSessionID);
+		});
+
+		test("should inject when registered boulder session has incomplete tasks even if last agent differs", async () => {
+			cleanupMessageStorage(MAIN_SESSION_ID);
+			setupMessageStorage(MAIN_SESSION_ID, "hephaestus");
+
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+				agent: "atlas",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			expect(mockInput._promptMock).toHaveBeenCalled();
+			const callArgs = mockInput._promptMock.mock.calls[0][0];
+			expect(callArgs.path.id).toBe(MAIN_SESSION_ID);
+			expect(callArgs.body.parts[0].text).toContain("2 remaining");
+		});
+
+		test("should not inject when boulder plan is complete", async () => {
+			// given - boulder state with complete plan
+			const planPath = join(TEST_DIR, "complete-plan.md");
+			writeFileSync(planPath, "# Plan\n- [x] Task 1\n- [x] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "complete-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should not call prompt
+			expect(mockInput._promptMock).not.toHaveBeenCalled();
+		});
+
+		test("should skip when abort error occurred before idle", async () => {
+			// given - boulder state with incomplete plan
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when - send abort error then idle
+			await hook.handler({
+				event: {
+					type: "session.error",
+					properties: {
+						sessionID: MAIN_SESSION_ID,
+						error: { name: "AbortError", message: "aborted" },
+					},
+				},
+			});
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should not call prompt
+			expect(mockInput._promptMock).not.toHaveBeenCalled();
+		});
+
+		test("should skip when background tasks are running", async () => {
+			// given - boulder state with incomplete plan
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockBackgroundManager = {
+				getTasksByParentSession: () => [{ status: "running" }],
+			};
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput, {
+				directory: TEST_DIR,
+				backgroundManager: mockBackgroundManager as any,
+			});
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should not call prompt
+			expect(mockInput._promptMock).not.toHaveBeenCalled();
+		});
+
+		test("should skip when continuation is stopped via isContinuationStopped", async () => {
+			// given - boulder state with incomplete plan
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput, {
+				directory: TEST_DIR,
+				isContinuationStopped: (sessionID: string) =>
+					sessionID === MAIN_SESSION_ID,
+			});
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should not call prompt because continuation is stopped
+			expect(mockInput._promptMock).not.toHaveBeenCalled();
+		});
+
+		test("should clear abort state on message.updated", async () => {
+			// given - boulder with incomplete plan
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when - abort error, then message update, then idle
+			await hook.handler({
+				event: {
+					type: "session.error",
+					properties: {
+						sessionID: MAIN_SESSION_ID,
+						error: { name: "AbortError" },
+					},
+				},
+			});
+			await hook.handler({
+				event: {
+					type: "message.updated",
+					properties: { info: { sessionID: MAIN_SESSION_ID, role: "user" } },
+				},
+			});
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should call prompt because abort state was cleared
+			expect(mockInput._promptMock).toHaveBeenCalled();
+		});
+
+		test("should include plan progress in continuation prompt", async () => {
+			// given - boulder state with specific progress
+			const planPath = join(TEST_DIR, "progress-plan.md");
+			writeFileSync(
+				planPath,
+				"# Plan\n- [x] Task 1\n- [x] Task 2\n- [ ] Task 3\n- [ ] Task 4",
+			);
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "progress-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should include progress
+			const callArgs = mockInput._promptMock.mock.calls[0][0];
+			expect(callArgs.body.parts[0].text).toContain("2/4 completed");
+			expect(callArgs.body.parts[0].text).toContain("2 remaining");
+		});
+
+		test("should include preferred reuse session in continuation prompt for current top-level task", async () => {
+			// given - boulder state with tracked preferred session
+			const planPath = join(TEST_DIR, "preferred-session-plan.md");
+			writeFileSync(
+				planPath,
+				`# Plan
 
 ## TODOs
 - [ ] 1. Implement auth flow
-`)
-
-      writeBoulderState(TEST_DIR, {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "preferred-session-plan",
-        task_sessions: {
-          "todo:1": {
-            task_key: "todo:1",
-            task_label: "1",
-            task_title: "Implement auth flow",
-            session_id: "ses_auth_flow_123",
-            updated_at: "2026-01-02T10:00:00Z",
-          },
-        },
-      })
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then
-      const callArgs = mockInput._promptMock.mock.calls[0][0]
-      expect(callArgs.body.parts[0].text).toContain("Preferred reuse session for current top-level plan task")
-      expect(callArgs.body.parts[0].text).toContain("ses_auth_flow_123")
-    })
-
-    test("should inject when last agent is sisyphus and boulder targets atlas explicitly", async () => {
-       // given - boulder explicitly set to atlas, but last agent is sisyphus (initial state after /start-work)
-       const planPath = join(TEST_DIR, "test-plan.md")
-       writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-       const state: BoulderState = {
-         active_plan: planPath,
-         started_at: "2026-01-02T10:00:00Z",
-         session_ids: [MAIN_SESSION_ID],
-         plan_name: "test-plan",
-         agent: "atlas",
-       }
-       writeBoulderState(TEST_DIR, state)
-
-       // given - last agent is sisyphus (typical state right after /start-work)
-       cleanupMessageStorage(MAIN_SESSION_ID)
-       setupMessageStorage(MAIN_SESSION_ID, "sisyphus")
-
-       const mockInput = createMockPluginInput()
-       const hook = createAtlasHook(mockInput)
-
-       // when
-       await hook.handler({
-         event: {
-           type: "session.idle",
-           properties: { sessionID: MAIN_SESSION_ID },
-         },
-       })
-
-       // then - should call prompt because sisyphus is always allowed for atlas boulders
-       expect(mockInput._promptMock).toHaveBeenCalled()
-     })
-
-    test("should inject when registered atlas boulder session last agent does not match", async () => {
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-       const state: BoulderState = {
-         active_plan: planPath,
-         started_at: "2026-01-02T10:00:00Z",
-         session_ids: [MAIN_SESSION_ID],
-         plan_name: "test-plan",
-         agent: "atlas",
-       }
-       writeBoulderState(TEST_DIR, state)
-
-       cleanupMessageStorage(MAIN_SESSION_ID)
-       setupMessageStorage(MAIN_SESSION_ID, "hephaestus")
-
-       const mockInput = createMockPluginInput()
-       const hook = createAtlasHook(mockInput)
-
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      expect(mockInput._promptMock).toHaveBeenCalled()
-    })
-
-     test("should inject when last agent matches boulder agent even if non-Atlas", async () => {
-       // given - boulder state expects sisyphus and last agent is sisyphus
-       const planPath = join(TEST_DIR, "test-plan.md")
-       writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-       const state: BoulderState = {
-         active_plan: planPath,
-         started_at: "2026-01-02T10:00:00Z",
-         session_ids: [MAIN_SESSION_ID],
-         plan_name: "test-plan",
-         agent: "sisyphus",
-       }
-       writeBoulderState(TEST_DIR, state)
-
-       cleanupMessageStorage(MAIN_SESSION_ID)
-       setupMessageStorage(MAIN_SESSION_ID, "sisyphus")
-
-       const mockInput = createMockPluginInput()
-       const hook = createAtlasHook(mockInput)
-
-       // when
-       await hook.handler({
-         event: {
-           type: "session.idle",
-           properties: { sessionID: MAIN_SESSION_ID },
-         },
-       })
-
-       // then - should call prompt for sisyphus
-       expect(mockInput._promptMock).toHaveBeenCalled()
-       const callArgs = mockInput._promptMock.mock.calls[0][0]
-       expect(callArgs.body.agent).toBe("sisyphus")
-     })
-
-    test("should debounce rapid continuation injections (prevent infinite loop)", async () => {
-      // given - boulder state with incomplete plan
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when - fire multiple idle events in rapid succession (simulating infinite loop bug)
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should only call prompt ONCE due to debouncing
-      expect(mockInput._promptMock).toHaveBeenCalledTimes(1)
-    })
-
-    test("should stop continuation after 10 consecutive prompt failures (issue #1355)", async () => {
-      //#given - boulder state with incomplete plan and prompt always fails
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const promptMock = mock((): Promise<void> => Promise.reject(new Error("Bad Request")))
-      const mockInput = createMockPluginInput({ promptMock })
-      const hook = createAtlasHook(mockInput)
-
-      const originalDateNow = Date.now
-      let now = 0
-      Date.now = () => now
-
-      try {
-        //#when - idle fires repeatedly, past cooldown each time
-        for (let i = 0; i < 10; i++) {
-          await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-          await flushMicrotasks()
-          now += 6000
-        }
-
-        await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-        await flushMicrotasks()
-
-        //#then - should attempt only 10 times, then disable continuation
-        expect(promptMock).toHaveBeenCalledTimes(10)
-      } finally {
-        Date.now = originalDateNow
-      }
-    })
-
-    test("should reset prompt failure counter on success and only stop after 10 consecutive failures", async () => {
-      //#given - boulder state with incomplete plan
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const promptMock = mock((): Promise<void> => Promise.reject(new Error("Bad Request")))
-      promptMock.mockImplementationOnce(() => Promise.reject(new Error("Bad Request")))
-      promptMock.mockImplementationOnce(() => Promise.resolve())
-
-      const mockInput = createMockPluginInput({ promptMock })
-      const hook = createAtlasHook(mockInput)
-
-      const originalDateNow = Date.now
-      let now = 0
-      Date.now = () => now
-
-      try {
-        //#when - fail, succeed (reset), then fail 10 times (disable), then attempt again
-        for (let i = 0; i < 13; i++) {
-          await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-          await flushMicrotasks()
-          now += 6000
-        }
-
-        //#then - 12 prompt attempts; 13th idle is skipped after 10 consecutive failures
-        expect(promptMock).toHaveBeenCalledTimes(12)
-      } finally {
-        Date.now = originalDateNow
-      }
-    })
-
-    test("should keep skipping continuation during 5-minute backoff after 10 consecutive failures", async () => {
-      //#given - boulder state with incomplete plan and prompt always fails
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const promptMock = mock(() => Promise.reject(new Error("Bad Request")))
-      const mockInput = createMockPluginInput({ promptMock })
-      const hook = createAtlasHook(mockInput)
-
-      const originalDateNow = Date.now
-      let now = 0
-      Date.now = () => now
-
-      try {
-        //#when - 11th idle occurs inside 5-minute backoff window
-        for (let i = 0; i < 10; i++) {
-          await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-          await flushMicrotasks()
-          now += 6000
-        }
-
-        now += 60000
-
-        await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-        await flushMicrotasks()
-
-        //#then - 11th attempt should still be skipped
-        expect(promptMock).toHaveBeenCalledTimes(10)
-      } finally {
-        Date.now = originalDateNow
-      }
-    })
-
-    test("should retry continuation after 5-minute backoff expires following 10 consecutive failures", async () => {
-      //#given - boulder state with incomplete plan and prompt always fails
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const promptMock = mock(() => Promise.reject(new Error("Bad Request")))
-      const mockInput = createMockPluginInput({ promptMock })
-      const hook = createAtlasHook(mockInput)
-
-      const originalDateNow = Date.now
-      let now = 0
-      Date.now = () => now
-
-      try {
-        //#when - 11th idle occurs after 5+ minutes
-        for (let i = 0; i < 10; i++) {
-          await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-          await flushMicrotasks()
-          now += 6000
-        }
-
-        now += 300000
-
-        await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-        await flushMicrotasks()
-
-        //#then - 11th attempt should run after backoff expiration
-        expect(promptMock).toHaveBeenCalledTimes(11)
-      } finally {
-        Date.now = originalDateNow
-      }
-    })
-
-    test("should reset prompt failure counter after successful retry beyond backoff window", async () => {
-      //#given - boulder state with incomplete plan and success on first retry after backoff
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const promptMock = mock((): Promise<void> => Promise.reject(new Error("Bad Request")))
-      for (let i = 0; i < 10; i++) {
-        promptMock.mockImplementationOnce(() => Promise.reject(new Error("Bad Request")))
-      }
-      promptMock.mockImplementationOnce(() => Promise.resolve(undefined))
-      const mockInput = createMockPluginInput({ promptMock })
-      const hook = createAtlasHook(mockInput)
-
-      const originalDateNow = Date.now
-      let now = 0
-      Date.now = () => now
-
-      try {
-        //#when - fail 10 times, recover after backoff with success, then fail 10 times again
-        for (let i = 0; i < 10; i++) {
-          await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-          await flushMicrotasks()
-          now += 6000
-        }
-
-        now += 300000
-
-        await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-        await flushMicrotasks()
-        now += 6000
-
-        for (let i = 0; i < 10; i++) {
-          await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-          await flushMicrotasks()
-          now += 6000
-        }
-
-        await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-        await flushMicrotasks()
-
-        //#then - success retry resets counter, so 10 additional failures are allowed before skip
-        expect(promptMock).toHaveBeenCalledTimes(21)
-      } finally {
-        Date.now = originalDateNow
-      }
-    })
-
-    test("should reset continuation failure state on session.compacted event", async () => {
-      //#given - boulder state with incomplete plan and prompt always fails
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const promptMock = mock(() => Promise.reject(new Error("Bad Request")))
-      const mockInput = createMockPluginInput({ promptMock })
-      const hook = createAtlasHook(mockInput)
-
-      const originalDateNow = Date.now
-      let now = 0
-      Date.now = () => now
-
-      try {
-        //#when - 10 failures disable continuation, then compaction resets it
-        for (let i = 0; i < 10; i++) {
-          await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-          await flushMicrotasks()
-          now += 6000
-        }
-
-        await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-        await flushMicrotasks()
-
-        await hook.handler({ event: { type: "session.compacted", properties: { sessionID: MAIN_SESSION_ID } } })
-        now += 6000
-
-        await hook.handler({ event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } } })
-        await flushMicrotasks()
-
-        //#then - 10 attempts + 1 after compaction (11 total)
-        expect(promptMock).toHaveBeenCalledTimes(11)
-      } finally {
-        Date.now = originalDateNow
-      }
-    })
-
-    test("should cleanup on session.deleted", async () => {
-      // given - boulder state
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when - create abort state then delete
-      await hook.handler({
-        event: {
-          type: "session.error",
-          properties: {
-            sessionID: MAIN_SESSION_ID,
-            error: { name: "AbortError" },
-          },
-        },
-      })
-      await hook.handler({
-        event: {
-          type: "session.deleted",
-          properties: { info: { id: MAIN_SESSION_ID } },
-        },
-      })
-
-      // Re-create boulder after deletion
-      writeBoulderState(TEST_DIR, state)
-
-      // Trigger idle - should inject because state was cleaned up
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should call prompt because session state was cleaned
-      expect(mockInput._promptMock).toHaveBeenCalled()
-    })
-
-    test("should inject when session agent was updated to atlas by start-work even if message storage agent differs", async () => {
-      // given - boulder targets atlas, but nearest stored message still says hephaestus
-      const planPath = join(TEST_DIR, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: [MAIN_SESSION_ID],
-        plan_name: "test-plan",
-        agent: "atlas",
-      }
-      writeBoulderState(TEST_DIR, state)
-
-      cleanupMessageStorage(MAIN_SESSION_ID)
-      setupMessageStorage(MAIN_SESSION_ID, "hephaestus")
-      updateSessionAgent(MAIN_SESSION_ID, "atlas")
-
-      const mockInput = createMockPluginInput()
-      const hook = createAtlasHook(mockInput)
-
-      // when
-      await hook.handler({
-        event: {
-          type: "session.idle",
-          properties: { sessionID: MAIN_SESSION_ID },
-        },
-      })
-
-      // then - should continue because start-work updated session agent to atlas
-      expect(mockInput._promptMock).toHaveBeenCalled()
-    })
-
-    describe("delayed retry timer (abort-stuck fix)", () => {
-      const capturedTimers = new Map<number, { callback: Function; cleared: boolean }>()
-      let nextFakeId = 99000
-      const originalSetTimeout = globalThis.setTimeout
-      const originalClearTimeout = globalThis.clearTimeout
-
-      beforeEach(() => {
-        capturedTimers.clear()
-        nextFakeId = 99000
-
-        globalThis.setTimeout = ((callback: Function, delay?: number, ...args: unknown[]) => {
-          const normalized = typeof delay === "number" ? delay : 0
-          if (normalized >= 5000) {
-            const id = nextFakeId++
-            capturedTimers.set(id, { callback: () => callback(...args), cleared: false })
-            return id as unknown as ReturnType<typeof setTimeout>
-          }
-          return originalSetTimeout(callback as Parameters<typeof originalSetTimeout>[0], delay)
-        }) as unknown as typeof setTimeout
-
-        globalThis.clearTimeout = ((id?: number | ReturnType<typeof setTimeout>) => {
-          if (typeof id === "number" && capturedTimers.has(id)) {
-            capturedTimers.get(id)!.cleared = true
-            capturedTimers.delete(id)
-            return
-          }
-          originalClearTimeout(id as Parameters<typeof originalClearTimeout>[0])
-        }) as unknown as typeof clearTimeout
-      })
-
-      afterEach(() => {
-        globalThis.setTimeout = originalSetTimeout
-        globalThis.clearTimeout = originalClearTimeout
-      })
-
-      async function firePendingTimers(): Promise<void> {
-        for (const [id, entry] of capturedTimers) {
-          if (!entry.cleared) {
-            capturedTimers.delete(id)
-            await entry.callback()
-          }
-        }
-        await flushMicrotasks()
-      }
-
-      test("should schedule delayed retry when cooldown blocks idle for incomplete boulder", async () => {
-        // given - boulder with incomplete plan
-        const planPath = join(TEST_DIR, "test-plan.md")
-        writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2")
-
-        const state: BoulderState = {
-          active_plan: planPath,
-          started_at: "2026-01-02T10:00:00Z",
-          session_ids: [MAIN_SESSION_ID],
-          plan_name: "test-plan",
-        }
-        writeBoulderState(TEST_DIR, state)
-
-        const mockInput = createMockPluginInput()
-        const hook = createAtlasHook(mockInput)
-
-        // when - first idle injects, second idle within cooldown schedules retry timer
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-
-        // then - fire pending timer and verify retry
-        await firePendingTimers()
-        expect(mockInput._promptMock).toHaveBeenCalledTimes(2)
-      })
-
-      test("should not schedule duplicate retry timers for rapid idle events", async () => {
-        // given - boulder with incomplete plan
-        const planPath = join(TEST_DIR, "test-plan.md")
-        writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2")
-
-        const state: BoulderState = {
-          active_plan: planPath,
-          started_at: "2026-01-02T10:00:00Z",
-          session_ids: [MAIN_SESSION_ID],
-          plan_name: "test-plan",
-        }
-        writeBoulderState(TEST_DIR, state)
-
-        const mockInput = createMockPluginInput()
-        const hook = createAtlasHook(mockInput)
-
-        // when - first idle injects, then 3 rapid idles within cooldown
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-
-        // then - only one retry fires despite multiple cooldown-blocked idles
-        await firePendingTimers()
-        expect(mockInput._promptMock).toHaveBeenCalledTimes(2)
-      })
-
-      test("should not retry if plan completes before timer fires", async () => {
-        // given - boulder with incomplete plan
-        const planPath = join(TEST_DIR, "test-plan.md")
-        writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2")
-
-        const state: BoulderState = {
-          active_plan: planPath,
-          started_at: "2026-01-02T10:00:00Z",
-          session_ids: [MAIN_SESSION_ID],
-          plan_name: "test-plan",
-        }
-        writeBoulderState(TEST_DIR, state)
-
-        const mockInput = createMockPluginInput()
-        const hook = createAtlasHook(mockInput)
-
-        // when - first idle injects, second schedules retry, then plan completes before timer fires
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-
-        writeFileSync(planPath, "# Plan\n- [x] Task 1\n- [x] Task 2")
-
-        // then - retry sees complete plan and bails out
-        await firePendingTimers()
-        expect(mockInput._promptMock).toHaveBeenCalledTimes(1)
-      })
-
-      test("should cleanup pending retry timer on session.deleted", async () => {
-        // given - boulder with incomplete plan, schedule retry timer
-        const planPath = join(TEST_DIR, "test-plan.md")
-        writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2")
-
-        const state: BoulderState = {
-          active_plan: planPath,
-          started_at: "2026-01-02T10:00:00Z",
-          session_ids: [MAIN_SESSION_ID],
-          plan_name: "test-plan",
-        }
-        writeBoulderState(TEST_DIR, state)
-
-        const mockInput = createMockPluginInput()
-        const hook = createAtlasHook(mockInput)
-
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-
-        // when - delete session before timer fires
-        await hook.handler({
-          event: { type: "session.deleted", properties: { info: { id: MAIN_SESSION_ID } } },
-        })
-
-        // then - timer was cleared, prompt called only once
-        await firePendingTimers()
-        expect(mockInput._promptMock).toHaveBeenCalledTimes(1)
-      })
-
-      test("should cleanup pending retry timer on session.compacted", async () => {
-        // given - boulder with incomplete plan, schedule retry timer
-        const planPath = join(TEST_DIR, "test-plan.md")
-        writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2")
-
-        const state: BoulderState = {
-          active_plan: planPath,
-          started_at: "2026-01-02T10:00:00Z",
-          session_ids: [MAIN_SESSION_ID],
-          plan_name: "test-plan",
-        }
-        writeBoulderState(TEST_DIR, state)
-
-        const mockInput = createMockPluginInput()
-        const hook = createAtlasHook(mockInput)
-
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-        await hook.handler({
-          event: { type: "session.idle", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-
-        // when - compact session before timer fires
-        await hook.handler({
-          event: { type: "session.compacted", properties: { sessionID: MAIN_SESSION_ID } },
-        })
-
-        // then - timer was cleared, prompt called only once
-        await firePendingTimers()
-        expect(mockInput._promptMock).toHaveBeenCalledTimes(1)
-      })
-    })
-  })
-})
+`,
+			);
+
+			writeBoulderState(TEST_DIR, {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "preferred-session-plan",
+				task_sessions: {
+					"todo:1": {
+						task_key: "todo:1",
+						task_label: "1",
+						task_title: "Implement auth flow",
+						session_id: "ses_auth_flow_123",
+						updated_at: "2026-01-02T10:00:00Z",
+					},
+				},
+			});
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then
+			const callArgs = mockInput._promptMock.mock.calls[0][0];
+			expect(callArgs.body.parts[0].text).toContain(
+				"Preferred reuse session for current top-level plan task",
+			);
+			expect(callArgs.body.parts[0].text).toContain("ses_auth_flow_123");
+		});
+
+		test("should inject when last agent is sisyphus and boulder targets atlas explicitly", async () => {
+			// given - boulder explicitly set to atlas, but last agent is sisyphus (initial state after /start-work)
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+				agent: "atlas",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			// given - last agent is sisyphus (typical state right after /start-work)
+			cleanupMessageStorage(MAIN_SESSION_ID);
+			setupMessageStorage(MAIN_SESSION_ID, "sisyphus");
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should call prompt because sisyphus is always allowed for atlas boulders
+			expect(mockInput._promptMock).toHaveBeenCalled();
+		});
+
+		test("should inject when registered atlas boulder session last agent does not match", async () => {
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+				agent: "atlas",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			cleanupMessageStorage(MAIN_SESSION_ID);
+			setupMessageStorage(MAIN_SESSION_ID, "hephaestus");
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			expect(mockInput._promptMock).toHaveBeenCalled();
+		});
+
+		test("should inject when last agent matches boulder agent even if non-Atlas", async () => {
+			// given - boulder state expects sisyphus and last agent is sisyphus
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+				agent: "sisyphus",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			cleanupMessageStorage(MAIN_SESSION_ID);
+			setupMessageStorage(MAIN_SESSION_ID, "sisyphus");
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should call prompt for sisyphus
+			expect(mockInput._promptMock).toHaveBeenCalled();
+			const callArgs = mockInput._promptMock.mock.calls[0][0];
+			expect(callArgs.body.agent).toBe(getAgentDisplayName("sisyphus"));
+		});
+
+		test("should debounce rapid continuation injections (prevent infinite loop)", async () => {
+			// given - boulder state with incomplete plan
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when - fire multiple idle events in rapid succession (simulating infinite loop bug)
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should only call prompt ONCE due to debouncing
+			expect(mockInput._promptMock).toHaveBeenCalledTimes(1);
+		});
+
+		test("should stop continuation after 10 consecutive prompt failures (issue #1355)", async () => {
+			//#given - boulder state with incomplete plan and prompt always fails
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const promptMock = mock(
+				(): Promise<void> => Promise.reject(new Error("Bad Request")),
+			);
+			const mockInput = createMockPluginInput({ promptMock });
+			const hook = createAtlasHook(mockInput);
+
+			const originalDateNow = Date.now;
+			let now = 0;
+			Date.now = () => now;
+
+			try {
+				//#when - idle fires repeatedly, past cooldown each time
+				for (let i = 0; i < 10; i++) {
+					await hook.handler({
+						event: {
+							type: "session.idle",
+							properties: { sessionID: MAIN_SESSION_ID },
+						},
+					});
+					await flushMicrotasks();
+					now += 6000;
+				}
+
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await flushMicrotasks();
+
+				//#then - should attempt only 10 times, then disable continuation
+				expect(promptMock).toHaveBeenCalledTimes(10);
+			} finally {
+				Date.now = originalDateNow;
+			}
+		});
+
+		test("should reset prompt failure counter on success and only stop after 10 consecutive failures", async () => {
+			//#given - boulder state with incomplete plan
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const promptMock = mock(
+				(): Promise<void> => Promise.reject(new Error("Bad Request")),
+			);
+			promptMock.mockImplementationOnce(() =>
+				Promise.reject(new Error("Bad Request")),
+			);
+			promptMock.mockImplementationOnce(() => Promise.resolve());
+
+			const mockInput = createMockPluginInput({ promptMock });
+			const hook = createAtlasHook(mockInput);
+
+			const originalDateNow = Date.now;
+			let now = 0;
+			Date.now = () => now;
+
+			try {
+				//#when - fail, succeed (reset), then fail 10 times (disable), then attempt again
+				for (let i = 0; i < 13; i++) {
+					await hook.handler({
+						event: {
+							type: "session.idle",
+							properties: { sessionID: MAIN_SESSION_ID },
+						},
+					});
+					await flushMicrotasks();
+					now += 6000;
+				}
+
+				//#then - 12 prompt attempts; 13th idle is skipped after 10 consecutive failures
+				expect(promptMock).toHaveBeenCalledTimes(12);
+			} finally {
+				Date.now = originalDateNow;
+			}
+		});
+
+		test("should keep skipping continuation during 5-minute backoff after 10 consecutive failures", async () => {
+			//#given - boulder state with incomplete plan and prompt always fails
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const promptMock = mock(() => Promise.reject(new Error("Bad Request")));
+			const mockInput = createMockPluginInput({ promptMock });
+			const hook = createAtlasHook(mockInput);
+
+			const originalDateNow = Date.now;
+			let now = 0;
+			Date.now = () => now;
+
+			try {
+				//#when - 11th idle occurs inside 5-minute backoff window
+				for (let i = 0; i < 10; i++) {
+					await hook.handler({
+						event: {
+							type: "session.idle",
+							properties: { sessionID: MAIN_SESSION_ID },
+						},
+					});
+					await flushMicrotasks();
+					now += 6000;
+				}
+
+				now += 60000;
+
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await flushMicrotasks();
+
+				//#then - 11th attempt should still be skipped
+				expect(promptMock).toHaveBeenCalledTimes(10);
+			} finally {
+				Date.now = originalDateNow;
+			}
+		});
+
+		test("should retry continuation after 5-minute backoff expires following 10 consecutive failures", async () => {
+			//#given - boulder state with incomplete plan and prompt always fails
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const promptMock = mock(() => Promise.reject(new Error("Bad Request")));
+			const mockInput = createMockPluginInput({ promptMock });
+			const hook = createAtlasHook(mockInput);
+
+			const originalDateNow = Date.now;
+			let now = 0;
+			Date.now = () => now;
+
+			try {
+				//#when - 11th idle occurs after 5+ minutes
+				for (let i = 0; i < 10; i++) {
+					await hook.handler({
+						event: {
+							type: "session.idle",
+							properties: { sessionID: MAIN_SESSION_ID },
+						},
+					});
+					await flushMicrotasks();
+					now += 6000;
+				}
+
+				now += 300000;
+
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await flushMicrotasks();
+
+				//#then - 11th attempt should run after backoff expiration
+				expect(promptMock).toHaveBeenCalledTimes(11);
+			} finally {
+				Date.now = originalDateNow;
+			}
+		});
+
+		test("should reset prompt failure counter after successful retry beyond backoff window", async () => {
+			//#given - boulder state with incomplete plan and success on first retry after backoff
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const promptMock = mock(
+				(): Promise<void> => Promise.reject(new Error("Bad Request")),
+			);
+			for (let i = 0; i < 10; i++) {
+				promptMock.mockImplementationOnce(() =>
+					Promise.reject(new Error("Bad Request")),
+				);
+			}
+			promptMock.mockImplementationOnce(() => Promise.resolve(undefined));
+			const mockInput = createMockPluginInput({ promptMock });
+			const hook = createAtlasHook(mockInput);
+
+			const originalDateNow = Date.now;
+			let now = 0;
+			Date.now = () => now;
+
+			try {
+				//#when - fail 10 times, recover after backoff with success, then fail 10 times again
+				for (let i = 0; i < 10; i++) {
+					await hook.handler({
+						event: {
+							type: "session.idle",
+							properties: { sessionID: MAIN_SESSION_ID },
+						},
+					});
+					await flushMicrotasks();
+					now += 6000;
+				}
+
+				now += 300000;
+
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await flushMicrotasks();
+				now += 6000;
+
+				for (let i = 0; i < 10; i++) {
+					await hook.handler({
+						event: {
+							type: "session.idle",
+							properties: { sessionID: MAIN_SESSION_ID },
+						},
+					});
+					await flushMicrotasks();
+					now += 6000;
+				}
+
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await flushMicrotasks();
+
+				//#then - success retry resets counter, so 10 additional failures are allowed before skip
+				expect(promptMock).toHaveBeenCalledTimes(21);
+			} finally {
+				Date.now = originalDateNow;
+			}
+		});
+
+		test("should reset continuation failure state on session.compacted event", async () => {
+			//#given - boulder state with incomplete plan and prompt always fails
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const promptMock = mock(() => Promise.reject(new Error("Bad Request")));
+			const mockInput = createMockPluginInput({ promptMock });
+			const hook = createAtlasHook(mockInput);
+
+			const originalDateNow = Date.now;
+			let now = 0;
+			Date.now = () => now;
+
+			try {
+				//#when - 10 failures disable continuation, then compaction resets it
+				for (let i = 0; i < 10; i++) {
+					await hook.handler({
+						event: {
+							type: "session.idle",
+							properties: { sessionID: MAIN_SESSION_ID },
+						},
+					});
+					await flushMicrotasks();
+					now += 6000;
+				}
+
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await flushMicrotasks();
+
+				await hook.handler({
+					event: {
+						type: "session.compacted",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				now += 6000;
+
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await flushMicrotasks();
+
+				//#then - 10 attempts + 1 after compaction (11 total)
+				expect(promptMock).toHaveBeenCalledTimes(11);
+			} finally {
+				Date.now = originalDateNow;
+			}
+		});
+
+		test("should cleanup on session.deleted", async () => {
+			// given - boulder state
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when - create abort state then delete
+			await hook.handler({
+				event: {
+					type: "session.error",
+					properties: {
+						sessionID: MAIN_SESSION_ID,
+						error: { name: "AbortError" },
+					},
+				},
+			});
+			await hook.handler({
+				event: {
+					type: "session.deleted",
+					properties: { info: { id: MAIN_SESSION_ID } },
+				},
+			});
+
+			// Re-create boulder after deletion
+			writeBoulderState(TEST_DIR, state);
+
+			// Trigger idle - should inject because state was cleaned up
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should call prompt because session state was cleaned
+			expect(mockInput._promptMock).toHaveBeenCalled();
+		});
+
+		test("should inject when session agent was updated to atlas by start-work even if message storage agent differs", async () => {
+			// given - boulder targets atlas, but nearest stored message still says hephaestus
+			const planPath = join(TEST_DIR, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: [MAIN_SESSION_ID],
+				plan_name: "test-plan",
+				agent: "atlas",
+			};
+			writeBoulderState(TEST_DIR, state);
+
+			cleanupMessageStorage(MAIN_SESSION_ID);
+			setupMessageStorage(MAIN_SESSION_ID, "hephaestus");
+			updateSessionAgent(MAIN_SESSION_ID, "atlas");
+
+			const mockInput = createMockPluginInput();
+			const hook = createAtlasHook(mockInput);
+
+			// when
+			await hook.handler({
+				event: {
+					type: "session.idle",
+					properties: { sessionID: MAIN_SESSION_ID },
+				},
+			});
+
+			// then - should continue because start-work updated session agent to atlas
+			expect(mockInput._promptMock).toHaveBeenCalled();
+		});
+
+		describe("delayed retry timer (abort-stuck fix)", () => {
+			const capturedTimers = new Map<
+				number,
+				{ callback: Function; cleared: boolean }
+			>();
+			let nextFakeId = 99000;
+			const originalSetTimeout = globalThis.setTimeout;
+			const originalClearTimeout = globalThis.clearTimeout;
+
+			beforeEach(() => {
+				capturedTimers.clear();
+				nextFakeId = 99000;
+
+				globalThis.setTimeout = ((
+					callback: Function,
+					delay?: number,
+					...args: unknown[]
+				) => {
+					const normalized = typeof delay === "number" ? delay : 0;
+					if (normalized >= 5000) {
+						const id = nextFakeId++;
+						capturedTimers.set(id, {
+							callback: () => callback(...args),
+							cleared: false,
+						});
+						return id as unknown as ReturnType<typeof setTimeout>;
+					}
+					return originalSetTimeout(
+						callback as Parameters<typeof originalSetTimeout>[0],
+						delay,
+					);
+				}) as unknown as typeof setTimeout;
+
+				globalThis.clearTimeout = ((
+					id?: number | ReturnType<typeof setTimeout>,
+				) => {
+					if (typeof id === "number" && capturedTimers.has(id)) {
+						capturedTimers.get(id)!.cleared = true;
+						capturedTimers.delete(id);
+						return;
+					}
+					originalClearTimeout(
+						id as Parameters<typeof originalClearTimeout>[0],
+					);
+				}) as unknown as typeof clearTimeout;
+			});
+
+			afterEach(() => {
+				globalThis.setTimeout = originalSetTimeout;
+				globalThis.clearTimeout = originalClearTimeout;
+			});
+
+			async function firePendingTimers(): Promise<void> {
+				for (const [id, entry] of capturedTimers) {
+					if (!entry.cleared) {
+						capturedTimers.delete(id);
+						await entry.callback();
+					}
+				}
+				await flushMicrotasks();
+			}
+
+			test("should schedule delayed retry when cooldown blocks idle for incomplete boulder", async () => {
+				// given - boulder with incomplete plan
+				const planPath = join(TEST_DIR, "test-plan.md");
+				writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2");
+
+				const state: BoulderState = {
+					active_plan: planPath,
+					started_at: "2026-01-02T10:00:00Z",
+					session_ids: [MAIN_SESSION_ID],
+					plan_name: "test-plan",
+				};
+				writeBoulderState(TEST_DIR, state);
+
+				const mockInput = createMockPluginInput();
+				const hook = createAtlasHook(mockInput);
+
+				// when - first idle injects, second idle within cooldown schedules retry timer
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+
+				// then - fire pending timer and verify retry
+				await firePendingTimers();
+				expect(mockInput._promptMock).toHaveBeenCalledTimes(2);
+			});
+
+			test("should not schedule duplicate retry timers for rapid idle events", async () => {
+				// given - boulder with incomplete plan
+				const planPath = join(TEST_DIR, "test-plan.md");
+				writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [ ] Task 2");
+
+				const state: BoulderState = {
+					active_plan: planPath,
+					started_at: "2026-01-02T10:00:00Z",
+					session_ids: [MAIN_SESSION_ID],
+					plan_name: "test-plan",
+				};
+				writeBoulderState(TEST_DIR, state);
+
+				const mockInput = createMockPluginInput();
+				const hook = createAtlasHook(mockInput);
+
+				// when - first idle injects, then 3 rapid idles within cooldown
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+
+				// then - only one retry fires despite multiple cooldown-blocked idles
+				await firePendingTimers();
+				expect(mockInput._promptMock).toHaveBeenCalledTimes(2);
+			});
+
+			test("should not retry if plan completes before timer fires", async () => {
+				// given - boulder with incomplete plan
+				const planPath = join(TEST_DIR, "test-plan.md");
+				writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2");
+
+				const state: BoulderState = {
+					active_plan: planPath,
+					started_at: "2026-01-02T10:00:00Z",
+					session_ids: [MAIN_SESSION_ID],
+					plan_name: "test-plan",
+				};
+				writeBoulderState(TEST_DIR, state);
+
+				const mockInput = createMockPluginInput();
+				const hook = createAtlasHook(mockInput);
+
+				// when - first idle injects, second schedules retry, then plan completes before timer fires
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+
+				writeFileSync(planPath, "# Plan\n- [x] Task 1\n- [x] Task 2");
+
+				// then - retry sees complete plan and bails out
+				await firePendingTimers();
+				expect(mockInput._promptMock).toHaveBeenCalledTimes(1);
+			});
+
+			test("should cleanup pending retry timer on session.deleted", async () => {
+				// given - boulder with incomplete plan, schedule retry timer
+				const planPath = join(TEST_DIR, "test-plan.md");
+				writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2");
+
+				const state: BoulderState = {
+					active_plan: planPath,
+					started_at: "2026-01-02T10:00:00Z",
+					session_ids: [MAIN_SESSION_ID],
+					plan_name: "test-plan",
+				};
+				writeBoulderState(TEST_DIR, state);
+
+				const mockInput = createMockPluginInput();
+				const hook = createAtlasHook(mockInput);
+
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+
+				// when - delete session before timer fires
+				await hook.handler({
+					event: {
+						type: "session.deleted",
+						properties: { info: { id: MAIN_SESSION_ID } },
+					},
+				});
+
+				// then - timer was cleared, prompt called only once
+				await firePendingTimers();
+				expect(mockInput._promptMock).toHaveBeenCalledTimes(1);
+			});
+
+			test("should cleanup pending retry timer on session.compacted", async () => {
+				// given - boulder with incomplete plan, schedule retry timer
+				const planPath = join(TEST_DIR, "test-plan.md");
+				writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2");
+
+				const state: BoulderState = {
+					active_plan: planPath,
+					started_at: "2026-01-02T10:00:00Z",
+					session_ids: [MAIN_SESSION_ID],
+					plan_name: "test-plan",
+				};
+				writeBoulderState(TEST_DIR, state);
+
+				const mockInput = createMockPluginInput();
+				const hook = createAtlasHook(mockInput);
+
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+				await hook.handler({
+					event: {
+						type: "session.idle",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+
+				// when - compact session before timer fires
+				await hook.handler({
+					event: {
+						type: "session.compacted",
+						properties: { sessionID: MAIN_SESSION_ID },
+					},
+				});
+
+				// then - timer was cleared, prompt called only once
+				await firePendingTimers();
+				expect(mockInput._promptMock).toHaveBeenCalledTimes(1);
+			});
+		});
+	});
+});

--- a/src/hooks/auto-slash-command/auto-slash-command-leak.test.ts
+++ b/src/hooks/auto-slash-command/auto-slash-command-leak.test.ts
@@ -1,207 +1,253 @@
-import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
-import { AUTO_SLASH_COMMAND_TAG_OPEN } from "./constants"
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import * as shared from "../../shared";
+import { AUTO_SLASH_COMMAND_TAG_OPEN } from "./constants";
+import * as executorModule from "./executor";
 import type {
-  AutoSlashCommandHookInput,
-  AutoSlashCommandHookOutput,
-  CommandExecuteBeforeInput,
-  CommandExecuteBeforeOutput,
-} from "./types"
-import * as shared from "../../shared"
+	AutoSlashCommandHookInput,
+	AutoSlashCommandHookOutput,
+	CommandExecuteBeforeInput,
+	CommandExecuteBeforeOutput,
+} from "./types";
 
 const executeSlashCommandMock = mock(
-  async (parsed: { command: string; args: string; raw: string }) => ({
-    success: true,
-    replacementText: parsed.raw,
-  })
-)
+	async (parsed: { command: string; args: string; raw: string }) => ({
+		success: true,
+		replacementText: parsed.raw,
+	}),
+);
 
-mock.module("./executor", () => ({
-  executeSlashCommand: executeSlashCommandMock,
-}))
+let logMock: ReturnType<typeof spyOn>;
+let createAutoSlashCommandHook: typeof import("./hook").createAutoSlashCommandHook;
 
-const logMock = spyOn(shared, "log").mockImplementation(() => {})
-
-const { createAutoSlashCommandHook } = await import("./hook")
-
-function createChatInput(sessionID: string, messageID: string): AutoSlashCommandHookInput {
-  return {
-    sessionID,
-    messageID,
-  }
+function createChatInput(
+	sessionID: string,
+	messageID: string,
+): AutoSlashCommandHookInput {
+	return {
+		sessionID,
+		messageID,
+	};
 }
 
 function createChatOutput(text: string): AutoSlashCommandHookOutput {
-  return {
-    message: {},
-    parts: [{ type: "text", text }],
-  }
+	return {
+		message: {},
+		parts: [{ type: "text", text }],
+	};
 }
 
-function createCommandInput(sessionID: string, command: string): CommandExecuteBeforeInput {
-  return {
-    sessionID,
-    command,
-    arguments: "",
-  }
+function createCommandInput(
+	sessionID: string,
+	command: string,
+): CommandExecuteBeforeInput {
+	return {
+		sessionID,
+		command,
+		arguments: "",
+	};
 }
 
 function createCommandOutput(text: string): CommandExecuteBeforeOutput {
-  return {
-    parts: [{ type: "text", text }],
-  }
+	return {
+		parts: [{ type: "text", text }],
+	};
 }
 
 describe("createAutoSlashCommandHook leak prevention", () => {
-  beforeEach(() => {
-    executeSlashCommandMock.mockClear()
-    logMock.mockClear()
-  })
+	beforeEach(async () => {
+		mock.restore();
+		logMock = spyOn(shared, "log").mockImplementation(() => {});
+		spyOn(executorModule, "executeSlashCommand").mockImplementation(
+			executeSlashCommandMock,
+		);
+		executeSlashCommandMock.mockClear();
+		logMock.mockClear();
+		({ createAutoSlashCommandHook } = await import(
+			`./hook?leak-${Date.now()}-${Math.random()}`
+		));
+	});
 
-  describe("#given hook with sessionProcessedCommandExecutions", () => {
-    describe("#when same command executed twice after fallback dedup window", () => {
-      it("#then second execution is treated as intentional rerun", async () => {
-        //#given
-        const nowSpy = spyOn(Date, "now")
-        try {
-          const hook = createAutoSlashCommandHook()
-          const input = createCommandInput("session-dedup", "leak-test-command")
-          const firstOutput = createCommandOutput("first")
-          const secondOutput = createCommandOutput("second")
+	afterEach(() => {
+		mock.restore();
+	});
 
-          //#when
-          nowSpy.mockReturnValue(0)
-          await hook["command.execute.before"](input, firstOutput)
-          nowSpy.mockReturnValue(101)
-          await hook["command.execute.before"](input, secondOutput)
+	describe("#given hook with sessionProcessedCommandExecutions", () => {
+		describe("#when same command executed twice after fallback dedup window", () => {
+			it("#then second execution is treated as intentional rerun", async () => {
+				//#given
+				const nowSpy = spyOn(Date, "now");
+				try {
+					const hook = createAutoSlashCommandHook();
+					const input = createCommandInput(
+						"session-dedup",
+						"leak-test-command",
+					);
+					const firstOutput = createCommandOutput("first");
+					const secondOutput = createCommandOutput("second");
 
-          //#then
-          expect(executeSlashCommandMock).toHaveBeenCalledTimes(2)
-          expect(firstOutput.parts[0].text).toContain(AUTO_SLASH_COMMAND_TAG_OPEN)
-          expect(secondOutput.parts[0].text).toContain(AUTO_SLASH_COMMAND_TAG_OPEN)
-        } finally {
-          nowSpy.mockRestore()
-        }
-      })
-    })
+					//#when
+					nowSpy.mockReturnValue(0);
+					await hook["command.execute.before"](input, firstOutput);
+					nowSpy.mockReturnValue(101);
+					await hook["command.execute.before"](input, secondOutput);
 
-    describe("#when same command is repeated within fallback dedup window", () => {
-      it("#then duplicate dispatch is suppressed", async () => {
-        //#given
-        const nowSpy = spyOn(Date, "now")
-        try {
-          const hook = createAutoSlashCommandHook()
-          const input = createCommandInput("session-dedup", "leak-test-command")
-          const firstOutput = createCommandOutput("first")
-          const secondOutput = createCommandOutput("second")
+					//#then
+					expect(executeSlashCommandMock).toHaveBeenCalledTimes(2);
+					expect(firstOutput.parts[0].text).toContain(
+						AUTO_SLASH_COMMAND_TAG_OPEN,
+					);
+					expect(secondOutput.parts[0].text).toContain(
+						AUTO_SLASH_COMMAND_TAG_OPEN,
+					);
+				} finally {
+					nowSpy.mockRestore();
+				}
+			});
+		});
 
-          //#when
-          nowSpy.mockReturnValue(0)
-          await hook["command.execute.before"](input, firstOutput)
-          nowSpy.mockReturnValue(99)
-          await hook["command.execute.before"](input, secondOutput)
+		describe("#when same command is repeated within fallback dedup window", () => {
+			it("#then duplicate dispatch is suppressed", async () => {
+				//#given
+				const nowSpy = spyOn(Date, "now");
+				try {
+					const hook = createAutoSlashCommandHook();
+					const input = createCommandInput(
+						"session-dedup",
+						"leak-test-command",
+					);
+					const firstOutput = createCommandOutput("first");
+					const secondOutput = createCommandOutput("second");
 
-          //#then
-          expect(executeSlashCommandMock).toHaveBeenCalledTimes(1)
-          expect(firstOutput.parts[0].text).toContain(AUTO_SLASH_COMMAND_TAG_OPEN)
-          expect(secondOutput.parts[0].text).toBe("second")
-        } finally {
-          nowSpy.mockRestore()
-        }
-      })
-    })
+					//#when
+					nowSpy.mockReturnValue(0);
+					await hook["command.execute.before"](input, firstOutput);
+					nowSpy.mockReturnValue(99);
+					await hook["command.execute.before"](input, secondOutput);
 
-    describe("#when same event identifier is dispatched twice", () => {
-      it("#then second dispatch is deduplicated regardless of elapsed seconds", async () => {
-        //#given
-        const nowSpy = spyOn(Date, "now")
-        try {
-          const hook = createAutoSlashCommandHook()
-          const input: CommandExecuteBeforeInput = {
-            ...createCommandInput("session-dedup", "leak-test-command"),
-            eventID: "event-1",
-          }
-          const firstOutput = createCommandOutput("first")
-          const secondOutput = createCommandOutput("second")
+					//#then
+					expect(executeSlashCommandMock).toHaveBeenCalledTimes(1);
+					expect(firstOutput.parts[0].text).toContain(
+						AUTO_SLASH_COMMAND_TAG_OPEN,
+					);
+					expect(secondOutput.parts[0].text).toBe("second");
+				} finally {
+					nowSpy.mockRestore();
+				}
+			});
+		});
 
-          //#when
-          nowSpy.mockReturnValue(0)
-          await hook["command.execute.before"](input, firstOutput)
-          nowSpy.mockReturnValue(29_999)
-          await hook["command.execute.before"](input, secondOutput)
+		describe("#when same event identifier is dispatched twice", () => {
+			it("#then second dispatch is deduplicated regardless of elapsed seconds", async () => {
+				//#given
+				const nowSpy = spyOn(Date, "now");
+				try {
+					const hook = createAutoSlashCommandHook();
+					const input: CommandExecuteBeforeInput = {
+						...createCommandInput("session-dedup", "leak-test-command"),
+						eventID: "event-1",
+					};
+					const firstOutput = createCommandOutput("first");
+					const secondOutput = createCommandOutput("second");
 
-          //#then
-          expect(executeSlashCommandMock).toHaveBeenCalledTimes(1)
-          expect(firstOutput.parts[0].text).toContain(AUTO_SLASH_COMMAND_TAG_OPEN)
-          expect(secondOutput.parts[0].text).toBe("second")
-        } finally {
-          nowSpy.mockRestore()
-        }
-      })
-    })
-  })
+					//#when
+					nowSpy.mockReturnValue(0);
+					await hook["command.execute.before"](input, firstOutput);
+					nowSpy.mockReturnValue(29_999);
+					await hook["command.execute.before"](input, secondOutput);
 
-  describe("#given hook with entries from multiple sessions", () => {
-    describe("#when dispose() is called", () => {
-      it("#then both Sets are empty", async () => {
-        const hook = createAutoSlashCommandHook()
-        await hook["chat.message"](
-          createChatInput("session-chat", "message-chat"),
-          createChatOutput("/leak-chat")
-        )
-        await hook["command.execute.before"](
-          createCommandInput("session-command", "leak-command"),
-          createCommandOutput("before")
-        )
-        executeSlashCommandMock.mockClear()
+					//#then
+					expect(executeSlashCommandMock).toHaveBeenCalledTimes(1);
+					expect(firstOutput.parts[0].text).toContain(
+						AUTO_SLASH_COMMAND_TAG_OPEN,
+					);
+					expect(secondOutput.parts[0].text).toBe("second");
+				} finally {
+					nowSpy.mockRestore();
+				}
+			});
+		});
+	});
 
-        hook.dispose()
-        const chatOutputAfterDispose = createChatOutput("/leak-chat")
-        const commandOutputAfterDispose = createCommandOutput("after")
-        await hook["chat.message"](
-          createChatInput("session-chat", "message-chat"),
-          chatOutputAfterDispose
-        )
-        await hook["command.execute.before"](
-          createCommandInput("session-command", "leak-command"),
-          commandOutputAfterDispose
-        )
+	describe("#given hook with entries from multiple sessions", () => {
+		describe("#when dispose() is called", () => {
+			it("#then both Sets are empty", async () => {
+				const hook = createAutoSlashCommandHook();
+				await hook["chat.message"](
+					createChatInput("session-chat", "message-chat"),
+					createChatOutput("/leak-chat"),
+				);
+				await hook["command.execute.before"](
+					createCommandInput("session-command", "leak-command"),
+					createCommandOutput("before"),
+				);
+				executeSlashCommandMock.mockClear();
 
-        expect(executeSlashCommandMock).toHaveBeenCalledTimes(2)
-        expect(chatOutputAfterDispose.parts[0].text).toContain(AUTO_SLASH_COMMAND_TAG_OPEN)
-        expect(commandOutputAfterDispose.parts[0].text).toContain(
-          AUTO_SLASH_COMMAND_TAG_OPEN
-        )
-      })
-    })
-  })
+				hook.dispose();
+				const chatOutputAfterDispose = createChatOutput("/leak-chat");
+				const commandOutputAfterDispose = createCommandOutput("after");
+				await hook["chat.message"](
+					createChatInput("session-chat", "message-chat"),
+					chatOutputAfterDispose,
+				);
+				await hook["command.execute.before"](
+					createCommandInput("session-command", "leak-command"),
+					commandOutputAfterDispose,
+				);
 
-  describe("#given Set with more than 10000 entries", () => {
-    describe("#when new entry added", () => {
-      it("#then Set size is reduced", async () => {
-        const hook = createAutoSlashCommandHook()
-        const oldestInput = createChatInput("session-oldest", "message-oldest")
-        await hook["chat.message"](oldestInput, createChatOutput("/leak-oldest"))
+				expect(executeSlashCommandMock).toHaveBeenCalledTimes(2);
+				expect(chatOutputAfterDispose.parts[0].text).toContain(
+					AUTO_SLASH_COMMAND_TAG_OPEN,
+				);
+				expect(commandOutputAfterDispose.parts[0].text).toContain(
+					AUTO_SLASH_COMMAND_TAG_OPEN,
+				);
+			});
+		});
+	});
 
-        for (let index = 0; index < 10000; index += 1) {
-          await hook["chat.message"](
-            createChatInput(`session-${index}`, `message-${index}`),
-            createChatOutput(`/leak-${index}`)
-          )
-        }
+	describe("#given Set with more than 10000 entries", () => {
+		describe("#when new entry added", () => {
+			it("#then Set size is reduced", async () => {
+				const hook = createAutoSlashCommandHook();
+				const oldestInput = createChatInput("session-oldest", "message-oldest");
+				await hook["chat.message"](
+					oldestInput,
+					createChatOutput("/leak-oldest"),
+				);
 
-        const newestInput = createChatInput("session-newest", "message-newest")
-        await hook["chat.message"](newestInput, createChatOutput("/leak-newest"))
-        executeSlashCommandMock.mockClear()
-        const oldestRetryOutput = createChatOutput("/leak-oldest")
-        const newestRetryOutput = createChatOutput("/leak-newest")
+				for (let index = 0; index < 10000; index += 1) {
+					await hook["chat.message"](
+						createChatInput(`session-${index}`, `message-${index}`),
+						createChatOutput(`/leak-${index}`),
+					);
+				}
 
-        await hook["chat.message"](oldestInput, oldestRetryOutput)
-        await hook["chat.message"](newestInput, newestRetryOutput)
+				const newestInput = createChatInput("session-newest", "message-newest");
+				await hook["chat.message"](
+					newestInput,
+					createChatOutput("/leak-newest"),
+				);
+				executeSlashCommandMock.mockClear();
+				const oldestRetryOutput = createChatOutput("/leak-oldest");
+				const newestRetryOutput = createChatOutput("/leak-newest");
 
-        expect(executeSlashCommandMock).toHaveBeenCalledTimes(1)
-        expect(oldestRetryOutput.parts[0].text).toContain(AUTO_SLASH_COMMAND_TAG_OPEN)
-        expect(newestRetryOutput.parts[0].text).toBe("/leak-newest")
-      })
-    })
-  })
-})
+				await hook["chat.message"](oldestInput, oldestRetryOutput);
+				await hook["chat.message"](newestInput, newestRetryOutput);
+
+				expect(executeSlashCommandMock).toHaveBeenCalledTimes(1);
+				expect(oldestRetryOutput.parts[0].text).toContain(
+					AUTO_SLASH_COMMAND_TAG_OPEN,
+				);
+				expect(newestRetryOutput.parts[0].text).toBe("/leak-newest");
+			});
+		});
+	});
+});

--- a/src/hooks/auto-slash-command/executor-resolution.test.ts
+++ b/src/hooks/auto-slash-command/executor-resolution.test.ts
@@ -1,98 +1,126 @@
-import { describe, expect, it, mock } from "bun:test"
-import type { LoadedSkill } from "../../features/opencode-skill-loader"
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import type { LoadedSkill } from "../../features/opencode-skill-loader";
+import * as skillLoaderModule from "../../features/opencode-skill-loader";
+import * as shared from "../../shared";
+import * as slashcommandModule from "../../tools/slashcommand";
 
-mock.module("../../shared", () => ({
-  resolveCommandsInText: async (content: string) => content,
-  resolveFileReferencesInText: async (content: string) => content,
-}))
+let executeSlashCommand: typeof import("./executor").executeSlashCommand;
 
-mock.module("../../tools/slashcommand", () => ({
-  discoverCommandsSync: () => [
-    {
-      name: "shadowed",
-      metadata: { name: "shadowed", description: "builtin" },
-      content: "builtin template",
-      scope: "builtin",
-    },
-    {
-      name: "shadowed",
-      metadata: { name: "shadowed", description: "project" },
-      content: "project template",
-      scope: "project",
-    },
-  ],
-}))
+beforeEach(async () => {
+	mock.restore();
+	mock &&
+		spyOn(shared, "resolveCommandsInText").mockImplementation(
+			async (content: string) => content,
+		);
+	mock &&
+		spyOn(shared, "resolveFileReferencesInText").mockImplementation(
+			async (content: string) => content,
+		);
+	mock &&
+		spyOn(slashcommandModule, "discoverCommandsSync").mockImplementation(() => [
+			{
+				name: "shadowed",
+				metadata: { name: "shadowed", description: "builtin" },
+				content: "builtin template",
+				scope: "builtin",
+			},
+			{
+				name: "shadowed",
+				metadata: { name: "shadowed", description: "project" },
+				content: "project template",
+				scope: "project",
+			},
+		]);
+	mock &&
+		spyOn(skillLoaderModule, "discoverAllSkills").mockResolvedValue(
+			[] as LoadedSkill[],
+		);
 
-mock.module("../../features/opencode-skill-loader", () => ({
-  discoverAllSkills: async (): Promise<LoadedSkill[]> => [],
-}))
+	({ executeSlashCommand } = await import(
+		`./executor?resolution-${Date.now()}-${Math.random()}`
+	));
+});
 
-const { executeSlashCommand } = await import("./executor")
+afterEach(() => {
+	mock.restore();
+});
 
 function createRestrictedSkill(): LoadedSkill {
-  return {
-    name: "restricted-skill",
-    definition: {
-      name: "restricted-skill",
-      description: "restricted",
-      template: "restricted template",
-      agent: "hephaestus",
-    },
-    scope: "user",
-  }
+	return {
+		name: "restricted-skill",
+		definition: {
+			name: "restricted-skill",
+			description: "restricted",
+			template: "restricted template",
+			agent: "hephaestus",
+		},
+		scope: "user",
+	};
 }
 
 describe("executeSlashCommand resolution semantics", () => {
-  it("returns project command when project and builtin names collide", async () => {
-    //#given
-    const parsed = {
-      command: "shadowed",
-      args: "",
-      raw: "/shadowed",
-    }
+	it("returns project command when project and builtin names collide", async () => {
+		//#given
+		const parsed = {
+			command: "shadowed",
+			args: "",
+			raw: "/shadowed",
+		};
 
-    //#when
-    const result = await executeSlashCommand(parsed, { skills: [] })
+		//#when
+		const result = await executeSlashCommand(parsed, { skills: [] });
 
-    //#then
-    expect(result.success).toBe(true)
-    expect(result.replacementText).toContain("**Scope**: project")
-    expect(result.replacementText).toContain("project template")
-    expect(result.replacementText).not.toContain("builtin template")
-  })
+		//#then
+		expect(result.success).toBe(true);
+		expect(result.replacementText).toContain("**Scope**: project");
+		expect(result.replacementText).toContain("project template");
+		expect(result.replacementText).not.toContain("builtin template");
+	});
 
-  it("blocks slash skill invocation when invoking agent is missing", async () => {
-    //#given
-    const parsed = {
-      command: "restricted-skill",
-      args: "",
-      raw: "/restricted-skill",
-    }
+	it("blocks slash skill invocation when invoking agent is missing", async () => {
+		//#given
+		const parsed = {
+			command: "restricted-skill",
+			args: "",
+			raw: "/restricted-skill",
+		};
 
-    //#when
-    const result = await executeSlashCommand(parsed, { skills: [createRestrictedSkill()] })
+		//#when
+		const result = await executeSlashCommand(parsed, {
+			skills: [createRestrictedSkill()],
+		});
 
-    //#then
-    expect(result.success).toBe(false)
-    expect(result.error).toBe('Skill "restricted-skill" is restricted to agent "hephaestus"')
-  })
+		//#then
+		expect(result.success).toBe(false);
+		expect(result.error).toBe(
+			'Skill "restricted-skill" is restricted to agent "hephaestus"',
+		);
+	});
 
-  it("allows slash skill invocation when invoking agent matches restriction", async () => {
-    //#given
-    const parsed = {
-      command: "restricted-skill",
-      args: "",
-      raw: "/restricted-skill",
-    }
+	it("allows slash skill invocation when invoking agent matches restriction", async () => {
+		//#given
+		const parsed = {
+			command: "restricted-skill",
+			args: "",
+			raw: "/restricted-skill",
+		};
 
-    //#when
-    const result = await executeSlashCommand(parsed, {
-      skills: [createRestrictedSkill()],
-      agent: "hephaestus",
-    })
+		//#when
+		const result = await executeSlashCommand(parsed, {
+			skills: [createRestrictedSkill()],
+			agent: "hephaestus",
+		});
 
-    //#then
-    expect(result.success).toBe(true)
-    expect(result.replacementText).toContain("restricted template")
-  })
-})
+		//#then
+		expect(result.success).toBe(true);
+		expect(result.replacementText).toContain("restricted template");
+	});
+});

--- a/src/hooks/auto-slash-command/executor.test.ts
+++ b/src/hooks/auto-slash-command/executor.test.ts
@@ -1,195 +1,201 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { executeSlashCommand } from "./executor"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let executeSlashCommand: typeof import("./executor").executeSlashCommand;
 
 const ENV_KEYS = [
-  "CLAUDE_CONFIG_DIR",
-  "CLAUDE_PLUGINS_HOME",
-  "CLAUDE_SETTINGS_PATH",
-  "OPENCODE_CONFIG_DIR",
-] as const
+	"CLAUDE_CONFIG_DIR",
+	"CLAUDE_PLUGINS_HOME",
+	"CLAUDE_SETTINGS_PATH",
+	"OPENCODE_CONFIG_DIR",
+] as const;
 
-type EnvKey = (typeof ENV_KEYS)[number]
-type EnvSnapshot = Record<EnvKey, string | undefined>
+type EnvKey = (typeof ENV_KEYS)[number];
+type EnvSnapshot = Record<EnvKey, string | undefined>;
 
 function writePluginFixture(baseDir: string): void {
-  const claudeConfigDir = join(baseDir, "claude-config")
-  const pluginsHome = join(claudeConfigDir, "plugins")
-  const settingsPath = join(claudeConfigDir, "settings.json")
-  const opencodeConfigDir = join(baseDir, "opencode-config")
-  const pluginInstallPath = join(baseDir, "installed-plugins", "daplug")
-  const pluginKey = "daplug@1.0.0"
+	const claudeConfigDir = join(baseDir, "claude-config");
+	const pluginsHome = join(claudeConfigDir, "plugins");
+	const settingsPath = join(claudeConfigDir, "settings.json");
+	const opencodeConfigDir = join(baseDir, "opencode-config");
+	const pluginInstallPath = join(baseDir, "installed-plugins", "daplug");
+	const pluginKey = "daplug@1.0.0";
 
-  mkdirSync(join(pluginInstallPath, ".claude-plugin"), { recursive: true })
-  mkdirSync(join(pluginInstallPath, "commands"), { recursive: true })
+	mkdirSync(join(pluginInstallPath, ".claude-plugin"), { recursive: true });
+	mkdirSync(join(pluginInstallPath, "commands"), { recursive: true });
 
-  writeFileSync(
-    join(pluginInstallPath, ".claude-plugin", "plugin.json"),
-    JSON.stringify({ name: "daplug", version: "1.0.0" }, null, 2),
-  )
-  writeFileSync(
-    join(pluginInstallPath, "commands", "run-prompt.md"),
-    `---
+	writeFileSync(
+		join(pluginInstallPath, ".claude-plugin", "plugin.json"),
+		JSON.stringify({ name: "daplug", version: "1.0.0" }, null, 2),
+	);
+	writeFileSync(
+		join(pluginInstallPath, "commands", "run-prompt.md"),
+		`---
 description: Run prompt from daplug
 ---
 Execute daplug prompt flow.
 `,
-  )
-  writeFileSync(
-    join(pluginInstallPath, "commands", "templated.md"),
-    `---
+	);
+	writeFileSync(
+		join(pluginInstallPath, "commands", "templated.md"),
+		`---
 description: Templated prompt from daplug
 ---
 Echo $ARGUMENTS and \${user_message}.
 `,
-  )
+	);
 
-  mkdirSync(pluginsHome, { recursive: true })
-  writeFileSync(
-    join(pluginsHome, "installed_plugins.json"),
-    JSON.stringify(
-      {
-        version: 2,
-        plugins: {
-          [pluginKey]: [
-            {
-              scope: "user",
-              installPath: pluginInstallPath,
-              version: "1.0.0",
-              installedAt: "2026-01-01T00:00:00.000Z",
-              lastUpdated: "2026-01-01T00:00:00.000Z",
-            },
-          ],
-        },
-      },
-      null,
-      2,
-    ),
-  )
+	mkdirSync(pluginsHome, { recursive: true });
+	writeFileSync(
+		join(pluginsHome, "installed_plugins.json"),
+		JSON.stringify(
+			{
+				version: 2,
+				plugins: {
+					[pluginKey]: [
+						{
+							scope: "user",
+							installPath: pluginInstallPath,
+							version: "1.0.0",
+							installedAt: "2026-01-01T00:00:00.000Z",
+							lastUpdated: "2026-01-01T00:00:00.000Z",
+						},
+					],
+				},
+			},
+			null,
+			2,
+		),
+	);
 
-  mkdirSync(claudeConfigDir, { recursive: true })
-  writeFileSync(
-    settingsPath,
-    JSON.stringify(
-      {
-        enabledPlugins: {
-          [pluginKey]: true,
-        },
-      },
-      null,
-      2,
-    ),
-  )
-  mkdirSync(opencodeConfigDir, { recursive: true })
+	mkdirSync(claudeConfigDir, { recursive: true });
+	writeFileSync(
+		settingsPath,
+		JSON.stringify(
+			{
+				enabledPlugins: {
+					[pluginKey]: true,
+				},
+			},
+			null,
+			2,
+		),
+	);
+	mkdirSync(opencodeConfigDir, { recursive: true });
 
-  process.env.CLAUDE_CONFIG_DIR = claudeConfigDir
-  process.env.CLAUDE_PLUGINS_HOME = pluginsHome
-  process.env.CLAUDE_SETTINGS_PATH = settingsPath
-  process.env.OPENCODE_CONFIG_DIR = opencodeConfigDir
+	process.env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+	process.env.CLAUDE_PLUGINS_HOME = pluginsHome;
+	process.env.CLAUDE_SETTINGS_PATH = settingsPath;
+	process.env.OPENCODE_CONFIG_DIR = opencodeConfigDir;
 }
 
 describe("auto-slash command executor plugin dispatch", () => {
-  let tempDir = ""
-  let envSnapshot: EnvSnapshot
+	let tempDir = "";
+	let envSnapshot: EnvSnapshot;
 
-  beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), "omo-executor-plugin-test-"))
-    envSnapshot = {
-      CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
-      CLAUDE_PLUGINS_HOME: process.env.CLAUDE_PLUGINS_HOME,
-      CLAUDE_SETTINGS_PATH: process.env.CLAUDE_SETTINGS_PATH,
-      OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
-    }
-    writePluginFixture(tempDir)
-  })
+	beforeEach(async () => {
+		mock.restore();
+		tempDir = mkdtempSync(join(tmpdir(), "omo-executor-plugin-test-"));
+		envSnapshot = {
+			CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+			CLAUDE_PLUGINS_HOME: process.env.CLAUDE_PLUGINS_HOME,
+			CLAUDE_SETTINGS_PATH: process.env.CLAUDE_SETTINGS_PATH,
+			OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
+		};
+		writePluginFixture(tempDir);
+		({ executeSlashCommand } = await import(
+			`./executor?exec-${Date.now()}-${Math.random()}`
+		));
+	});
 
-  afterEach(() => {
-    for (const key of ENV_KEYS) {
-      const previousValue = envSnapshot[key]
-      if (previousValue === undefined) {
-        delete process.env[key]
-      } else {
-        process.env[key] = previousValue
-      }
-    }
-    rmSync(tempDir, { recursive: true, force: true })
-  })
+	afterEach(() => {
+		mock.restore();
+		for (const key of ENV_KEYS) {
+			const previousValue = envSnapshot[key];
+			if (previousValue === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = previousValue;
+			}
+		}
+		rmSync(tempDir, { recursive: true, force: true });
+	});
 
-  it("resolves marketplace plugin commands when plugin loading is enabled", async () => {
-    const result = await executeSlashCommand(
-      {
-        command: "daplug:run-prompt",
-        args: "ship it",
-        raw: "/daplug:run-prompt ship it",
-      },
-      {
-        skills: [],
-        pluginsEnabled: true,
-      },
-    )
+	it("resolves marketplace plugin commands when plugin loading is enabled", async () => {
+		const result = await executeSlashCommand(
+			{
+				command: "daplug:run-prompt",
+				args: "ship it",
+				raw: "/daplug:run-prompt ship it",
+			},
+			{
+				skills: [],
+				pluginsEnabled: true,
+			},
+		);
 
-    expect(result.success).toBe(true)
-    expect(result.replacementText).toContain("# /daplug:run-prompt Command")
-    expect(result.replacementText).toContain("**Scope**: plugin")
-  })
+		expect(result.success).toBe(true);
+		expect(result.replacementText).toContain("# /daplug:run-prompt Command");
+		expect(result.replacementText).toContain("**Scope**: plugin");
+	});
 
-  it("excludes marketplace commands when plugins are disabled via config toggle", async () => {
-    const result = await executeSlashCommand(
-      {
-        command: "daplug:run-prompt",
-        args: "",
-        raw: "/daplug:run-prompt",
-      },
-      {
-        skills: [],
-        pluginsEnabled: false,
-      },
-    )
+	it("excludes marketplace commands when plugins are disabled via config toggle", async () => {
+		const result = await executeSlashCommand(
+			{
+				command: "daplug:run-prompt",
+				args: "",
+				raw: "/daplug:run-prompt",
+			},
+			{
+				skills: [],
+				pluginsEnabled: false,
+			},
+		);
 
-    expect(result.success).toBe(false)
-    expect(result.error).toBe(
-      'Command "/daplug:run-prompt" not found. Use the skill tool to list available skills and commands.',
-    )
-  })
+		expect(result.success).toBe(false);
+		expect(result.error).toBe(
+			'Command "/daplug:run-prompt" not found. Use the skill tool to list available skills and commands.',
+		);
+	});
 
-  it("returns standard not-found for unknown namespaced commands", async () => {
-    const result = await executeSlashCommand(
-      {
-        command: "daplug:missing",
-        args: "",
-        raw: "/daplug:missing",
-      },
-      {
-        skills: [],
-        pluginsEnabled: true,
-      },
-    )
+	it("returns standard not-found for unknown namespaced commands", async () => {
+		const result = await executeSlashCommand(
+			{
+				command: "daplug:missing",
+				args: "",
+				raw: "/daplug:missing",
+			},
+			{
+				skills: [],
+				pluginsEnabled: true,
+			},
+		);
 
-    expect(result.success).toBe(false)
-    expect(result.error).toBe(
-      'Command "/daplug:missing" not found. Use the skill tool to list available skills and commands.',
-    )
-    expect(result.error).not.toContain("Marketplace plugin commands")
-  })
+		expect(result.success).toBe(false);
+		expect(result.error).toBe(
+			'Command "/daplug:missing" not found. Use the skill tool to list available skills and commands.',
+		);
+		expect(result.error).not.toContain("Marketplace plugin commands");
+	});
 
-  it("replaces $ARGUMENTS placeholders in plugin command templates", async () => {
-    const result = await executeSlashCommand(
-      {
-        command: "daplug:templated",
-        args: "ship it",
-        raw: "/daplug:templated ship it",
-      },
-      {
-        skills: [],
-        pluginsEnabled: true,
-      },
-    )
+	it("replaces $ARGUMENTS placeholders in plugin command templates", async () => {
+		const result = await executeSlashCommand(
+			{
+				command: "daplug:templated",
+				args: "ship it",
+				raw: "/daplug:templated ship it",
+			},
+			{
+				skills: [],
+				pluginsEnabled: true,
+			},
+		);
 
-    expect(result.success).toBe(true)
-    expect(result.replacementText).toContain("Echo ship it and ship it.")
-    expect(result.replacementText).not.toContain("$ARGUMENTS")
-    expect(result.replacementText).not.toContain("${user_message}")
-  })
-})
+		expect(result.success).toBe(true);
+		expect(result.replacementText).toContain("Echo ship it and ship it.");
+		expect(result.replacementText).not.toContain("$ARGUMENTS");
+		expect(result.replacementText).not.toContain("${user_message}");
+	});
+});

--- a/src/hooks/auto-slash-command/index.test.ts
+++ b/src/hooks/auto-slash-command/index.test.ts
@@ -1,417 +1,446 @@
-import { describe, expect, it, beforeEach, mock, spyOn } from "bun:test"
-import type { LoadedSkill } from "../../features/opencode-skill-loader/types"
-import type {
-  AutoSlashCommandHookInput,
-  AutoSlashCommandHookOutput,
-  CommandExecuteBeforeInput,
-  CommandExecuteBeforeOutput,
-} from "./types"
-
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import type { LoadedSkill } from "../../features/opencode-skill-loader/types";
 // Import real shared module to avoid mock leaking to other test files
-import * as shared from "../../shared"
+import * as shared from "../../shared";
+import type {
+	AutoSlashCommandHookInput,
+	AutoSlashCommandHookOutput,
+	CommandExecuteBeforeInput,
+	CommandExecuteBeforeOutput,
+} from "./types";
 
-// Spy on log instead of mocking the entire module
-const logMock = spyOn(shared, "log").mockImplementation(() => {})
+let logMock: ReturnType<typeof spyOn>;
+let createAutoSlashCommandHook: typeof import("./index").createAutoSlashCommandHook;
 
-
-
-const { createAutoSlashCommandHook } = await import("./index")
-
-function createMockInput(sessionID: string, messageID?: string): AutoSlashCommandHookInput {
-  return {
-    sessionID,
-    messageID: messageID ?? `msg-${Date.now()}-${Math.random()}`,
-    agent: "test-agent",
-    model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
-  }
+function createMockInput(
+	sessionID: string,
+	messageID?: string,
+): AutoSlashCommandHookInput {
+	return {
+		sessionID,
+		messageID: messageID ?? `msg-${Date.now()}-${Math.random()}`,
+		agent: "test-agent",
+		model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+	};
 }
 
 function createMockOutput(text: string): AutoSlashCommandHookOutput {
-  return {
-    message: {
-      agent: "test-agent",
-      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
-      path: { cwd: "/test", root: "/test" },
-      tools: {},
-    },
-    parts: [{ type: "text", text }],
-  }
+	return {
+		message: {
+			agent: "test-agent",
+			model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+			path: { cwd: "/test", root: "/test" },
+			tools: {},
+		},
+		parts: [{ type: "text", text }],
+	};
 }
 
 describe("createAutoSlashCommandHook", () => {
-  beforeEach(() => {
-    logMock.mockClear()
-  })
+	beforeEach(async () => {
+		mock.restore();
+		logMock = spyOn(shared, "log").mockImplementation(() => {});
+		({ createAutoSlashCommandHook } = await import(
+			`./index?index-${Date.now()}-${Math.random()}`
+		));
+		logMock.mockClear();
+	});
 
-  describe("slash command replacement", () => {
-    it("should not modify message when command not found", async () => {
-      // given a slash command that doesn't exist
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-notfound-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("/nonexistent-command args")
-      const originalText = output.parts[0].text
+	afterEach(() => {
+		mock.restore();
+	});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+	describe("slash command replacement", () => {
+		it("should not modify message when command not found", async () => {
+			// given a slash command that doesn't exist
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-notfound-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("/nonexistent-command args");
+			const originalText = output.parts[0].text;
 
-      // then should NOT modify the message (feature inactive when command not found)
-      expect(output.parts[0].text).toBe(originalText)
-    })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-    it("should not modify message for unknown command (feature inactive)", async () => {
-      // given unknown slash command
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-tags-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("/some-command")
-      const originalText = output.parts[0].text
+			// then should NOT modify the message (feature inactive when command not found)
+			expect(output.parts[0].text).toBe(originalText);
+		});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+		it("should not modify message for unknown command (feature inactive)", async () => {
+			// given unknown slash command
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-tags-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("/some-command");
+			const originalText = output.parts[0].text;
 
-      // then should NOT modify (command not found = feature inactive)
-      expect(output.parts[0].text).toBe(originalText)
-    })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-    it("should not modify for unknown command (no prepending)", async () => {
-      // given unknown slash command
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-replace-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("/test-cmd some args")
-      const originalText = output.parts[0].text
+			// then should NOT modify (command not found = feature inactive)
+			expect(output.parts[0].text).toBe(originalText);
+		});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+		it("should not modify for unknown command (no prepending)", async () => {
+			// given unknown slash command
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-replace-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("/test-cmd some args");
+			const originalText = output.parts[0].text;
 
-      // then should not modify (feature inactive for unknown commands)
-      expect(output.parts[0].text).toBe(originalText)
-    })
-  })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-  describe("no slash command", () => {
-    it("should do nothing for regular text", async () => {
-      // given regular text without slash
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-regular-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("Just regular text")
-      const originalText = output.parts[0].text
+			// then should not modify (feature inactive for unknown commands)
+			expect(output.parts[0].text).toBe(originalText);
+		});
+	});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+	describe("no slash command", () => {
+		it("should do nothing for regular text", async () => {
+			// given regular text without slash
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-regular-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("Just regular text");
+			const originalText = output.parts[0].text;
 
-      // then should not modify
-      expect(output.parts[0].text).toBe(originalText)
-    })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-    it("should do nothing for slash in middle of text", async () => {
-      // given slash in middle
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-middle-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("Please run /commit later")
-      const originalText = output.parts[0].text
+			// then should not modify
+			expect(output.parts[0].text).toBe(originalText);
+		});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+		it("should do nothing for slash in middle of text", async () => {
+			// given slash in middle
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-middle-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("Please run /commit later");
+			const originalText = output.parts[0].text;
 
-      // then should not detect (not at start)
-      expect(output.parts[0].text).toBe(originalText)
-    })
-  })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-  describe("excluded commands", () => {
-    it("should NOT trigger for ralph-loop command", async () => {
-      // given ralph-loop command
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-ralph-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("/ralph-loop do something")
-      const originalText = output.parts[0].text
+			// then should not detect (not at start)
+			expect(output.parts[0].text).toBe(originalText);
+		});
+	});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+	describe("excluded commands", () => {
+		it("should NOT trigger for ralph-loop command", async () => {
+			// given ralph-loop command
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-ralph-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("/ralph-loop do something");
+			const originalText = output.parts[0].text;
 
-      // then should not modify (excluded command)
-      expect(output.parts[0].text).toBe(originalText)
-    })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-    it("should NOT trigger for cancel-ralph command", async () => {
-      // given cancel-ralph command
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-cancel-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("/cancel-ralph")
-      const originalText = output.parts[0].text
+			// then should not modify (excluded command)
+			expect(output.parts[0].text).toBe(originalText);
+		});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+		it("should NOT trigger for cancel-ralph command", async () => {
+			// given cancel-ralph command
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-cancel-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("/cancel-ralph");
+			const originalText = output.parts[0].text;
 
-      // then should not modify
-      expect(output.parts[0].text).toBe(originalText)
-    })
-  })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-  describe("already processed", () => {
-    it("should skip if auto-slash-command tags already present", async () => {
-      // given text with existing tags
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-existing-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput(
-        "<auto-slash-command>/commit</auto-slash-command>"
-      )
-      const originalText = output.parts[0].text
+			// then should not modify
+			expect(output.parts[0].text).toBe(originalText);
+		});
+	});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+	describe("already processed", () => {
+		it("should skip if auto-slash-command tags already present", async () => {
+			// given text with existing tags
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-existing-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput(
+				"<auto-slash-command>/commit</auto-slash-command>",
+			);
+			const originalText = output.parts[0].text;
 
-      // then should not modify
-      expect(output.parts[0].text).toBe(originalText)
-    })
-  })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-  describe("code blocks", () => {
-    it("should NOT detect command inside code block", async () => {
-      // given command inside code block
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-codeblock-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("```\n/commit\n```")
-      const originalText = output.parts[0].text
+			// then should not modify
+			expect(output.parts[0].text).toBe(originalText);
+		});
+	});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+	describe("code blocks", () => {
+		it("should NOT detect command inside code block", async () => {
+			// given command inside code block
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-codeblock-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("```\n/commit\n```");
+			const originalText = output.parts[0].text;
 
-      // then should not detect
-      expect(output.parts[0].text).toBe(originalText)
-    })
-  })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-  describe("edge cases", () => {
-    it("should handle empty text", async () => {
-      // given empty text
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-empty-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("")
+			// then should not detect
+			expect(output.parts[0].text).toBe(originalText);
+		});
+	});
 
-      // when hook is called
-      // then should not throw
-      await expect(hook["chat.message"](input, output)).resolves.toBeUndefined()
-    })
+	describe("edge cases", () => {
+		it("should handle empty text", async () => {
+			// given empty text
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-empty-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("");
 
-    it("should handle just slash", async () => {
-      // given just slash
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-slash-only-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("/")
-      const originalText = output.parts[0].text
+			// when hook is called
+			// then should not throw
+			await expect(
+				hook["chat.message"](input, output),
+			).resolves.toBeUndefined();
+		});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+		it("should handle just slash", async () => {
+			// given just slash
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-slash-only-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("/");
+			const originalText = output.parts[0].text;
 
-      // then should not modify
-      expect(output.parts[0].text).toBe(originalText)
-    })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-    it("should handle command with special characters in args (not found = no modification)", async () => {
-      // given command with special characters that doesn't exist
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-special-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput('/execute "test & stuff <tag>"')
-      const originalText = output.parts[0].text
+			// then should not modify
+			expect(output.parts[0].text).toBe(originalText);
+		});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+		it("should handle command with special characters in args (not found = no modification)", async () => {
+			// given command with special characters that doesn't exist
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-special-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput('/execute "test & stuff <tag>"');
+			const originalText = output.parts[0].text;
 
-      // then should not modify (command not found = feature inactive)
-      expect(output.parts[0].text).toBe(originalText)
-    })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-    it("should handle multiple text parts (unknown command = no modification)", async () => {
-      // given multiple text parts with unknown command
-      const hook = createAutoSlashCommandHook()
-      const sessionID = `test-session-multi-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output: AutoSlashCommandHookOutput = {
-        message: {},
-        parts: [
-          { type: "text", text: "/truly-nonexistent-xyz-cmd " },
-          { type: "text", text: "some args" },
-        ],
-      }
-      const originalText = output.parts[0].text
+			// then should not modify (command not found = feature inactive)
+			expect(output.parts[0].text).toBe(originalText);
+		});
 
-      // when hook is called
-      await hook["chat.message"](input, output)
+		it("should handle multiple text parts (unknown command = no modification)", async () => {
+			// given multiple text parts with unknown command
+			const hook = createAutoSlashCommandHook();
+			const sessionID = `test-session-multi-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output: AutoSlashCommandHookOutput = {
+				message: {},
+				parts: [
+					{ type: "text", text: "/truly-nonexistent-xyz-cmd " },
+					{ type: "text", text: "some args" },
+				],
+			};
+			const originalText = output.parts[0].text;
 
-      // then should not modify (command not found = feature inactive)
-      expect(output.parts[0].text).toBe(originalText)
-    })
-  })
+			// when hook is called
+			await hook["chat.message"](input, output);
 
-  describe("command.execute.before hook", () => {
-    function createCommandInput(command: string, args: string = ""): CommandExecuteBeforeInput {
-      return {
-        command,
-        sessionID: `test-session-cmd-${Date.now()}-${Math.random()}`,
-        arguments: args,
-      }
-    }
+			// then should not modify (command not found = feature inactive)
+			expect(output.parts[0].text).toBe(originalText);
+		});
+	});
 
-    function createCommandOutput(text?: string): CommandExecuteBeforeOutput {
-      return {
-        parts: text ? [{ type: "text", text }] : [],
-      }
-    }
+	describe("command.execute.before hook", () => {
+		function createCommandInput(
+			command: string,
+			args: string = "",
+		): CommandExecuteBeforeInput {
+			return {
+				command,
+				sessionID: `test-session-cmd-${Date.now()}-${Math.random()}`,
+				arguments: args,
+			};
+		}
 
-    it("should not modify output for unknown command", async () => {
-      //#given
-      const hook = createAutoSlashCommandHook()
-      const input = createCommandInput("nonexistent-command-xyz")
-      const output = createCommandOutput("original text")
-      const originalText = output.parts[0].text
+		function createCommandOutput(text?: string): CommandExecuteBeforeOutput {
+			return {
+				parts: text ? [{ type: "text", text }] : [],
+			};
+		}
 
-      //#when
-      await hook["command.execute.before"](input, output)
+		it("should not modify output for unknown command", async () => {
+			//#given
+			const hook = createAutoSlashCommandHook();
+			const input = createCommandInput("nonexistent-command-xyz");
+			const output = createCommandOutput("original text");
+			const originalText = output.parts[0].text;
 
-      //#then
-      expect(output.parts[0].text).toBe(originalText)
-    })
+			//#when
+			await hook["command.execute.before"](input, output);
 
-    it("should add text part when parts array is empty and command is unknown", async () => {
-      //#given
-      const hook = createAutoSlashCommandHook()
-      const input = createCommandInput("nonexistent-command-abc")
-      const output = createCommandOutput()
+			//#then
+			expect(output.parts[0].text).toBe(originalText);
+		});
 
-      //#when
-      await hook["command.execute.before"](input, output)
+		it("should add text part when parts array is empty and command is unknown", async () => {
+			//#given
+			const hook = createAutoSlashCommandHook();
+			const input = createCommandInput("nonexistent-command-abc");
+			const output = createCommandOutput();
 
-      //#then
-      expect(output.parts.length).toBe(0)
-    })
+			//#when
+			await hook["command.execute.before"](input, output);
 
-    it("should inject template for known builtin commands like ralph-loop", async () => {
-      //#given
-      const hook = createAutoSlashCommandHook()
-      const input = createCommandInput("ralph-loop")
-      const output = createCommandOutput("original")
+			//#then
+			expect(output.parts.length).toBe(0);
+		});
 
-      //#when
-      await hook["command.execute.before"](input, output)
+		it("should inject template for known builtin commands like ralph-loop", async () => {
+			//#given
+			const hook = createAutoSlashCommandHook();
+			const input = createCommandInput("ralph-loop");
+			const output = createCommandOutput("original");
 
-      //#then
-      expect(output.parts[0].text).toContain("<auto-slash-command>")
-      expect(output.parts[0].text).toContain("/ralph-loop Command")
-    })
+			//#when
+			await hook["command.execute.before"](input, output);
 
-    it("should pass command arguments correctly", async () => {
-      //#given
-      const hook = createAutoSlashCommandHook()
-      const input = createCommandInput("some-command", "arg1 arg2 arg3")
-      const output = createCommandOutput("original")
+			//#then
+			expect(output.parts[0].text).toContain("<auto-slash-command>");
+			expect(output.parts[0].text).toContain("/ralph-loop Command");
+		});
 
-      //#when
-      await hook["command.execute.before"](input, output)
+		it("should pass command arguments correctly", async () => {
+			//#given
+			const hook = createAutoSlashCommandHook();
+			const input = createCommandInput("some-command", "arg1 arg2 arg3");
+			const output = createCommandOutput("original");
 
-      //#then
-      expect(logMock).toHaveBeenCalledWith(
-        "[auto-slash-command] command.execute.before received",
-        expect.objectContaining({
-          command: "some-command",
-          arguments: "arg1 arg2 arg3",
-        })
-      )
-    })
+			//#when
+			await hook["command.execute.before"](input, output);
 
-  })
-  describe("skills as slash commands", () => {
-    function createTestSkill(name: string, template: string): LoadedSkill {
-      return {
-        name,
-        path: `/test/skills/${name}/SKILL.md`,
-        definition: {
-          name,
-          description: `Test skill: ${name}`,
-          template,
-        },
-        scope: "user",
-      }
-    }
+			//#then
+			expect(logMock).toHaveBeenCalledWith(
+				"[auto-slash-command] command.execute.before received",
+				expect.objectContaining({
+					command: "some-command",
+					arguments: "arg1 arg2 arg3",
+				}),
+			);
+		});
+	});
+	describe("skills as slash commands", () => {
+		function createTestSkill(name: string, template: string): LoadedSkill {
+			return {
+				name,
+				path: `/test/skills/${name}/SKILL.md`,
+				definition: {
+					name,
+					description: `Test skill: ${name}`,
+					template,
+				},
+				scope: "user",
+			};
+		}
 
-    it("should replace message with skill template when skill is used as slash command via chat.message", async () => {
-      // given a hook with a skill
-      const skill = createTestSkill("my-test-skill", "This is the skill template content")
-      const hook = createAutoSlashCommandHook({ skills: [skill] })
-      const sessionID = `test-session-skill-chat-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("/my-test-skill some arguments")
+		it("should replace message with skill template when skill is used as slash command via chat.message", async () => {
+			// given a hook with a skill
+			const skill = createTestSkill(
+				"my-test-skill",
+				"This is the skill template content",
+			);
+			const hook = createAutoSlashCommandHook({ skills: [skill] });
+			const sessionID = `test-session-skill-chat-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("/my-test-skill some arguments");
 
-      // when hook processes the message
-      await hook["chat.message"](input, output)
+			// when hook processes the message
+			await hook["chat.message"](input, output);
 
-      // then should replace message with skill template
-      expect(output.parts[0].text).toContain("<auto-slash-command>")
-      expect(output.parts[0].text).toContain("/my-test-skill Command")
-      expect(output.parts[0].text).toContain("This is the skill template content")
-    })
+			// then should replace message with skill template
+			expect(output.parts[0].text).toContain("<auto-slash-command>");
+			expect(output.parts[0].text).toContain("/my-test-skill Command");
+			expect(output.parts[0].text).toContain(
+				"This is the skill template content",
+			);
+		});
 
-    it("should inject skill template via command.execute.before", async () => {
-      // given a hook with a skill
-      const skill = createTestSkill("my-test-skill", "Skill template for command execute")
-      const hook = createAutoSlashCommandHook({ skills: [skill] })
-      const input: CommandExecuteBeforeInput = {
-        command: "my-test-skill",
-        sessionID: `test-session-skill-cmd-${Date.now()}-${Math.random()}`,
-        arguments: "extra args",
-      }
-      const output: CommandExecuteBeforeOutput = {
-        parts: [{ type: "text", text: "original" }],
-      }
+		it("should inject skill template via command.execute.before", async () => {
+			// given a hook with a skill
+			const skill = createTestSkill(
+				"my-test-skill",
+				"Skill template for command execute",
+			);
+			const hook = createAutoSlashCommandHook({ skills: [skill] });
+			const input: CommandExecuteBeforeInput = {
+				command: "my-test-skill",
+				sessionID: `test-session-skill-cmd-${Date.now()}-${Math.random()}`,
+				arguments: "extra args",
+			};
+			const output: CommandExecuteBeforeOutput = {
+				parts: [{ type: "text", text: "original" }],
+			};
 
-      // when hook processes the command
-      await hook["command.execute.before"](input, output)
+			// when hook processes the command
+			await hook["command.execute.before"](input, output);
 
-      // then should inject skill template
-      expect(output.parts[0].text).toContain("<auto-slash-command>")
-      expect(output.parts[0].text).toContain("/my-test-skill Command")
-      expect(output.parts[0].text).toContain("Skill template for command execute")
-      expect(output.parts[0].text).toContain("extra args")
-    })
+			// then should inject skill template
+			expect(output.parts[0].text).toContain("<auto-slash-command>");
+			expect(output.parts[0].text).toContain("/my-test-skill Command");
+			expect(output.parts[0].text).toContain(
+				"Skill template for command execute",
+			);
+			expect(output.parts[0].text).toContain("extra args");
+		});
 
-    it("should handle skill with lazy content loader", async () => {
-      // given a skill with lazy content (no inline template)
-      const skill: LoadedSkill = {
-        name: "lazy-skill",
-        path: "/test/skills/lazy-skill/SKILL.md",
-        definition: {
-          name: "lazy-skill",
-          description: "A lazy-loaded skill",
-          template: "",
-        },
-        scope: "user",
-        lazyContent: {
-          loaded: false,
-          load: async () => "Lazy loaded skill content here",
-        },
-      }
-      const hook = createAutoSlashCommandHook({ skills: [skill] })
-      const sessionID = `test-session-lazy-skill-${Date.now()}`
-      const input = createMockInput(sessionID)
-      const output = createMockOutput("/lazy-skill")
+		it("should handle skill with lazy content loader", async () => {
+			// given a skill with lazy content (no inline template)
+			const skill: LoadedSkill = {
+				name: "lazy-skill",
+				path: "/test/skills/lazy-skill/SKILL.md",
+				definition: {
+					name: "lazy-skill",
+					description: "A lazy-loaded skill",
+					template: "",
+				},
+				scope: "user",
+				lazyContent: {
+					loaded: false,
+					load: async () => "Lazy loaded skill content here",
+				},
+			};
+			const hook = createAutoSlashCommandHook({ skills: [skill] });
+			const sessionID = `test-session-lazy-skill-${Date.now()}`;
+			const input = createMockInput(sessionID);
+			const output = createMockOutput("/lazy-skill");
 
-      // when hook processes the message
-      await hook["chat.message"](input, output)
+			// when hook processes the message
+			await hook["chat.message"](input, output);
 
-      // then should replace message with lazily loaded content
-      expect(output.parts[0].text).toContain("<auto-slash-command>")
-      expect(output.parts[0].text).toContain("Lazy loaded skill content here")
-    })
-  })
-})
+			// then should replace message with lazily loaded content
+			expect(output.parts[0].text).toContain("<auto-slash-command>");
+			expect(output.parts[0].text).toContain("Lazy loaded skill content here");
+		});
+	});
+});

--- a/src/hooks/auto-update-checker/hook/workspace-resolution.test.ts
+++ b/src/hooks/auto-update-checker/hook/workspace-resolution.test.ts
@@ -1,223 +1,266 @@
-import type { PluginInput } from "@opencode-ai/plugin"
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { PluginInput } from "@opencode-ai/plugin";
+import * as shared from "../../../shared";
 
 type PluginEntry = {
-  entry: string
-  isPinned: boolean
-  pinnedVersion: string | null
-  configPath: string
-}
+	entry: string;
+	isPinned: boolean;
+	pinnedVersion: string | null;
+	configPath: string;
+};
 
-type ToastMessageGetter = (isUpdate: boolean, version?: string) => string
+type ToastMessageGetter = (isUpdate: boolean, version?: string) => string;
 
 function createPluginEntry(overrides?: Partial<PluginEntry>): PluginEntry {
-  return {
-    entry: "oh-my-opencode@3.4.0",
-    isPinned: false,
-    pinnedVersion: null,
-    configPath: "/test/opencode.json",
-    ...overrides,
-  }
+	return {
+		entry: "oh-my-opencode@3.4.0",
+		isPinned: false,
+		pinnedVersion: null,
+		configPath: "/test/opencode.json",
+		...overrides,
+	};
 }
 
-const TEST_DIR = join(import.meta.dir, "__test-workspace-resolution__")
-const TEST_CACHE_DIR = join(TEST_DIR, "cache")
-const TEST_CONFIG_DIR = join(TEST_DIR, "config")
+const TEST_DIR = join(import.meta.dir, "__test-workspace-resolution__");
+const TEST_CACHE_DIR = join(TEST_DIR, "cache");
+const TEST_CONFIG_DIR = join(TEST_DIR, "config");
 
-const mockFindPluginEntry = mock((_directory: string): PluginEntry | null => createPluginEntry())
-const mockGetCachedVersion = mock((): string | null => "3.4.0")
-const mockGetLatestVersion = mock(async (): Promise<string | null> => "3.5.0")
-const mockExtractChannel = mock(() => "latest")
-const mockInvalidatePackage = mock(() => {})
+const mockFindPluginEntry = mock((_directory: string): PluginEntry | null =>
+	createPluginEntry(),
+);
+const mockGetCachedVersion = mock((): string | null => "3.4.0");
+const mockGetLatestVersion = mock(async (): Promise<string | null> => "3.5.0");
+const mockExtractChannel = mock(() => "latest");
+const mockInvalidatePackage = mock(() => {});
 const mockShowUpdateAvailableToast = mock(
-  async (_ctx: PluginInput, _latestVersion: string, _getToastMessage: ToastMessageGetter): Promise<void> => {}
-)
+	async (
+		_ctx: PluginInput,
+		_latestVersion: string,
+		_getToastMessage: ToastMessageGetter,
+	): Promise<void> => {},
+);
 const mockShowAutoUpdatedToast = mock(
-  async (_ctx: PluginInput, _fromVersion: string, _toVersion: string): Promise<void> => {}
-)
-const mockSyncCachePackageJsonToIntent = mock(() => ({ synced: true, error: null }))
+	async (
+		_ctx: PluginInput,
+		_fromVersion: string,
+		_toVersion: string,
+	): Promise<void> => {},
+);
+const mockSyncCachePackageJsonToIntent = mock(() => ({
+	synced: true,
+	error: null,
+}));
 
 const mockRunBunInstallWithDetails = mock(
-  async (opts?: { outputMode?: string; workspaceDir?: string }) => {
-    return { success: true }
-  }
-)
+	async (opts?: { outputMode?: string; workspaceDir?: string }) => {
+		return { success: true };
+	},
+);
 
 mock.module("../checker", () => ({
-  findPluginEntry: mockFindPluginEntry,
-  getCachedVersion: mockGetCachedVersion,
-  getLatestVersion: mockGetLatestVersion,
-  revertPinnedVersion: mock(() => false),
-  syncCachePackageJsonToIntent: mockSyncCachePackageJsonToIntent,
-}))
-mock.module("../version-channel", () => ({ extractChannel: mockExtractChannel }))
-mock.module("../cache", () => ({ invalidatePackage: mockInvalidatePackage }))
+	findPluginEntry: mockFindPluginEntry,
+	getCachedVersion: mockGetCachedVersion,
+	getLatestVersion: mockGetLatestVersion,
+	revertPinnedVersion: mock(() => false),
+	syncCachePackageJsonToIntent: mockSyncCachePackageJsonToIntent,
+}));
+mock.module("../version-channel", () => ({
+	extractChannel: mockExtractChannel,
+}));
+mock.module("../cache", () => ({ invalidatePackage: mockInvalidatePackage }));
 mock.module("../../../cli/config-manager", () => ({
-  runBunInstallWithDetails: mockRunBunInstallWithDetails,
-}))
+	runBunInstallWithDetails: mockRunBunInstallWithDetails,
+}));
 mock.module("./update-toasts", () => ({
-  showUpdateAvailableToast: mockShowUpdateAvailableToast,
-  showAutoUpdatedToast: mockShowAutoUpdatedToast,
-}))
-mock.module("../../../shared/logger", () => ({ log: () => {} }))
-mock.module("../../../shared", () => ({
-  getOpenCodeCacheDir: () => TEST_CACHE_DIR,
-  getOpenCodeConfigPaths: () => ({
-    configDir: TEST_CONFIG_DIR,
-    configJson: join(TEST_CONFIG_DIR, "opencode.json"),
-    configJsonc: join(TEST_CONFIG_DIR, "opencode.jsonc"),
-    packageJson: join(TEST_CONFIG_DIR, "package.json"),
-    omoConfig: join(TEST_CONFIG_DIR, "oh-my-opencode.json"),
-  }),
-  getOpenCodeConfigDir: () => TEST_CONFIG_DIR,
-}))
+	showUpdateAvailableToast: mockShowUpdateAvailableToast,
+	showAutoUpdatedToast: mockShowAutoUpdatedToast,
+}));
+mock.module("../../../shared/logger", () => ({ log: () => {} }));
 
 // Mock constants BEFORE importing the module
-const ORIGINAL_PACKAGE_NAME = "oh-my-opencode"
+const ORIGINAL_PACKAGE_NAME = "oh-my-opencode";
 mock.module("../constants", () => ({
-  PACKAGE_NAME: ORIGINAL_PACKAGE_NAME,
-  CACHE_DIR: TEST_CACHE_DIR,
-  USER_CONFIG_DIR: TEST_CONFIG_DIR,
-}))
+	PACKAGE_NAME: ORIGINAL_PACKAGE_NAME,
+	CACHE_DIR: TEST_CACHE_DIR,
+	USER_CONFIG_DIR: TEST_CONFIG_DIR,
+}));
 
-// Need to mock getOpenCodeCacheDir and getOpenCodeConfigPaths before importing the module
-mock.module("../../../shared/data-path", () => ({
-  getDataDir: () => join(TEST_DIR, "data"),
-  getOpenCodeStorageDir: () => join(TEST_DIR, "data", "opencode", "storage"),
-  getCacheDir: () => TEST_DIR,
-  getOmoOpenCodeCacheDir: () => join(TEST_DIR, "oh-my-opencode"),
-  getOpenCodeCacheDir: () => TEST_CACHE_DIR,
-}))
-mock.module("../../../shared/opencode-config-dir", () => ({
-  getOpenCodeConfigDir: () => TEST_CONFIG_DIR,
-  getOpenCodeConfigPaths: () => ({
-    configDir: TEST_CONFIG_DIR,
-    configJson: join(TEST_CONFIG_DIR, "opencode.json"),
-    configJsonc: join(TEST_CONFIG_DIR, "opencode.jsonc"),
-    packageJson: join(TEST_CONFIG_DIR, "package.json"),
-    omoConfig: join(TEST_CONFIG_DIR, "oh-my-opencode.json"),
-  }),
-}))
+const modulePath = "./background-update-check?test";
+const { runBackgroundUpdateCheck } = await import(modulePath);
 
-const modulePath = "./background-update-check?test"
-const { runBackgroundUpdateCheck } = await import(modulePath)
+let getOpenCodeCacheDirSpy: ReturnType<typeof spyOn>;
+let getOpenCodeConfigPathsSpy: ReturnType<typeof spyOn>;
 
 describe("workspace resolution", () => {
-  const mockCtx = { directory: "/test" } as PluginInput
-  const getToastMessage: ToastMessageGetter = (isUpdate, version) =>
-    isUpdate ? `Update to ${version}` : "Up to date"
+	const mockCtx = { directory: "/test" } as PluginInput;
+	const getToastMessage: ToastMessageGetter = (isUpdate, version) =>
+		isUpdate ? `Update to ${version}` : "Up to date";
 
-  beforeEach(() => {
-    // Setup test directories
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true, force: true })
-    }
-    mkdirSync(TEST_DIR, { recursive: true })
+	beforeEach(() => {
+		// Setup test directories
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+		mkdirSync(TEST_DIR, { recursive: true });
 
-    mockFindPluginEntry.mockReset()
-    mockGetCachedVersion.mockReset()
-    mockGetLatestVersion.mockReset()
-    mockExtractChannel.mockReset()
-    mockInvalidatePackage.mockReset()
-    mockRunBunInstallWithDetails.mockReset()
-    mockShowUpdateAvailableToast.mockReset()
-    mockShowAutoUpdatedToast.mockReset()
+		getOpenCodeCacheDirSpy?.mockRestore();
+		getOpenCodeConfigPathsSpy?.mockRestore();
+		getOpenCodeCacheDirSpy = spyOn(
+			shared,
+			"getOpenCodeCacheDir",
+		).mockImplementation(() => TEST_CACHE_DIR);
+		getOpenCodeConfigPathsSpy = spyOn(
+			shared,
+			"getOpenCodeConfigPaths",
+		).mockImplementation(() => ({
+			configDir: TEST_CONFIG_DIR,
+			configJson: join(TEST_CONFIG_DIR, "opencode.json"),
+			configJsonc: join(TEST_CONFIG_DIR, "opencode.jsonc"),
+			packageJson: join(TEST_CONFIG_DIR, "package.json"),
+			omoConfig: join(TEST_CONFIG_DIR, "oh-my-opencode.json"),
+		}));
 
-    mockFindPluginEntry.mockReturnValue(createPluginEntry())
-    mockGetCachedVersion.mockReturnValue("3.4.0")
-    mockGetLatestVersion.mockResolvedValue("3.5.0")
-    mockExtractChannel.mockReturnValue("latest")
-    // Note: Don't use mockResolvedValue here - it overrides the function that captures args
-    mockSyncCachePackageJsonToIntent.mockReturnValue({ synced: true, error: null })
-  })
+		mockFindPluginEntry.mockReset();
+		mockGetCachedVersion.mockReset();
+		mockGetLatestVersion.mockReset();
+		mockExtractChannel.mockReset();
+		mockInvalidatePackage.mockReset();
+		mockRunBunInstallWithDetails.mockReset();
+		mockShowUpdateAvailableToast.mockReset();
+		mockShowAutoUpdatedToast.mockReset();
 
-  afterEach(() => {
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true, force: true })
-    }
-  })
+		mockFindPluginEntry.mockReturnValue(createPluginEntry());
+		mockGetCachedVersion.mockReturnValue("3.4.0");
+		mockGetLatestVersion.mockResolvedValue("3.5.0");
+		mockExtractChannel.mockReturnValue("latest");
+		// Note: Don't use mockResolvedValue here - it overrides the function that captures args
+		mockSyncCachePackageJsonToIntent.mockReturnValue({
+			synced: true,
+			error: null,
+		});
+	});
 
-  describe("#given config-dir install exists but cache-dir does not", () => {
-    it("installs to config-dir, not cache-dir", async () => {
-      //#given - config-dir has installation, cache-dir does not
-      mkdirSync(join(TEST_CONFIG_DIR, "node_modules", "oh-my-opencode"), { recursive: true })
-      writeFileSync(
-        join(TEST_CONFIG_DIR, "package.json"),
-        JSON.stringify({ dependencies: { "oh-my-opencode": "3.4.0" } }, null, 2)
-      )
-      writeFileSync(
-        join(TEST_CONFIG_DIR, "node_modules", "oh-my-opencode", "package.json"),
-        JSON.stringify({ name: "oh-my-opencode", version: "3.4.0" }, null, 2)
-      )
+	afterEach(() => {
+		getOpenCodeCacheDirSpy?.mockRestore();
+		getOpenCodeConfigPathsSpy?.mockRestore();
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
 
-      // cache-dir should NOT exist
-      expect(existsSync(TEST_CACHE_DIR)).toBe(false)
+	describe("#given config-dir install exists but cache-dir does not", () => {
+		it("installs to config-dir, not cache-dir", async () => {
+			//#given - config-dir has installation, cache-dir does not
+			mkdirSync(join(TEST_CONFIG_DIR, "node_modules", "oh-my-opencode"), {
+				recursive: true,
+			});
+			writeFileSync(
+				join(TEST_CONFIG_DIR, "package.json"),
+				JSON.stringify(
+					{ dependencies: { "oh-my-opencode": "3.4.0" } },
+					null,
+					2,
+				),
+			);
+			writeFileSync(
+				join(TEST_CONFIG_DIR, "node_modules", "oh-my-opencode", "package.json"),
+				JSON.stringify({ name: "oh-my-opencode", version: "3.4.0" }, null, 2),
+			);
 
-      //#when
-      await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
+			// cache-dir should NOT exist
+			expect(existsSync(TEST_CACHE_DIR)).toBe(false);
 
-      //#then - install should be called with config-dir
-      const mockCalls = mockRunBunInstallWithDetails.mock.calls
-      expect(mockCalls[0][0]?.workspaceDir).toBe(TEST_CONFIG_DIR)
-    })
-  })
+			//#when
+			await runBackgroundUpdateCheck(mockCtx, true, getToastMessage);
 
-  describe("#given both config-dir and cache-dir exist", () => {
-    it("prefers config-dir over cache-dir", async () => {
-      //#given - both directories have installations
-      mkdirSync(join(TEST_CONFIG_DIR, "node_modules", "oh-my-opencode"), { recursive: true })
-      writeFileSync(
-        join(TEST_CONFIG_DIR, "package.json"),
-        JSON.stringify({ dependencies: { "oh-my-opencode": "3.4.0" } }, null, 2)
-      )
-      writeFileSync(
-        join(TEST_CONFIG_DIR, "node_modules", "oh-my-opencode", "package.json"),
-        JSON.stringify({ name: "oh-my-opencode", version: "3.4.0" }, null, 2)
-      )
+			//#then - install should be called with config-dir
+			const mockCalls = mockRunBunInstallWithDetails.mock.calls;
+			expect(mockCalls[0][0]?.workspaceDir).toBe(TEST_CONFIG_DIR);
+		});
+	});
 
-      mkdirSync(join(TEST_CACHE_DIR, "node_modules", "oh-my-opencode"), { recursive: true })
-      writeFileSync(
-        join(TEST_CACHE_DIR, "package.json"),
-        JSON.stringify({ dependencies: { "oh-my-opencode": "3.4.0" } }, null, 2)
-      )
-      writeFileSync(
-        join(TEST_CACHE_DIR, "node_modules", "oh-my-opencode", "package.json"),
-        JSON.stringify({ name: "oh-my-opencode", version: "3.4.0" }, null, 2)
-      )
+	describe("#given both config-dir and cache-dir exist", () => {
+		it("prefers config-dir over cache-dir", async () => {
+			//#given - both directories have installations
+			mkdirSync(join(TEST_CONFIG_DIR, "node_modules", "oh-my-opencode"), {
+				recursive: true,
+			});
+			writeFileSync(
+				join(TEST_CONFIG_DIR, "package.json"),
+				JSON.stringify(
+					{ dependencies: { "oh-my-opencode": "3.4.0" } },
+					null,
+					2,
+				),
+			);
+			writeFileSync(
+				join(TEST_CONFIG_DIR, "node_modules", "oh-my-opencode", "package.json"),
+				JSON.stringify({ name: "oh-my-opencode", version: "3.4.0" }, null, 2),
+			);
 
-      //#when
-      await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
+			mkdirSync(join(TEST_CACHE_DIR, "node_modules", "oh-my-opencode"), {
+				recursive: true,
+			});
+			writeFileSync(
+				join(TEST_CACHE_DIR, "package.json"),
+				JSON.stringify(
+					{ dependencies: { "oh-my-opencode": "3.4.0" } },
+					null,
+					2,
+				),
+			);
+			writeFileSync(
+				join(TEST_CACHE_DIR, "node_modules", "oh-my-opencode", "package.json"),
+				JSON.stringify({ name: "oh-my-opencode", version: "3.4.0" }, null, 2),
+			);
 
-      //#then - install should prefer config-dir
-      const mockCalls2 = mockRunBunInstallWithDetails.mock.calls
-      expect(mockCalls2[0][0]?.workspaceDir).toBe(TEST_CONFIG_DIR)
-    })
-  })
+			//#when
+			await runBackgroundUpdateCheck(mockCtx, true, getToastMessage);
 
-  describe("#given only cache-dir install exists", () => {
-    it("falls back to cache-dir", async () => {
-      //#given - only cache-dir has installation
-      mkdirSync(join(TEST_CACHE_DIR, "node_modules", "oh-my-opencode"), { recursive: true })
-      writeFileSync(
-        join(TEST_CACHE_DIR, "package.json"),
-        JSON.stringify({ dependencies: { "oh-my-opencode": "3.4.0" } }, null, 2)
-      )
-      writeFileSync(
-        join(TEST_CACHE_DIR, "node_modules", "oh-my-opencode", "package.json"),
-        JSON.stringify({ name: "oh-my-opencode", version: "3.4.0" }, null, 2)
-      )
+			//#then - install should prefer config-dir
+			const mockCalls2 = mockRunBunInstallWithDetails.mock.calls;
+			expect(mockCalls2[0][0]?.workspaceDir).toBe(TEST_CONFIG_DIR);
+		});
+	});
 
-      // config-dir should NOT exist
-      expect(existsSync(TEST_CONFIG_DIR)).toBe(false)
+	describe("#given only cache-dir install exists", () => {
+		it("falls back to cache-dir", async () => {
+			//#given - only cache-dir has installation
+			mkdirSync(join(TEST_CACHE_DIR, "node_modules", "oh-my-opencode"), {
+				recursive: true,
+			});
+			writeFileSync(
+				join(TEST_CACHE_DIR, "package.json"),
+				JSON.stringify(
+					{ dependencies: { "oh-my-opencode": "3.4.0" } },
+					null,
+					2,
+				),
+			);
+			writeFileSync(
+				join(TEST_CACHE_DIR, "node_modules", "oh-my-opencode", "package.json"),
+				JSON.stringify({ name: "oh-my-opencode", version: "3.4.0" }, null, 2),
+			);
 
-      //#when
-      await runBackgroundUpdateCheck(mockCtx, true, getToastMessage)
+			// config-dir should NOT exist
+			expect(existsSync(TEST_CONFIG_DIR)).toBe(false);
 
-      //#then - install should fall back to cache-dir
-      const mockCalls3 = mockRunBunInstallWithDetails.mock.calls
-      expect(mockCalls3[0][0]?.workspaceDir).toBe(TEST_CACHE_DIR)
-    })
-  })
-})
+			//#when
+			await runBackgroundUpdateCheck(mockCtx, true, getToastMessage);
+
+			//#then - install should fall back to cache-dir
+			const mockCalls3 = mockRunBunInstallWithDetails.mock.calls;
+			expect(mockCalls3[0][0]?.workspaceDir).toBe(TEST_CACHE_DIR);
+		});
+	});
+});

--- a/src/hooks/claude-code-hooks/stop.test.ts
+++ b/src/hooks/claude-code-hooks/stop.test.ts
@@ -1,200 +1,219 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test"
-import type { ClaudeHooksConfig } from "./types"
-import type { StopContext } from "./stop"
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import * as loggerModule from "../../shared/logger";
+import * as dispatchHookModule from "./dispatch-hook";
+import type { StopContext } from "./stop";
+import type { ClaudeHooksConfig } from "./types";
 
 const mockExecuteHookCommand = mock(() =>
-  Promise.resolve({ exitCode: 0, stdout: "", stderr: "" })
-)
+	Promise.resolve({ exitCode: 0, stdout: "", stderr: "" }),
+);
 
-mock.module("../../shared/command-executor", () => ({
-  executeHookCommand: mockExecuteHookCommand,
-  executeCommand: mock(),
-  resolveCommandsInText: mock(),
-}))
-
-mock.module("../../shared/logger", () => ({
-  log: () => {},
-  getLogFilePath: () => "/tmp/test.log",
-}))
-
-const { executeStopHooks } = await import("./stop")
+let executeStopHooks: typeof import("./stop").executeStopHooks;
 
 function createStopContext(overrides?: Partial<StopContext>): StopContext {
-  return {
-    sessionId: "test-session",
-    cwd: "/tmp",
-    ...overrides,
-  }
+	return {
+		sessionId: "test-session",
+		cwd: "/tmp",
+		...overrides,
+	};
 }
 
 function createConfig(stopHooks: ClaudeHooksConfig["Stop"]): ClaudeHooksConfig {
-  return { Stop: stopHooks }
+	return { Stop: stopHooks };
 }
 
 describe("executeStopHooks", () => {
-  beforeEach(() => {
-    mockExecuteHookCommand.mockReset()
-    mockExecuteHookCommand.mockImplementation(() =>
-      Promise.resolve({ exitCode: 0, stdout: "", stderr: "" })
-    )
-  })
+	beforeEach(async () => {
+		mock.restore();
+		mockExecuteHookCommand.mockReset();
+		mockExecuteHookCommand.mockImplementation(() =>
+			Promise.resolve({ exitCode: 0, stdout: "", stderr: "" }),
+		);
 
-  it("#given parent session #when stop hooks called #then skips execution", async () => {
-    const ctx = createStopContext({ parentSessionId: "parent-session" })
-    const config = createConfig([
-      { matcher: "*", hooks: [{ type: "command", command: "echo test" }] },
-    ])
+		spyOn(dispatchHookModule, "dispatchHook").mockImplementation(
+			async () => await mockExecuteHookCommand(),
+		);
+		spyOn(loggerModule, "log").mockImplementation(() => {});
 
-    const result = await executeStopHooks(ctx, config)
+		({ executeStopHooks } = await import(
+			`./stop?stop-${Date.now()}-${Math.random()}`
+		));
+	});
 
-    expect(result.block).toBe(false)
-    expect(mockExecuteHookCommand).not.toHaveBeenCalled()
-  })
+	afterEach(() => {
+		mock.restore();
+	});
 
-  it("#given null config #when stop hooks called #then returns non-blocking", async () => {
-    const ctx = createStopContext()
+	it("#given parent session #when stop hooks called #then skips execution", async () => {
+		const ctx = createStopContext({ parentSessionId: "parent-session" });
+		const config = createConfig([
+			{ matcher: "*", hooks: [{ type: "command", command: "echo test" }] },
+		]);
 
-    const result = await executeStopHooks(ctx, null)
+		const result = await executeStopHooks(ctx, config);
 
-    expect(result.block).toBe(false)
-    expect(mockExecuteHookCommand).not.toHaveBeenCalled()
-  })
+		expect(result.block).toBe(false);
+		expect(mockExecuteHookCommand).not.toHaveBeenCalled();
+	});
 
-  it("#given empty stop hooks #when stop hooks called #then returns non-blocking", async () => {
-    const ctx = createStopContext()
-    const config = createConfig([])
+	it("#given null config #when stop hooks called #then returns non-blocking", async () => {
+		const ctx = createStopContext();
 
-    const result = await executeStopHooks(ctx, config)
+		const result = await executeStopHooks(ctx, null);
 
-    expect(result.block).toBe(false)
-  })
+		expect(result.block).toBe(false);
+		expect(mockExecuteHookCommand).not.toHaveBeenCalled();
+	});
 
-  it("#given hook with exit code 2 #when stop hooks called #then blocks", async () => {
-    const ctx = createStopContext()
-    const config = createConfig([
-      { matcher: "*", hooks: [{ type: "command", command: "exit 2" }] },
-    ])
-    mockExecuteHookCommand.mockResolvedValueOnce({
-      exitCode: 2,
-      stdout: "",
-      stderr: "blocked reason",
-    })
+	it("#given empty stop hooks #when stop hooks called #then returns non-blocking", async () => {
+		const ctx = createStopContext();
+		const config = createConfig([]);
 
-    const result = await executeStopHooks(ctx, config)
+		const result = await executeStopHooks(ctx, config);
 
-    expect(result.block).toBe(true)
-    expect(result.reason).toBe("blocked reason")
-  })
+		expect(result.block).toBe(false);
+	});
 
-  it("#given hook with decision=block #when stop hooks called #then blocks", async () => {
-    const ctx = createStopContext()
-    const config = createConfig([
-      { matcher: "*", hooks: [{ type: "command", command: "blocker" }] },
-    ])
-    mockExecuteHookCommand.mockResolvedValueOnce({
-      exitCode: 0,
-      stdout: JSON.stringify({ decision: "block", reason: "must fix" }),
-      stderr: "",
-    })
+	it("#given hook with exit code 2 #when stop hooks called #then blocks", async () => {
+		const ctx = createStopContext();
+		const config = createConfig([
+			{ matcher: "*", hooks: [{ type: "command", command: "exit 2" }] },
+		]);
+		mockExecuteHookCommand.mockResolvedValueOnce({
+			exitCode: 2,
+			stdout: "",
+			stderr: "blocked reason",
+		});
 
-    const result = await executeStopHooks(ctx, config)
+		const result = await executeStopHooks(ctx, config);
 
-    expect(result.block).toBe(true)
-    expect(result.reason).toBe("must fix")
-  })
+		expect(result.block).toBe(true);
+		expect(result.reason).toBe("blocked reason");
+	});
 
-  it("#given first hook returns non-blocking JSON #when multiple hooks #then executes all hooks", async () => {
-    const ctx = createStopContext()
-    const config = createConfig([
-      { matcher: "*", hooks: [{ type: "command", command: "hook-a" }] },
-      { matcher: "*", hooks: [{ type: "command", command: "hook-b" }] },
-    ])
-    mockExecuteHookCommand
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: JSON.stringify({ suppressOutput: true }),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: JSON.stringify({ suppressOutput: true }),
-        stderr: "",
-      })
+	it("#given hook with decision=block #when stop hooks called #then blocks", async () => {
+		const ctx = createStopContext();
+		const config = createConfig([
+			{ matcher: "*", hooks: [{ type: "command", command: "blocker" }] },
+		]);
+		mockExecuteHookCommand.mockResolvedValueOnce({
+			exitCode: 0,
+			stdout: JSON.stringify({ decision: "block", reason: "must fix" }),
+			stderr: "",
+		});
 
-    const result = await executeStopHooks(ctx, config)
+		const result = await executeStopHooks(ctx, config);
 
-    expect(result.block).toBe(false)
-    expect(mockExecuteHookCommand).toHaveBeenCalledTimes(2)
-  })
+		expect(result.block).toBe(true);
+		expect(result.reason).toBe("must fix");
+	});
 
-  it("#given first hook returns stdin passthrough JSON #when multiple hooks #then executes all hooks", async () => {
-    const ctx = createStopContext()
-    const stdinPassthrough = {
-      session_id: "test-session",
-      hook_event_name: "Stop",
-      hook_source: "opencode-plugin",
-    }
-    const config = createConfig([
-      { matcher: "*", hooks: [{ type: "command", command: "check-console-log" }] },
-      { matcher: "*", hooks: [{ type: "command", command: "task-complete-notify" }] },
-    ])
-    mockExecuteHookCommand
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: JSON.stringify(stdinPassthrough),
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: JSON.stringify({ suppressOutput: true }),
-        stderr: "",
-      })
+	it("#given first hook returns non-blocking JSON #when multiple hooks #then executes all hooks", async () => {
+		const ctx = createStopContext();
+		const config = createConfig([
+			{ matcher: "*", hooks: [{ type: "command", command: "hook-a" }] },
+			{ matcher: "*", hooks: [{ type: "command", command: "hook-b" }] },
+		]);
+		mockExecuteHookCommand
+			.mockResolvedValueOnce({
+				exitCode: 0,
+				stdout: JSON.stringify({ suppressOutput: true }),
+				stderr: "",
+			})
+			.mockResolvedValueOnce({
+				exitCode: 0,
+				stdout: JSON.stringify({ suppressOutput: true }),
+				stderr: "",
+			});
 
-    const result = await executeStopHooks(ctx, config)
+		const result = await executeStopHooks(ctx, config);
 
-    expect(result.block).toBe(false)
-    expect(mockExecuteHookCommand).toHaveBeenCalledTimes(2)
-  })
+		expect(result.block).toBe(false);
+		expect(mockExecuteHookCommand).toHaveBeenCalledTimes(2);
+	});
 
-  it("#given first hook blocks #when multiple hooks #then stops at blocking hook", async () => {
-    const ctx = createStopContext()
-    const config = createConfig([
-      { matcher: "*", hooks: [{ type: "command", command: "blocker" }] },
-      { matcher: "*", hooks: [{ type: "command", command: "notifier" }] },
-    ])
-    mockExecuteHookCommand.mockResolvedValueOnce({
-      exitCode: 0,
-      stdout: JSON.stringify({ decision: "block", reason: "fix first" }),
-      stderr: "",
-    })
+	it("#given first hook returns stdin passthrough JSON #when multiple hooks #then executes all hooks", async () => {
+		const ctx = createStopContext();
+		const stdinPassthrough = {
+			session_id: "test-session",
+			hook_event_name: "Stop",
+			hook_source: "opencode-plugin",
+		};
+		const config = createConfig([
+			{
+				matcher: "*",
+				hooks: [{ type: "command", command: "check-console-log" }],
+			},
+			{
+				matcher: "*",
+				hooks: [{ type: "command", command: "task-complete-notify" }],
+			},
+		]);
+		mockExecuteHookCommand
+			.mockResolvedValueOnce({
+				exitCode: 0,
+				stdout: JSON.stringify(stdinPassthrough),
+				stderr: "",
+			})
+			.mockResolvedValueOnce({
+				exitCode: 0,
+				stdout: JSON.stringify({ suppressOutput: true }),
+				stderr: "",
+			});
 
-    const result = await executeStopHooks(ctx, config)
+		const result = await executeStopHooks(ctx, config);
 
-    expect(result.block).toBe(true)
-    expect(mockExecuteHookCommand).toHaveBeenCalledTimes(1)
-  })
+		expect(result.block).toBe(false);
+		expect(mockExecuteHookCommand).toHaveBeenCalledTimes(2);
+	});
 
-  it("#given hook with non-JSON stdout #when stop hooks called #then continues to next hook", async () => {
-    const ctx = createStopContext()
-    const config = createConfig([
-      { matcher: "*", hooks: [{ type: "command", command: "hook-a" }] },
-      { matcher: "*", hooks: [{ type: "command", command: "hook-b" }] },
-    ])
-    mockExecuteHookCommand
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "not json",
-        stderr: "",
-      })
-      .mockResolvedValueOnce({
-        exitCode: 0,
-        stdout: "",
-        stderr: "",
-      })
+	it("#given first hook blocks #when multiple hooks #then stops at blocking hook", async () => {
+		const ctx = createStopContext();
+		const config = createConfig([
+			{ matcher: "*", hooks: [{ type: "command", command: "blocker" }] },
+			{ matcher: "*", hooks: [{ type: "command", command: "notifier" }] },
+		]);
+		mockExecuteHookCommand.mockResolvedValueOnce({
+			exitCode: 0,
+			stdout: JSON.stringify({ decision: "block", reason: "fix first" }),
+			stderr: "",
+		});
 
-    const result = await executeStopHooks(ctx, config)
+		const result = await executeStopHooks(ctx, config);
 
-    expect(result.block).toBe(false)
-    expect(mockExecuteHookCommand).toHaveBeenCalledTimes(2)
-  })
-})
+		expect(result.block).toBe(true);
+		expect(mockExecuteHookCommand).toHaveBeenCalledTimes(1);
+	});
+
+	it("#given hook with non-JSON stdout #when stop hooks called #then continues to next hook", async () => {
+		const ctx = createStopContext();
+		const config = createConfig([
+			{ matcher: "*", hooks: [{ type: "command", command: "hook-a" }] },
+			{ matcher: "*", hooks: [{ type: "command", command: "hook-b" }] },
+		]);
+		mockExecuteHookCommand
+			.mockResolvedValueOnce({
+				exitCode: 0,
+				stdout: "not json",
+				stderr: "",
+			})
+			.mockResolvedValueOnce({
+				exitCode: 0,
+				stdout: "",
+				stderr: "",
+			});
+
+		const result = await executeStopHooks(ctx, config);
+
+		expect(result.block).toBe(false);
+		expect(mockExecuteHookCommand).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/hooks/comment-checker/cli.test.ts
+++ b/src/hooks/comment-checker/cli.test.ts
@@ -1,205 +1,292 @@
-import { describe, test, expect, mock } from "bun:test"
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
-import { tmpdir } from "node:os"
+import { describe, expect, mock, test } from "bun:test";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import type { PendingCall } from "./types"
+import type { PendingCall } from "./types";
 
 function createMockInput() {
-  return {
-    session_id: "test",
-    tool_name: "Write",
-    transcript_path: "",
-    cwd: "/tmp",
-    hook_event_name: "PostToolUse",
-    tool_input: { file_path: "/tmp/test.ts", content: "const x = 1" },
-  }
+	return {
+		session_id: "test",
+		tool_name: "Write",
+		transcript_path: "",
+		cwd: "/tmp",
+		hook_event_name: "PostToolUse",
+		tool_input: { file_path: "/tmp/test.ts", content: "const x = 1" },
+	};
 }
 
 function createScriptBinary(scriptContent: string): string {
-  const directory = mkdtempSync(join(tmpdir(), "comment-checker-cli-test-"))
-  const binaryPath = join(directory, "comment-checker")
-  writeFileSync(binaryPath, scriptContent)
-  chmodSync(binaryPath, 0o755)
-  return binaryPath
+	const directory = mkdtempSync(join(tmpdir(), "comment-checker-cli-test-"));
+	const binaryPath = join(
+		directory,
+		process.platform === "win32" ? "comment-checker.cmd" : "comment-checker",
+	);
+	writeFileSync(binaryPath, scriptContent);
+	chmodSync(binaryPath, 0o755);
+	return binaryPath;
+}
+
+function createTimeoutBinary(): string {
+	return createScriptBinary(
+		process.platform === "win32"
+			? [
+					"@echo off",
+					'if not "%1"=="check" exit /b 1',
+					"more > nul",
+					":loop",
+					"goto loop",
+				].join("\r\n")
+			: [
+					"#!/bin/sh",
+					'if [ "$1" != "check" ]; then',
+					"  exit 1",
+					"fi",
+					"trap '' TERM",
+					"while :; do",
+					"  :",
+					"done",
+					"",
+				].join("\n"),
+	);
+}
+
+function createCommentBinary(): string {
+	return createScriptBinary(
+		process.platform === "win32"
+			? [
+					"@echo off",
+					'if not "%1"=="check" exit /b 1',
+					"more > nul",
+					"echo found comments>&2",
+					"exit /b 2",
+				].join("\r\n")
+			: [
+					"#!/bin/sh",
+					'if [ "$1" != "check" ]; then',
+					"  exit 1",
+					"fi",
+					"cat >/dev/null",
+					'echo "found comments" 1>&2',
+					"exit 2",
+					"",
+				].join("\n"),
+	);
+}
+
+async function withExecutableFriendlyCwd<T>(fn: () => Promise<T>): Promise<T> {
+	if (process.platform !== "win32") {
+		return await fn();
+	}
+
+	const previousCwd = process.cwd();
+	process.chdir(tmpdir());
+	try {
+		return await fn();
+	} finally {
+		process.chdir(previousCwd);
+	}
 }
 
 describe("comment-checker CLI", () => {
-  describe("lazy initialization", () => {
-    test("getCommentCheckerPathSync should be lazy and callable", async () => {
-      // given
-      const cliModule = await import("./cli")
-      // when
-      const result = cliModule.getCommentCheckerPathSync()
-      // then
-      expect(typeof cliModule.getCommentCheckerPathSync).toBe("function")
-      expect(result === null || typeof result === "string").toBe(true)
-    })
+	describe("lazy initialization", () => {
+		test("getCommentCheckerPathSync should be lazy and callable", async () => {
+			// given
+			const cliModule = await import("./cli");
+			// when
+			const result = cliModule.getCommentCheckerPathSync();
+			// then
+			expect(typeof cliModule.getCommentCheckerPathSync).toBe("function");
+			expect(result === null || typeof result === "string").toBe(true);
+		});
 
-    test("COMMENT_CHECKER_CLI_PATH export should not exist", async () => {
-      // given
-      const cliModule = await import("./cli")
-      // when
-      // then
-      expect("COMMENT_CHECKER_CLI_PATH" in cliModule).toBe(false)
-    })
-  })
+		test("COMMENT_CHECKER_CLI_PATH export should not exist", async () => {
+			// given
+			const cliModule = await import("./cli");
+			// when
+			// then
+			expect("COMMENT_CHECKER_CLI_PATH" in cliModule).toBe(false);
+		});
+	});
 
-  describe("runCommentChecker", () => {
-    test("returns CheckResult shape without explicit CLI path", async () => {
-      // given
-      const { runCommentChecker } = await import("./cli")
-      // when
-      const result = await runCommentChecker(createMockInput())
-      // then
-      expect(typeof result.hasComments).toBe("boolean")
-      expect(typeof result.message).toBe("string")
-    })
+	describe("runCommentChecker", () => {
+		test("returns CheckResult shape without explicit CLI path", async () => {
+			// given
+			const { runCommentChecker } = await import("./cli");
+			// when
+			const result = await runCommentChecker(createMockInput());
+			// then
+			expect(typeof result.hasComments).toBe("boolean");
+			expect(typeof result.message).toBe("string");
+		});
 
-    test("sends SIGKILL after grace period when process ignores SIGTERM", async () => {
-      // given
-      const { runCommentChecker } = await import("./cli")
-      const binaryPath = createScriptBinary(`#!/bin/sh
-if [ "$1" != "check" ]; then
-  exit 1
-fi
-trap '' TERM
-while :; do
-  :
-done
-`)
-      const originalSetTimeout = globalThis.setTimeout
-      globalThis.setTimeout = ((fn: (...args: unknown[]) => void, _ms?: number) => {
-        fn()
-        return 0 as unknown as ReturnType<typeof setTimeout>
-      }) as typeof setTimeout
+		test("sends SIGKILL after grace period when process ignores SIGTERM", async () => {
+			// given
+			const { runCommentChecker } = await import("./cli");
+			const binaryPath = createTimeoutBinary();
+			const originalSetTimeout = globalThis.setTimeout;
+			globalThis.setTimeout = ((
+				fn: (...args: unknown[]) => void,
+				_ms?: number,
+			) => {
+				fn();
+				return 0 as unknown as ReturnType<typeof setTimeout>;
+			}) as typeof setTimeout;
 
-      try {
-        // when
-        const result = await runCommentChecker(createMockInput(), binaryPath)
-        // then
-        expect(result).toEqual({ hasComments: false, message: "" })
-      } finally {
-        globalThis.setTimeout = originalSetTimeout
-      }
-    })
+			try {
+				// when
+				const result = await withExecutableFriendlyCwd(() =>
+					runCommentChecker(createMockInput(), binaryPath),
+				);
+				// then
+				expect(result).toEqual({ hasComments: false, message: "" });
+			} finally {
+				globalThis.setTimeout = originalSetTimeout;
+			}
+		});
 
-    test("returns empty result on timeout", async () => {
-      // given
-      const { runCommentChecker } = await import("./cli")
-      const binaryPath = createScriptBinary(`#!/bin/sh
-if [ "$1" != "check" ]; then
-  exit 1
-fi
-trap '' TERM
-while :; do
-  :
-done
-`)
-      const originalSetTimeout = globalThis.setTimeout
-      globalThis.setTimeout = ((fn: (...args: unknown[]) => void, _ms?: number) => {
-        fn()
-        return 0 as unknown as ReturnType<typeof setTimeout>
-      }) as typeof setTimeout
+		test("returns empty result on timeout", async () => {
+			// given
+			const { runCommentChecker } = await import("./cli");
+			const binaryPath = createTimeoutBinary();
+			const originalSetTimeout = globalThis.setTimeout;
+			globalThis.setTimeout = ((
+				fn: (...args: unknown[]) => void,
+				_ms?: number,
+			) => {
+				fn();
+				return 0 as unknown as ReturnType<typeof setTimeout>;
+			}) as typeof setTimeout;
 
-      try {
-        // when
-        const result = await runCommentChecker(createMockInput(), binaryPath)
-        // then
-        expect(result).toEqual({ hasComments: false, message: "" })
-      } finally {
-        globalThis.setTimeout = originalSetTimeout
-      }
-    })
+			try {
+				// when
+				const result = await withExecutableFriendlyCwd(() =>
+					runCommentChecker(createMockInput(), binaryPath),
+				);
+				// then
+				expect(result).toEqual({ hasComments: false, message: "" });
+			} finally {
+				globalThis.setTimeout = originalSetTimeout;
+			}
+		});
 
-    test("keeps non-timeout flow unchanged", async () => {
-      // given
-      const { runCommentChecker } = await import("./cli")
-      const binaryPath = createScriptBinary(`#!/bin/sh
-if [ "$1" != "check" ]; then
-  exit 1
-fi
-cat >/dev/null
-echo "found comments" 1>&2
-exit 2
-`)
-      // when
-      const result = await runCommentChecker(createMockInput(), binaryPath)
-      // then
-      expect(result).toEqual({ hasComments: true, message: "found comments\n" })
-    })
-  })
+		test("keeps non-timeout flow unchanged", async () => {
+			// given
+			const { runCommentChecker } = await import("./cli");
+			const binaryPath = createCommentBinary();
+			// when
+			const result = await withExecutableFriendlyCwd(() =>
+				runCommentChecker(createMockInput(), binaryPath),
+			);
+			// then
+			expect(result.hasComments).toBe(true);
+			expect(result.message.replace(/\r\n/g, "\n")).toBe("found comments\n");
+		});
+	});
 
-  describe("processWithCli semaphore", () => {
-    test("skips second concurrent processWithCli call", async () => {
-      // given
-      let callCount = 0
-      let resolveFirst = () => {}
-      const firstCallPromise = new Promise<void>((resolve) => {
-        resolveFirst = resolve
-      })
-      const cliMockFactory = () => ({
-        runCommentChecker: mock(async () => {
-          callCount += 1
-          if (callCount === 1) {
-            await firstCallPromise
-          }
-          return { hasComments: false, message: "" }
-        }),
-        getCommentCheckerPath: mock(async () => "/fake"),
-        startBackgroundInit: mock(() => {}),
-      })
-      mock.module("./cli", cliMockFactory)
-      mock.module("./cli.ts", cliMockFactory)
-      mock.module(new URL("./cli.ts", import.meta.url).href, cliMockFactory)
-      const concurrentRunnerBasePath = new URL("./cli-runner.ts", import.meta.url).pathname
-      const concurrentModulePath = `${concurrentRunnerBasePath}?semaphore-concurrent`
-      const { processWithCli } = await import(concurrentModulePath)
-      const pendingCall: PendingCall = {
-        tool: "write",
-        sessionID: "ses-1",
-        filePath: "/tmp/a.ts",
-        timestamp: Date.now(),
-      }
-      const firstCall = processWithCli({ tool: "write", sessionID: "ses-1", callID: "call-1" }, pendingCall, { output: "" }, "/fake", undefined, () => {})
-      const secondCall = processWithCli({ tool: "write", sessionID: "ses-2", callID: "call-2" }, pendingCall, { output: "" }, "/fake", undefined, () => {})
+	describe("processWithCli semaphore", () => {
+		test("skips second concurrent processWithCli call", async () => {
+			// given
+			let callCount = 0;
+			let resolveFirst = () => {};
+			const firstCallPromise = new Promise<void>((resolve) => {
+				resolveFirst = resolve;
+			});
+			const cliMockFactory = () => ({
+				runCommentChecker: mock(async () => {
+					callCount += 1;
+					if (callCount === 1) {
+						await firstCallPromise;
+					}
+					return { hasComments: false, message: "" };
+				}),
+				getCommentCheckerPath: mock(async () => "/fake"),
+				startBackgroundInit: mock(() => {}),
+			});
+			mock.module("./cli", cliMockFactory);
+			mock.module("./cli.ts", cliMockFactory);
+			mock.module(new URL("./cli.ts", import.meta.url).href, cliMockFactory);
+			const concurrentRunnerBasePath = fileURLToPath(
+				new URL("./cli-runner.ts", import.meta.url),
+			);
+			const concurrentModulePath = `${concurrentRunnerBasePath}?semaphore-concurrent`;
+			const { processWithCli } = await import(concurrentModulePath);
+			const pendingCall: PendingCall = {
+				tool: "write",
+				sessionID: "ses-1",
+				filePath: "/tmp/a.ts",
+				timestamp: Date.now(),
+			};
+			const firstCall = processWithCli(
+				{ tool: "write", sessionID: "ses-1", callID: "call-1" },
+				pendingCall,
+				{ output: "" },
+				"/fake",
+				undefined,
+				() => {},
+			);
+			const secondCall = processWithCli(
+				{ tool: "write", sessionID: "ses-2", callID: "call-2" },
+				pendingCall,
+				{ output: "" },
+				"/fake",
+				undefined,
+				() => {},
+			);
 
-      // when
-      await secondCall
-      resolveFirst()
-      await firstCall
-      // then
-      expect(callCount).toBe(1)
-    })
+			// when
+			await secondCall;
+			resolveFirst();
+			await firstCall;
+			// then
+			expect(callCount).toBe(1);
+		});
 
-    test("allows second call after first call completes", async () => {
-      // given
-      let callCount = 0
-      const cliMockFactory = () => ({
-        runCommentChecker: mock(async () => {
-          callCount += 1
-          return { hasComments: false, message: "" }
-        }),
-        getCommentCheckerPath: mock(async () => "/fake"),
-        startBackgroundInit: mock(() => {}),
-      })
-      mock.module("./cli", cliMockFactory)
-      mock.module("./cli.ts", cliMockFactory)
-      mock.module(new URL("./cli.ts", import.meta.url).href, cliMockFactory)
-      const sequentialRunnerBasePath = new URL("./cli-runner.ts", import.meta.url).pathname
-      const sequentialModulePath = `${sequentialRunnerBasePath}?semaphore-sequential`
-      const { processWithCli } = await import(sequentialModulePath)
-      const pendingCall: PendingCall = {
-        tool: "write",
-        sessionID: "ses-1",
-        filePath: "/tmp/a.ts",
-        timestamp: Date.now(),
-      }
-      // when
-      await processWithCli({ tool: "write", sessionID: "ses-1", callID: "call-1" }, pendingCall, { output: "" }, "/fake", undefined, () => {})
-      await processWithCli({ tool: "write", sessionID: "ses-2", callID: "call-2" }, pendingCall, { output: "" }, "/fake", undefined, () => {})
-      // then
-      expect(callCount).toBe(2)
-    })
-  })
-})
+		test("allows second call after first call completes", async () => {
+			// given
+			let callCount = 0;
+			const cliMockFactory = () => ({
+				runCommentChecker: mock(async () => {
+					callCount += 1;
+					return { hasComments: false, message: "" };
+				}),
+				getCommentCheckerPath: mock(async () => "/fake"),
+				startBackgroundInit: mock(() => {}),
+			});
+			mock.module("./cli", cliMockFactory);
+			mock.module("./cli.ts", cliMockFactory);
+			mock.module(new URL("./cli.ts", import.meta.url).href, cliMockFactory);
+			const sequentialRunnerBasePath = fileURLToPath(
+				new URL("./cli-runner.ts", import.meta.url),
+			);
+			const sequentialModulePath = `${sequentialRunnerBasePath}?semaphore-sequential`;
+			const { processWithCli } = await import(sequentialModulePath);
+			const pendingCall: PendingCall = {
+				tool: "write",
+				sessionID: "ses-1",
+				filePath: "/tmp/a.ts",
+				timestamp: Date.now(),
+			};
+			// when
+			await processWithCli(
+				{ tool: "write", sessionID: "ses-1", callID: "call-1" },
+				pendingCall,
+				{ output: "" },
+				"/fake",
+				undefined,
+				() => {},
+			);
+			await processWithCli(
+				{ tool: "write", sessionID: "ses-2", callID: "call-2" },
+				pendingCall,
+				{ output: "" },
+				"/fake",
+				undefined,
+				() => {},
+			);
+			// then
+			expect(callCount).toBe(2);
+		});
+	});
+});

--- a/src/hooks/comment-checker/pending-calls.test.ts
+++ b/src/hooks/comment-checker/pending-calls.test.ts
@@ -1,38 +1,43 @@
-import { describe, test, expect } from "bun:test"
+import { describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
 
 describe("pending-calls cleanup interval", () => {
-  test("starts cleanup once and unrefs timer", async () => {
-    //#given
-    const originalSetInterval = globalThis.setInterval
-    const setIntervalCalls: number[] = []
-    let unrefCalled = 0
+	test("starts cleanup once and unrefs timer", async () => {
+		//#given
+		const originalSetInterval = globalThis.setInterval;
+		const setIntervalCalls: number[] = [];
+		let unrefCalled = 0;
 
-    globalThis.setInterval = ((
-      _handler: TimerHandler,
-      timeout?: number,
-      ..._args: any[]
-    ) => {
-      setIntervalCalls.push(timeout as number)
-      return {
-        unref: () => {
-          unrefCalled += 1
-        },
-      } as unknown as ReturnType<typeof setInterval>
-    }) as unknown as typeof setInterval
+		globalThis.setInterval = ((
+			_handler: TimerHandler,
+			timeout?: number,
+			..._args: any[]
+		) => {
+			setIntervalCalls.push(timeout as number);
+			return {
+				unref: () => {
+					unrefCalled += 1;
+				},
+			} as unknown as ReturnType<typeof setInterval>;
+		}) as unknown as typeof setInterval;
 
-    try {
-      const modulePath = new URL("./pending-calls.ts", import.meta.url).pathname
-      const pendingCallsModule = await import(`${modulePath}?pending-calls-test-once`)
+		try {
+			const modulePath = fileURLToPath(
+				new URL("./pending-calls.ts", import.meta.url),
+			);
+			const pendingCallsModule = await import(
+				`${modulePath}?pending-calls-test-once`
+			);
 
-      //#when
-      pendingCallsModule.startPendingCallCleanup()
-      pendingCallsModule.startPendingCallCleanup()
+			//#when
+			pendingCallsModule.startPendingCallCleanup();
+			pendingCallsModule.startPendingCallCleanup();
 
-      //#then
-      expect(setIntervalCalls).toEqual([10_000])
-      expect(unrefCalled).toBe(1)
-    } finally {
-      globalThis.setInterval = originalSetInterval
-    }
-  })
-})
+			//#then
+			expect(setIntervalCalls).toEqual([10_000]);
+			expect(unrefCalled).toBe(1);
+		} finally {
+			globalThis.setInterval = originalSetInterval;
+		}
+	});
+});

--- a/src/hooks/read-image-resizer/hook.test.ts
+++ b/src/hooks/read-image-resizer/hook.test.ts
@@ -1,286 +1,394 @@
 /// <reference types="bun-types" />
 
-import { beforeEach, describe, expect, it, mock } from "bun:test"
-import type { PluginInput } from "@opencode-ai/plugin"
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	mock,
+	spyOn,
+} from "bun:test";
+import type { PluginInput } from "@opencode-ai/plugin";
+import * as sessionModelState from "../../shared/session-model-state";
+import * as imageDimensions from "./image-dimensions";
+import * as imageResizer from "./image-resizer";
 
-import type { ImageDimensions, ResizeResult } from "./types"
+import type { ImageDimensions, ResizeResult } from "./types";
 
-const mockParseImageDimensions = mock((): ImageDimensions | null => null)
-const mockCalculateTargetDimensions = mock((): ImageDimensions | null => null)
-const mockResizeImage = mock(async (): Promise<ResizeResult | null> => null)
-const mockGetSessionModel = mock((_sessionID: string) => ({
-  providerID: "anthropic",
-  modelID: "claude-sonnet-4-6",
-} as { providerID: string; modelID: string } | undefined))
+const mockParseImageDimensions = mock((): ImageDimensions | null => null);
+const mockCalculateTargetDimensions = mock((): ImageDimensions | null => null);
+const mockResizeImage = mock(async (): Promise<ResizeResult | null> => null);
+const mockGetSessionModel = mock(
+	(_sessionID: string) =>
+		({
+			providerID: "anthropic",
+			modelID: "claude-sonnet-4-6",
+		}) as { providerID: string; modelID: string } | undefined,
+);
 
-mock.module("./image-dimensions", () => ({
-  parseImageDimensions: mockParseImageDimensions,
-}))
+import { createReadImageResizerHook } from "./hook";
 
-mock.module("./image-resizer", () => ({
-  calculateTargetDimensions: mockCalculateTargetDimensions,
-  resizeImage: mockResizeImage,
-}))
-
-mock.module("../../shared/session-model-state", () => ({
-  getSessionModel: mockGetSessionModel,
-}))
-
-import { createReadImageResizerHook } from "./hook"
+let parseImageDimensionsSpy: ReturnType<typeof spyOn>;
+let calculateTargetDimensionsSpy: ReturnType<typeof spyOn>;
+let resizeImageSpy: ReturnType<typeof spyOn>;
+let getSessionModelSpy: ReturnType<typeof spyOn>;
 
 type ToolOutput = {
-  title: string
-  output: string
-  metadata: unknown
-  attachments?: Array<{ mime: string; url: string; filename?: string }>
-}
+	title: string;
+	output: string;
+	metadata: unknown;
+	attachments?: Array<{ mime: string; url: string; filename?: string }>;
+};
 
 function createMockContext(): PluginInput {
-  return {
-    client: {} as PluginInput["client"],
-    directory: "/test",
-  } as PluginInput
+	return {
+		client: {} as PluginInput["client"],
+		directory: "/test",
+	} as PluginInput;
 }
 
-function createInput(tool: string): { tool: string; sessionID: string; callID: string } {
-  return {
-    tool,
-    sessionID: "session-1",
-    callID: "call-1",
-  }
+function createInput(tool: string): {
+	tool: string;
+	sessionID: string;
+	callID: string;
+} {
+	return {
+		tool,
+		sessionID: "session-1",
+		callID: "call-1",
+	};
 }
 
 describe("createReadImageResizerHook", () => {
-  beforeEach(() => {
-    mockParseImageDimensions.mockReset()
-    mockCalculateTargetDimensions.mockReset()
-    mockResizeImage.mockReset()
-    mockGetSessionModel.mockReset()
-    mockGetSessionModel.mockReturnValue({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })
-  })
+	beforeEach(() => {
+		mockParseImageDimensions.mockReset();
+		mockCalculateTargetDimensions.mockReset();
+		mockResizeImage.mockReset();
+		mockGetSessionModel.mockReset();
+		mockGetSessionModel.mockReturnValue({
+			providerID: "anthropic",
+			modelID: "claude-sonnet-4-6",
+		});
 
-  it("skips non-Read tools", async () => {
-    //#given
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "image/png", url: "data:image/png;base64,old", filename: "image.png" }],
-    }
+		parseImageDimensionsSpy = spyOn(
+			imageDimensions,
+			"parseImageDimensions",
+		).mockImplementation(mockParseImageDimensions);
+		calculateTargetDimensionsSpy = spyOn(
+			imageResizer,
+			"calculateTargetDimensions",
+		).mockImplementation(mockCalculateTargetDimensions);
+		resizeImageSpy = spyOn(imageResizer, "resizeImage").mockImplementation(
+			mockResizeImage,
+		);
+		getSessionModelSpy = spyOn(
+			sessionModelState,
+			"getSessionModel",
+		).mockImplementation(mockGetSessionModel);
+	});
 
-    //#when
-    await hook["tool.execute.after"](createInput("Bash"), output)
+	afterEach(() => {
+		getSessionModelSpy.mockRestore();
+		resizeImageSpy.mockRestore();
+		calculateTargetDimensionsSpy.mockRestore();
+		parseImageDimensionsSpy.mockRestore();
+	});
 
-    //#then
-    expect(output.output).toBe("original output")
-    expect(mockParseImageDimensions).not.toHaveBeenCalled()
-  })
+	it("skips non-Read tools", async () => {
+		//#given
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "image/png",
+					url: "data:image/png;base64,old",
+					filename: "image.png",
+				},
+			],
+		};
 
-  it("skips when provider is not anthropic", async () => {
-    //#given
-    mockGetSessionModel.mockReturnValue({ providerID: "openai", modelID: "gpt-5.3-codex" })
-    mockParseImageDimensions.mockReturnValue({ width: 3000, height: 2000 })
-    mockCalculateTargetDimensions.mockReturnValue({ width: 1568, height: 1045 })
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "image/png", url: "data:image/png;base64,old", filename: "image.png" }],
-    }
+		//#when
+		await hook["tool.execute.after"](createInput("Bash"), output);
 
-    //#when
-    await hook["tool.execute.after"](createInput("Read"), output)
+		//#then
+		expect(output.output).toBe("original output");
+		expect(mockParseImageDimensions).not.toHaveBeenCalled();
+	});
 
-    //#then
-    expect(output.output).toBe("original output")
-    expect(mockParseImageDimensions).not.toHaveBeenCalled()
-  })
+	it("skips when provider is not anthropic", async () => {
+		//#given
+		mockGetSessionModel.mockReturnValue({
+			providerID: "openai",
+			modelID: "gpt-5.3-codex",
+		});
+		mockParseImageDimensions.mockReturnValue({ width: 3000, height: 2000 });
+		mockCalculateTargetDimensions.mockReturnValue({
+			width: 1568,
+			height: 1045,
+		});
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "image/png",
+					url: "data:image/png;base64,old",
+					filename: "image.png",
+				},
+			],
+		};
 
-  it("skips when session model is unknown", async () => {
-    //#given
-    mockGetSessionModel.mockReturnValue(undefined)
-    mockParseImageDimensions.mockReturnValue({ width: 3000, height: 2000 })
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "image/png", url: "data:image/png;base64,old", filename: "image.png" }],
-    }
+		//#when
+		await hook["tool.execute.after"](createInput("Read"), output);
 
-    //#when
-    await hook["tool.execute.after"](createInput("Read"), output)
+		//#then
+		expect(output.output).toBe("original output");
+		expect(mockParseImageDimensions).not.toHaveBeenCalled();
+	});
 
-    //#then
-    expect(output.output).toBe("original output")
-    expect(mockParseImageDimensions).not.toHaveBeenCalled()
-  })
+	it("skips when session model is unknown", async () => {
+		//#given
+		mockGetSessionModel.mockReturnValue(undefined);
+		mockParseImageDimensions.mockReturnValue({ width: 3000, height: 2000 });
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "image/png",
+					url: "data:image/png;base64,old",
+					filename: "image.png",
+				},
+			],
+		};
 
-  it("skips Read output with no attachments", async () => {
-    //#given
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-    }
+		//#when
+		await hook["tool.execute.after"](createInput("Read"), output);
 
-    //#when
-    await hook["tool.execute.after"](createInput("Read"), output)
+		//#then
+		expect(output.output).toBe("original output");
+		expect(mockParseImageDimensions).not.toHaveBeenCalled();
+	});
 
-    //#then
-    expect(output.output).toBe("original output")
-    expect(mockParseImageDimensions).not.toHaveBeenCalled()
-  })
+	it("skips Read output with no attachments", async () => {
+		//#given
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+		};
 
-  it("skips non-image attachments", async () => {
-    //#given
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "application/pdf", url: "data:application/pdf;base64,AAAA", filename: "file.pdf" }],
-    }
+		//#when
+		await hook["tool.execute.after"](createInput("Read"), output);
 
-    //#when
-    await hook["tool.execute.after"](createInput("Read"), output)
+		//#then
+		expect(output.output).toBe("original output");
+		expect(mockParseImageDimensions).not.toHaveBeenCalled();
+	});
 
-    //#then
-    expect(output.output).toBe("original output")
-    expect(mockParseImageDimensions).not.toHaveBeenCalled()
-  })
+	it("skips non-image attachments", async () => {
+		//#given
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "application/pdf",
+					url: "data:application/pdf;base64,AAAA",
+					filename: "file.pdf",
+				},
+			],
+		};
 
-  it("skips unsupported image mime types", async () => {
-    //#given
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "image/heic", url: "data:image/heic;base64,AAAA", filename: "photo.heic" }],
-    }
+		//#when
+		await hook["tool.execute.after"](createInput("Read"), output);
 
-    //#when
-    await hook["tool.execute.after"](createInput("Read"), output)
+		//#then
+		expect(output.output).toBe("original output");
+		expect(mockParseImageDimensions).not.toHaveBeenCalled();
+	});
 
-    //#then
-    expect(output.output).toBe("original output")
-    expect(mockParseImageDimensions).not.toHaveBeenCalled()
-  })
+	it("skips unsupported image mime types", async () => {
+		//#given
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "image/heic",
+					url: "data:image/heic;base64,AAAA",
+					filename: "photo.heic",
+				},
+			],
+		};
 
-  it("appends within-limits metadata when image is already valid", async () => {
-    //#given
-    mockParseImageDimensions.mockReturnValue({ width: 800, height: 600 })
-    mockCalculateTargetDimensions.mockReturnValue(null)
+		//#when
+		await hook["tool.execute.after"](createInput("Read"), output);
 
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "image/png", url: "data:image/png;base64,old", filename: "image.png" }],
-    }
+		//#then
+		expect(output.output).toBe("original output");
+		expect(mockParseImageDimensions).not.toHaveBeenCalled();
+	});
 
-    //#when
-    await hook["tool.execute.after"](createInput("Read"), output)
+	it("appends within-limits metadata when image is already valid", async () => {
+		//#given
+		mockParseImageDimensions.mockReturnValue({ width: 800, height: 600 });
+		mockCalculateTargetDimensions.mockReturnValue(null);
 
-    //#then
-    expect(output.output).toContain("[Image Info]")
-    expect(output.output).toContain("within limits")
-    expect(output.attachments?.[0]?.url).toBe("data:image/png;base64,old")
-    expect(mockResizeImage).not.toHaveBeenCalled()
-  })
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "image/png",
+					url: "data:image/png;base64,old",
+					filename: "image.png",
+				},
+			],
+		};
 
-  it("replaces attachment URL and appends resize metadata for oversized image", async () => {
-    //#given
-    mockParseImageDimensions.mockReturnValue({ width: 3000, height: 2000 })
-    mockCalculateTargetDimensions.mockReturnValue({ width: 1568, height: 1045 })
-    mockResizeImage.mockResolvedValue({
-      resizedDataUrl: "data:image/png;base64,resized",
-      original: { width: 3000, height: 2000 },
-      resized: { width: 1568, height: 1045 },
-    })
+		//#when
+		await hook["tool.execute.after"](createInput("Read"), output);
 
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "image/png", url: "data:image/png;base64,old", filename: "big.png" }],
-    }
+		//#then
+		expect(output.output).toContain("[Image Info]");
+		expect(output.output).toContain("within limits");
+		expect(output.attachments?.[0]?.url).toBe("data:image/png;base64,old");
+		expect(mockResizeImage).not.toHaveBeenCalled();
+	});
 
-    //#when
-    await hook["tool.execute.after"](createInput("Read"), output)
+	it("replaces attachment URL and appends resize metadata for oversized image", async () => {
+		//#given
+		mockParseImageDimensions.mockReturnValue({ width: 3000, height: 2000 });
+		mockCalculateTargetDimensions.mockReturnValue({
+			width: 1568,
+			height: 1045,
+		});
+		mockResizeImage.mockResolvedValue({
+			resizedDataUrl: "data:image/png;base64,resized",
+			original: { width: 3000, height: 2000 },
+			resized: { width: 1568, height: 1045 },
+		});
 
-    //#then
-    expect(output.attachments?.[0]?.url).toBe("data:image/png;base64,resized")
-    expect(output.output).toContain("[Image Resize Info]")
-    expect(output.output).toContain("resized")
-  })
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "image/png",
+					url: "data:image/png;base64,old",
+					filename: "big.png",
+				},
+			],
+		};
 
-  it("keeps original attachment URL and marks resize skipped when resize fails", async () => {
-    //#given
-    mockParseImageDimensions.mockReturnValue({ width: 3000, height: 2000 })
-    mockCalculateTargetDimensions.mockReturnValue({ width: 1568, height: 1045 })
-    mockResizeImage.mockResolvedValue(null)
+		//#when
+		await hook["tool.execute.after"](createInput("Read"), output);
 
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "image/png", url: "data:image/png;base64,old", filename: "fail.png" }],
-    }
+		//#then
+		expect(output.attachments?.[0]?.url).toBe("data:image/png;base64,resized");
+		expect(output.output).toContain("[Image Resize Info]");
+		expect(output.output).toContain("resized");
+	});
 
-    //#when
-    await hook["tool.execute.after"](createInput("Read"), output)
+	it("keeps original attachment URL and marks resize skipped when resize fails", async () => {
+		//#given
+		mockParseImageDimensions.mockReturnValue({ width: 3000, height: 2000 });
+		mockCalculateTargetDimensions.mockReturnValue({
+			width: 1568,
+			height: 1045,
+		});
+		mockResizeImage.mockResolvedValue(null);
 
-    //#then
-    expect(output.attachments?.[0]?.url).toBe("data:image/png;base64,old")
-    expect(output.output).toContain("resize skipped")
-  })
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "image/png",
+					url: "data:image/png;base64,old",
+					filename: "fail.png",
+				},
+			],
+		};
 
-  it("appends unknown-dimensions metadata when parsing fails", async () => {
-    //#given
-    mockParseImageDimensions.mockReturnValue(null)
+		//#when
+		await hook["tool.execute.after"](createInput("Read"), output);
 
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "image/png", url: "data:image/png;base64,old", filename: "corrupt.png" }],
-    }
+		//#then
+		expect(output.attachments?.[0]?.url).toBe("data:image/png;base64,old");
+		expect(output.output).toContain("resize skipped");
+	});
 
-    //#when
-    await hook["tool.execute.after"](createInput("Read"), output)
+	it("appends unknown-dimensions metadata when parsing fails", async () => {
+		//#given
+		mockParseImageDimensions.mockReturnValue(null);
 
-    //#then
-    expect(output.output).toContain("dimensions could not be parsed")
-    expect(mockCalculateTargetDimensions).not.toHaveBeenCalled()
-  })
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "image/png",
+					url: "data:image/png;base64,old",
+					filename: "corrupt.png",
+				},
+			],
+		};
 
-  it("fires for lowercase read tool name", async () => {
-    //#given
-    mockParseImageDimensions.mockReturnValue({ width: 800, height: 600 })
-    mockCalculateTargetDimensions.mockReturnValue(null)
+		//#when
+		await hook["tool.execute.after"](createInput("Read"), output);
 
-    const hook = createReadImageResizerHook(createMockContext())
-    const output: ToolOutput = {
-      title: "Read",
-      output: "original output",
-      metadata: {},
-      attachments: [{ mime: "image/png", url: "data:image/png;base64,old", filename: "image.png" }],
-    }
+		//#then
+		expect(output.output).toContain("dimensions could not be parsed");
+		expect(mockCalculateTargetDimensions).not.toHaveBeenCalled();
+	});
 
-    //#when
-    await hook["tool.execute.after"](createInput("read"), output)
+	it("fires for lowercase read tool name", async () => {
+		//#given
+		mockParseImageDimensions.mockReturnValue({ width: 800, height: 600 });
+		mockCalculateTargetDimensions.mockReturnValue(null);
 
-    //#then
-    expect(mockParseImageDimensions).toHaveBeenCalledTimes(1)
-    expect(output.output).toContain("within limits")
-  })
-})
+		const hook = createReadImageResizerHook(createMockContext());
+		const output: ToolOutput = {
+			title: "Read",
+			output: "original output",
+			metadata: {},
+			attachments: [
+				{
+					mime: "image/png",
+					url: "data:image/png;base64,old",
+					filename: "image.png",
+				},
+			],
+		};
+
+		//#when
+		await hook["tool.execute.after"](createInput("read"), output);
+
+		//#then
+		expect(mockParseImageDimensions).toHaveBeenCalledTimes(1);
+		expect(output.output).toContain("within limits");
+	});
+});

--- a/src/hooks/rules-injector/finder.test.ts
+++ b/src/hooks/rules-injector/finder.test.ts
@@ -4,378 +4,361 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { findProjectRoot, findRuleFiles } from "./finder";
 
+function toPosixPath(path: string): string {
+	return path.replace(/\\/g, "/");
+}
+
 describe("findRuleFiles", () => {
-  const TEST_DIR = join(tmpdir(), `rules-injector-test-${Date.now()}`);
-  const homeDir = join(TEST_DIR, "home");
+	const TEST_DIR = join(tmpdir(), `rules-injector-test-${Date.now()}`);
+	const homeDir = join(TEST_DIR, "home");
 
-  beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true });
-    mkdirSync(homeDir, { recursive: true });
-    mkdirSync(join(TEST_DIR, ".git"), { recursive: true });
-  });
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+		mkdirSync(homeDir, { recursive: true });
+		mkdirSync(join(TEST_DIR, ".git"), { recursive: true });
+	});
 
-  afterEach(() => {
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true, force: true });
-    }
-  });
+	afterEach(() => {
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
 
-  describe(".github/instructions/ discovery", () => {
-    it("should discover .github/instructions/*.instructions.md files", () => {
-      // given .github/instructions/ with valid files
-      const instructionsDir = join(TEST_DIR, ".github", "instructions");
-      mkdirSync(instructionsDir, { recursive: true });
-      writeFileSync(
-        join(instructionsDir, "typescript.instructions.md"),
-        "TS rules"
-      );
-      writeFileSync(
-        join(instructionsDir, "python.instructions.md"),
-        "PY rules"
-      );
+	describe(".github/instructions/ discovery", () => {
+		it("should discover .github/instructions/*.instructions.md files", () => {
+			// given .github/instructions/ with valid files
+			const instructionsDir = join(TEST_DIR, ".github", "instructions");
+			mkdirSync(instructionsDir, { recursive: true });
+			writeFileSync(
+				join(instructionsDir, "typescript.instructions.md"),
+				"TS rules",
+			);
+			writeFileSync(
+				join(instructionsDir, "python.instructions.md"),
+				"PY rules",
+			);
 
-      const srcDir = join(TEST_DIR, "src");
-      mkdirSync(srcDir, { recursive: true });
-      const currentFile = join(srcDir, "index.ts");
-      writeFileSync(currentFile, "code");
+			const srcDir = join(TEST_DIR, "src");
+			mkdirSync(srcDir, { recursive: true });
+			const currentFile = join(srcDir, "index.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules for a file
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules for a file
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should find both instruction files
-      const paths = candidates.map((c) => c.path);
-      expect(
-        paths.some((p) => p.includes("typescript.instructions.md"))
-      ).toBe(true);
-      expect(paths.some((p) => p.includes("python.instructions.md"))).toBe(
-        true
-      );
-    });
+			// then should find both instruction files
+			const paths = candidates.map((c) => toPosixPath(c.path));
+			expect(paths.some((p) => p.includes("typescript.instructions.md"))).toBe(
+				true,
+			);
+			expect(paths.some((p) => p.includes("python.instructions.md"))).toBe(
+				true,
+			);
+		});
 
-    it("should ignore non-.instructions.md files in .github/instructions/", () => {
-      // given .github/instructions/ with invalid files
-      const instructionsDir = join(TEST_DIR, ".github", "instructions");
-      mkdirSync(instructionsDir, { recursive: true });
-      writeFileSync(
-        join(instructionsDir, "valid.instructions.md"),
-        "valid"
-      );
-      writeFileSync(join(instructionsDir, "invalid.md"), "invalid");
-      writeFileSync(join(instructionsDir, "readme.txt"), "readme");
+		it("should ignore non-.instructions.md files in .github/instructions/", () => {
+			// given .github/instructions/ with invalid files
+			const instructionsDir = join(TEST_DIR, ".github", "instructions");
+			mkdirSync(instructionsDir, { recursive: true });
+			writeFileSync(join(instructionsDir, "valid.instructions.md"), "valid");
+			writeFileSync(join(instructionsDir, "invalid.md"), "invalid");
+			writeFileSync(join(instructionsDir, "readme.txt"), "readme");
 
-      const currentFile = join(TEST_DIR, "index.ts");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "index.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should only find .instructions.md file
-      const paths = candidates.map((c) => c.path);
-      expect(paths.some((p) => p.includes("valid.instructions.md"))).toBe(
-        true
-      );
-      expect(paths.some((p) => p.endsWith("invalid.md"))).toBe(false);
-      expect(paths.some((p) => p.includes("readme.txt"))).toBe(false);
-    });
+			// then should only find .instructions.md file
+			const paths = candidates.map((c) => toPosixPath(c.path));
+			expect(paths.some((p) => p.includes("valid.instructions.md"))).toBe(true);
+			expect(paths.some((p) => p.endsWith("invalid.md"))).toBe(false);
+			expect(paths.some((p) => p.includes("readme.txt"))).toBe(false);
+		});
 
-    it("should discover nested .instructions.md files in subdirectories", () => {
-      // given nested .github/instructions/ structure
-      const instructionsDir = join(TEST_DIR, ".github", "instructions");
-      const frontendDir = join(instructionsDir, "frontend");
-      mkdirSync(frontendDir, { recursive: true });
-      writeFileSync(
-        join(frontendDir, "react.instructions.md"),
-        "React rules"
-      );
+		it("should discover nested .instructions.md files in subdirectories", () => {
+			// given nested .github/instructions/ structure
+			const instructionsDir = join(TEST_DIR, ".github", "instructions");
+			const frontendDir = join(instructionsDir, "frontend");
+			mkdirSync(frontendDir, { recursive: true });
+			writeFileSync(join(frontendDir, "react.instructions.md"), "React rules");
 
-      const currentFile = join(TEST_DIR, "app.tsx");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "app.tsx");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should find nested instruction file
-      const paths = candidates.map((c) => c.path);
-      expect(paths.some((p) => p.includes("react.instructions.md"))).toBe(
-        true
-      );
-    });
-  });
+			// then should find nested instruction file
+			const paths = candidates.map((c) => toPosixPath(c.path));
+			expect(paths.some((p) => p.includes("react.instructions.md"))).toBe(true);
+		});
+	});
 
-  describe(".github/copilot-instructions.md (single file)", () => {
-    it("should discover copilot-instructions.md at project root", () => {
-      // given .github/copilot-instructions.md at root
-      const githubDir = join(TEST_DIR, ".github");
-      mkdirSync(githubDir, { recursive: true });
-      writeFileSync(
-        join(githubDir, "copilot-instructions.md"),
-        "Global instructions"
-      );
+	describe(".github/copilot-instructions.md (single file)", () => {
+		it("should discover copilot-instructions.md at project root", () => {
+			// given .github/copilot-instructions.md at root
+			const githubDir = join(TEST_DIR, ".github");
+			mkdirSync(githubDir, { recursive: true });
+			writeFileSync(
+				join(githubDir, "copilot-instructions.md"),
+				"Global instructions",
+			);
 
-      const currentFile = join(TEST_DIR, "index.ts");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "index.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should find the single file rule
-      const singleFile = candidates.find((c) =>
-        c.path.includes("copilot-instructions.md")
-      );
-      expect(singleFile).toBeDefined();
-      expect(singleFile?.isSingleFile).toBe(true);
-    });
+			// then should find the single file rule
+			const singleFile = candidates.find((c) =>
+				c.path.includes("copilot-instructions.md"),
+			);
+			expect(singleFile).toBeDefined();
+			expect(singleFile?.isSingleFile).toBe(true);
+		});
 
-    it("should mark single file rules with isSingleFile: true", () => {
-      // given copilot-instructions.md
-      const githubDir = join(TEST_DIR, ".github");
-      mkdirSync(githubDir, { recursive: true });
-      writeFileSync(
-        join(githubDir, "copilot-instructions.md"),
-        "Instructions"
-      );
+		it("should mark single file rules with isSingleFile: true", () => {
+			// given copilot-instructions.md
+			const githubDir = join(TEST_DIR, ".github");
+			mkdirSync(githubDir, { recursive: true });
+			writeFileSync(join(githubDir, "copilot-instructions.md"), "Instructions");
 
-      const currentFile = join(TEST_DIR, "file.ts");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "file.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then isSingleFile should be true
-      const copilotFile = candidates.find((c) => c.isSingleFile);
-      expect(copilotFile).toBeDefined();
-      expect(copilotFile?.path).toContain("copilot-instructions.md");
-    });
+			// then isSingleFile should be true
+			const copilotFile = candidates.find((c) => c.isSingleFile);
+			expect(copilotFile).toBeDefined();
+			expect(copilotFile?.path).toContain("copilot-instructions.md");
+		});
 
-    it("should set distance to 0 for single file rules", () => {
-      // given copilot-instructions.md at project root
-      const githubDir = join(TEST_DIR, ".github");
-      mkdirSync(githubDir, { recursive: true });
-      writeFileSync(
-        join(githubDir, "copilot-instructions.md"),
-        "Instructions"
-      );
+		it("should set distance to 0 for single file rules", () => {
+			// given copilot-instructions.md at project root
+			const githubDir = join(TEST_DIR, ".github");
+			mkdirSync(githubDir, { recursive: true });
+			writeFileSync(join(githubDir, "copilot-instructions.md"), "Instructions");
 
-      const srcDir = join(TEST_DIR, "src", "deep", "nested");
-      mkdirSync(srcDir, { recursive: true });
-      const currentFile = join(srcDir, "file.ts");
-      writeFileSync(currentFile, "code");
+			const srcDir = join(TEST_DIR, "src", "deep", "nested");
+			mkdirSync(srcDir, { recursive: true });
+			const currentFile = join(srcDir, "file.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules from deeply nested file
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules from deeply nested file
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then single file should have distance 0
-      const copilotFile = candidates.find((c) => c.isSingleFile);
-      expect(copilotFile?.distance).toBe(0);
-    });
-  });
+			// then single file should have distance 0
+			const copilotFile = candidates.find((c) => c.isSingleFile);
+			expect(copilotFile?.distance).toBe(0);
+		});
+	});
 
-  describe("backward compatibility", () => {
-    it("should still discover .claude/rules/ files", () => {
-      // given .claude/rules/ directory
-      const rulesDir = join(TEST_DIR, ".claude", "rules");
-      mkdirSync(rulesDir, { recursive: true });
-      writeFileSync(join(rulesDir, "typescript.md"), "TS rules");
+	describe("backward compatibility", () => {
+		it("should still discover .claude/rules/ files", () => {
+			// given .claude/rules/ directory
+			const rulesDir = join(TEST_DIR, ".claude", "rules");
+			mkdirSync(rulesDir, { recursive: true });
+			writeFileSync(join(rulesDir, "typescript.md"), "TS rules");
 
-      const currentFile = join(TEST_DIR, "index.ts");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "index.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should find claude rules
-      const paths = candidates.map((c) => c.path);
-      expect(paths.some((p) => p.includes(".claude/rules/"))).toBe(true);
-    });
+			// then should find claude rules
+			const paths = candidates.map((c) => toPosixPath(c.path));
+			expect(paths.some((p) => p.includes(".claude/rules/"))).toBe(true);
+		});
 
-    it("should still discover .cursor/rules/ files", () => {
-      // given .cursor/rules/ directory
-      const rulesDir = join(TEST_DIR, ".cursor", "rules");
-      mkdirSync(rulesDir, { recursive: true });
-      writeFileSync(join(rulesDir, "python.md"), "PY rules");
+		it("should still discover .cursor/rules/ files", () => {
+			// given .cursor/rules/ directory
+			const rulesDir = join(TEST_DIR, ".cursor", "rules");
+			mkdirSync(rulesDir, { recursive: true });
+			writeFileSync(join(rulesDir, "python.md"), "PY rules");
 
-      const currentFile = join(TEST_DIR, "main.py");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "main.py");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should find cursor rules
-      const paths = candidates.map((c) => c.path);
-      expect(paths.some((p) => p.includes(".cursor/rules/"))).toBe(true);
-    });
+			// then should find cursor rules
+			const paths = candidates.map((c) => toPosixPath(c.path));
+			expect(paths.some((p) => p.includes(".cursor/rules/"))).toBe(true);
+		});
 
-    it("should discover .mdc files in rule directories", () => {
-      // given .mdc file in .claude/rules/
-      const rulesDir = join(TEST_DIR, ".claude", "rules");
-      mkdirSync(rulesDir, { recursive: true });
-      writeFileSync(join(rulesDir, "advanced.mdc"), "MDC rules");
+		it("should discover .mdc files in rule directories", () => {
+			// given .mdc file in .claude/rules/
+			const rulesDir = join(TEST_DIR, ".claude", "rules");
+			mkdirSync(rulesDir, { recursive: true });
+			writeFileSync(join(rulesDir, "advanced.mdc"), "MDC rules");
 
-      const currentFile = join(TEST_DIR, "app.ts");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "app.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should find .mdc file
-      const paths = candidates.map((c) => c.path);
-      expect(paths.some((p) => p.endsWith("advanced.mdc"))).toBe(true);
-    });
-  });
+			// then should find .mdc file
+			const paths = candidates.map((c) => toPosixPath(c.path));
+			expect(paths.some((p) => p.endsWith("advanced.mdc"))).toBe(true);
+		});
+	});
 
-  describe("mixed sources", () => {
-    it("should discover rules from all sources", () => {
-      // given rules in multiple directories
-      const claudeRules = join(TEST_DIR, ".claude", "rules");
-      const cursorRules = join(TEST_DIR, ".cursor", "rules");
-      const githubInstructions = join(TEST_DIR, ".github", "instructions");
-      const githubDir = join(TEST_DIR, ".github");
+	describe("mixed sources", () => {
+		it("should discover rules from all sources", () => {
+			// given rules in multiple directories
+			const claudeRules = join(TEST_DIR, ".claude", "rules");
+			const cursorRules = join(TEST_DIR, ".cursor", "rules");
+			const githubInstructions = join(TEST_DIR, ".github", "instructions");
+			const githubDir = join(TEST_DIR, ".github");
 
-      mkdirSync(claudeRules, { recursive: true });
-      mkdirSync(cursorRules, { recursive: true });
-      mkdirSync(githubInstructions, { recursive: true });
+			mkdirSync(claudeRules, { recursive: true });
+			mkdirSync(cursorRules, { recursive: true });
+			mkdirSync(githubInstructions, { recursive: true });
 
-      writeFileSync(join(claudeRules, "claude.md"), "claude");
-      writeFileSync(join(cursorRules, "cursor.md"), "cursor");
-      writeFileSync(
-        join(githubInstructions, "copilot.instructions.md"),
-        "copilot"
-      );
-      writeFileSync(join(githubDir, "copilot-instructions.md"), "global");
+			writeFileSync(join(claudeRules, "claude.md"), "claude");
+			writeFileSync(join(cursorRules, "cursor.md"), "cursor");
+			writeFileSync(
+				join(githubInstructions, "copilot.instructions.md"),
+				"copilot",
+			);
+			writeFileSync(join(githubDir, "copilot-instructions.md"), "global");
 
-      const currentFile = join(TEST_DIR, "index.ts");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "index.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should find all rules
-      expect(candidates.length).toBeGreaterThanOrEqual(4);
-      const paths = candidates.map((c) => c.path);
-      expect(paths.some((p) => p.includes(".claude/rules/"))).toBe(true);
-      expect(paths.some((p) => p.includes(".cursor/rules/"))).toBe(true);
-      expect(paths.some((p) => p.includes(".github/instructions/"))).toBe(
-        true
-      );
-      expect(paths.some((p) => p.includes("copilot-instructions.md"))).toBe(
-        true
-      );
-    });
+			// then should find all rules
+			expect(candidates.length).toBeGreaterThanOrEqual(4);
+			const paths = candidates.map((c) => toPosixPath(c.path));
+			expect(paths.some((p) => p.includes(".claude/rules/"))).toBe(true);
+			expect(paths.some((p) => p.includes(".cursor/rules/"))).toBe(true);
+			expect(paths.some((p) => p.includes(".github/instructions/"))).toBe(true);
+			expect(paths.some((p) => p.includes("copilot-instructions.md"))).toBe(
+				true,
+			);
+		});
 
-    it("should not duplicate single file rules", () => {
-      // given copilot-instructions.md
-      const githubDir = join(TEST_DIR, ".github");
-      mkdirSync(githubDir, { recursive: true });
-      writeFileSync(
-        join(githubDir, "copilot-instructions.md"),
-        "Instructions"
-      );
+		it("should not duplicate single file rules", () => {
+			// given copilot-instructions.md
+			const githubDir = join(TEST_DIR, ".github");
+			mkdirSync(githubDir, { recursive: true });
+			writeFileSync(join(githubDir, "copilot-instructions.md"), "Instructions");
 
-      const currentFile = join(TEST_DIR, "file.ts");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "file.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should only have one copilot-instructions.md entry
-      const copilotFiles = candidates.filter((c) =>
-        c.path.includes("copilot-instructions.md")
-      );
-      expect(copilotFiles.length).toBe(1);
-    });
-  });
+			// then should only have one copilot-instructions.md entry
+			const copilotFiles = candidates.filter((c) =>
+				c.path.includes("copilot-instructions.md"),
+			);
+			expect(copilotFiles.length).toBe(1);
+		});
+	});
 
-  describe("user-level rules", () => {
-    it("should discover user-level .claude/rules/ files", () => {
-      // given user-level rules
-      const userRulesDir = join(homeDir, ".claude", "rules");
-      mkdirSync(userRulesDir, { recursive: true });
-      writeFileSync(join(userRulesDir, "global.md"), "Global user rules");
+	describe("user-level rules", () => {
+		it("should discover user-level .claude/rules/ files", () => {
+			// given user-level rules
+			const userRulesDir = join(homeDir, ".claude", "rules");
+			mkdirSync(userRulesDir, { recursive: true });
+			writeFileSync(join(userRulesDir, "global.md"), "Global user rules");
 
-      const currentFile = join(TEST_DIR, "app.ts");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "app.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then should find user-level rules
-      const userRule = candidates.find((c) => c.isGlobal);
-      expect(userRule).toBeDefined();
-      expect(userRule?.path).toContain("global.md");
-    });
+			// then should find user-level rules
+			const userRule = candidates.find((c) => c.isGlobal);
+			expect(userRule).toBeDefined();
+			expect(userRule?.path).toContain("global.md");
+		});
 
-    it("should mark user-level rules as isGlobal: true", () => {
-      // given user-level rules
-      const userRulesDir = join(homeDir, ".claude", "rules");
-      mkdirSync(userRulesDir, { recursive: true });
-      writeFileSync(join(userRulesDir, "user.md"), "User rules");
+		it("should mark user-level rules as isGlobal: true", () => {
+			// given user-level rules
+			const userRulesDir = join(homeDir, ".claude", "rules");
+			mkdirSync(userRulesDir, { recursive: true });
+			writeFileSync(join(userRulesDir, "user.md"), "User rules");
 
-      const currentFile = join(TEST_DIR, "app.ts");
-      writeFileSync(currentFile, "code");
+			const currentFile = join(TEST_DIR, "app.ts");
+			writeFileSync(currentFile, "code");
 
-      // when finding rules
-      const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
+			// when finding rules
+			const candidates = findRuleFiles(TEST_DIR, homeDir, currentFile);
 
-      // then isGlobal should be true
-      const userRule = candidates.find((c) => c.path.includes("user.md"));
-      expect(userRule?.isGlobal).toBe(true);
-      expect(userRule?.distance).toBe(9999);
-    });
-  });
+			// then isGlobal should be true
+			const userRule = candidates.find((c) => c.path.includes("user.md"));
+			expect(userRule?.isGlobal).toBe(true);
+			expect(userRule?.distance).toBe(9999);
+		});
+	});
 });
 
 describe("findProjectRoot", () => {
-  const TEST_DIR = join(tmpdir(), `project-root-test-${Date.now()}`);
+	const TEST_DIR = join(tmpdir(), `project-root-test-${Date.now()}`);
 
-  beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true });
-  });
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
 
-  afterEach(() => {
-    if (existsSync(TEST_DIR)) {
-      rmSync(TEST_DIR, { recursive: true, force: true });
-    }
-  });
+	afterEach(() => {
+		if (existsSync(TEST_DIR)) {
+			rmSync(TEST_DIR, { recursive: true, force: true });
+		}
+	});
 
-  it("should find project root with .git directory", () => {
-    // given directory with .git
-    mkdirSync(join(TEST_DIR, ".git"), { recursive: true });
-    const nestedFile = join(TEST_DIR, "src", "components", "Button.tsx");
-    mkdirSync(join(TEST_DIR, "src", "components"), { recursive: true });
-    writeFileSync(nestedFile, "code");
+	it("should find project root with .git directory", () => {
+		// given directory with .git
+		mkdirSync(join(TEST_DIR, ".git"), { recursive: true });
+		const nestedFile = join(TEST_DIR, "src", "components", "Button.tsx");
+		mkdirSync(join(TEST_DIR, "src", "components"), { recursive: true });
+		writeFileSync(nestedFile, "code");
 
-    // when finding project root from nested file
-    const root = findProjectRoot(nestedFile);
+		// when finding project root from nested file
+		const root = findProjectRoot(nestedFile);
 
-    // then should return the directory with .git
-    expect(root).toBe(TEST_DIR);
-  });
+		// then should return the directory with .git
+		expect(root).toBe(TEST_DIR);
+	});
 
-  it("should find project root with package.json", () => {
-    // given directory with package.json
-    writeFileSync(join(TEST_DIR, "package.json"), "{}");
-    const nestedFile = join(TEST_DIR, "lib", "index.js");
-    mkdirSync(join(TEST_DIR, "lib"), { recursive: true });
-    writeFileSync(nestedFile, "code");
+	it("should find project root with package.json", () => {
+		// given directory with package.json
+		writeFileSync(join(TEST_DIR, "package.json"), "{}");
+		const nestedFile = join(TEST_DIR, "lib", "index.js");
+		mkdirSync(join(TEST_DIR, "lib"), { recursive: true });
+		writeFileSync(nestedFile, "code");
 
-    // when finding project root
-    const root = findProjectRoot(nestedFile);
+		// when finding project root
+		const root = findProjectRoot(nestedFile);
 
-    // then should find the package.json directory
-    expect(root).toBe(TEST_DIR);
-  });
+		// then should find the package.json directory
+		expect(root).toBe(TEST_DIR);
+	});
 
-  it("should return null when no project markers found", () => {
-    // given directory without any project markers
-    const isolatedDir = join(TEST_DIR, "isolated");
-    mkdirSync(isolatedDir, { recursive: true });
-    const file = join(isolatedDir, "file.txt");
-    writeFileSync(file, "content");
+	it("should return null when no project markers found", () => {
+		// given directory without any project markers
+		const isolatedDir = join(TEST_DIR, "isolated");
+		mkdirSync(isolatedDir, { recursive: true });
+		const file = join(isolatedDir, "file.txt");
+		writeFileSync(file, "content");
 
-    // when finding project root
-    const root = findProjectRoot(file);
+		// when finding project root
+		const root = findProjectRoot(file);
 
-    // then should return null
-    expect(root).toBeNull();
-  });
+		// then should return null
+		expect(root).toBeNull();
+	});
 });

--- a/src/hooks/rules-injector/rule-file-scanner.ts
+++ b/src/hooks/rules-injector/rule-file-scanner.ts
@@ -3,14 +3,18 @@ import { join } from "node:path";
 import { GITHUB_INSTRUCTIONS_PATTERN, RULE_EXTENSIONS } from "./constants";
 
 function isGitHubInstructionsDir(dir: string): boolean {
-  return dir.includes(".github/instructions") || dir.endsWith(".github/instructions");
+	const normalizedDir = dir.replace(/\\/g, "/");
+	return (
+		normalizedDir.includes(".github/instructions") ||
+		normalizedDir.endsWith(".github/instructions")
+	);
 }
 
 function isValidRuleFile(fileName: string, dir: string): boolean {
-  if (isGitHubInstructionsDir(dir)) {
-    return GITHUB_INSTRUCTIONS_PATTERN.test(fileName);
-  }
-  return RULE_EXTENSIONS.some((ext) => fileName.endsWith(ext));
+	if (isGitHubInstructionsDir(dir)) {
+		return GITHUB_INSTRUCTIONS_PATTERN.test(fileName);
+	}
+	return RULE_EXTENSIONS.some((ext) => fileName.endsWith(ext));
 }
 
 /**
@@ -20,24 +24,24 @@ function isValidRuleFile(fileName: string, dir: string): boolean {
  * @param results - Array to accumulate results
  */
 export function findRuleFilesRecursive(dir: string, results: string[]): void {
-  if (!existsSync(dir)) return;
+	if (!existsSync(dir)) return;
 
-  try {
-    const entries = readdirSync(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = join(dir, entry.name);
+	try {
+		const entries = readdirSync(dir, { withFileTypes: true });
+		for (const entry of entries) {
+			const fullPath = join(dir, entry.name);
 
-      if (entry.isDirectory()) {
-        findRuleFilesRecursive(fullPath, results);
-      } else if (entry.isFile()) {
-        if (isValidRuleFile(entry.name, dir)) {
-          results.push(fullPath);
-        }
-      }
-    }
-  } catch {
-    // Permission denied or other errors - silently skip
-  }
+			if (entry.isDirectory()) {
+				findRuleFilesRecursive(fullPath, results);
+			} else if (entry.isFile()) {
+				if (isValidRuleFile(entry.name, dir)) {
+					results.push(fullPath);
+				}
+			}
+		}
+	} catch {
+		// Permission denied or other errors - silently skip
+	}
 }
 
 /**
@@ -47,9 +51,9 @@ export function findRuleFilesRecursive(dir: string, results: string[]): void {
  * @returns Real path or original path if resolution fails
  */
 export function safeRealpathSync(filePath: string): string {
-  try {
-    return realpathSync(filePath);
-  } catch {
-    return filePath;
-  }
+	try {
+		return realpathSync(filePath);
+	} catch {
+		return filePath;
+	}
 }

--- a/src/hooks/runtime-fallback/dispose.test.ts
+++ b/src/hooks/runtime-fallback/dispose.test.ts
@@ -1,160 +1,198 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
-import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	spyOn,
+	test,
+} from "bun:test";
+import * as autoRetryModule from "./auto-retry";
+import * as chatMessageHandlerModule from "./chat-message-handler";
+import * as eventHandlerModule from "./event-handler";
+import * as messageUpdateHandlerModule from "./message-update-handler";
+import type { HookDeps, RuntimeFallbackPluginInput } from "./types";
 
-let capturedDeps: HookDeps | undefined
+let capturedDeps: HookDeps | undefined;
 
 const mockCreateAutoRetryHelpers = mock((deps: HookDeps) => {
-  capturedDeps = deps
+	capturedDeps = deps;
 
-  return {
-    abortSessionRequest: async () => {},
-    clearSessionFallbackTimeout: () => {},
-    scheduleSessionFallbackTimeout: () => {},
-    autoRetryWithFallback: async () => {},
-    resolveAgentForSessionFromContext: async () => undefined,
-    cleanupStaleSessions: () => {},
-  }
-})
+	return {
+		abortSessionRequest: async () => {},
+		clearSessionFallbackTimeout: () => {},
+		scheduleSessionFallbackTimeout: () => {},
+		autoRetryWithFallback: async () => {},
+		resolveAgentForSessionFromContext: async () => undefined,
+		cleanupStaleSessions: () => {},
+	};
+});
 
-const mockCreateEventHandler = mock(() => async () => {})
-const mockCreateMessageUpdateHandler = mock(() => async () => {})
-const mockCreateChatMessageHandler = mock(() => async () => {})
+const mockCreateEventHandler = mock(() => async () => {});
+const mockCreateMessageUpdateHandler = mock(() => async () => {});
+const mockCreateChatMessageHandler = mock(() => async () => {});
 
-mock.module("./auto-retry", () => ({
-  createAutoRetryHelpers: mockCreateAutoRetryHelpers,
-}))
+let createRuntimeFallbackHook: typeof import("./hook").createRuntimeFallbackHook;
 
-mock.module("./event-handler", () => ({
-  createEventHandler: mockCreateEventHandler,
-}))
+async function importHookFactory(): Promise<void> {
+	mock &&
+		spyOn(autoRetryModule, "createAutoRetryHelpers").mockImplementation(
+			mockCreateAutoRetryHelpers,
+		);
+	mock &&
+		spyOn(eventHandlerModule, "createEventHandler").mockImplementation(
+			mockCreateEventHandler,
+		);
+	mock &&
+		spyOn(
+			messageUpdateHandlerModule,
+			"createMessageUpdateHandler",
+		).mockImplementation(mockCreateMessageUpdateHandler);
+	mock &&
+		spyOn(
+			chatMessageHandlerModule,
+			"createChatMessageHandler",
+		).mockImplementation(mockCreateChatMessageHandler);
 
-mock.module("./message-update-handler", () => ({
-  createMessageUpdateHandler: mockCreateMessageUpdateHandler,
-}))
-
-mock.module("./chat-message-handler", () => ({
-  createChatMessageHandler: mockCreateChatMessageHandler,
-}))
-
-const { createRuntimeFallbackHook } = await import("./hook")
+	const hookModule = await import(
+		`./hook?dispose-${Date.now()}-${Math.random()}`
+	);
+	createRuntimeFallbackHook = hookModule.createRuntimeFallbackHook;
+}
 
 function createMockContext(): RuntimeFallbackPluginInput {
-  return {
-    client: {
-      session: {
-        abort: async () => ({}),
-        messages: async () => ({}),
-        promptAsync: async () => ({}),
-      },
-      tui: {
-        showToast: async () => ({}),
-      },
-    },
-    directory: "/test",
-  }
+	return {
+		client: {
+			session: {
+				abort: async () => ({}),
+				messages: async () => ({}),
+				promptAsync: async () => ({}),
+			},
+			tui: {
+				showToast: async () => ({}),
+			},
+		},
+		directory: "/test",
+	};
 }
 
 describe("createRuntimeFallbackHook dispose", () => {
-  const originalSetInterval = globalThis.setInterval
-  const originalClearInterval = globalThis.clearInterval
-  const originalClearTimeout = globalThis.clearTimeout
-  const createdIntervals: Array<ReturnType<typeof originalSetInterval>> = []
-  const clearedIntervals: Array<Parameters<typeof originalClearInterval>[0]> = []
-  const clearedTimeouts: Array<Parameters<typeof originalClearTimeout>[0]> = []
-  const timeoutMapSizesDuringClear: number[] = []
+	const originalSetInterval = globalThis.setInterval;
+	const originalClearInterval = globalThis.clearInterval;
+	const originalClearTimeout = globalThis.clearTimeout;
+	const createdIntervals: Array<ReturnType<typeof originalSetInterval>> = [];
+	const clearedIntervals: Array<Parameters<typeof originalClearInterval>[0]> =
+		[];
+	const clearedTimeouts: Array<Parameters<typeof originalClearTimeout>[0]> = [];
+	const timeoutMapSizesDuringClear: number[] = [];
 
-  beforeEach(() => {
-    capturedDeps = undefined
-    createdIntervals.length = 0
-    clearedIntervals.length = 0
-    clearedTimeouts.length = 0
-    timeoutMapSizesDuringClear.length = 0
+	beforeEach(async () => {
+		capturedDeps = undefined;
+		createdIntervals.length = 0;
+		clearedIntervals.length = 0;
+		clearedTimeouts.length = 0;
+		timeoutMapSizesDuringClear.length = 0;
 
-    mockCreateAutoRetryHelpers.mockClear()
-    mockCreateEventHandler.mockClear()
-    mockCreateMessageUpdateHandler.mockClear()
-    mockCreateChatMessageHandler.mockClear()
+		mockCreateAutoRetryHelpers.mockClear();
+		mockCreateEventHandler.mockClear();
+		mockCreateMessageUpdateHandler.mockClear();
+		mockCreateChatMessageHandler.mockClear();
 
-    const wrappedSetInterval = ((handler: () => void, timeout?: number) => {
-      const interval = originalSetInterval(handler, timeout)
-      createdIntervals.push(interval)
-      return interval
-    }) as typeof globalThis.setInterval
+		const wrappedSetInterval = ((handler: () => void, timeout?: number) => {
+			const interval = originalSetInterval(handler, timeout);
+			createdIntervals.push(interval);
+			return interval;
+		}) as typeof globalThis.setInterval;
 
-    const wrappedClearInterval = ((interval?: Parameters<typeof clearInterval>[0]) => {
-      clearedIntervals.push(interval)
-      return originalClearInterval(interval)
-    }) as typeof globalThis.clearInterval
+		const wrappedClearInterval = ((
+			interval?: Parameters<typeof clearInterval>[0],
+		) => {
+			clearedIntervals.push(interval);
+			return originalClearInterval(interval);
+		}) as typeof globalThis.clearInterval;
 
-    const wrappedClearTimeout = ((timeout?: Parameters<typeof clearTimeout>[0]) => {
-      timeoutMapSizesDuringClear.push(capturedDeps?.sessionFallbackTimeouts.size ?? -1)
-      clearedTimeouts.push(timeout)
-      return originalClearTimeout(timeout)
-    }) as typeof globalThis.clearTimeout
+		const wrappedClearTimeout = ((
+			timeout?: Parameters<typeof clearTimeout>[0],
+		) => {
+			timeoutMapSizesDuringClear.push(
+				capturedDeps?.sessionFallbackTimeouts.size ?? -1,
+			);
+			clearedTimeouts.push(timeout);
+			return originalClearTimeout(timeout);
+		}) as typeof globalThis.clearTimeout;
 
-    globalThis.setInterval = wrappedSetInterval
-    globalThis.clearInterval = wrappedClearInterval
-    globalThis.clearTimeout = wrappedClearTimeout
-  })
+		globalThis.setInterval = wrappedSetInterval;
+		globalThis.clearInterval = wrappedClearInterval;
+		globalThis.clearTimeout = wrappedClearTimeout;
+		await importHookFactory();
+	});
 
-  afterEach(() => {
-    globalThis.setInterval = originalSetInterval
-    globalThis.clearInterval = originalClearInterval
-    globalThis.clearTimeout = originalClearTimeout
-  })
+	afterEach(() => {
+		globalThis.setInterval = originalSetInterval;
+		globalThis.clearInterval = originalClearInterval;
+		globalThis.clearTimeout = originalClearTimeout;
+		capturedDeps = undefined;
+		mock.restore();
+	});
 
-  test("#given runtime-fallback hook created #when dispose() is called #then cleanup interval is cleared", () => {
-    // given
-    const hook = createRuntimeFallbackHook(createMockContext(), { pluginConfig: {} })
+	test("#given runtime-fallback hook created #when dispose() is called #then cleanup interval is cleared", () => {
+		// given
+		const hook = createRuntimeFallbackHook(createMockContext(), {
+			pluginConfig: {},
+		});
 
-    // when
-    hook.dispose?.()
+		// when
+		hook.dispose?.();
 
-    // then
-    expect(createdIntervals).toHaveLength(1)
-    expect(clearedIntervals).toEqual([createdIntervals[0]])
-  })
+		// then
+		expect(createdIntervals).toHaveLength(1);
+		expect(clearedIntervals).toEqual([createdIntervals[0]]);
+	});
 
-  test("#given hook with session state data #when dispose() is called #then all Maps and Sets are empty", () => {
-    // given
-    const hook = createRuntimeFallbackHook(createMockContext(), { pluginConfig: {} })
-    const fallbackTimeout = setTimeout(() => {}, 60_000)
+	test("#given hook with session state data #when dispose() is called #then all Maps and Sets are empty", () => {
+		// given
+		const hook = createRuntimeFallbackHook(createMockContext(), {
+			pluginConfig: {},
+		});
+		const fallbackTimeout = setTimeout(() => {}, 60_000);
 
-    capturedDeps?.sessionStates.set("session-1", {
-      originalModel: "anthropic/claude-opus-4-6",
-      currentModel: "openai/gpt-5.4",
-      fallbackIndex: 1,
-      failedModels: new Map([["anthropic/claude-opus-4-6", 1]]),
-      attemptCount: 1,
-    })
-    capturedDeps?.sessionLastAccess.set("session-1", Date.now())
-    capturedDeps?.sessionRetryInFlight.add("session-1")
-    capturedDeps?.sessionAwaitingFallbackResult.add("session-1")
-    capturedDeps?.sessionFallbackTimeouts.set("session-1", fallbackTimeout)
+		capturedDeps?.sessionStates.set("session-1", {
+			originalModel: "anthropic/claude-opus-4-6",
+			currentModel: "openai/gpt-5.4",
+			fallbackIndex: 1,
+			failedModels: new Map([["anthropic/claude-opus-4-6", 1]]),
+			attemptCount: 1,
+		});
+		capturedDeps?.sessionLastAccess.set("session-1", Date.now());
+		capturedDeps?.sessionRetryInFlight.add("session-1");
+		capturedDeps?.sessionAwaitingFallbackResult.add("session-1");
+		capturedDeps?.sessionFallbackTimeouts.set("session-1", fallbackTimeout);
 
-    // when
-    hook.dispose?.()
+		// when
+		hook.dispose?.();
 
-    // then
-    expect(capturedDeps?.sessionStates.size).toBe(0)
-    expect(capturedDeps?.sessionLastAccess.size).toBe(0)
-    expect(capturedDeps?.sessionRetryInFlight.size).toBe(0)
-    expect(capturedDeps?.sessionAwaitingFallbackResult.size).toBe(0)
-    expect(capturedDeps?.sessionFallbackTimeouts.size).toBe(0)
-  })
+		// then
+		expect(capturedDeps?.sessionStates.size).toBe(0);
+		expect(capturedDeps?.sessionLastAccess.size).toBe(0);
+		expect(capturedDeps?.sessionRetryInFlight.size).toBe(0);
+		expect(capturedDeps?.sessionAwaitingFallbackResult.size).toBe(0);
+		expect(capturedDeps?.sessionFallbackTimeouts.size).toBe(0);
+	});
 
-  test("#given hook with pending fallback timeouts #when dispose() is called #then timeouts are cleared before Map is emptied", () => {
-    // given
-    const hook = createRuntimeFallbackHook(createMockContext(), { pluginConfig: {} })
-    const fallbackTimeout = setTimeout(() => {}, 60_000)
-    capturedDeps?.sessionFallbackTimeouts.set("session-1", fallbackTimeout)
+	test("#given hook with pending fallback timeouts #when dispose() is called #then timeouts are cleared before Map is emptied", () => {
+		// given
+		const hook = createRuntimeFallbackHook(createMockContext(), {
+			pluginConfig: {},
+		});
+		const fallbackTimeout = setTimeout(() => {}, 60_000);
+		capturedDeps?.sessionFallbackTimeouts.set("session-1", fallbackTimeout);
 
-    // when
-    hook.dispose?.()
+		// when
+		hook.dispose?.();
 
-    // then
-    expect(clearedTimeouts).toEqual([fallbackTimeout])
-    expect(timeoutMapSizesDuringClear).toEqual([1])
-    expect(capturedDeps?.sessionFallbackTimeouts.size).toBe(0)
-  })
-})
+		// then
+		expect(clearedTimeouts).toEqual([fallbackTimeout]);
+		expect(timeoutMapSizesDuringClear).toEqual([1]);
+		expect(capturedDeps?.sessionFallbackTimeouts.size).toBe(0);
+	});
+});

--- a/src/hooks/session-recovery/recover-tool-result-missing.test.ts
+++ b/src/hooks/session-recovery/recover-tool-result-missing.test.ts
@@ -1,134 +1,198 @@
-const { describe, it, expect, mock, beforeEach } = require("bun:test")
+const {
+	describe,
+	it,
+	expect,
+	mock,
+	beforeEach,
+	afterEach,
+	spyOn,
+} = require("bun:test");
 
-import type { MessageData } from "./types"
+import * as normalizeSdkResponseModule from "../../shared/normalize-sdk-response";
+import * as storageDetectionModule from "../../shared/opencode-storage-detection";
+import * as storageModule from "./storage";
+import type { MessageData } from "./types";
 
-let sqliteBackend = false
-let storedParts: Array<{ type: string; id?: string; callID?: string; [key: string]: unknown }> = []
+let sqliteBackend = false;
+let storedParts: Array<{
+	type: string;
+	id?: string;
+	callID?: string;
+	[key: string]: unknown;
+}> = [];
 
-mock.module("../../shared/opencode-storage-detection", () => ({
-  isSqliteBackend: () => sqliteBackend,
-}))
+let recoverToolResultMissing: typeof import("./recover-tool-result-missing").recoverToolResultMissing;
 
-mock.module("../../shared", () => ({
-  normalizeSDKResponse: <TData>(response: { data?: TData }, fallback: TData): TData => response.data ?? fallback,
-}))
+async function importRecoverToolResultMissing() {
+	spyOn(storageDetectionModule, "isSqliteBackend").mockImplementation(
+		() => sqliteBackend,
+	);
+	spyOn(normalizeSdkResponseModule, "normalizeSDKResponse").mockImplementation(
+		<TData>(response: { data?: TData }, fallback: TData): TData =>
+			response.data ?? fallback,
+	);
+	spyOn(storageModule, "readParts").mockImplementation(
+		() => storedParts as ReturnType<typeof storageModule.readParts>,
+	);
 
-mock.module("./storage", () => ({
-  readParts: () => storedParts,
-}))
-
-const { recoverToolResultMissing } = await import("./recover-tool-result-missing")
+	const recoverModule = await import(
+		`./recover-tool-result-missing?recover-${Date.now()}-${Math.random()}`
+	);
+	recoverToolResultMissing = recoverModule.recoverToolResultMissing;
+}
 
 function createMockClient(messages: MessageData[] = []) {
-  const promptAsync = mock(() => Promise.resolve({}))
+	const promptAsync = mock(() => Promise.resolve({}));
 
-  return {
-    client: {
-      session: {
-        messages: mock(() => Promise.resolve({ data: messages })),
-        promptAsync,
-      },
-    } as never,
-    promptAsync,
-  }
+	return {
+		client: {
+			session: {
+				messages: mock(() => Promise.resolve({ data: messages })),
+				promptAsync,
+			},
+		} as never,
+		promptAsync,
+	};
 }
 
 const failedAssistantMsg: MessageData = {
-  info: { id: "msg_failed", role: "assistant" },
-  parts: [],
-}
+	info: { id: "msg_failed", role: "assistant" },
+	parts: [],
+};
 
 describe("recoverToolResultMissing", () => {
-  beforeEach(() => {
-    sqliteBackend = false
-    storedParts = []
-  })
+	beforeEach(async () => {
+		sqliteBackend = false;
+		storedParts = [];
+		await importRecoverToolResultMissing();
+	});
 
-  it("returns false for sqlite fallback when tool part has no valid callID", async () => {
-    //#given
-    sqliteBackend = true
-    const { client, promptAsync } = createMockClient([
-      {
-        info: { id: "msg_failed", role: "assistant" },
-        parts: [{ type: "tool", id: "prt_missing_call", name: "bash", input: {} }],
-      },
-    ])
+	afterEach(() => {
+		mock.restore();
+	});
 
-    //#when
-    const result = await recoverToolResultMissing(client, "ses_1", failedAssistantMsg)
+	it("returns false for sqlite fallback when tool part has no valid callID", async () => {
+		//#given
+		sqliteBackend = true;
+		const { client, promptAsync } = createMockClient([
+			{
+				info: { id: "msg_failed", role: "assistant" },
+				parts: [
+					{ type: "tool", id: "prt_missing_call", name: "bash", input: {} },
+				],
+			},
+		]);
 
-    //#then
-    expect(result).toBe(false)
-    expect(promptAsync).not.toHaveBeenCalled()
-  })
+		//#when
+		const result = await recoverToolResultMissing(
+			client,
+			"ses_1",
+			failedAssistantMsg,
+		);
 
-  it("sends the recovered sqlite tool result when callID is valid", async () => {
-    //#given
-    sqliteBackend = true
-    const { client, promptAsync } = createMockClient([
-      {
-        info: { id: "msg_failed", role: "assistant" },
-        parts: [{ type: "tool", id: "prt_valid_call", callID: "call_recovered", name: "bash", input: {} }],
-      },
-    ])
+		//#then
+		expect(result).toBe(false);
+		expect(promptAsync).not.toHaveBeenCalled();
+	});
 
-    //#when
-    const result = await recoverToolResultMissing(client, "ses_1", failedAssistantMsg)
+	it("sends the recovered sqlite tool result when callID is valid", async () => {
+		//#given
+		sqliteBackend = true;
+		const { client, promptAsync } = createMockClient([
+			{
+				info: { id: "msg_failed", role: "assistant" },
+				parts: [
+					{
+						type: "tool",
+						id: "prt_valid_call",
+						callID: "call_recovered",
+						name: "bash",
+						input: {},
+					},
+				],
+			},
+		]);
 
-    //#then
-    expect(result).toBe(true)
-    expect(promptAsync).toHaveBeenCalledWith({
-      path: { id: "ses_1" },
-      body: {
-        parts: [{
-          type: "tool_result",
-          tool_use_id: "call_recovered",
-          content: "Operation cancelled by user (ESC pressed)",
-        }],
-      },
-    })
-  })
+		//#when
+		const result = await recoverToolResultMissing(
+			client,
+			"ses_1",
+			failedAssistantMsg,
+		);
 
-  it("returns false for stored parts when tool part has no valid callID", async () => {
-    //#given
-    storedParts = [{ type: "tool", id: "prt_stored_missing_call", tool: "bash", state: { input: {} } }]
-    const { client, promptAsync } = createMockClient()
+		//#then
+		expect(result).toBe(true);
+		expect(promptAsync).toHaveBeenCalledWith({
+			path: { id: "ses_1" },
+			body: {
+				parts: [
+					{
+						type: "tool_result",
+						tool_use_id: "call_recovered",
+						content: "Operation cancelled by user (ESC pressed)",
+					},
+				],
+			},
+		});
+	});
 
-    //#when
-    const result = await recoverToolResultMissing(client, "ses_2", failedAssistantMsg)
+	it("returns false for stored parts when tool part has no valid callID", async () => {
+		//#given
+		storedParts = [
+			{
+				type: "tool",
+				id: "prt_stored_missing_call",
+				tool: "bash",
+				state: { input: {} },
+			},
+		];
+		const { client, promptAsync } = createMockClient();
 
-    //#then
-    expect(result).toBe(false)
-    expect(promptAsync).not.toHaveBeenCalled()
-  })
+		//#when
+		const result = await recoverToolResultMissing(
+			client,
+			"ses_2",
+			failedAssistantMsg,
+		);
 
-  it("sends the recovered stored tool result when callID is valid", async () => {
-    //#given
-    storedParts = [{
-      type: "tool",
-      id: "prt_stored_valid_call",
-      callID: "toolu_recovered",
-      tool: "bash",
-      state: { input: {} },
-    }]
-    const { client, promptAsync } = createMockClient()
+		//#then
+		expect(result).toBe(false);
+		expect(promptAsync).not.toHaveBeenCalled();
+	});
 
-    //#when
-    const result = await recoverToolResultMissing(client, "ses_2", failedAssistantMsg)
+	it("sends the recovered stored tool result when callID is valid", async () => {
+		//#given
+		storedParts = [
+			{
+				type: "tool",
+				id: "prt_stored_valid_call",
+				callID: "toolu_recovered",
+				tool: "bash",
+				state: { input: {} },
+			},
+		];
+		const { client, promptAsync } = createMockClient();
 
-    //#then
-    expect(result).toBe(true)
-    expect(promptAsync).toHaveBeenCalledWith({
-      path: { id: "ses_2" },
-      body: {
-        parts: [{
-          type: "tool_result",
-          tool_use_id: "toolu_recovered",
-          content: "Operation cancelled by user (ESC pressed)",
-        }],
-      },
-    })
-  })
-})
+		//#when
+		const result = await recoverToolResultMissing(
+			client,
+			"ses_2",
+			failedAssistantMsg,
+		);
 
-export {}
+		//#then
+		expect(result).toBe(true);
+		expect(promptAsync).toHaveBeenCalledWith({
+			path: { id: "ses_2" },
+			body: {
+				parts: [
+					{
+						type: "tool_result",
+						tool_use_id: "toolu_recovered",
+						content: "Operation cancelled by user (ESC pressed)",
+					},
+				],
+			},
+		});
+	});
+});

--- a/src/hooks/session-recovery/storage/readers-from-sdk.test.ts
+++ b/src/hooks/session-recovery/storage/readers-from-sdk.test.ts
@@ -1,98 +1,104 @@
-import { describe, expect, it } from "bun:test"
-import { readMessagesFromSDK, readPartsFromSDK } from "../storage"
-import { readMessages } from "./messages-reader"
-import { readParts } from "./parts-reader"
+import { describe, expect, it } from "bun:test";
+import { readMessagesFromSDK, readPartsFromSDK } from "../storage";
+import { readMessages } from "./messages-reader";
+import { readParts } from "./parts-reader";
 
 function createMockClient(handlers: {
-  messages?: (sessionID: string) => unknown[]
-  message?: (sessionID: string, messageID: string) => unknown
+	messages?: (sessionID: string) => unknown[];
+	message?: (sessionID: string, messageID: string) => unknown;
 }) {
-  return {
-    session: {
-      messages: async (opts: { path: { id: string } }) => {
-        if (handlers.messages) {
-          return { data: handlers.messages(opts.path.id) }
-        }
-        throw new Error("not implemented")
-      },
-      message: async (opts: { path: { id: string; messageID: string } }) => {
-        if (handlers.message) {
-          return { data: handlers.message(opts.path.id, opts.path.messageID) }
-        }
-        throw new Error("not implemented")
-      },
-    },
-  } as unknown
+	return {
+		session: {
+			messages: async (opts: { path: { id: string } }) => {
+				if (handlers.messages) {
+					return { data: handlers.messages(opts.path.id) };
+				}
+				throw new Error("not implemented");
+			},
+			message: async (opts: { path: { id: string; messageID: string } }) => {
+				if (handlers.message) {
+					return { data: handlers.message(opts.path.id, opts.path.messageID) };
+				}
+				throw new Error("not implemented");
+			},
+		},
+	} as unknown;
 }
 
 describe("session-recovery storage SDK readers", () => {
-  it("readPartsFromSDK returns empty array when fetch fails", async () => {
-    //#given a client that throws on request
-    const client = createMockClient({}) as Parameters<typeof readPartsFromSDK>[0]
+	it("readPartsFromSDK returns empty array when fetch fails", async () => {
+		//#given a client that throws on request
+		const client = createMockClient({}) as Parameters<
+			typeof readPartsFromSDK
+		>[0];
 
-    //#when readPartsFromSDK is called
-    const result = await readPartsFromSDK(client, "ses_test", "msg_test")
+		//#when readPartsFromSDK is called
+		const result = await readPartsFromSDK(client, "ses_test", "msg_test");
 
-    //#then it returns empty array
-    expect(result).toEqual([])
-  })
+		//#then it returns empty array
+		expect(result).toEqual([]);
+	});
 
-  it("readPartsFromSDK returns stored parts from SDK response", async () => {
-    //#given a client that returns a message with parts
-    const sessionID = "ses_test"
-    const messageID = "msg_test"
-    const storedParts = [
-      { id: "prt_1", sessionID, messageID, type: "text", text: "hello" },
-    ]
+	it("readPartsFromSDK returns stored parts from SDK response", async () => {
+		//#given a client that returns a message with parts
+		const sessionID = "ses_test";
+		const messageID = "msg_test";
+		const storedParts = [
+			{ id: "prt_1", sessionID, messageID, type: "text", text: "hello" },
+		];
 
-    const client = createMockClient({
-      message: (_sid, _mid) => ({ parts: storedParts }),
-    }) as Parameters<typeof readPartsFromSDK>[0]
+		const client = createMockClient({
+			message: (_sid, _mid) => ({ parts: storedParts }),
+		}) as Parameters<typeof readPartsFromSDK>[0];
 
-    //#when readPartsFromSDK is called
-    const result = await readPartsFromSDK(client, sessionID, messageID)
+		//#when readPartsFromSDK is called
+		const result = await readPartsFromSDK(client, sessionID, messageID);
 
-    //#then it returns the parts
-    expect(result).toEqual(storedParts)
-  })
+		//#then it returns the parts
+		expect(result).toEqual(storedParts);
+	});
 
-  it("readMessagesFromSDK normalizes and sorts messages", async () => {
-    //#given a client that returns messages list
-    const sessionID = "ses_test"
-    const client = createMockClient({
-      messages: () => [
-        { id: "msg_b", role: "assistant", time: { created: 2 } },
-        { id: "msg_a", role: "user", time: { created: 1 } },
-        { id: "msg_c" },
-      ],
-    }) as Parameters<typeof readMessagesFromSDK>[0]
+	it("readMessagesFromSDK normalizes and sorts messages", async () => {
+		//#given a client that returns messages list
+		const sessionID = "ses_test";
+		const client = createMockClient({
+			messages: () => [
+				{ id: "msg_b", role: "assistant", time: { created: 2 } },
+				{ id: "msg_a", role: "user", time: { created: 1 } },
+				{ id: "msg_c" },
+			],
+		}) as Parameters<typeof readMessagesFromSDK>[0];
 
-    //#when readMessagesFromSDK is called
-    const result = await readMessagesFromSDK(client, sessionID)
+		//#when readMessagesFromSDK is called
+		const result = await readMessagesFromSDK(client, sessionID);
 
-    //#then it returns sorted StoredMessageMeta with defaults
-    expect(result).toEqual([
-      { id: "msg_c", sessionID, role: "user", time: { created: 0 } },
-      { id: "msg_a", sessionID, role: "user", time: { created: 1 } },
-      { id: "msg_b", sessionID, role: "assistant", time: { created: 2 } },
-    ])
-  })
+		//#then it returns sorted StoredMessageMeta with defaults
+		expect(result).toEqual([
+			{ id: "msg_c", sessionID, role: "user", time: { created: 0 } },
+			{ id: "msg_a", sessionID, role: "user", time: { created: 1 } },
+			{ id: "msg_b", sessionID, role: "assistant", time: { created: 2 } },
+		]);
+	});
 
-  it("readParts returns empty array for nonexistent message", () => {
-    //#given a message ID that has no stored parts
-    //#when readParts is called
-    const parts = readParts("msg_nonexistent")
+	it("readParts returns empty array for nonexistent message", () => {
+		//#given a message ID that has no stored parts
+		const missingMessageID = `msg_nonexistent_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 
-    //#then it returns empty array
-    expect(parts).toEqual([])
-  })
+		//#when readParts is called
+		const parts = readParts(missingMessageID);
 
-  it("readMessages returns empty array for nonexistent session", () => {
-    //#given a session ID that has no stored messages
-    //#when readMessages is called
-    const messages = readMessages("ses_nonexistent")
+		//#then it returns empty array
+		expect(parts).toEqual([]);
+	});
 
-    //#then it returns empty array
-    expect(messages).toEqual([])
-  })
-})
+	it("readMessages returns empty array for nonexistent session", () => {
+		//#given a session ID that has no stored messages
+		const missingSessionID = `ses_nonexistent_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+
+		//#when readMessages is called
+		const messages = readMessages(missingSessionID);
+
+		//#then it returns empty array
+		expect(messages).toEqual([]);
+	});
+});

--- a/src/hooks/start-work/index.test.ts
+++ b/src/hooks/start-work/index.test.ts
@@ -1,578 +1,575 @@
-import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test"
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
-import { tmpdir, homedir } from "node:os"
-import { randomUUID } from "node:crypto"
-import { createStartWorkHook } from "./index"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BoulderState } from "../../features/boulder-state";
 import {
-  writeBoulderState,
-  clearBoulderState,
-  readBoulderState,
-} from "../../features/boulder-state"
-import type { BoulderState } from "../../features/boulder-state"
-import * as sessionState from "../../features/claude-code-session-state"
-import * as worktreeDetector from "./worktree-detector"
-import * as worktreeDetector from "./worktree-detector"
+	clearBoulderState,
+	readBoulderState,
+	writeBoulderState,
+} from "../../features/boulder-state";
+import * as sessionState from "../../features/claude-code-session-state";
+import { createStartWorkHook } from "./index";
+import * as worktreeDetector from "./worktree-detector";
 
 describe("start-work hook", () => {
-  let testDir: string
-  let sisyphusDir: string
+	let testDir: string;
+	let sisyphusDir: string;
 
-  function createMockPluginInput() {
-    return {
-      directory: testDir,
-      client: {},
-    } as Parameters<typeof createStartWorkHook>[0]
-  }
+	function createMockPluginInput() {
+		return {
+			directory: testDir,
+			client: {},
+		} as Parameters<typeof createStartWorkHook>[0];
+	}
 
-  beforeEach(() => {
-    testDir = join(tmpdir(), `start-work-test-${randomUUID()}`)
-    sisyphusDir = join(testDir, ".sisyphus")
-    if (!existsSync(testDir)) {
-      mkdirSync(testDir, { recursive: true })
-    }
-    if (!existsSync(sisyphusDir)) {
-      mkdirSync(sisyphusDir, { recursive: true })
-    }
-    clearBoulderState(testDir)
-  })
+	beforeEach(() => {
+		testDir = join(tmpdir(), `start-work-test-${randomUUID()}`);
+		sisyphusDir = join(testDir, ".sisyphus");
+		sessionState._resetForTesting();
+		if (!existsSync(testDir)) {
+			mkdirSync(testDir, { recursive: true });
+		}
+		if (!existsSync(sisyphusDir)) {
+			mkdirSync(sisyphusDir, { recursive: true });
+		}
+		clearBoulderState(testDir);
+	});
 
-  afterEach(() => {
-    clearBoulderState(testDir)
-    if (existsSync(testDir)) {
-      rmSync(testDir, { recursive: true, force: true })
-    }
-  })
+	afterEach(() => {
+		sessionState._resetForTesting();
+		clearBoulderState(testDir);
+		if (existsSync(testDir)) {
+			rmSync(testDir, { recursive: true, force: true });
+		}
+	});
 
-  describe("chat.message handler", () => {
-    test("should ignore non-start-work commands", async () => {
-      // given - hook and non-start-work message
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "Just a regular message" }],
-      }
+	describe("chat.message handler", () => {
+		test("should ignore non-start-work commands", async () => {
+			// given - hook and non-start-work message
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [{ type: "text", text: "Just a regular message" }],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - output should be unchanged
-      expect(output.parts[0].text).toBe("Just a regular message")
-    })
+			// then - output should be unchanged
+			expect(output.parts[0].text).toBe("Just a regular message");
+		});
 
-    test("should detect start-work command via session-context tag", async () => {
-      // given - hook and start-work message
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [
-          {
-            type: "text",
-            text: "<session-context>Some context here</session-context>",
-          },
-        ],
-      }
+		test("should detect start-work command via session-context tag", async () => {
+			// given - hook and start-work message
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: "<session-context>Some context here</session-context>",
+					},
+				],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - output should be modified with context info
-      expect(output.parts[0].text).toContain("---")
-    })
+			// then - output should be modified with context info
+			expect(output.parts[0].text).toContain("---");
+		});
 
-    test("should inject resume info when existing boulder state found", async () => {
-      // given - existing boulder state with incomplete plan
-      const planPath = join(testDir, "test-plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2")
+		test("should inject resume info when existing boulder state found", async () => {
+			// given - existing boulder state with incomplete plan
+			const planPath = join(testDir, "test-plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1\n- [x] Task 2");
 
-      const state: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-02T10:00:00Z",
-        session_ids: ["session-1"],
-        plan_name: "test-plan",
-      }
-      writeBoulderState(testDir, state)
+			const state: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-02T10:00:00Z",
+				session_ids: ["session-1"],
+				plan_name: "test-plan",
+			};
+			writeBoulderState(testDir, state);
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context></session-context>" }],
-      }
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [{ type: "text", text: "<session-context></session-context>" }],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - should show resuming status
-      expect(output.parts[0].text).toContain("RESUMING")
-      expect(output.parts[0].text).toContain("test-plan")
-    })
+			// then - should show resuming status
+			expect(output.parts[0].text).toContain("RESUMING");
+			expect(output.parts[0].text).toContain("test-plan");
+		});
 
-    test("should replace $SESSION_ID placeholder", async () => {
-      // given - hook and message with placeholder
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [
-          {
-            type: "text",
-            text: "<session-context>Session: $SESSION_ID</session-context>",
-          },
-        ],
-      }
+		test("should replace $SESSION_ID placeholder", async () => {
+			// given - hook and message with placeholder
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: "<session-context>Session: $SESSION_ID</session-context>",
+					},
+				],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "ses-abc123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "ses-abc123" }, output);
 
-      // then - placeholder should be replaced
-      expect(output.parts[0].text).toContain("ses-abc123")
-      expect(output.parts[0].text).not.toContain("$SESSION_ID")
-    })
+			// then - placeholder should be replaced
+			expect(output.parts[0].text).toContain("ses-abc123");
+			expect(output.parts[0].text).not.toContain("$SESSION_ID");
+		});
 
-    test("should replace $TIMESTAMP placeholder", async () => {
-      // given - hook and message with placeholder
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [
-          {
-            type: "text",
-            text: "<session-context>Time: $TIMESTAMP</session-context>",
-          },
-        ],
-      }
+		test("should replace $TIMESTAMP placeholder", async () => {
+			// given - hook and message with placeholder
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: "<session-context>Time: $TIMESTAMP</session-context>",
+					},
+				],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - placeholder should be replaced with ISO timestamp
-      expect(output.parts[0].text).not.toContain("$TIMESTAMP")
-      expect(output.parts[0].text).toMatch(/\d{4}-\d{2}-\d{2}T/)
-    })
+			// then - placeholder should be replaced with ISO timestamp
+			expect(output.parts[0].text).not.toContain("$TIMESTAMP");
+			expect(output.parts[0].text).toMatch(/\d{4}-\d{2}-\d{2}T/);
+		});
 
-    test("should auto-select when only one incomplete plan among multiple plans", async () => {
-      // given - multiple plans but only one incomplete
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
+		test("should auto-select when only one incomplete plan among multiple plans", async () => {
+			// given - multiple plans but only one incomplete
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
 
-      // Plan 1: complete (all checked)
-      const plan1Path = join(plansDir, "plan-complete.md")
-      writeFileSync(plan1Path, "# Plan Complete\n- [x] Task 1\n- [x] Task 2")
+			// Plan 1: complete (all checked)
+			const plan1Path = join(plansDir, "plan-complete.md");
+			writeFileSync(plan1Path, "# Plan Complete\n- [x] Task 1\n- [x] Task 2");
 
-      // Plan 2: incomplete (has unchecked)
-      const plan2Path = join(plansDir, "plan-incomplete.md")
-      writeFileSync(plan2Path, "# Plan Incomplete\n- [ ] Task 1\n- [x] Task 2")
+			// Plan 2: incomplete (has unchecked)
+			const plan2Path = join(plansDir, "plan-incomplete.md");
+			writeFileSync(plan2Path, "# Plan Incomplete\n- [ ] Task 1\n- [x] Task 2");
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context></session-context>" }],
-      }
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [{ type: "text", text: "<session-context></session-context>" }],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - should auto-select the incomplete plan, not ask user
-      expect(output.parts[0].text).toContain("Auto-Selected Plan")
-      expect(output.parts[0].text).toContain("plan-incomplete")
-      expect(output.parts[0].text).not.toContain("Multiple Plans Found")
-    })
+			// then - should auto-select the incomplete plan, not ask user
+			expect(output.parts[0].text).toContain("Auto-Selected Plan");
+			expect(output.parts[0].text).toContain("plan-incomplete");
+			expect(output.parts[0].text).not.toContain("Multiple Plans Found");
+		});
 
-    test("should wrap multiple plans message in system-reminder tag", async () => {
-      // given - multiple incomplete plans
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
+		test("should wrap multiple plans message in system-reminder tag", async () => {
+			// given - multiple incomplete plans
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
 
-      const plan1Path = join(plansDir, "plan-a.md")
-      writeFileSync(plan1Path, "# Plan A\n- [ ] Task 1")
+			const plan1Path = join(plansDir, "plan-a.md");
+			writeFileSync(plan1Path, "# Plan A\n- [ ] Task 1");
 
-      const plan2Path = join(plansDir, "plan-b.md")
-      writeFileSync(plan2Path, "# Plan B\n- [ ] Task 2")
+			const plan2Path = join(plansDir, "plan-b.md");
+			writeFileSync(plan2Path, "# Plan B\n- [ ] Task 2");
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context></session-context>" }],
-      }
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [{ type: "text", text: "<session-context></session-context>" }],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - should use system-reminder tag format
-      expect(output.parts[0].text).toContain("<system-reminder>")
-      expect(output.parts[0].text).toContain("</system-reminder>")
-      expect(output.parts[0].text).toContain("Multiple Plans Found")
-    })
+			// then - should use system-reminder tag format
+			expect(output.parts[0].text).toContain("<system-reminder>");
+			expect(output.parts[0].text).toContain("</system-reminder>");
+			expect(output.parts[0].text).toContain("Multiple Plans Found");
+		});
 
-    test("should use 'ask user' prompt style for multiple plans", async () => {
-      // given - multiple incomplete plans
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
+		test("should use 'ask user' prompt style for multiple plans", async () => {
+			// given - multiple incomplete plans
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
 
-      const plan1Path = join(plansDir, "plan-x.md")
-      writeFileSync(plan1Path, "# Plan X\n- [ ] Task 1")
+			const plan1Path = join(plansDir, "plan-x.md");
+			writeFileSync(plan1Path, "# Plan X\n- [ ] Task 1");
 
-      const plan2Path = join(plansDir, "plan-y.md")
-      writeFileSync(plan2Path, "# Plan Y\n- [ ] Task 2")
+			const plan2Path = join(plansDir, "plan-y.md");
+			writeFileSync(plan2Path, "# Plan Y\n- [ ] Task 2");
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context></session-context>" }],
-      }
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [{ type: "text", text: "<session-context></session-context>" }],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - should prompt agent to ask user, not ask directly
-      expect(output.parts[0].text).toContain("Ask the user")
-      expect(output.parts[0].text).not.toContain("Which plan would you like to work on?")
-    })
+			// then - should prompt agent to ask user, not ask directly
+			expect(output.parts[0].text).toContain("Ask the user");
+			expect(output.parts[0].text).not.toContain(
+				"Which plan would you like to work on?",
+			);
+		});
 
-    test("should select explicitly specified plan name from user-request, ignoring existing boulder state", async () => {
-      // given - existing boulder state pointing to old plan
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
+		test("should select explicitly specified plan name from user-request, ignoring existing boulder state", async () => {
+			// given - existing boulder state pointing to old plan
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
 
-      // Old plan (in boulder state)
-      const oldPlanPath = join(plansDir, "old-plan.md")
-      writeFileSync(oldPlanPath, "# Old Plan\n- [ ] Old Task 1")
+			// Old plan (in boulder state)
+			const oldPlanPath = join(plansDir, "old-plan.md");
+			writeFileSync(oldPlanPath, "# Old Plan\n- [ ] Old Task 1");
 
-      // New plan (user wants this one)
-      const newPlanPath = join(plansDir, "new-plan.md")
-      writeFileSync(newPlanPath, "# New Plan\n- [ ] New Task 1")
+			// New plan (user wants this one)
+			const newPlanPath = join(plansDir, "new-plan.md");
+			writeFileSync(newPlanPath, "# New Plan\n- [ ] New Task 1");
 
-      // Set up stale boulder state pointing to old plan
-      const staleState: BoulderState = {
-        active_plan: oldPlanPath,
-        started_at: "2026-01-01T10:00:00Z",
-        session_ids: ["old-session"],
-        plan_name: "old-plan",
-      }
-      writeBoulderState(testDir, staleState)
+			// Set up stale boulder state pointing to old plan
+			const staleState: BoulderState = {
+				active_plan: oldPlanPath,
+				started_at: "2026-01-01T10:00:00Z",
+				session_ids: ["old-session"],
+				plan_name: "old-plan",
+			};
+			writeBoulderState(testDir, staleState);
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [
-          {
-            type: "text",
-            text: `<session-context>
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: `<session-context>
 <user-request>new-plan</user-request>
 </session-context>`,
-          },
-        ],
-      }
+					},
+				],
+			};
 
-      // when - user explicitly specifies new-plan
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when - user explicitly specifies new-plan
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - should select new-plan, NOT resume old-plan
-      expect(output.parts[0].text).toContain("new-plan")
-      expect(output.parts[0].text).not.toContain("RESUMING")
-      expect(output.parts[0].text).not.toContain("old-plan")
-    })
+			// then - should select new-plan, NOT resume old-plan
+			expect(output.parts[0].text).toContain("new-plan");
+			expect(output.parts[0].text).not.toContain("RESUMING");
+			expect(output.parts[0].text).not.toContain("old-plan");
+		});
 
-    test("should strip ultrawork/ulw keywords from plan name argument", async () => {
-      // given - plan with ultrawork keyword in user-request
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
+		test("should strip ultrawork/ulw keywords from plan name argument", async () => {
+			// given - plan with ultrawork keyword in user-request
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
 
-      const planPath = join(plansDir, "my-feature-plan.md")
-      writeFileSync(planPath, "# My Feature Plan\n- [ ] Task 1")
+			const planPath = join(plansDir, "my-feature-plan.md");
+			writeFileSync(planPath, "# My Feature Plan\n- [ ] Task 1");
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [
-          {
-            type: "text",
-            text: `<session-context>
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: `<session-context>
 <user-request>my-feature-plan ultrawork</user-request>
 </session-context>`,
-          },
-        ],
-      }
+					},
+				],
+			};
 
-      // when - user specifies plan with ultrawork keyword
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when - user specifies plan with ultrawork keyword
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - should find plan without ultrawork suffix
-      expect(output.parts[0].text).toContain("my-feature-plan")
-      expect(output.parts[0].text).toContain("Auto-Selected Plan")
-    })
+			// then - should find plan without ultrawork suffix
+			expect(output.parts[0].text).toContain("my-feature-plan");
+			expect(output.parts[0].text).toContain("Auto-Selected Plan");
+		});
 
-    test("should strip ulw keyword from plan name argument", async () => {
-      // given - plan with ulw keyword in user-request
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
+		test("should strip ulw keyword from plan name argument", async () => {
+			// given - plan with ulw keyword in user-request
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
 
-      const planPath = join(plansDir, "api-refactor.md")
-      writeFileSync(planPath, "# API Refactor\n- [ ] Task 1")
+			const planPath = join(plansDir, "api-refactor.md");
+			writeFileSync(planPath, "# API Refactor\n- [ ] Task 1");
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [
-          {
-            type: "text",
-            text: `<session-context>
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: `<session-context>
 <user-request>api-refactor ulw</user-request>
 </session-context>`,
-          },
-        ],
-      }
+					},
+				],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - should find plan without ulw suffix
-      expect(output.parts[0].text).toContain("api-refactor")
-      expect(output.parts[0].text).toContain("Auto-Selected Plan")
-    })
+			// then - should find plan without ulw suffix
+			expect(output.parts[0].text).toContain("api-refactor");
+			expect(output.parts[0].text).toContain("Auto-Selected Plan");
+		});
 
-    test("should match plan by partial name", async () => {
-      // given - user specifies partial plan name
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
+		test("should match plan by partial name", async () => {
+			// given - user specifies partial plan name
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
 
-      const planPath = join(plansDir, "2026-01-15-feature-implementation.md")
-      writeFileSync(planPath, "# Feature Implementation\n- [ ] Task 1")
+			const planPath = join(plansDir, "2026-01-15-feature-implementation.md");
+			writeFileSync(planPath, "# Feature Implementation\n- [ ] Task 1");
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [
-          {
-            type: "text",
-            text: `<session-context>
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: `<session-context>
 <user-request>feature-implementation</user-request>
 </session-context>`,
-          },
-        ],
-      }
+					},
+				],
+			};
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "session-123" },
-        output
-      )
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-      // then - should find plan by partial match
-      expect(output.parts[0].text).toContain("2026-01-15-feature-implementation")
-      expect(output.parts[0].text).toContain("Auto-Selected Plan")
-    })
-  })
+			// then - should find plan by partial match
+			expect(output.parts[0].text).toContain(
+				"2026-01-15-feature-implementation",
+			);
+			expect(output.parts[0].text).toContain("Auto-Selected Plan");
+		});
+	});
 
-  describe("session agent management", () => {
-    test("should update session agent to Atlas when start-work command is triggered", async () => {
-      // given
-      const updateSpy = spyOn(sessionState, "updateSessionAgent")
-      
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context></session-context>" }],
-      }
+	describe("session agent management", () => {
+		test("should update session agent to Atlas when start-work command is triggered", async () => {
+			// given
+			sessionState.registerAgentName("atlas");
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "ses-prometheus-to-sisyphus" },
-        output
-      )
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [{ type: "text", text: "<session-context></session-context>" }],
+			};
 
-      // then
-      expect(updateSpy).toHaveBeenCalledWith("ses-prometheus-to-sisyphus", "atlas")
-      updateSpy.mockRestore()
-    })
+			// when
+			await hook["chat.message"](
+				{ sessionID: "ses-prometheus-to-sisyphus" },
+				output,
+			);
 
-    test("should stamp the outgoing message with Atlas so follow-up events keep the handoff", async () => {
-      // given
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        message: {},
-        parts: [{ type: "text", text: "<session-context></session-context>" }],
-      }
+			// then
+			expect(sessionState.getSessionAgent("ses-prometheus-to-sisyphus")).toBe(
+				"atlas",
+			);
+		});
 
-      // when
-      await hook["chat.message"](
-        { sessionID: "ses-prometheus-to-atlas" },
-        output
-      )
+		test("should stamp the outgoing message with Atlas so follow-up events keep the handoff", async () => {
+			// given
+			sessionState.registerAgentName("atlas");
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				message: {},
+				parts: [{ type: "text", text: "<session-context></session-context>" }],
+			};
 
-      // then
-      expect(output.message.agent).toBe("Atlas (Plan Executor)")
-    })
-  })
+			// when
+			await hook["chat.message"](
+				{ sessionID: "ses-prometheus-to-atlas" },
+				output,
+			);
 
-  describe("worktree support", () => {
-    let detectSpy: ReturnType<typeof spyOn>
+			// then
+			expect(output.message.agent).toBe("Atlas (Plan Executor)");
+		});
+	});
 
-    beforeEach(() => {
-      detectSpy = spyOn(worktreeDetector, "detectWorktreePath").mockReturnValue(null)
-    })
+	describe("worktree support", () => {
+		let detectSpy: ReturnType<typeof spyOn>;
 
-    afterEach(() => {
-      detectSpy.mockRestore()
-    })
+		beforeEach(() => {
+			detectSpy = spyOn(worktreeDetector, "detectWorktreePath").mockReturnValue(
+				null,
+			);
+		});
 
-    test("should NOT inject worktree instructions when no --worktree flag", async () => {
-      // given - single plan, no worktree flag
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
-      writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
+		afterEach(() => {
+			detectSpy.mockRestore();
+		});
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context></session-context>" }],
-      }
+		test("should NOT inject worktree instructions when no --worktree flag", async () => {
+			// given - single plan, no worktree flag
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
+			writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1");
 
-      // when
-      await hook["chat.message"]({ sessionID: "session-123" }, output)
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [{ type: "text", text: "<session-context></session-context>" }],
+			};
 
-      // then - no worktree instructions should appear
-      expect(output.parts[0].text).not.toContain("Worktree Setup Required")
-      expect(output.parts[0].text).not.toContain("Worktree Active")
-      expect(output.parts[0].text).not.toContain("git worktree list --porcelain")
-    })
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-    test("should inject worktree path when --worktree flag is valid", async () => {
-      // given - single plan + valid worktree path
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
-      writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
-      detectSpy.mockReturnValue("/validated/worktree")
+			// then - no worktree instructions should appear
+			expect(output.parts[0].text).not.toContain("Worktree Setup Required");
+			expect(output.parts[0].text).not.toContain("Worktree Active");
+			expect(output.parts[0].text).not.toContain(
+				"git worktree list --porcelain",
+			);
+		});
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /validated/worktree</user-request>\n</session-context>" }],
-      }
+		test("should inject worktree path when --worktree flag is valid", async () => {
+			// given - single plan + valid worktree path
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
+			writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1");
+			detectSpy.mockReturnValue("/validated/worktree");
 
-      // when
-      await hook["chat.message"]({ sessionID: "session-123" }, output)
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: "<session-context>\n<user-request>--worktree /validated/worktree</user-request>\n</session-context>",
+					},
+				],
+			};
 
-      // then - strong worktree active instructions shown
-      expect(output.parts[0].text).toContain("Worktree Active")
-      expect(output.parts[0].text).toContain("/validated/worktree")
-      expect(output.parts[0].text).toContain("subagent")
-      expect(output.parts[0].text).not.toContain("Worktree Setup Required")
-    })
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-    test("should store worktree_path in boulder when --worktree is valid", async () => {
-      // given - plan + valid worktree
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
-      writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
-      detectSpy.mockReturnValue("/valid/wt")
+			// then - strong worktree active instructions shown
+			expect(output.parts[0].text).toContain("Worktree Active");
+			expect(output.parts[0].text).toContain("/validated/worktree");
+			expect(output.parts[0].text).toContain("subagent");
+			expect(output.parts[0].text).not.toContain("Worktree Setup Required");
+		});
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /valid/wt</user-request>\n</session-context>" }],
-      }
+		test("should store worktree_path in boulder when --worktree is valid", async () => {
+			// given - plan + valid worktree
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
+			writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1");
+			detectSpy.mockReturnValue("/valid/wt");
 
-      // when
-      await hook["chat.message"]({ sessionID: "session-123" }, output)
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: "<session-context>\n<user-request>--worktree /valid/wt</user-request>\n</session-context>",
+					},
+				],
+			};
 
-      // then - boulder.json has worktree_path
-      const state = readBoulderState(testDir)
-      expect(state?.worktree_path).toBe("/valid/wt")
-    })
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-    test("should NOT store worktree_path when --worktree path is invalid", async () => {
-      // given - plan + invalid worktree path (detectWorktreePath returns null)
-      const plansDir = join(testDir, ".sisyphus", "plans")
-      mkdirSync(plansDir, { recursive: true })
-      writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1")
-      // detectSpy already returns null by default
+			// then - boulder.json has worktree_path
+			const state = readBoulderState(testDir);
+			expect(state?.worktree_path).toBe("/valid/wt");
+		});
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /nonexistent/wt</user-request>\n</session-context>" }],
-      }
+		test("should NOT store worktree_path when --worktree path is invalid", async () => {
+			// given - plan + invalid worktree path (detectWorktreePath returns null)
+			const plansDir = join(testDir, ".sisyphus", "plans");
+			mkdirSync(plansDir, { recursive: true });
+			writeFileSync(join(plansDir, "my-plan.md"), "# Plan\n- [ ] Task 1");
+			// detectSpy already returns null by default
 
-      // when
-      await hook["chat.message"]({ sessionID: "session-123" }, output)
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: "<session-context>\n<user-request>--worktree /nonexistent/wt</user-request>\n</session-context>",
+					},
+				],
+			};
 
-      // then - worktree_path absent, setup instructions present
-      const state = readBoulderState(testDir)
-      expect(state?.worktree_path).toBeUndefined()
-      expect(output.parts[0].text).toContain("needs setup")
-      expect(output.parts[0].text).toContain("git worktree add /nonexistent/wt")
-    })
+			// when
+			await hook["chat.message"]({ sessionID: "session-123" }, output);
 
-    test("should update boulder worktree_path on resume when new --worktree given", async () => {
-      // given - existing boulder with old worktree, user provides new worktree
-      const planPath = join(testDir, "plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
-      const existingState: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-01T00:00:00Z",
-        session_ids: ["old-session"],
-        plan_name: "plan",
-        worktree_path: "/old/wt",
-      }
-      writeBoulderState(testDir, existingState)
-      detectSpy.mockReturnValue("/new/wt")
+			// then - worktree_path absent, setup instructions present
+			const state = readBoulderState(testDir);
+			expect(state?.worktree_path).toBeUndefined();
+			expect(output.parts[0].text).toContain("needs setup");
+			expect(output.parts[0].text).toContain(
+				"git worktree add /nonexistent/wt",
+			);
+		});
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context>\n<user-request>--worktree /new/wt</user-request>\n</session-context>" }],
-      }
+		test("should update boulder worktree_path on resume when new --worktree given", async () => {
+			// given - existing boulder with old worktree, user provides new worktree
+			const planPath = join(testDir, "plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
+			const existingState: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-01T00:00:00Z",
+				session_ids: ["old-session"],
+				plan_name: "plan",
+				worktree_path: "/old/wt",
+			};
+			writeBoulderState(testDir, existingState);
+			detectSpy.mockReturnValue("/new/wt");
 
-      // when
-      await hook["chat.message"]({ sessionID: "session-456" }, output)
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [
+					{
+						type: "text",
+						text: "<session-context>\n<user-request>--worktree /new/wt</user-request>\n</session-context>",
+					},
+				],
+			};
 
-      // then - boulder reflects updated worktree and new session appended
-      const state = readBoulderState(testDir)
-      expect(state?.worktree_path).toBe("/new/wt")
-      expect(state?.session_ids).toContain("session-456")
-    })
+			// when
+			await hook["chat.message"]({ sessionID: "session-456" }, output);
 
-    test("should show existing worktree on resume when no --worktree flag", async () => {
-      // given - existing boulder already has worktree_path, no flag given
-      const planPath = join(testDir, "plan.md")
-      writeFileSync(planPath, "# Plan\n- [ ] Task 1")
-      const existingState: BoulderState = {
-        active_plan: planPath,
-        started_at: "2026-01-01T00:00:00Z",
-        session_ids: ["old-session"],
-        plan_name: "plan",
-        worktree_path: "/existing/wt",
-      }
-      writeBoulderState(testDir, existingState)
+			// then - boulder reflects updated worktree and new session appended
+			const state = readBoulderState(testDir);
+			expect(state?.worktree_path).toBe("/new/wt");
+			expect(state?.session_ids).toContain("session-456");
+		});
 
-      const hook = createStartWorkHook(createMockPluginInput())
-      const output = {
-        parts: [{ type: "text", text: "<session-context></session-context>" }],
-      }
+		test("should show existing worktree on resume when no --worktree flag", async () => {
+			// given - existing boulder already has worktree_path, no flag given
+			const planPath = join(testDir, "plan.md");
+			writeFileSync(planPath, "# Plan\n- [ ] Task 1");
+			const existingState: BoulderState = {
+				active_plan: planPath,
+				started_at: "2026-01-01T00:00:00Z",
+				session_ids: ["old-session"],
+				plan_name: "plan",
+				worktree_path: "/existing/wt",
+			};
+			writeBoulderState(testDir, existingState);
 
-      // when
-      await hook["chat.message"]({ sessionID: "session-789" }, output)
+			const hook = createStartWorkHook(createMockPluginInput());
+			const output = {
+				parts: [{ type: "text", text: "<session-context></session-context>" }],
+			};
 
-      // then - shows strong worktree active instructions
-      expect(output.parts[0].text).toContain("Worktree Active")
-      expect(output.parts[0].text).toContain("/existing/wt")
-      expect(output.parts[0].text).toContain("subagent")
-      expect(output.parts[0].text).not.toContain("Worktree Setup Required")
-    })
-  })
-})
+			// when
+			await hook["chat.message"]({ sessionID: "session-789" }, output);
+
+			// then - shows strong worktree active instructions
+			expect(output.parts[0].text).toContain("Worktree Active");
+			expect(output.parts[0].text).toContain("/existing/wt");
+			expect(output.parts[0].text).toContain("subagent");
+			expect(output.parts[0].text).not.toContain("Worktree Setup Required");
+		});
+	});
+});

--- a/src/hooks/write-existing-file-guard/hook.ts
+++ b/src/hooks/write-existing-file-guard/hook.ts
@@ -1,254 +1,301 @@
-import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import type { Hooks, PluginInput } from "@opencode-ai/plugin";
 
-import { existsSync, realpathSync } from "fs"
-import { basename, dirname, isAbsolute, join, normalize, relative, resolve } from "path"
+import { existsSync, realpathSync } from "fs";
+import {
+	basename,
+	dirname,
+	isAbsolute,
+	join,
+	normalize,
+	relative,
+	resolve,
+	sep,
+} from "path";
 
-import { log } from "../../shared"
+import { log } from "../../shared";
 
 type GuardArgs = {
-  filePath?: string
-  path?: string
-  file_path?: string
-  overwrite?: boolean | string
-}
+	filePath?: string;
+	path?: string;
+	file_path?: string;
+	overwrite?: boolean | string;
+};
 
-const MAX_TRACKED_SESSIONS = 256
-export const MAX_TRACKED_PATHS_PER_SESSION = 1024
-const BLOCK_MESSAGE = "File already exists. Use edit tool instead."
+const MAX_TRACKED_SESSIONS = 256;
+export const MAX_TRACKED_PATHS_PER_SESSION = 1024;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined
-  }
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
 
-  return value as Record<string, unknown>
+	return value as Record<string, unknown>;
 }
 
 function getPathFromArgs(args: GuardArgs | undefined): string | undefined {
-  return args?.filePath ?? args?.path ?? args?.file_path
+	return args?.filePath ?? args?.path ?? args?.file_path;
 }
 
 function resolveInputPath(ctx: PluginInput, inputPath: string): string {
-  return normalize(isAbsolute(inputPath) ? inputPath : resolve(ctx.directory, inputPath))
+	return normalize(
+		isAbsolute(inputPath) ? inputPath : resolve(ctx.directory, inputPath),
+	);
 }
 
-function isPathInsideDirectory(pathToCheck: string, directory: string): boolean {
-  const relativePath = relative(directory, pathToCheck)
-  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))
+function isPathInsideDirectory(
+	pathToCheck: string,
+	directory: string,
+): boolean {
+	const relativePath = relative(directory, pathToCheck);
+	return (
+		relativePath === "" ||
+		(!relativePath.startsWith("..") && !isAbsolute(relativePath))
+	);
 }
-
-
 
 function toCanonicalPath(absolutePath: string): string {
-  let canonicalPath = absolutePath
+	let canonicalPath = absolutePath;
 
-  if (existsSync(absolutePath)) {
-    try {
-      canonicalPath = realpathSync.native(absolutePath)
-    } catch {
-      canonicalPath = absolutePath
-    }
-  } else {
-    const absoluteDir = dirname(absolutePath)
-    const resolvedDir = existsSync(absoluteDir) ? realpathSync.native(absoluteDir) : absoluteDir
-    canonicalPath = join(resolvedDir, basename(absolutePath))
-  }
+	if (existsSync(absolutePath)) {
+		try {
+			canonicalPath = realpathSync.native(absolutePath);
+		} catch {
+			canonicalPath = absolutePath;
+		}
+	} else {
+		const absoluteDir = dirname(absolutePath);
+		const resolvedDir = existsSync(absoluteDir)
+			? realpathSync.native(absoluteDir)
+			: absoluteDir;
+		canonicalPath = join(resolvedDir, basename(absolutePath));
+	}
 
-  // Preserve canonical casing from the filesystem to avoid collapsing distinct
-  // files on case-sensitive volumes (supported on all major OSes).
-  return normalize(canonicalPath)
+	// Preserve canonical casing from the filesystem to avoid collapsing distinct
+	// files on case-sensitive volumes (supported on all major OSes).
+	return normalize(canonicalPath);
 }
 
 function isOverwriteEnabled(value: boolean | string | undefined): boolean {
-  if (value === true) {
-    return true
-  }
+	if (value === true) {
+		return true;
+	}
 
-  if (typeof value === "string") {
-    return value.toLowerCase() === "true"
-  }
+	if (typeof value === "string") {
+		return value.toLowerCase() === "true";
+	}
 
-  return false
+	return false;
+}
+
+export function isSisyphusCanonicalPath(
+	canonicalPath: string,
+	pathSeparator: string = sep,
+): boolean {
+	return canonicalPath
+		.split(pathSeparator)
+		.filter((segment) => segment.length > 0)
+		.includes(".sisyphus");
 }
 
 export function createWriteExistingFileGuardHook(ctx: PluginInput): Hooks {
-  const readPermissionsBySession = new Map<string, Set<string>>()
-  const sessionLastAccess = new Map<string, number>()
-  const canonicalSessionRoot = toCanonicalPath(resolveInputPath(ctx, ctx.directory))
+	const readPermissionsBySession = new Map<string, Set<string>>();
+	const sessionLastAccess = new Map<string, number>();
+	const canonicalSessionRoot = toCanonicalPath(
+		resolveInputPath(ctx, ctx.directory),
+	);
 
-  const touchSession = (sessionID: string): void => {
-    sessionLastAccess.set(sessionID, Date.now())
-  }
+	const touchSession = (sessionID: string): void => {
+		sessionLastAccess.set(sessionID, Date.now());
+	};
 
-  const evictLeastRecentlyUsedSession = (): void => {
-    let oldestSessionID: string | undefined
-    let oldestSeen = Number.POSITIVE_INFINITY
+	const evictLeastRecentlyUsedSession = (): void => {
+		let oldestSessionID: string | undefined;
+		let oldestSeen = Number.POSITIVE_INFINITY;
 
-    for (const [sessionID, lastSeen] of sessionLastAccess.entries()) {
-      if (lastSeen < oldestSeen) {
-        oldestSeen = lastSeen
-        oldestSessionID = sessionID
-      }
-    }
+		for (const [sessionID, lastSeen] of sessionLastAccess.entries()) {
+			if (lastSeen < oldestSeen) {
+				oldestSeen = lastSeen;
+				oldestSessionID = sessionID;
+			}
+		}
 
-    if (!oldestSessionID) {
-      return
-    }
+		if (!oldestSessionID) {
+			return;
+		}
 
-    readPermissionsBySession.delete(oldestSessionID)
-    sessionLastAccess.delete(oldestSessionID)
-  }
+		readPermissionsBySession.delete(oldestSessionID);
+		sessionLastAccess.delete(oldestSessionID);
+	};
 
-  const ensureSessionReadSet = (sessionID: string): Set<string> => {
-    let readSet = readPermissionsBySession.get(sessionID)
-    if (!readSet) {
-      if (readPermissionsBySession.size >= MAX_TRACKED_SESSIONS) {
-        evictLeastRecentlyUsedSession()
-      }
+	const ensureSessionReadSet = (sessionID: string): Set<string> => {
+		let readSet = readPermissionsBySession.get(sessionID);
+		if (!readSet) {
+			if (readPermissionsBySession.size >= MAX_TRACKED_SESSIONS) {
+				evictLeastRecentlyUsedSession();
+			}
 
-      readSet = new Set<string>()
-      readPermissionsBySession.set(sessionID, readSet)
-    }
+			readSet = new Set<string>();
+			readPermissionsBySession.set(sessionID, readSet);
+		}
 
-    touchSession(sessionID)
-    return readSet
-  }
+		touchSession(sessionID);
+		return readSet;
+	};
 
-  const trimSessionReadSet = (readSet: Set<string>): void => {
-    while (readSet.size > MAX_TRACKED_PATHS_PER_SESSION) {
-      const oldestPath = readSet.values().next().value
-      if (!oldestPath) {
-        return
-      }
+	const trimSessionReadSet = (readSet: Set<string>): void => {
+		while (readSet.size > MAX_TRACKED_PATHS_PER_SESSION) {
+			const oldestPath = readSet.values().next().value;
+			if (!oldestPath) {
+				return;
+			}
 
-      readSet.delete(oldestPath)
-    }
-  }
+			readSet.delete(oldestPath);
+		}
+	};
 
-  const registerReadPermission = (sessionID: string, canonicalPath: string): void => {
-    const readSet = ensureSessionReadSet(sessionID)
-    if (readSet.has(canonicalPath)) {
-      readSet.delete(canonicalPath)
-    }
+	const registerReadPermission = (
+		sessionID: string,
+		canonicalPath: string,
+	): void => {
+		const readSet = ensureSessionReadSet(sessionID);
+		if (readSet.has(canonicalPath)) {
+			readSet.delete(canonicalPath);
+		}
 
-    readSet.add(canonicalPath)
-    trimSessionReadSet(readSet)
-  }
+		readSet.add(canonicalPath);
+		trimSessionReadSet(readSet);
+	};
 
-  const consumeReadPermission = (sessionID: string, canonicalPath: string): boolean => {
-    const readSet = readPermissionsBySession.get(sessionID)
-    if (!readSet || !readSet.has(canonicalPath)) {
-      return false
-    }
+	const consumeReadPermission = (
+		sessionID: string,
+		canonicalPath: string,
+	): boolean => {
+		const readSet = readPermissionsBySession.get(sessionID);
+		if (!readSet || !readSet.has(canonicalPath)) {
+			return false;
+		}
 
-    readSet.delete(canonicalPath)
-    touchSession(sessionID)
-    return true
-  }
+		readSet.delete(canonicalPath);
+		touchSession(sessionID);
+		return true;
+	};
 
-  const invalidateOtherSessions = (canonicalPath: string, writingSessionID?: string): void => {
-    for (const [sessionID, readSet] of readPermissionsBySession.entries()) {
-      if (writingSessionID && sessionID === writingSessionID) {
-        continue
-      }
+	const invalidateOtherSessions = (
+		canonicalPath: string,
+		writingSessionID?: string,
+	): void => {
+		for (const [sessionID, readSet] of readPermissionsBySession.entries()) {
+			if (writingSessionID && sessionID === writingSessionID) {
+				continue;
+			}
 
-      readSet.delete(canonicalPath)
-    }
-  }
+			readSet.delete(canonicalPath);
+		}
+	};
 
-  return {
-    "tool.execute.before": async (input, output) => {
-      const toolName = input.tool?.toLowerCase()
-      if (toolName !== "write" && toolName !== "read") {
-        return
-      }
+	return {
+		"tool.execute.before": async (input, output) => {
+			const toolName = input.tool?.toLowerCase();
+			if (toolName !== "write" && toolName !== "read") {
+				return;
+			}
 
-      const argsRecord = asRecord(output.args)
-      const args = argsRecord as GuardArgs | undefined
-      const filePath = getPathFromArgs(args)
-      if (!filePath) {
-        return
-      }
+			const argsRecord = asRecord(output.args);
+			const args = argsRecord as GuardArgs | undefined;
+			const filePath = getPathFromArgs(args);
+			if (!filePath) {
+				return;
+			}
 
-      const resolvedPath = resolveInputPath(ctx, filePath)
-      const canonicalPath = toCanonicalPath(resolvedPath)
-      const isInsideSessionDirectory = isPathInsideDirectory(canonicalPath, canonicalSessionRoot)
+			const resolvedPath = resolveInputPath(ctx, filePath);
+			const canonicalPath = toCanonicalPath(resolvedPath);
+			const isInsideSessionDirectory = isPathInsideDirectory(
+				canonicalPath,
+				canonicalSessionRoot,
+			);
 
-      if (!isInsideSessionDirectory) {
-        return
-      }
+			if (!isInsideSessionDirectory) {
+				return;
+			}
 
-      if (toolName === "read") {
-        if (!existsSync(resolvedPath) || !input.sessionID) {
-          return
-        }
+			if (toolName === "read") {
+				if (!existsSync(resolvedPath) || !input.sessionID) {
+					return;
+				}
 
-        registerReadPermission(input.sessionID, canonicalPath)
-        return
-      }
+				registerReadPermission(input.sessionID, canonicalPath);
+				return;
+			}
 
-      const overwriteEnabled = isOverwriteEnabled(args?.overwrite)
+			const overwriteEnabled = isOverwriteEnabled(args?.overwrite);
 
-      if (argsRecord && "overwrite" in argsRecord) {
-        // Intentionally mutate output args so overwrite bypass remains hook-only.
-        delete argsRecord.overwrite
-      }
+			if (argsRecord && "overwrite" in argsRecord) {
+				// Intentionally mutate output args so overwrite bypass remains hook-only.
+				delete argsRecord.overwrite;
+			}
 
-      if (!existsSync(resolvedPath)) {
-        return
-      }
+			if (!existsSync(resolvedPath)) {
+				return;
+			}
 
-      const isSisyphusPath = canonicalPath.includes("/.sisyphus/")
-      if (isSisyphusPath) {
-        log("[write-existing-file-guard] Allowing .sisyphus/** overwrite", {
-          sessionID: input.sessionID,
-          filePath,
-        })
-        invalidateOtherSessions(canonicalPath, input.sessionID)
-        return
-      }
+			const isSisyphusPath = isSisyphusCanonicalPath(canonicalPath);
+			if (isSisyphusPath) {
+				log("[write-existing-file-guard] Allowing .sisyphus/** overwrite", {
+					sessionID: input.sessionID,
+					filePath,
+				});
+				invalidateOtherSessions(canonicalPath, input.sessionID);
+				return;
+			}
 
-      if (overwriteEnabled) {
-        log("[write-existing-file-guard] Allowing overwrite flag bypass", {
-          sessionID: input.sessionID,
-          filePath,
-          resolvedPath,
-        })
-        invalidateOtherSessions(canonicalPath, input.sessionID)
-        return
-      }
+			if (overwriteEnabled) {
+				log("[write-existing-file-guard] Allowing overwrite flag bypass", {
+					sessionID: input.sessionID,
+					filePath,
+					resolvedPath,
+				});
+				invalidateOtherSessions(canonicalPath, input.sessionID);
+				return;
+			}
 
-      if (input.sessionID && consumeReadPermission(input.sessionID, canonicalPath)) {
-        log("[write-existing-file-guard] Allowing overwrite after read", {
-          sessionID: input.sessionID,
-          filePath,
-          resolvedPath,
-        })
-        invalidateOtherSessions(canonicalPath, input.sessionID)
-        return
-      }
+			if (
+				input.sessionID &&
+				consumeReadPermission(input.sessionID, canonicalPath)
+			) {
+				log("[write-existing-file-guard] Allowing overwrite after read", {
+					sessionID: input.sessionID,
+					filePath,
+					resolvedPath,
+				});
+				invalidateOtherSessions(canonicalPath, input.sessionID);
+				return;
+			}
 
-      log("[write-existing-file-guard] Blocking write to existing file", {
-        sessionID: input.sessionID,
-        filePath,
-        resolvedPath,
-      })
+			log("[write-existing-file-guard] Blocking write to existing file", {
+				sessionID: input.sessionID,
+				filePath,
+				resolvedPath,
+			});
 
-      throw new Error("File already exists. Use edit tool instead.")
-    },
-    event: async ({ event }: { event: { type: string; properties?: unknown } }) => {
-      if (event.type !== "session.deleted") {
-        return
-      }
+			throw new Error("File already exists. Use edit tool instead.");
+		},
+		event: async ({
+			event,
+		}: {
+			event: { type: string; properties?: unknown };
+		}) => {
+			if (event.type !== "session.deleted") {
+				return;
+			}
 
-      const props = event.properties as { info?: { id?: string } } | undefined
-      const sessionID = props?.info?.id
-      if (!sessionID) {
-        return
-      }
+			const props = event.properties as { info?: { id?: string } } | undefined;
+			const sessionID = props?.info?.id;
+			if (!sessionID) {
+				return;
+			}
 
-      readPermissionsBySession.delete(sessionID)
-      sessionLastAccess.delete(sessionID)
-    },
-  }
+			readPermissionsBySession.delete(sessionID);
+			sessionLastAccess.delete(sessionID);
+		},
+	};
 }

--- a/src/hooks/write-existing-file-guard/index.test.ts
+++ b/src/hooks/write-existing-file-guard/index.test.ts
@@ -1,550 +1,600 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { dirname, join, resolve } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 
-import { MAX_TRACKED_PATHS_PER_SESSION } from "./hook"
-import { createWriteExistingFileGuardHook } from "./index"
+import { isSisyphusCanonicalPath, MAX_TRACKED_PATHS_PER_SESSION } from "./hook";
+import { createWriteExistingFileGuardHook } from "./index";
 
-const BLOCK_MESSAGE = "File already exists. Use edit tool instead."
+const BLOCK_MESSAGE = "File already exists. Use edit tool instead.";
 
-type Hook = ReturnType<typeof createWriteExistingFileGuardHook>
+type Hook = ReturnType<typeof createWriteExistingFileGuardHook>;
 
 function isCaseInsensitiveFilesystem(directory: string): boolean {
-  const probeName = `CaseProbe_${Date.now()}_A.txt`
-  const upperPath = join(directory, probeName)
-  const lowerPath = join(directory, probeName.toLowerCase())
+	const probeName = `CaseProbe_${Date.now()}_A.txt`;
+	const upperPath = join(directory, probeName);
+	const lowerPath = join(directory, probeName.toLowerCase());
 
-  writeFileSync(upperPath, "probe")
-  try {
-    return existsSync(lowerPath)
-  } finally {
-    rmSync(upperPath, { force: true })
-  }
+	writeFileSync(upperPath, "probe");
+	try {
+		return existsSync(lowerPath);
+	} finally {
+		rmSync(upperPath, { force: true });
+	}
 }
 
 describe("createWriteExistingFileGuardHook", () => {
-  let tempDir = ""
-  let hook: Hook
-  let callCounter = 0
-
-  const createFile = (relativePath: string, content = "existing content"): string => {
-    const absolutePath = join(tempDir, relativePath)
-    mkdirSync(dirname(absolutePath), { recursive: true })
-    writeFileSync(absolutePath, content)
-    return absolutePath
-  }
-
-  const invoke = async (args: {
-    tool: string
-    sessionID?: string
-    outputArgs: Record<string, unknown>
-  }): Promise<{ args: Record<string, unknown> }> => {
-    callCounter += 1
-    const output = { args: args.outputArgs }
-
-    await hook["tool.execute.before"]?.(
-      {
-        tool: args.tool,
-        sessionID: args.sessionID ?? "ses_default",
-        callID: `call_${callCounter}`,
-      } as never,
-      output as never
-    )
-
-    return output
-  }
-
-  const emitSessionDeleted = async (sessionID: string): Promise<void> => {
-    await hook.event?.({ event: { type: "session.deleted", properties: { info: { id: sessionID } } } })
-  }
-
-  beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), "write-existing-file-guard-"))
-    hook = createWriteExistingFileGuardHook({ directory: tempDir } as never)
-    callCounter = 0
-  })
-
-  afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true })
-  })
-
-  test("#given non-existing file #when write executes #then allows", async () => {
-    await expect(
-      invoke({
-        tool: "write",
-        outputArgs: { filePath: join(tempDir, "new-file.txt"), content: "new content" },
-      })
-    ).resolves.toBeDefined()
-  })
-
-  test("#given existing file without read or overwrite #when write executes #then blocks", async () => {
-    const existingFile = createFile("existing.txt")
-
-    await expect(
-      invoke({
-        tool: "write",
-        outputArgs: { filePath: existingFile, content: "new content" },
-      })
-    ).rejects.toThrow(BLOCK_MESSAGE)
-  })
-
-  test("#given same-session read #when write executes #then allows once and consumes permission", async () => {
-    const existingFile = createFile("consume-once.txt")
-    const sessionID = "ses_consume"
-
-    await invoke({
-      tool: "read",
-      sessionID,
-      outputArgs: { filePath: existingFile },
-    })
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: existingFile, content: "first overwrite" },
-      })
-    ).resolves.toBeDefined()
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: existingFile, content: "second overwrite" },
-      })
-    ).rejects.toThrow(BLOCK_MESSAGE)
-  })
-
-  test("#given same-session concurrent writes #when only one read permission exists #then allows only one write", async () => {
-    const existingFile = createFile("concurrent-consume.txt")
-    const sessionID = "ses_concurrent"
-
-    await invoke({
-      tool: "read",
-      sessionID,
-      outputArgs: { filePath: existingFile },
-    })
-
-    const results = await Promise.allSettled([
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: existingFile, content: "first attempt" },
-      }),
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: existingFile, content: "second attempt" },
-      }),
-    ])
-
-    const successCount = results.filter((result) => result.status === "fulfilled").length
-    const failures = results.filter(
-      (result): result is PromiseRejectedResult => result.status === "rejected"
-    )
-
-    expect(successCount).toBe(1)
-    expect(failures).toHaveLength(1)
-    expect(String(failures[0]?.reason)).toContain(BLOCK_MESSAGE)
-  })
-
-  test("#given read in another session #when write executes #then blocks", async () => {
-    const existingFile = createFile("cross-session.txt")
-
-    await invoke({
-      tool: "read",
-      sessionID: "ses_reader",
-      outputArgs: { filePath: existingFile },
-    })
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID: "ses_writer",
-        outputArgs: { filePath: existingFile, content: "new content" },
-      })
-    ).rejects.toThrow(BLOCK_MESSAGE)
-  })
-
-  test("#given overwrite true boolean #when write executes #then bypasses guard and strips overwrite", async () => {
-    const existingFile = createFile("overwrite-boolean.txt")
-
-    const output = await invoke({
-      tool: "write",
-      outputArgs: {
-        filePath: existingFile,
-        content: "new content",
-        overwrite: true,
-      },
-    })
-
-    expect(output.args.overwrite).toBeUndefined()
-  })
-
-  test("#given overwrite true string #when write executes #then bypasses guard and strips overwrite", async () => {
-    const existingFile = createFile("overwrite-string.txt")
-
-    const output = await invoke({
-      tool: "write",
-      outputArgs: {
-        filePath: existingFile,
-        content: "new content",
-        overwrite: "true",
-      },
-    })
-
-    expect(output.args.overwrite).toBeUndefined()
-  })
-
-  test("#given overwrite falsy values #when write executes #then does not bypass guard", async () => {
-    const existingFile = createFile("overwrite-falsy.txt")
-
-    for (const overwrite of [false, "false"] as const) {
-      await expect(
-        invoke({
-          tool: "write",
-          outputArgs: {
-            filePath: existingFile,
-            content: "new content",
-            overwrite,
-          },
-        })
-      ).rejects.toThrow(BLOCK_MESSAGE)
-    }
-  })
-
-  test("#given two sessions read same file #when one writes #then other session is invalidated", async () => {
-    const existingFile = createFile("invalidate.txt")
-
-    await invoke({
-      tool: "read",
-      sessionID: "ses_a",
-      outputArgs: { filePath: existingFile },
-    })
-    await invoke({
-      tool: "read",
-      sessionID: "ses_b",
-      outputArgs: { filePath: existingFile },
-    })
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID: "ses_b",
-        outputArgs: { filePath: existingFile, content: "updated by B" },
-      })
-    ).resolves.toBeDefined()
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID: "ses_a",
-        outputArgs: { filePath: existingFile, content: "updated by A" },
-      })
-    ).rejects.toThrow(BLOCK_MESSAGE)
-  })
-
-  test("#given existing file under .sisyphus #when write executes #then always allows", async () => {
-    const existingFile = createFile(".sisyphus/plans/plan.txt")
-
-    await expect(
-      invoke({
-        tool: "write",
-        outputArgs: { filePath: existingFile, content: "new plan" },
-      })
-    ).resolves.toBeDefined()
-  })
-
-  test("#given file arg variants #when read then write executes #then supports all variants", async () => {
-    const existingFile = createFile("variants.txt")
-    const variants: Array<"filePath" | "path" | "file_path"> = [
-      "filePath",
-      "path",
-      "file_path",
-    ]
-
-    for (const variant of variants) {
-      const sessionID = `ses_${variant}`
-      await invoke({
-        tool: "read",
-        sessionID,
-        outputArgs: { [variant]: existingFile },
-      })
-
-      await expect(
-        invoke({
-          tool: "write",
-          sessionID,
-          outputArgs: { [variant]: existingFile, content: `overwrite via ${variant}` },
-        })
-      ).resolves.toBeDefined()
-    }
-  })
-
-  test("#given tools without file path arg #when write and read execute #then ignores safely", async () => {
-    await expect(
-      invoke({
-        tool: "write",
-        outputArgs: { content: "no path" },
-      })
-    ).resolves.toBeDefined()
-
-    await expect(
-      invoke({
-        tool: "read",
-        outputArgs: {},
-      })
-    ).resolves.toBeDefined()
-  })
-
-  test("#given non-read-write tool #when it executes #then does not grant write permission", async () => {
-    const existingFile = createFile("ignored-tool.txt")
-    const sessionID = "ses_ignored_tool"
-
-    await invoke({
-      tool: "edit",
-      sessionID,
-      outputArgs: { filePath: existingFile, oldString: "old", newString: "new" },
-    })
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: existingFile, content: "should block" },
-      })
-    ).rejects.toThrow(BLOCK_MESSAGE)
-  })
-
-  test("#given relative read and absolute write #when same session writes #then allows", async () => {
-    createFile("relative-absolute.txt")
-    const sessionID = "ses_relative_absolute"
-    const relativePath = "relative-absolute.txt"
-    const absolutePath = resolve(tempDir, relativePath)
-
-    await invoke({
-      tool: "read",
-      sessionID,
-      outputArgs: { filePath: relativePath },
-    })
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: absolutePath, content: "updated" },
-      })
-    ).resolves.toBeDefined()
-  })
-
-  test("#given existing file outside session directory #when write executes #then allows", async () => {
-    const outsideDir = mkdtempSync(join(tmpdir(), "write-existing-file-guard-outside-"))
-
-    try {
-      const outsideFile = join(outsideDir, "outside.txt")
-      writeFileSync(outsideFile, "outside")
-
-      await expect(
-        invoke({
-          tool: "write",
-          outputArgs: { filePath: outsideFile, content: "allowed overwrite" },
-        })
-      ).resolves.toBeDefined()
-    } finally {
-      rmSync(outsideDir, { recursive: true, force: true })
-    }
-  })
-
-  test("#given session read permission #when session deleted #then permission is cleaned up", async () => {
-    const existingFile = createFile("session-cleanup.txt")
-    const sessionID = "ses_cleanup"
-
-    await invoke({
-      tool: "read",
-      sessionID,
-      outputArgs: { filePath: existingFile },
-    })
-
-    await emitSessionDeleted(sessionID)
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: existingFile, content: "after cleanup" },
-      })
-    ).rejects.toThrow(BLOCK_MESSAGE)
-  })
-
-  test("#given case-different read path #when writing canonical path #then follows platform behavior", async () => {
-    const canonicalFile = createFile("CaseFile.txt")
-    const lowerCasePath = join(tempDir, "casefile.txt")
-    const sessionID = "ses_case"
-    const isCaseInsensitiveFs = isCaseInsensitiveFilesystem(tempDir)
-
-    await invoke({
-      tool: "read",
-      sessionID,
-      outputArgs: { filePath: lowerCasePath },
-    })
-
-    const writeAttempt = invoke({
-      tool: "write",
-      sessionID,
-      outputArgs: { filePath: canonicalFile, content: "updated" },
-    })
-
-    if (isCaseInsensitiveFs) {
-      await expect(writeAttempt).resolves.toBeDefined()
-      return
-    }
-
-    await expect(writeAttempt).rejects.toThrow(BLOCK_MESSAGE)
-  })
-
-  test("#given read via symlink #when write via real path #then allows overwrite", async () => {
-    const targetFile = createFile("real/target.txt")
-    const symlinkPath = join(tempDir, "linked-target.txt")
-    const sessionID = "ses_symlink"
-
-    try {
-      symlinkSync(targetFile, symlinkPath)
-    } catch (error) {
-      // Symlinks not supported in this environment — skip
-      return
-    }
-
-    await invoke({
-      tool: "read",
-      sessionID,
-      outputArgs: { filePath: symlinkPath },
-    })
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: targetFile, content: "updated via symlink read" },
-      })
-    ).resolves.toBeDefined()
-  })
-
-  test("#given session reads beyond path cap #when writing oldest and newest #then only newest is authorized", async () => {
-    const sessionID = "ses_path_cap"
-    const oldestFile = createFile("path-cap/0.txt")
-    let newestFile = oldestFile
-
-    await invoke({
-      tool: "read",
-      sessionID,
-      outputArgs: { filePath: oldestFile },
-    })
-
-    for (let index = 1; index <= MAX_TRACKED_PATHS_PER_SESSION; index += 1) {
-      newestFile = createFile(`path-cap/${index}.txt`)
-      await invoke({
-        tool: "read",
-        sessionID,
-        outputArgs: { filePath: newestFile },
-      })
-    }
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: oldestFile, content: "stale write" },
-      })
-    ).rejects.toThrow(BLOCK_MESSAGE)
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: newestFile, content: "fresh write" },
-      })
-    ).resolves.toBeDefined()
-  })
-
-  test("#given recently active session #when lru evicts #then keeps recent session permission", async () => {
-    const existingFile = createFile("lru.txt")
-    const hotSession = "ses_hot"
-
-    await invoke({
-      tool: "read",
-      sessionID: hotSession,
-      outputArgs: { filePath: existingFile },
-    })
-
-    for (let index = 0; index < 255; index += 1) {
-      await invoke({
-        tool: "read",
-        sessionID: `ses_${index}`,
-        outputArgs: { filePath: existingFile },
-      })
-    }
-
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 2))
-
-    await invoke({
-      tool: "read",
-      sessionID: hotSession,
-      outputArgs: { filePath: existingFile },
-    })
-
-    await invoke({
-      tool: "read",
-      sessionID: "ses_overflow",
-      outputArgs: { filePath: existingFile },
-    })
-
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID: hotSession,
-        outputArgs: { filePath: existingFile, content: "hot session write" },
-      })
-    ).resolves.toBeDefined()
-  })
-
-  test("#given session permissions #when session deleted #then subsequent writes are blocked", async () => {
-    const existingFile = createFile("cleanup.txt")
-    const sessionID = "ses_cleanup"
-
-    // establish permission by reading the existing file
-    await invoke({
-      tool: "read",
-      sessionID,
-      outputArgs: { filePath: existingFile },
-    })
-
-    // sanity check: write should be allowed while the session is active
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: existingFile, content: "first write" },
-      })
-    ).resolves.toBeDefined()
-
-    // read the file again to re-establish permission after first write consumed it
-    await invoke({
-      tool: "read",
-      sessionID,
-      outputArgs: { filePath: existingFile },
-    })
-
-    // delete the session to trigger cleanup of any stored permissions/state
-    await emitSessionDeleted(sessionID)
-
-    // after session deletion, the previous permissions must no longer apply
-    await expect(
-      invoke({
-        tool: "write",
-        sessionID,
-        outputArgs: { filePath: existingFile, content: "second write after delete" },
-      })
-    ).rejects.toThrow(BLOCK_MESSAGE)
-  })
-})
+	let tempDir = "";
+	let hook: Hook;
+	let callCounter = 0;
+
+	const createFile = (
+		relativePath: string,
+		content = "existing content",
+	): string => {
+		const absolutePath = join(tempDir, relativePath);
+		mkdirSync(dirname(absolutePath), { recursive: true });
+		writeFileSync(absolutePath, content);
+		return absolutePath;
+	};
+
+	const invoke = async (args: {
+		tool: string;
+		sessionID?: string;
+		outputArgs: Record<string, unknown>;
+	}): Promise<{ args: Record<string, unknown> }> => {
+		callCounter += 1;
+		const output = { args: args.outputArgs };
+
+		await hook["tool.execute.before"]?.(
+			{
+				tool: args.tool,
+				sessionID: args.sessionID ?? "ses_default",
+				callID: `call_${callCounter}`,
+			} as never,
+			output as never,
+		);
+
+		return output;
+	};
+
+	const emitSessionDeleted = async (sessionID: string): Promise<void> => {
+		await hook.event?.({
+			event: {
+				type: "session.deleted",
+				properties: { info: { id: sessionID } },
+			},
+		});
+	};
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "write-existing-file-guard-"));
+		hook = createWriteExistingFileGuardHook({ directory: tempDir } as never);
+		callCounter = 0;
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("#given non-existing file #when write executes #then allows", async () => {
+		await expect(
+			invoke({
+				tool: "write",
+				outputArgs: {
+					filePath: join(tempDir, "new-file.txt"),
+					content: "new content",
+				},
+			}),
+		).resolves.toBeDefined();
+	});
+
+	test("#given existing file without read or overwrite #when write executes #then blocks", async () => {
+		const existingFile = createFile("existing.txt");
+
+		await expect(
+			invoke({
+				tool: "write",
+				outputArgs: { filePath: existingFile, content: "new content" },
+			}),
+		).rejects.toThrow(BLOCK_MESSAGE);
+	});
+
+	test("#given same-session read #when write executes #then allows once and consumes permission", async () => {
+		const existingFile = createFile("consume-once.txt");
+		const sessionID = "ses_consume";
+
+		await invoke({
+			tool: "read",
+			sessionID,
+			outputArgs: { filePath: existingFile },
+		});
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: existingFile, content: "first overwrite" },
+			}),
+		).resolves.toBeDefined();
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: existingFile, content: "second overwrite" },
+			}),
+		).rejects.toThrow(BLOCK_MESSAGE);
+	});
+
+	test("#given same-session concurrent writes #when only one read permission exists #then allows only one write", async () => {
+		const existingFile = createFile("concurrent-consume.txt");
+		const sessionID = "ses_concurrent";
+
+		await invoke({
+			tool: "read",
+			sessionID,
+			outputArgs: { filePath: existingFile },
+		});
+
+		const results = await Promise.allSettled([
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: existingFile, content: "first attempt" },
+			}),
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: existingFile, content: "second attempt" },
+			}),
+		]);
+
+		const successCount = results.filter(
+			(result) => result.status === "fulfilled",
+		).length;
+		const failures = results.filter(
+			(result): result is PromiseRejectedResult => result.status === "rejected",
+		);
+
+		expect(successCount).toBe(1);
+		expect(failures).toHaveLength(1);
+		expect(String(failures[0]?.reason)).toContain(BLOCK_MESSAGE);
+	});
+
+	test("#given read in another session #when write executes #then blocks", async () => {
+		const existingFile = createFile("cross-session.txt");
+
+		await invoke({
+			tool: "read",
+			sessionID: "ses_reader",
+			outputArgs: { filePath: existingFile },
+		});
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID: "ses_writer",
+				outputArgs: { filePath: existingFile, content: "new content" },
+			}),
+		).rejects.toThrow(BLOCK_MESSAGE);
+	});
+
+	test("#given overwrite true boolean #when write executes #then bypasses guard and strips overwrite", async () => {
+		const existingFile = createFile("overwrite-boolean.txt");
+
+		const output = await invoke({
+			tool: "write",
+			outputArgs: {
+				filePath: existingFile,
+				content: "new content",
+				overwrite: true,
+			},
+		});
+
+		expect(output.args.overwrite).toBeUndefined();
+	});
+
+	test("#given overwrite true string #when write executes #then bypasses guard and strips overwrite", async () => {
+		const existingFile = createFile("overwrite-string.txt");
+
+		const output = await invoke({
+			tool: "write",
+			outputArgs: {
+				filePath: existingFile,
+				content: "new content",
+				overwrite: "true",
+			},
+		});
+
+		expect(output.args.overwrite).toBeUndefined();
+	});
+
+	test("#given overwrite falsy values #when write executes #then does not bypass guard", async () => {
+		const existingFile = createFile("overwrite-falsy.txt");
+
+		for (const overwrite of [false, "false"] as const) {
+			await expect(
+				invoke({
+					tool: "write",
+					outputArgs: {
+						filePath: existingFile,
+						content: "new content",
+						overwrite,
+					},
+				}),
+			).rejects.toThrow(BLOCK_MESSAGE);
+		}
+	});
+
+	test("#given two sessions read same file #when one writes #then other session is invalidated", async () => {
+		const existingFile = createFile("invalidate.txt");
+
+		await invoke({
+			tool: "read",
+			sessionID: "ses_a",
+			outputArgs: { filePath: existingFile },
+		});
+		await invoke({
+			tool: "read",
+			sessionID: "ses_b",
+			outputArgs: { filePath: existingFile },
+		});
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID: "ses_b",
+				outputArgs: { filePath: existingFile, content: "updated by B" },
+			}),
+		).resolves.toBeDefined();
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID: "ses_a",
+				outputArgs: { filePath: existingFile, content: "updated by A" },
+			}),
+		).rejects.toThrow(BLOCK_MESSAGE);
+	});
+
+	test("#given existing file under .sisyphus #when write executes #then always allows", async () => {
+		const existingFile = createFile(".sisyphus/plans/plan.txt");
+
+		await expect(
+			invoke({
+				tool: "write",
+				outputArgs: { filePath: existingFile, content: "new plan" },
+			}),
+		).resolves.toBeDefined();
+	});
+
+	test("#given canonical paths #when checking for .sisyphus directory #then matches exact path segments only", () => {
+		expect(
+			isSisyphusCanonicalPath("/tmp/project/.sisyphus/plans/plan.txt", "/"),
+		).toBe(true);
+		expect(isSisyphusCanonicalPath("literal\\.sisyphus\\plan.txt", "/")).toBe(
+			false,
+		);
+		expect(
+			isSisyphusCanonicalPath(
+				String.raw`C:\project\.sisyphus\plans\plan.txt`,
+				"\\",
+			),
+		).toBe(true);
+	});
+
+	test("#given file arg variants #when read then write executes #then supports all variants", async () => {
+		const existingFile = createFile("variants.txt");
+		const variants: Array<"filePath" | "path" | "file_path"> = [
+			"filePath",
+			"path",
+			"file_path",
+		];
+
+		for (const variant of variants) {
+			const sessionID = `ses_${variant}`;
+			await invoke({
+				tool: "read",
+				sessionID,
+				outputArgs: { [variant]: existingFile },
+			});
+
+			await expect(
+				invoke({
+					tool: "write",
+					sessionID,
+					outputArgs: {
+						[variant]: existingFile,
+						content: `overwrite via ${variant}`,
+					},
+				}),
+			).resolves.toBeDefined();
+		}
+	});
+
+	test("#given tools without file path arg #when write and read execute #then ignores safely", async () => {
+		await expect(
+			invoke({
+				tool: "write",
+				outputArgs: { content: "no path" },
+			}),
+		).resolves.toBeDefined();
+
+		await expect(
+			invoke({
+				tool: "read",
+				outputArgs: {},
+			}),
+		).resolves.toBeDefined();
+	});
+
+	test("#given non-read-write tool #when it executes #then does not grant write permission", async () => {
+		const existingFile = createFile("ignored-tool.txt");
+		const sessionID = "ses_ignored_tool";
+
+		await invoke({
+			tool: "edit",
+			sessionID,
+			outputArgs: {
+				filePath: existingFile,
+				oldString: "old",
+				newString: "new",
+			},
+		});
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: existingFile, content: "should block" },
+			}),
+		).rejects.toThrow(BLOCK_MESSAGE);
+	});
+
+	test("#given relative read and absolute write #when same session writes #then allows", async () => {
+		createFile("relative-absolute.txt");
+		const sessionID = "ses_relative_absolute";
+		const relativePath = "relative-absolute.txt";
+		const absolutePath = resolve(tempDir, relativePath);
+
+		await invoke({
+			tool: "read",
+			sessionID,
+			outputArgs: { filePath: relativePath },
+		});
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: absolutePath, content: "updated" },
+			}),
+		).resolves.toBeDefined();
+	});
+
+	test("#given existing file outside session directory #when write executes #then allows", async () => {
+		const outsideDir = mkdtempSync(
+			join(tmpdir(), "write-existing-file-guard-outside-"),
+		);
+
+		try {
+			const outsideFile = join(outsideDir, "outside.txt");
+			writeFileSync(outsideFile, "outside");
+
+			await expect(
+				invoke({
+					tool: "write",
+					outputArgs: { filePath: outsideFile, content: "allowed overwrite" },
+				}),
+			).resolves.toBeDefined();
+		} finally {
+			rmSync(outsideDir, { recursive: true, force: true });
+		}
+	});
+
+	test("#given session read permission #when session deleted #then permission is cleaned up", async () => {
+		const existingFile = createFile("session-cleanup.txt");
+		const sessionID = "ses_cleanup";
+
+		await invoke({
+			tool: "read",
+			sessionID,
+			outputArgs: { filePath: existingFile },
+		});
+
+		await emitSessionDeleted(sessionID);
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: existingFile, content: "after cleanup" },
+			}),
+		).rejects.toThrow(BLOCK_MESSAGE);
+	});
+
+	test("#given case-different read path #when writing canonical path #then follows platform behavior", async () => {
+		const canonicalFile = createFile("CaseFile.txt");
+		const lowerCasePath = join(tempDir, "casefile.txt");
+		const sessionID = "ses_case";
+		const isCaseInsensitiveFs = isCaseInsensitiveFilesystem(tempDir);
+
+		await invoke({
+			tool: "read",
+			sessionID,
+			outputArgs: { filePath: lowerCasePath },
+		});
+
+		const writeAttempt = invoke({
+			tool: "write",
+			sessionID,
+			outputArgs: { filePath: canonicalFile, content: "updated" },
+		});
+
+		if (isCaseInsensitiveFs) {
+			await expect(writeAttempt).resolves.toBeDefined();
+			return;
+		}
+
+		await expect(writeAttempt).rejects.toThrow(BLOCK_MESSAGE);
+	});
+
+	test("#given read via symlink #when write via real path #then allows overwrite", async () => {
+		const targetFile = createFile("real/target.txt");
+		const symlinkPath = join(tempDir, "linked-target.txt");
+		const sessionID = "ses_symlink";
+
+		try {
+			symlinkSync(targetFile, symlinkPath);
+		} catch {
+			// Symlinks not supported in this environment — skip
+			return;
+		}
+
+		await invoke({
+			tool: "read",
+			sessionID,
+			outputArgs: { filePath: symlinkPath },
+		});
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: {
+					filePath: targetFile,
+					content: "updated via symlink read",
+				},
+			}),
+		).resolves.toBeDefined();
+	});
+
+	test("#given session reads beyond path cap #when writing oldest and newest #then only newest is authorized", async () => {
+		const sessionID = "ses_path_cap";
+		const oldestFile = createFile("path-cap/0.txt");
+		let newestFile = oldestFile;
+
+		await invoke({
+			tool: "read",
+			sessionID,
+			outputArgs: { filePath: oldestFile },
+		});
+
+		for (let index = 1; index <= MAX_TRACKED_PATHS_PER_SESSION; index += 1) {
+			newestFile = createFile(`path-cap/${index}.txt`);
+			await invoke({
+				tool: "read",
+				sessionID,
+				outputArgs: { filePath: newestFile },
+			});
+		}
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: oldestFile, content: "stale write" },
+			}),
+		).rejects.toThrow(BLOCK_MESSAGE);
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: newestFile, content: "fresh write" },
+			}),
+		).resolves.toBeDefined();
+	});
+
+	test("#given recently active session #when lru evicts #then keeps recent session permission", async () => {
+		const existingFile = createFile("lru.txt");
+		const hotSession = "ses_hot";
+
+		await invoke({
+			tool: "read",
+			sessionID: hotSession,
+			outputArgs: { filePath: existingFile },
+		});
+
+		for (let index = 0; index < 255; index += 1) {
+			await invoke({
+				tool: "read",
+				sessionID: `ses_${index}`,
+				outputArgs: { filePath: existingFile },
+			});
+		}
+
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 2));
+
+		await invoke({
+			tool: "read",
+			sessionID: hotSession,
+			outputArgs: { filePath: existingFile },
+		});
+
+		await invoke({
+			tool: "read",
+			sessionID: "ses_overflow",
+			outputArgs: { filePath: existingFile },
+		});
+
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID: hotSession,
+				outputArgs: { filePath: existingFile, content: "hot session write" },
+			}),
+		).resolves.toBeDefined();
+	});
+
+	test("#given session permissions #when session deleted #then subsequent writes are blocked", async () => {
+		const existingFile = createFile("cleanup.txt");
+		const sessionID = "ses_cleanup";
+
+		// establish permission by reading the existing file
+		await invoke({
+			tool: "read",
+			sessionID,
+			outputArgs: { filePath: existingFile },
+		});
+
+		// sanity check: write should be allowed while the session is active
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: { filePath: existingFile, content: "first write" },
+			}),
+		).resolves.toBeDefined();
+
+		// read the file again to re-establish permission after first write consumed it
+		await invoke({
+			tool: "read",
+			sessionID,
+			outputArgs: { filePath: existingFile },
+		});
+
+		// delete the session to trigger cleanup of any stored permissions/state
+		await emitSessionDeleted(sessionID);
+
+		// after session deletion, the previous permissions must no longer apply
+		await expect(
+			invoke({
+				tool: "write",
+				sessionID,
+				outputArgs: {
+					filePath: existingFile,
+					content: "second write after delete",
+				},
+			}),
+		).rejects.toThrow(BLOCK_MESSAGE);
+	});
+});

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -385,4 +385,22 @@ describe("loadPluginConfig", () => {
 			existsSync(join(projectDir, ".opencode", "oh-my-openagent.jsonc")),
 		).toBe(true);
 	});
+
+	it("falls back to legacy config when canonical config is malformed", () => {
+		writeFileSync(
+			join(userConfigDir, "oh-my-openagent.jsonc"),
+			"{ invalid jsonc",
+			"utf-8",
+		);
+		writeFileSync(
+			join(userConfigDir, "oh-my-opencode.jsonc"),
+			JSON.stringify({ disabled_hooks: ["legacy-fallback-hook"] }, null, 2) +
+				"\n",
+			"utf-8",
+		);
+
+		const result = loadPluginConfig(projectDir, {});
+
+		expect(result.disabled_hooks).toEqual(["legacy-fallback-hook"]);
+	});
 });

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -1,273 +1,388 @@
-import { describe, expect, it } from "bun:test";
-import { mergeConfigs, parseConfigPartially } from "./plugin-config";
-import { OhMyOpenCodeConfigSchema, type OhMyOpenCodeConfig } from "./config";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type OhMyOpenCodeConfig, OhMyOpenCodeConfigSchema } from "./config";
+import {
+	loadPluginConfig,
+	mergeConfigs,
+	parseConfigPartially,
+} from "./plugin-config";
 
 describe("mergeConfigs", () => {
-  describe("categories merging", () => {
-    // given base config has categories, override has different categories
-    // when merging configs
-    // then should deep merge categories, not override completely
+	describe("categories merging", () => {
+		// given base config has categories, override has different categories
+		// when merging configs
+		// then should deep merge categories, not override completely
 
-    it("should deep merge categories from base and override", () => {
-      const base = {
-        categories: {
-          general: {
-            model: "openai/gpt-5.4",
-            temperature: 0.5,
-          },
-          quick: {
-            model: "anthropic/claude-haiku-4-5",
-          },
-        },
-      } as OhMyOpenCodeConfig;
+		it("should deep merge categories from base and override", () => {
+			const base = {
+				categories: {
+					general: {
+						model: "openai/gpt-5.4",
+						temperature: 0.5,
+					},
+					quick: {
+						model: "anthropic/claude-haiku-4-5",
+					},
+				},
+			} as OhMyOpenCodeConfig;
 
-      const override = {
-        categories: {
-          general: {
-            temperature: 0.3,
-          },
-          visual: {
-            model: "google/gemini-3.1-pro",
-          },
-        },
-      } as unknown as OhMyOpenCodeConfig;
+			const override = {
+				categories: {
+					general: {
+						temperature: 0.3,
+					},
+					visual: {
+						model: "google/gemini-3.1-pro",
+					},
+				},
+			} as unknown as OhMyOpenCodeConfig;
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      // then general.model should be preserved from base
-      expect(result.categories?.general?.model).toBe("openai/gpt-5.4");
-      // then general.temperature should be overridden
-      expect(result.categories?.general?.temperature).toBe(0.3);
-      // then quick should be preserved from base
-      expect(result.categories?.quick?.model).toBe("anthropic/claude-haiku-4-5");
-      // then visual should be added from override
-      expect(result.categories?.visual?.model).toBe("google/gemini-3.1-pro");
-    });
+			// then general.model should be preserved from base
+			expect(result.categories?.general?.model).toBe("openai/gpt-5.4");
+			// then general.temperature should be overridden
+			expect(result.categories?.general?.temperature).toBe(0.3);
+			// then quick should be preserved from base
+			expect(result.categories?.quick?.model).toBe(
+				"anthropic/claude-haiku-4-5",
+			);
+			// then visual should be added from override
+			expect(result.categories?.visual?.model).toBe("google/gemini-3.1-pro");
+		});
 
-    it("should preserve base categories when override has no categories", () => {
-      const base: OhMyOpenCodeConfig = {
-        categories: {
-          general: {
-            model: "openai/gpt-5.4",
-          },
-        },
-      };
+		it("should preserve base categories when override has no categories", () => {
+			const base: OhMyOpenCodeConfig = {
+				categories: {
+					general: {
+						model: "openai/gpt-5.4",
+					},
+				},
+			};
 
-      const override: OhMyOpenCodeConfig = {};
+			const override: OhMyOpenCodeConfig = {};
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      expect(result.categories?.general?.model).toBe("openai/gpt-5.4");
-    });
+			expect(result.categories?.general?.model).toBe("openai/gpt-5.4");
+		});
 
-    it("should use override categories when base has no categories", () => {
-      const base: OhMyOpenCodeConfig = {};
+		it("should use override categories when base has no categories", () => {
+			const base: OhMyOpenCodeConfig = {};
 
-      const override: OhMyOpenCodeConfig = {
-        categories: {
-          general: {
-            model: "openai/gpt-5.4",
-          },
-        },
-      };
+			const override: OhMyOpenCodeConfig = {
+				categories: {
+					general: {
+						model: "openai/gpt-5.4",
+					},
+				},
+			};
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      expect(result.categories?.general?.model).toBe("openai/gpt-5.4");
-    });
-  });
+			expect(result.categories?.general?.model).toBe("openai/gpt-5.4");
+		});
+	});
 
-  describe("existing behavior preservation", () => {
-    it("should deep merge agents", () => {
-      const base: OhMyOpenCodeConfig = {
-        agents: {
-          oracle: { model: "openai/gpt-5.4" },
-        },
-      };
+	describe("existing behavior preservation", () => {
+		it("should deep merge agents", () => {
+			const base: OhMyOpenCodeConfig = {
+				agents: {
+					oracle: { model: "openai/gpt-5.4" },
+				},
+			};
 
-      const override: OhMyOpenCodeConfig = {
-        agents: {
-          oracle: { temperature: 0.5 },
-          explore: { model: "anthropic/claude-haiku-4-5" },
-        },
-      };
+			const override: OhMyOpenCodeConfig = {
+				agents: {
+					oracle: { temperature: 0.5 },
+					explore: { model: "anthropic/claude-haiku-4-5" },
+				},
+			};
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      expect(result.agents?.oracle).toMatchObject({ model: "openai/gpt-5.4" });
-      expect(result.agents?.oracle?.temperature).toBe(0.5);
-      expect(result.agents?.explore).toMatchObject({ model: "anthropic/claude-haiku-4-5" });
-    });
+			expect(result.agents?.oracle).toMatchObject({ model: "openai/gpt-5.4" });
+			expect(result.agents?.oracle?.temperature).toBe(0.5);
+			expect(result.agents?.explore).toMatchObject({
+				model: "anthropic/claude-haiku-4-5",
+			});
+		});
 
-    it("should merge disabled arrays without duplicates", () => {
-      const base: OhMyOpenCodeConfig = {
-        disabled_hooks: ["comment-checker", "think-mode"],
-      };
+		it("should merge disabled arrays without duplicates", () => {
+			const base: OhMyOpenCodeConfig = {
+				disabled_hooks: ["comment-checker", "think-mode"],
+			};
 
-      const override: OhMyOpenCodeConfig = {
-        disabled_hooks: ["think-mode", "session-recovery"],
-      };
+			const override: OhMyOpenCodeConfig = {
+				disabled_hooks: ["think-mode", "session-recovery"],
+			};
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      expect(result.disabled_hooks).toContain("comment-checker");
-      expect(result.disabled_hooks).toContain("think-mode");
-      expect(result.disabled_hooks).toContain("session-recovery");
-      expect(result.disabled_hooks?.length).toBe(3);
-    });
+			expect(result.disabled_hooks).toContain("comment-checker");
+			expect(result.disabled_hooks).toContain("think-mode");
+			expect(result.disabled_hooks).toContain("session-recovery");
+			expect(result.disabled_hooks?.length).toBe(3);
+		});
 
-    it("should union disabled_tools from base and override without duplicates", () => {
-      const base: OhMyOpenCodeConfig = {
-        disabled_tools: ["todowrite", "interactive_bash"],
-      };
+		it("should union disabled_tools from base and override without duplicates", () => {
+			const base: OhMyOpenCodeConfig = {
+				disabled_tools: ["todowrite", "interactive_bash"],
+			};
 
-      const override: OhMyOpenCodeConfig = {
-        disabled_tools: ["interactive_bash", "look_at"],
-      };
+			const override: OhMyOpenCodeConfig = {
+				disabled_tools: ["interactive_bash", "look_at"],
+			};
 
-      const result = mergeConfigs(base, override);
+			const result = mergeConfigs(base, override);
 
-      expect(result.disabled_tools).toContain("todowrite");
-      expect(result.disabled_tools).toContain("interactive_bash");
-      expect(result.disabled_tools).toContain("look_at");
-      expect(result.disabled_tools?.length).toBe(3);
-    });
-  });
+			expect(result.disabled_tools).toContain("todowrite");
+			expect(result.disabled_tools).toContain("interactive_bash");
+			expect(result.disabled_tools).toContain("look_at");
+			expect(result.disabled_tools?.length).toBe(3);
+		});
+	});
 });
 
 describe("parseConfigPartially", () => {
-  describe("disabled_hooks compatibility", () => {
-    //#given a config with a future hook name unknown to this version
-    //#when validating against the full config schema
-    //#then should accept the hook name so runtime and schema stay aligned
+	describe("disabled_hooks compatibility", () => {
+		//#given a config with a future hook name unknown to this version
+		//#when validating against the full config schema
+		//#then should accept the hook name so runtime and schema stay aligned
 
-    it("should accept unknown disabled_hooks values for forward compatibility", () => {
-      const result = OhMyOpenCodeConfigSchema.safeParse({
-        disabled_hooks: ["future-hook-name"],
-      });
+		it("should accept unknown disabled_hooks values for forward compatibility", () => {
+			const result = OhMyOpenCodeConfigSchema.safeParse({
+				disabled_hooks: ["future-hook-name"],
+			});
 
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.disabled_hooks).toEqual(["future-hook-name"]);
-      }
-    });
-  });
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.disabled_hooks).toEqual(["future-hook-name"]);
+			}
+		});
+	});
 
-  describe("fully valid config", () => {
-    //#given a config where all sections are valid
-    //#when parsing the config
-    //#then should return the full parsed config unchanged
+	describe("fully valid config", () => {
+		//#given a config where all sections are valid
+		//#when parsing the config
+		//#then should return the full parsed config unchanged
 
-    it("should return the full config when everything is valid", () => {
-      const rawConfig = {
-        agents: {
-          oracle: { model: "openai/gpt-5.4" },
-          momus: { model: "openai/gpt-5.4" },
-        },
-        disabled_hooks: ["comment-checker"],
-      };
+		it("should return the full config when everything is valid", () => {
+			const rawConfig = {
+				agents: {
+					oracle: { model: "openai/gpt-5.4" },
+					momus: { model: "openai/gpt-5.4" },
+				},
+				disabled_hooks: ["comment-checker"],
+			};
 
-      const result = parseConfigPartially(rawConfig);
+			const result = parseConfigPartially(rawConfig);
 
-      expect(result).not.toBeNull();
-      expect(result!.agents?.oracle).toMatchObject({ model: "openai/gpt-5.4" });
-      expect(result!.agents?.momus).toMatchObject({ model: "openai/gpt-5.4" });
-      expect(result!.disabled_hooks).toEqual(["comment-checker"]);
-    });
-  });
+			expect(result).not.toBeNull();
+			expect(result!.agents?.oracle).toMatchObject({ model: "openai/gpt-5.4" });
+			expect(result!.agents?.momus).toMatchObject({ model: "openai/gpt-5.4" });
+			expect(result!.disabled_hooks).toEqual(["comment-checker"]);
+		});
+	});
 
-  describe("partially invalid config", () => {
-    //#given a config where one section is invalid but others are valid
-    //#when parsing the config
-    //#then should return valid sections and skip invalid ones
+	describe("partially invalid config", () => {
+		//#given a config where one section is invalid but others are valid
+		//#when parsing the config
+		//#then should return valid sections and skip invalid ones
 
-    it("should preserve valid agent overrides when another section is invalid", () => {
-      const rawConfig = {
-        agents: {
-          oracle: { model: "openai/gpt-5.4" },
-          momus: { model: "openai/gpt-5.4" },
-          prometheus: {
-            permission: {
-              edit: { "*": "ask", ".sisyphus/**": "allow" },
-            },
-          },
-        },
-        disabled_hooks: ["comment-checker"],
-      };
+		it("should preserve valid agent overrides when another section is invalid", () => {
+			const rawConfig = {
+				agents: {
+					oracle: { model: "openai/gpt-5.4" },
+					momus: { model: "openai/gpt-5.4" },
+					prometheus: {
+						permission: {
+							edit: { "*": "ask", ".sisyphus/**": "allow" },
+						},
+					},
+				},
+				disabled_hooks: ["comment-checker"],
+			};
 
-      const result = parseConfigPartially(rawConfig);
+			const result = parseConfigPartially(rawConfig);
 
-      expect(result).not.toBeNull();
-      expect(result!.disabled_hooks).toEqual(["comment-checker"]);
-      expect(result!.agents).toBeUndefined();
-    });
+			expect(result).not.toBeNull();
+			expect(result!.disabled_hooks).toEqual(["comment-checker"]);
+			expect(result!.agents).toBeUndefined();
+		});
 
-    it("should preserve valid agents when a non-agent section is invalid", () => {
-      const rawConfig = {
-        agents: {
-          oracle: { model: "openai/gpt-5.4" },
-        },
-        disabled_hooks: ["not-a-real-hook"],
-      };
+		it("should preserve valid agents when a non-agent section is invalid", () => {
+			const rawConfig = {
+				agents: {
+					oracle: { model: "openai/gpt-5.4" },
+				},
+				disabled_hooks: ["not-a-real-hook"],
+			};
 
-      const result = parseConfigPartially(rawConfig);
+			const result = parseConfigPartially(rawConfig);
 
-      expect(result).not.toBeNull();
-      expect(result!.agents?.oracle).toMatchObject({ model: "openai/gpt-5.4" });
-      expect(result!.disabled_hooks).toEqual(["not-a-real-hook"]);
-    });
-  });
+			expect(result).not.toBeNull();
+			expect(result!.agents?.oracle).toMatchObject({ model: "openai/gpt-5.4" });
+			expect(result!.disabled_hooks).toEqual(["not-a-real-hook"]);
+		});
+	});
 
-  describe("completely invalid config", () => {
-    //#given a config where all sections are invalid
-    //#when parsing the config
-    //#then should return an empty object (not null)
+	describe("completely invalid config", () => {
+		//#given a config where all sections are invalid
+		//#when parsing the config
+		//#then should return an empty object (not null)
 
-    it("should return empty object when all sections are invalid", () => {
-      const rawConfig = {
-        agents: { oracle: { temperature: "not-a-number" } },
-        disabled_hooks: ["not-a-real-hook"],
-      };
+		it("should return empty object when all sections are invalid", () => {
+			const rawConfig = {
+				agents: { oracle: { temperature: "not-a-number" } },
+				disabled_hooks: ["not-a-real-hook"],
+			};
 
-      const result = parseConfigPartially(rawConfig);
+			const result = parseConfigPartially(rawConfig);
 
-      expect(result).not.toBeNull();
-      expect(result!.agents).toBeUndefined();
-      expect(result!.disabled_hooks).toEqual(["not-a-real-hook"]);
-    });
-  });
+			expect(result).not.toBeNull();
+			expect(result!.agents).toBeUndefined();
+			expect(result!.disabled_hooks).toEqual(["not-a-real-hook"]);
+		});
+	});
 
-  describe("empty config", () => {
-    //#given an empty config object
-    //#when parsing the config
-    //#then should return an empty object (fast path - full parse succeeds)
+	describe("empty config", () => {
+		//#given an empty config object
+		//#when parsing the config
+		//#then should return schema defaults applied by zod
 
-    it("should return empty object for empty input", () => {
-      const result = parseConfigPartially({});
+		it("should return schema defaults for empty input", () => {
+			const result = parseConfigPartially({});
 
-      expect(result).not.toBeNull();
-      expect(Object.keys(result!).length).toBe(0);
-    });
-  });
+			expect(result).not.toBeNull();
+			expect(result!.git_master).toBeDefined();
+			expect(result!.git_master?.commit_footer).toBe(true);
+			expect(result!.git_master?.include_co_authored_by).toBe(true);
+			expect(result!.git_master?.git_env_prefix).toBe("GIT_MASTER=1");
+		});
+	});
 
-  describe("unknown keys", () => {
-    //#given a config with keys not in the schema
-    //#when parsing the config
-    //#then should silently ignore unknown keys and preserve valid ones
+	describe("unknown keys", () => {
+		//#given a config with keys not in the schema
+		//#when parsing the config
+		//#then should silently ignore unknown keys and preserve valid ones
 
-    it("should ignore unknown keys and return valid sections", () => {
-      const rawConfig = {
-        agents: {
-          oracle: { model: "openai/gpt-5.4" },
-        },
-        some_future_key: { foo: "bar" },
-      };
+		it("should ignore unknown keys and return valid sections", () => {
+			const rawConfig = {
+				agents: {
+					oracle: { model: "openai/gpt-5.4" },
+				},
+				some_future_key: { foo: "bar" },
+			};
 
-      const result = parseConfigPartially(rawConfig);
+			const result = parseConfigPartially(rawConfig);
 
-      expect(result).not.toBeNull();
-      expect(result!.agents?.oracle).toMatchObject({ model: "openai/gpt-5.4" });
-      expect((result as Record<string, unknown>)["some_future_key"]).toBeUndefined();
-    });
-  });
+			expect(result).not.toBeNull();
+			expect(result!.agents?.oracle).toMatchObject({ model: "openai/gpt-5.4" });
+			expect(
+				(result as Record<string, unknown>)["some_future_key"],
+			).toBeUndefined();
+		});
+	});
+});
+
+describe("loadPluginConfig", () => {
+	let userConfigDir = "";
+	let projectDir = "";
+
+	beforeEach(() => {
+		userConfigDir = join(
+			tmpdir(),
+			`omo-plugin-config-user-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		projectDir = join(
+			tmpdir(),
+			`omo-plugin-config-project-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+
+		mkdirSync(userConfigDir, { recursive: true });
+		mkdirSync(join(projectDir, ".opencode"), { recursive: true });
+		process.env.OPENCODE_CONFIG_DIR = userConfigDir;
+	});
+
+	afterEach(() => {
+		rmSync(userConfigDir, { recursive: true, force: true });
+		rmSync(projectDir, { recursive: true, force: true });
+		delete process.env.OPENCODE_CONFIG_DIR;
+	});
+
+	it("loads legacy-only user config for compatibility and copies canonical jsonc", () => {
+		writeFileSync(
+			join(userConfigDir, "oh-my-opencode.jsonc"),
+			JSON.stringify({ disabled_hooks: ["legacy-user-hook"] }, null, 2) + "\n",
+			"utf-8",
+		);
+
+		const result = loadPluginConfig(projectDir, {});
+
+		expect(result.disabled_hooks).toEqual(["legacy-user-hook"]);
+		expect(existsSync(join(userConfigDir, "oh-my-openagent.jsonc"))).toBe(true);
+	});
+
+	it("merges user canonical config with project canonical override", () => {
+		writeFileSync(
+			join(userConfigDir, "oh-my-openagent.jsonc"),
+			JSON.stringify(
+				{ agents: { oracle: { model: "openai/gpt-5.4" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+		writeFileSync(
+			join(projectDir, ".opencode", "oh-my-openagent.jsonc"),
+			JSON.stringify(
+				{ agents: { oracle: { model: "anthropic/claude-opus-4-6" } } },
+				null,
+				2,
+			) + "\n",
+			"utf-8",
+		);
+
+		const result = loadPluginConfig(projectDir, {});
+
+		expect(result.agents?.oracle?.model).toBe("anthropic/claude-opus-4-6");
+	});
+
+	it("prefers project canonical config over project legacy config when both exist", () => {
+		writeFileSync(
+			join(projectDir, ".opencode", "oh-my-opencode.jsonc"),
+			JSON.stringify({ disabled_hooks: ["legacy-project-hook"] }, null, 2) +
+				"\n",
+			"utf-8",
+		);
+		writeFileSync(
+			join(projectDir, ".opencode", "oh-my-openagent.jsonc"),
+			JSON.stringify({ disabled_hooks: ["canonical-project-hook"] }, null, 2) +
+				"\n",
+			"utf-8",
+		);
+
+		const result = loadPluginConfig(projectDir, {});
+
+		expect(result.disabled_hooks).toEqual(["canonical-project-hook"]);
+	});
+
+	it("loads legacy-only project config and copies canonical jsonc", () => {
+		writeFileSync(
+			join(projectDir, ".opencode", "oh-my-opencode.jsonc"),
+			JSON.stringify({ disabled_hooks: ["legacy-project-hook"] }, null, 2) +
+				"\n",
+			"utf-8",
+		);
+
+		const result = loadPluginConfig(projectDir, {});
+
+		expect(result.disabled_hooks).toEqual(["legacy-project-hook"]);
+		expect(
+			existsSync(join(projectDir, ".opencode", "oh-my-openagent.jsonc")),
+		).toBe(true);
+	});
 });

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -74,13 +74,28 @@ export function parseConfigPartially(
 export function loadConfigFromPath(
 	configPath: string,
 	_ctx: unknown,
+	options: { migrate?: boolean; persistMigration?: boolean } = {},
 ): OhMyOpenCodeConfig | null {
+	const shouldMigrate = options.migrate ?? true;
+	const persistMigration = options.persistMigration ?? true;
 	try {
 		if (fs.existsSync(configPath)) {
 			const content = fs.readFileSync(configPath, "utf-8");
 			const rawConfig = parseJsonc<Record<string, unknown>>(content);
 
-			migrateConfigFile(configPath, rawConfig);
+			if (
+				!rawConfig ||
+				typeof rawConfig !== "object" ||
+				Array.isArray(rawConfig)
+			) {
+				throw new TypeError("Plugin config root must be an object");
+			}
+
+			if (shouldMigrate) {
+				migrateConfigFile(configPath, rawConfig, {
+					persist: persistMigration,
+				});
+			}
 
 			const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
 

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -4,8 +4,8 @@ import { type OhMyOpenCodeConfig, OhMyOpenCodeConfigSchema } from "./config";
 import {
 	addConfigLoadError,
 	deepMerge,
-	detectPluginConfigFile,
 	getOpenCodeConfigDir,
+	getPluginConfigFileCandidates,
 	log,
 	migrateConfigFile,
 	parseJsonc,
@@ -165,43 +165,40 @@ export function mergeConfigs(
 	};
 }
 
+function loadFirstValidPluginConfig(
+	directory: string,
+	ctx: unknown,
+): OhMyOpenCodeConfig | null {
+	for (const candidatePath of getPluginConfigFileCandidates(directory)) {
+		if (!fs.existsSync(candidatePath)) continue;
+
+		const loadedConfig = loadConfigFromPath(candidatePath, ctx);
+		if (!loadedConfig) continue;
+
+		if (path.basename(candidatePath).startsWith(LEGACY_CONFIG_BASENAME)) {
+			migrateLegacyConfigFile(candidatePath);
+		}
+
+		return loadedConfig;
+	}
+
+	return null;
+}
+
 export function loadPluginConfig(
 	directory: string,
 	ctx: unknown,
 ): OhMyOpenCodeConfig {
-	// User-level config path - prefer .jsonc over .json
 	const configDir = getOpenCodeConfigDir({ binary: "opencode" });
-	const userDetected = detectPluginConfigFile(configDir);
-	const userConfigPath = userDetected.path;
-
-	// Auto-copy legacy config file to canonical name if needed
-	if (
-		userDetected.format !== "none" &&
-		path.basename(userDetected.path).startsWith(LEGACY_CONFIG_BASENAME)
-	) {
-		migrateLegacyConfigFile(userDetected.path);
-	}
-
-	// Project-level config path - prefer .jsonc over .json
 	const projectBasePath = path.join(directory, ".opencode");
-	const projectDetected = detectPluginConfigFile(projectBasePath);
-	const projectConfigPath = projectDetected.path;
-
-	// Auto-copy legacy project config file to canonical name if needed
-	if (
-		projectDetected.format !== "none" &&
-		path.basename(projectDetected.path).startsWith(LEGACY_CONFIG_BASENAME)
-	) {
-		migrateLegacyConfigFile(projectDetected.path);
-	}
 
 	// Load user config first (base). Parse empty config through Zod to apply field defaults.
 	let config: OhMyOpenCodeConfig =
-		loadConfigFromPath(userConfigPath, ctx) ??
+		loadFirstValidPluginConfig(configDir, ctx) ??
 		OhMyOpenCodeConfigSchema.parse({});
 
 	// Override with project config
-	const projectConfig = loadConfigFromPath(projectConfigPath, ctx);
+	const projectConfig = loadFirstValidPluginConfig(projectBasePath, ctx);
 	if (projectConfig) {
 		config = mergeConfigs(config, projectConfig);
 	}

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -1,213 +1,221 @@
 import * as fs from "fs";
 import * as path from "path";
-import { OhMyOpenCodeConfigSchema, type OhMyOpenCodeConfig } from "./config";
+import { type OhMyOpenCodeConfig, OhMyOpenCodeConfigSchema } from "./config";
 import {
-  log,
-  deepMerge,
-  getOpenCodeConfigDir,
-  addConfigLoadError,
-  parseJsonc,
-  detectPluginConfigFile,
-  migrateConfigFile,
+	addConfigLoadError,
+	deepMerge,
+	detectPluginConfigFile,
+	getOpenCodeConfigDir,
+	log,
+	migrateConfigFile,
+	parseJsonc,
 } from "./shared";
 import { migrateLegacyConfigFile } from "./shared/migrate-legacy-config-file";
 import { LEGACY_CONFIG_BASENAME } from "./shared/plugin-identity";
 
 const PARTIAL_STRING_ARRAY_KEYS = new Set([
-  "disabled_mcps",
-  "disabled_agents",
-  "disabled_skills",
-  "disabled_hooks",
-  "disabled_commands",
-  "disabled_tools",
+	"disabled_mcps",
+	"disabled_agents",
+	"disabled_skills",
+	"disabled_hooks",
+	"disabled_commands",
+	"disabled_tools",
 ]);
 
 export function parseConfigPartially(
-  rawConfig: Record<string, unknown>
+	rawConfig: Record<string, unknown>,
 ): OhMyOpenCodeConfig | null {
-  const fullResult = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
-  if (fullResult.success) {
-    return fullResult.data;
-  }
+	const fullResult = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
+	if (fullResult.success) {
+		return fullResult.data;
+	}
 
-  const partialConfig: Record<string, unknown> = {};
-  const invalidSections: string[] = [];
+	const partialConfig: Record<string, unknown> = {};
+	const invalidSections: string[] = [];
 
-  for (const key of Object.keys(rawConfig)) {
-    if (PARTIAL_STRING_ARRAY_KEYS.has(key)) {
-      const sectionValue = rawConfig[key];
-      if (Array.isArray(sectionValue) && sectionValue.every((value) => typeof value === "string")) {
-        partialConfig[key] = sectionValue;
-      }
-      continue;
-    }
+	for (const key of Object.keys(rawConfig)) {
+		if (PARTIAL_STRING_ARRAY_KEYS.has(key)) {
+			const sectionValue = rawConfig[key];
+			if (
+				Array.isArray(sectionValue) &&
+				sectionValue.every((value) => typeof value === "string")
+			) {
+				partialConfig[key] = sectionValue;
+			}
+			continue;
+		}
 
-    const sectionResult = OhMyOpenCodeConfigSchema.safeParse({ [key]: rawConfig[key] });
-    if (sectionResult.success) {
-      const parsed = sectionResult.data as Record<string, unknown>;
-      if (parsed[key] !== undefined) {
-        partialConfig[key] = parsed[key];
-      }
-    } else {
-      const sectionErrors = sectionResult.error.issues
-        .filter((i) => i.path[0] === key)
-        .map((i) => `${i.path.join(".")}: ${i.message}`)
-        .join(", ");
-      if (sectionErrors) {
-        invalidSections.push(`${key}: ${sectionErrors}`);
-      }
-    }
-  }
+		const sectionResult = OhMyOpenCodeConfigSchema.safeParse({
+			[key]: rawConfig[key],
+		});
+		if (sectionResult.success) {
+			const parsed = sectionResult.data as Record<string, unknown>;
+			if (parsed[key] !== undefined) {
+				partialConfig[key] = parsed[key];
+			}
+		} else {
+			const sectionErrors = sectionResult.error.issues
+				.filter((i) => i.path[0] === key)
+				.map((i) => `${i.path.join(".")}: ${i.message}`)
+				.join(", ");
+			if (sectionErrors) {
+				invalidSections.push(`${key}: ${sectionErrors}`);
+			}
+		}
+	}
 
-  if (invalidSections.length > 0) {
-    log("Partial config loaded — invalid sections skipped:", invalidSections);
-  }
+	if (invalidSections.length > 0) {
+		log("Partial config loaded — invalid sections skipped:", invalidSections);
+	}
 
-  return partialConfig as OhMyOpenCodeConfig;
+	return partialConfig as OhMyOpenCodeConfig;
 }
 
 export function loadConfigFromPath(
-  configPath: string,
-  _ctx: unknown
+	configPath: string,
+	_ctx: unknown,
 ): OhMyOpenCodeConfig | null {
-  try {
-    if (fs.existsSync(configPath)) {
-      const content = fs.readFileSync(configPath, "utf-8");
-      const rawConfig = parseJsonc<Record<string, unknown>>(content);
+	try {
+		if (fs.existsSync(configPath)) {
+			const content = fs.readFileSync(configPath, "utf-8");
+			const rawConfig = parseJsonc<Record<string, unknown>>(content);
 
-      migrateConfigFile(configPath, rawConfig);
+			migrateConfigFile(configPath, rawConfig);
 
-      const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
+			const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig);
 
-      if (result.success) {
-        log(`Config loaded from ${configPath}`, { agents: result.data.agents });
-        return result.data;
-      }
+			if (result.success) {
+				log(`Config loaded from ${configPath}`, { agents: result.data.agents });
+				return result.data;
+			}
 
-      const errorMsg = result.error.issues
-        .map((i) => `${i.path.join(".")}: ${i.message}`)
-        .join(", ");
-      log(`Config validation error in ${configPath}:`, result.error.issues);
-      addConfigLoadError({
-        path: configPath,
-        error: `Partial config loaded — invalid sections skipped: ${errorMsg}`,
-      });
+			const errorMsg = result.error.issues
+				.map((i) => `${i.path.join(".")}: ${i.message}`)
+				.join(", ");
+			log(`Config validation error in ${configPath}:`, result.error.issues);
+			addConfigLoadError({
+				path: configPath,
+				error: `Partial config loaded — invalid sections skipped: ${errorMsg}`,
+			});
 
-      const partialResult = parseConfigPartially(rawConfig);
-      if (partialResult) {
-        log(`Partial config loaded from ${configPath}`, { agents: partialResult.agents });
-        return partialResult;
-      }
+			const partialResult = parseConfigPartially(rawConfig);
+			if (partialResult) {
+				log(`Partial config loaded from ${configPath}`, {
+					agents: partialResult.agents,
+				});
+				return partialResult;
+			}
 
-      return null;
-    }
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err);
-    log(`Error loading config from ${configPath}:`, err);
-    addConfigLoadError({ path: configPath, error: errorMsg });
-  }
-  return null;
+			return null;
+		}
+	} catch (err) {
+		const errorMsg = err instanceof Error ? err.message : String(err);
+		log(`Error loading config from ${configPath}:`, err);
+		addConfigLoadError({ path: configPath, error: errorMsg });
+	}
+	return null;
 }
 
 export function mergeConfigs(
-  base: OhMyOpenCodeConfig,
-  override: OhMyOpenCodeConfig
+	base: OhMyOpenCodeConfig,
+	override: OhMyOpenCodeConfig,
 ): OhMyOpenCodeConfig {
-  return {
-    ...base,
-    ...override,
-    agents: deepMerge(base.agents, override.agents),
-    categories: deepMerge(base.categories, override.categories),
-    disabled_agents: [
-      ...new Set([
-        ...(base.disabled_agents ?? []),
-        ...(override.disabled_agents ?? []),
-      ]),
-    ],
-    disabled_mcps: [
-      ...new Set([
-        ...(base.disabled_mcps ?? []),
-        ...(override.disabled_mcps ?? []),
-      ]),
-    ],
-    disabled_hooks: [
-      ...new Set([
-        ...(base.disabled_hooks ?? []),
-        ...(override.disabled_hooks ?? []),
-      ]),
-    ],
-    disabled_commands: [
-      ...new Set([
-        ...(base.disabled_commands ?? []),
-        ...(override.disabled_commands ?? []),
-      ]),
-    ],
-    disabled_skills: [
-      ...new Set([
-        ...(base.disabled_skills ?? []),
-        ...(override.disabled_skills ?? []),
-      ]),
-    ],
-    disabled_tools: [
-      ...new Set([
-        ...(base.disabled_tools ?? []),
-        ...(override.disabled_tools ?? []),
-      ]),
-    ],
-    claude_code: deepMerge(base.claude_code, override.claude_code),
-  };
+	return {
+		...base,
+		...override,
+		agents: deepMerge(base.agents, override.agents),
+		categories: deepMerge(base.categories, override.categories),
+		disabled_agents: [
+			...new Set([
+				...(base.disabled_agents ?? []),
+				...(override.disabled_agents ?? []),
+			]),
+		],
+		disabled_mcps: [
+			...new Set([
+				...(base.disabled_mcps ?? []),
+				...(override.disabled_mcps ?? []),
+			]),
+		],
+		disabled_hooks: [
+			...new Set([
+				...(base.disabled_hooks ?? []),
+				...(override.disabled_hooks ?? []),
+			]),
+		],
+		disabled_commands: [
+			...new Set([
+				...(base.disabled_commands ?? []),
+				...(override.disabled_commands ?? []),
+			]),
+		],
+		disabled_skills: [
+			...new Set([
+				...(base.disabled_skills ?? []),
+				...(override.disabled_skills ?? []),
+			]),
+		],
+		disabled_tools: [
+			...new Set([
+				...(base.disabled_tools ?? []),
+				...(override.disabled_tools ?? []),
+			]),
+		],
+		claude_code: deepMerge(base.claude_code, override.claude_code),
+	};
 }
 
 export function loadPluginConfig(
-  directory: string,
-  ctx: unknown
+	directory: string,
+	ctx: unknown,
 ): OhMyOpenCodeConfig {
-  // User-level config path - prefer .jsonc over .json
-  const configDir = getOpenCodeConfigDir({ binary: "opencode" });
-  const userDetected = detectPluginConfigFile(configDir);
-  const userConfigPath =
-    userDetected.format !== "none"
-      ? userDetected.path
-      : path.join(configDir, "oh-my-opencode.json");
+	// User-level config path - prefer .jsonc over .json
+	const configDir = getOpenCodeConfigDir({ binary: "opencode" });
+	const userDetected = detectPluginConfigFile(configDir);
+	const userConfigPath = userDetected.path;
 
-  // Auto-copy legacy config file to canonical name if needed
-  if (userDetected.format !== "none" && path.basename(userDetected.path).startsWith(LEGACY_CONFIG_BASENAME)) {
-    migrateLegacyConfigFile(userDetected.path);
-  }
+	// Auto-copy legacy config file to canonical name if needed
+	if (
+		userDetected.format !== "none" &&
+		path.basename(userDetected.path).startsWith(LEGACY_CONFIG_BASENAME)
+	) {
+		migrateLegacyConfigFile(userDetected.path);
+	}
 
-  // Project-level config path - prefer .jsonc over .json
-  const projectBasePath = path.join(directory, ".opencode");
-  const projectDetected = detectPluginConfigFile(projectBasePath);
-  const projectConfigPath =
-    projectDetected.format !== "none"
-      ? projectDetected.path
-      : path.join(projectBasePath, "oh-my-opencode.json");
+	// Project-level config path - prefer .jsonc over .json
+	const projectBasePath = path.join(directory, ".opencode");
+	const projectDetected = detectPluginConfigFile(projectBasePath);
+	const projectConfigPath = projectDetected.path;
 
-  // Auto-copy legacy project config file to canonical name if needed
-  if (projectDetected.format !== "none" && path.basename(projectDetected.path).startsWith(LEGACY_CONFIG_BASENAME)) {
-    migrateLegacyConfigFile(projectDetected.path);
-  }
+	// Auto-copy legacy project config file to canonical name if needed
+	if (
+		projectDetected.format !== "none" &&
+		path.basename(projectDetected.path).startsWith(LEGACY_CONFIG_BASENAME)
+	) {
+		migrateLegacyConfigFile(projectDetected.path);
+	}
 
-  // Load user config first (base). Parse empty config through Zod to apply field defaults.
-  let config: OhMyOpenCodeConfig =
-    loadConfigFromPath(userConfigPath, ctx) ?? OhMyOpenCodeConfigSchema.parse({});
+	// Load user config first (base). Parse empty config through Zod to apply field defaults.
+	let config: OhMyOpenCodeConfig =
+		loadConfigFromPath(userConfigPath, ctx) ??
+		OhMyOpenCodeConfigSchema.parse({});
 
-  // Override with project config
-  const projectConfig = loadConfigFromPath(projectConfigPath, ctx);
-  if (projectConfig) {
-    config = mergeConfigs(config, projectConfig);
-  }
+	// Override with project config
+	const projectConfig = loadConfigFromPath(projectConfigPath, ctx);
+	if (projectConfig) {
+		config = mergeConfigs(config, projectConfig);
+	}
 
-  config = {
-    ...config,
-  };
+	config = {
+		...config,
+	};
 
-  log("Final merged config", {
-    agents: config.agents,
-    disabled_agents: config.disabled_agents,
-    disabled_mcps: config.disabled_mcps,
-    disabled_hooks: config.disabled_hooks,
-    claude_code: config.claude_code,
-  });
-  return config;
+	log("Final merged config", {
+		agents: config.agents,
+		disabled_agents: config.disabled_agents,
+		disabled_mcps: config.disabled_mcps,
+		disabled_hooks: config.disabled_hooks,
+		claude_code: config.claude_code,
+	});
+	return config;
 }

--- a/src/plugin-handlers/AGENTS.md
+++ b/src/plugin-handlers/AGENTS.md
@@ -8,51 +8,53 @@
 
 ## 6-PHASE PIPELINE
 
-| Phase | Handler | Purpose |
-|-------|---------|---------|
-| 1 | `applyProviderConfig` | Cache model context limits, detect anthropic-beta headers |
-| 2 | `loadPluginComponents` | Discover Claude Code plugins (10s timeout, error isolation) |
-| 3 | `applyAgentConfig` | Load agents from 5 sources, skill discovery, plan demotion |
-| 4 | `applyToolConfig` | Agent-specific tool permissions |
-| 5 | `applyMcpConfig` | Merge builtin + CC + plugin MCPs |
-| 6 | `applyCommandConfig` | Merge commands/skills from 9 parallel sources |
+| Phase | Handler                | Purpose                                                     |
+| ----- | ---------------------- | ----------------------------------------------------------- |
+| 1     | `applyProviderConfig`  | Cache model context limits, detect anthropic-beta headers   |
+| 2     | `loadPluginComponents` | Discover Claude Code plugins (10s timeout, error isolation) |
+| 3     | `applyAgentConfig`     | Load agents from 5 sources, skill discovery, plan demotion  |
+| 4     | `applyToolConfig`      | Agent-specific tool permissions                             |
+| 5     | `applyMcpConfig`       | Merge builtin + CC + plugin MCPs                            |
+| 6     | `applyCommandConfig`   | Merge commands/skills from 9 parallel sources               |
 
 ## FILES
 
-| File | Lines | Purpose |
-|------|-------|---------|
-| `config-handler.ts` | ~200 | Main orchestrator, 6-phase sequential |
-| `plugin-components-loader.ts` | ~100 | CC plugin discovery (10s timeout) |
-| `agent-config-handler.ts` | ~300 | Agent loading + skill discovery from 5 sources |
-| `mcp-config-handler.ts` | ~150 | Builtin + CC + plugin MCP merge |
-| `command-config-handler.ts` | ~200 | 9 parallel sources for commands/skills |
-| `tool-config-handler.ts` | ~100 | Agent-specific tool grants/denials |
-| `provider-config-handler.ts` | ~80 | Provider config + model cache |
-| `prometheus-agent-config-builder.ts` | ~100 | Prometheus config with model resolution |
-| `plan-model-inheritance.ts` | 28 | Plan demotion logic |
-| `agent-priority-order.ts` | ~30 | sisyphus, hephaestus, prometheus, atlas first |
-| `agent-key-remapper.ts` | ~30 | Agent key → display name |
-| `category-config-resolver.ts` | ~40 | User vs default category lookup |
-| `index.ts` | ~10 | Barrel exports |
+| File                                 | Lines | Purpose                                        |
+| ------------------------------------ | ----- | ---------------------------------------------- |
+| `config-handler.ts`                  | ~200  | Main orchestrator, 6-phase sequential          |
+| `plugin-components-loader.ts`        | ~100  | CC plugin discovery (10s timeout)              |
+| `agent-config-handler.ts`            | ~300  | Agent loading + skill discovery from 5 sources |
+| `mcp-config-handler.ts`              | ~150  | Builtin + CC + plugin MCP merge                |
+| `command-config-handler.ts`          | ~200  | 9 parallel sources for commands/skills         |
+| `tool-config-handler.ts`             | ~100  | Agent-specific tool grants/denials             |
+| `provider-config-handler.ts`         | ~80   | Provider config + model cache                  |
+| `prometheus-agent-config-builder.ts` | ~100  | Prometheus config with model resolution        |
+| `plan-model-inheritance.ts`          | 28    | Plan demotion logic                            |
+| `agent-priority-order.ts`            | ~30   | sisyphus, hephaestus, prometheus, atlas first  |
+| `agent-key-remapper.ts`              | ~30   | Agent key → display name                       |
+| `category-config-resolver.ts`        | ~40   | User vs default category lookup                |
+| `index.ts`                           | ~10   | Barrel exports                                 |
 
 ## TOOL PERMISSIONS
 
-| Agent | Granted | Denied |
-|-------|---------|--------|
-| Librarian | grep_app_* | — |
-| Atlas, Sisyphus, Prometheus | task, task_*, teammate | — |
-| Hephaestus | task | — |
-| Default (all others) | — | grep_app_*, task_*, teammate, LSP |
+| Agent                       | Granted                  | Denied                             |
+| --------------------------- | ------------------------ | ---------------------------------- |
+| Librarian                   | grep*app*\*              | —                                  |
+| Atlas, Sisyphus, Prometheus | task, task\_\*, teammate | —                                  |
+| Hephaestus                  | task                     | —                                  |
+| Default (all others)        | —                        | grep*app*_, task\__, teammate, LSP |
 
 ## MULTI-LEVEL CONFIG MERGE
 
 ```
-User (~/.config/opencode/oh-my-opencode.jsonc)
+User (~/.config/opencode/oh-my-openagent.jsonc or legacy ~/.config/opencode/oh-my-opencode.jsonc)
   ↓ deepMerge
-Project (.opencode/oh-my-opencode.jsonc)
+Project (.opencode/oh-my-openagent.jsonc or legacy .opencode/oh-my-opencode.jsonc)
   ↓ Zod defaults
 Final Config
 ```
+
+- Per-directory precedence: canonical `oh-my-openagent` files win over legacy `oh-my-opencode` files, and `.jsonc` wins over `.json`
 
 - `agents`, `categories`, `claude_code`: deep merged
 - `disabled_*` arrays: Set union

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -1,1349 +1,1419 @@
 /// <reference types="bun-types" />
 
-import { describe, test, expect, spyOn, beforeEach, afterEach } from "bun:test"
-import { resolveCategoryConfig, createConfigHandler } from "./config-handler"
-import type { CategoryConfig } from "../config/schema"
-import type { OhMyOpenCodeConfig } from "../config"
-import { getAgentDisplayName } from "../shared/agent-display-names"
-
-import * as agents from "../agents"
-import * as sisyphusJunior from "../agents/sisyphus-junior"
-import * as commandLoader from "../features/claude-code-command-loader"
-import * as builtinCommands from "../features/builtin-commands"
-import * as skillLoader from "../features/opencode-skill-loader"
-import * as agentLoader from "../features/claude-code-agent-loader"
-import * as mcpLoader from "../features/claude-code-mcp-loader"
-import * as pluginLoader from "../features/claude-code-plugin-loader"
-import * as mcpModule from "../mcp"
-import * as shared from "../shared"
-import * as configDir from "../shared/opencode-config-dir"
-import * as permissionCompat from "../shared/permission-compat"
-import * as modelResolver from "../shared/model-resolver"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as agents from "../agents";
+import * as sisyphusJunior from "../agents/sisyphus-junior";
+import type { OhMyOpenCodeConfig } from "../config";
+import type { CategoryConfig } from "../config/schema";
+import * as builtinCommands from "../features/builtin-commands";
+import * as agentLoader from "../features/claude-code-agent-loader";
+import * as commandLoader from "../features/claude-code-command-loader";
+import * as mcpLoader from "../features/claude-code-mcp-loader";
+import * as pluginLoader from "../features/claude-code-plugin-loader";
+import * as skillLoader from "../features/opencode-skill-loader";
+import * as mcpModule from "../mcp";
+import * as shared from "../shared";
+import { getAgentDisplayName } from "../shared/agent-display-names";
+import * as modelResolver from "../shared/model-resolver";
+import * as configDir from "../shared/opencode-config-dir";
+import * as permissionCompat from "../shared/permission-compat";
+import { createConfigHandler, resolveCategoryConfig } from "./config-handler";
 
 beforeEach(() => {
-  spyOn(agents, "createBuiltinAgents" as any).mockResolvedValue({
-    sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
-    oracle: { name: "oracle", prompt: "test", mode: "subagent" },
-  })
+	spyOn(agents, "createBuiltinAgents" as any).mockResolvedValue({
+		sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+		oracle: { name: "oracle", prompt: "test", mode: "subagent" },
+	});
 
-  spyOn(commandLoader, "loadUserCommands" as any).mockResolvedValue({})
-  spyOn(commandLoader, "loadProjectCommands" as any).mockResolvedValue({})
-  spyOn(commandLoader, "loadOpencodeGlobalCommands" as any).mockResolvedValue({})
-  spyOn(commandLoader, "loadOpencodeProjectCommands" as any).mockResolvedValue({})
+	spyOn(commandLoader, "loadUserCommands" as any).mockResolvedValue({});
+	spyOn(commandLoader, "loadProjectCommands" as any).mockResolvedValue({});
+	spyOn(commandLoader, "loadOpencodeGlobalCommands" as any).mockResolvedValue(
+		{},
+	);
+	spyOn(commandLoader, "loadOpencodeProjectCommands" as any).mockResolvedValue(
+		{},
+	);
 
-  spyOn(builtinCommands, "loadBuiltinCommands" as any).mockReturnValue({})
+	spyOn(builtinCommands, "loadBuiltinCommands" as any).mockReturnValue({});
 
-  spyOn(skillLoader, "loadUserSkills" as any).mockResolvedValue({})
-  spyOn(skillLoader, "loadProjectSkills" as any).mockResolvedValue({})
-  spyOn(skillLoader, "loadOpencodeGlobalSkills" as any).mockResolvedValue({})
-  spyOn(skillLoader, "loadOpencodeProjectSkills" as any).mockResolvedValue({})
-  spyOn(skillLoader, "discoverUserClaudeSkills" as any).mockResolvedValue([])
-  spyOn(skillLoader, "discoverProjectClaudeSkills" as any).mockResolvedValue([])
-  spyOn(skillLoader, "discoverOpencodeGlobalSkills" as any).mockResolvedValue([])
-  spyOn(skillLoader, "discoverOpencodeProjectSkills" as any).mockResolvedValue([])
+	spyOn(skillLoader, "loadUserSkills" as any).mockResolvedValue({});
+	spyOn(skillLoader, "loadProjectSkills" as any).mockResolvedValue({});
+	spyOn(skillLoader, "loadOpencodeGlobalSkills" as any).mockResolvedValue({});
+	spyOn(skillLoader, "loadOpencodeProjectSkills" as any).mockResolvedValue({});
+	spyOn(skillLoader, "discoverUserClaudeSkills" as any).mockResolvedValue([]);
+	spyOn(skillLoader, "discoverProjectClaudeSkills" as any).mockResolvedValue(
+		[],
+	);
+	spyOn(skillLoader, "discoverOpencodeGlobalSkills" as any).mockResolvedValue(
+		[],
+	);
+	spyOn(skillLoader, "discoverOpencodeProjectSkills" as any).mockResolvedValue(
+		[],
+	);
 
-  spyOn(agentLoader, "loadUserAgents" as any).mockReturnValue({})
-  spyOn(agentLoader, "loadProjectAgents" as any).mockReturnValue({})
+	spyOn(agentLoader, "loadUserAgents" as any).mockReturnValue({});
+	spyOn(agentLoader, "loadProjectAgents" as any).mockReturnValue({});
 
-  spyOn(mcpLoader, "loadMcpConfigs" as any).mockResolvedValue({ servers: {} })
+	spyOn(mcpLoader, "loadMcpConfigs" as any).mockResolvedValue({ servers: {} });
 
-  spyOn(pluginLoader, "loadAllPluginComponents" as any).mockResolvedValue({
-    commands: {},
-    skills: {},
-    agents: {},
-    mcpServers: {},
-    hooksConfigs: [],
-    plugins: [],
-    errors: [],
-  })
+	spyOn(pluginLoader, "loadAllPluginComponents" as any).mockResolvedValue({
+		commands: {},
+		skills: {},
+		agents: {},
+		mcpServers: {},
+		hooksConfigs: [],
+		plugins: [],
+		errors: [],
+	});
 
-  spyOn(mcpModule, "createBuiltinMcps" as any).mockReturnValue({})
+	spyOn(mcpModule, "createBuiltinMcps" as any).mockReturnValue({});
 
-  spyOn(shared, "log" as any).mockImplementation(() => {})
-  spyOn(shared, "fetchAvailableModels" as any).mockResolvedValue(new Set(["anthropic/claude-opus-4-6"]))
-  spyOn(shared, "readConnectedProvidersCache" as any).mockReturnValue(null)
+	spyOn(shared, "log" as any).mockImplementation(() => {});
+	spyOn(shared, "fetchAvailableModels" as any).mockResolvedValue(
+		new Set(["anthropic/claude-opus-4-6"]),
+	);
+	spyOn(shared, "readConnectedProvidersCache" as any).mockReturnValue(null);
 
-  spyOn(configDir, "getOpenCodeConfigPaths" as any).mockReturnValue({
-    global: "/tmp/.config/opencode",
-    project: "/tmp/.opencode",
-  })
+	spyOn(configDir, "getOpenCodeConfigPaths" as any).mockReturnValue({
+		global: "/tmp/.config/opencode",
+		project: "/tmp/.opencode",
+	});
 
-  spyOn(permissionCompat, "migrateAgentConfig" as any).mockImplementation((config: Record<string, unknown>) => config)
+	spyOn(permissionCompat, "migrateAgentConfig" as any).mockImplementation(
+		(config: Record<string, unknown>) => config,
+	);
 
-  spyOn(modelResolver, "resolveModelWithFallback" as any).mockReturnValue({ model: "anthropic/claude-opus-4-6" })
-})
+	spyOn(modelResolver, "resolveModelWithFallback" as any).mockReturnValue({
+		model: "anthropic/claude-opus-4-6",
+	});
+});
 
 afterEach(() => {
-  (agents.createBuiltinAgents as any)?.mockRestore?.()
-  ;(sisyphusJunior.createSisyphusJuniorAgentWithOverrides as any)?.mockRestore?.()
-  ;(commandLoader.loadUserCommands as any)?.mockRestore?.()
-  ;(commandLoader.loadProjectCommands as any)?.mockRestore?.()
-  ;(commandLoader.loadOpencodeGlobalCommands as any)?.mockRestore?.()
-  ;(commandLoader.loadOpencodeProjectCommands as any)?.mockRestore?.()
-  ;(builtinCommands.loadBuiltinCommands as any)?.mockRestore?.()
-  ;(skillLoader.loadUserSkills as any)?.mockRestore?.()
-  ;(skillLoader.loadProjectSkills as any)?.mockRestore?.()
-  ;(skillLoader.loadOpencodeGlobalSkills as any)?.mockRestore?.()
-  ;(skillLoader.loadOpencodeProjectSkills as any)?.mockRestore?.()
-  ;(skillLoader.discoverUserClaudeSkills as any)?.mockRestore?.()
-  ;(skillLoader.discoverProjectClaudeSkills as any)?.mockRestore?.()
-  ;(skillLoader.discoverOpencodeGlobalSkills as any)?.mockRestore?.()
-  ;(skillLoader.discoverOpencodeProjectSkills as any)?.mockRestore?.()
-  ;(agentLoader.loadUserAgents as any)?.mockRestore?.()
-  ;(agentLoader.loadProjectAgents as any)?.mockRestore?.()
-  ;(mcpLoader.loadMcpConfigs as any)?.mockRestore?.()
-  ;(pluginLoader.loadAllPluginComponents as any)?.mockRestore?.()
-  ;(mcpModule.createBuiltinMcps as any)?.mockRestore?.()
-  ;(shared.log as any)?.mockRestore?.()
-  ;(shared.fetchAvailableModels as any)?.mockRestore?.()
-  ;(shared.readConnectedProvidersCache as any)?.mockRestore?.()
-  ;(configDir.getOpenCodeConfigPaths as any)?.mockRestore?.()
-  ;(permissionCompat.migrateAgentConfig as any)?.mockRestore?.()
-  ;(modelResolver.resolveModelWithFallback as any)?.mockRestore?.()
-})
+	(agents.createBuiltinAgents as any)?.mockRestore?.();
+	(
+		sisyphusJunior.createSisyphusJuniorAgentWithOverrides as any
+	)?.mockRestore?.();
+	(commandLoader.loadUserCommands as any)?.mockRestore?.();
+	(commandLoader.loadProjectCommands as any)?.mockRestore?.();
+	(commandLoader.loadOpencodeGlobalCommands as any)?.mockRestore?.();
+	(commandLoader.loadOpencodeProjectCommands as any)?.mockRestore?.();
+	(builtinCommands.loadBuiltinCommands as any)?.mockRestore?.();
+	(skillLoader.loadUserSkills as any)?.mockRestore?.();
+	(skillLoader.loadProjectSkills as any)?.mockRestore?.();
+	(skillLoader.loadOpencodeGlobalSkills as any)?.mockRestore?.();
+	(skillLoader.loadOpencodeProjectSkills as any)?.mockRestore?.();
+	(skillLoader.discoverUserClaudeSkills as any)?.mockRestore?.();
+	(skillLoader.discoverProjectClaudeSkills as any)?.mockRestore?.();
+	(skillLoader.discoverOpencodeGlobalSkills as any)?.mockRestore?.();
+	(skillLoader.discoverOpencodeProjectSkills as any)?.mockRestore?.();
+	(agentLoader.loadUserAgents as any)?.mockRestore?.();
+	(agentLoader.loadProjectAgents as any)?.mockRestore?.();
+	(mcpLoader.loadMcpConfigs as any)?.mockRestore?.();
+	(pluginLoader.loadAllPluginComponents as any)?.mockRestore?.();
+	(mcpModule.createBuiltinMcps as any)?.mockRestore?.();
+	(shared.log as any)?.mockRestore?.();
+	(shared.fetchAvailableModels as any)?.mockRestore?.();
+	(shared.readConnectedProvidersCache as any)?.mockRestore?.();
+	(shared.resolveModelPipeline as any)?.mockRestore?.();
+	(configDir.getOpenCodeConfigPaths as any)?.mockRestore?.();
+	(permissionCompat.migrateAgentConfig as any)?.mockRestore?.();
+	(modelResolver.resolveModelWithFallback as any)?.mockRestore?.();
+});
 
 describe("Sisyphus-Junior model inheritance", () => {
-  test("does not inherit UI-selected model as system default", async () => {
-    // #given
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "opencode/kimi-k2.5-free",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("does not inherit UI-selected model as system default", async () => {
+		// #given
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "opencode/kimi-k2.5-free",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then
-    const agentConfig = config.agent as Record<string, { model?: string }>
-    expect(agentConfig[getAgentDisplayName("sisyphus-junior")]?.model).toBe(
-      sisyphusJunior.SISYPHUS_JUNIOR_DEFAULTS.model
-    )
-  })
+		// #then
+		const agentConfig = config.agent as Record<string, { model?: string }>;
+		expect(agentConfig[getAgentDisplayName("sisyphus-junior")]?.model).toBe(
+			sisyphusJunior.SISYPHUS_JUNIOR_DEFAULTS.model,
+		);
+	});
 
-  test("uses explicitly configured sisyphus-junior model", async () => {
-    // #given
-    const pluginConfig: OhMyOpenCodeConfig = {
-      agents: {
-        "sisyphus-junior": {
-          model: "openai/gpt-5.3-codex",
-        },
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "opencode/kimi-k2.5-free",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("uses explicitly configured sisyphus-junior model", async () => {
+		// #given
+		const pluginConfig: OhMyOpenCodeConfig = {
+			agents: {
+				"sisyphus-junior": {
+					model: "openai/gpt-5.3-codex",
+				},
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "opencode/kimi-k2.5-free",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then
-    const agentConfig = config.agent as Record<string, { model?: string }>
-    expect(agentConfig[getAgentDisplayName("sisyphus-junior")]?.model).toBe(
-      "openai/gpt-5.3-codex"
-    )
-  })
-})
+		// #then
+		const agentConfig = config.agent as Record<string, { model?: string }>;
+		expect(agentConfig[getAgentDisplayName("sisyphus-junior")]?.model).toBe(
+			"openai/gpt-5.3-codex",
+		);
+	});
+});
 
 describe("Plan agent demote behavior", () => {
-  test("orders core agents as sisyphus -> hephaestus -> prometheus -> atlas", async () => {
-    // #given
-    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
-      mockResolvedValue: (value: Record<string, unknown>) => void
-    }
-    createBuiltinAgentsMock.mockResolvedValue({
-      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
-      hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
-      oracle: { name: "oracle", prompt: "test", mode: "subagent" },
-      atlas: { name: "atlas", prompt: "test", mode: "primary" },
-    })
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("orders core agents as sisyphus -> hephaestus -> prometheus -> atlas", async () => {
+		// #given
+		const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+			mockResolvedValue: (value: Record<string, unknown>) => void;
+		};
+		createBuiltinAgentsMock.mockResolvedValue({
+			sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+			hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
+			oracle: { name: "oracle", prompt: "test", mode: "subagent" },
+			atlas: { name: "atlas", prompt: "test", mode: "primary" },
+		});
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then
-    const keys = Object.keys(config.agent as Record<string, unknown>)
-    const coreAgents = [
-      getAgentDisplayName("sisyphus"),
-      getAgentDisplayName("hephaestus"),
-      getAgentDisplayName("prometheus"),
-      getAgentDisplayName("atlas"),
-    ]
-    const ordered = keys.filter((key) => coreAgents.includes(key))
-    expect(ordered).toEqual(coreAgents)
-  })
+		// #then
+		const keys = Object.keys(config.agent as Record<string, unknown>);
+		const coreAgents = [
+			getAgentDisplayName("sisyphus"),
+			getAgentDisplayName("hephaestus"),
+			getAgentDisplayName("prometheus"),
+			getAgentDisplayName("atlas"),
+		];
+		const ordered = keys.filter((key) => coreAgents.includes(key));
+		expect(ordered).toEqual(coreAgents);
+	});
 
-  test("plan agent should be demoted to subagent without inheriting prometheus prompt", async () => {
-    // #given
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-        replace_plan: true,
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {
-        plan: {
-          name: "plan",
-          mode: "primary",
-          prompt: "original plan prompt",
-        },
-      },
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("plan agent should be demoted to subagent without inheriting prometheus prompt", async () => {
+		// #given
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+				replace_plan: true,
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {
+				plan: {
+					name: "plan",
+					mode: "primary",
+					prompt: "original plan prompt",
+				},
+			},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then - plan is demoted to subagent but does NOT inherit prometheus prompt
-    const agents = config.agent as Record<string, { mode?: string; name?: string; prompt?: string }>
-    expect(agents.plan).toBeDefined()
-    expect(agents.plan.mode).toBe("subagent")
-    expect(agents.plan.prompt).toBeUndefined()
-    expect(agents[getAgentDisplayName("prometheus")]?.prompt).toBeDefined()
-  })
+		// #then - plan is demoted to subagent but does NOT inherit prometheus prompt
+		const agents = config.agent as Record<
+			string,
+			{ mode?: string; name?: string; prompt?: string }
+		>;
+		expect(agents.plan).toBeDefined();
+		expect(agents.plan.mode).toBe("subagent");
+		expect(agents.plan.prompt).toBeUndefined();
+		expect(agents[getAgentDisplayName("prometheus")]?.prompt).toBeDefined();
+	});
 
-  test("plan agent remains unchanged when planner is disabled", async () => {
-    // #given
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: false,
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {
-        plan: {
-          name: "plan",
-          mode: "primary",
-          prompt: "original plan prompt",
-        },
-      },
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("plan agent remains unchanged when planner is disabled", async () => {
+		// #given
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: false,
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {
+				plan: {
+					name: "plan",
+					mode: "primary",
+					prompt: "original plan prompt",
+				},
+			},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then - plan is not touched, prometheus is not created
-    const agents = config.agent as Record<string, { mode?: string; name?: string; prompt?: string }>
-    expect(agents[getAgentDisplayName("prometheus")]).toBeUndefined()
-    expect(agents.plan).toBeDefined()
-    expect(agents.plan.mode).toBe("primary")
-    expect(agents.plan.prompt).toBe("original plan prompt")
-  })
+		// #then - plan is not touched, prometheus is not created
+		const agents = config.agent as Record<
+			string,
+			{ mode?: string; name?: string; prompt?: string }
+		>;
+		expect(agents[getAgentDisplayName("prometheus")]).toBeUndefined();
+		expect(agents.plan).toBeDefined();
+		expect(agents.plan.mode).toBe("primary");
+		expect(agents.plan.prompt).toBe("original plan prompt");
+	});
 
-  test("prometheus should have mode 'all' to be callable via task", async () => {
-    // given
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("prometheus should have mode 'all' to be callable via task", async () => {
+		// given
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then
-    const agents = config.agent as Record<string, { mode?: string }>
-    const prometheusKey = getAgentDisplayName("prometheus")
-    expect(agents[prometheusKey]).toBeDefined()
-    expect(agents[prometheusKey].mode).toBe("all")
-  })
-})
+		// then
+		const agents = config.agent as Record<string, { mode?: string }>;
+		const prometheusKey = getAgentDisplayName("prometheus");
+		expect(agents[prometheusKey]).toBeDefined();
+		expect(agents[prometheusKey].mode).toBe("all");
+	});
+});
 
 describe("Agent permission defaults", () => {
-  test("hephaestus should allow task", async () => {
-    // #given
-    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
-      mockResolvedValue: (value: Record<string, unknown>) => void
-    }
-    createBuiltinAgentsMock.mockResolvedValue({
-      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
-      hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
-      oracle: { name: "oracle", prompt: "test", mode: "subagent" },
-    })
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("hephaestus should allow task", async () => {
+		// #given
+		const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+			mockResolvedValue: (value: Record<string, unknown>) => void;
+		};
+		createBuiltinAgentsMock.mockResolvedValue({
+			sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+			hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
+			oracle: { name: "oracle", prompt: "test", mode: "subagent" },
+		});
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then
-    const agentConfig = config.agent as Record<string, { permission?: Record<string, string> }>
-    const hephaestusKey = getAgentDisplayName("hephaestus")
-    expect(agentConfig[hephaestusKey]).toBeDefined()
-    expect(agentConfig[hephaestusKey].permission?.task).toBe("allow")
-  })
-})
+		// #then
+		const agentConfig = config.agent as Record<
+			string,
+			{ permission?: Record<string, string> }
+		>;
+		const hephaestusKey = getAgentDisplayName("hephaestus");
+		expect(agentConfig[hephaestusKey]).toBeDefined();
+		expect(agentConfig[hephaestusKey].permission?.task).toBe("allow");
+	});
+});
 
 describe("default_agent behavior with Sisyphus orchestration", () => {
-  test("canonicalizes configured default_agent with surrounding whitespace", async () => {
-    // given
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      default_agent: "  hephaestus  ",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("canonicalizes configured default_agent with surrounding whitespace", async () => {
+		// given
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			default_agent: "  hephaestus  ",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then
-    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
-  })
+		// then
+		expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"));
+	});
 
-  test("canonicalizes configured default_agent when key uses mixed case", async () => {
-    // given
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      default_agent: "HePhAeStUs",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("canonicalizes configured default_agent when key uses mixed case", async () => {
+		// given
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			default_agent: "HePhAeStUs",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then
-    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
-  })
+		// then
+		expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"));
+	});
 
-  test("canonicalizes configured default_agent key to display name", async () => {
-    // #given
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      default_agent: "hephaestus",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("canonicalizes configured default_agent key to display name", async () => {
+		// #given
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			default_agent: "hephaestus",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then
-    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
-  })
+		// #then
+		expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"));
+	});
 
-  test("preserves existing display-name default_agent", async () => {
-    // #given
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const displayName = getAgentDisplayName("hephaestus")
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      default_agent: displayName,
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("preserves existing display-name default_agent", async () => {
+		// #given
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const displayName = getAgentDisplayName("hephaestus");
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			default_agent: displayName,
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then
-    expect(config.default_agent).toBe(displayName)
-  })
+		// #then
+		expect(config.default_agent).toBe(displayName);
+	});
 
-  test("sets default_agent to sisyphus when missing", async () => {
-    // #given
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("sets default_agent to sisyphus when missing", async () => {
+		// #given
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then
-    expect(config.default_agent).toBe(getAgentDisplayName("sisyphus"))
-  })
+		// #then
+		expect(config.default_agent).toBe(getAgentDisplayName("sisyphus"));
+	});
 
-  test("sets default_agent to sisyphus when configured default_agent is empty after trim", async () => {
-    // given
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      default_agent: "    ",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("sets default_agent to sisyphus when configured default_agent is empty after trim", async () => {
+		// given
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			default_agent: "    ",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then
-    expect(config.default_agent).toBe(getAgentDisplayName("sisyphus"))
-  })
+		// then
+		expect(config.default_agent).toBe(getAgentDisplayName("sisyphus"));
+	});
 
-  test("preserves custom default_agent names while trimming whitespace", async () => {
-    // given
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      default_agent: "  Custom Agent  ",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("preserves custom default_agent names while trimming whitespace", async () => {
+		// given
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			default_agent: "  Custom Agent  ",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then
-    expect(config.default_agent).toBe("Custom Agent")
-  })
+		// then
+		expect(config.default_agent).toBe("Custom Agent");
+	});
 
-  test("does not normalize configured default_agent when Sisyphus is disabled", async () => {
-    // given
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        disabled: true,
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      default_agent: "  HePhAeStUs  ",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("does not normalize configured default_agent when Sisyphus is disabled", async () => {
+		// given
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				disabled: true,
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			default_agent: "  HePhAeStUs  ",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then
-    expect(config.default_agent).toBe("  HePhAeStUs  ")
-  })
-})
+		// then
+		expect(config.default_agent).toBe("  HePhAeStUs  ");
+	});
+});
 
 describe("Prometheus category config resolution", () => {
-  test("resolves ultrabrain category config", () => {
-    // given
-    const categoryName = "ultrabrain"
+	test("resolves ultrabrain category config", () => {
+		// given
+		const categoryName = "ultrabrain";
 
-    // when
-    const config = resolveCategoryConfig(categoryName)
+		// when
+		const config = resolveCategoryConfig(categoryName);
 
-    // then
-    expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.4")
-    expect(config?.variant).toBe("xhigh")
-  })
+		// then
+		expect(config).toBeDefined();
+		expect(config?.model).toBe("openai/gpt-5.4");
+		expect(config?.variant).toBe("xhigh");
+	});
 
-  test("resolves visual-engineering category config", () => {
-    // given
-    const categoryName = "visual-engineering"
+	test("resolves visual-engineering category config", () => {
+		// given
+		const categoryName = "visual-engineering";
 
-    // when
-    const config = resolveCategoryConfig(categoryName)
+		// when
+		const config = resolveCategoryConfig(categoryName);
 
-    // then
-    expect(config).toBeDefined()
-    expect(config?.model).toBe("google/gemini-3.1-pro")
-  })
+		// then
+		expect(config).toBeDefined();
+		expect(config?.model).toBe("google/gemini-3.1-pro");
+	});
 
-  test("user categories override default categories", () => {
-    // given
-    const categoryName = "ultrabrain"
-    const userCategories: Record<string, CategoryConfig> = {
-      ultrabrain: {
-        model: "google/antigravity-claude-opus-4-5-thinking",
-        temperature: 0.1,
-      },
-    }
+	test("user categories override default categories", () => {
+		// given
+		const categoryName = "ultrabrain";
+		const userCategories: Record<string, CategoryConfig> = {
+			ultrabrain: {
+				model: "google/antigravity-claude-opus-4-5-thinking",
+				temperature: 0.1,
+			},
+		};
 
-    // when
-    const config = resolveCategoryConfig(categoryName, userCategories)
+		// when
+		const config = resolveCategoryConfig(categoryName, userCategories);
 
-    // then
-    expect(config).toBeDefined()
-    expect(config?.model).toBe("google/antigravity-claude-opus-4-5-thinking")
-    expect(config?.temperature).toBe(0.1)
-  })
+		// then
+		expect(config).toBeDefined();
+		expect(config?.model).toBe("google/antigravity-claude-opus-4-5-thinking");
+		expect(config?.temperature).toBe(0.1);
+	});
 
-  test("returns undefined for unknown category", () => {
-    // given
-    const categoryName = "nonexistent-category"
+	test("returns undefined for unknown category", () => {
+		// given
+		const categoryName = "nonexistent-category";
 
-    // when
-    const config = resolveCategoryConfig(categoryName)
+		// when
+		const config = resolveCategoryConfig(categoryName);
 
-    // then
-    expect(config).toBeUndefined()
-  })
+		// then
+		expect(config).toBeUndefined();
+	});
 
-  test("falls back to default when user category has no entry", () => {
-    // given
-    const categoryName = "ultrabrain"
-    const userCategories: Record<string, CategoryConfig> = {
-      "visual-engineering": {
-        model: "custom/visual-model",
-      },
-    }
+	test("falls back to default when user category has no entry", () => {
+		// given
+		const categoryName = "ultrabrain";
+		const userCategories: Record<string, CategoryConfig> = {
+			"visual-engineering": {
+				model: "custom/visual-model",
+			},
+		};
 
-    // when
-    const config = resolveCategoryConfig(categoryName, userCategories)
+		// when
+		const config = resolveCategoryConfig(categoryName, userCategories);
 
-    // then - falls back to DEFAULT_CATEGORIES
-    expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.4")
-    expect(config?.variant).toBe("xhigh")
-  })
+		// then - falls back to DEFAULT_CATEGORIES
+		expect(config).toBeDefined();
+		expect(config?.model).toBe("openai/gpt-5.4");
+		expect(config?.variant).toBe("xhigh");
+	});
 
-  test("preserves all category properties (temperature, top_p, tools, etc.)", () => {
-    // given
-    const categoryName = "custom-category"
-    const userCategories: Record<string, CategoryConfig> = {
-      "custom-category": {
-        model: "test/model",
-        temperature: 0.5,
-        top_p: 0.9,
-        maxTokens: 32000,
-        tools: { tool1: true, tool2: false },
-      },
-    }
+	test("preserves all category properties (temperature, top_p, tools, etc.)", () => {
+		// given
+		const categoryName = "custom-category";
+		const userCategories: Record<string, CategoryConfig> = {
+			"custom-category": {
+				model: "test/model",
+				temperature: 0.5,
+				top_p: 0.9,
+				maxTokens: 32000,
+				tools: { tool1: true, tool2: false },
+			},
+		};
 
-    // when
-    const config = resolveCategoryConfig(categoryName, userCategories)
+		// when
+		const config = resolveCategoryConfig(categoryName, userCategories);
 
-    // then
-    expect(config).toBeDefined()
-    expect(config?.model).toBe("test/model")
-    expect(config?.temperature).toBe(0.5)
-    expect(config?.top_p).toBe(0.9)
-    expect(config?.maxTokens).toBe(32000)
-    expect(config?.tools).toEqual({ tool1: true, tool2: false })
-  })
-})
+		// then
+		expect(config).toBeDefined();
+		expect(config?.model).toBe("test/model");
+		expect(config?.temperature).toBe(0.5);
+		expect(config?.top_p).toBe(0.9);
+		expect(config?.maxTokens).toBe(32000);
+		expect(config?.tools).toEqual({ tool1: true, tool2: false });
+	});
+});
 
 describe("Prometheus direct override priority over category", () => {
-  test("direct reasoningEffort takes priority over category reasoningEffort", async () => {
-    // given - category has reasoningEffort=xhigh, direct override says "low"
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-      },
-      categories: {
-        "test-planning": {
-          model: "openai/gpt-5.4",
-          reasoningEffort: "xhigh",
-        },
-      },
-      agents: {
-        prometheus: {
-          category: "test-planning",
-          reasoningEffort: "low",
-        },
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("direct reasoningEffort takes priority over category reasoningEffort", async () => {
+		// given - category has reasoningEffort=xhigh, direct override says "low"
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+			},
+			categories: {
+				"test-planning": {
+					model: "openai/gpt-5.4",
+					reasoningEffort: "xhigh",
+				},
+			},
+			agents: {
+				prometheus: {
+					category: "test-planning",
+					reasoningEffort: "low",
+				},
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then - direct override's reasoningEffort wins
-    const agents = config.agent as Record<string, { reasoningEffort?: string }>
-    const pKey = getAgentDisplayName("prometheus")
-    expect(agents[pKey]).toBeDefined()
-    expect(agents[pKey].reasoningEffort).toBe("low")
-  })
+		// then - direct override's reasoningEffort wins
+		const agents = config.agent as Record<string, { reasoningEffort?: string }>;
+		const pKey = getAgentDisplayName("prometheus");
+		expect(agents[pKey]).toBeDefined();
+		expect(agents[pKey].reasoningEffort).toBe("low");
+	});
 
-  test("category reasoningEffort applied when no direct override", async () => {
-    // given - category has reasoningEffort but no direct override
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-      },
-      categories: {
-        "reasoning-cat": {
-          model: "openai/gpt-5.4",
-          reasoningEffort: "high",
-        },
-      },
-      agents: {
-        prometheus: {
-          category: "reasoning-cat",
-        },
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("category reasoningEffort applied when no direct override", async () => {
+		// given - category has reasoningEffort but no direct override
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+			},
+			categories: {
+				"reasoning-cat": {
+					model: "openai/gpt-5.4",
+					reasoningEffort: "high",
+				},
+			},
+			agents: {
+				prometheus: {
+					category: "reasoning-cat",
+				},
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then - category's reasoningEffort is applied
-    const agents = config.agent as Record<string, { reasoningEffort?: string }>
-    const pKey = getAgentDisplayName("prometheus")
-    expect(agents[pKey]).toBeDefined()
-    expect(agents[pKey].reasoningEffort).toBe("high")
-  })
+		// then - category's reasoningEffort is applied
+		const agents = config.agent as Record<string, { reasoningEffort?: string }>;
+		const pKey = getAgentDisplayName("prometheus");
+		expect(agents[pKey]).toBeDefined();
+		expect(agents[pKey].reasoningEffort).toBe("high");
+	});
 
-  test("direct temperature takes priority over category temperature", async () => {
-    // given
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-      },
-      categories: {
-        "temp-cat": {
-          model: "openai/gpt-5.4",
-          temperature: 0.8,
-        },
-      },
-      agents: {
-        prometheus: {
-          category: "temp-cat",
-          temperature: 0.1,
-        },
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("direct temperature takes priority over category temperature", async () => {
+		// given
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+			},
+			categories: {
+				"temp-cat": {
+					model: "openai/gpt-5.4",
+					temperature: 0.8,
+				},
+			},
+			agents: {
+				prometheus: {
+					category: "temp-cat",
+					temperature: 0.1,
+				},
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then - direct temperature wins over category
-    const agents = config.agent as Record<string, { temperature?: number }>
-    const pKey = getAgentDisplayName("prometheus")
-    expect(agents[pKey]).toBeDefined()
-    expect(agents[pKey].temperature).toBe(0.1)
-  })
+		// then - direct temperature wins over category
+		const agents = config.agent as Record<string, { temperature?: number }>;
+		const pKey = getAgentDisplayName("prometheus");
+		expect(agents[pKey]).toBeDefined();
+		expect(agents[pKey].temperature).toBe(0.1);
+	});
 
-  test("prometheus prompt_append is appended to base prompt", async () => {
-    // #given - prometheus override with prompt_append
-    const customInstructions = "## Custom Project Rules\nUse max 2 commits."
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-      },
-      agents: {
-        prometheus: {
-          prompt_append: customInstructions,
-        },
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("prometheus prompt_append is appended to base prompt", async () => {
+		// #given - prometheus override with prompt_append
+		const customInstructions = "## Custom Project Rules\nUse max 2 commits.";
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+			},
+			agents: {
+				prometheus: {
+					prompt_append: customInstructions,
+				},
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // #when
-    await handler(config)
+		// #when
+		await handler(config);
 
-    // #then - prompt_append is appended to base prompt, not overwriting it
-    const agents = config.agent as Record<string, { prompt?: string }>
-    const pKey = getAgentDisplayName("prometheus")
-    expect(agents[pKey]).toBeDefined()
-    expect(agents[pKey].prompt).toContain("Prometheus")
-    expect(agents[pKey].prompt).toContain(customInstructions)
-    expect(agents[pKey].prompt!.endsWith(customInstructions)).toBe(true)
-  })
-})
+		// #then - prompt_append is appended to base prompt, not overwriting it
+		const agents = config.agent as Record<string, { prompt?: string }>;
+		const pKey = getAgentDisplayName("prometheus");
+		expect(agents[pKey]).toBeDefined();
+		expect(agents[pKey].prompt).toContain("Prometheus");
+		expect(agents[pKey].prompt).toContain(customInstructions);
+		expect(agents[pKey].prompt!.endsWith(customInstructions)).toBe(true);
+	});
+});
 
 describe("Plan agent model inheritance from prometheus", () => {
-  test("plan agent inherits all model-related settings from resolved prometheus config", async () => {
-    //#given - prometheus resolves to claude-opus-4-6 with model settings
-    spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
-      model: "anthropic/claude-opus-4-6",
-      provenance: "provider-fallback",
-      variant: "max",
-    })
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-        replace_plan: true,
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {
-        plan: {
-          name: "plan",
-          mode: "primary",
-          prompt: "original plan prompt",
-        },
-      },
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("plan agent inherits all model-related settings from resolved prometheus config", async () => {
+		//#given - prometheus resolves to claude-opus-4-6 with model settings
+		spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
+			model: "anthropic/claude-opus-4-6",
+			provenance: "provider-fallback",
+			variant: "max",
+		});
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+				replace_plan: true,
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {
+				plan: {
+					name: "plan",
+					mode: "primary",
+					prompt: "original plan prompt",
+				},
+			},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then - plan inherits model and variant from prometheus, but NOT prompt
-    const agents = config.agent as Record<string, { mode?: string; model?: string; variant?: string; prompt?: string }>
-    expect(agents.plan).toBeDefined()
-    expect(agents.plan.mode).toBe("subagent")
-    expect(agents.plan.model).toBe("anthropic/claude-opus-4-6")
-    expect(agents.plan.variant).toBe("max")
-    expect(agents.plan.prompt).toBeUndefined()
-  })
+		//#then - plan inherits model and variant from prometheus, but NOT prompt
+		const agents = config.agent as Record<
+			string,
+			{ mode?: string; model?: string; variant?: string; prompt?: string }
+		>;
+		expect(agents.plan).toBeDefined();
+		expect(agents.plan.mode).toBe("subagent");
+		expect(agents.plan.model).toBe("anthropic/claude-opus-4-6");
+		expect(agents.plan.variant).toBe("max");
+		expect(agents.plan.prompt).toBeUndefined();
+	});
 
-  test("plan agent inherits temperature, reasoningEffort, and other model settings from prometheus", async () => {
-    //#given - prometheus configured with category that has temperature and reasoningEffort
-    spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
-      model: "openai/gpt-5.4",
-      provenance: "override",
-      variant: "high",
-    })
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-        replace_plan: true,
-      },
-      agents: {
-        prometheus: {
-          model: "openai/gpt-5.4",
-          variant: "high",
-          temperature: 0.3,
-          top_p: 0.9,
-          maxTokens: 16000,
-          reasoningEffort: "high",
-          textVerbosity: "medium",
-          thinking: { type: "enabled", budgetTokens: 8000 },
-        },
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("plan agent inherits temperature, reasoningEffort, and other model settings from prometheus", async () => {
+		//#given - prometheus configured with category that has temperature and reasoningEffort
+		spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
+			model: "openai/gpt-5.4",
+			provenance: "override",
+			variant: "high",
+		});
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+				replace_plan: true,
+			},
+			agents: {
+				prometheus: {
+					model: "openai/gpt-5.4",
+					variant: "high",
+					temperature: 0.3,
+					top_p: 0.9,
+					maxTokens: 16000,
+					reasoningEffort: "high",
+					textVerbosity: "medium",
+					thinking: { type: "enabled", budgetTokens: 8000 },
+				},
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then - plan inherits ALL model-related settings from resolved prometheus
-    const agents = config.agent as Record<string, Record<string, unknown>>
-    expect(agents.plan).toBeDefined()
-    expect(agents.plan.mode).toBe("subagent")
-    expect(agents.plan.model).toBe("openai/gpt-5.4")
-    expect(agents.plan.variant).toBe("high")
-    expect(agents.plan.temperature).toBe(0.3)
-    expect(agents.plan.top_p).toBe(0.9)
-    expect(agents.plan.maxTokens).toBe(16000)
-    expect(agents.plan.reasoningEffort).toBe("high")
-    expect(agents.plan.textVerbosity).toBe("medium")
-    expect(agents.plan.thinking).toEqual({ type: "enabled", budgetTokens: 8000 })
-  })
+		//#then - plan inherits ALL model-related settings from resolved prometheus
+		const agents = config.agent as Record<string, Record<string, unknown>>;
+		expect(agents.plan).toBeDefined();
+		expect(agents.plan.mode).toBe("subagent");
+		expect(agents.plan.model).toBe("openai/gpt-5.4");
+		expect(agents.plan.variant).toBe("high");
+		expect(agents.plan.temperature).toBe(0.3);
+		expect(agents.plan.top_p).toBe(0.9);
+		expect(agents.plan.maxTokens).toBe(16000);
+		expect(agents.plan.reasoningEffort).toBe("high");
+		expect(agents.plan.textVerbosity).toBe("medium");
+		expect(agents.plan.thinking).toEqual({
+			type: "enabled",
+			budgetTokens: 8000,
+		});
+	});
 
-  test("plan agent user override takes priority over prometheus inherited settings", async () => {
-    //#given - prometheus resolves to opus, but user has plan override for gpt-5.4
-    spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
-      model: "anthropic/claude-opus-4-6",
-      provenance: "provider-fallback",
-      variant: "max",
-    })
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-        replace_plan: true,
-      },
-      agents: {
-        plan: {
-          model: "openai/gpt-5.4",
-          variant: "high",
-          temperature: 0.5,
-        },
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("plan agent user override takes priority over prometheus inherited settings", async () => {
+		//#given - prometheus resolves to opus, but user has plan override for gpt-5.4
+		spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
+			model: "anthropic/claude-opus-4-6",
+			provenance: "provider-fallback",
+			variant: "max",
+		});
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+				replace_plan: true,
+			},
+			agents: {
+				plan: {
+					model: "openai/gpt-5.4",
+					variant: "high",
+					temperature: 0.5,
+				},
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then - plan uses its own override, not prometheus settings
-    const agents = config.agent as Record<string, Record<string, unknown>>
-    expect(agents.plan.model).toBe("openai/gpt-5.4")
-    expect(agents.plan.variant).toBe("high")
-    expect(agents.plan.temperature).toBe(0.5)
-  })
+		//#then - plan uses its own override, not prometheus settings
+		const agents = config.agent as Record<string, Record<string, unknown>>;
+		expect(agents.plan.model).toBe("openai/gpt-5.4");
+		expect(agents.plan.variant).toBe("high");
+		expect(agents.plan.temperature).toBe(0.5);
+	});
 
-  test("plan agent does NOT inherit prompt, description, or color from prometheus", async () => {
-    //#given
-    spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
-      model: "anthropic/claude-opus-4-6",
-      provenance: "provider-fallback",
-      variant: "max",
-    })
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-        replace_plan: true,
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("plan agent does NOT inherit prompt, description, or color from prometheus", async () => {
+		//#given
+		spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
+			model: "anthropic/claude-opus-4-6",
+			provenance: "provider-fallback",
+			variant: "max",
+		});
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+				replace_plan: true,
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then - plan has model settings but NOT prompt/description/color
-    const agents = config.agent as Record<string, Record<string, unknown>>
-    expect(agents.plan.model).toBe("anthropic/claude-opus-4-6")
-    expect(agents.plan.prompt).toBeUndefined()
-    expect(agents.plan.description).toBeUndefined()
-    expect(agents.plan.color).toBeUndefined()
-  })
-})
+		//#then - plan has model settings but NOT prompt/description/color
+		const agents = config.agent as Record<string, Record<string, unknown>>;
+		expect(agents.plan.model).toBe("anthropic/claude-opus-4-6");
+		expect(agents.plan.prompt).toBeUndefined();
+		expect(agents.plan.description).toBeUndefined();
+		expect(agents.plan.color).toBeUndefined();
+	});
+});
 
 describe("Deadlock prevention - fetchAvailableModels must not receive client", () => {
-  test("fetchAvailableModels should be called with undefined client to prevent deadlock during plugin init", async () => {
-    // given - This test ensures we don't regress on issue #1301
-    // Passing client to fetchAvailableModels during config handler causes deadlock:
-    // - Plugin init waits for server response (client.provider.list())
-    // - Server waits for plugin init to complete before handling requests
-    const fetchSpy = spyOn(shared, "fetchAvailableModels" as any).mockResolvedValue(new Set<string>())
+	test("fetchAvailableModels should be called with undefined client to prevent deadlock during plugin init", async () => {
+		// given - This test ensures we don't regress on issue #1301
+		// Passing client to fetchAvailableModels during config handler causes deadlock:
+		// - Plugin init waits for server response (client.provider.list())
+		// - Server waits for plugin init to complete before handling requests
+		const fetchSpy = spyOn(
+			shared,
+			"fetchAvailableModels" as any,
+		).mockResolvedValue(new Set<string>());
 
-    const pluginConfig: OhMyOpenCodeConfig = {
-      sisyphus_agent: {
-        planner_enabled: true,
-      },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const mockClient = {
-      provider: { list: () => Promise.resolve({ data: { connected: [] } }) },
-      model: { list: () => Promise.resolve({ data: [] }) },
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp", client: mockClient },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+		const pluginConfig: OhMyOpenCodeConfig = {
+			sisyphus_agent: {
+				planner_enabled: true,
+			},
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const mockClient = {
+			provider: { list: () => Promise.resolve({ data: { connected: [] } }) },
+			model: { list: () => Promise.resolve({ data: [] }) },
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp", client: mockClient },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    // when
-    await handler(config)
+		// when
+		await handler(config);
 
-    // then - fetchAvailableModels must be called with undefined as first argument (no client)
-    // This prevents the deadlock described in issue #1301
-    expect(fetchSpy).toHaveBeenCalled()
-    const firstCallArgs = fetchSpy.mock.calls[0]
-    expect(firstCallArgs[0]).toBeUndefined()
+		// then - fetchAvailableModels must be called with undefined as first argument (no client)
+		// This prevents the deadlock described in issue #1301
+		expect(fetchSpy).toHaveBeenCalled();
+		const firstCallArgs = fetchSpy.mock.calls[0];
+		expect(firstCallArgs[0]).toBeUndefined();
 
-    fetchSpy.mockRestore?.()
-  })
-})
+		fetchSpy.mockRestore?.();
+	});
+});
 
 describe("config-handler plugin loading error boundary (#1559)", () => {
-  test("returns empty defaults when loadAllPluginComponents throws", async () => {
-    //#given
-    ;(pluginLoader.loadAllPluginComponents as any).mockRestore?.()
-    spyOn(pluginLoader, "loadAllPluginComponents" as any).mockRejectedValue(new Error("crash"))
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("returns empty defaults when loadAllPluginComponents throws", async () => {
+		//#given
+		(pluginLoader.loadAllPluginComponents as any).mockRestore?.();
+		spyOn(pluginLoader, "loadAllPluginComponents" as any).mockRejectedValue(
+			new Error("crash"),
+		);
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then
-    expect(config.agent).toBeDefined()
-  })
+		//#then
+		expect(config.agent).toBeDefined();
+	});
 
-  test("returns empty defaults when loadAllPluginComponents times out", async () => {
-    //#given
-    ;(pluginLoader.loadAllPluginComponents as any).mockRestore?.()
-    spyOn(pluginLoader, "loadAllPluginComponents" as any).mockImplementation(
-      () => new Promise(() => {})
-    )
-    const pluginConfig: OhMyOpenCodeConfig = {
-      experimental: { plugin_load_timeout_ms: 100 },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("returns empty defaults when loadAllPluginComponents times out", async () => {
+		//#given
+		(pluginLoader.loadAllPluginComponents as any).mockRestore?.();
+		spyOn(pluginLoader, "loadAllPluginComponents" as any).mockImplementation(
+			() => new Promise(() => {}),
+		);
+		const pluginConfig: OhMyOpenCodeConfig = {
+			experimental: { plugin_load_timeout_ms: 100 },
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then
-    expect(config.agent).toBeDefined()
-  }, 5000)
+		//#then
+		expect(config.agent).toBeDefined();
+	}, 5000);
 
-  test("logs error when loadAllPluginComponents fails", async () => {
-    //#given
-    ;(pluginLoader.loadAllPluginComponents as any).mockRestore?.()
-    spyOn(pluginLoader, "loadAllPluginComponents" as any).mockRejectedValue(new Error("crash"))
-    const logSpy = shared.log as ReturnType<typeof spyOn>
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("logs error when loadAllPluginComponents fails", async () => {
+		//#given
+		(pluginLoader.loadAllPluginComponents as any).mockRestore?.();
+		spyOn(pluginLoader, "loadAllPluginComponents" as any).mockRejectedValue(
+			new Error("crash"),
+		);
+		const logSpy = shared.log as ReturnType<typeof spyOn>;
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then
-    const logCalls = logSpy.mock.calls.map((c: unknown[]) => c[0])
-    const hasPluginFailureLog = logCalls.some(
-      (msg: string) => typeof msg === "string" && msg.includes("Plugin loading failed")
-    )
-    expect(hasPluginFailureLog).toBe(true)
-  })
+		//#then
+		const logCalls = logSpy.mock.calls.map((c: unknown[]) => c[0]);
+		const hasPluginFailureLog = logCalls.some(
+			(msg: string) =>
+				typeof msg === "string" && msg.includes("Plugin loading failed"),
+		);
+		expect(hasPluginFailureLog).toBe(true);
+	});
 
-  test("passes through plugin data on successful load (identity test)", async () => {
-    //#given
-    ;(pluginLoader.loadAllPluginComponents as any).mockRestore?.()
-    spyOn(pluginLoader, "loadAllPluginComponents" as any).mockResolvedValue({
-      commands: { "test-cmd": { description: "test", template: "test" } },
-      skills: {},
-      agents: {},
-      mcpServers: {},
-      hooksConfigs: [],
-      plugins: [{ name: "test-plugin", version: "1.0.0" }],
-      errors: [],
-    })
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+	test("passes through plugin data on successful load (identity test)", async () => {
+		//#given
+		(pluginLoader.loadAllPluginComponents as any).mockRestore?.();
+		spyOn(pluginLoader, "loadAllPluginComponents" as any).mockResolvedValue({
+			commands: { "test-cmd": { description: "test", template: "test" } },
+			skills: {},
+			agents: {},
+			mcpServers: {},
+			hooksConfigs: [],
+			plugins: [{ name: "test-plugin", version: "1.0.0" }],
+			errors: [],
+		});
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then
-    const commands = config.command as Record<string, unknown>
-    expect(commands["test-cmd"]).toBeDefined()
-  })
-})
+		//#then
+		const commands = config.command as Record<string, unknown>;
+		expect(commands["test-cmd"]).toBeDefined();
+	});
+});
 
 describe("per-agent todowrite/todoread deny when task_system enabled", () => {
-  const AGENTS_WITH_TODO_DENY = new Set([
-    getAgentDisplayName("sisyphus"),
-    getAgentDisplayName("hephaestus"),
-    getAgentDisplayName("atlas"),
-    getAgentDisplayName("prometheus"),
-    getAgentDisplayName("sisyphus-junior"),
-  ])
+	const AGENTS_WITH_TODO_DENY = new Set([
+		getAgentDisplayName("sisyphus"),
+		getAgentDisplayName("hephaestus"),
+		getAgentDisplayName("atlas"),
+		getAgentDisplayName("prometheus"),
+		getAgentDisplayName("sisyphus-junior"),
+	]);
 
-  test("denies todowrite and todoread for primary agents when task_system is enabled", async () => {
-    //#given
-    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
-      mockResolvedValue: (value: Record<string, unknown>) => void
-    }
-    createBuiltinAgentsMock.mockResolvedValue({
-      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
-      hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
-      atlas: { name: "atlas", prompt: "test", mode: "primary" },
-      prometheus: { name: "prometheus", prompt: "test", mode: "primary" },
-      "sisyphus-junior": { name: "sisyphus-junior", prompt: "test", mode: "subagent" },
-      oracle: { name: "oracle", prompt: "test", mode: "subagent" },
-    })
+	test("denies todowrite and todoread for primary agents when task_system is enabled", async () => {
+		//#given
+		const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+			mockResolvedValue: (value: Record<string, unknown>) => void;
+		};
+		createBuiltinAgentsMock.mockResolvedValue({
+			sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+			hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
+			atlas: { name: "atlas", prompt: "test", mode: "primary" },
+			prometheus: { name: "prometheus", prompt: "test", mode: "primary" },
+			"sisyphus-junior": {
+				name: "sisyphus-junior",
+				prompt: "test",
+				mode: "subagent",
+			},
+			oracle: { name: "oracle", prompt: "test", mode: "subagent" },
+		});
 
-    const pluginConfig: OhMyOpenCodeConfig = {
-      experimental: { task_system: true },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+		const pluginConfig: OhMyOpenCodeConfig = {
+			experimental: { task_system: true },
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then
-    const agentResult = config.agent as Record<string, { permission?: Record<string, unknown> }>
-    for (const agentName of AGENTS_WITH_TODO_DENY) {
-      expect(agentResult[agentName]?.permission?.todowrite).toBe("deny")
-      expect(agentResult[agentName]?.permission?.todoread).toBe("deny")
-    }
-  })
+		//#then
+		const agentResult = config.agent as Record<
+			string,
+			{ permission?: Record<string, unknown> }
+		>;
+		for (const agentName of AGENTS_WITH_TODO_DENY) {
+			expect(agentResult[agentName]?.permission?.todowrite).toBe("deny");
+			expect(agentResult[agentName]?.permission?.todoread).toBe("deny");
+		}
+	});
 
-  test("does not deny todowrite/todoread when task_system is disabled", async () => {
-    //#given
-    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
-      mockResolvedValue: (value: Record<string, unknown>) => void
-    }
-    createBuiltinAgentsMock.mockResolvedValue({
-      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
-      hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
-    })
+	test("does not deny todowrite/todoread when task_system is disabled", async () => {
+		//#given
+		const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+			mockResolvedValue: (value: Record<string, unknown>) => void;
+		};
+		createBuiltinAgentsMock.mockResolvedValue({
+			sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+			hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
+		});
 
-    const pluginConfig: OhMyOpenCodeConfig = {
-      experimental: { task_system: false },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+		const pluginConfig: OhMyOpenCodeConfig = {
+			experimental: { task_system: false },
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then
-    const agentResult = config.agent as Record<string, { permission?: Record<string, unknown> }>
-    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
-    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
-    expect(agentResult[getAgentDisplayName("hephaestus")]?.permission?.todowrite).toBeUndefined()
-    expect(agentResult[getAgentDisplayName("hephaestus")]?.permission?.todoread).toBeUndefined()
-  })
+		//#then
+		const agentResult = config.agent as Record<
+			string,
+			{ permission?: Record<string, unknown> }
+		>;
+		expect(
+			agentResult[getAgentDisplayName("sisyphus")]?.permission?.todowrite,
+		).toBeUndefined();
+		expect(
+			agentResult[getAgentDisplayName("sisyphus")]?.permission?.todoread,
+		).toBeUndefined();
+		expect(
+			agentResult[getAgentDisplayName("hephaestus")]?.permission?.todowrite,
+		).toBeUndefined();
+		expect(
+			agentResult[getAgentDisplayName("hephaestus")]?.permission?.todoread,
+		).toBeUndefined();
+	});
 
-  test("does not deny todowrite/todoread when task_system is undefined", async () => {
-    //#given
-    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
-      mockResolvedValue: (value: Record<string, unknown>) => void
-    }
-    createBuiltinAgentsMock.mockResolvedValue({
-      sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
-    })
+	test("does not deny todowrite/todoread when task_system is undefined", async () => {
+		//#given
+		const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+			mockResolvedValue: (value: Record<string, unknown>) => void;
+		};
+		createBuiltinAgentsMock.mockResolvedValue({
+			sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+		});
 
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then
-    const agentResult = config.agent as Record<string, { permission?: Record<string, unknown> }>
-    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
-    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
-  })
-})
+		//#then
+		const agentResult = config.agent as Record<
+			string,
+			{ permission?: Record<string, unknown> }
+		>;
+		expect(
+			agentResult[getAgentDisplayName("sisyphus")]?.permission?.todowrite,
+		).toBeUndefined();
+		expect(
+			agentResult[getAgentDisplayName("sisyphus")]?.permission?.todoread,
+		).toBeUndefined();
+	});
+});
 
 describe("disable_omo_env pass-through", () => {
-  test("passes disable_omo_env=true to createBuiltinAgents", async () => {
-    //#given
-    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
-      mockResolvedValue: (value: Record<string, unknown>) => void
-      mock: { calls: unknown[][] }
-    }
-    createBuiltinAgentsMock.mockResolvedValue({
-      sisyphus: { name: "sisyphus", prompt: "without-env", mode: "primary" },
-    })
+	test("passes disable_omo_env=true to createBuiltinAgents", async () => {
+		//#given
+		const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+			mockResolvedValue: (value: Record<string, unknown>) => void;
+			mock: { calls: unknown[][] };
+		};
+		createBuiltinAgentsMock.mockResolvedValue({
+			sisyphus: { name: "sisyphus", prompt: "without-env", mode: "primary" },
+		});
 
-    const pluginConfig: OhMyOpenCodeConfig = {
-      experimental: { disable_omo_env: true },
-    }
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+		const pluginConfig: OhMyOpenCodeConfig = {
+			experimental: { disable_omo_env: true },
+		};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then
-    const lastCall =
-      createBuiltinAgentsMock.mock.calls[createBuiltinAgentsMock.mock.calls.length - 1]
-    expect(lastCall).toBeDefined()
-    expect(lastCall?.[12]).toBe(true)
-  })
+		//#then
+		const lastCall =
+			createBuiltinAgentsMock.mock.calls[
+				createBuiltinAgentsMock.mock.calls.length - 1
+			];
+		expect(lastCall).toBeDefined();
+		expect(lastCall?.[12]).toBe(true);
+	});
 
-  test("passes disable_omo_env=false to createBuiltinAgents when omitted", async () => {
-    //#given
-    const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
-      mockResolvedValue: (value: Record<string, unknown>) => void
-      mock: { calls: unknown[][] }
-    }
-    createBuiltinAgentsMock.mockResolvedValue({
-      sisyphus: { name: "sisyphus", prompt: "with-env", mode: "primary" },
-    })
+	test("passes disable_omo_env=false to createBuiltinAgents when omitted", async () => {
+		//#given
+		const createBuiltinAgentsMock = agents.createBuiltinAgents as unknown as {
+			mockResolvedValue: (value: Record<string, unknown>) => void;
+			mock: { calls: unknown[][] };
+		};
+		createBuiltinAgentsMock.mockResolvedValue({
+			sisyphus: { name: "sisyphus", prompt: "with-env", mode: "primary" },
+		});
 
-    const pluginConfig: OhMyOpenCodeConfig = {}
-    const config: Record<string, unknown> = {
-      model: "anthropic/claude-opus-4-6",
-      agent: {},
-    }
-    const handler = createConfigHandler({
-      ctx: { directory: "/tmp" },
-      pluginConfig,
-      modelCacheState: {
-        anthropicContext1MEnabled: false,
-        modelContextLimitsCache: new Map(),
-      },
-    })
+		const pluginConfig: OhMyOpenCodeConfig = {};
+		const config: Record<string, unknown> = {
+			model: "anthropic/claude-opus-4-6",
+			agent: {},
+		};
+		const handler = createConfigHandler({
+			ctx: { directory: "/tmp" },
+			pluginConfig,
+			modelCacheState: {
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache: new Map(),
+			},
+		});
 
-    //#when
-    await handler(config)
+		//#when
+		await handler(config);
 
-    //#then
-    const lastCall =
-      createBuiltinAgentsMock.mock.calls[createBuiltinAgentsMock.mock.calls.length - 1]
-    expect(lastCall).toBeDefined()
-    expect(lastCall?.[12]).toBe(false)
-  })
-})
+		//#then
+		const lastCall =
+			createBuiltinAgentsMock.mock.calls[
+				createBuiltinAgentsMock.mock.calls.length - 1
+			];
+		expect(lastCall).toBeDefined();
+		expect(lastCall?.[12]).toBe(false);
+	});
+});

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -3,128 +3,148 @@ import { getAgentDisplayName } from "../shared/agent-display-names";
 
 type AgentWithPermission = { permission?: Record<string, unknown> };
 
-function getConfigQuestionPermission(): string | null {
-  const configContent = process.env.OPENCODE_CONFIG_CONTENT;
-  if (!configContent) return null;
-  try {
-    const parsed = JSON.parse(configContent);
-    return parsed?.permission?.question ?? null;
-  } catch {
-    return null;
-  }
+function updateAgentPermissions(
+	agentResult: Record<string, unknown>,
+	key: string,
+	permissionUpdate: Record<string, unknown>,
+): void {
+	const aliases = new Set([key, getAgentDisplayName(key)]);
+
+	for (const alias of aliases) {
+		const agent = agentResult[alias] as AgentWithPermission | undefined;
+		if (!agent) continue;
+		agent.permission = { ...agent.permission, ...permissionUpdate };
+	}
 }
 
-function agentByKey(agentResult: Record<string, unknown>, key: string): AgentWithPermission | undefined {
-  return (agentResult[key] ?? agentResult[getAgentDisplayName(key)]) as
-    | AgentWithPermission
-    | undefined;
+function getConfigQuestionPermission(): string | null {
+	const configContent = process.env.OPENCODE_CONFIG_CONTENT;
+	if (!configContent) return null;
+	try {
+		const parsed = JSON.parse(configContent);
+		return parsed?.permission?.question ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function agentByKey(
+	agentResult: Record<string, unknown>,
+	key: string,
+): AgentWithPermission | undefined {
+	return (agentResult[key] ?? agentResult[getAgentDisplayName(key)]) as
+		| AgentWithPermission
+		| undefined;
 }
 
 export function applyToolConfig(params: {
-  config: Record<string, unknown>;
-  pluginConfig: OhMyOpenCodeConfig;
-  agentResult: Record<string, unknown>;
+	config: Record<string, unknown>;
+	pluginConfig: OhMyOpenCodeConfig;
+	agentResult: Record<string, unknown>;
 }): void {
-  const denyTodoTools = params.pluginConfig.experimental?.task_system
-    ? { todowrite: "deny", todoread: "deny" }
-    : {}
+	const denyTodoTools = params.pluginConfig.experimental?.task_system
+		? { todowrite: "deny", todoread: "deny" }
+		: {};
 
-  const existingPermission = params.config.permission as Record<string, unknown> | undefined;
-  const skillDeniedByHost = existingPermission?.skill === "deny";
+	const existingPermission = params.config.permission as
+		| Record<string, unknown>
+		| undefined;
+	const skillDeniedByHost = existingPermission?.skill === "deny";
 
-  params.config.tools = {
-    ...(params.config.tools as Record<string, unknown>),
-    "grep_app_*": false,
-    LspHover: false,
-    LspCodeActions: false,
-    LspCodeActionResolve: false,
-    "task_*": false,
-    teammate: false,
-    ...(params.pluginConfig.experimental?.task_system
-      ? { todowrite: false, todoread: false }
-      : {}),
-    ...(skillDeniedByHost
-      ? { skill: false, skill_mcp: false }
-      : {}),
-  };
+	params.config.tools = {
+		...(params.config.tools as Record<string, unknown>),
+		"grep_app_*": false,
+		LspHover: false,
+		LspCodeActions: false,
+		LspCodeActionResolve: false,
+		"task_*": false,
+		teammate: false,
+		...(params.pluginConfig.experimental?.task_system
+			? { todowrite: false, todoread: false }
+			: {}),
+		...(skillDeniedByHost ? { skill: false, skill_mcp: false } : {}),
+	};
 
-  const isCliRunMode = process.env.OPENCODE_CLI_RUN_MODE === "true";
-  const configQuestionPermission = getConfigQuestionPermission();
-  const isQuestionDisabledByPlugin = params.pluginConfig.disabled_tools?.includes("question") ?? false;
-  const questionPermission =
-    isQuestionDisabledByPlugin ? "deny" :
-    configQuestionPermission === "deny" ? "deny" :
-    isCliRunMode ? "deny" :
-    "allow";
+	const isCliRunMode = process.env.OPENCODE_CLI_RUN_MODE === "true";
+	const configQuestionPermission = getConfigQuestionPermission();
+	const isQuestionDisabledByPlugin =
+		params.pluginConfig.disabled_tools?.includes("question") ?? false;
+	const questionPermission = isQuestionDisabledByPlugin
+		? "deny"
+		: configQuestionPermission === "deny"
+			? "deny"
+			: isCliRunMode
+				? "deny"
+				: "allow";
 
-  const librarian = agentByKey(params.agentResult, "librarian");
-  if (librarian) {
-    librarian.permission = { ...librarian.permission, "grep_app_*": "allow" };
-  }
-  const looker = agentByKey(params.agentResult, "multimodal-looker");
-  if (looker) {
-    looker.permission = { ...looker.permission, task: "deny", look_at: "deny" };
-  }
-  const atlas = agentByKey(params.agentResult, "atlas");
-  if (atlas) {
-    atlas.permission = {
-      ...atlas.permission,
-      task: "allow",
-      call_omo_agent: "deny",
-      "task_*": "allow",
-      teammate: "allow",
-      ...denyTodoTools,
-    };
-  }
-  const sisyphus = agentByKey(params.agentResult, "sisyphus");
-  if (sisyphus) {
-    sisyphus.permission = {
-      ...sisyphus.permission,
-      call_omo_agent: "deny",
-      task: "allow",
-      question: questionPermission,
-      "task_*": "allow",
-      teammate: "allow",
-      ...denyTodoTools,
-    };
-  }
-  const hephaestus = agentByKey(params.agentResult, "hephaestus");
-  if (hephaestus) {
-    hephaestus.permission = {
-      ...hephaestus.permission,
-      call_omo_agent: "deny",
-      task: "allow",
-      question: questionPermission,
-      ...denyTodoTools,
-    };
-  }
-  const prometheus = agentByKey(params.agentResult, "prometheus");
-  if (prometheus) {
-    prometheus.permission = {
-      ...prometheus.permission,
-      call_omo_agent: "deny",
-      task: "allow",
-      question: questionPermission,
-      "task_*": "allow",
-      teammate: "allow",
-      ...denyTodoTools,
-    };
-  }
-  const junior = agentByKey(params.agentResult, "sisyphus-junior");
-  if (junior) {
-    junior.permission = {
-      ...junior.permission,
-      task: "allow",
-      "task_*": "allow",
-      teammate: "allow",
-      ...denyTodoTools,
-    };
-  }
+	const librarian = agentByKey(params.agentResult, "librarian");
+	if (librarian) {
+		updateAgentPermissions(params.agentResult, "librarian", {
+			"grep_app_*": "allow",
+		});
+	}
+	const looker = agentByKey(params.agentResult, "multimodal-looker");
+	if (looker) {
+		updateAgentPermissions(params.agentResult, "multimodal-looker", {
+			task: "deny",
+			look_at: "deny",
+		});
+	}
+	const atlas = agentByKey(params.agentResult, "atlas");
+	if (atlas) {
+		updateAgentPermissions(params.agentResult, "atlas", {
+			task: "allow",
+			call_omo_agent: "deny",
+			"task_*": "allow",
+			teammate: "allow",
+			...denyTodoTools,
+		});
+	}
+	const sisyphus = agentByKey(params.agentResult, "sisyphus");
+	if (sisyphus) {
+		updateAgentPermissions(params.agentResult, "sisyphus", {
+			call_omo_agent: "deny",
+			task: "allow",
+			question: questionPermission,
+			"task_*": "allow",
+			teammate: "allow",
+			...denyTodoTools,
+		});
+	}
+	const hephaestus = agentByKey(params.agentResult, "hephaestus");
+	if (hephaestus) {
+		updateAgentPermissions(params.agentResult, "hephaestus", {
+			call_omo_agent: "deny",
+			task: "allow",
+			question: questionPermission,
+			...denyTodoTools,
+		});
+	}
+	const prometheus = agentByKey(params.agentResult, "prometheus");
+	if (prometheus) {
+		updateAgentPermissions(params.agentResult, "prometheus", {
+			call_omo_agent: "deny",
+			task: "allow",
+			question: questionPermission,
+			"task_*": "allow",
+			teammate: "allow",
+			...denyTodoTools,
+		});
+	}
+	const junior = agentByKey(params.agentResult, "sisyphus-junior");
+	if (junior) {
+		updateAgentPermissions(params.agentResult, "sisyphus-junior", {
+			task: "allow",
+			"task_*": "allow",
+			teammate: "allow",
+			...denyTodoTools,
+		});
+	}
 
-  params.config.permission = {
-    webfetch: "allow",
-    external_directory: "allow",
-    ...(params.config.permission as Record<string, unknown>),
-    task: "deny",
-  };
+	params.config.permission = {
+		webfetch: "allow",
+		external_directory: "allow",
+		...(params.config.permission as Record<string, unknown>),
+		task: "deny",
+	};
 }

--- a/src/plugin/tool-execute-before-session-notification.test.ts
+++ b/src/plugin/tool-execute-before-session-notification.test.ts
@@ -1,33 +1,44 @@
-const { describe, expect, test, spyOn } = require("bun:test")
+const { describe, expect, test, spyOn } = require("bun:test");
 
-const sessionState = require("../features/claude-code-session-state")
-const { createToolExecuteBeforeHandler } = require("./tool-execute-before")
+const sessionState = require("../features/claude-code-session-state");
+const { createToolExecuteBeforeHandler } = require("./tool-execute-before");
 
 describe("createToolExecuteBeforeHandler session notification sessionID", () => {
-  test("uses main session fallback when input sessionID is empty", async () => {
-    const mainSessionID = "ses_main"
-    const getMainSessionIDSpy = spyOn(sessionState, "getMainSessionID").mockReturnValue(mainSessionID)
+	test("uses main session fallback when input sessionID is empty", async () => {
+		const mainSessionID = "ses_main";
+		const getMainSessionIDSpy = spyOn(
+			sessionState,
+			"getMainSessionID",
+		).mockReturnValue(mainSessionID);
 
-    let capturedSessionID: string | undefined
-    const hooks = {
-      sessionNotification: async (input) => {
-        capturedSessionID = input.event.properties?.sessionID
-      },
-    }
+		try {
+			let capturedSessionID: string | undefined;
+			const hooks = {
+				sessionNotification: async (input) => {
+					capturedSessionID = input.event.properties?.sessionID;
+				},
+			};
 
-    const handler = createToolExecuteBeforeHandler({
-      ctx: { client: { session: { messages: async () => ({ data: [] }) } } },
-      hooks,
-    })
+			const handler = createToolExecuteBeforeHandler({
+				ctx: { client: { session: { messages: async () => ({ data: [] }) } } },
+				hooks,
+			});
 
-    await handler(
-      { tool: "question", sessionID: "", callID: "call_q" },
-      { args: { questions: [{ question: "Continue?", options: [{ label: "Yes" }] }] } },
-    )
+			await handler(
+				{ tool: "question", sessionID: "", callID: "call_q" },
+				{
+					args: {
+						questions: [{ question: "Continue?", options: [{ label: "Yes" }] }],
+					},
+				},
+			);
 
-    expect(getMainSessionIDSpy).toHaveBeenCalled()
-    expect(capturedSessionID).toBe(mainSessionID)
-  })
-})
+			expect(getMainSessionIDSpy).toHaveBeenCalled();
+			expect(capturedSessionID).toBe(mainSessionID);
+		} finally {
+			getMainSessionIDSpy.mockRestore();
+		}
+	});
+});
 
-export {}
+export {};

--- a/src/plugin/ultrawork-db-model-override.test.ts
+++ b/src/plugin/ultrawork-db-model-override.test.ts
@@ -1,45 +1,62 @@
-import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test"
-import { Database } from "bun:sqlite"
-import { mkdtempSync, mkdirSync, rmSync } from "node:fs"
-import { join } from "node:path"
-import { tmpdir } from "node:os"
-import * as dataPathModule from "../shared/data-path"
-import * as sharedModule from "../shared"
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as sharedModule from "../shared";
+import * as dataPathModule from "../shared/data-path";
 
 function flushMicrotasks(depth: number): Promise<void> {
-  return new Promise<void>((resolve) => {
-    let remaining = depth
-    function step() {
-      if (remaining <= 0) { resolve(); return }
-      remaining--
-      queueMicrotask(step)
-    }
-    queueMicrotask(step)
-  })
+	return new Promise<void>((resolve) => {
+		let remaining = depth;
+		function step() {
+			if (remaining <= 0) {
+				resolve();
+				return;
+			}
+			remaining--;
+			queueMicrotask(step);
+		}
+		queueMicrotask(step);
+	});
 }
 
 function flushWithTimeout(): Promise<void> {
-  return new Promise<void>((resolve) => setTimeout(resolve, 10))
+	return new Promise<void>((resolve) => setTimeout(resolve, 10));
+}
+
+async function waitForCondition(
+	condition: () => boolean,
+	timeoutMs = 250,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (condition()) {
+			return;
+		}
+		await flushWithTimeout();
+	}
+	throw new Error("Timed out waiting for condition");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
+	return typeof value === "object" && value !== null;
 }
 
 describe("scheduleDeferredModelOverride", () => {
-  let tempDir: string
-  let dbPath: string
-  let logSpy: ReturnType<typeof spyOn>
-  let getDataDirSpy: ReturnType<typeof spyOn>
+	let tempDir: string;
+	let dbPath: string;
+	let logSpy: ReturnType<typeof spyOn>;
+	let getDataDirSpy: ReturnType<typeof spyOn>;
 
-  beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), "ultrawork-db-test-"))
-    const opencodePath = join(tempDir, "opencode")
-    mkdirSync(opencodePath, { recursive: true })
-    dbPath = join(opencodePath, "opencode.db")
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "ultrawork-db-test-"));
+		const opencodePath = join(tempDir, "opencode");
+		mkdirSync(opencodePath, { recursive: true });
+		dbPath = join(opencodePath, "opencode.db");
 
-    const db = new Database(dbPath)
-    db.run(`
+		const db = new Database(dbPath);
+		db.run(`
       CREATE TABLE IF NOT EXISTS message (
         id TEXT PRIMARY KEY,
         session_id TEXT NOT NULL,
@@ -47,165 +64,222 @@ describe("scheduleDeferredModelOverride", () => {
         time_updated TEXT NOT NULL DEFAULT (datetime('now')),
         data TEXT NOT NULL DEFAULT '{}'
       )
-    `)
-    db.close()
+    `);
+		db.close();
 
-    getDataDirSpy = spyOn(dataPathModule, "getDataDir").mockReturnValue(tempDir)
-    logSpy = spyOn(sharedModule, "log").mockImplementation(() => {})
-  })
+		getDataDirSpy = spyOn(dataPathModule, "getDataDir").mockReturnValue(
+			tempDir,
+		);
+		logSpy = spyOn(sharedModule, "log").mockImplementation(() => {});
+	});
 
-  afterEach(() => {
-    getDataDirSpy?.mockRestore()
-    logSpy?.mockRestore()
-    rmSync(tempDir, { recursive: true, force: true })
-  })
+	afterEach(async () => {
+		getDataDirSpy?.mockRestore();
+		logSpy?.mockRestore();
+		await flushWithTimeout();
+		try {
+			rmSync(tempDir, { recursive: true, force: true });
+		} catch {
+			await flushWithTimeout();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 
-  function insertMessage(id: string, model: { providerID: string; modelID: string }) {
-    const db = new Database(dbPath)
-    db.run(
-      `INSERT INTO message (id, session_id, data) VALUES (?, ?, ?)`,
-      [id, "ses_test", JSON.stringify({ model })],
-    )
-    db.close()
-  }
+	function insertMessage(
+		id: string,
+		model: { providerID: string; modelID: string },
+	) {
+		const db = new Database(dbPath);
+		db.run(`INSERT INTO message (id, session_id, data) VALUES (?, ?, ?)`, [
+			id,
+			"ses_test",
+			JSON.stringify({ model }),
+		]);
+		db.close();
+	}
 
-  function readMessageModel(id: string): { providerID: string; modelID: string } | null {
-    const db = new Database(dbPath)
-    const row = db.query(`SELECT data FROM message WHERE id = ?`).get(id) as
-      | { data: string }
-      | null
-    db.close()
-    if (!row) return null
-    const parsed = JSON.parse(row.data)
-    return parsed.model ?? null
-  }
+	function readMessageModel(
+		id: string,
+	): { providerID: string; modelID: string } | null {
+		const db = new Database(dbPath);
+		const query = db.query(`SELECT data FROM message WHERE id = ?`);
+		const row = query.get(id) as {
+			data: string;
+		} | null;
+		query.finalize();
+		db.close();
+		if (!row) return null;
+		const parsed = JSON.parse(row.data);
+		return parsed.model ?? null;
+	}
 
-  function readMessageField(id: string, field: string): unknown {
-    const db = new Database(dbPath)
-    const row = db.query(`SELECT data FROM message WHERE id = ?`).get(id) as
-      | { data: string }
-      | null
-    db.close()
-    if (!row) return null
-    return JSON.parse(row.data)[field] ?? null
-  }
+	function readMessageField(id: string, field: string): unknown {
+		const db = new Database(dbPath);
+		const query = db.query(`SELECT data FROM message WHERE id = ?`);
+		const row = query.get(id) as {
+			data: string;
+		} | null;
+		query.finalize();
+		db.close();
+		if (!row) return null;
+		return JSON.parse(row.data)[field] ?? null;
+	}
 
-  test("should update model in DB after microtask flushes", async () => {
-    //#given
-    insertMessage("msg_001", { providerID: "anthropic", modelID: "claude-sonnet-4-6" })
+	test("should update model in DB after microtask flushes", async () => {
+		//#given
+		insertMessage("msg_001", {
+			providerID: "anthropic",
+			modelID: "claude-sonnet-4-6",
+		});
 
-    //#when
-    const { scheduleDeferredModelOverride } = await import("./ultrawork-db-model-override")
-    scheduleDeferredModelOverride(
-      "msg_001",
-      { providerID: "anthropic", modelID: "claude-opus-4-6" },
-    )
-    await flushMicrotasks(5)
+		//#when
+		const { scheduleDeferredModelOverride } = await import(
+			"./ultrawork-db-model-override"
+		);
+		scheduleDeferredModelOverride("msg_001", {
+			providerID: "anthropic",
+			modelID: "claude-opus-4-6",
+		});
+		await flushMicrotasks(5);
 
-    //#then
-    const model = readMessageModel("msg_001")
-    expect(model).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-6" })
-  })
+		//#then
+		const model = readMessageModel("msg_001");
+		expect(model).toEqual({
+			providerID: "anthropic",
+			modelID: "claude-opus-4-6",
+		});
+	});
 
-  test("should update variant and thinking fields when variant provided", async () => {
-    //#given
-    insertMessage("msg_002", { providerID: "anthropic", modelID: "claude-sonnet-4-6" })
+	test("should update variant and thinking fields when variant provided", async () => {
+		//#given
+		insertMessage("msg_002", {
+			providerID: "anthropic",
+			modelID: "claude-sonnet-4-6",
+		});
 
-    //#when
-    const { scheduleDeferredModelOverride } = await import("./ultrawork-db-model-override")
-    scheduleDeferredModelOverride(
-      "msg_002",
-      { providerID: "anthropic", modelID: "claude-opus-4-6" },
-      "max",
-    )
-    await flushMicrotasks(5)
+		//#when
+		const { scheduleDeferredModelOverride } = await import(
+			"./ultrawork-db-model-override"
+		);
+		scheduleDeferredModelOverride(
+			"msg_002",
+			{ providerID: "anthropic", modelID: "claude-opus-4-6" },
+			"max",
+		);
+		await flushMicrotasks(5);
 
-    //#then
-    expect(readMessageField("msg_002", "variant")).toBe("max")
-    expect(readMessageField("msg_002", "thinking")).toBe("max")
-  })
+		//#then
+		expect(readMessageField("msg_002", "variant")).toBe("max");
+		expect(readMessageField("msg_002", "thinking")).toBe("max");
+	});
 
-  test("should fall back to setTimeout when message never appears", async () => {
-    //#given — no message inserted
+	test("should fall back to setTimeout when message never appears", async () => {
+		//#given — no message inserted
 
-    //#when
-    const { scheduleDeferredModelOverride } = await import("./ultrawork-db-model-override")
-    scheduleDeferredModelOverride(
-      "msg_nonexistent",
-      { providerID: "anthropic", modelID: "claude-opus-4-6" },
-    )
-    await flushWithTimeout()
+		//#when
+		const { scheduleDeferredModelOverride } = await import(
+			"./ultrawork-db-model-override"
+		);
+		scheduleDeferredModelOverride("msg_nonexistent", {
+			providerID: "anthropic",
+			modelID: "claude-opus-4-6",
+		});
+		await waitForCondition(() =>
+			logSpy.mock.calls.some(
+				([message, metadata]) =>
+					typeof message === "string" &&
+					message.includes("setTimeout fallback failed") &&
+					isRecord(metadata) &&
+					metadata.messageId === "msg_nonexistent",
+			),
+		);
 
-    //#then
-    expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining("setTimeout fallback failed"),
-      expect.objectContaining({ messageId: "msg_nonexistent" }),
-    )
-  })
+		//#then
+		expect(
+			logSpy.mock.calls.some(
+				([message, metadata]) =>
+					typeof message === "string" &&
+					message.includes("setTimeout fallback failed") &&
+					isRecord(metadata) &&
+					metadata.messageId === "msg_nonexistent",
+			),
+		).toBe(true);
+	});
 
-  test("should not update variant fields when variant is undefined", async () => {
-    //#given
-    insertMessage("msg_003", { providerID: "anthropic", modelID: "claude-sonnet-4-6" })
+	test("should not update variant fields when variant is undefined", async () => {
+		//#given
+		insertMessage("msg_003", {
+			providerID: "anthropic",
+			modelID: "claude-sonnet-4-6",
+		});
 
-    //#when
-    const { scheduleDeferredModelOverride } = await import("./ultrawork-db-model-override")
-    scheduleDeferredModelOverride(
-      "msg_003",
-      { providerID: "anthropic", modelID: "claude-opus-4-6" },
-    )
-    await flushMicrotasks(5)
+		//#when
+		const { scheduleDeferredModelOverride } = await import(
+			"./ultrawork-db-model-override"
+		);
+		scheduleDeferredModelOverride("msg_003", {
+			providerID: "anthropic",
+			modelID: "claude-opus-4-6",
+		});
+		await flushMicrotasks(5);
 
-    //#then
-    const model = readMessageModel("msg_003")
-    expect(model).toEqual({ providerID: "anthropic", modelID: "claude-opus-4-6" })
-    expect(readMessageField("msg_003", "variant")).toBeNull()
-    expect(readMessageField("msg_003", "thinking")).toBeNull()
-  })
+		//#then
+		const model = readMessageModel("msg_003");
+		expect(model).toEqual({
+			providerID: "anthropic",
+			modelID: "claude-opus-4-6",
+		});
+		expect(readMessageField("msg_003", "variant")).toBeNull();
+		expect(readMessageField("msg_003", "thinking")).toBeNull();
+	});
 
-  test("should not crash when DB path does not exist", async () => {
-    //#given
-    getDataDirSpy.mockReturnValue("/nonexistent/path/that/does/not/exist")
+	test("should not crash when DB path does not exist", async () => {
+		//#given
+		getDataDirSpy.mockReturnValue("/nonexistent/path/that/does/not/exist");
 
-    //#when
-    const { scheduleDeferredModelOverride } = await import("./ultrawork-db-model-override")
-    scheduleDeferredModelOverride(
-      "msg_004",
-      { providerID: "anthropic", modelID: "claude-opus-4-6" },
-    )
-    await flushMicrotasks(5)
+		//#when
+		const { scheduleDeferredModelOverride } = await import(
+			"./ultrawork-db-model-override"
+		);
+		scheduleDeferredModelOverride("msg_004", {
+			providerID: "anthropic",
+			modelID: "claude-opus-4-6",
+		});
+		await flushMicrotasks(5);
 
-    //#then
-    expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining("DB not found"),
-    )
-  })
+		//#then
+		expect(logSpy).toHaveBeenCalledWith(
+			expect.stringContaining("DB not found"),
+		);
+	});
 
-  test("should log a DB failure when DB file exists but is corrupted", async () => {
-    //#given
-    const { chmodSync, writeFileSync } = await import("node:fs")
-    const corruptedDbPath = join(tempDir, "opencode", "opencode.db")
-    writeFileSync(corruptedDbPath, "this is not a valid sqlite database file")
-    chmodSync(corruptedDbPath, 0o000)
+	test("should log a DB failure when DB file exists but is corrupted", async () => {
+		//#given
+		const { chmodSync, writeFileSync } = await import("node:fs");
+		const corruptedDbPath = join(tempDir, "opencode", "opencode.db");
+		writeFileSync(corruptedDbPath, "this is not a valid sqlite database file");
+		chmodSync(corruptedDbPath, 0o000);
 
-    //#when
-    const { scheduleDeferredModelOverride } = await import("./ultrawork-db-model-override")
-    scheduleDeferredModelOverride(
-      "msg_corrupt",
-      { providerID: "anthropic", modelID: "claude-opus-4-6" },
-    )
-    await flushMicrotasks(5)
+		//#when
+		const { scheduleDeferredModelOverride } = await import(
+			"./ultrawork-db-model-override"
+		);
+		scheduleDeferredModelOverride("msg_corrupt", {
+			providerID: "anthropic",
+			modelID: "claude-opus-4-6",
+		});
+		await flushMicrotasks(5);
 
-    //#then
-    const failureCall = logSpy.mock.calls.find(([message, metadata]) =>
-      typeof message === "string"
-      && (
-        message.includes("Failed to open DB")
-        || message.includes("Deferred DB update failed with error")
-      )
-      && isRecord(metadata)
-      && metadata.messageId === "msg_corrupt"
-    )
+		//#then
+		const failureCall = logSpy.mock.calls.find(
+			([message, metadata]) =>
+				typeof message === "string" &&
+				(message.includes("Failed to open DB") ||
+					message.includes("Deferred DB update failed with error")) &&
+				isRecord(metadata) &&
+				metadata.messageId === "msg_corrupt",
+		);
 
-    expect(failureCall).toBeDefined()
-  })
-})
+		expect(failureCall).toBeDefined();
+	});
+});

--- a/src/plugin/ultrawork-db-model-override.ts
+++ b/src/plugin/ultrawork-db-model-override.ts
@@ -1,103 +1,135 @@
-import { Database } from "bun:sqlite"
-import { join } from "node:path"
-import { existsSync } from "node:fs"
-import { getDataDir } from "../shared/data-path"
-import { log } from "../shared"
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { log } from "../shared";
+import { getDataDir } from "../shared/data-path";
 
 function getDbPath(): string {
-  return join(getDataDir(), "opencode", "opencode.db")
+	return join(getDataDir(), "opencode", "opencode.db");
 }
 
-const MAX_MICROTASK_RETRIES = 10
+const MAX_MICROTASK_RETRIES = 10;
 
 function tryUpdateMessageModel(
-  db: InstanceType<typeof Database>,
-  messageId: string,
-  targetModel: { providerID: string; modelID: string },
-  variant?: string,
+	db: InstanceType<typeof Database>,
+	messageId: string,
+	targetModel: { providerID: string; modelID: string },
+	variant?: string,
 ): boolean {
-  const stmt = db.prepare(
-    `UPDATE message SET data = json_set(data, '$.model.providerID', ?, '$.model.modelID', ?) WHERE id = ?`,
-  )
-  const result = stmt.run(targetModel.providerID, targetModel.modelID, messageId)
-  if (result.changes === 0) return false
-  if (variant) {
-    db.prepare(
-      `UPDATE message SET data = json_set(data, '$.variant', ?, '$.thinking', ?) WHERE id = ?`,
-    ).run(variant, variant, messageId)
-  }
-  return true
+	const stmt = db.prepare(
+		`UPDATE message SET data = json_set(data, '$.model.providerID', ?, '$.model.modelID', ?) WHERE id = ?`,
+	);
+	const result = stmt.run(
+		targetModel.providerID,
+		targetModel.modelID,
+		messageId,
+	);
+	stmt.finalize();
+	if (result.changes === 0) return false;
+	if (variant) {
+		const variantStmt = db.prepare(
+			`UPDATE message SET data = json_set(data, '$.variant', ?, '$.thinking', ?) WHERE id = ?`,
+		);
+		variantStmt.run(variant, variant, messageId);
+		variantStmt.finalize();
+	}
+	return true;
 }
 
 function retryViaMicrotask(
-  db: InstanceType<typeof Database>,
-  messageId: string,
-  targetModel: { providerID: string; modelID: string },
-  variant: string | undefined,
-  attempt: number,
+	dbPath: string,
+	messageId: string,
+	targetModel: { providerID: string; modelID: string },
+	variant: string | undefined,
+	attempt: number,
 ): void {
-  if (attempt >= MAX_MICROTASK_RETRIES) {
-    log("[ultrawork-db-override] Exhausted microtask retries, falling back to setTimeout", {
-      messageId,
-      attempt,
-    })
-    setTimeout(() => {
-      try {
-        if (tryUpdateMessageModel(db, messageId, targetModel, variant)) {
-          log(`[ultrawork-db-override] setTimeout fallback succeeded: ${targetModel.providerID}/${targetModel.modelID}`, { messageId })
-        } else {
-          log("[ultrawork-db-override] setTimeout fallback failed - message not found", { messageId })
-        }
-      } catch (error) {
-        log("[ultrawork-db-override] setTimeout fallback failed with error", {
-          messageId,
-          error: String(error),
-        })
-      } finally {
-        try {
-          db.close()
-        } catch (error) {
-          log("[ultrawork-db-override] Failed to close DB after setTimeout fallback", {
-            messageId,
-            error: String(error),
-          })
-        }
-      }
-    }, 0)
-    return
-  }
+	if (attempt >= MAX_MICROTASK_RETRIES) {
+		log(
+			"[ultrawork-db-override] Exhausted microtask retries, falling back to setTimeout",
+			{
+				messageId,
+				attempt,
+			},
+		);
+		setTimeout(() => {
+			let db: InstanceType<typeof Database> | undefined;
+			try {
+				db = new Database(dbPath);
+				if (tryUpdateMessageModel(db, messageId, targetModel, variant)) {
+					log(
+						`[ultrawork-db-override] setTimeout fallback succeeded: ${targetModel.providerID}/${targetModel.modelID}`,
+						{ messageId },
+					);
+				} else {
+					log(
+						"[ultrawork-db-override] setTimeout fallback failed - message not found",
+						{
+							messageId,
+						},
+					);
+				}
+			} catch (error) {
+				log("[ultrawork-db-override] setTimeout fallback failed with error", {
+					messageId,
+					error: String(error),
+				});
+			} finally {
+				if (db) {
+					try {
+						db.close();
+					} catch (error) {
+						log(
+							"[ultrawork-db-override] Failed to close DB after setTimeout fallback",
+							{
+								messageId,
+								error: String(error),
+							},
+						);
+					}
+				}
+			}
+		}, 0);
+		return;
+	}
 
-  queueMicrotask(() => {
-    let shouldCloseDb = true
+	queueMicrotask(() => {
+		let db: InstanceType<typeof Database> | undefined;
 
-    try {
-      if (tryUpdateMessageModel(db, messageId, targetModel, variant)) {
-        log(`[ultrawork-db-override] Deferred DB update (attempt ${attempt}): ${targetModel.providerID}/${targetModel.modelID}`, { messageId })
-        return
-      }
+		try {
+			db = new Database(dbPath);
 
-      shouldCloseDb = false
-      retryViaMicrotask(db, messageId, targetModel, variant, attempt + 1)
-    } catch (error) {
-      log("[ultrawork-db-override] Deferred DB update failed with error", {
-        messageId,
-        attempt,
-        error: String(error),
-      })
-    } finally {
-      if (shouldCloseDb) {
-        try {
-          db.close()
-        } catch (error) {
-          log("[ultrawork-db-override] Failed to close DB after deferred DB update", {
-            messageId,
-            attempt,
-            error: String(error),
-          })
-        }
-      }
-    }
-  })
+			if (tryUpdateMessageModel(db, messageId, targetModel, variant)) {
+				log(
+					`[ultrawork-db-override] Deferred DB update (attempt ${attempt}): ${targetModel.providerID}/${targetModel.modelID}`,
+					{ messageId },
+				);
+				return;
+			}
+
+			retryViaMicrotask(dbPath, messageId, targetModel, variant, attempt + 1);
+		} catch (error) {
+			log("[ultrawork-db-override] Deferred DB update failed with error", {
+				messageId,
+				attempt,
+				error: String(error),
+			});
+		} finally {
+			if (db) {
+				try {
+					db.close();
+				} catch (error) {
+					log(
+						"[ultrawork-db-override] Failed to close DB after deferred DB update",
+						{
+							messageId,
+							attempt,
+							error: String(error),
+						},
+					);
+				}
+			}
+		}
+	});
 }
 
 /**
@@ -108,35 +140,17 @@ function retryViaMicrotask(
  * Falls back to setTimeout(fn, 0) after 10 microtask attempts.
  */
 export function scheduleDeferredModelOverride(
-  messageId: string,
-  targetModel: { providerID: string; modelID: string },
-  variant?: string,
+	messageId: string,
+	targetModel: { providerID: string; modelID: string },
+	variant?: string,
 ): void {
-  queueMicrotask(() => {
-    const dbPath = getDbPath()
-    if (!existsSync(dbPath)) {
-      log("[ultrawork-db-override] DB not found, skipping deferred override")
-      return
-    }
+	queueMicrotask(() => {
+		const dbPath = getDbPath();
+		if (!existsSync(dbPath)) {
+			log("[ultrawork-db-override] DB not found, skipping deferred override");
+			return;
+		}
 
-    let db: InstanceType<typeof Database>
-    try {
-      db = new Database(dbPath)
-    } catch (error) {
-      log("[ultrawork-db-override] Failed to open DB, skipping deferred override", {
-        messageId,
-        error: String(error),
-      })
-      return
-    }
-
-    try {
-      retryViaMicrotask(db, messageId, targetModel, variant, 0)
-    } catch (error) {
-      log("[ultrawork-db-override] Failed to apply deferred model override", {
-        error: String(error),
-      })
-      db.close()
-    }
-  })
+		retryViaMicrotask(dbPath, messageId, targetModel, variant, 0);
+	});
 }

--- a/src/shared/context-limit-resolver.test.ts
+++ b/src/shared/context-limit-resolver.test.ts
@@ -1,142 +1,230 @@
-import process from "node:process"
-import { afterEach, describe, expect, it } from "bun:test"
+import { afterEach, describe, expect, it } from "bun:test";
+import process from "node:process";
 
-import { resolveActualContextLimit } from "./context-limit-resolver"
+import { resolveActualContextLimit } from "./context-limit-resolver";
 
-const ANTHROPIC_CONTEXT_ENV_KEY = "ANTHROPIC_1M_CONTEXT"
-const VERTEX_CONTEXT_ENV_KEY = "VERTEX_ANTHROPIC_1M_CONTEXT"
+const ANTHROPIC_CONTEXT_ENV_KEY = "ANTHROPIC_1M_CONTEXT";
+const VERTEX_CONTEXT_ENV_KEY = "VERTEX_ANTHROPIC_1M_CONTEXT";
 
-const originalAnthropicContextEnv = process.env[ANTHROPIC_CONTEXT_ENV_KEY]
-const originalVertexContextEnv = process.env[VERTEX_CONTEXT_ENV_KEY]
+const originalAnthropicContextEnv = process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+const originalVertexContextEnv = process.env[VERTEX_CONTEXT_ENV_KEY];
 
 function resetContextLimitEnv(): void {
-  if (originalAnthropicContextEnv === undefined) {
-    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
-  } else {
-    process.env[ANTHROPIC_CONTEXT_ENV_KEY] = originalAnthropicContextEnv
-  }
+	if (originalAnthropicContextEnv === undefined) {
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+	} else {
+		process.env[ANTHROPIC_CONTEXT_ENV_KEY] = originalAnthropicContextEnv;
+	}
 
-  if (originalVertexContextEnv === undefined) {
-    delete process.env[VERTEX_CONTEXT_ENV_KEY]
-  } else {
-    process.env[VERTEX_CONTEXT_ENV_KEY] = originalVertexContextEnv
-  }
+	if (originalVertexContextEnv === undefined) {
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
+	} else {
+		process.env[VERTEX_CONTEXT_ENV_KEY] = originalVertexContextEnv;
+	}
 }
 
 describe("resolveActualContextLimit", () => {
-  afterEach(() => {
-    resetContextLimitEnv()
-  })
+	afterEach(() => {
+		resetContextLimitEnv();
+	});
 
-  it("returns cached limit for Anthropic 4.6 models when 1M mode is disabled (GA support)", () => {
-    // given
-    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
-    delete process.env[VERTEX_CONTEXT_ENV_KEY]
-    const modelContextLimitsCache = new Map<string, number>()
-    modelContextLimitsCache.set("anthropic/claude-opus-4-6", 1_000_000)
+	it("returns cached limit for Anthropic 4.6 models when 1M mode is disabled (GA support)", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
+		const modelContextLimitsCache = new Map<string, number>();
+		modelContextLimitsCache.set("anthropic/claude-opus-4-6", 1_000_000);
 
-    // when
-    const actualLimit = resolveActualContextLimit("anthropic", "claude-opus-4-6", {
-      anthropicContext1MEnabled: false,
-      modelContextLimitsCache,
-    })
+		// when
+		const actualLimit = resolveActualContextLimit(
+			"anthropic",
+			"claude-opus-4-6",
+			{
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache,
+			},
+		);
 
-    // then — models.dev reports 1M for GA models, resolver should respect it
-    expect(actualLimit).toBe(1_000_000)
-  })
+		// then — models.dev reports 1M for GA models, resolver should respect it
+		expect(actualLimit).toBe(1_000_000);
+	});
 
-  it("returns cached limit for Anthropic models when modelContextLimitsCache has entry", () => {
-    // given
-    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
-    delete process.env[VERTEX_CONTEXT_ENV_KEY]
-    const modelContextLimitsCache = new Map<string, number>()
-    modelContextLimitsCache.set("anthropic/claude-sonnet-4-5", 500_000)
+	it("ignores cached limit for older Anthropic models when modelContextLimitsCache has entry", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
+		const modelContextLimitsCache = new Map<string, number>();
+		modelContextLimitsCache.set("anthropic/claude-sonnet-4-5", 500_000);
 
-    // when
-    const actualLimit = resolveActualContextLimit("anthropic", "claude-sonnet-4-5", {
-      anthropicContext1MEnabled: false,
-      modelContextLimitsCache,
-    })
+		// when
+		const actualLimit = resolveActualContextLimit(
+			"anthropic",
+			"claude-sonnet-4-5",
+			{
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache,
+			},
+		);
 
-    // then
-    expect(actualLimit).toBe(500_000)
-  })
+		// then
+		expect(actualLimit).toBe(200_000);
+	});
 
-  it("returns default 200K for Anthropic models without cached limit and 1M mode disabled", () => {
-    // given
-    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
-    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+	it("returns default 200K for Anthropic models without cached limit and 1M mode disabled", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
 
-    // when
-    const actualLimit = resolveActualContextLimit("anthropic", "claude-sonnet-4-5", {
-      anthropicContext1MEnabled: false,
-    })
+		// when
+		const actualLimit = resolveActualContextLimit(
+			"anthropic",
+			"claude-sonnet-4-5",
+			{
+				anthropicContext1MEnabled: false,
+			},
+		);
 
-    // then
-    expect(actualLimit).toBe(200_000)
-  })
+		// then
+		expect(actualLimit).toBe(200_000);
+	});
 
-  it("explicit 1M mode takes priority over cached limit", () => {
-    // given
-    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
-    delete process.env[VERTEX_CONTEXT_ENV_KEY]
-    const modelContextLimitsCache = new Map<string, number>()
-    modelContextLimitsCache.set("anthropic/claude-sonnet-4-5", 200_000)
+	it("explicit 1M mode takes priority over cached limit", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
+		const modelContextLimitsCache = new Map<string, number>();
+		modelContextLimitsCache.set("anthropic/claude-sonnet-4-5", 200_000);
 
-    // when
-    const actualLimit = resolveActualContextLimit("anthropic", "claude-sonnet-4-5", {
-      anthropicContext1MEnabled: true,
-      modelContextLimitsCache,
-    })
+		// when
+		const actualLimit = resolveActualContextLimit(
+			"anthropic",
+			"claude-sonnet-4-5",
+			{
+				anthropicContext1MEnabled: true,
+				modelContextLimitsCache,
+			},
+		);
 
-    // then — explicit 1M flag overrides cached 200K
-    expect(actualLimit).toBe(1_000_000)
-  })
+		// then — explicit 1M flag overrides cached 200K
+		expect(actualLimit).toBe(1_000_000);
+	});
 
-  it("treats Anthropics aliases as Anthropic providers", () => {
-    // given
-    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
-    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+	it("treats Anthropics aliases as Anthropic providers", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
 
-    // when
-    const actualLimit = resolveActualContextLimit(
-      "aws-bedrock-anthropic",
-      "claude-sonnet-4-5",
-      { anthropicContext1MEnabled: false },
-    )
+		// when
+		const actualLimit = resolveActualContextLimit(
+			"aws-bedrock-anthropic",
+			"claude-sonnet-4-5",
+			{
+				anthropicContext1MEnabled: false,
+			},
+		);
 
-    // then
-    expect(actualLimit).toBe(200000)
-  })
+		// then
+		expect(actualLimit).toBe(200000);
+	});
 
-  it("supports Anthropic 4.6 dot-version model IDs without explicit 1M mode", () => {
-    // given
-    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
-    delete process.env[VERTEX_CONTEXT_ENV_KEY]
-    const modelContextLimitsCache = new Map<string, number>()
-    modelContextLimitsCache.set("anthropic/claude-opus-4.6", 1_000_000)
+	it("supports Anthropic 4.6 dot-version model IDs without explicit 1M mode", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
+		const modelContextLimitsCache = new Map<string, number>();
+		modelContextLimitsCache.set("anthropic/claude-opus-4.6", 1_000_000);
 
-    // when
-    const actualLimit = resolveActualContextLimit("anthropic", "claude-opus-4.6", {
-      anthropicContext1MEnabled: false,
-      modelContextLimitsCache,
-    })
+		// when
+		const actualLimit = resolveActualContextLimit(
+			"anthropic",
+			"claude-opus-4.6",
+			{
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache,
+			},
+		);
 
-    // then
-    expect(actualLimit).toBe(1_000_000)
-  })
+		// then
+		expect(actualLimit).toBe(1_000_000);
+	});
 
-  it("returns null for non-Anthropic providers without a cached limit", () => {
-    // given
-    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
-    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+	it("supports dated Anthropic 4.6 GA model IDs without explicit 1M mode", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
+		const modelContextLimitsCache = new Map<string, number>();
+		modelContextLimitsCache.set(
+			"anthropic/claude-opus-4-6-20251101",
+			1_000_000,
+		);
 
-    // when
-    const actualLimit = resolveActualContextLimit("openai", "gpt-5", {
-      anthropicContext1MEnabled: false,
-    })
+		// when
+		const actualLimit = resolveActualContextLimit(
+			"anthropic",
+			"claude-opus-4-6-20251101",
+			{
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache,
+			},
+		);
 
-    // then
-    expect(actualLimit).toBeNull()
-  })
-})
+		// then
+		expect(actualLimit).toBe(1_000_000);
+	});
+
+	it("returns cached limit for approved Anthropic sonnet 4.6 model IDs when 1M mode is disabled", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
+		const modelContextLimitsCache = new Map<string, number>();
+		modelContextLimitsCache.set("anthropic/claude-sonnet-4-6", 1_000_000);
+
+		// when
+		const actualLimit = resolveActualContextLimit(
+			"anthropic",
+			"claude-sonnet-4-6",
+			{
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache,
+			},
+		);
+
+		// then
+		expect(actualLimit).toBe(1_000_000);
+	});
+
+	it("ignores cached limit for Anthropic 4.6-like aliases outside the approved model IDs", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
+		const modelContextLimitsCache = new Map<string, number>();
+		modelContextLimitsCache.set("anthropic/claude-opus-4-6-preview", 1_000_000);
+
+		// when
+		const actualLimit = resolveActualContextLimit(
+			"anthropic",
+			"claude-opus-4-6-preview",
+			{
+				anthropicContext1MEnabled: false,
+				modelContextLimitsCache,
+			},
+		);
+
+		// then
+		expect(actualLimit).toBe(200_000);
+	});
+
+	it("returns null for non-Anthropic providers without a cached limit", () => {
+		// given
+		delete process.env[ANTHROPIC_CONTEXT_ENV_KEY];
+		delete process.env[VERTEX_CONTEXT_ENV_KEY];
+
+		// when
+		const actualLimit = resolveActualContextLimit("openai", "gpt-5", {
+			anthropicContext1MEnabled: false,
+		});
+
+		// then
+		expect(actualLimit).toBeNull();
+	});
+});

--- a/src/shared/context-limit-resolver.ts
+++ b/src/shared/context-limit-resolver.ts
@@ -1,38 +1,57 @@
-import process from "node:process"
+import process from "node:process";
 
-const DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000
+const DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000;
+const ANTHROPIC_46_CACHED_LIMIT_PATTERN =
+	/^claude-(opus|sonnet)-4(?:[.-])6(?:-\d{8})?$/;
+
 export type ContextLimitModelCacheState = {
-  anthropicContext1MEnabled: boolean
-  modelContextLimitsCache?: Map<string, number>
-}
+	anthropicContext1MEnabled: boolean;
+	modelContextLimitsCache?: Map<string, number>;
+};
 
 function isAnthropicProvider(providerID: string): boolean {
-  const normalized = providerID.toLowerCase()
-  return normalized === "anthropic" || normalized === "google-vertex-anthropic" || normalized === "aws-bedrock-anthropic"
+	const normalized = providerID.toLowerCase();
+	return (
+		normalized === "anthropic" ||
+		normalized === "google-vertex-anthropic" ||
+		normalized === "aws-bedrock-anthropic"
+	);
 }
 
-function getAnthropicActualLimit(modelCacheState?: ContextLimitModelCacheState): number {
-  return (modelCacheState?.anthropicContext1MEnabled ?? false) ||
-    process.env.ANTHROPIC_1M_CONTEXT === "true" ||
-    process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
-    ? 1_000_000
-    : DEFAULT_ANTHROPIC_ACTUAL_LIMIT
+function getAnthropicActualLimit(
+	modelCacheState?: ContextLimitModelCacheState,
+): number {
+	return (modelCacheState?.anthropicContext1MEnabled ?? false) ||
+		process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+		process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+		? 1_000_000
+		: DEFAULT_ANTHROPIC_ACTUAL_LIMIT;
+}
+
+function supportsCachedAnthropicLimit(modelID: string): boolean {
+	return ANTHROPIC_46_CACHED_LIMIT_PATTERN.test(modelID.toLowerCase());
 }
 
 export function resolveActualContextLimit(
-  providerID: string,
-  modelID: string,
-  modelCacheState?: ContextLimitModelCacheState,
+	providerID: string,
+	modelID: string,
+	modelCacheState?: ContextLimitModelCacheState,
 ): number | null {
-  if (isAnthropicProvider(providerID)) {
-    const explicit1M = getAnthropicActualLimit(modelCacheState)
-    if (explicit1M === 1_000_000) return explicit1M
+	if (isAnthropicProvider(providerID)) {
+		const explicit1M = getAnthropicActualLimit(modelCacheState);
+		if (explicit1M === 1_000_000) return explicit1M;
 
-    const cachedLimit = modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`)
-    if (cachedLimit) return cachedLimit
+		const cachedLimit = modelCacheState?.modelContextLimitsCache?.get(
+			`${providerID}/${modelID}`,
+		);
+		if (cachedLimit && supportsCachedAnthropicLimit(modelID))
+			return cachedLimit;
 
-    return DEFAULT_ANTHROPIC_ACTUAL_LIMIT
-  }
+		return DEFAULT_ANTHROPIC_ACTUAL_LIMIT;
+	}
 
-  return modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`) ?? null
+	return (
+		modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`) ??
+		null
+	);
 }

--- a/src/shared/external-plugin-detector.ts
+++ b/src/shared/external-plugin-detector.ts
@@ -3,14 +3,14 @@
  * Used to prevent crashes from concurrent notification plugins.
  */
 
-import * as fs from "node:fs"
-import * as path from "node:path"
-import * as os from "node:os"
-import { log } from "./logger"
-import { parseJsoncSafe } from "./jsonc-parser"
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseJsoncSafe } from "./jsonc-parser";
+import { log } from "./logger";
 
 interface OpencodeConfig {
-  plugin?: string[]
+	plugin?: string[];
 }
 
 /**
@@ -19,59 +19,54 @@ interface OpencodeConfig {
  * which can cause crashes on Windows due to resource contention.
  */
 const KNOWN_NOTIFICATION_PLUGINS = [
-  "opencode-notifier",
-  "@mohak34/opencode-notifier",
-  "mohak34/opencode-notifier",
-]
+	"opencode-notifier",
+	"@mohak34/opencode-notifier",
+	"mohak34/opencode-notifier",
+];
 
 /**
  * Known skill plugins that conflict with oh-my-opencode's skill loading.
  * Both plugins scan ~/.config/opencode/skills/ and register tools independently,
  * causing "Duplicate tool names detected" warnings and HTTP 400 errors.
  */
-const KNOWN_SKILL_PLUGINS = [
-  "opencode-skills",
-  "@opencode/skills",
-]
+const KNOWN_SKILL_PLUGINS = ["opencode-skills", "@opencode/skills"];
 
 function getWindowsAppdataDir(): string | null {
-  return process.env.APPDATA || null
+	return process.env.APPDATA || null;
 }
 
 function getConfigPaths(directory: string): string[] {
-  const crossPlatformDir = path.join(os.homedir(), ".config")
-  const paths = [
-    path.join(directory, ".opencode", "opencode.json"),
-    path.join(directory, ".opencode", "opencode.jsonc"),
-    path.join(crossPlatformDir, "opencode", "opencode.json"),
-    path.join(crossPlatformDir, "opencode", "opencode.jsonc"),
-  ]
+	const crossPlatformDir = path.join(os.homedir(), ".config");
+	const paths = [
+		path.join(directory, ".opencode", "opencode.json"),
+		path.join(directory, ".opencode", "opencode.jsonc"),
+		path.join(crossPlatformDir, "opencode", "opencode.json"),
+		path.join(crossPlatformDir, "opencode", "opencode.jsonc"),
+	];
 
-  if (process.platform === "win32") {
-    const appdataDir = getWindowsAppdataDir()
-    if (appdataDir) {
-      paths.push(path.join(appdataDir, "opencode", "opencode.json"))
-      paths.push(path.join(appdataDir, "opencode", "opencode.jsonc"))
-    }
-  }
+	if (process.platform === "win32") {
+		const appdataDir = getWindowsAppdataDir();
+		if (appdataDir) {
+			paths.push(path.join(appdataDir, "opencode", "opencode.json"));
+			paths.push(path.join(appdataDir, "opencode", "opencode.jsonc"));
+		}
+	}
 
-  return paths
+	return paths;
 }
 
 function loadOpencodePlugins(directory: string): string[] {
-  for (const configPath of getConfigPaths(directory)) {
-    try {
-      if (!fs.existsSync(configPath)) continue
-      const content = fs.readFileSync(configPath, "utf-8")
-      const result = parseJsoncSafe<OpencodeConfig>(content)
-      if (result.data) {
-        return result.data.plugin ?? []
-      }
-    } catch {
-      continue
-    }
-  }
-  return []
+	for (const configPath of getConfigPaths(directory)) {
+		try {
+			if (!fs.existsSync(configPath)) continue;
+			const content = fs.readFileSync(configPath, "utf-8");
+			const result = parseJsoncSafe<OpencodeConfig>(content);
+			if (result.data) {
+				return result.data.plugin ?? [];
+			}
+		} catch {}
+	}
+	return [];
 }
 
 /**
@@ -79,23 +74,29 @@ function loadOpencodePlugins(directory: string): string[] {
  * Handles various formats: "name", "name@version", "npm:name", "file://path/name"
  */
 function matchesNotificationPlugin(entry: string): string | null {
-  const normalized = entry.toLowerCase()
-  for (const known of KNOWN_NOTIFICATION_PLUGINS) {
-    // Exact match
-    if (normalized === known) return known
-    // Version suffix: "opencode-notifier@1.2.3"
-    if (normalized.startsWith(`${known}@`)) return known
-    // Scoped package: "@mohak34/opencode-notifier" or "@mohak34/opencode-notifier@1.2.3"
-    if (normalized === `@mohak34/${known}` || normalized.startsWith(`@mohak34/${known}@`)) return known
-    // npm: prefix
-    if (normalized === `npm:${known}` || normalized.startsWith(`npm:${known}@`)) return known
-    // file:// path ending exactly with package name
-    if (normalized.startsWith("file://") && (
-      normalized.endsWith(`/${known}`) || 
-      normalized.endsWith(`\\${known}`)
-    )) return known
-  }
-  return null
+	const normalized = entry.toLowerCase();
+	for (const known of KNOWN_NOTIFICATION_PLUGINS) {
+		// Exact match
+		if (normalized === known) return known;
+		// Version suffix: "opencode-notifier@1.2.3"
+		if (normalized.startsWith(`${known}@`)) return known;
+		// Scoped package: "@mohak34/opencode-notifier" or "@mohak34/opencode-notifier@1.2.3"
+		if (
+			normalized === `@mohak34/${known}` ||
+			normalized.startsWith(`@mohak34/${known}@`)
+		)
+			return known;
+		// npm: prefix
+		if (normalized === `npm:${known}` || normalized.startsWith(`npm:${known}@`))
+			return known;
+		// file:// path ending exactly with package name
+		if (
+			normalized.startsWith("file://") &&
+			(normalized.endsWith(`/${known}`) || normalized.endsWith(`\\${known}`))
+		)
+			return known;
+	}
+	return null;
 }
 
 /**
@@ -103,92 +104,98 @@ function matchesNotificationPlugin(entry: string): string | null {
  * Handles various formats: "name", "name@version", "npm:name", "file://path/name"
  */
 function matchesSkillPlugin(entry: string): string | null {
-  const normalized = entry.toLowerCase()
-  for (const known of KNOWN_SKILL_PLUGINS) {
-    // Exact match
-    if (normalized === known) return known
-    // Version suffix: "opencode-skills@1.2.3"
-    if (normalized.startsWith(`${known}@`)) return known
-    // npm: prefix
-    if (normalized === `npm:${known}` || normalized.startsWith(`npm:${known}@`)) return known
-    // file:// path ending exactly with package name
-    if (normalized.startsWith("file://") && (
-      normalized.endsWith(`/${known}`) || 
-      normalized.endsWith(`\\${known}`)
-    )) return known
-  }
-  return null
+	const normalized = entry.toLowerCase();
+	for (const known of KNOWN_SKILL_PLUGINS) {
+		// Exact match
+		if (normalized === known) return known;
+		// Version suffix: "opencode-skills@1.2.3"
+		if (normalized.startsWith(`${known}@`)) return known;
+		// npm: prefix
+		if (normalized === `npm:${known}` || normalized.startsWith(`npm:${known}@`))
+			return known;
+		// file:// path ending exactly with package name
+		if (
+			normalized.startsWith("file://") &&
+			(normalized.endsWith(`/${known}`) || normalized.endsWith(`\\${known}`))
+		)
+			return known;
+	}
+	return null;
 }
 
 export interface ExternalNotifierResult {
-  detected: boolean
-  pluginName: string | null
-  allPlugins: string[]
+	detected: boolean;
+	pluginName: string | null;
+	allPlugins: string[];
 }
 
 export interface ExternalSkillPluginResult {
-  detected: boolean
-  pluginName: string | null
-  allPlugins: string[]
+	detected: boolean;
+	pluginName: string | null;
+	allPlugins: string[];
 }
 
 /**
  * Detect if any external notification plugin is configured.
  * Returns information about detected plugins for logging/warning.
  */
-export function detectExternalNotificationPlugin(directory: string): ExternalNotifierResult {
-  const plugins = loadOpencodePlugins(directory)
-  
-  for (const plugin of plugins) {
-    const match = matchesNotificationPlugin(plugin)
-    if (match) {
-      log(`Detected external notification plugin: ${plugin}`)
-      return {
-        detected: true,
-        pluginName: match,
-        allPlugins: plugins,
-      }
-    }
-  }
+export function detectExternalNotificationPlugin(
+	directory: string,
+): ExternalNotifierResult {
+	const plugins = loadOpencodePlugins(directory);
 
-  return {
-    detected: false,
-    pluginName: null,
-    allPlugins: plugins,
-  }
+	for (const plugin of plugins) {
+		const match = matchesNotificationPlugin(plugin);
+		if (match) {
+			log(`Detected external notification plugin: ${plugin}`);
+			return {
+				detected: true,
+				pluginName: match,
+				allPlugins: plugins,
+			};
+		}
+	}
+
+	return {
+		detected: false,
+		pluginName: null,
+		allPlugins: plugins,
+	};
 }
 
 /**
  * Detect if any external skill plugin is configured.
  * Returns information about detected plugins for logging/warning.
  */
-export function detectExternalSkillPlugin(directory: string): ExternalSkillPluginResult {
-  const plugins = loadOpencodePlugins(directory)
-  
-  for (const plugin of plugins) {
-    const match = matchesSkillPlugin(plugin)
-    if (match) {
-      log(`Detected external skill plugin: ${plugin}`)
-      return {
-        detected: true,
-        pluginName: match,
-        allPlugins: plugins,
-      }
-    }
-  }
+export function detectExternalSkillPlugin(
+	directory: string,
+): ExternalSkillPluginResult {
+	const plugins = loadOpencodePlugins(directory);
 
-  return {
-    detected: false,
-    pluginName: null,
-    allPlugins: plugins,
-  }
+	for (const plugin of plugins) {
+		const match = matchesSkillPlugin(plugin);
+		if (match) {
+			log(`Detected external skill plugin: ${plugin}`);
+			return {
+				detected: true,
+				pluginName: match,
+				allPlugins: plugins,
+			};
+		}
+	}
+
+	return {
+		detected: false,
+		pluginName: null,
+		allPlugins: plugins,
+	};
 }
 
 /**
  * Generate a warning message for users with conflicting notification plugins.
  */
 export function getNotificationConflictWarning(pluginName: string): string {
-  return `[oh-my-opencode] External notification plugin detected: ${pluginName}
+	return `[oh-my-opencode] External notification plugin detected: ${pluginName}
 
 Both oh-my-opencode and ${pluginName} listen to session.idle events.
    Running both simultaneously can cause crashes on Windows.
@@ -197,20 +204,20 @@ Both oh-my-opencode and ${pluginName} listen to session.idle events.
 
    To use oh-my-opencode's notifications instead, either:
    1. Remove ${pluginName} from your opencode.json plugins
-   2. Or set "notification": { "force_enable": true } in oh-my-opencode.json`
+   2. Or set "notification": { "force_enable": true } in oh-my-openagent.jsonc`;
 }
 
 /**
  * Generate a warning message for users with conflicting skill plugins.
  */
 export function getSkillPluginConflictWarning(pluginName: string): string {
-  return `[oh-my-opencode] External skill plugin detected: ${pluginName}
+	return `[oh-my-opencode] External skill plugin detected: ${pluginName}
 
 Both oh-my-opencode and ${pluginName} scan ~/.config/opencode/skills/ and register tools independently.
    Running both simultaneously causes "Duplicate tool names detected" warnings and HTTP 400 errors.
 
    Consider either:
    1. Remove ${pluginName} from your opencode.json plugins to use oh-my-opencode's skill loading
-   2. Or disable oh-my-opencode's skill loading by setting "claude_code.skills": false in oh-my-opencode.json
-   3. Or uninstall oh-my-opencode if you prefer ${pluginName}'s skill management`
+   2. Or disable oh-my-opencode's skill loading by setting "claude_code.skills": false in oh-my-openagent.jsonc
+   3. Or uninstall oh-my-opencode if you prefer ${pluginName}'s skill management`;
 }

--- a/src/shared/file-utils.test.ts
+++ b/src/shared/file-utils.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeAll, afterAll } from "bun:test"
-import { mkdirSync, writeFileSync, symlinkSync, rmSync } from "fs"
-import { join } from "path"
-import { tmpdir } from "os"
-import { resolveSymlink, resolveSymlinkAsync, isSymbolicLink } from "./file-utils"
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+	isSymbolicLink,
+	resolveSymlink,
+	resolveSymlinkAsync,
+} from "./file-utils";
 
-const testDir = join(tmpdir(), "file-utils-test-" + Date.now())
+const testDir = join(tmpdir(), "file-utils-test-" + Date.now());
 
 // Create a directory structure that mimics the real-world scenario:
 //
@@ -20,84 +24,94 @@ const testDir = join(tmpdir(), "file-utils-test-" + Date.now())
 //   └── config/
 //       └── skills -> ../repo/.opencode/skills                  (absolute symlink)
 
-const realSkillDir = join(testDir, "repo", "skills", "category", "my-skill")
-const repoOpencodeSkills = join(testDir, "repo", ".opencode", "skills")
-const configSkills = join(testDir, "config", "skills")
+const realSkillDir = join(testDir, "repo", "skills", "category", "my-skill");
+const repoOpencodeSkills = join(testDir, "repo", ".opencode", "skills");
+const configSkills = join(testDir, "config", "skills");
 
 beforeAll(() => {
 	// Create real skill directory with a file
-	mkdirSync(realSkillDir, { recursive: true })
-	writeFileSync(join(realSkillDir, "SKILL.md"), "# My Skill")
+	mkdirSync(realSkillDir, { recursive: true });
+	writeFileSync(join(realSkillDir, "SKILL.md"), "# My Skill");
+	mkdirSync(join(testDir, "config"), { recursive: true });
+
+	if (process.platform === "win32") return;
 
 	// Create .opencode/skills/ with a relative symlink to the real skill
-	mkdirSync(repoOpencodeSkills, { recursive: true })
-	symlinkSync("../../skills/category/my-skill", join(repoOpencodeSkills, "my-skill"))
+	mkdirSync(repoOpencodeSkills, { recursive: true });
+	symlinkSync(
+		"../../skills/category/my-skill",
+		join(repoOpencodeSkills, "my-skill"),
+	);
 
 	// Create config/skills as an absolute symlink to .opencode/skills
-	mkdirSync(join(testDir, "config"), { recursive: true })
-	symlinkSync(repoOpencodeSkills, configSkills)
-})
+	symlinkSync(repoOpencodeSkills, configSkills);
+});
 
 afterAll(() => {
-	rmSync(testDir, { recursive: true, force: true })
-})
+	rmSync(testDir, { recursive: true, force: true });
+});
 
 describe("resolveSymlink", () => {
 	it("resolves a regular file path to itself", () => {
-		const filePath = join(realSkillDir, "SKILL.md")
-		expect(resolveSymlink(filePath)).toBe(filePath)
-	})
+		const filePath = join(realSkillDir, "SKILL.md");
+		expect(resolveSymlink(filePath)).toBe(filePath);
+	});
 
 	it("resolves a relative symlink to its real path", () => {
-		const symlinkPath = join(repoOpencodeSkills, "my-skill")
-		expect(resolveSymlink(symlinkPath)).toBe(realSkillDir)
-	})
+		if (process.platform === "win32") return;
+		const symlinkPath = join(repoOpencodeSkills, "my-skill");
+		expect(resolveSymlink(symlinkPath)).toBe(realSkillDir);
+	});
 
 	it("resolves a chained symlink (symlink-to-dir-containing-symlinks) to the real path", () => {
+		if (process.platform === "win32") return;
 		// This is the real-world scenario:
 		// config/skills/my-skill -> (follows config/skills) -> repo/.opencode/skills/my-skill -> repo/skills/category/my-skill
-		const chainedPath = join(configSkills, "my-skill")
-		expect(resolveSymlink(chainedPath)).toBe(realSkillDir)
-	})
+		const chainedPath = join(configSkills, "my-skill");
+		expect(resolveSymlink(chainedPath)).toBe(realSkillDir);
+	});
 
 	it("returns the original path for non-existent paths", () => {
-		const fakePath = join(testDir, "does-not-exist")
-		expect(resolveSymlink(fakePath)).toBe(fakePath)
-	})
-})
+		const fakePath = join(testDir, "does-not-exist");
+		expect(resolveSymlink(fakePath)).toBe(fakePath);
+	});
+});
 
 describe("resolveSymlinkAsync", () => {
 	it("resolves a regular file path to itself", async () => {
-		const filePath = join(realSkillDir, "SKILL.md")
-		expect(await resolveSymlinkAsync(filePath)).toBe(filePath)
-	})
+		const filePath = join(realSkillDir, "SKILL.md");
+		expect(await resolveSymlinkAsync(filePath)).toBe(filePath);
+	});
 
 	it("resolves a relative symlink to its real path", async () => {
-		const symlinkPath = join(repoOpencodeSkills, "my-skill")
-		expect(await resolveSymlinkAsync(symlinkPath)).toBe(realSkillDir)
-	})
+		if (process.platform === "win32") return;
+		const symlinkPath = join(repoOpencodeSkills, "my-skill");
+		expect(await resolveSymlinkAsync(symlinkPath)).toBe(realSkillDir);
+	});
 
 	it("resolves a chained symlink (symlink-to-dir-containing-symlinks) to the real path", async () => {
-		const chainedPath = join(configSkills, "my-skill")
-		expect(await resolveSymlinkAsync(chainedPath)).toBe(realSkillDir)
-	})
+		if (process.platform === "win32") return;
+		const chainedPath = join(configSkills, "my-skill");
+		expect(await resolveSymlinkAsync(chainedPath)).toBe(realSkillDir);
+	});
 
 	it("returns the original path for non-existent paths", async () => {
-		const fakePath = join(testDir, "does-not-exist")
-		expect(await resolveSymlinkAsync(fakePath)).toBe(fakePath)
-	})
-})
+		const fakePath = join(testDir, "does-not-exist");
+		expect(await resolveSymlinkAsync(fakePath)).toBe(fakePath);
+	});
+});
 
 describe("isSymbolicLink", () => {
 	it("returns true for a symlink", () => {
-		expect(isSymbolicLink(join(repoOpencodeSkills, "my-skill"))).toBe(true)
-	})
+		if (process.platform === "win32") return;
+		expect(isSymbolicLink(join(repoOpencodeSkills, "my-skill"))).toBe(true);
+	});
 
 	it("returns false for a regular directory", () => {
-		expect(isSymbolicLink(realSkillDir)).toBe(false)
-	})
+		expect(isSymbolicLink(realSkillDir)).toBe(false);
+	});
 
 	it("returns false for a non-existent path", () => {
-		expect(isSymbolicLink(join(testDir, "does-not-exist"))).toBe(false)
-	})
-})
+		expect(isSymbolicLink(join(testDir, "does-not-exist"))).toBe(false);
+	});
+});

--- a/src/shared/jsonc-parser.test.ts
+++ b/src/shared/jsonc-parser.test.ts
@@ -1,347 +1,353 @@
-import { describe, expect, test } from "bun:test"
-import { detectConfigFile, detectPluginConfigFile, parseJsonc, parseJsoncSafe, readJsoncFile } from "./jsonc-parser"
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	detectConfigFile,
+	detectPluginConfigFile,
+	parseJsonc,
+	parseJsoncSafe,
+	readJsoncFile,
+} from "./jsonc-parser";
 
 describe("parseJsonc", () => {
-  test("parses plain JSON", () => {
-    // given
-    const json = `{"key": "value"}`
+	test("parses plain JSON", () => {
+		// given
+		const json = `{"key": "value"}`;
 
-    // when
-    const result = parseJsonc<{ key: string }>(json)
+		// when
+		const result = parseJsonc<{ key: string }>(json);
 
-    // then
-    expect(result.key).toBe("value")
-  })
+		// then
+		expect(result.key).toBe("value");
+	});
 
-  test("parses JSONC with line comments", () => {
-    // given
-    const jsonc = `{
+	test("parses JSONC with line comments", () => {
+		// given
+		const jsonc = `{
       // This is a comment
       "key": "value"
-    }`
+    }`;
 
-    // when
-    const result = parseJsonc<{ key: string }>(jsonc)
+		// when
+		const result = parseJsonc<{ key: string }>(jsonc);
 
-    // then
-    expect(result.key).toBe("value")
-  })
+		// then
+		expect(result.key).toBe("value");
+	});
 
-  test("parses JSONC with block comments", () => {
-    // given
-    const jsonc = `{
+	test("parses JSONC with block comments", () => {
+		// given
+		const jsonc = `{
       /* Block comment */
       "key": "value"
-    }`
+    }`;
 
-    // when
-    const result = parseJsonc<{ key: string }>(jsonc)
+		// when
+		const result = parseJsonc<{ key: string }>(jsonc);
 
-    // then
-    expect(result.key).toBe("value")
-  })
+		// then
+		expect(result.key).toBe("value");
+	});
 
-  test("parses JSONC with multi-line block comments", () => {
-    // given
-    const jsonc = `{
+	test("parses JSONC with multi-line block comments", () => {
+		// given
+		const jsonc = `{
       /* Multi-line
          comment
          here */
       "key": "value"
-    }`
+    }`;
 
-    // when
-    const result = parseJsonc<{ key: string }>(jsonc)
+		// when
+		const result = parseJsonc<{ key: string }>(jsonc);
 
-    // then
-    expect(result.key).toBe("value")
-  })
+		// then
+		expect(result.key).toBe("value");
+	});
 
-  test("parses JSONC with trailing commas", () => {
-    // given
-    const jsonc = `{
+	test("parses JSONC with trailing commas", () => {
+		// given
+		const jsonc = `{
       "key1": "value1",
       "key2": "value2",
-    }`
+    }`;
 
-    // when
-    const result = parseJsonc<{ key1: string; key2: string }>(jsonc)
+		// when
+		const result = parseJsonc<{ key1: string; key2: string }>(jsonc);
 
-    // then
-    expect(result.key1).toBe("value1")
-    expect(result.key2).toBe("value2")
-  })
+		// then
+		expect(result.key1).toBe("value1");
+		expect(result.key2).toBe("value2");
+	});
 
-  test("parses JSONC with trailing comma in array", () => {
-    // given
-    const jsonc = `{
+	test("parses JSONC with trailing comma in array", () => {
+		// given
+		const jsonc = `{
       "arr": [1, 2, 3,]
-    }`
+    }`;
 
-    // when
-    const result = parseJsonc<{ arr: number[] }>(jsonc)
+		// when
+		const result = parseJsonc<{ arr: number[] }>(jsonc);
 
-    // then
-    expect(result.arr).toEqual([1, 2, 3])
-  })
+		// then
+		expect(result.arr).toEqual([1, 2, 3]);
+	});
 
-  test("preserves URLs with // in strings", () => {
-    // given
-    const jsonc = `{
+	test("preserves URLs with // in strings", () => {
+		// given
+		const jsonc = `{
       "url": "https://example.com"
-    }`
+    }`;
 
-    // when
-    const result = parseJsonc<{ url: string }>(jsonc)
+		// when
+		const result = parseJsonc<{ url: string }>(jsonc);
 
-    // then
-    expect(result.url).toBe("https://example.com")
-  })
+		// then
+		expect(result.url).toBe("https://example.com");
+	});
 
-  test("parses complex JSONC config", () => {
-    // given
-    const jsonc = `{
+	test("parses complex JSONC config", () => {
+		// given
+		const jsonc = `{
       // This is an example config
       "agents": {
         "oracle": { "model": "openai/gpt-5.4" }, // GPT for strategic reasoning
       },
       /* Agent overrides */
       "disabled_agents": [],
-    }`
+    }`;
 
-    // when
-    const result = parseJsonc<{
-      agents: { oracle: { model: string } }
-      disabled_agents: string[]
-    }>(jsonc)
+		// when
+		const result = parseJsonc<{
+			agents: { oracle: { model: string } };
+			disabled_agents: string[];
+		}>(jsonc);
 
-    // then
-    expect(result.agents.oracle.model).toBe("openai/gpt-5.4")
-    expect(result.disabled_agents).toEqual([])
-  })
+		// then
+		expect(result.agents.oracle.model).toBe("openai/gpt-5.4");
+		expect(result.disabled_agents).toEqual([]);
+	});
 
-  test("throws on invalid JSON", () => {
-    // given
-    const invalid = `{ "key": invalid }`
+	test("throws on invalid JSON", () => {
+		// given
+		const invalid = `{ "key": invalid }`;
 
-    // when
-    // then
-    expect(() => parseJsonc(invalid)).toThrow()
-  })
+		// when
+		// then
+		expect(() => parseJsonc(invalid)).toThrow();
+	});
 
-  test("throws on unclosed string", () => {
-    // given
-    const invalid = `{ "key": "unclosed }`
+	test("throws on unclosed string", () => {
+		// given
+		const invalid = `{ "key": "unclosed }`;
 
-    // when
-    // then
-    expect(() => parseJsonc(invalid)).toThrow()
-  })
-})
+		// when
+		// then
+		expect(() => parseJsonc(invalid)).toThrow();
+	});
+});
 
 describe("parseJsoncSafe", () => {
-  test("returns data on valid JSONC", () => {
-    // given
-    const jsonc = `{ "key": "value" }`
+	test("returns data on valid JSONC", () => {
+		// given
+		const jsonc = `{ "key": "value" }`;
 
-    // when
-    const result = parseJsoncSafe<{ key: string }>(jsonc)
+		// when
+		const result = parseJsoncSafe<{ key: string }>(jsonc);
 
-    // then
-    expect(result.data).not.toBeNull()
-    expect(result.data?.key).toBe("value")
-    expect(result.errors).toHaveLength(0)
-  })
+		// then
+		expect(result.data).not.toBeNull();
+		expect(result.data?.key).toBe("value");
+		expect(result.errors).toHaveLength(0);
+	});
 
-  test("returns errors on invalid JSONC", () => {
-    // given
-    const invalid = `{ "key": invalid }`
+	test("returns errors on invalid JSONC", () => {
+		// given
+		const invalid = `{ "key": invalid }`;
 
-    // when
-    const result = parseJsoncSafe(invalid)
+		// when
+		const result = parseJsoncSafe(invalid);
 
-    // then
-    expect(result.data).toBeNull()
-    expect(result.errors.length).toBeGreaterThan(0)
-  })
-})
+		// then
+		expect(result.data).toBeNull();
+		expect(result.errors.length).toBeGreaterThan(0);
+	});
+});
 
 describe("readJsoncFile", () => {
-  const testDir = join(__dirname, ".test-jsonc")
-  const testFile = join(testDir, "config.jsonc")
+	const testDir = join(__dirname, ".test-jsonc");
+	const testFile = join(testDir, "config.jsonc");
 
-  test("reads and parses valid JSONC file", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    const content = `{
+	test("reads and parses valid JSONC file", () => {
+		// given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		const content = `{
       // Comment
       "test": "value"
-    }`
-    writeFileSync(testFile, content)
+    }`;
+		writeFileSync(testFile, content);
 
-    // when
-    const result = readJsoncFile<{ test: string }>(testFile)
+		// when
+		const result = readJsoncFile<{ test: string }>(testFile);
 
-    // then
-    expect(result).not.toBeNull()
-    expect(result?.test).toBe("value")
+		// then
+		expect(result).not.toBeNull();
+		expect(result?.test).toBe("value");
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
+		rmSync(testDir, { recursive: true, force: true });
+	});
 
-  test("returns null for non-existent file", () => {
-    // given
-    const nonExistent = join(testDir, "does-not-exist.jsonc")
+	test("returns null for non-existent file", () => {
+		// given
+		const nonExistent = join(testDir, "does-not-exist.jsonc");
 
-    // when
-    const result = readJsoncFile(nonExistent)
+		// when
+		const result = readJsoncFile(nonExistent);
 
-    // then
-    expect(result).toBeNull()
-  })
+		// then
+		expect(result).toBeNull();
+	});
 
-  test("returns null for malformed JSON", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    writeFileSync(testFile, "{ invalid }")
+	test("returns null for malformed JSON", () => {
+		// given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		writeFileSync(testFile, "{ invalid }");
 
-    // when
-    const result = readJsoncFile(testFile)
+		// when
+		const result = readJsoncFile(testFile);
 
-    // then
-    expect(result).toBeNull()
+		// then
+		expect(result).toBeNull();
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
-})
+		rmSync(testDir, { recursive: true, force: true });
+	});
+});
 
 describe("detectConfigFile", () => {
-  const testDir = join(__dirname, ".test-detect")
+	const testDir = join(__dirname, ".test-detect");
 
-  test("prefers .jsonc over .json", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    const basePath = join(testDir, "config")
-    writeFileSync(`${basePath}.json`, "{}")
-    writeFileSync(`${basePath}.jsonc`, "{}")
+	test("prefers .jsonc over .json", () => {
+		// given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		const basePath = join(testDir, "config");
+		writeFileSync(`${basePath}.json`, "{}");
+		writeFileSync(`${basePath}.jsonc`, "{}");
 
-    // when
-    const result = detectConfigFile(basePath)
+		// when
+		const result = detectConfigFile(basePath);
 
-    // then
-    expect(result.format).toBe("jsonc")
-    expect(result.path).toBe(`${basePath}.jsonc`)
+		// then
+		expect(result.format).toBe("jsonc");
+		expect(result.path).toBe(`${basePath}.jsonc`);
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
+		rmSync(testDir, { recursive: true, force: true });
+	});
 
-  test("detects .json when .jsonc doesn't exist", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    const basePath = join(testDir, "config")
-    writeFileSync(`${basePath}.json`, "{}")
+	test("detects .json when .jsonc doesn't exist", () => {
+		// given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		const basePath = join(testDir, "config");
+		writeFileSync(`${basePath}.json`, "{}");
 
-    // when
-    const result = detectConfigFile(basePath)
+		// when
+		const result = detectConfigFile(basePath);
 
-    // then
-    expect(result.format).toBe("json")
-    expect(result.path).toBe(`${basePath}.json`)
+		// then
+		expect(result.format).toBe("json");
+		expect(result.path).toBe(`${basePath}.json`);
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
+		rmSync(testDir, { recursive: true, force: true });
+	});
 
-  test("returns none when neither exists", () => {
-    // given
-    const basePath = join(testDir, "nonexistent")
+	test("returns none when neither exists", () => {
+		// given
+		const basePath = join(testDir, "nonexistent");
 
-    // when
-    const result = detectConfigFile(basePath)
+		// when
+		const result = detectConfigFile(basePath);
 
-    // then
-    expect(result.format).toBe("none")
-  })
-})
+		// then
+		expect(result.format).toBe("none");
+	});
+});
 
 describe("detectPluginConfigFile", () => {
-  const testDir = join(__dirname, ".test-detect-plugin")
+	const testDir = join(__dirname, ".test-detect-plugin");
 
-  test("prefers oh-my-opencode over oh-my-openagent", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}")
-    writeFileSync(join(testDir, "oh-my-opencode.jsonc"), "{}")
+	test("prefers oh-my-openagent over oh-my-opencode", () => {
+		// given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}");
+		writeFileSync(join(testDir, "oh-my-opencode.jsonc"), "{}");
 
-    // when
-    const result = detectPluginConfigFile(testDir)
+		// when
+		const result = detectPluginConfigFile(testDir);
 
-    // then
-    expect(result.format).toBe("jsonc")
-    expect(result.path).toBe(join(testDir, "oh-my-opencode.jsonc"))
+		// then
+		expect(result.format).toBe("jsonc");
+		expect(result.path).toBe(join(testDir, "oh-my-openagent.jsonc"));
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
+		rmSync(testDir, { recursive: true, force: true });
+	});
 
-  test("falls back to oh-my-opencode when oh-my-openagent doesn't exist", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    writeFileSync(join(testDir, "oh-my-opencode.jsonc"), "{}")
+	test("falls back to oh-my-opencode when oh-my-openagent doesn't exist", () => {
+		// given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		writeFileSync(join(testDir, "oh-my-opencode.jsonc"), "{}");
 
-    // when
-    const result = detectPluginConfigFile(testDir)
+		// when
+		const result = detectPluginConfigFile(testDir);
 
-    // then
-    expect(result.format).toBe("jsonc")
-    expect(result.path).toBe(join(testDir, "oh-my-opencode.jsonc"))
+		// then
+		expect(result.format).toBe("jsonc");
+		expect(result.path).toBe(join(testDir, "oh-my-opencode.jsonc"));
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
+		rmSync(testDir, { recursive: true, force: true });
+	});
 
-  test("falls back to oh-my-opencode.json when no jsonc exists", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    writeFileSync(join(testDir, "oh-my-opencode.json"), "{}")
+	test("falls back to oh-my-opencode.json when no jsonc exists", () => {
+		// given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		writeFileSync(join(testDir, "oh-my-opencode.json"), "{}");
 
-    // when
-    const result = detectPluginConfigFile(testDir)
+		// when
+		const result = detectPluginConfigFile(testDir);
 
-    // then
-    expect(result.format).toBe("json")
-    expect(result.path).toBe(join(testDir, "oh-my-opencode.json"))
+		// then
+		expect(result.format).toBe("json");
+		expect(result.path).toBe(join(testDir, "oh-my-opencode.json"));
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
+		rmSync(testDir, { recursive: true, force: true });
+	});
 
-  test("returns none when no config files exist", () => {
-    // given
-    const emptyDir = join(testDir, "empty")
-    if (!existsSync(emptyDir)) mkdirSync(emptyDir, { recursive: true })
+	test("returns none when no config files exist", () => {
+		// given
+		const emptyDir = join(testDir, "empty");
+		if (!existsSync(emptyDir)) mkdirSync(emptyDir, { recursive: true });
 
-    // when
-    const result = detectPluginConfigFile(emptyDir)
+		// when
+		const result = detectPluginConfigFile(emptyDir);
 
-    // then
-    expect(result.format).toBe("none")
-    expect(result.path).toBe(join(emptyDir, "oh-my-opencode.json"))
+		// then
+		expect(result.format).toBe("none");
+		expect(result.path).toBe(join(emptyDir, "oh-my-openagent.jsonc"));
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
+		rmSync(testDir, { recursive: true, force: true });
+	});
 
-  test("prefers oh-my-opencode.json over oh-my-openagent.jsonc", () => {
-    // given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    writeFileSync(join(testDir, "oh-my-opencode.json"), "{}")
-    writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}")
+	test("prefers oh-my-openagent.jsonc over oh-my-opencode.json", () => {
+		// given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		writeFileSync(join(testDir, "oh-my-opencode.json"), "{}");
+		writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}");
 
-    // when
-    const result = detectPluginConfigFile(testDir)
+		// when
+		const result = detectPluginConfigFile(testDir);
 
-    // then
-    expect(result.format).toBe("json")
-    expect(result.path).toBe(join(testDir, "oh-my-opencode.json"))
+		// then
+		expect(result.format).toBe("jsonc");
+		expect(result.path).toBe(join(testDir, "oh-my-openagent.jsonc"));
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
-})
+		rmSync(testDir, { recursive: true, force: true });
+	});
+});

--- a/src/shared/jsonc-parser.ts
+++ b/src/shared/jsonc-parser.ts
@@ -107,10 +107,15 @@ export function readFirstValidPluginConfigFile<T = unknown>(
 		if (!existsSync(candidate)) continue;
 
 		try {
+			const parsed = parseJsonc<unknown>(readFileSync(candidate, "utf-8"));
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+				continue;
+			}
+
 			return {
 				format: candidate.endsWith(".jsonc") ? "jsonc" : "json",
 				path: candidate,
-				data: parseJsonc<T>(readFileSync(candidate, "utf-8")),
+				data: parsed as T,
 			};
 		} catch {}
 	}

--- a/src/shared/jsonc-parser.ts
+++ b/src/shared/jsonc-parser.ts
@@ -93,3 +93,27 @@ export function detectPluginConfigFile(dir: string): {
 
 	return { format: "none", path: candidates[0] };
 }
+
+export function readFirstValidPluginConfigFile<T = unknown>(
+	dir: string,
+): {
+	format: "json" | "jsonc" | "none";
+	path: string;
+	data: T | null;
+} {
+	const candidates = getPluginConfigFileCandidates(dir);
+
+	for (const candidate of candidates) {
+		if (!existsSync(candidate)) continue;
+
+		try {
+			return {
+				format: candidate.endsWith(".jsonc") ? "jsonc" : "json",
+				path: candidate,
+				data: parseJsonc<T>(readFileSync(candidate, "utf-8")),
+			};
+		} catch {}
+	}
+
+	return { format: "none", path: candidates[0], data: null };
+}

--- a/src/shared/jsonc-parser.ts
+++ b/src/shared/jsonc-parser.ts
@@ -70,13 +70,26 @@ export function detectConfigFile(basePath: string): {
 
 const PLUGIN_CONFIG_NAMES = ["oh-my-openagent", "oh-my-opencode"] as const;
 
+export function getPluginConfigFileCandidates(dir: string): string[] {
+	return PLUGIN_CONFIG_NAMES.flatMap((name) => [
+		join(dir, `${name}.jsonc`),
+		join(dir, `${name}.json`),
+	]);
+}
+
 export function detectPluginConfigFile(dir: string): {
 	format: "json" | "jsonc" | "none";
 	path: string;
 } {
-	for (const name of PLUGIN_CONFIG_NAMES) {
-		const result = detectConfigFile(join(dir, name));
-		if (result.format !== "none") return result;
+	const candidates = getPluginConfigFileCandidates(dir);
+
+	for (const candidate of candidates) {
+		if (!existsSync(candidate)) continue;
+		return {
+			format: candidate.endsWith(".jsonc") ? "jsonc" : "json",
+			path: candidate,
+		};
 	}
-	return { format: "none", path: join(dir, PLUGIN_CONFIG_NAMES[0] + ".jsonc") };
+
+	return { format: "none", path: candidates[0] };
 }

--- a/src/shared/jsonc-parser.ts
+++ b/src/shared/jsonc-parser.ts
@@ -1,80 +1,82 @@
-import { existsSync, readFileSync } from "node:fs"
-import { join } from "node:path"
-import { parse, ParseError, printParseErrorCode } from "jsonc-parser"
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { type ParseError, parse, printParseErrorCode } from "jsonc-parser";
 
 export interface JsoncParseResult<T> {
-  data: T | null
-  errors: Array<{ message: string; offset: number; length: number }>
+	data: T | null;
+	errors: Array<{ message: string; offset: number; length: number }>;
 }
 
 export function parseJsonc<T = unknown>(content: string): T {
-  const errors: ParseError[] = []
-  const result = parse(content, errors, {
-    allowTrailingComma: true,
-    disallowComments: false,
-  }) as T
+	const errors: ParseError[] = [];
+	const result = parse(content, errors, {
+		allowTrailingComma: true,
+		disallowComments: false,
+	}) as T;
 
-  if (errors.length > 0) {
-    const errorMessages = errors
-      .map((e) => `${printParseErrorCode(e.error)} at offset ${e.offset}`)
-      .join(", ")
-    throw new SyntaxError(`JSONC parse error: ${errorMessages}`)
-  }
+	if (errors.length > 0) {
+		const errorMessages = errors
+			.map((e) => `${printParseErrorCode(e.error)} at offset ${e.offset}`)
+			.join(", ");
+		throw new SyntaxError(`JSONC parse error: ${errorMessages}`);
+	}
 
-  return result
+	return result;
 }
 
-export function parseJsoncSafe<T = unknown>(content: string): JsoncParseResult<T> {
-  const errors: ParseError[] = []
-  const data = parse(content, errors, {
-    allowTrailingComma: true,
-    disallowComments: false,
-  }) as T | null
+export function parseJsoncSafe<T = unknown>(
+	content: string,
+): JsoncParseResult<T> {
+	const errors: ParseError[] = [];
+	const data = parse(content, errors, {
+		allowTrailingComma: true,
+		disallowComments: false,
+	}) as T | null;
 
-  return {
-    data: errors.length > 0 ? null : data,
-    errors: errors.map((e) => ({
-      message: printParseErrorCode(e.error),
-      offset: e.offset,
-      length: e.length,
-    })),
-  }
+	return {
+		data: errors.length > 0 ? null : data,
+		errors: errors.map((e) => ({
+			message: printParseErrorCode(e.error),
+			offset: e.offset,
+			length: e.length,
+		})),
+	};
 }
 
 export function readJsoncFile<T = unknown>(filePath: string): T | null {
-  try {
-    const content = readFileSync(filePath, "utf-8")
-    return parseJsonc<T>(content)
-  } catch {
-    return null
-  }
+	try {
+		const content = readFileSync(filePath, "utf-8");
+		return parseJsonc<T>(content);
+	} catch {
+		return null;
+	}
 }
 
 export function detectConfigFile(basePath: string): {
-  format: "json" | "jsonc" | "none"
-  path: string
+	format: "json" | "jsonc" | "none";
+	path: string;
 } {
-  const jsoncPath = `${basePath}.jsonc`
-  const jsonPath = `${basePath}.json`
+	const jsoncPath = `${basePath}.jsonc`;
+	const jsonPath = `${basePath}.json`;
 
-  if (existsSync(jsoncPath)) {
-    return { format: "jsonc", path: jsoncPath }
-  }
-  if (existsSync(jsonPath)) {
-    return { format: "json", path: jsonPath }
-  }
-  return { format: "none", path: jsonPath }
+	if (existsSync(jsoncPath)) {
+		return { format: "jsonc", path: jsoncPath };
+	}
+	if (existsSync(jsonPath)) {
+		return { format: "json", path: jsonPath };
+	}
+	return { format: "none", path: jsonPath };
 }
 
-const PLUGIN_CONFIG_NAMES = ["oh-my-opencode", "oh-my-openagent"] as const
+const PLUGIN_CONFIG_NAMES = ["oh-my-openagent", "oh-my-opencode"] as const;
 
 export function detectPluginConfigFile(dir: string): {
-  format: "json" | "jsonc" | "none"
-  path: string
+	format: "json" | "jsonc" | "none";
+	path: string;
 } {
-  for (const name of PLUGIN_CONFIG_NAMES) {
-    const result = detectConfigFile(join(dir, name))
-    if (result.format !== "none") return result
-  }
-  return { format: "none", path: join(dir, PLUGIN_CONFIG_NAMES[0] + ".json") }
+	for (const name of PLUGIN_CONFIG_NAMES) {
+		const result = detectConfigFile(join(dir, name));
+		if (result.format !== "none") return result;
+	}
+	return { format: "none", path: join(dir, PLUGIN_CONFIG_NAMES[0] + ".jsonc") };
 }

--- a/src/shared/legacy-plugin-warning.test.ts
+++ b/src/shared/legacy-plugin-warning.test.ts
@@ -1,83 +1,105 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { checkForLegacyPluginEntry } from "./legacy-plugin-warning"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let checkForLegacyPluginEntry: typeof import("./legacy-plugin-warning").checkForLegacyPluginEntry;
 
 describe("checkForLegacyPluginEntry", () => {
-  let testConfigDir = ""
+	let testConfigDir = "";
 
-  beforeEach(() => {
-    testConfigDir = join(tmpdir(), `omo-legacy-check-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    mkdirSync(testConfigDir, { recursive: true })
-  })
+	beforeEach(() => {
+		testConfigDir = join(
+			tmpdir(),
+			`omo-legacy-check-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(testConfigDir, { recursive: true });
+	});
 
-  afterEach(() => {
-    rmSync(testConfigDir, { recursive: true, force: true })
-  })
+	beforeEach(async () => {
+		({ checkForLegacyPluginEntry } = await import(
+			`./legacy-plugin-warning?check-${Date.now()}-${Math.random()}`
+		));
+	});
 
-  it("detects a bare legacy plugin entry", () => {
-    // given
-    writeFileSync(join(testConfigDir, "opencode.json"), JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2))
+	afterEach(() => {
+		rmSync(testConfigDir, { recursive: true, force: true });
+	});
 
-    // when
-    const result = checkForLegacyPluginEntry(testConfigDir)
+	it("detects a bare legacy plugin entry", () => {
+		// given
+		writeFileSync(
+			join(testConfigDir, "opencode.json"),
+			JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2),
+		);
 
-    // then
-    expect(result.hasLegacyEntry).toBe(true)
-    expect(result.hasCanonicalEntry).toBe(false)
-    expect(result.legacyEntries).toEqual(["oh-my-opencode"])
-    expect(result.configPath).toBe(join(testConfigDir, "opencode.json"))
-  })
+		// when
+		const result = checkForLegacyPluginEntry(testConfigDir);
 
-  it("detects a version-pinned legacy plugin entry", () => {
-    // given
-    writeFileSync(join(testConfigDir, "opencode.json"), JSON.stringify({ plugin: ["oh-my-opencode@3.10.0"] }, null, 2))
+		// then
+		expect(result.hasLegacyEntry).toBe(true);
+		expect(result.hasCanonicalEntry).toBe(false);
+		expect(result.legacyEntries).toEqual(["oh-my-opencode"]);
+		expect(result.configPath).toBe(join(testConfigDir, "opencode.json"));
+	});
 
-    // when
-    const result = checkForLegacyPluginEntry(testConfigDir)
+	it("detects a version-pinned legacy plugin entry", () => {
+		// given
+		writeFileSync(
+			join(testConfigDir, "opencode.json"),
+			JSON.stringify({ plugin: ["oh-my-opencode@3.10.0"] }, null, 2),
+		);
 
-    // then
-    expect(result.hasLegacyEntry).toBe(true)
-    expect(result.hasCanonicalEntry).toBe(false)
-    expect(result.legacyEntries).toEqual(["oh-my-opencode@3.10.0"])
-  })
+		// when
+		const result = checkForLegacyPluginEntry(testConfigDir);
 
-  it("does not flag a canonical plugin entry", () => {
-    // given
-    writeFileSync(join(testConfigDir, "opencode.json"), JSON.stringify({ plugin: ["oh-my-openagent"] }, null, 2))
+		// then
+		expect(result.hasLegacyEntry).toBe(true);
+		expect(result.hasCanonicalEntry).toBe(false);
+		expect(result.legacyEntries).toEqual(["oh-my-opencode@3.10.0"]);
+	});
 
-    // when
-    const result = checkForLegacyPluginEntry(testConfigDir)
+	it("does not flag a canonical plugin entry", () => {
+		// given
+		writeFileSync(
+			join(testConfigDir, "opencode.json"),
+			JSON.stringify({ plugin: ["oh-my-openagent"] }, null, 2),
+		);
 
-    // then
-    expect(result.hasLegacyEntry).toBe(false)
-    expect(result.hasCanonicalEntry).toBe(true)
-    expect(result.legacyEntries).toEqual([])
-  })
+		// when
+		const result = checkForLegacyPluginEntry(testConfigDir);
 
-  it("detects legacy entries in quoted jsonc config", () => {
-    // given
-    writeFileSync(join(testConfigDir, "opencode.jsonc"), '{\n  "plugin": ["oh-my-opencode"]\n}\n')
+		// then
+		expect(result.hasLegacyEntry).toBe(false);
+		expect(result.hasCanonicalEntry).toBe(true);
+		expect(result.legacyEntries).toEqual([]);
+	});
 
-    // when
-    const result = checkForLegacyPluginEntry(testConfigDir)
+	it("detects legacy entries in quoted jsonc config", () => {
+		// given
+		writeFileSync(
+			join(testConfigDir, "opencode.jsonc"),
+			'{\n  "plugin": ["oh-my-opencode"]\n}\n',
+		);
 
-    // then
-    expect(result.hasLegacyEntry).toBe(true)
-    expect(result.legacyEntries).toEqual(["oh-my-opencode"])
-  })
+		// when
+		const result = checkForLegacyPluginEntry(testConfigDir);
 
-  it("returns no warning data when config is missing", () => {
-    // given — empty dir, no config files
+		// then
+		expect(result.hasLegacyEntry).toBe(true);
+		expect(result.legacyEntries).toEqual(["oh-my-opencode"]);
+	});
 
-    // when
-    const result = checkForLegacyPluginEntry(testConfigDir)
+	it("returns no warning data when config is missing", () => {
+		// given — empty dir, no config files
 
-    // then
-    expect(result.hasLegacyEntry).toBe(false)
-    expect(result.hasCanonicalEntry).toBe(false)
-    expect(result.legacyEntries).toEqual([])
-    expect(result.configPath).toBeNull()
-  })
-})
+		// when
+		const result = checkForLegacyPluginEntry(testConfigDir);
+
+		// then
+		expect(result.hasLegacyEntry).toBe(false);
+		expect(result.hasCanonicalEntry).toBe(false);
+		expect(result.legacyEntries).toEqual([]);
+		expect(result.configPath).toBeNull();
+	});
+});

--- a/src/shared/log-legacy-plugin-startup-warning.test.ts
+++ b/src/shared/log-legacy-plugin-startup-warning.test.ts
@@ -1,150 +1,162 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
-import type { LegacyPluginCheckResult } from "./legacy-plugin-warning"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import type { LegacyPluginCheckResult } from "./legacy-plugin-warning";
+import * as legacyPluginWarning from "./legacy-plugin-warning";
+import * as logger from "./logger";
+import * as migrateLegacyPluginEntryModule from "./migrate-legacy-plugin-entry";
 
 function createLegacyPluginCheckResult(
-  overrides: Partial<LegacyPluginCheckResult> = {},
+	overrides: Partial<LegacyPluginCheckResult> = {},
 ): LegacyPluginCheckResult {
-  return {
-    hasLegacyEntry: false,
-    hasCanonicalEntry: false,
-    legacyEntries: [],
-    configPath: null,
-    ...overrides,
-  }
+	return {
+		hasLegacyEntry: false,
+		hasCanonicalEntry: false,
+		legacyEntries: [],
+		configPath: null,
+		...overrides,
+	};
 }
 
-const mockCheckForLegacyPluginEntry = mock(() => createLegacyPluginCheckResult())
-const mockLog = mock(() => {})
-const mockMigrateLegacyPluginEntry = mock(() => false)
-let consoleWarnSpy: ReturnType<typeof spyOn>
+let consoleWarnSpy: ReturnType<typeof spyOn>;
+let checkForLegacyPluginEntrySpy: ReturnType<typeof spyOn>;
+let logSpy: ReturnType<typeof spyOn>;
+let migrateLegacyPluginEntrySpy: ReturnType<typeof spyOn>;
 
-mock.module("./legacy-plugin-warning", () => ({
-  checkForLegacyPluginEntry: mockCheckForLegacyPluginEntry,
-}))
-
-mock.module("./logger", () => ({
-  log: mockLog,
-}))
-
-mock.module("./migrate-legacy-plugin-entry", () => ({
-  migrateLegacyPluginEntry: mockMigrateLegacyPluginEntry,
-}))
-
-afterAll(() => {
-  mock.restore()
-})
-
-async function importFreshStartupWarningModule(): Promise<typeof import("./log-legacy-plugin-startup-warning")> {
-  return import(`./log-legacy-plugin-startup-warning?test=${Date.now()}-${Math.random()}`)
+async function importFreshStartupWarningModule(): Promise<
+	typeof import("./log-legacy-plugin-startup-warning")
+> {
+	return import(
+		`./log-legacy-plugin-startup-warning?test=${Date.now()}-${Math.random()}`
+	);
 }
 
 describe("logLegacyPluginStartupWarning", () => {
-  beforeEach(() => {
-    mockCheckForLegacyPluginEntry.mockReset()
-    mockLog.mockReset()
-    mockMigrateLegacyPluginEntry.mockReset()
-    consoleWarnSpy = spyOn(console, "warn").mockImplementation(() => {})
+	beforeEach(() => {
+		checkForLegacyPluginEntrySpy = spyOn(
+			legacyPluginWarning,
+			"checkForLegacyPluginEntry",
+		).mockReturnValue(createLegacyPluginCheckResult());
+		logSpy = spyOn(logger, "log").mockImplementation(() => {});
+		migrateLegacyPluginEntrySpy = spyOn(
+			migrateLegacyPluginEntryModule,
+			"migrateLegacyPluginEntry",
+		).mockReturnValue(false);
+		consoleWarnSpy = spyOn(console, "warn").mockImplementation(() => {});
+	});
 
-    mockCheckForLegacyPluginEntry.mockReturnValue(createLegacyPluginCheckResult())
-    mockMigrateLegacyPluginEntry.mockReturnValue(false)
-  })
+	afterEach(() => {
+		consoleWarnSpy?.mockRestore();
+		checkForLegacyPluginEntrySpy?.mockRestore();
+		logSpy?.mockRestore();
+		migrateLegacyPluginEntrySpy?.mockRestore();
+	});
 
-  afterEach(() => {
-    consoleWarnSpy?.mockRestore()
-  })
+	describe("#given OpenCode config contains legacy plugin entries", () => {
+		it("#then logs the legacy entries with canonical replacements", async () => {
+			//#given
+			checkForLegacyPluginEntrySpy.mockReturnValue(
+				createLegacyPluginCheckResult({
+					hasLegacyEntry: true,
+					legacyEntries: ["oh-my-opencode", "oh-my-opencode@3.13.1"],
+					configPath: "/tmp/opencode.json",
+				}),
+			);
+			const { logLegacyPluginStartupWarning } =
+				await importFreshStartupWarningModule();
 
-  describe("#given OpenCode config contains legacy plugin entries", () => {
-    it("#then logs the legacy entries with canonical replacements", async () => {
-      //#given
-      mockCheckForLegacyPluginEntry.mockReturnValue(createLegacyPluginCheckResult({
-        hasLegacyEntry: true,
-        legacyEntries: ["oh-my-opencode", "oh-my-opencode@3.13.1"],
-        configPath: "/tmp/opencode.json",
-      }))
-      const { logLegacyPluginStartupWarning } = await importFreshStartupWarningModule()
+			//#when
+			logLegacyPluginStartupWarning();
 
-      //#when
-      logLegacyPluginStartupWarning()
+			//#then
+			expect(logSpy).toHaveBeenCalledTimes(1);
+			expect(logSpy).toHaveBeenCalledWith(
+				"[OhMyOpenCodePlugin] Legacy plugin entry detected in OpenCode config",
+				{
+					legacyEntries: ["oh-my-opencode", "oh-my-opencode@3.13.1"],
+					suggestedEntries: ["oh-my-openagent", "oh-my-openagent@3.13.1"],
+					hasCanonicalEntry: false,
+				},
+			);
+		});
 
-      //#then
-      expect(mockLog).toHaveBeenCalledTimes(1)
-      expect(mockLog).toHaveBeenCalledWith(
-        "[OhMyOpenCodePlugin] Legacy plugin entry detected in OpenCode config",
-        {
-          legacyEntries: ["oh-my-opencode", "oh-my-opencode@3.13.1"],
-          suggestedEntries: ["oh-my-openagent", "oh-my-openagent@3.13.1"],
-          hasCanonicalEntry: false,
-        },
-      )
-    })
+		it("#then emits console.warn about the rename", async () => {
+			//#given
+			checkForLegacyPluginEntrySpy.mockReturnValue(
+				createLegacyPluginCheckResult({
+					hasLegacyEntry: true,
+					legacyEntries: ["oh-my-opencode@latest"],
+					configPath: "/tmp/opencode.json",
+				}),
+			);
+			const { logLegacyPluginStartupWarning } =
+				await importFreshStartupWarningModule();
 
-    it("#then emits console.warn about the rename", async () => {
-      //#given
-      mockCheckForLegacyPluginEntry.mockReturnValue(createLegacyPluginCheckResult({
-        hasLegacyEntry: true,
-        legacyEntries: ["oh-my-opencode@latest"],
-        configPath: "/tmp/opencode.json",
-      }))
-      const { logLegacyPluginStartupWarning } = await importFreshStartupWarningModule()
+			//#when
+			logLegacyPluginStartupWarning();
 
-      //#when
-      logLegacyPluginStartupWarning()
+			//#then
+			expect(consoleWarnSpy).toHaveBeenCalled();
+			const firstCall = consoleWarnSpy.mock.calls[0]?.[0] as string;
+			expect(firstCall).toContain("oh-my-opencode");
+			expect(firstCall).toContain("oh-my-openagent");
+		});
 
-      //#then
-      expect(consoleWarnSpy).toHaveBeenCalled()
-      const firstCall = consoleWarnSpy.mock.calls[0]?.[0] as string
-      expect(firstCall).toContain("oh-my-opencode")
-      expect(firstCall).toContain("oh-my-openagent")
-    })
+		it("#then attempts auto-migration of the opencode.json", async () => {
+			//#given
+			checkForLegacyPluginEntrySpy.mockReturnValue(
+				createLegacyPluginCheckResult({
+					hasLegacyEntry: true,
+					legacyEntries: ["oh-my-opencode"],
+					configPath: "/tmp/opencode.json",
+				}),
+			);
+			const { logLegacyPluginStartupWarning } =
+				await importFreshStartupWarningModule();
 
-    it("#then attempts auto-migration of the opencode.json", async () => {
-      //#given
-      mockCheckForLegacyPluginEntry.mockReturnValue(createLegacyPluginCheckResult({
-        hasLegacyEntry: true,
-        legacyEntries: ["oh-my-opencode"],
-        configPath: "/tmp/opencode.json",
-      }))
-      const { logLegacyPluginStartupWarning } = await importFreshStartupWarningModule()
+			//#when
+			logLegacyPluginStartupWarning();
 
-      //#when
-      logLegacyPluginStartupWarning()
+			//#then
+			expect(migrateLegacyPluginEntrySpy).toHaveBeenCalledWith(
+				"/tmp/opencode.json",
+			);
+		});
+	});
 
-      //#then
-      expect(mockMigrateLegacyPluginEntry).toHaveBeenCalledWith("/tmp/opencode.json")
-    })
-  })
+	describe("#given OpenCode config uses only canonical plugin entries", () => {
+		it("#then does not log a startup warning", async () => {
+			//#given
+			const { logLegacyPluginStartupWarning } =
+				await importFreshStartupWarningModule();
 
-  describe("#given OpenCode config uses only canonical plugin entries", () => {
-    it("#then does not log a startup warning", async () => {
-      //#given
-      const { logLegacyPluginStartupWarning } = await importFreshStartupWarningModule()
+			//#when
+			logLegacyPluginStartupWarning();
 
-      //#when
-      logLegacyPluginStartupWarning()
+			//#then
+			expect(logSpy).not.toHaveBeenCalled();
+			expect(consoleWarnSpy).not.toHaveBeenCalled();
+		});
+	});
 
-      //#then
-      expect(mockLog).not.toHaveBeenCalled()
-      expect(consoleWarnSpy).not.toHaveBeenCalled()
-    })
-  })
+	describe("#given migration succeeds", () => {
+		it("#then logs success message to console", async () => {
+			//#given
+			checkForLegacyPluginEntrySpy.mockReturnValue(
+				createLegacyPluginCheckResult({
+					hasLegacyEntry: true,
+					legacyEntries: ["oh-my-opencode@latest"],
+					configPath: "/tmp/opencode.json",
+				}),
+			);
+			migrateLegacyPluginEntrySpy.mockReturnValue(true);
+			const { logLegacyPluginStartupWarning } =
+				await importFreshStartupWarningModule();
 
-  describe("#given migration succeeds", () => {
-    it("#then logs success message to console", async () => {
-      //#given
-      mockCheckForLegacyPluginEntry.mockReturnValue(createLegacyPluginCheckResult({
-        hasLegacyEntry: true,
-        legacyEntries: ["oh-my-opencode@latest"],
-        configPath: "/tmp/opencode.json",
-      }))
-      mockMigrateLegacyPluginEntry.mockReturnValue(true)
-      const { logLegacyPluginStartupWarning } = await importFreshStartupWarningModule()
+			//#when
+			logLegacyPluginStartupWarning();
 
-      //#when
-      logLegacyPluginStartupWarning()
-
-      //#then
-      const calls = consoleWarnSpy.mock.calls.map((c) => c[0] as string)
-      expect(calls.some((c) => c.includes("Auto-migrated"))).toBe(true)
-    })
-  })
-})
+			//#then
+			const calls = consoleWarnSpy.mock.calls.map((c) => c[0] as string);
+			expect(calls.some((c) => c.includes("Auto-migrated"))).toBe(true);
+		});
+	});
+});

--- a/src/shared/migrate-legacy-config-file.test.ts
+++ b/src/shared/migrate-legacy-config-file.test.ts
@@ -1,86 +1,119 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { migrateLegacyConfigFile } from "./migrate-legacy-config-file"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateLegacyConfigFile } from "./migrate-legacy-config-file";
 
 describe("migrateLegacyConfigFile", () => {
-  let testDir = ""
+	let testDir = "";
 
-  beforeEach(() => {
-    testDir = join(tmpdir(), `omo-migrate-config-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    mkdirSync(testDir, { recursive: true })
-  })
+	beforeEach(() => {
+		testDir = join(
+			tmpdir(),
+			`omo-migrate-config-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(testDir, { recursive: true });
+	});
 
-  afterEach(() => {
-    rmSync(testDir, { recursive: true, force: true })
-  })
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
 
-  describe("#given oh-my-opencode.jsonc exists but oh-my-openagent.jsonc does not", () => {
-    describe("#when migrating the config file", () => {
-      it("#then copies to oh-my-openagent.jsonc", () => {
-        const legacyPath = join(testDir, "oh-my-opencode.jsonc")
-        writeFileSync(legacyPath, '{ "agents": {} }')
+	describe("#given oh-my-opencode.jsonc exists but oh-my-openagent.jsonc does not", () => {
+		describe("#when migrating the config file", () => {
+			it("#then copies to oh-my-openagent.jsonc", () => {
+				const legacyPath = join(testDir, "oh-my-opencode.jsonc");
+				writeFileSync(legacyPath, '{ "agents": {} }');
 
-        const result = migrateLegacyConfigFile(legacyPath)
+				const result = migrateLegacyConfigFile(legacyPath);
 
-        expect(result).toBe(true)
-        expect(existsSync(join(testDir, "oh-my-openagent.jsonc"))).toBe(true)
-        expect(readFileSync(join(testDir, "oh-my-openagent.jsonc"), "utf-8")).toBe('{ "agents": {} }')
-      })
-    })
-  })
+				expect(result).toBe(true);
+				expect(existsSync(join(testDir, "oh-my-openagent.jsonc"))).toBe(true);
+				expect(
+					readFileSync(join(testDir, "oh-my-openagent.jsonc"), "utf-8"),
+				).toBe('{ "agents": {} }');
+			});
+		});
+	});
 
-  describe("#given oh-my-opencode.json exists but oh-my-openagent.json does not", () => {
-    describe("#when migrating the config file", () => {
-      it("#then copies to oh-my-openagent.json", () => {
-        const legacyPath = join(testDir, "oh-my-opencode.json")
-        writeFileSync(legacyPath, '{ "agents": {} }')
+	describe("#given oh-my-opencode.json exists but oh-my-openagent.json does not", () => {
+		describe("#when migrating the config file", () => {
+			it("#then copies to oh-my-openagent.json", () => {
+				const legacyPath = join(testDir, "oh-my-opencode.json");
+				writeFileSync(legacyPath, '{ "agents": {} }');
 
-        const result = migrateLegacyConfigFile(legacyPath)
+				const result = migrateLegacyConfigFile(legacyPath);
 
-        expect(result).toBe(true)
-        expect(existsSync(join(testDir, "oh-my-openagent.json"))).toBe(true)
-      })
-    })
-  })
+				expect(result).toBe(true);
+				expect(existsSync(join(testDir, "oh-my-openagent.json"))).toBe(true);
+			});
+		});
+	});
 
-  describe("#given oh-my-openagent.jsonc already exists", () => {
-    describe("#when attempting migration", () => {
-      it("#then returns false and does not overwrite", () => {
-        const legacyPath = join(testDir, "oh-my-opencode.jsonc")
-        const canonicalPath = join(testDir, "oh-my-openagent.jsonc")
-        writeFileSync(legacyPath, '{ "old": true }')
-        writeFileSync(canonicalPath, '{ "new": true }')
+	describe("#given oh-my-openagent.jsonc already exists", () => {
+		describe("#when attempting migration", () => {
+			it("#then returns false and does not overwrite", () => {
+				const legacyPath = join(testDir, "oh-my-opencode.jsonc");
+				const canonicalPath = join(testDir, "oh-my-openagent.jsonc");
+				writeFileSync(legacyPath, '{ "old": true }');
+				writeFileSync(canonicalPath, '{ "new": true }');
 
-        const result = migrateLegacyConfigFile(legacyPath)
+				const result = migrateLegacyConfigFile(legacyPath);
 
-        expect(result).toBe(false)
-        expect(readFileSync(canonicalPath, "utf-8")).toBe('{ "new": true }')
-      })
-    })
-  })
+				expect(result).toBe(false);
+				expect(readFileSync(canonicalPath, "utf-8")).toBe('{ "new": true }');
+			});
+		});
+	});
 
-  describe("#given the file does not exist", () => {
-    describe("#when attempting migration", () => {
-      it("#then returns false", () => {
-        const result = migrateLegacyConfigFile(join(testDir, "oh-my-opencode.jsonc"))
+	describe("#given oh-my-openagent.jsonc exists and legacy .json is migrated", () => {
+		describe("#when attempting migration", () => {
+			it("#then returns false and does not create oh-my-openagent.json", () => {
+				const legacyPath = join(testDir, "oh-my-opencode.json");
+				const canonicalJsoncPath = join(testDir, "oh-my-openagent.jsonc");
+				const canonicalJsonPath = join(testDir, "oh-my-openagent.json");
+				writeFileSync(legacyPath, '{ "old": true }');
+				writeFileSync(canonicalJsoncPath, '{ "new": true }');
 
-        expect(result).toBe(false)
-      })
-    })
-  })
+				const result = migrateLegacyConfigFile(legacyPath);
 
-  describe("#given the file is not a legacy config file", () => {
-    describe("#when attempting migration", () => {
-      it("#then returns false", () => {
-        const nonLegacyPath = join(testDir, "something-else.jsonc")
-        writeFileSync(nonLegacyPath, "{}")
+				expect(result).toBe(false);
+				expect(existsSync(canonicalJsonPath)).toBe(false);
+				expect(readFileSync(canonicalJsoncPath, "utf-8")).toBe(
+					'{ "new": true }',
+				);
+			});
+		});
+	});
 
-        const result = migrateLegacyConfigFile(nonLegacyPath)
+	describe("#given the file does not exist", () => {
+		describe("#when attempting migration", () => {
+			it("#then returns false", () => {
+				const result = migrateLegacyConfigFile(
+					join(testDir, "oh-my-opencode.jsonc"),
+				);
 
-        expect(result).toBe(false)
-      })
-    })
-  })
-})
+				expect(result).toBe(false);
+			});
+		});
+	});
+
+	describe("#given the file is not a legacy config file", () => {
+		describe("#when attempting migration", () => {
+			it("#then returns false", () => {
+				const nonLegacyPath = join(testDir, "something-else.jsonc");
+				writeFileSync(nonLegacyPath, "{}");
+
+				const result = migrateLegacyConfigFile(nonLegacyPath);
+
+				expect(result).toBe(false);
+			});
+		});
+	});
+});

--- a/src/shared/migrate-legacy-config-file.ts
+++ b/src/shared/migrate-legacy-config-file.ts
@@ -1,31 +1,43 @@
-import { existsSync, copyFileSync, renameSync } from "node:fs"
-import { join, dirname, basename } from "node:path"
+import { copyFileSync, existsSync, renameSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 
-import { log } from "./logger"
-import { CONFIG_BASENAME, LEGACY_CONFIG_BASENAME } from "./plugin-identity"
+import { log } from "./logger";
+import { CONFIG_BASENAME, LEGACY_CONFIG_BASENAME } from "./plugin-identity";
 
 function buildCanonicalPath(legacyPath: string): string {
-  const dir = dirname(legacyPath)
-  const ext = basename(legacyPath).includes(".jsonc") ? ".jsonc" : ".json"
-  return join(dir, `${CONFIG_BASENAME}${ext}`)
+	const dir = dirname(legacyPath);
+	const ext = basename(legacyPath).includes(".jsonc") ? ".jsonc" : ".json";
+	return join(dir, `${CONFIG_BASENAME}${ext}`);
+}
+
+function hasAnyCanonicalPath(dir: string): boolean {
+	return (
+		existsSync(join(dir, `${CONFIG_BASENAME}.jsonc`)) ||
+		existsSync(join(dir, `${CONFIG_BASENAME}.json`))
+	);
 }
 
 export function migrateLegacyConfigFile(legacyPath: string): boolean {
-  if (!existsSync(legacyPath)) return false
-  if (!basename(legacyPath).startsWith(LEGACY_CONFIG_BASENAME)) return false
+	if (!existsSync(legacyPath)) return false;
+	if (!basename(legacyPath).startsWith(LEGACY_CONFIG_BASENAME)) return false;
 
-  const canonicalPath = buildCanonicalPath(legacyPath)
-  if (existsSync(canonicalPath)) return false
+	const dir = dirname(legacyPath);
+	if (hasAnyCanonicalPath(dir)) return false;
 
-  try {
-    copyFileSync(legacyPath, canonicalPath)
-    log("[migrateLegacyConfigFile] Copied legacy config to canonical path", {
-      from: legacyPath,
-      to: canonicalPath,
-    })
-    return true
-  } catch (error) {
-    log("[migrateLegacyConfigFile] Failed to copy legacy config file", { legacyPath, error })
-    return false
-  }
+	const canonicalPath = buildCanonicalPath(legacyPath);
+
+	try {
+		copyFileSync(legacyPath, canonicalPath);
+		log("[migrateLegacyConfigFile] Copied legacy config to canonical path", {
+			from: legacyPath,
+			to: canonicalPath,
+		});
+		return true;
+	} catch (error) {
+		log("[migrateLegacyConfigFile] Failed to copy legacy config file", {
+			legacyPath,
+			error,
+		});
+		return false;
+	}
 }

--- a/src/shared/migration.test.ts
+++ b/src/shared/migration.test.ts
@@ -1,1341 +1,1469 @@
 /// <reference types="bun-types" />
 
-import { describe, test, expect, afterEach } from "bun:test"
-import * as fs from "fs"
-import * as path from "path"
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
 import {
-  AGENT_NAME_MAP,
-  HOOK_NAME_MAP,
-  MODEL_VERSION_MAP,
-  migrateAgentNames,
-  migrateHookNames,
-  migrateModelVersions,
-  migrateConfigFile,
-  migrateAgentConfigToCategory,
-  shouldDeleteAgentConfig,
-} from "./migration"
+	AGENT_NAME_MAP,
+	HOOK_NAME_MAP,
+	MODEL_VERSION_MAP,
+	migrateAgentConfigToCategory,
+	migrateAgentNames,
+	migrateConfigFile,
+	migrateHookNames,
+	migrateModelVersions,
+	shouldDeleteAgentConfig,
+} from "./migration";
+
+function cleanupTempDir(tmpDir: string): void {
+	try {
+		fs.rmSync(tmpDir, { recursive: true });
+	} catch (error) {
+		if (
+			!(error instanceof Error) ||
+			!String(error.message).includes("EFAULT")
+		) {
+			throw error;
+		}
+	}
+}
 
 describe("migrateAgentNames", () => {
-  test("migrates legacy OmO names to lowercase", () => {
-    // given: Config with legacy OmO agent names
-    const agents = {
-      omo: { model: "anthropic/claude-opus-4-6" },
-      OmO: { temperature: 0.5 },
-      "OmO-Plan": { prompt: "custom prompt" },
-    }
+	test("migrates legacy OmO names to lowercase", () => {
+		// given: Config with legacy OmO agent names
+		const agents = {
+			omo: { model: "anthropic/claude-opus-4-6" },
+			OmO: { temperature: 0.5 },
+			"OmO-Plan": { prompt: "custom prompt" },
+		};
 
-    // when: Migrate agent names
-    const { migrated, changed } = migrateAgentNames(agents)
+		// when: Migrate agent names
+		const { migrated, changed } = migrateAgentNames(agents);
 
-    // then: Legacy names should be migrated to lowercase
-    expect(changed).toBe(true)
-    expect(migrated["sisyphus"]).toEqual({ temperature: 0.5 })
-    expect(migrated["prometheus"]).toEqual({ prompt: "custom prompt" })
-    expect(migrated["omo"]).toBeUndefined()
-    expect(migrated["OmO"]).toBeUndefined()
-    expect(migrated["OmO-Plan"]).toBeUndefined()
-  })
+		// then: Legacy names should be migrated to lowercase
+		expect(changed).toBe(true);
+		expect(migrated["sisyphus"]).toEqual({ temperature: 0.5 });
+		expect(migrated["prometheus"]).toEqual({ prompt: "custom prompt" });
+		expect(migrated["omo"]).toBeUndefined();
+		expect(migrated["OmO"]).toBeUndefined();
+		expect(migrated["OmO-Plan"]).toBeUndefined();
+	});
 
-  test("preserves current agent names unchanged", () => {
-    // given: Config with current agent names
-    const agents = {
-      oracle: { model: "openai/gpt-5.4" },
-      librarian: { model: "google/gemini-3-flash" },
-      explore: { model: "opencode/gpt-5-nano" },
-    }
+	test("preserves current agent names unchanged", () => {
+		// given: Config with current agent names
+		const agents = {
+			oracle: { model: "openai/gpt-5.4" },
+			librarian: { model: "google/gemini-3-flash" },
+			explore: { model: "opencode/gpt-5-nano" },
+		};
 
-    // when: Migrate agent names
-    const { migrated, changed } = migrateAgentNames(agents)
+		// when: Migrate agent names
+		const { migrated, changed } = migrateAgentNames(agents);
 
-    // then: Current names should remain unchanged
-    expect(changed).toBe(false)
-    expect(migrated["oracle"]).toEqual({ model: "openai/gpt-5.4" })
-    expect(migrated["librarian"]).toEqual({ model: "google/gemini-3-flash" })
-    expect(migrated["explore"]).toEqual({ model: "opencode/gpt-5-nano" })
-  })
+		// then: Current names should remain unchanged
+		expect(changed).toBe(false);
+		expect(migrated["oracle"]).toEqual({ model: "openai/gpt-5.4" });
+		expect(migrated["librarian"]).toEqual({ model: "google/gemini-3-flash" });
+		expect(migrated["explore"]).toEqual({ model: "opencode/gpt-5-nano" });
+	});
 
-  test("handles case-insensitive migration", () => {
-    // given: Config with mixed case agent names
-    const agents = {
-      SISYPHUS: { model: "test" },
-      "planner-sisyphus": { prompt: "test" },
-      "Orchestrator-Sisyphus": { model: "openai/gpt-5.4" },
-    }
+	test("handles case-insensitive migration", () => {
+		// given: Config with mixed case agent names
+		const agents = {
+			SISYPHUS: { model: "test" },
+			"planner-sisyphus": { prompt: "test" },
+			"Orchestrator-Sisyphus": { model: "openai/gpt-5.4" },
+		};
 
-    // when: Migrate agent names
-    const { migrated, changed } = migrateAgentNames(agents)
+		// when: Migrate agent names
+		const { migrated } = migrateAgentNames(agents);
 
-    // then: Case-insensitive lookup should migrate correctly
-    expect(migrated["sisyphus"]).toEqual({ model: "test" })
-    expect(migrated["prometheus"]).toEqual({ prompt: "test" })
-    expect(migrated["atlas"]).toEqual({ model: "openai/gpt-5.4" })
-  })
+		// then: Case-insensitive lookup should migrate correctly
+		expect(migrated["sisyphus"]).toEqual({ model: "test" });
+		expect(migrated["prometheus"]).toEqual({ prompt: "test" });
+		expect(migrated["atlas"]).toEqual({ model: "openai/gpt-5.4" });
+	});
 
-  test("passes through unknown agent names unchanged", () => {
-    // given: Config with unknown agent name
-    const agents = {
-      "custom-agent": { model: "custom/model" },
-    }
+	test("passes through unknown agent names unchanged", () => {
+		// given: Config with unknown agent name
+		const agents = {
+			"custom-agent": { model: "custom/model" },
+		};
 
-    // when: Migrate agent names
-    const { migrated, changed } = migrateAgentNames(agents)
+		// when: Migrate agent names
+		const { migrated, changed } = migrateAgentNames(agents);
 
-    // then: Unknown names should pass through
-    expect(changed).toBe(false)
-    expect(migrated["custom-agent"]).toEqual({ model: "custom/model" })
-  })
+		// then: Unknown names should pass through
+		expect(changed).toBe(false);
+		expect(migrated["custom-agent"]).toEqual({ model: "custom/model" });
+	});
 
-  test("migrates orchestrator-sisyphus to atlas", () => {
-    // given: Config with legacy orchestrator-sisyphus agent name
-    const agents = {
-      "orchestrator-sisyphus": { model: "anthropic/claude-opus-4-6" },
-    }
+	test("migrates orchestrator-sisyphus to atlas", () => {
+		// given: Config with legacy orchestrator-sisyphus agent name
+		const agents = {
+			"orchestrator-sisyphus": { model: "anthropic/claude-opus-4-6" },
+		};
 
-    // when: Migrate agent names
-    const { migrated, changed } = migrateAgentNames(agents)
+		// when: Migrate agent names
+		const { migrated, changed } = migrateAgentNames(agents);
 
-    // then: orchestrator-sisyphus should be migrated to atlas
-    expect(changed).toBe(true)
-    expect(migrated["atlas"]).toEqual({ model: "anthropic/claude-opus-4-6" })
-    expect(migrated["orchestrator-sisyphus"]).toBeUndefined()
-  })
+		// then: orchestrator-sisyphus should be migrated to atlas
+		expect(changed).toBe(true);
+		expect(migrated["atlas"]).toEqual({ model: "anthropic/claude-opus-4-6" });
+		expect(migrated["orchestrator-sisyphus"]).toBeUndefined();
+	});
 
-  test("migrates lowercase atlas to atlas", () => {
-    // given: Config with lowercase atlas agent name
-    const agents = {
-      atlas: { model: "anthropic/claude-opus-4-6" },
-    }
+	test("migrates lowercase atlas to atlas", () => {
+		// given: Config with lowercase atlas agent name
+		const agents = {
+			atlas: { model: "anthropic/claude-opus-4-6" },
+		};
 
-    // when: Migrate agent names
-    const { migrated, changed } = migrateAgentNames(agents)
+		// when: Migrate agent names
+		const { migrated, changed } = migrateAgentNames(agents);
 
-    // then: lowercase atlas should remain atlas (no change needed)
-    expect(changed).toBe(false)
-    expect(migrated["atlas"]).toEqual({ model: "anthropic/claude-opus-4-6" })
-  })
+		// then: lowercase atlas should remain atlas (no change needed)
+		expect(changed).toBe(false);
+		expect(migrated["atlas"]).toEqual({ model: "anthropic/claude-opus-4-6" });
+	});
 
-  test("migrates Sisyphus variants to lowercase", () => {
-    // given agents config with "Sisyphus" key
-    // when migrateAgentNames called
-    // then key becomes "sisyphus"
-    const agents = { "Sisyphus": { model: "test" } }
-    const { migrated, changed } = migrateAgentNames(agents)
-    expect(changed).toBe(true)
-    expect(migrated["sisyphus"]).toEqual({ model: "test" })
-    expect(migrated["Sisyphus"]).toBeUndefined()
-  })
+	test("migrates Sisyphus variants to lowercase", () => {
+		// given agents config with "Sisyphus" key
+		// when migrateAgentNames called
+		// then key becomes "sisyphus"
+		const agents = { Sisyphus: { model: "test" } };
+		const { migrated, changed } = migrateAgentNames(agents);
+		expect(changed).toBe(true);
+		expect(migrated["sisyphus"]).toEqual({ model: "test" });
+		expect(migrated["Sisyphus"]).toBeUndefined();
+	});
 
-  test("migrates omo key to sisyphus", () => {
-    // given agents config with "omo" key
-    // when migrateAgentNames called
-    // then key becomes "sisyphus"
-    const agents = { "omo": { model: "test" } }
-    const { migrated, changed } = migrateAgentNames(agents)
-    expect(changed).toBe(true)
-    expect(migrated["sisyphus"]).toEqual({ model: "test" })
-    expect(migrated["omo"]).toBeUndefined()
-  })
+	test("migrates omo key to sisyphus", () => {
+		// given agents config with "omo" key
+		// when migrateAgentNames called
+		// then key becomes "sisyphus"
+		const agents = { omo: { model: "test" } };
+		const { migrated, changed } = migrateAgentNames(agents);
+		expect(changed).toBe(true);
+		expect(migrated["sisyphus"]).toEqual({ model: "test" });
+		expect(migrated["omo"]).toBeUndefined();
+	});
 
-  test("migrates Atlas variants to lowercase", () => {
-    // given agents config with "Atlas" key
-    // when migrateAgentNames called
-    // then key becomes "atlas"
-    const agents = { "Atlas": { model: "test" } }
-    const { migrated, changed } = migrateAgentNames(agents)
-    expect(changed).toBe(true)
-    expect(migrated["atlas"]).toEqual({ model: "test" })
-    expect(migrated["Atlas"]).toBeUndefined()
-  })
+	test("migrates Atlas variants to lowercase", () => {
+		// given agents config with "Atlas" key
+		// when migrateAgentNames called
+		// then key becomes "atlas"
+		const agents = { Atlas: { model: "test" } };
+		const { migrated, changed } = migrateAgentNames(agents);
+		expect(changed).toBe(true);
+		expect(migrated["atlas"]).toEqual({ model: "test" });
+		expect(migrated["Atlas"]).toBeUndefined();
+	});
 
-  test("migrates Prometheus variants to lowercase", () => {
-    // given agents config with "Prometheus (Planner)" key
-    // when migrateAgentNames called
-    // then key becomes "prometheus"
-    const agents = { "Prometheus (Planner)": { model: "test" } }
-    const { migrated, changed } = migrateAgentNames(agents)
-    expect(changed).toBe(true)
-    expect(migrated["prometheus"]).toEqual({ model: "test" })
-    expect(migrated["Prometheus (Planner)"]).toBeUndefined()
-  })
+	test("migrates Prometheus variants to lowercase", () => {
+		// given agents config with "Prometheus (Planner)" key
+		// when migrateAgentNames called
+		// then key becomes "prometheus"
+		const agents = { "Prometheus (Planner)": { model: "test" } };
+		const { migrated, changed } = migrateAgentNames(agents);
+		expect(changed).toBe(true);
+		expect(migrated["prometheus"]).toEqual({ model: "test" });
+		expect(migrated["Prometheus (Planner)"]).toBeUndefined();
+	});
 
-  test("migrates Metis variants to lowercase", () => {
-    // given agents config with "Metis (Plan Consultant)" key
-    // when migrateAgentNames called
-    // then key becomes "metis"
-    const agents = { "Metis (Plan Consultant)": { model: "test" } }
-    const { migrated, changed } = migrateAgentNames(agents)
-    expect(changed).toBe(true)
-    expect(migrated["metis"]).toEqual({ model: "test" })
-    expect(migrated["Metis (Plan Consultant)"]).toBeUndefined()
-  })
+	test("migrates Metis variants to lowercase", () => {
+		// given agents config with "Metis (Plan Consultant)" key
+		// when migrateAgentNames called
+		// then key becomes "metis"
+		const agents = { "Metis (Plan Consultant)": { model: "test" } };
+		const { migrated, changed } = migrateAgentNames(agents);
+		expect(changed).toBe(true);
+		expect(migrated["metis"]).toEqual({ model: "test" });
+		expect(migrated["Metis (Plan Consultant)"]).toBeUndefined();
+	});
 
-  test("migrates Momus variants to lowercase", () => {
-    // given agents config with "Momus (Plan Reviewer)" key
-    // when migrateAgentNames called
-    // then key becomes "momus"
-    const agents = { "Momus (Plan Reviewer)": { model: "test" } }
-    const { migrated, changed } = migrateAgentNames(agents)
-    expect(changed).toBe(true)
-    expect(migrated["momus"]).toEqual({ model: "test" })
-    expect(migrated["Momus (Plan Reviewer)"]).toBeUndefined()
-  })
+	test("migrates Momus variants to lowercase", () => {
+		// given agents config with "Momus (Plan Reviewer)" key
+		// when migrateAgentNames called
+		// then key becomes "momus"
+		const agents = { "Momus (Plan Reviewer)": { model: "test" } };
+		const { migrated, changed } = migrateAgentNames(agents);
+		expect(changed).toBe(true);
+		expect(migrated["momus"]).toEqual({ model: "test" });
+		expect(migrated["Momus (Plan Reviewer)"]).toBeUndefined();
+	});
 
-  test("migrates Sisyphus-Junior to lowercase", () => {
-    // given agents config with "Sisyphus-Junior" key
-    // when migrateAgentNames called
-    // then key becomes "sisyphus-junior"
-    const agents = { "Sisyphus-Junior": { model: "test" } }
-    const { migrated, changed } = migrateAgentNames(agents)
-    expect(changed).toBe(true)
-    expect(migrated["sisyphus-junior"]).toEqual({ model: "test" })
-    expect(migrated["Sisyphus-Junior"]).toBeUndefined()
-  })
+	test("migrates Sisyphus-Junior to lowercase", () => {
+		// given agents config with "Sisyphus-Junior" key
+		// when migrateAgentNames called
+		// then key becomes "sisyphus-junior"
+		const agents = { "Sisyphus-Junior": { model: "test" } };
+		const { migrated, changed } = migrateAgentNames(agents);
+		expect(changed).toBe(true);
+		expect(migrated["sisyphus-junior"]).toEqual({ model: "test" });
+		expect(migrated["Sisyphus-Junior"]).toBeUndefined();
+	});
 
-  test("preserves lowercase passthrough", () => {
-    // given agents config with "oracle" key
-    // when migrateAgentNames called
-    // then key remains "oracle" (no change needed)
-    const agents = { "oracle": { model: "test" } }
-    const { migrated, changed } = migrateAgentNames(agents)
-    expect(changed).toBe(false)
-    expect(migrated["oracle"]).toEqual({ model: "test" })
-  })
-})
+	test("preserves lowercase passthrough", () => {
+		// given agents config with "oracle" key
+		// when migrateAgentNames called
+		// then key remains "oracle" (no change needed)
+		const agents = { oracle: { model: "test" } };
+		const { migrated, changed } = migrateAgentNames(agents);
+		expect(changed).toBe(false);
+		expect(migrated["oracle"]).toEqual({ model: "test" });
+	});
+});
 
 describe("migrateHookNames", () => {
-  test("migrates anthropic-auto-compact to anthropic-context-window-limit-recovery", () => {
-    // given: Config with legacy hook name
-    const hooks = ["anthropic-auto-compact", "comment-checker"]
+	test("migrates anthropic-auto-compact to anthropic-context-window-limit-recovery", () => {
+		// given: Config with legacy hook name
+		const hooks = ["anthropic-auto-compact", "comment-checker"];
 
-    // when: Migrate hook names
-    const { migrated, changed, removed } = migrateHookNames(hooks)
+		// when: Migrate hook names
+		const { migrated, changed, removed } = migrateHookNames(hooks);
 
-    // then: Legacy hook name should be migrated
-    expect(changed).toBe(true)
-    expect(migrated).toContain("anthropic-context-window-limit-recovery")
-    expect(migrated).toContain("comment-checker")
-    expect(migrated).not.toContain("anthropic-auto-compact")
-    expect(removed).toEqual([])
-  })
+		// then: Legacy hook name should be migrated
+		expect(changed).toBe(true);
+		expect(migrated).toContain("anthropic-context-window-limit-recovery");
+		expect(migrated).toContain("comment-checker");
+		expect(migrated).not.toContain("anthropic-auto-compact");
+		expect(removed).toEqual([]);
+	});
 
-  test("preserves current hook names unchanged", () => {
-    // given: Config with current hook names
-    const hooks = [
-      "anthropic-context-window-limit-recovery",
-      "todo-continuation-enforcer",
-      "session-recovery",
-    ]
+	test("preserves current hook names unchanged", () => {
+		// given: Config with current hook names
+		const hooks = [
+			"anthropic-context-window-limit-recovery",
+			"todo-continuation-enforcer",
+			"session-recovery",
+		];
 
-    // when: Migrate hook names
-    const { migrated, changed, removed } = migrateHookNames(hooks)
+		// when: Migrate hook names
+		const { migrated, changed, removed } = migrateHookNames(hooks);
 
-    // then: Current names should remain unchanged
-    expect(changed).toBe(false)
-    expect(migrated).toEqual(hooks)
-    expect(removed).toEqual([])
-  })
+		// then: Current names should remain unchanged
+		expect(changed).toBe(false);
+		expect(migrated).toEqual(hooks);
+		expect(removed).toEqual([]);
+	});
 
-  test("handles empty hooks array", () => {
-    // given: Empty hooks array
-    const hooks: string[] = []
+	test("handles empty hooks array", () => {
+		// given: Empty hooks array
+		const hooks: string[] = [];
 
-    // when: Migrate hook names
-    const { migrated, changed, removed } = migrateHookNames(hooks)
+		// when: Migrate hook names
+		const { migrated, changed, removed } = migrateHookNames(hooks);
 
-    // then: Should return empty array with no changes
-    expect(changed).toBe(false)
-    expect(migrated).toEqual([])
-    expect(removed).toEqual([])
-  })
+		// then: Should return empty array with no changes
+		expect(changed).toBe(false);
+		expect(migrated).toEqual([]);
+		expect(removed).toEqual([]);
+	});
 
-  test("migrates multiple legacy hook names", () => {
-    // given: Multiple legacy hook names (if more are added in future)
-    const hooks = ["anthropic-auto-compact"]
+	test("migrates multiple legacy hook names", () => {
+		// given: Multiple legacy hook names (if more are added in future)
+		const hooks = ["anthropic-auto-compact"];
 
-    // when: Migrate hook names
-    const { migrated, changed } = migrateHookNames(hooks)
+		// when: Migrate hook names
+		const { migrated, changed } = migrateHookNames(hooks);
 
-    // then: All legacy names should be migrated
-    expect(changed).toBe(true)
-    expect(migrated).toEqual(["anthropic-context-window-limit-recovery"])
-  })
+		// then: All legacy names should be migrated
+		expect(changed).toBe(true);
+		expect(migrated).toEqual(["anthropic-context-window-limit-recovery"]);
+	});
 
-  test("migrates sisyphus-orchestrator to atlas", () => {
-    // given: Config with legacy sisyphus-orchestrator hook
-    const hooks = ["sisyphus-orchestrator", "comment-checker"]
+	test("migrates sisyphus-orchestrator to atlas", () => {
+		// given: Config with legacy sisyphus-orchestrator hook
+		const hooks = ["sisyphus-orchestrator", "comment-checker"];
 
-    // when: Migrate hook names
-    const { migrated, changed, removed } = migrateHookNames(hooks)
+		// when: Migrate hook names
+		const { migrated, changed, removed } = migrateHookNames(hooks);
 
-    // then: sisyphus-orchestrator should be migrated to atlas
-    expect(changed).toBe(true)
-    expect(migrated).toContain("atlas")
-    expect(migrated).toContain("comment-checker")
-    expect(migrated).not.toContain("sisyphus-orchestrator")
-    expect(removed).toEqual([])
-  })
+		// then: sisyphus-orchestrator should be migrated to atlas
+		expect(changed).toBe(true);
+		expect(migrated).toContain("atlas");
+		expect(migrated).toContain("comment-checker");
+		expect(migrated).not.toContain("sisyphus-orchestrator");
+		expect(removed).toEqual([]);
+	});
 
-  test("removes obsolete hooks and returns them in removed array", () => {
-    // given: Config with removed hooks from v3.0.0
-    const hooks = ["preemptive-compaction", "empty-message-sanitizer", "comment-checker"]
+	test("removes obsolete hooks and returns them in removed array", () => {
+		// given: Config with removed hooks from v3.0.0
+		const hooks = [
+			"preemptive-compaction",
+			"empty-message-sanitizer",
+			"comment-checker",
+		];
 
-    // when: Migrate hook names
-    const { migrated, changed, removed } = migrateHookNames(hooks)
+		// when: Migrate hook names
+		const { migrated, changed, removed } = migrateHookNames(hooks);
 
-    // then: Removed hooks should be filtered out
-    expect(changed).toBe(true)
-    expect(migrated).toEqual(["preemptive-compaction", "comment-checker"])
-    expect(removed).toContain("empty-message-sanitizer")
-    expect(removed).toHaveLength(1)
-  })
+		// then: Removed hooks should be filtered out
+		expect(changed).toBe(true);
+		expect(migrated).toEqual(["preemptive-compaction", "comment-checker"]);
+		expect(removed).toContain("empty-message-sanitizer");
+		expect(removed).toHaveLength(1);
+	});
 
-  test("removes gpt-permission-continuation from disabled hooks", () => {
-    // given: Config with removed GPT permission continuation hook
-    const hooks = ["gpt-permission-continuation", "comment-checker"]
+	test("removes gpt-permission-continuation from disabled hooks", () => {
+		// given: Config with removed GPT permission continuation hook
+		const hooks = ["gpt-permission-continuation", "comment-checker"];
 
-    // when: Migrate hook names
-    const { migrated, changed, removed } = migrateHookNames(hooks)
+		// when: Migrate hook names
+		const { migrated, changed, removed } = migrateHookNames(hooks);
 
-    // then: Removed hook should be filtered out
-    expect(changed).toBe(true)
-    expect(migrated).toEqual(["comment-checker"])
-    expect(removed).toEqual(["gpt-permission-continuation"])
-  })
+		// then: Removed hook should be filtered out
+		expect(changed).toBe(true);
+		expect(migrated).toEqual(["comment-checker"]);
+		expect(removed).toEqual(["gpt-permission-continuation"]);
+	});
 
-  test("handles mixed migration and removal", () => {
-    // given: Config with both legacy rename and removed hooks
-    const hooks = ["anthropic-auto-compact", "preemptive-compaction", "sisyphus-orchestrator"]
+	test("handles mixed migration and removal", () => {
+		// given: Config with both legacy rename and removed hooks
+		const hooks = [
+			"anthropic-auto-compact",
+			"preemptive-compaction",
+			"sisyphus-orchestrator",
+		];
 
-    // when: Migrate hook names
-    const { migrated, changed, removed } = migrateHookNames(hooks)
+		// when: Migrate hook names
+		const { migrated, changed, removed } = migrateHookNames(hooks);
 
-    // then: Legacy should be renamed, removed should be filtered
-    expect(changed).toBe(true)
-    expect(migrated).toContain("anthropic-context-window-limit-recovery")
-    expect(migrated).toContain("atlas")
-    expect(migrated).toContain("preemptive-compaction")
-    expect(removed).toEqual([])
-  })
-})
+		// then: Legacy should be renamed, removed should be filtered
+		expect(changed).toBe(true);
+		expect(migrated).toContain("anthropic-context-window-limit-recovery");
+		expect(migrated).toContain("atlas");
+		expect(migrated).toContain("preemptive-compaction");
+		expect(removed).toEqual([]);
+	});
+});
 
 describe("migrateConfigFile", () => {
-  const testConfigPath = "/tmp/nonexistent-path-for-test.json"
+	const testConfigPath = "/tmp/nonexistent-path-for-test.json";
 
-  test("migrates experimental.hashline_edit to top-level hashline_edit", () => {
-    // given: Config with legacy experimental.hashline_edit
-    const rawConfig: Record<string, unknown> = {
-      experimental: { hashline_edit: false, safe_hook_creation: true },
-    }
+	test("migrates experimental.hashline_edit to top-level hashline_edit", () => {
+		// given: Config with legacy experimental.hashline_edit
+		const rawConfig: Record<string, unknown> = {
+			experimental: { hashline_edit: false, safe_hook_creation: true },
+		};
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: hashline_edit should move to top-level and be removed from experimental
-    expect(needsWrite).toBe(true)
-    expect(rawConfig.hashline_edit).toBe(false)
-    expect(rawConfig.experimental).toEqual({ safe_hook_creation: true })
-  })
+		// then: hashline_edit should move to top-level and be removed from experimental
+		expect(needsWrite).toBe(true);
+		expect(rawConfig.hashline_edit).toBe(false);
+		expect(rawConfig.experimental).toEqual({ safe_hook_creation: true });
+	});
 
-  test("migrates and removes empty experimental object", () => {
-    // given: Config with only experimental.hashline_edit
-    const rawConfig: Record<string, unknown> = {
-      experimental: { hashline_edit: true },
-    }
+	test("migrates and removes empty experimental object", () => {
+		// given: Config with only experimental.hashline_edit
+		const rawConfig: Record<string, unknown> = {
+			experimental: { hashline_edit: true },
+		};
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: hashline_edit moves top-level and empty experimental is removed
-    expect(needsWrite).toBe(true)
-    expect(rawConfig.hashline_edit).toBe(true)
-    expect(rawConfig.experimental).toBeUndefined()
-  })
+		// then: hashline_edit moves top-level and empty experimental is removed
+		expect(needsWrite).toBe(true);
+		expect(rawConfig.hashline_edit).toBe(true);
+		expect(rawConfig.experimental).toBeUndefined();
+	});
 
-  test("does not overwrite top-level hashline_edit when already set", () => {
-    // given: Config with both top-level and legacy location
-    const rawConfig: Record<string, unknown> = {
-      hashline_edit: false,
-      experimental: { hashline_edit: true },
-    }
+	test("does not overwrite top-level hashline_edit when already set", () => {
+		// given: Config with both top-level and legacy location
+		const rawConfig: Record<string, unknown> = {
+			hashline_edit: false,
+			experimental: { hashline_edit: true },
+		};
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: top-level value wins, legacy key removed
-    expect(needsWrite).toBe(true)
-    expect(rawConfig.hashline_edit).toBe(false)
-    expect(rawConfig.experimental).toBeUndefined()
-  })
+		// then: top-level value wins, legacy key removed
+		expect(needsWrite).toBe(true);
+		expect(rawConfig.hashline_edit).toBe(false);
+		expect(rawConfig.experimental).toBeUndefined();
+	});
 
-  test("migrates omo_agent to sisyphus_agent", () => {
-    // given: Config with legacy omo_agent key
-    const rawConfig: Record<string, unknown> = {
-      omo_agent: { disabled: false },
-    }
+	test("migrates omo_agent to sisyphus_agent", () => {
+		// given: Config with legacy omo_agent key
+		const rawConfig: Record<string, unknown> = {
+			omo_agent: { disabled: false },
+		};
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: omo_agent should be migrated to sisyphus_agent
-    expect(needsWrite).toBe(true)
-    expect(rawConfig.sisyphus_agent).toEqual({ disabled: false })
-    expect(rawConfig.omo_agent).toBeUndefined()
-  })
+		// then: omo_agent should be migrated to sisyphus_agent
+		expect(needsWrite).toBe(true);
+		expect(rawConfig.sisyphus_agent).toEqual({ disabled: false });
+		expect(rawConfig.omo_agent).toBeUndefined();
+	});
 
-  test("migrates legacy agent names in agents object", () => {
-    // given: Config with legacy agent names
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        omo: { model: "test" },
-        OmO: { temperature: 0.5 },
-      },
-    }
+	test("migrates legacy agent names in agents object", () => {
+		// given: Config with legacy agent names
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				omo: { model: "test" },
+				OmO: { temperature: 0.5 },
+			},
+		};
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: Agent names should be migrated
-    expect(needsWrite).toBe(true)
-    const agents = rawConfig.agents as Record<string, unknown>
-    expect(agents["sisyphus"]).toBeDefined()
-  })
+		// then: Agent names should be migrated
+		expect(needsWrite).toBe(true);
+		const agents = rawConfig.agents as Record<string, unknown>;
+		expect(agents["sisyphus"]).toBeDefined();
+	});
 
-  test("migrates legacy hook names in disabled_hooks", () => {
-    // given: Config with legacy hook names
-    const rawConfig: Record<string, unknown> = {
-      disabled_hooks: ["anthropic-auto-compact", "comment-checker"],
-    }
+	test("migrates legacy hook names in disabled_hooks", () => {
+		// given: Config with legacy hook names
+		const rawConfig: Record<string, unknown> = {
+			disabled_hooks: ["anthropic-auto-compact", "comment-checker"],
+		};
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: Hook names should be migrated
-    expect(needsWrite).toBe(true)
-    expect(rawConfig.disabled_hooks).toContain("anthropic-context-window-limit-recovery")
-    expect(rawConfig.disabled_hooks).not.toContain("anthropic-auto-compact")
-  })
+		// then: Hook names should be migrated
+		expect(needsWrite).toBe(true);
+		expect(rawConfig.disabled_hooks).toContain(
+			"anthropic-context-window-limit-recovery",
+		);
+		expect(rawConfig.disabled_hooks).not.toContain("anthropic-auto-compact");
+	});
 
-  test("removes deleted hook names from disabled_hooks", () => {
-    const rawConfig: Record<string, unknown> = {
-      disabled_hooks: ["delegate-task-english-directive", "comment-checker"],
-    }
+	test("removes deleted hook names from disabled_hooks", () => {
+		const rawConfig: Record<string, unknown> = {
+			disabled_hooks: ["delegate-task-english-directive", "comment-checker"],
+		};
 
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    expect(needsWrite).toBe(true)
-    expect(rawConfig.disabled_hooks).toEqual(["comment-checker"])
-  })
+		expect(needsWrite).toBe(true);
+		expect(rawConfig.disabled_hooks).toEqual(["comment-checker"]);
+	});
 
-  test("removes gpt-permission-continuation from disabled_hooks", () => {
-    // given: Config with removed GPT permission continuation hook
-    const rawConfig: Record<string, unknown> = {
-      disabled_hooks: ["gpt-permission-continuation", "comment-checker"],
-    }
+	test("removes gpt-permission-continuation from disabled_hooks", () => {
+		// given: Config with removed GPT permission continuation hook
+		const rawConfig: Record<string, unknown> = {
+			disabled_hooks: ["gpt-permission-continuation", "comment-checker"],
+		};
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: Removed hook should be filtered out
-    expect(needsWrite).toBe(true)
-    expect(rawConfig.disabled_hooks).toEqual(["comment-checker"])
-  })
+		// then: Removed hook should be filtered out
+		expect(needsWrite).toBe(true);
+		expect(rawConfig.disabled_hooks).toEqual(["comment-checker"]);
+	});
 
-  test("does not write if no migration needed", () => {
-    // given: Config with current names
-    const rawConfig: Record<string, unknown> = {
-      sisyphus_agent: { disabled: false },
-      agents: {
-        sisyphus: { model: "test" },
-      },
-      disabled_hooks: ["anthropic-context-window-limit-recovery"],
-    }
+	test("does not write if no migration needed", () => {
+		// given: Config with current names
+		const rawConfig: Record<string, unknown> = {
+			sisyphus_agent: { disabled: false },
+			agents: {
+				sisyphus: { model: "test" },
+			},
+			disabled_hooks: ["anthropic-context-window-limit-recovery"],
+		};
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: No write should be needed
-    expect(needsWrite).toBe(false)
-  })
+		// then: No write should be needed
+		expect(needsWrite).toBe(false);
+	});
 
-   test("handles migration of all legacy items together", () => {
-     // given: Config with all legacy items
-     const rawConfig: Record<string, unknown> = {
-       omo_agent: { disabled: false },
-       agents: {
-         omo: { model: "test" },
-         "OmO-Plan": { prompt: "custom" },
-       },
-       disabled_hooks: ["anthropic-auto-compact"],
-     }
+	test("handles migration of all legacy items together", () => {
+		// given: Config with all legacy items
+		const rawConfig: Record<string, unknown> = {
+			omo_agent: { disabled: false },
+			agents: {
+				omo: { model: "test" },
+				"OmO-Plan": { prompt: "custom" },
+			},
+			disabled_hooks: ["anthropic-auto-compact"],
+		};
 
-     // when: Migrate config file
-     const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-     // then: All legacy items should be migrated
-     expect(needsWrite).toBe(true)
-     expect(rawConfig.sisyphus_agent).toEqual({ disabled: false })
-     expect(rawConfig.omo_agent).toBeUndefined()
-     const agents = rawConfig.agents as Record<string, unknown>
-     expect(agents["sisyphus"]).toBeDefined()
-     expect(agents["prometheus"]).toBeDefined()
-     expect(rawConfig.disabled_hooks).toContain("anthropic-context-window-limit-recovery")
-   })
+		// then: All legacy items should be migrated
+		expect(needsWrite).toBe(true);
+		expect(rawConfig.sisyphus_agent).toEqual({ disabled: false });
+		expect(rawConfig.omo_agent).toBeUndefined();
+		const agents = rawConfig.agents as Record<string, unknown>;
+		expect(agents["sisyphus"]).toBeDefined();
+		expect(agents["prometheus"]).toBeDefined();
+		expect(rawConfig.disabled_hooks).toContain(
+			"anthropic-context-window-limit-recovery",
+		);
+	});
 
-   test("does not migrate gpt-5.4-codex model versions in agents", () => {
-     // given: Config with old model version in agents
-     const rawConfig: Record<string, unknown> = {
-       agents: {
-         sisyphus: { model: "openai/gpt-5.4-codex", temperature: 0.1 },
-       },
-     }
+	test("does not migrate gpt-5.4-codex model versions in agents", () => {
+		// given: Config with old model version in agents
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				sisyphus: { model: "openai/gpt-5.4-codex", temperature: 0.1 },
+			},
+		};
 
-     // when: Migrate config file
-     const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-     // then: Model version should remain unchanged
-     expect(needsWrite).toBe(false)
-     const agents = rawConfig.agents as Record<string, Record<string, unknown>>
-     expect(agents["sisyphus"].model).toBe("openai/gpt-5.4-codex")
-   })
+		// then: Model version should remain unchanged
+		expect(needsWrite).toBe(false);
+		const agents = rawConfig.agents as Record<string, Record<string, unknown>>;
+		expect(agents["sisyphus"].model).toBe("openai/gpt-5.4-codex");
+	});
 
-   test("migrates model versions in categories", () => {
-     // given: Config with old model version in categories
-     const rawConfig: Record<string, unknown> = {
-       categories: {
-         "my-category": { model: "anthropic/claude-opus-4-5", temperature: 0.2 },
-       },
-     }
+	test("migrates model versions in categories", () => {
+		// given: Config with old model version in categories
+		const rawConfig: Record<string, unknown> = {
+			categories: {
+				"my-category": { model: "anthropic/claude-opus-4-5", temperature: 0.2 },
+			},
+		};
 
-     // when: Migrate config file
-     const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-     // then: Model version should be migrated
-     expect(needsWrite).toBe(true)
-     const categories = rawConfig.categories as Record<string, Record<string, unknown>>
-     expect(categories["my-category"].model).toBe("anthropic/claude-opus-4-6")
-   })
+		// then: Model version should be migrated
+		expect(needsWrite).toBe(true);
+		const categories = rawConfig.categories as Record<
+			string,
+			Record<string, unknown>
+		>;
+		expect(categories["my-category"].model).toBe("anthropic/claude-opus-4-6");
+	});
 
-   test("does not set needsWrite when no model versions need migration", () => {
-     // given: Config with current model versions
-     const rawConfig: Record<string, unknown> = {
-       agents: {
-         sisyphus: { model: "openai/gpt-5.4-codex" },
-       },
-       categories: {
-         "my-category": { model: "anthropic/claude-opus-4-6" },
-       },
-     }
+	test("does not set needsWrite when no model versions need migration", () => {
+		// given: Config with current model versions
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				sisyphus: { model: "openai/gpt-5.4-codex" },
+			},
+			categories: {
+				"my-category": { model: "anthropic/claude-opus-4-6" },
+			},
+		};
 
-     // when: Migrate config file
-     const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-     // then: No write should be needed
-     expect(needsWrite).toBe(false)
-   })
-})
+		// then: No write should be needed
+		expect(needsWrite).toBe(false);
+	});
+});
 
 describe("migration maps", () => {
-  test("AGENT_NAME_MAP contains all expected legacy mappings", () => {
-    // given/#when: Check AGENT_NAME_MAP
-    // then: Should contain all legacy → lowercase mappings
-    expect(AGENT_NAME_MAP["omo"]).toBe("sisyphus")
-    expect(AGENT_NAME_MAP["OmO"]).toBe("sisyphus")
-    expect(AGENT_NAME_MAP["OmO-Plan"]).toBe("prometheus")
-    expect(AGENT_NAME_MAP["omo-plan"]).toBe("prometheus")
-    expect(AGENT_NAME_MAP["Planner-Sisyphus"]).toBe("prometheus")
-    expect(AGENT_NAME_MAP["plan-consultant"]).toBe("metis")
-  })
+	test("AGENT_NAME_MAP contains all expected legacy mappings", () => {
+		// given/#when: Check AGENT_NAME_MAP
+		// then: Should contain all legacy → lowercase mappings
+		expect(AGENT_NAME_MAP["omo"]).toBe("sisyphus");
+		expect(AGENT_NAME_MAP["OmO"]).toBe("sisyphus");
+		expect(AGENT_NAME_MAP["OmO-Plan"]).toBe("prometheus");
+		expect(AGENT_NAME_MAP["omo-plan"]).toBe("prometheus");
+		expect(AGENT_NAME_MAP["Planner-Sisyphus"]).toBe("prometheus");
+		expect(AGENT_NAME_MAP["plan-consultant"]).toBe("metis");
+	});
 
-  test("HOOK_NAME_MAP contains anthropic-auto-compact migration", () => {
-    // given/#when: Check HOOK_NAME_MAP
-    // then: Should contain be legacy hook name mapping
-    expect(HOOK_NAME_MAP["anthropic-auto-compact"]).toBe("anthropic-context-window-limit-recovery")
-  })
-})
+	test("HOOK_NAME_MAP contains anthropic-auto-compact migration", () => {
+		// given/#when: Check HOOK_NAME_MAP
+		// then: Should contain be legacy hook name mapping
+		expect(HOOK_NAME_MAP["anthropic-auto-compact"]).toBe(
+			"anthropic-context-window-limit-recovery",
+		);
+	});
+});
 
 describe("MODEL_VERSION_MAP", () => {
-  test("does not include openai/gpt-5.4-codex migration", () => {
-    // given/when: Check MODEL_VERSION_MAP
-    // then: openai/gpt-5.4-codex should not be migrated
-    expect(MODEL_VERSION_MAP["openai/gpt-5.4-codex"]).toBeUndefined()
-  })
+	test("does not include openai/gpt-5.4-codex migration", () => {
+		// given/when: Check MODEL_VERSION_MAP
+		// then: openai/gpt-5.4-codex should not be migrated
+		expect(MODEL_VERSION_MAP["openai/gpt-5.4-codex"]).toBeUndefined();
+	});
 
-  test("maps anthropic/claude-opus-4-5 to anthropic/claude-opus-4-6", () => {
-    // given/when: Check MODEL_VERSION_MAP
-    // then: Should contain correct mapping
-    expect(MODEL_VERSION_MAP["anthropic/claude-opus-4-5"]).toBe("anthropic/claude-opus-4-6")
-  })
-})
+	test("maps anthropic/claude-opus-4-5 to anthropic/claude-opus-4-6", () => {
+		// given/when: Check MODEL_VERSION_MAP
+		// then: Should contain correct mapping
+		expect(MODEL_VERSION_MAP["anthropic/claude-opus-4-5"]).toBe(
+			"anthropic/claude-opus-4-6",
+		);
+	});
+});
 
 describe("migrateModelVersions", () => {
-  test("#given a config with gpt-5.4-codex model #when migrating model versions #then does not overwrite with non-existent gpt-5.3-codex", () => {
-    // given: Agent config with gpt-5.4-codex model
-    const agents = {
-      sisyphus: { model: "openai/gpt-5.4-codex", temperature: 0.1 },
-    }
+	test("#given a config with gpt-5.4-codex model #when migrating model versions #then does not overwrite with non-existent gpt-5.3-codex", () => {
+		// given: Agent config with gpt-5.4-codex model
+		const agents = {
+			sisyphus: { model: "openai/gpt-5.4-codex", temperature: 0.1 },
+		};
 
-    // when: Migrate model versions
-    const { migrated, changed } = migrateModelVersions(agents)
+		// when: Migrate model versions
+		const { migrated, changed } = migrateModelVersions(agents);
 
-    // then: Model should remain unchanged
-    expect(changed).toBe(false)
-    const sisyphus = migrated["sisyphus"] as Record<string, unknown>
-    expect(sisyphus.model).toBe("openai/gpt-5.4-codex")
-    expect(sisyphus.temperature).toBe(0.1)
-  })
+		// then: Model should remain unchanged
+		expect(changed).toBe(false);
+		const sisyphus = migrated["sisyphus"] as Record<string, unknown>;
+		expect(sisyphus.model).toBe("openai/gpt-5.4-codex");
+		expect(sisyphus.temperature).toBe(0.1);
+	});
 
-  test("replaces anthropic model version", () => {
-    // given: Agent config with old anthropic model
-    const agents = {
-      prometheus: { model: "anthropic/claude-opus-4-5" },
-    }
+	test("replaces anthropic model version", () => {
+		// given: Agent config with old anthropic model
+		const agents = {
+			prometheus: { model: "anthropic/claude-opus-4-5" },
+		};
 
-    // when: Migrate model versions
-    const { migrated, changed } = migrateModelVersions(agents)
+		// when: Migrate model versions
+		const { migrated, changed } = migrateModelVersions(agents);
 
-    // then: Model should be updated
-    expect(changed).toBe(true)
-    const prometheus = migrated["prometheus"] as Record<string, unknown>
-    expect(prometheus.model).toBe("anthropic/claude-opus-4-6")
-  })
+		// then: Model should be updated
+		expect(changed).toBe(true);
+		const prometheus = migrated["prometheus"] as Record<string, unknown>;
+		expect(prometheus.model).toBe("anthropic/claude-opus-4-6");
+	});
 
-  test("leaves unknown model strings untouched", () => {
-    // given: Agent config with unknown model
-    const agents = {
-      oracle: { model: "openai/gpt-5.4", temperature: 0.5 },
-    }
+	test("leaves unknown model strings untouched", () => {
+		// given: Agent config with unknown model
+		const agents = {
+			oracle: { model: "openai/gpt-5.4", temperature: 0.5 },
+		};
 
-    // when: Migrate model versions
-    const { migrated, changed } = migrateModelVersions(agents)
+		// when: Migrate model versions
+		const { migrated, changed } = migrateModelVersions(agents);
 
-    // then: Config should remain unchanged
-    expect(changed).toBe(false)
-    const oracle = migrated["oracle"] as Record<string, unknown>
-    expect(oracle.model).toBe("openai/gpt-5.4")
-  })
+		// then: Config should remain unchanged
+		expect(changed).toBe(false);
+		const oracle = migrated["oracle"] as Record<string, unknown>;
+		expect(oracle.model).toBe("openai/gpt-5.4");
+	});
 
-  test("handles agent config with no model field", () => {
-    // given: Agent config without model field
-    const agents = {
-      sisyphus: { temperature: 0.1, prompt: "custom" },
-    }
+	test("handles agent config with no model field", () => {
+		// given: Agent config without model field
+		const agents = {
+			sisyphus: { temperature: 0.1, prompt: "custom" },
+		};
 
-    // when: Migrate model versions
-    const { migrated, changed } = migrateModelVersions(agents)
+		// when: Migrate model versions
+		const { migrated, changed } = migrateModelVersions(agents);
 
-    // then: Config should remain unchanged
-    expect(changed).toBe(false)
-    const sisyphus = migrated["sisyphus"] as Record<string, unknown>
-    expect(sisyphus.temperature).toBe(0.1)
-  })
+		// then: Config should remain unchanged
+		expect(changed).toBe(false);
+		const sisyphus = migrated["sisyphus"] as Record<string, unknown>;
+		expect(sisyphus.temperature).toBe(0.1);
+	});
 
-  test("handles agent config with non-string model", () => {
-    // given: Agent config with non-string model
-    const agents = {
-      sisyphus: { model: 123, temperature: 0.1 },
-    }
+	test("handles agent config with non-string model", () => {
+		// given: Agent config with non-string model
+		const agents = {
+			sisyphus: { model: 123, temperature: 0.1 },
+		};
 
-    // when: Migrate model versions
-    const { migrated, changed } = migrateModelVersions(agents)
+		// when: Migrate model versions
+		const { changed } = migrateModelVersions(agents);
 
-    // then: Config should remain unchanged
-    expect(changed).toBe(false)
-  })
+		// then: Config should remain unchanged
+		expect(changed).toBe(false);
+	});
 
-  test("migrates multiple agents in one pass", () => {
-    // given: Multiple agents with old models
-    const agents = {
-      sisyphus: { model: "openai/gpt-5.4-codex" },
-      prometheus: { model: "anthropic/claude-opus-4-5" },
-      oracle: { model: "openai/gpt-5.4" },
-    }
+	test("migrates multiple agents in one pass", () => {
+		// given: Multiple agents with old models
+		const agents = {
+			sisyphus: { model: "openai/gpt-5.4-codex" },
+			prometheus: { model: "anthropic/claude-opus-4-5" },
+			oracle: { model: "openai/gpt-5.4" },
+		};
 
-    // when: Migrate model versions
-    const { migrated, changed } = migrateModelVersions(agents)
+		// when: Migrate model versions
+		const { migrated, changed } = migrateModelVersions(agents);
 
-    // then: Only mapped models should be updated
-    expect(changed).toBe(true)
-    expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
-    expect((migrated["prometheus"] as Record<string, unknown>).model).toBe("anthropic/claude-opus-4-6")
-    expect((migrated["oracle"] as Record<string, unknown>).model).toBe("openai/gpt-5.4")
-  })
+		// then: Only mapped models should be updated
+		expect(changed).toBe(true);
+		expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe(
+			"openai/gpt-5.4-codex",
+		);
+		expect((migrated["prometheus"] as Record<string, unknown>).model).toBe(
+			"anthropic/claude-opus-4-6",
+		);
+		expect((migrated["oracle"] as Record<string, unknown>).model).toBe(
+			"openai/gpt-5.4",
+		);
+	});
 
-  test("handles empty object", () => {
-    // given: Empty agents object
-    const agents = {}
+	test("handles empty object", () => {
+		// given: Empty agents object
+		const agents = {};
 
-    // when: Migrate model versions
-    const { migrated, changed } = migrateModelVersions(agents)
+		// when: Migrate model versions
+		const { migrated, changed } = migrateModelVersions(agents);
 
-    // then: Should return empty with no change
-    expect(changed).toBe(false)
-    expect(Object.keys(migrated)).toHaveLength(0)
-  })
+		// then: Should return empty with no change
+		expect(changed).toBe(false);
+		expect(Object.keys(migrated)).toHaveLength(0);
+	});
 
-  test("skips already-applied migrations", () => {
-    // given: Agent config with old model, but migration already applied
-    const agents = {
-      sisyphus: { model: "openai/gpt-5.4-codex", temperature: 0.1 },
-    }
-    const appliedMigrations = new Set(["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"])
+	test("skips already-applied migrations", () => {
+		// given: Agent config with old model, but migration already applied
+		const agents = {
+			sisyphus: { model: "openai/gpt-5.4-codex", temperature: 0.1 },
+		};
+		const appliedMigrations = new Set([
+			"model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex",
+		]);
 
-    // when: Migrate with applied migrations
-    const { migrated, changed, newMigrations } = migrateModelVersions(agents, appliedMigrations)
+		// when: Migrate with applied migrations
+		const { migrated, changed, newMigrations } = migrateModelVersions(
+			agents,
+			appliedMigrations,
+		);
 
-    // then: Model should NOT be changed (user reverted intentionally)
-    expect(changed).toBe(false)
-    expect(newMigrations).toHaveLength(0)
-    const sisyphus = migrated["sisyphus"] as Record<string, unknown>
-    expect(sisyphus.model).toBe("openai/gpt-5.4-codex")
-  })
+		// then: Model should NOT be changed (user reverted intentionally)
+		expect(changed).toBe(false);
+		expect(newMigrations).toHaveLength(0);
+		const sisyphus = migrated["sisyphus"] as Record<string, unknown>;
+		expect(sisyphus.model).toBe("openai/gpt-5.4-codex");
+	});
 
-  test("applies new migrations and records them", () => {
-    // given: Agent config with old model, no prior migrations
-    const agents = {
-      sisyphus: { model: "openai/gpt-5.4-codex" },
-    }
+	test("applies new migrations and records them", () => {
+		// given: Agent config with old model, no prior migrations
+		const agents = {
+			sisyphus: { model: "openai/gpt-5.4-codex" },
+		};
 
-    // when: Migrate without applied migrations
-    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
+		// when: Migrate without applied migrations
+		const { migrated, changed, newMigrations } = migrateModelVersions(agents);
 
-    // then: No migration should be applied for gpt-5.4-codex
-    expect(changed).toBe(false)
-    expect(newMigrations).toEqual([])
-    const sisyphus = migrated["sisyphus"] as Record<string, unknown>
-    expect(sisyphus.model).toBe("openai/gpt-5.4-codex")
-  })
+		// then: No migration should be applied for gpt-5.4-codex
+		expect(changed).toBe(false);
+		expect(newMigrations).toEqual([]);
+		const sisyphus = migrated["sisyphus"] as Record<string, unknown>;
+		expect(sisyphus.model).toBe("openai/gpt-5.4-codex");
+	});
 
-  test("handles mixed: some applied, some new", () => {
-    // given: Multiple agents, one migration already applied
-    const agents = {
-      sisyphus: { model: "openai/gpt-5.4-codex" },
-      prometheus: { model: "anthropic/claude-opus-4-5" },
-    }
-    const appliedMigrations = new Set(["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"])
+	test("handles mixed: some applied, some new", () => {
+		// given: Multiple agents, one migration already applied
+		const agents = {
+			sisyphus: { model: "openai/gpt-5.4-codex" },
+			prometheus: { model: "anthropic/claude-opus-4-5" },
+		};
+		const appliedMigrations = new Set([
+			"model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex",
+		]);
 
-    // when: Migrate with partial history
-    const { migrated, changed, newMigrations } = migrateModelVersions(agents, appliedMigrations)
+		// when: Migrate with partial history
+		const { migrated, changed, newMigrations } = migrateModelVersions(
+			agents,
+			appliedMigrations,
+		);
 
-    // then: Only prometheus should be migrated
-    expect(changed).toBe(true)
-    expect(newMigrations).toEqual(["model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-6"])
-    expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
-    expect((migrated["prometheus"] as Record<string, unknown>).model).toBe("anthropic/claude-opus-4-6")
-  })
+		// then: Only prometheus should be migrated
+		expect(changed).toBe(true);
+		expect(newMigrations).toEqual([
+			"model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-6",
+		]);
+		expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe(
+			"openai/gpt-5.4-codex",
+		);
+		expect((migrated["prometheus"] as Record<string, unknown>).model).toBe(
+			"anthropic/claude-opus-4-6",
+		);
+	});
 
-  test("backward compatible without appliedMigrations param", () => {
-    // given: Agent config with old model, no appliedMigrations param
-    const agents = {
-      sisyphus: { model: "openai/gpt-5.4-codex" },
-    }
+	test("backward compatible without appliedMigrations param", () => {
+		// given: Agent config with old model, no appliedMigrations param
+		const agents = {
+			sisyphus: { model: "openai/gpt-5.4-codex" },
+		};
 
-    // when: Migrate without the param (backward compat)
-    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
+		// when: Migrate without the param (backward compat)
+		const { migrated, changed, newMigrations } = migrateModelVersions(agents);
 
-    // then: Should keep gpt-5.4-codex unchanged
-    expect(changed).toBe(false)
-    expect(newMigrations).toHaveLength(0)
-    expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
-  })
-})
+		// then: Should keep gpt-5.4-codex unchanged
+		expect(changed).toBe(false);
+		expect(newMigrations).toHaveLength(0);
+		expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe(
+			"openai/gpt-5.4-codex",
+		);
+	});
+});
 
 describe("migrateConfigFile _migrations tracking", () => {
-  test("records migrations in _migrations field", () => {
-    // given: Config with old model, no prior migrations
-    const tmpDir = fs.mkdtempSync("/tmp/migration-test-")
-    const configPath = `${tmpDir}/oh-my-opencode.json`
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        sisyphus: { model: "openai/gpt-5.4-codex" },
-      },
-    }
+	test("records migrations in _migrations field", () => {
+		// given: Config with old model, no prior migrations
+		const tmpDir = fs.mkdtempSync("/tmp/migration-test-");
+		const configPath = `${tmpDir}/oh-my-opencode.json`;
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				sisyphus: { model: "openai/gpt-5.4-codex" },
+			},
+		};
 
-    // when: Migrate config file
-    const result = migrateConfigFile(configPath, rawConfig)
+		// when: Migrate config file
+		const result = migrateConfigFile(configPath, rawConfig);
 
-    // then: gpt-5.4-codex should not produce migrations
-    expect(result).toBe(false)
-    expect(rawConfig._migrations).toBeUndefined()
+		// then: gpt-5.4-codex should not produce migrations
+		expect(result).toBe(false);
+		expect(rawConfig._migrations).toBeUndefined();
 
-    // cleanup
-    fs.rmSync(tmpDir, { recursive: true })
-  })
+		// cleanup
+		cleanupTempDir(tmpDir);
+	});
 
-  test("skips re-migration when _migrations contains the key", () => {
-    // given: Config with old model BUT migration already recorded
-    const tmpDir = fs.mkdtempSync("/tmp/migration-test-")
-    const configPath = `${tmpDir}/oh-my-opencode.json`
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        sisyphus: { model: "openai/gpt-5.4-codex" },
-      },
-      _migrations: ["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"],
-    }
+	test("skips re-migration when _migrations contains the key", () => {
+		// given: Config with old model BUT migration already recorded
+		const tmpDir = fs.mkdtempSync("/tmp/migration-test-");
+		const configPath = `${tmpDir}/oh-my-opencode.json`;
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				sisyphus: { model: "openai/gpt-5.4-codex" },
+			},
+			_migrations: ["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"],
+		};
 
-    // when: Migrate config file
-    const result = migrateConfigFile(configPath, rawConfig)
+		// when: Migrate config file
+		migrateConfigFile(configPath, rawConfig);
 
-    // then: Should NOT rewrite (model stays as user set it)
-    // Note: result may be true due to other migrations, but model should NOT change
-    const sisyphus = (rawConfig.agents as Record<string, Record<string, unknown>>).sisyphus
-    expect(sisyphus.model).toBe("openai/gpt-5.4-codex")
+		// then: Should NOT rewrite (model stays as user set it)
+		// Note: result may be true due to other migrations, but model should NOT change
+		const sisyphus = (
+			rawConfig.agents as Record<string, Record<string, unknown>>
+		).sisyphus;
+		expect(sisyphus.model).toBe("openai/gpt-5.4-codex");
 
-    // cleanup
-    fs.rmSync(tmpDir, { recursive: true })
-  })
+		// cleanup
+		cleanupTempDir(tmpDir);
+	});
 
-  test("preserves existing _migrations and appends new ones", () => {
-    // given: Config with existing migration history and a new migratable model
-    const tmpDir = fs.mkdtempSync("/tmp/migration-test-")
-    const configPath = `${tmpDir}/oh-my-opencode.json`
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        prometheus: { model: "anthropic/claude-opus-4-5" },
-      },
-      _migrations: ["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"],
-    }
+	test("preserves existing _migrations and appends new ones", () => {
+		// given: Config with existing migration history and a new migratable model
+		const tmpDir = fs.mkdtempSync("/tmp/migration-test-");
+		const configPath = `${tmpDir}/oh-my-opencode.json`;
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				prometheus: { model: "anthropic/claude-opus-4-5" },
+			},
+			_migrations: ["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"],
+		};
 
-    // when: Migrate config file
-    const result = migrateConfigFile(configPath, rawConfig)
+		// when: Migrate config file
+		const result = migrateConfigFile(configPath, rawConfig);
 
-    // then: New migration appended, old one preserved
-    expect(result).toBe(true)
-    expect(rawConfig._migrations).toEqual([
-      "model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex",
-      "model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-6",
-    ])
+		// then: New migration appended, old one preserved
+		expect(result).toBe(true);
+		expect(rawConfig._migrations).toEqual([
+			"model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex",
+			"model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-6",
+		]);
 
-    // cleanup
-    fs.rmSync(tmpDir, { recursive: true })
-  })
-})
+		// cleanup
+		cleanupTempDir(tmpDir);
+	});
+});
 
 describe("migrateAgentConfigToCategory", () => {
-  test("migrates model to category when mapping exists", () => {
-    // given: Config with a model that has a category mapping
-    const config = {
-      model: "google/gemini-3.1-pro",
-      temperature: 0.5,
-      top_p: 0.9,
-    }
+	test("migrates model to category when mapping exists", () => {
+		// given: Config with a model that has a category mapping
+		const config = {
+			model: "google/gemini-3.1-pro",
+			temperature: 0.5,
+			top_p: 0.9,
+		};
 
-    // when: Migrate agent config to category
-    const { migrated, changed } = migrateAgentConfigToCategory(config)
+		// when: Migrate agent config to category
+		const { migrated, changed } = migrateAgentConfigToCategory(config);
 
-    // then: Model should be replaced with category
-    expect(changed).toBe(true)
-    expect(migrated.category).toBe("visual-engineering")
-    expect(migrated.model).toBeUndefined()
-    expect(migrated.temperature).toBe(0.5)
-    expect(migrated.top_p).toBe(0.9)
-  })
+		// then: Model should be replaced with category
+		expect(changed).toBe(true);
+		expect(migrated.category).toBe("visual-engineering");
+		expect(migrated.model).toBeUndefined();
+		expect(migrated.temperature).toBe(0.5);
+		expect(migrated.top_p).toBe(0.9);
+	});
 
-  test("does not migrate when model is not in map", () => {
-    // given: Config with a model that has no mapping
-    const config = {
-      model: "custom/model",
-      temperature: 0.5,
-    }
+	test("does not migrate when model is not in map", () => {
+		// given: Config with a model that has no mapping
+		const config = {
+			model: "custom/model",
+			temperature: 0.5,
+		};
 
-    // when: Migrate agent config to category
-    const { migrated, changed } = migrateAgentConfigToCategory(config)
+		// when: Migrate agent config to category
+		const { migrated, changed } = migrateAgentConfigToCategory(config);
 
-    // then: Config should remain unchanged
-    expect(changed).toBe(false)
-    expect(migrated).toEqual(config)
-  })
+		// then: Config should remain unchanged
+		expect(changed).toBe(false);
+		expect(migrated).toEqual(config);
+	});
 
-  test("does not migrate when model is not a string", () => {
-    // given: Config with non-string model
-    const config = {
-      model: { name: "test" },
-      temperature: 0.5,
-    }
+	test("does not migrate when model is not a string", () => {
+		// given: Config with non-string model
+		const config = {
+			model: { name: "test" },
+			temperature: 0.5,
+		};
 
-    // when: Migrate agent config to category
-    const { migrated, changed } = migrateAgentConfigToCategory(config)
+		// when: Migrate agent config to category
+		const { migrated, changed } = migrateAgentConfigToCategory(config);
 
-    // then: Config should remain unchanged
-    expect(changed).toBe(false)
-    expect(migrated).toEqual(config)
-  })
+		// then: Config should remain unchanged
+		expect(changed).toBe(false);
+		expect(migrated).toEqual(config);
+	});
 
-  test("handles all mapped models correctly", () => {
-    // given: Configs for each mapped model
-    const configs = [
-      { model: "google/gemini-3.1-pro" },
-      { model: "google/gemini-3-flash" },
-      { model: "openai/gpt-5.4" },
-      { model: "anthropic/claude-haiku-4-5" },
-      { model: "anthropic/claude-opus-4-6" },
-      { model: "anthropic/claude-sonnet-4-6" },
-    ]
+	test("handles all mapped models correctly", () => {
+		// given: Configs for each mapped model
+		const configs = [
+			{ model: "google/gemini-3.1-pro" },
+			{ model: "google/gemini-3-flash" },
+			{ model: "openai/gpt-5.4" },
+			{ model: "anthropic/claude-haiku-4-5" },
+			{ model: "anthropic/claude-opus-4-6" },
+			{ model: "anthropic/claude-sonnet-4-6" },
+		];
 
-    const expectedCategories = ["visual-engineering", "writing", "ultrabrain", "quick", "unspecified-high", "unspecified-low"]
+		const expectedCategories = [
+			"visual-engineering",
+			"writing",
+			"ultrabrain",
+			"quick",
+			"unspecified-high",
+			"unspecified-low",
+		];
 
-    // when: Migrate each config
-    const results = configs.map(migrateAgentConfigToCategory)
+		// when: Migrate each config
+		const results = configs.map(migrateAgentConfigToCategory);
 
-    // then: Each model should map to correct category
-    results.forEach((result, index) => {
-      expect(result.changed).toBe(true)
-      expect(result.migrated.category).toBe(expectedCategories[index])
-      expect(result.migrated.model).toBeUndefined()
-    })
-  })
+		// then: Each model should map to correct category
+		results.forEach((result, index) => {
+			expect(result.changed).toBe(true);
+			expect(result.migrated.category).toBe(expectedCategories[index]);
+			expect(result.migrated.model).toBeUndefined();
+		});
+	});
 
-  test("preserves non-model fields during migration", () => {
-    // given: Config with multiple fields
-    const config = {
-      model: "openai/gpt-5.4",
-      temperature: 0.1,
-      top_p: 0.95,
-      maxTokens: 4096,
-      prompt_append: "custom instruction",
-    }
+	test("preserves non-model fields during migration", () => {
+		// given: Config with multiple fields
+		const config = {
+			model: "openai/gpt-5.4",
+			temperature: 0.1,
+			top_p: 0.95,
+			maxTokens: 4096,
+			prompt_append: "custom instruction",
+		};
 
-    // when: Migrate agent config to category
-    const { migrated } = migrateAgentConfigToCategory(config)
+		// when: Migrate agent config to category
+		const { migrated } = migrateAgentConfigToCategory(config);
 
-    // then: All non-model fields should be preserved
-    expect(migrated.category).toBe("ultrabrain")
-    expect(migrated.temperature).toBe(0.1)
-    expect(migrated.top_p).toBe(0.95)
-    expect(migrated.maxTokens).toBe(4096)
-    expect(migrated.prompt_append).toBe("custom instruction")
-  })
-})
+		// then: All non-model fields should be preserved
+		expect(migrated.category).toBe("ultrabrain");
+		expect(migrated.temperature).toBe(0.1);
+		expect(migrated.top_p).toBe(0.95);
+		expect(migrated.maxTokens).toBe(4096);
+		expect(migrated.prompt_append).toBe("custom instruction");
+	});
+});
 
 describe("shouldDeleteAgentConfig", () => {
-  test("returns true when config only has category field", () => {
-    // given: Config with only category field (no overrides)
-    const config = { category: "visual-engineering" }
+	test("returns true when config only has category field", () => {
+		// given: Config with only category field (no overrides)
+		const config = { category: "visual-engineering" };
 
-    // when: Check if config should be deleted
-    const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering")
+		// when: Check if config should be deleted
+		const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering");
 
-    // then: Should return true (matches category defaults)
-    expect(shouldDelete).toBe(true)
-  })
+		// then: Should return true (matches category defaults)
+		expect(shouldDelete).toBe(true);
+	});
 
-  test("returns false when category does not exist", () => {
-    // given: Config with unknown category
-    const config = { category: "unknown" }
+	test("returns false when category does not exist", () => {
+		// given: Config with unknown category
+		const config = { category: "unknown" };
 
-    // when: Check if config should be deleted
-    const shouldDelete = shouldDeleteAgentConfig(config, "unknown")
+		// when: Check if config should be deleted
+		const shouldDelete = shouldDeleteAgentConfig(config, "unknown");
 
-    // then: Should return false (category not found)
-    expect(shouldDelete).toBe(false)
-  })
+		// then: Should return false (category not found)
+		expect(shouldDelete).toBe(false);
+	});
 
-  test("returns true when all fields match category defaults", () => {
-    // given: Config with fields matching category defaults
-    const config = {
-      category: "visual-engineering",
-      model: "google/gemini-3.1-pro",
-    }
+	test("returns true when all fields match category defaults", () => {
+		// given: Config with fields matching category defaults
+		const config = {
+			category: "visual-engineering",
+			model: "google/gemini-3.1-pro",
+		};
 
-    // when: Check if config should be deleted
-    const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering")
+		// when: Check if config should be deleted
+		const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering");
 
-    // then: Should return true (all fields match defaults)
-    expect(shouldDelete).toBe(true)
-  })
+		// then: Should return true (all fields match defaults)
+		expect(shouldDelete).toBe(true);
+	});
 
-  test("returns false when fields differ from category defaults", () => {
-    // given: Config with custom model override
-    const config = {
-      category: "visual-engineering",
-      model: "anthropic/claude-opus-4-6",
-    }
+	test("returns false when fields differ from category defaults", () => {
+		// given: Config with custom model override
+		const config = {
+			category: "visual-engineering",
+			model: "anthropic/claude-opus-4-6",
+		};
 
-    // when: Check if config should be deleted
-    const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering")
+		// when: Check if config should be deleted
+		const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering");
 
-    // then: Should return false (has custom override)
-    expect(shouldDelete).toBe(false)
-  })
+		// then: Should return false (has custom override)
+		expect(shouldDelete).toBe(false);
+	});
 
-  test("handles different categories with their defaults", () => {
-    // given: Configs for different categories
-    const configs = [
-      { category: "ultrabrain" },
-      { category: "quick" },
-      { category: "unspecified-high" },
-      { category: "unspecified-low" },
-    ]
+	test("handles different categories with their defaults", () => {
+		// given: Configs for different categories
+		const configs = [
+			{ category: "ultrabrain" },
+			{ category: "quick" },
+			{ category: "unspecified-high" },
+			{ category: "unspecified-low" },
+		];
 
-    // when: Check each config
-    const results = configs.map((config) => shouldDeleteAgentConfig(config, config.category as string))
+		// when: Check each config
+		const results = configs.map((config) =>
+			shouldDeleteAgentConfig(config, config.category as string),
+		);
 
-    // then: All should be true (all match defaults)
-    results.forEach((result) => {
-      expect(result).toBe(true)
-    })
-  })
+		// then: All should be true (all match defaults)
+		results.forEach((result) => {
+			expect(result).toBe(true);
+		});
+	});
 
-  test("returns false when additional fields are present", () => {
-    // given: Config with extra fields
-    const config = {
-      category: "visual-engineering",
-      temperature: 0.7,
-      custom_field: "value", // Extra field not in defaults
-    }
+	test("returns false when additional fields are present", () => {
+		// given: Config with extra fields
+		const config = {
+			category: "visual-engineering",
+			temperature: 0.7,
+			custom_field: "value", // Extra field not in defaults
+		};
 
-    // when: Check if config should be deleted
-    const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering")
+		// when: Check if config should be deleted
+		const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering");
 
-    // then: Should return false (has extra field)
-    expect(shouldDelete).toBe(false)
-  })
+		// then: Should return false (has extra field)
+		expect(shouldDelete).toBe(false);
+	});
 
-  test("handles complex config with multiple overrides", () => {
-    // given: Config with multiple custom overrides
-    const config = {
-      category: "visual-engineering",
-      temperature: 0.5, // Different from default
-      top_p: 0.8, // Different from default
-      prompt_append: "custom prompt", // Custom field
-    }
+	test("handles complex config with multiple overrides", () => {
+		// given: Config with multiple custom overrides
+		const config = {
+			category: "visual-engineering",
+			temperature: 0.5, // Different from default
+			top_p: 0.8, // Different from default
+			prompt_append: "custom prompt", // Custom field
+		};
 
-    // when: Check if config should be deleted
-    const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering")
+		// when: Check if config should be deleted
+		const shouldDelete = shouldDeleteAgentConfig(config, "visual-engineering");
 
-    // then: Should return false (has overrides)
-    expect(shouldDelete).toBe(false)
-  })
-})
+		// then: Should return false (has overrides)
+		expect(shouldDelete).toBe(false);
+	});
+});
 
 describe("migrateConfigFile with backup", () => {
-  const cleanupPaths: string[] = []
+	const cleanupPaths: string[] = [];
 
-  afterEach(() => {
-    cleanupPaths.forEach((p) => {
-      try {
-        fs.unlinkSync(p)
-      } catch {
-      }
-    })
-  })
+	afterEach(() => {
+		cleanupPaths.forEach((p) => {
+			try {
+				fs.unlinkSync(p);
+			} catch {}
+		});
+	});
 
-  test("creates backup file with timestamp when legacy migration needed", () => {
-    // given: Config file path with legacy agent names needing migration
-    const testConfigPath = "/tmp/test-config-migration.json"
-    const testConfigContent = globalThis.JSON.stringify({ agents: { omo: { model: "test" } } }, null, 2)
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        omo: { model: "test" },
-      },
-    }
+	test("creates backup file with timestamp when legacy migration needed", () => {
+		// given: Config file path with legacy agent names needing migration
+		const testConfigPath = "/tmp/test-config-migration.json";
+		const testConfigContent = globalThis.JSON.stringify(
+			{ agents: { omo: { model: "test" } } },
+			null,
+			2,
+		);
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				omo: { model: "test" },
+			},
+		};
 
-    fs.writeFileSync(testConfigPath, testConfigContent)
-    cleanupPaths.push(testConfigPath)
+		fs.writeFileSync(testConfigPath, testConfigContent);
+		cleanupPaths.push(testConfigPath);
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: Backup file should be created with timestamp
-    expect(needsWrite).toBe(true)
+		// then: Backup file should be created with timestamp
+		expect(needsWrite).toBe(true);
 
-    const dir = path.dirname(testConfigPath)
-    const basename = path.basename(testConfigPath)
-    const files = fs.readdirSync(dir)
-    const backupFiles = files.filter((f) => f.startsWith(`${basename}.bak.`))
-    expect(backupFiles.length).toBeGreaterThan(0)
+		const dir = path.dirname(testConfigPath);
+		const basename = path.basename(testConfigPath);
+		const files = fs.readdirSync(dir);
+		const backupFiles = files.filter((f) => f.startsWith(`${basename}.bak.`));
+		expect(backupFiles.length).toBeGreaterThan(0);
 
-    const backupFile = backupFiles[0]
-    const backupPath = path.join(dir, backupFile)
-    cleanupPaths.push(backupPath)
+		const backupFile = backupFiles[0];
+		const backupPath = path.join(dir, backupFile);
+		cleanupPaths.push(backupPath);
 
-    expect(backupFile).toMatch(/test-config-migration\.json\.bak\.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/)
+		expect(backupFile).toMatch(
+			/test-config-migration\.json\.bak\.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/,
+		);
 
-    const backupContent = fs.readFileSync(backupPath, "utf-8")
-    expect(backupContent).toBe(testConfigContent)
-  })
+		const backupContent = fs.readFileSync(backupPath, "utf-8");
+		expect(backupContent).toBe(testConfigContent);
+	});
 
-  test("preserves model setting without auto-conversion to category", () => {
-    // given: Config with model setting (should NOT be converted to category)
-    const testConfigPath = "/tmp/test-config-preserve-model.json"
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        "multimodal-looker": { model: "anthropic/claude-haiku-4-5" },
-        oracle: { model: "openai/gpt-5.4" },
-        "my-custom-agent": { model: "google/gemini-3.1-pro" },
-      },
-    }
+	test("preserves model setting without auto-conversion to category", () => {
+		// given: Config with model setting (should NOT be converted to category)
+		const testConfigPath = "/tmp/test-config-preserve-model.json";
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				"multimodal-looker": { model: "anthropic/claude-haiku-4-5" },
+				oracle: { model: "openai/gpt-5.4" },
+				"my-custom-agent": { model: "google/gemini-3.1-pro" },
+			},
+		};
 
-    fs.writeFileSync(testConfigPath, globalThis.JSON.stringify(rawConfig, null, 2))
-    cleanupPaths.push(testConfigPath)
+		fs.writeFileSync(
+			testConfigPath,
+			globalThis.JSON.stringify(rawConfig, null, 2),
+		);
+		cleanupPaths.push(testConfigPath);
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: No migration needed - model settings should be preserved as-is
-    expect(needsWrite).toBe(false)
+		// then: No migration needed - model settings should be preserved as-is
+		expect(needsWrite).toBe(false);
 
-    const agents = rawConfig.agents as Record<string, Record<string, unknown>>
-    expect(agents["multimodal-looker"].model).toBe("anthropic/claude-haiku-4-5")
-    expect(agents.oracle.model).toBe("openai/gpt-5.4")
-    expect(agents["my-custom-agent"].model).toBe("google/gemini-3.1-pro")
-  })
+		const agents = rawConfig.agents as Record<string, Record<string, unknown>>;
+		expect(agents["multimodal-looker"].model).toBe(
+			"anthropic/claude-haiku-4-5",
+		);
+		expect(agents.oracle.model).toBe("openai/gpt-5.4");
+		expect(agents["my-custom-agent"].model).toBe("google/gemini-3.1-pro");
+	});
 
-  test("preserves category setting when explicitly set", () => {
-    // given: Config with explicit category setting
-    const testConfigPath = "/tmp/test-config-preserve-category.json"
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        "multimodal-looker": { category: "quick" },
-        oracle: { category: "ultrabrain" },
-      },
-    }
+	test("preserves category setting when explicitly set", () => {
+		// given: Config with explicit category setting
+		const testConfigPath = "/tmp/test-config-preserve-category.json";
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				"multimodal-looker": { category: "quick" },
+				oracle: { category: "ultrabrain" },
+			},
+		};
 
-    fs.writeFileSync(testConfigPath, globalThis.JSON.stringify(rawConfig, null, 2))
-    cleanupPaths.push(testConfigPath)
+		fs.writeFileSync(
+			testConfigPath,
+			globalThis.JSON.stringify(rawConfig, null, 2),
+		);
+		cleanupPaths.push(testConfigPath);
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: No migration needed - category settings should be preserved as-is
-    expect(needsWrite).toBe(false)
+		// then: No migration needed - category settings should be preserved as-is
+		expect(needsWrite).toBe(false);
 
-    const agents = rawConfig.agents as Record<string, Record<string, unknown>>
-    expect(agents["multimodal-looker"].category).toBe("quick")
-    expect(agents.oracle.category).toBe("ultrabrain")
-  })
+		const agents = rawConfig.agents as Record<string, Record<string, unknown>>;
+		expect(agents["multimodal-looker"].category).toBe("quick");
+		expect(agents.oracle.category).toBe("ultrabrain");
+	});
 
-  test("does not write or create backups for experimental.task_system", () => {
-    //#given: Config with experimental.task_system enabled
-    const testConfigPath = "/tmp/test-config-task-system.json"
-    const rawConfig: Record<string, unknown> = {
-      experimental: { task_system: true },
-    }
+	test("does not write or create backups for experimental.task_system", () => {
+		//#given: Config with experimental.task_system enabled
+		const testConfigPath = "/tmp/test-config-task-system.json";
+		const rawConfig: Record<string, unknown> = {
+			experimental: { task_system: true },
+		};
 
-    fs.writeFileSync(testConfigPath, globalThis.JSON.stringify(rawConfig, null, 2))
-    cleanupPaths.push(testConfigPath)
+		fs.writeFileSync(
+			testConfigPath,
+			globalThis.JSON.stringify(rawConfig, null, 2),
+		);
+		cleanupPaths.push(testConfigPath);
 
-    const dir = path.dirname(testConfigPath)
-    const basename = path.basename(testConfigPath)
-    const existingFiles = fs.readdirSync(dir)
-    const existingBackups = existingFiles.filter((f) => f.startsWith(`${basename}.bak.`))
-    existingBackups.forEach((f) => {
-      const backupPath = path.join(dir, f)
-      try {
-        fs.unlinkSync(backupPath)
-        cleanupPaths.splice(cleanupPaths.indexOf(backupPath), 1)
-      } catch {
-      }
-    })
+		const dir = path.dirname(testConfigPath);
+		const basename = path.basename(testConfigPath);
+		const existingFiles = fs.readdirSync(dir);
+		const existingBackups = existingFiles.filter((f) =>
+			f.startsWith(`${basename}.bak.`),
+		);
+		existingBackups.forEach((f) => {
+			const backupPath = path.join(dir, f);
+			try {
+				fs.unlinkSync(backupPath);
+				cleanupPaths.splice(cleanupPaths.indexOf(backupPath), 1);
+			} catch {}
+		});
 
-    //#when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		//#when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    //#then: No write or backup should occur
-    expect(needsWrite).toBe(false)
+		//#then: No write or backup should occur
+		expect(needsWrite).toBe(false);
 
-    const files = fs.readdirSync(dir)
-    const backupFiles = files.filter((f) => f.startsWith(`${basename}.bak.`))
-    expect(backupFiles.length).toBe(0)
-  })
+		const files = fs.readdirSync(dir);
+		const backupFiles = files.filter((f) => f.startsWith(`${basename}.bak.`));
+		expect(backupFiles.length).toBe(0);
+	});
 
-  test("does not write when no migration needed", () => {
-     // given: Config with no migrations needed
-     const testConfigPath = "/tmp/test-config-no-migration.json"
-     const rawConfig: Record<string, unknown> = {
-       agents: {
-         sisyphus: { model: "test" },
-       },
-     }
+	test("does not write when no migration needed", () => {
+		// given: Config with no migrations needed
+		const testConfigPath = "/tmp/test-config-no-migration.json";
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				sisyphus: { model: "test" },
+			},
+		};
 
-     fs.writeFileSync(testConfigPath, globalThis.JSON.stringify({ agents: { sisyphus: { model: "test" } } }, null, 2))
-     cleanupPaths.push(testConfigPath)
+		fs.writeFileSync(
+			testConfigPath,
+			globalThis.JSON.stringify(
+				{ agents: { sisyphus: { model: "test" } } },
+				null,
+				2,
+			),
+		);
+		cleanupPaths.push(testConfigPath);
 
-     // Clean up any existing backup files from previous test runs
-     const dir = path.dirname(testConfigPath)
-     const basename = path.basename(testConfigPath)
-     const existingFiles = fs.readdirSync(dir)
-     const existingBackups = existingFiles.filter((f) => f.startsWith(`${basename}.bak.`))
-     existingBackups.forEach((f) => {
-       const backupPath = path.join(dir, f)
-       try {
-         fs.unlinkSync(backupPath)
-         cleanupPaths.splice(cleanupPaths.indexOf(backupPath), 1)
-       } catch {
-       }
-     })
+		// Clean up any existing backup files from previous test runs
+		const dir = path.dirname(testConfigPath);
+		const basename = path.basename(testConfigPath);
+		const existingFiles = fs.readdirSync(dir);
+		const existingBackups = existingFiles.filter((f) =>
+			f.startsWith(`${basename}.bak.`),
+		);
+		existingBackups.forEach((f) => {
+			const backupPath = path.join(dir, f);
+			try {
+				fs.unlinkSync(backupPath);
+				cleanupPaths.splice(cleanupPaths.indexOf(backupPath), 1);
+			} catch {}
+		});
 
-     // when: Migrate config file
-     const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-     // then: Should not write or create backup
-     expect(needsWrite).toBe(false)
+		// then: Should not write or create backup
+		expect(needsWrite).toBe(false);
 
-     const files = fs.readdirSync(dir)
-     const backupFiles = files.filter((f) => f.startsWith(`${basename}.bak.`))
-     expect(backupFiles.length).toBe(0)
-   })
-})
+		const files = fs.readdirSync(dir);
+		const backupFiles = files.filter((f) => f.startsWith(`${basename}.bak.`));
+		expect(backupFiles.length).toBe(0);
+	});
+});
 
 describe("migrateModelVersions with applied migrations", () => {
-  test("skips already-applied migrations", () => {
-    // given: Config with old model and migration already applied
-    const configs = {
-      sisyphus: { model: "openai/gpt-5.4-codex" },
-    }
-    const appliedMigrations = new Set(["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"])
+	test("skips already-applied migrations", () => {
+		// given: Config with old model and migration already applied
+		const configs = {
+			sisyphus: { model: "openai/gpt-5.4-codex" },
+		};
+		const appliedMigrations = new Set([
+			"model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex",
+		]);
 
-    // when: Migrate model versions
-    const { migrated, changed, newMigrations } = migrateModelVersions(configs, appliedMigrations)
+		// when: Migrate model versions
+		const { migrated, changed, newMigrations } = migrateModelVersions(
+			configs,
+			appliedMigrations,
+		);
 
-    // then: Migration should be skipped (user reverted)
-    expect(changed).toBe(false)
-    expect(newMigrations).toEqual([])
-    expect((migrated.sisyphus as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
-  })
+		// then: Migration should be skipped (user reverted)
+		expect(changed).toBe(false);
+		expect(newMigrations).toEqual([]);
+		expect((migrated.sisyphus as Record<string, unknown>).model).toBe(
+			"openai/gpt-5.4-codex",
+		);
+	});
 
-  test("applies new migrations not in history", () => {
-    // given: Config with old model, no migration history
-    const configs = {
-      sisyphus: { model: "openai/gpt-5.4-codex" },
-    }
-    const appliedMigrations = new Set<string>()
+	test("applies new migrations not in history", () => {
+		// given: Config with old model, no migration history
+		const configs = {
+			sisyphus: { model: "openai/gpt-5.4-codex" },
+		};
+		const appliedMigrations = new Set<string>();
 
-    // when: Migrate model versions
-    const { migrated, changed, newMigrations } = migrateModelVersions(configs, appliedMigrations)
+		// when: Migrate model versions
+		const { migrated, changed, newMigrations } = migrateModelVersions(
+			configs,
+			appliedMigrations,
+		);
 
-    // then: gpt-5.4-codex should not be migrated
-    expect(changed).toBe(false)
-    expect(newMigrations).toEqual([])
-    expect((migrated.sisyphus as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
-  })
+		// then: gpt-5.4-codex should not be migrated
+		expect(changed).toBe(false);
+		expect(newMigrations).toEqual([]);
+		expect((migrated.sisyphus as Record<string, unknown>).model).toBe(
+			"openai/gpt-5.4-codex",
+		);
+	});
 
-  test("handles mixed: skip applied, apply new", () => {
-    // given: Config with 2 old models, 1 already migrated
-    const configs = {
-      sisyphus: { model: "openai/gpt-5.4-codex" },
-      oracle: { model: "anthropic/claude-opus-4-5" },
-    }
-    const appliedMigrations = new Set(["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"])
+	test("handles mixed: skip applied, apply new", () => {
+		// given: Config with 2 old models, 1 already migrated
+		const configs = {
+			sisyphus: { model: "openai/gpt-5.4-codex" },
+			oracle: { model: "anthropic/claude-opus-4-5" },
+		};
+		const appliedMigrations = new Set([
+			"model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex",
+		]);
 
-    // when: Migrate model versions
-    const { migrated, changed, newMigrations } = migrateModelVersions(configs, appliedMigrations)
+		// when: Migrate model versions
+		const { migrated, changed, newMigrations } = migrateModelVersions(
+			configs,
+			appliedMigrations,
+		);
 
-    // then: Skip sisyphus (already applied), apply oracle
-    expect(changed).toBe(true)
-    expect(newMigrations).toEqual(["model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-6"])
-    expect((migrated.sisyphus as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
-    expect((migrated.oracle as Record<string, unknown>).model).toBe("anthropic/claude-opus-4-6")
-  })
+		// then: Skip sisyphus (already applied), apply oracle
+		expect(changed).toBe(true);
+		expect(newMigrations).toEqual([
+			"model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-6",
+		]);
+		expect((migrated.sisyphus as Record<string, unknown>).model).toBe(
+			"openai/gpt-5.4-codex",
+		);
+		expect((migrated.oracle as Record<string, unknown>).model).toBe(
+			"anthropic/claude-opus-4-6",
+		);
+	});
 
-  test("backward compatible: no appliedMigrations param", () => {
-    // given: Config with old model, no appliedMigrations param (legacy call)
-    const configs = {
-      sisyphus: { model: "openai/gpt-5.4-codex" },
-    }
+	test("backward compatible: no appliedMigrations param", () => {
+		// given: Config with old model, no appliedMigrations param (legacy call)
+		const configs = {
+			sisyphus: { model: "openai/gpt-5.4-codex" },
+		};
 
-    // when: Migrate model versions (without appliedMigrations)
-    const { migrated, changed, newMigrations } = migrateModelVersions(configs)
+		// when: Migrate model versions (without appliedMigrations)
+		const { migrated, changed, newMigrations } = migrateModelVersions(configs);
 
-    // then: gpt-5.4-codex remains unchanged
-    expect(changed).toBe(false)
-    expect(newMigrations).toEqual([])
-    expect((migrated.sisyphus as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
-  })
+		// then: gpt-5.4-codex remains unchanged
+		expect(changed).toBe(false);
+		expect(newMigrations).toEqual([]);
+		expect((migrated.sisyphus as Record<string, unknown>).model).toBe(
+			"openai/gpt-5.4-codex",
+		);
+	});
 
-  test("returns empty newMigrations when no migrations applied", () => {
-    // given: Config with no old models
-    const configs = {
-      sisyphus: { model: "openai/gpt-5.4-codex" },
-    }
+	test("returns empty newMigrations when no migrations applied", () => {
+		// given: Config with no old models
+		const configs = {
+			sisyphus: { model: "openai/gpt-5.4-codex" },
+		};
 
-    // when: Migrate model versions
-    const { migrated, changed, newMigrations } = migrateModelVersions(configs, new Set())
+		// when: Migrate model versions
+		const { changed, newMigrations } = migrateModelVersions(configs, new Set());
 
-    // then: No migrations
-    expect(changed).toBe(false)
-    expect(newMigrations).toEqual([])
-  })
-})
+		// then: No migrations
+		expect(changed).toBe(false);
+		expect(newMigrations).toEqual([]);
+	});
+});
 
 describe("migrateConfigFile with _migrations tracking", () => {
-  const cleanupPaths: string[] = []
+	const cleanupPaths: string[] = [];
 
-  afterEach(() => {
-    for (const p of cleanupPaths) {
-      try {
-        fs.unlinkSync(p)
-      } catch {
-      }
-    }
-    cleanupPaths.length = 0
-  })
+	afterEach(() => {
+		for (const p of cleanupPaths) {
+			try {
+				fs.unlinkSync(p);
+			} catch {}
+		}
+		cleanupPaths.length = 0;
+	});
 
-  test("records new migrations in _migrations field", () => {
-    // given: Config with old model, no _migrations field
-    const testConfigPath = "/tmp/test-config-migrations-1.json"
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        sisyphus: { model: "openai/gpt-5.4-codex" },
-      },
-    }
-    fs.writeFileSync(testConfigPath, JSON.stringify(rawConfig, null, 2))
-    cleanupPaths.push(testConfigPath)
+	test("records new migrations in _migrations field", () => {
+		// given: Config with old model, no _migrations field
+		const testConfigPath = "/tmp/test-config-migrations-1.json";
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				sisyphus: { model: "openai/gpt-5.4-codex" },
+			},
+		};
+		fs.writeFileSync(testConfigPath, JSON.stringify(rawConfig, null, 2));
+		cleanupPaths.push(testConfigPath);
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: gpt-5.4-codex should not create migration history
-    expect(needsWrite).toBe(false)
-    expect(rawConfig._migrations).toBeUndefined()
-    expect((rawConfig.agents as Record<string, Record<string, unknown>>).sisyphus.model).toBe("openai/gpt-5.4-codex")
-  })
+		// then: gpt-5.4-codex should not create migration history
+		expect(needsWrite).toBe(false);
+		expect(rawConfig._migrations).toBeUndefined();
+		expect(
+			(rawConfig.agents as Record<string, Record<string, unknown>>).sisyphus
+				.model,
+		).toBe("openai/gpt-5.4-codex");
+	});
 
-  test("skips re-applying already-recorded migrations", () => {
-    // given: Config with old model but migration already in _migrations
-    const testConfigPath = "/tmp/test-config-migrations-2.json"
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        sisyphus: { model: "openai/gpt-5.4-codex" },
-      },
-      _migrations: ["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"],
-    }
-    fs.writeFileSync(testConfigPath, JSON.stringify(rawConfig, null, 2))
-    cleanupPaths.push(testConfigPath)
+	test("skips re-applying already-recorded migrations", () => {
+		// given: Config with old model but migration already in _migrations
+		const testConfigPath = "/tmp/test-config-migrations-2.json";
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				sisyphus: { model: "openai/gpt-5.4-codex" },
+			},
+			_migrations: ["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"],
+		};
+		fs.writeFileSync(testConfigPath, JSON.stringify(rawConfig, null, 2));
+		cleanupPaths.push(testConfigPath);
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: Should not migrate (user reverted)
-    expect(needsWrite).toBe(false)
-    expect((rawConfig.agents as Record<string, Record<string, unknown>>).sisyphus.model).toBe("openai/gpt-5.4-codex")
-    expect(rawConfig._migrations).toEqual(["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"])
-  })
+		// then: Should not migrate (user reverted)
+		expect(needsWrite).toBe(false);
+		expect(
+			(rawConfig.agents as Record<string, Record<string, unknown>>).sisyphus
+				.model,
+		).toBe("openai/gpt-5.4-codex");
+		expect(rawConfig._migrations).toEqual([
+			"model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex",
+		]);
+	});
 
-  test("preserves existing _migrations and appends new ones", () => {
-    // given: Config with multiple old models, partial migration history
-    const testConfigPath = "/tmp/test-config-migrations-3.json"
-    const rawConfig: Record<string, unknown> = {
-      agents: {
-        sisyphus: { model: "openai/gpt-5.4-codex" },
-        oracle: { model: "anthropic/claude-opus-4-5" },
-      },
-      _migrations: ["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"],
-    }
-    fs.writeFileSync(testConfigPath, JSON.stringify(rawConfig, null, 2))
-    cleanupPaths.push(testConfigPath)
+	test("preserves existing _migrations and appends new ones", () => {
+		// given: Config with multiple old models, partial migration history
+		const testConfigPath = "/tmp/test-config-migrations-3.json";
+		const rawConfig: Record<string, unknown> = {
+			agents: {
+				sisyphus: { model: "openai/gpt-5.4-codex" },
+				oracle: { model: "anthropic/claude-opus-4-5" },
+			},
+			_migrations: ["model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex"],
+		};
+		fs.writeFileSync(testConfigPath, JSON.stringify(rawConfig, null, 2));
+		cleanupPaths.push(testConfigPath);
 
-    // when: Migrate config file
-    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+		// when: Migrate config file
+		const needsWrite = migrateConfigFile(testConfigPath, rawConfig);
 
-    // then: Should skip sisyphus, migrate oracle, append to _migrations
-    expect(needsWrite).toBe(true)
-    expect((rawConfig.agents as Record<string, Record<string, unknown>>).sisyphus.model).toBe("openai/gpt-5.4-codex")
-    expect((rawConfig.agents as Record<string, Record<string, unknown>>).oracle.model).toBe("anthropic/claude-opus-4-6")
-    expect(rawConfig._migrations).toEqual([
-      "model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex",
-      "model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-6",
-    ])
-  })
-
-
-})
+		// then: Should skip sisyphus, migrate oracle, append to _migrations
+		expect(needsWrite).toBe(true);
+		expect(
+			(rawConfig.agents as Record<string, Record<string, unknown>>).sisyphus
+				.model,
+		).toBe("openai/gpt-5.4-codex");
+		expect(
+			(rawConfig.agents as Record<string, Record<string, unknown>>).oracle
+				.model,
+		).toBe("anthropic/claude-opus-4-6");
+		expect(rawConfig._migrations).toEqual([
+			"model-version:openai/gpt-5.4-codex->openai/gpt-5.3-codex",
+			"model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-6",
+		]);
+	});
+});

--- a/src/shared/migration/config-migration.ts
+++ b/src/shared/migration/config-migration.ts
@@ -1,147 +1,166 @@
-import * as fs from "fs"
-import { log } from "../logger"
-import { AGENT_NAME_MAP, migrateAgentNames } from "./agent-names"
-import { migrateHookNames } from "./hook-names"
-import { migrateModelVersions } from "./model-versions"
+import * as fs from "fs";
+import { log } from "../logger";
+import { AGENT_NAME_MAP, migrateAgentNames } from "./agent-names";
+import { migrateHookNames } from "./hook-names";
+import { migrateModelVersions } from "./model-versions";
 
 export function migrateConfigFile(
-  configPath: string,
-  rawConfig: Record<string, unknown>
+	configPath: string,
+	rawConfig: Record<string, unknown>,
+	options: { persist?: boolean } = {},
 ): boolean {
-  const copy = structuredClone(rawConfig)
-  let needsWrite = false
+	const persist = options.persist ?? true;
+	const copy = structuredClone(rawConfig);
+	let needsWrite = false;
 
-  // Load previously applied migrations
-  const existingMigrations = Array.isArray(copy._migrations)
-    ? new Set(copy._migrations as string[])
-    : new Set<string>()
-  const allNewMigrations: string[] = []
+	// Load previously applied migrations
+	const existingMigrations = Array.isArray(copy._migrations)
+		? new Set(copy._migrations as string[])
+		: new Set<string>();
+	const allNewMigrations: string[] = [];
 
-  if (copy.agents && typeof copy.agents === "object") {
-    const { migrated, changed } = migrateAgentNames(copy.agents as Record<string, unknown>)
-    if (changed) {
-      copy.agents = migrated
-      needsWrite = true
-    }
-  }
+	if (copy.agents && typeof copy.agents === "object") {
+		const { migrated, changed } = migrateAgentNames(
+			copy.agents as Record<string, unknown>,
+		);
+		if (changed) {
+			copy.agents = migrated;
+			needsWrite = true;
+		}
+	}
 
-  // Migrate model versions in agents (skip already-applied migrations)
-  if (copy.agents && typeof copy.agents === "object") {
-    const { migrated, changed, newMigrations } = migrateModelVersions(
-      copy.agents as Record<string, unknown>,
-      existingMigrations
-    )
-    if (changed) {
-      copy.agents = migrated
-      needsWrite = true
-      log("Migrated model versions in agents config")
-    }
-    allNewMigrations.push(...newMigrations)
-  }
+	// Migrate model versions in agents (skip already-applied migrations)
+	if (copy.agents && typeof copy.agents === "object") {
+		const { migrated, changed, newMigrations } = migrateModelVersions(
+			copy.agents as Record<string, unknown>,
+			existingMigrations,
+		);
+		if (changed) {
+			copy.agents = migrated;
+			needsWrite = true;
+			log("Migrated model versions in agents config");
+		}
+		allNewMigrations.push(...newMigrations);
+	}
 
-  // Migrate model versions in categories (skip already-applied migrations)
-  if (copy.categories && typeof copy.categories === "object") {
-    const { migrated, changed, newMigrations } = migrateModelVersions(
-      copy.categories as Record<string, unknown>,
-      existingMigrations
-    )
-    if (changed) {
-      copy.categories = migrated
-      needsWrite = true
-      log("Migrated model versions in categories config")
-    }
-    allNewMigrations.push(...newMigrations)
-  }
+	// Migrate model versions in categories (skip already-applied migrations)
+	if (copy.categories && typeof copy.categories === "object") {
+		const { migrated, changed, newMigrations } = migrateModelVersions(
+			copy.categories as Record<string, unknown>,
+			existingMigrations,
+		);
+		if (changed) {
+			copy.categories = migrated;
+			needsWrite = true;
+			log("Migrated model versions in categories config");
+		}
+		allNewMigrations.push(...newMigrations);
+	}
 
-  // Record newly applied migrations
-  if (allNewMigrations.length > 0) {
-    const updatedMigrations = Array.from(existingMigrations)
-    updatedMigrations.push(...allNewMigrations)
-    copy._migrations = updatedMigrations
-    needsWrite = true
-  }
+	// Record newly applied migrations
+	if (allNewMigrations.length > 0) {
+		const updatedMigrations = Array.from(existingMigrations);
+		updatedMigrations.push(...allNewMigrations);
+		copy._migrations = updatedMigrations;
+		needsWrite = true;
+	}
 
-  if (copy.omo_agent) {
-    copy.sisyphus_agent = copy.omo_agent
-    delete copy.omo_agent
-    needsWrite = true
-  }
+	if (copy.omo_agent) {
+		copy.sisyphus_agent = copy.omo_agent;
+		delete copy.omo_agent;
+		needsWrite = true;
+	}
 
-  if (copy.experimental && typeof copy.experimental === "object") {
-    const experimental = copy.experimental as Record<string, unknown>
-    if ("hashline_edit" in experimental) {
-      if (copy.hashline_edit === undefined) {
-        copy.hashline_edit = experimental.hashline_edit
-      }
-      delete experimental.hashline_edit
-      if (Object.keys(experimental).length === 0) {
-        delete copy.experimental
-      }
-      needsWrite = true
-    }
-  }
+	if (copy.experimental && typeof copy.experimental === "object") {
+		const experimental = copy.experimental as Record<string, unknown>;
+		if ("hashline_edit" in experimental) {
+			if (copy.hashline_edit === undefined) {
+				copy.hashline_edit = experimental.hashline_edit;
+			}
+			delete experimental.hashline_edit;
+			if (Object.keys(experimental).length === 0) {
+				delete copy.experimental;
+			}
+			needsWrite = true;
+		}
+	}
 
-  if (copy.disabled_agents && Array.isArray(copy.disabled_agents)) {
-    const migrated: string[] = []
-    let changed = false
-    for (const agent of copy.disabled_agents as string[]) {
-      const newAgent = AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent
-      if (newAgent !== agent) {
-        changed = true
-      }
-      migrated.push(newAgent)
-    }
-    if (changed) {
-      copy.disabled_agents = migrated
-      needsWrite = true
-    }
-  }
+	if (copy.disabled_agents && Array.isArray(copy.disabled_agents)) {
+		const migrated: string[] = [];
+		let changed = false;
+		for (const agent of copy.disabled_agents as string[]) {
+			const newAgent =
+				AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent;
+			if (newAgent !== agent) {
+				changed = true;
+			}
+			migrated.push(newAgent);
+		}
+		if (changed) {
+			copy.disabled_agents = migrated;
+			needsWrite = true;
+		}
+	}
 
-  if (copy.disabled_hooks && Array.isArray(copy.disabled_hooks)) {
-    const { migrated, changed, removed } = migrateHookNames(copy.disabled_hooks as string[])
-    if (changed) {
-      copy.disabled_hooks = migrated
-      needsWrite = true
-    }
-    if (removed.length > 0) {
-      log(
-        `Removed obsolete hooks from disabled_hooks: ${removed.join(", ")} (these hooks no longer exist in v3.0.0)`
-      )
-    }
-  }
+	if (copy.disabled_hooks && Array.isArray(copy.disabled_hooks)) {
+		const { migrated, changed, removed } = migrateHookNames(
+			copy.disabled_hooks as string[],
+		);
+		if (changed) {
+			copy.disabled_hooks = migrated;
+			needsWrite = true;
+		}
+		if (removed.length > 0) {
+			log(
+				`Removed obsolete hooks from disabled_hooks: ${removed.join(", ")} (these hooks no longer exist in v3.0.0)`,
+			);
+		}
+	}
 
-  if (needsWrite) {
-    const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
-    const backupPath = `${configPath}.bak.${timestamp}`
-    let backupSucceeded = false
-    try {
-      fs.copyFileSync(configPath, backupPath)
-      backupSucceeded = true
-    } catch {
-      // Original file may not exist yet — skip backup
-    }
+	if (needsWrite) {
+		let backupPath: string | null = null;
+		let backupSucceeded = false;
+		let writeSucceeded = false;
 
-    let writeSucceeded = false
-    try {
-      fs.writeFileSync(configPath, JSON.stringify(copy, null, 2) + "\n", "utf-8")
-      writeSucceeded = true
-    } catch (err) {
-      log(`Failed to write migrated config to ${configPath}:`, err)
-    }
+		if (persist) {
+			const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+			backupPath = `${configPath}.bak.${timestamp}`;
+			try {
+				fs.copyFileSync(configPath, backupPath);
+				backupSucceeded = true;
+			} catch {
+				// Original file may not exist yet — skip backup
+			}
 
-    for (const key of Object.keys(rawConfig)) {
-      delete rawConfig[key]
-    }
-    Object.assign(rawConfig, copy)
+			try {
+				fs.writeFileSync(
+					configPath,
+					JSON.stringify(copy, null, 2) + "\n",
+					"utf-8",
+				);
+				writeSucceeded = true;
+			} catch (err) {
+				log(`Failed to write migrated config to ${configPath}:`, err);
+			}
+		}
 
-    if (writeSucceeded) {
-      const backupMessage = backupSucceeded ? ` (backup: ${backupPath})` : ""
-      log(`Migrated config file: ${configPath}${backupMessage}`)
-    } else {
-      const backupMessage = backupSucceeded ? ` (backup: ${backupPath})` : ""
-      log(`Applied migrated config in-memory for: ${configPath}${backupMessage}`)
-    }
-  }
+		for (const key of Object.keys(rawConfig)) {
+			delete rawConfig[key];
+		}
+		Object.assign(rawConfig, copy);
 
-  return needsWrite
+		if (writeSucceeded) {
+			const backupMessage = backupSucceeded ? ` (backup: ${backupPath})` : "";
+			log(`Migrated config file: ${configPath}${backupMessage}`);
+		} else if (!persist) {
+			log(`Applied migrated config in-memory for: ${configPath}`);
+		} else {
+			const backupMessage = backupSucceeded ? ` (backup: ${backupPath})` : "";
+			log(
+				`Applied migrated config in-memory for: ${configPath}${backupMessage}`,
+			);
+		}
+	}
+
+	return needsWrite;
 }

--- a/src/shared/opencode-command-dirs.test.ts
+++ b/src/shared/opencode-command-dirs.test.ts
@@ -1,71 +1,91 @@
-import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test"
-import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { resolve } from "node:path";
 
 describe("opencode-command-dirs", () => {
-  let originalEnv: string | undefined
+	let originalEnv: string | undefined;
 
-  beforeEach(() => {
-    originalEnv = process.env.OPENCODE_CONFIG_DIR
-  })
+	beforeEach(() => {
+		originalEnv = process.env.OPENCODE_CONFIG_DIR;
+	});
 
-  afterEach(() => {
-    if (originalEnv !== undefined) {
-      process.env.OPENCODE_CONFIG_DIR = originalEnv
-    } else {
-      delete process.env.OPENCODE_CONFIG_DIR
-    }
-  })
+	afterEach(() => {
+		if (originalEnv !== undefined) {
+			process.env.OPENCODE_CONFIG_DIR = originalEnv;
+		} else {
+			delete process.env.OPENCODE_CONFIG_DIR;
+		}
+	});
 
-  describe("getOpenCodeSkillDirs", () => {
-    describe("#given config dir inside profiles/", () => {
-      describe("#when getOpenCodeSkillDirs is called", () => {
-        it("#then returns both profile and parent skill dirs", async () => {
-          process.env.OPENCODE_CONFIG_DIR = "/home/user/.config/opencode/profiles/opus"
+	describe("getOpenCodeSkillDirs", () => {
+		describe("#given config dir inside profiles/", () => {
+			describe("#when getOpenCodeSkillDirs is called", () => {
+				it("#then returns both profile and parent skill dirs", async () => {
+					process.env.OPENCODE_CONFIG_DIR =
+						"/home/user/.config/opencode/profiles/opus";
 
-          const { getOpenCodeSkillDirs } = await import("./opencode-command-dirs")
-          const dirs = getOpenCodeSkillDirs({ binary: "opencode" })
+					const { getOpenCodeSkillDirs } = await import(
+						"./opencode-command-dirs"
+					);
+					const dirs = getOpenCodeSkillDirs({ binary: "opencode" });
 
-          expect(dirs).toContain("/home/user/.config/opencode/profiles/opus/skills")
-          expect(dirs).toContain("/home/user/.config/opencode/profiles/opus/skill")
-          expect(dirs).toContain("/home/user/.config/opencode/skill")
-          expect(dirs).toContain("/home/user/.config/opencode/skills")
-          expect(dirs).toHaveLength(4)
-        })
-      })
-    })
+					expect(dirs).toContain(
+						resolve("/home/user/.config/opencode/profiles/opus/skills"),
+					);
+					expect(dirs).toContain(
+						resolve("/home/user/.config/opencode/profiles/opus/skill"),
+					);
+					expect(dirs).toContain(resolve("/home/user/.config/opencode/skill"));
+					expect(dirs).toContain(resolve("/home/user/.config/opencode/skills"));
+					expect(dirs).toHaveLength(4);
+				});
+			});
+		});
 
-    describe("#given config dir NOT inside profiles/", () => {
-      describe("#when getOpenCodeSkillDirs is called", () => {
-        it("#then returns only the config dir skills", async () => {
-          process.env.OPENCODE_CONFIG_DIR = "/home/user/.config/opencode"
+		describe("#given config dir NOT inside profiles/", () => {
+			describe("#when getOpenCodeSkillDirs is called", () => {
+				it("#then returns only the config dir skills", async () => {
+					process.env.OPENCODE_CONFIG_DIR = "/home/user/.config/opencode";
 
-          const { getOpenCodeSkillDirs } = await import("./opencode-command-dirs")
-          const dirs = getOpenCodeSkillDirs({ binary: "opencode" })
+					const { getOpenCodeSkillDirs } = await import(
+						"./opencode-command-dirs"
+					);
+					const dirs = getOpenCodeSkillDirs({ binary: "opencode" });
 
-          expect(dirs).toContain("/home/user/.config/opencode/skills")
-          expect(dirs).toContain("/home/user/.config/opencode/skill")
-          expect(dirs).toHaveLength(2)
-        })
-      })
-    })
-  })
+					expect(dirs).toContain(resolve("/home/user/.config/opencode/skills"));
+					expect(dirs).toContain(resolve("/home/user/.config/opencode/skill"));
+					expect(dirs).toHaveLength(2);
+				});
+			});
+		});
+	});
 
-  describe("getOpenCodeCommandDirs", () => {
-    describe("#given config dir inside profiles/", () => {
-      describe("#when getOpenCodeCommandDirs is called", () => {
-        it("#then returns both profile and parent command dirs", async () => {
-          process.env.OPENCODE_CONFIG_DIR = "/home/user/.config/opencode/profiles/opus"
+	describe("getOpenCodeCommandDirs", () => {
+		describe("#given config dir inside profiles/", () => {
+			describe("#when getOpenCodeCommandDirs is called", () => {
+				it("#then returns both profile and parent command dirs", async () => {
+					process.env.OPENCODE_CONFIG_DIR =
+						"/home/user/.config/opencode/profiles/opus";
 
-          const { getOpenCodeCommandDirs } = await import("./opencode-command-dirs")
-          const dirs = getOpenCodeCommandDirs({ binary: "opencode" })
+					const { getOpenCodeCommandDirs } = await import(
+						"./opencode-command-dirs"
+					);
+					const dirs = getOpenCodeCommandDirs({ binary: "opencode" });
 
-          expect(dirs).toContain("/home/user/.config/opencode/profiles/opus/commands")
-          expect(dirs).toContain("/home/user/.config/opencode/profiles/opus/command")
-          expect(dirs).toContain("/home/user/.config/opencode/commands")
-          expect(dirs).toContain("/home/user/.config/opencode/command")
-          expect(dirs).toHaveLength(4)
-        })
-      })
-    })
-  })
-})
+					expect(dirs).toContain(
+						resolve("/home/user/.config/opencode/profiles/opus/commands"),
+					);
+					expect(dirs).toContain(
+						resolve("/home/user/.config/opencode/profiles/opus/command"),
+					);
+					expect(dirs).toContain(
+						resolve("/home/user/.config/opencode/commands"),
+					);
+					expect(dirs).toContain(
+						resolve("/home/user/.config/opencode/command"),
+					);
+					expect(dirs).toHaveLength(4);
+				});
+			});
+		});
+	});
+});

--- a/src/shared/opencode-config-dir.test.ts
+++ b/src/shared/opencode-config-dir.test.ts
@@ -1,340 +1,427 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { homedir } from "node:os"
-import { join, resolve, win32 } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { homedir } from "node:os";
+import { join, resolve, win32 } from "node:path";
 import {
-  getOpenCodeConfigDir,
-  getOpenCodeConfigPaths,
-  isDevBuild,
-  detectExistingConfigDir,
-  TAURI_APP_IDENTIFIER,
-  TAURI_APP_IDENTIFIER_DEV,
-} from "./opencode-config-dir"
+	detectExistingConfigDir,
+	getOpenCodeConfigDir,
+	getOpenCodeConfigPaths,
+	isDevBuild,
+	TAURI_APP_IDENTIFIER,
+	TAURI_APP_IDENTIFIER_DEV,
+} from "./opencode-config-dir";
 
 describe("opencode-config-dir", () => {
-  let originalPlatform: NodeJS.Platform
-  let originalEnv: Record<string, string | undefined>
-
-  beforeEach(() => {
-    originalPlatform = process.platform
-    originalEnv = {
-      APPDATA: process.env.APPDATA,
-      XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
-      XDG_DATA_HOME: process.env.XDG_DATA_HOME,
-      OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
-    }
-  })
-
-  afterEach(() => {
-    Object.defineProperty(process, "platform", { value: originalPlatform })
-    for (const [key, value] of Object.entries(originalEnv)) {
-      if (value !== undefined) {
-        process.env[key] = value
-      } else {
-        delete process.env[key]
-      }
-    }
-  })
-
-  describe("OPENCODE_CONFIG_DIR environment variable", () => {
-    test("returns OPENCODE_CONFIG_DIR when env var is set", () => {
-      // given OPENCODE_CONFIG_DIR is set to a custom path
-      process.env.OPENCODE_CONFIG_DIR = "/custom/opencode/path"
-      Object.defineProperty(process, "platform", { value: "linux" })
-
-      // when getOpenCodeConfigDir is called with binary="opencode"
-      const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200" })
-
-      // then returns the custom path
-      expect(result).toBe("/custom/opencode/path")
-    })
-
-    test("falls back to default when env var is not set", () => {
-      // given OPENCODE_CONFIG_DIR is not set, platform is Linux
-      delete process.env.OPENCODE_CONFIG_DIR
-      delete process.env.XDG_CONFIG_HOME
-      Object.defineProperty(process, "platform", { value: "linux" })
-
-      // when getOpenCodeConfigDir is called with binary="opencode"
-      const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200" })
-
-      // then returns default ~/.config/opencode
-      expect(result).toBe(join(homedir(), ".config", "opencode"))
-    })
-
-    test("falls back to default when env var is empty string", () => {
-      // given OPENCODE_CONFIG_DIR is set to empty string
-      process.env.OPENCODE_CONFIG_DIR = ""
-      delete process.env.XDG_CONFIG_HOME
-      Object.defineProperty(process, "platform", { value: "linux" })
-
-      // when getOpenCodeConfigDir is called with binary="opencode"
-      const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200" })
-
-      // then returns default ~/.config/opencode
-      expect(result).toBe(join(homedir(), ".config", "opencode"))
-    })
-
-    test("falls back to default when env var is whitespace only", () => {
-      // given OPENCODE_CONFIG_DIR is set to whitespace only
-      process.env.OPENCODE_CONFIG_DIR = "   "
-      delete process.env.XDG_CONFIG_HOME
-      Object.defineProperty(process, "platform", { value: "linux" })
-
-      // when getOpenCodeConfigDir is called with binary="opencode"
-      const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200" })
-
-      // then returns default ~/.config/opencode
-      expect(result).toBe(join(homedir(), ".config", "opencode"))
-    })
-
-    test("resolves relative path to absolute path", () => {
-      // given OPENCODE_CONFIG_DIR is set to a relative path
-      process.env.OPENCODE_CONFIG_DIR = "./my-opencode-config"
-      Object.defineProperty(process, "platform", { value: "linux" })
-
-      // when getOpenCodeConfigDir is called with binary="opencode"
-      const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200" })
-
-      // then returns resolved absolute path
-      expect(result).toBe(resolve("./my-opencode-config"))
-    })
-
-    test("OPENCODE_CONFIG_DIR takes priority over XDG_CONFIG_HOME", () => {
-      // given both OPENCODE_CONFIG_DIR and XDG_CONFIG_HOME are set
-      process.env.OPENCODE_CONFIG_DIR = "/custom/opencode/path"
-      process.env.XDG_CONFIG_HOME = "/xdg/config"
-      Object.defineProperty(process, "platform", { value: "linux" })
-
-      // when getOpenCodeConfigDir is called with binary="opencode"
-      const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200" })
-
-      // then OPENCODE_CONFIG_DIR takes priority
-      expect(result).toBe("/custom/opencode/path")
-    })
-  })
-
-  describe("isDevBuild", () => {
-    test("returns false for null version", () => {
-      expect(isDevBuild(null)).toBe(false)
-    })
-
-    test("returns false for undefined version", () => {
-      expect(isDevBuild(undefined)).toBe(false)
-    })
-
-    test("returns false for production version", () => {
-      expect(isDevBuild("1.0.200")).toBe(false)
-      expect(isDevBuild("2.1.0")).toBe(false)
-    })
-
-    test("returns true for version containing -dev", () => {
-      expect(isDevBuild("1.0.0-dev")).toBe(true)
-      expect(isDevBuild("1.0.0-dev.123")).toBe(true)
-    })
-
-    test("returns true for version containing .dev", () => {
-      expect(isDevBuild("1.0.0.dev")).toBe(true)
-      expect(isDevBuild("1.0.0.dev.456")).toBe(true)
-    })
-  })
-
-  describe("getOpenCodeConfigDir", () => {
-    describe("for opencode CLI binary", () => {
-      test("returns ~/.config/opencode on Linux", () => {
-        // given opencode CLI binary detected, platform is Linux
-        Object.defineProperty(process, "platform", { value: "linux" })
-        delete process.env.XDG_CONFIG_HOME
-        delete process.env.OPENCODE_CONFIG_DIR
-
-        // when getOpenCodeConfigDir is called with binary="opencode"
-        const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200" })
-
-        // then returns ~/.config/opencode
-        expect(result).toBe(join(homedir(), ".config", "opencode"))
-      })
-
-      test("returns $XDG_CONFIG_HOME/opencode on Linux when XDG_CONFIG_HOME is set", () => {
-        // given opencode CLI binary detected, platform is Linux with XDG_CONFIG_HOME set
-        Object.defineProperty(process, "platform", { value: "linux" })
-        process.env.XDG_CONFIG_HOME = "/custom/config"
-        delete process.env.OPENCODE_CONFIG_DIR
-
-        // when getOpenCodeConfigDir is called with binary="opencode"
-        const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200" })
-
-        // then returns $XDG_CONFIG_HOME/opencode
-        expect(result).toBe("/custom/config/opencode")
-      })
-
-      test("returns ~/.config/opencode on macOS", () => {
-        // given opencode CLI binary detected, platform is macOS
-        Object.defineProperty(process, "platform", { value: "darwin" })
-        delete process.env.XDG_CONFIG_HOME
-        delete process.env.OPENCODE_CONFIG_DIR
-
-        // when getOpenCodeConfigDir is called with binary="opencode"
-        const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200" })
-
-        // then returns ~/.config/opencode
-        expect(result).toBe(join(homedir(), ".config", "opencode"))
-      })
-
-      test("returns ~/.config/opencode on Windows by default", () => {
-        // given opencode CLI binary detected, platform is Windows
-        Object.defineProperty(process, "platform", { value: "win32" })
-        delete process.env.APPDATA
-        delete process.env.XDG_CONFIG_HOME
-        delete process.env.OPENCODE_CONFIG_DIR
-
-        // when getOpenCodeConfigDir is called with binary="opencode"
-        const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200", checkExisting: false })
-
-        // then returns ~/.config/opencode (cross-platform default)
-        expect(result).toBe(join(homedir(), ".config", "opencode"))
-      })
-
-      test("returns ~/.config/opencode on Windows even when APPDATA is set (#2502)", () => {
-        // given opencode CLI binary detected, platform is Windows with APPDATA set
-        // (regression test: previously would check AppData for existing config)
-        Object.defineProperty(process, "platform", { value: "win32" })
-        process.env.APPDATA = "C:\\Users\\TestUser\\AppData\\Roaming"
-        delete process.env.XDG_CONFIG_HOME
-        delete process.env.OPENCODE_CONFIG_DIR
-
-        // when getOpenCodeConfigDir is called with binary="opencode"
-        const result = getOpenCodeConfigDir({ binary: "opencode", version: "1.0.200", checkExisting: false })
-
-        // then returns ~/.config/opencode (ignores APPDATA entirely for CLI)
-        expect(result).toBe(join(homedir(), ".config", "opencode"))
-      })
-    })
-
-    describe("for opencode-desktop Tauri binary", () => {
-      test("returns ~/.config/ai.opencode.desktop on Linux", () => {
-        // given opencode-desktop binary detected, platform is Linux
-        Object.defineProperty(process, "platform", { value: "linux" })
-        delete process.env.XDG_CONFIG_HOME
-
-        // when getOpenCodeConfigDir is called with binary="opencode-desktop"
-        const result = getOpenCodeConfigDir({ binary: "opencode-desktop", version: "1.0.200", checkExisting: false })
-
-        // then returns ~/.config/ai.opencode.desktop
-        expect(result).toBe(join(homedir(), ".config", TAURI_APP_IDENTIFIER))
-      })
-
-      test("returns ~/Library/Application Support/ai.opencode.desktop on macOS", () => {
-        // given opencode-desktop binary detected, platform is macOS
-        Object.defineProperty(process, "platform", { value: "darwin" })
-
-        // when getOpenCodeConfigDir is called with binary="opencode-desktop"
-        const result = getOpenCodeConfigDir({ binary: "opencode-desktop", version: "1.0.200", checkExisting: false })
-
-        // then returns ~/Library/Application Support/ai.opencode.desktop
-        expect(result).toBe(join(homedir(), "Library", "Application Support", TAURI_APP_IDENTIFIER))
-      })
-
-      test("returns %APPDATA%/ai.opencode.desktop on Windows", () => {
-        // given opencode-desktop binary detected, platform is Windows
-        Object.defineProperty(process, "platform", { value: "win32" })
-        process.env.APPDATA = "C:\\Users\\TestUser\\AppData\\Roaming"
-
-        // when getOpenCodeConfigDir is called with binary="opencode-desktop"
-        const result = getOpenCodeConfigDir({ binary: "opencode-desktop", version: "1.0.200", checkExisting: false })
-
-        // then returns %APPDATA%/ai.opencode.desktop using Windows path semantics
-        expect(result).toBe(win32.join("C:\\Users\\TestUser\\AppData\\Roaming", TAURI_APP_IDENTIFIER))
-      })
-
-    })
-
-    describe("dev build detection", () => {
-      test("returns ai.opencode.desktop.dev path when dev version detected", () => {
-        // given opencode-desktop dev version
-        Object.defineProperty(process, "platform", { value: "linux" })
-        delete process.env.XDG_CONFIG_HOME
-
-        // when getOpenCodeConfigDir is called with dev version
-        const result = getOpenCodeConfigDir({ binary: "opencode-desktop", version: "1.0.0-dev.123", checkExisting: false })
-
-        // then returns path with ai.opencode.desktop.dev
-        expect(result).toBe(join(homedir(), ".config", TAURI_APP_IDENTIFIER_DEV))
-      })
-
-      test("returns ai.opencode.desktop.dev on macOS for dev build", () => {
-        // given opencode-desktop dev version on macOS
-        Object.defineProperty(process, "platform", { value: "darwin" })
-
-        // when getOpenCodeConfigDir is called with dev version
-        const result = getOpenCodeConfigDir({ binary: "opencode-desktop", version: "1.0.0-dev", checkExisting: false })
-
-        // then returns path with ai.opencode.desktop.dev
-        expect(result).toBe(join(homedir(), "Library", "Application Support", TAURI_APP_IDENTIFIER_DEV))
-      })
-    })
-  })
-
-  describe("getOpenCodeConfigPaths", () => {
-    test("returns all config paths for CLI binary", () => {
-      // given opencode CLI binary on Linux
-      Object.defineProperty(process, "platform", { value: "linux" })
-      delete process.env.XDG_CONFIG_HOME
-      delete process.env.OPENCODE_CONFIG_DIR
-
-      // when getOpenCodeConfigPaths is called
-      const paths = getOpenCodeConfigPaths({ binary: "opencode", version: "1.0.200" })
-
-      // then returns all expected paths
-      const expectedDir = join(homedir(), ".config", "opencode")
-      expect(paths.configDir).toBe(expectedDir)
-      expect(paths.configJson).toBe(join(expectedDir, "opencode.json"))
-      expect(paths.configJsonc).toBe(join(expectedDir, "opencode.jsonc"))
-      expect(paths.packageJson).toBe(join(expectedDir, "package.json"))
-      expect(paths.omoConfig).toBe(join(expectedDir, "oh-my-opencode.json"))
-    })
-
-    test("returns all config paths for desktop binary", () => {
-      // given opencode-desktop binary on macOS
-      Object.defineProperty(process, "platform", { value: "darwin" })
-
-      // when getOpenCodeConfigPaths is called
-      const paths = getOpenCodeConfigPaths({ binary: "opencode-desktop", version: "1.0.200", checkExisting: false })
-
-      // then returns all expected paths
-      const expectedDir = join(homedir(), "Library", "Application Support", TAURI_APP_IDENTIFIER)
-      expect(paths.configDir).toBe(expectedDir)
-      expect(paths.configJson).toBe(join(expectedDir, "opencode.json"))
-      expect(paths.configJsonc).toBe(join(expectedDir, "opencode.jsonc"))
-      expect(paths.packageJson).toBe(join(expectedDir, "package.json"))
-      expect(paths.omoConfig).toBe(join(expectedDir, "oh-my-opencode.json"))
-    })
-  })
-
-  describe("detectExistingConfigDir", () => {
-    test("returns null when no config exists", () => {
-      // given no config files exist
-      Object.defineProperty(process, "platform", { value: "linux" })
-      delete process.env.XDG_CONFIG_HOME
-      delete process.env.OPENCODE_CONFIG_DIR
-
-      // when detectExistingConfigDir is called
-      const result = detectExistingConfigDir("opencode", "1.0.200")
-
-      // then result is either null or a valid string path
-      expect(result === null || typeof result === "string").toBe(true)
-    })
-
-    test("includes OPENCODE_CONFIG_DIR in search locations when set", () => {
-      // given OPENCODE_CONFIG_DIR is set to a custom path
-      process.env.OPENCODE_CONFIG_DIR = "/custom/opencode/path"
-      Object.defineProperty(process, "platform", { value: "linux" })
-      delete process.env.XDG_CONFIG_HOME
-
-      // when detectExistingConfigDir is called
-      const result = detectExistingConfigDir("opencode", "1.0.200")
-
-      // then result is either null (no config file exists) or a valid string path
-      // The important thing is that the function doesn't throw
-      expect(result === null || typeof result === "string").toBe(true)
-    })
-  })
-})
+	let originalPlatform: NodeJS.Platform;
+	let originalEnv: Record<string, string | undefined>;
+
+	beforeEach(() => {
+		originalPlatform = process.platform;
+		originalEnv = {
+			APPDATA: process.env.APPDATA,
+			XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+			XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+			OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
+		};
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: originalPlatform });
+		for (const [key, value] of Object.entries(originalEnv)) {
+			if (value !== undefined) {
+				process.env[key] = value;
+			} else {
+				delete process.env[key];
+			}
+		}
+	});
+
+	describe("OPENCODE_CONFIG_DIR environment variable", () => {
+		test("returns OPENCODE_CONFIG_DIR when env var is set", () => {
+			// given OPENCODE_CONFIG_DIR is set to a custom path
+			process.env.OPENCODE_CONFIG_DIR = "/custom/opencode/path";
+			Object.defineProperty(process, "platform", { value: "linux" });
+
+			// when getOpenCodeConfigDir is called with binary="opencode"
+			const result = getOpenCodeConfigDir({
+				binary: "opencode",
+				version: "1.0.200",
+			});
+
+			// then returns the custom path
+			expect(result).toBe(resolve("/custom/opencode/path"));
+		});
+
+		test("falls back to default when env var is not set", () => {
+			// given OPENCODE_CONFIG_DIR is not set, platform is Linux
+			delete process.env.OPENCODE_CONFIG_DIR;
+			delete process.env.XDG_CONFIG_HOME;
+			Object.defineProperty(process, "platform", { value: "linux" });
+
+			// when getOpenCodeConfigDir is called with binary="opencode"
+			const result = getOpenCodeConfigDir({
+				binary: "opencode",
+				version: "1.0.200",
+			});
+
+			// then returns default ~/.config/opencode
+			expect(result).toBe(join(homedir(), ".config", "opencode"));
+		});
+
+		test("falls back to default when env var is empty string", () => {
+			// given OPENCODE_CONFIG_DIR is set to empty string
+			process.env.OPENCODE_CONFIG_DIR = "";
+			delete process.env.XDG_CONFIG_HOME;
+			Object.defineProperty(process, "platform", { value: "linux" });
+
+			// when getOpenCodeConfigDir is called with binary="opencode"
+			const result = getOpenCodeConfigDir({
+				binary: "opencode",
+				version: "1.0.200",
+			});
+
+			// then returns default ~/.config/opencode
+			expect(result).toBe(join(homedir(), ".config", "opencode"));
+		});
+
+		test("falls back to default when env var is whitespace only", () => {
+			// given OPENCODE_CONFIG_DIR is set to whitespace only
+			process.env.OPENCODE_CONFIG_DIR = "   ";
+			delete process.env.XDG_CONFIG_HOME;
+			Object.defineProperty(process, "platform", { value: "linux" });
+
+			// when getOpenCodeConfigDir is called with binary="opencode"
+			const result = getOpenCodeConfigDir({
+				binary: "opencode",
+				version: "1.0.200",
+			});
+
+			// then returns default ~/.config/opencode
+			expect(result).toBe(join(homedir(), ".config", "opencode"));
+		});
+
+		test("resolves relative path to absolute path", () => {
+			// given OPENCODE_CONFIG_DIR is set to a relative path
+			process.env.OPENCODE_CONFIG_DIR = "./my-opencode-config";
+			Object.defineProperty(process, "platform", { value: "linux" });
+
+			// when getOpenCodeConfigDir is called with binary="opencode"
+			const result = getOpenCodeConfigDir({
+				binary: "opencode",
+				version: "1.0.200",
+			});
+
+			// then returns resolved absolute path
+			expect(result).toBe(resolve("./my-opencode-config"));
+		});
+
+		test("OPENCODE_CONFIG_DIR takes priority over XDG_CONFIG_HOME", () => {
+			// given both OPENCODE_CONFIG_DIR and XDG_CONFIG_HOME are set
+			process.env.OPENCODE_CONFIG_DIR = "/custom/opencode/path";
+			process.env.XDG_CONFIG_HOME = "/xdg/config";
+			Object.defineProperty(process, "platform", { value: "linux" });
+
+			// when getOpenCodeConfigDir is called with binary="opencode"
+			const result = getOpenCodeConfigDir({
+				binary: "opencode",
+				version: "1.0.200",
+			});
+
+			// then OPENCODE_CONFIG_DIR takes priority
+			expect(result).toBe(resolve("/custom/opencode/path"));
+		});
+	});
+
+	describe("isDevBuild", () => {
+		test("returns false for null version", () => {
+			expect(isDevBuild(null)).toBe(false);
+		});
+
+		test("returns false for undefined version", () => {
+			expect(isDevBuild(undefined)).toBe(false);
+		});
+
+		test("returns false for production version", () => {
+			expect(isDevBuild("1.0.200")).toBe(false);
+			expect(isDevBuild("2.1.0")).toBe(false);
+		});
+
+		test("returns true for version containing -dev", () => {
+			expect(isDevBuild("1.0.0-dev")).toBe(true);
+			expect(isDevBuild("1.0.0-dev.123")).toBe(true);
+		});
+
+		test("returns true for version containing .dev", () => {
+			expect(isDevBuild("1.0.0.dev")).toBe(true);
+			expect(isDevBuild("1.0.0.dev.456")).toBe(true);
+		});
+	});
+
+	describe("getOpenCodeConfigDir", () => {
+		describe("for opencode CLI binary", () => {
+			test("returns ~/.config/opencode on Linux", () => {
+				// given opencode CLI binary detected, platform is Linux
+				Object.defineProperty(process, "platform", { value: "linux" });
+				delete process.env.XDG_CONFIG_HOME;
+				delete process.env.OPENCODE_CONFIG_DIR;
+
+				// when getOpenCodeConfigDir is called with binary="opencode"
+				const result = getOpenCodeConfigDir({
+					binary: "opencode",
+					version: "1.0.200",
+				});
+
+				// then returns ~/.config/opencode
+				expect(result).toBe(join(homedir(), ".config", "opencode"));
+			});
+
+			test("returns $XDG_CONFIG_HOME/opencode on Linux when XDG_CONFIG_HOME is set", () => {
+				// given opencode CLI binary detected, platform is Linux with XDG_CONFIG_HOME set
+				Object.defineProperty(process, "platform", { value: "linux" });
+				process.env.XDG_CONFIG_HOME = "/custom/config";
+				delete process.env.OPENCODE_CONFIG_DIR;
+
+				// when getOpenCodeConfigDir is called with binary="opencode"
+				const result = getOpenCodeConfigDir({
+					binary: "opencode",
+					version: "1.0.200",
+				});
+
+				// then returns $XDG_CONFIG_HOME/opencode
+				expect(result).toBe(resolve("/custom/config/opencode"));
+			});
+
+			test("returns ~/.config/opencode on macOS", () => {
+				// given opencode CLI binary detected, platform is macOS
+				Object.defineProperty(process, "platform", { value: "darwin" });
+				delete process.env.XDG_CONFIG_HOME;
+				delete process.env.OPENCODE_CONFIG_DIR;
+
+				// when getOpenCodeConfigDir is called with binary="opencode"
+				const result = getOpenCodeConfigDir({
+					binary: "opencode",
+					version: "1.0.200",
+				});
+
+				// then returns ~/.config/opencode
+				expect(result).toBe(join(homedir(), ".config", "opencode"));
+			});
+
+			test("returns ~/.config/opencode on Windows by default", () => {
+				// given opencode CLI binary detected, platform is Windows
+				Object.defineProperty(process, "platform", { value: "win32" });
+				delete process.env.APPDATA;
+				delete process.env.XDG_CONFIG_HOME;
+				delete process.env.OPENCODE_CONFIG_DIR;
+
+				// when getOpenCodeConfigDir is called with binary="opencode"
+				const result = getOpenCodeConfigDir({
+					binary: "opencode",
+					version: "1.0.200",
+					checkExisting: false,
+				});
+
+				// then returns ~/.config/opencode (cross-platform default)
+				expect(result).toBe(join(homedir(), ".config", "opencode"));
+			});
+
+			test("returns ~/.config/opencode on Windows even when APPDATA is set (#2502)", () => {
+				// given opencode CLI binary detected, platform is Windows with APPDATA set
+				// (regression test: previously would check AppData for existing config)
+				Object.defineProperty(process, "platform", { value: "win32" });
+				process.env.APPDATA = "C:\\Users\\TestUser\\AppData\\Roaming";
+				delete process.env.XDG_CONFIG_HOME;
+				delete process.env.OPENCODE_CONFIG_DIR;
+
+				// when getOpenCodeConfigDir is called with binary="opencode"
+				const result = getOpenCodeConfigDir({
+					binary: "opencode",
+					version: "1.0.200",
+					checkExisting: false,
+				});
+
+				// then returns ~/.config/opencode (ignores APPDATA entirely for CLI)
+				expect(result).toBe(join(homedir(), ".config", "opencode"));
+			});
+		});
+
+		describe("for opencode-desktop Tauri binary", () => {
+			test("returns ~/.config/ai.opencode.desktop on Linux", () => {
+				// given opencode-desktop binary detected, platform is Linux
+				Object.defineProperty(process, "platform", { value: "linux" });
+				delete process.env.XDG_CONFIG_HOME;
+
+				// when getOpenCodeConfigDir is called with binary="opencode-desktop"
+				const result = getOpenCodeConfigDir({
+					binary: "opencode-desktop",
+					version: "1.0.200",
+					checkExisting: false,
+				});
+
+				// then returns ~/.config/ai.opencode.desktop
+				expect(result).toBe(join(homedir(), ".config", TAURI_APP_IDENTIFIER));
+			});
+
+			test("returns ~/Library/Application Support/ai.opencode.desktop on macOS", () => {
+				// given opencode-desktop binary detected, platform is macOS
+				Object.defineProperty(process, "platform", { value: "darwin" });
+
+				// when getOpenCodeConfigDir is called with binary="opencode-desktop"
+				const result = getOpenCodeConfigDir({
+					binary: "opencode-desktop",
+					version: "1.0.200",
+					checkExisting: false,
+				});
+
+				// then returns ~/Library/Application Support/ai.opencode.desktop
+				expect(result).toBe(
+					join(
+						homedir(),
+						"Library",
+						"Application Support",
+						TAURI_APP_IDENTIFIER,
+					),
+				);
+			});
+
+			test("returns %APPDATA%/ai.opencode.desktop on Windows", () => {
+				// given opencode-desktop binary detected, platform is Windows
+				Object.defineProperty(process, "platform", { value: "win32" });
+				process.env.APPDATA = "C:\\Users\\TestUser\\AppData\\Roaming";
+
+				// when getOpenCodeConfigDir is called with binary="opencode-desktop"
+				const result = getOpenCodeConfigDir({
+					binary: "opencode-desktop",
+					version: "1.0.200",
+					checkExisting: false,
+				});
+
+				// then returns %APPDATA%/ai.opencode.desktop using Windows path semantics
+				expect(result).toBe(
+					win32.join(
+						"C:\\Users\\TestUser\\AppData\\Roaming",
+						TAURI_APP_IDENTIFIER,
+					),
+				);
+			});
+		});
+
+		describe("dev build detection", () => {
+			test("returns ai.opencode.desktop.dev path when dev version detected", () => {
+				// given opencode-desktop dev version
+				Object.defineProperty(process, "platform", { value: "linux" });
+				delete process.env.XDG_CONFIG_HOME;
+
+				// when getOpenCodeConfigDir is called with dev version
+				const result = getOpenCodeConfigDir({
+					binary: "opencode-desktop",
+					version: "1.0.0-dev.123",
+					checkExisting: false,
+				});
+
+				// then returns path with ai.opencode.desktop.dev
+				expect(result).toBe(
+					join(homedir(), ".config", TAURI_APP_IDENTIFIER_DEV),
+				);
+			});
+
+			test("returns ai.opencode.desktop.dev on macOS for dev build", () => {
+				// given opencode-desktop dev version on macOS
+				Object.defineProperty(process, "platform", { value: "darwin" });
+
+				// when getOpenCodeConfigDir is called with dev version
+				const result = getOpenCodeConfigDir({
+					binary: "opencode-desktop",
+					version: "1.0.0-dev",
+					checkExisting: false,
+				});
+
+				// then returns path with ai.opencode.desktop.dev
+				expect(result).toBe(
+					join(
+						homedir(),
+						"Library",
+						"Application Support",
+						TAURI_APP_IDENTIFIER_DEV,
+					),
+				);
+			});
+		});
+	});
+
+	describe("getOpenCodeConfigPaths", () => {
+		test("returns all config paths for CLI binary", () => {
+			// given opencode CLI binary on Linux
+			Object.defineProperty(process, "platform", { value: "linux" });
+			delete process.env.XDG_CONFIG_HOME;
+			delete process.env.OPENCODE_CONFIG_DIR;
+
+			// when getOpenCodeConfigPaths is called
+			const paths = getOpenCodeConfigPaths({
+				binary: "opencode",
+				version: "1.0.200",
+			});
+
+			// then returns all expected paths
+			const expectedDir = join(homedir(), ".config", "opencode");
+			expect(paths.configDir).toBe(expectedDir);
+			expect(paths.configJson).toBe(join(expectedDir, "opencode.json"));
+			expect(paths.configJsonc).toBe(join(expectedDir, "opencode.jsonc"));
+			expect(paths.packageJson).toBe(join(expectedDir, "package.json"));
+			expect(paths.omoConfig).toBe(join(expectedDir, "oh-my-openagent.jsonc"));
+		});
+
+		test("returns all config paths for desktop binary", () => {
+			// given opencode-desktop binary on macOS
+			Object.defineProperty(process, "platform", { value: "darwin" });
+
+			// when getOpenCodeConfigPaths is called
+			const paths = getOpenCodeConfigPaths({
+				binary: "opencode-desktop",
+				version: "1.0.200",
+				checkExisting: false,
+			});
+
+			// then returns all expected paths
+			const expectedDir = join(
+				homedir(),
+				"Library",
+				"Application Support",
+				TAURI_APP_IDENTIFIER,
+			);
+			expect(paths.configDir).toBe(expectedDir);
+			expect(paths.configJson).toBe(join(expectedDir, "opencode.json"));
+			expect(paths.configJsonc).toBe(join(expectedDir, "opencode.jsonc"));
+			expect(paths.packageJson).toBe(join(expectedDir, "package.json"));
+			expect(paths.omoConfig).toBe(join(expectedDir, "oh-my-openagent.jsonc"));
+		});
+	});
+
+	describe("detectExistingConfigDir", () => {
+		test("returns null when no config exists", () => {
+			// given no config files exist
+			Object.defineProperty(process, "platform", { value: "linux" });
+			delete process.env.XDG_CONFIG_HOME;
+			delete process.env.OPENCODE_CONFIG_DIR;
+
+			// when detectExistingConfigDir is called
+			const result = detectExistingConfigDir("opencode", "1.0.200");
+
+			// then result is either null or a valid string path
+			expect(result === null || typeof result === "string").toBe(true);
+		});
+
+		test("includes OPENCODE_CONFIG_DIR in search locations when set", () => {
+			// given OPENCODE_CONFIG_DIR is set to a custom path
+			process.env.OPENCODE_CONFIG_DIR = "/custom/opencode/path";
+			Object.defineProperty(process, "platform", { value: "linux" });
+			delete process.env.XDG_CONFIG_HOME;
+
+			// when detectExistingConfigDir is called
+			const result = detectExistingConfigDir("opencode", "1.0.200");
+
+			// then result is either null (no config file exists) or a valid string path
+			// The important thing is that the function doesn't throw
+			expect(result === null || typeof result === "string").toBe(true);
+		});
+	});
+});

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -1,133 +1,149 @@
-import { existsSync, realpathSync } from "node:fs"
-import { homedir } from "node:os"
-import { join, resolve, win32 } from "node:path"
+import { existsSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve, win32 } from "node:path";
 
 import type {
-  OpenCodeBinaryType,
-  OpenCodeConfigDirOptions,
-  OpenCodeConfigPaths,
-} from "./opencode-config-dir-types"
+	OpenCodeBinaryType,
+	OpenCodeConfigDirOptions,
+	OpenCodeConfigPaths,
+} from "./opencode-config-dir-types";
 
 export type {
-  OpenCodeBinaryType,
-  OpenCodeConfigDirOptions,
-  OpenCodeConfigPaths,
-} from "./opencode-config-dir-types"
+	OpenCodeBinaryType,
+	OpenCodeConfigDirOptions,
+	OpenCodeConfigPaths,
+} from "./opencode-config-dir-types";
 
-export const TAURI_APP_IDENTIFIER = "ai.opencode.desktop"
-export const TAURI_APP_IDENTIFIER_DEV = "ai.opencode.desktop.dev"
+export const TAURI_APP_IDENTIFIER = "ai.opencode.desktop";
+export const TAURI_APP_IDENTIFIER_DEV = "ai.opencode.desktop.dev";
 
 export function isDevBuild(version: string | null | undefined): boolean {
-  if (!version) return false
-  return version.includes("-dev") || version.includes(".dev")
+	if (!version) return false;
+	return version.includes("-dev") || version.includes(".dev");
 }
 
 function getTauriConfigDir(identifier: string): string {
-  const platform = process.platform
+	const platform = process.platform;
 
-  switch (platform) {
-    case "darwin":
-      return join(homedir(), "Library", "Application Support", identifier)
+	switch (platform) {
+		case "darwin":
+			return join(homedir(), "Library", "Application Support", identifier);
 
-    case "win32": {
-      const appData = process.env.APPDATA || join(homedir(), "AppData", "Roaming")
-      return win32.join(appData, identifier)
-    }
+		case "win32": {
+			const appData =
+				process.env.APPDATA || join(homedir(), "AppData", "Roaming");
+			return win32.join(appData, identifier);
+		}
 
-    case "linux":
-    default: {
-      const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
-      return join(xdgConfig, identifier)
-    }
-  }
+		case "linux":
+		default: {
+			const xdgConfig =
+				process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+			return join(xdgConfig, identifier);
+		}
+	}
 }
 
 function resolveConfigPath(pathValue: string): string {
-  const resolvedPath = resolve(pathValue)
-  if (!existsSync(resolvedPath)) return resolvedPath
+	const resolvedPath = resolve(pathValue);
+	if (!existsSync(resolvedPath)) return resolvedPath;
 
-  try {
-    return realpathSync(resolvedPath)
-  } catch {
-    return resolvedPath
-  }
+	try {
+		return realpathSync(resolvedPath);
+	} catch {
+		return resolvedPath;
+	}
 }
 
 function getCliConfigDir(): string {
-  const envConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim()
-  if (envConfigDir) {
-    return resolveConfigPath(envConfigDir)
-  }
+	const envConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim();
+	if (envConfigDir) {
+		return resolveConfigPath(envConfigDir);
+	}
 
-  const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
-  return resolveConfigPath(join(xdgConfig, "opencode"))
+	const xdgConfig = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+	return resolveConfigPath(join(xdgConfig, "opencode"));
 }
 
-export function getOpenCodeConfigDir(options: OpenCodeConfigDirOptions): string {
-  const { binary, version, checkExisting = true } = options
+export function getOpenCodeConfigDir(
+	options: OpenCodeConfigDirOptions,
+): string {
+	const { binary, version, checkExisting = true } = options;
 
-  if (binary === "opencode") {
-    return getCliConfigDir()
-  }
+	if (binary === "opencode") {
+		return getCliConfigDir();
+	}
 
-  const identifier = isDevBuild(version) ? TAURI_APP_IDENTIFIER_DEV : TAURI_APP_IDENTIFIER
-  const tauriDirBase = getTauriConfigDir(identifier)
-  const tauriDir = process.platform === "win32"
-    ? (win32.isAbsolute(tauriDirBase) ? win32.normalize(tauriDirBase) : win32.resolve(tauriDirBase))
-    : resolveConfigPath(tauriDirBase)
+	const identifier = isDevBuild(version)
+		? TAURI_APP_IDENTIFIER_DEV
+		: TAURI_APP_IDENTIFIER;
+	const tauriDirBase = getTauriConfigDir(identifier);
+	const tauriDir =
+		process.platform === "win32"
+			? win32.isAbsolute(tauriDirBase)
+				? win32.normalize(tauriDirBase)
+				: win32.resolve(tauriDirBase)
+			: resolveConfigPath(tauriDirBase);
 
-  if (checkExisting) {
-    const legacyDir = getCliConfigDir()
-    const legacyConfig = join(legacyDir, "opencode.json")
-    const legacyConfigC = join(legacyDir, "opencode.jsonc")
+	if (checkExisting) {
+		const legacyDir = getCliConfigDir();
+		const legacyConfig = join(legacyDir, "opencode.json");
+		const legacyConfigC = join(legacyDir, "opencode.jsonc");
 
-    if (existsSync(legacyConfig) || existsSync(legacyConfigC)) {
-      return legacyDir
-    }
-  }
+		if (existsSync(legacyConfig) || existsSync(legacyConfigC)) {
+			return legacyDir;
+		}
+	}
 
-  return tauriDir
+	return tauriDir;
 }
 
-export function getOpenCodeConfigPaths(options: OpenCodeConfigDirOptions): OpenCodeConfigPaths {
-  const configDir = getOpenCodeConfigDir(options)
+export function getOpenCodeConfigPaths(
+	options: OpenCodeConfigDirOptions,
+): OpenCodeConfigPaths {
+	const configDir = getOpenCodeConfigDir(options);
 
-  return {
-    configDir,
-    configJson: join(configDir, "opencode.json"),
-    configJsonc: join(configDir, "opencode.jsonc"),
-    packageJson: join(configDir, "package.json"),
-    omoConfig: join(configDir, "oh-my-opencode.json"),
-  }
+	return {
+		configDir,
+		configJson: join(configDir, "opencode.json"),
+		configJsonc: join(configDir, "opencode.jsonc"),
+		packageJson: join(configDir, "package.json"),
+		omoConfig: join(configDir, "oh-my-openagent.jsonc"),
+	};
 }
 
-export function detectExistingConfigDir(binary: OpenCodeBinaryType, version?: string | null): string | null {
-  const locations: string[] = []
+export function detectExistingConfigDir(
+	binary: OpenCodeBinaryType,
+	version?: string | null,
+): string | null {
+	const locations: string[] = [];
 
-  const envConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim()
-  if (envConfigDir) {
-    locations.push(resolveConfigPath(envConfigDir))
-  }
+	const envConfigDir = process.env.OPENCODE_CONFIG_DIR?.trim();
+	if (envConfigDir) {
+		locations.push(resolveConfigPath(envConfigDir));
+	}
 
-  if (binary === "opencode-desktop") {
-    const identifier = isDevBuild(version) ? TAURI_APP_IDENTIFIER_DEV : TAURI_APP_IDENTIFIER
-    locations.push(getTauriConfigDir(identifier))
+	if (binary === "opencode-desktop") {
+		const identifier = isDevBuild(version)
+			? TAURI_APP_IDENTIFIER_DEV
+			: TAURI_APP_IDENTIFIER;
+		locations.push(getTauriConfigDir(identifier));
 
-    if (isDevBuild(version)) {
-      locations.push(getTauriConfigDir(TAURI_APP_IDENTIFIER))
-    }
-  }
+		if (isDevBuild(version)) {
+			locations.push(getTauriConfigDir(TAURI_APP_IDENTIFIER));
+		}
+	}
 
-  locations.push(getCliConfigDir())
+	locations.push(getCliConfigDir());
 
-  for (const dir of locations) {
-    const configJson = join(dir, "opencode.json")
-    const configJsonc = join(dir, "opencode.jsonc")
+	for (const dir of locations) {
+		const configJson = join(dir, "opencode.json");
+		const configJsonc = join(dir, "opencode.jsonc");
 
-    if (existsSync(configJson) || existsSync(configJsonc)) {
-      return dir
-    }
-  }
+		if (existsSync(configJson) || existsSync(configJsonc)) {
+			return dir;
+		}
+	}
 
-  return null
+	return null;
 }

--- a/src/shared/plugin-config-detection.test.ts
+++ b/src/shared/plugin-config-detection.test.ts
@@ -1,23 +1,54 @@
-import { describe, expect, test } from "bun:test"
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
-import { detectPluginConfigFile } from "./jsonc-parser"
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { detectPluginConfigFile } from "./jsonc-parser";
 
 describe("detectPluginConfigFile - canonical config detection", () => {
-  const testDir = join(__dirname, ".test-detect-plugin-canonical")
+	const testDir = join(__dirname, ".test-detect-plugin-canonical");
 
-  test("detects oh-my-openagent config when no legacy config exists", () => {
-    //#given
-    if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true })
-    writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}")
+	test("detects oh-my-openagent config when no legacy config exists", () => {
+		//#given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}");
 
-    //#when
-    const result = detectPluginConfigFile(testDir)
+		//#when
+		const result = detectPluginConfigFile(testDir);
 
-    //#then
-    expect(result.format).toBe("jsonc")
-    expect(result.path).toBe(join(testDir, "oh-my-openagent.jsonc"))
+		//#then
+		expect(result.format).toBe("jsonc");
+		expect(result.path).toBe(join(testDir, "oh-my-openagent.jsonc"));
 
-    rmSync(testDir, { recursive: true, force: true })
-  })
-})
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	test("falls back to legacy config when canonical config does not exist", () => {
+		//#given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		writeFileSync(join(testDir, "oh-my-opencode.jsonc"), "{}");
+
+		//#when
+		const result = detectPluginConfigFile(testDir);
+
+		//#then
+		expect(result.format).toBe("jsonc");
+		expect(result.path).toBe(join(testDir, "oh-my-opencode.jsonc"));
+
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	test("prefers canonical config when canonical and legacy configs coexist", () => {
+		//#given
+		if (!existsSync(testDir)) mkdirSync(testDir, { recursive: true });
+		writeFileSync(join(testDir, "oh-my-openagent.jsonc"), "{}");
+		writeFileSync(join(testDir, "oh-my-opencode.jsonc"), "{}");
+
+		//#when
+		const result = detectPluginConfigFile(testDir);
+
+		//#then
+		expect(result.format).toBe("jsonc");
+		expect(result.path).toBe(join(testDir, "oh-my-openagent.jsonc"));
+
+		rmSync(testDir, { recursive: true, force: true });
+	});
+});

--- a/src/shared/project-discovery-dirs.test.ts
+++ b/src/shared/project-discovery-dirs.test.ts
@@ -1,92 +1,196 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test"
-import { mkdirSync, realpathSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
-  findProjectAgentsSkillDirs,
-  findProjectClaudeSkillDirs,
-  findProjectOpencodeCommandDirs,
-  findProjectOpencodeSkillDirs,
-} from "./project-discovery-dirs"
+	findProjectAgentsSkillDirs,
+	findProjectClaudeSkillDirs,
+	findProjectOpencodeCommandDirs,
+	findProjectOpencodeSkillDirs,
+} from "./project-discovery-dirs";
 
-const TEST_DIR = join(tmpdir(), `project-discovery-dirs-${Date.now()}`)
+const TEST_DIR = join(tmpdir(), `project-discovery-dirs-${Date.now()}`);
 
 function canonicalPath(path: string): string {
-  return realpathSync(path)
+	return realpathSync(path);
 }
 
 describe("project-discovery-dirs", () => {
-  beforeEach(() => {
-    mkdirSync(TEST_DIR, { recursive: true })
-  })
+	beforeEach(() => {
+		mkdirSync(TEST_DIR, { recursive: true });
+	});
 
-  afterEach(() => {
-    rmSync(TEST_DIR, { recursive: true, force: true })
-  })
+	afterEach(() => {
+		rmSync(TEST_DIR, { recursive: true, force: true });
+	});
 
-  it("#given nested .opencode skill directories #when finding project opencode skill dirs #then returns nearest-first with aliases", () => {
-    // given
-    const projectDir = join(TEST_DIR, "project")
-    const childDir = join(projectDir, "apps", "cli")
-    mkdirSync(join(projectDir, ".opencode", "skill"), { recursive: true })
-    mkdirSync(join(projectDir, ".opencode", "skills"), { recursive: true })
-    mkdirSync(join(TEST_DIR, ".opencode", "skills"), { recursive: true })
+	it("#given nested .opencode skill directories #when finding project opencode skill dirs #then returns nearest-first with aliases", () => {
+		// given
+		const projectDir = join(TEST_DIR, "project");
+		const childDir = join(projectDir, "apps", "cli");
+		mkdirSync(join(projectDir, ".opencode", "skill"), { recursive: true });
+		mkdirSync(join(projectDir, ".opencode", "skills"), { recursive: true });
+		mkdirSync(join(TEST_DIR, ".opencode", "skills"), { recursive: true });
 
-    // when
-    const directories = findProjectOpencodeSkillDirs(childDir)
+		// when
+		const directories = findProjectOpencodeSkillDirs(childDir);
 
-    // then
-    expect(directories).toEqual([
-      canonicalPath(join(projectDir, ".opencode", "skills")),
-      canonicalPath(join(projectDir, ".opencode", "skill")),
-      canonicalPath(join(TEST_DIR, ".opencode", "skills")),
-    ])
-  })
+		// then
+		expect(directories).toEqual([
+			canonicalPath(join(projectDir, ".opencode", "skills")),
+			canonicalPath(join(projectDir, ".opencode", "skill")),
+		]);
+	});
 
-  it("#given nested .opencode command directories #when finding project opencode command dirs #then returns nearest-first with aliases", () => {
-    // given
-    const projectDir = join(TEST_DIR, "project")
-    const childDir = join(projectDir, "packages", "tool")
-    mkdirSync(join(projectDir, ".opencode", "commands"), { recursive: true })
-    mkdirSync(join(TEST_DIR, ".opencode", "command"), { recursive: true })
+	it("#given nested .opencode command directories #when finding project opencode command dirs #then returns nearest-first with aliases", () => {
+		// given
+		const projectDir = join(TEST_DIR, "project");
+		const childDir = join(projectDir, "packages", "tool");
+		mkdirSync(join(projectDir, ".opencode", "commands"), { recursive: true });
+		mkdirSync(join(TEST_DIR, ".opencode", "command"), { recursive: true });
 
-    // when
-    const directories = findProjectOpencodeCommandDirs(childDir)
+		// when
+		const directories = findProjectOpencodeCommandDirs(childDir);
 
-    // then
-    expect(directories).toEqual([
-      canonicalPath(join(projectDir, ".opencode", "commands")),
-      canonicalPath(join(TEST_DIR, ".opencode", "command")),
-    ])
-  })
+		// then
+		expect(directories).toEqual([
+			canonicalPath(join(projectDir, ".opencode", "commands")),
+		]);
+	});
 
-  it("#given ancestor claude and agents skill directories #when finding project compatibility dirs #then discovers both scopes", () => {
-    // given
-    const projectDir = join(TEST_DIR, "project")
-    const childDir = join(projectDir, "src", "nested")
-    mkdirSync(join(projectDir, ".claude", "skills"), { recursive: true })
-    mkdirSync(join(TEST_DIR, ".agents", "skills"), { recursive: true })
+	it("#given ancestor claude and agents skill directories #when finding project compatibility dirs #then discovers both scopes", () => {
+		// given
+		const projectDir = join(TEST_DIR, "project");
+		const childDir = join(projectDir, "src", "nested");
+		mkdirSync(join(projectDir, ".claude", "skills"), { recursive: true });
+		mkdirSync(join(TEST_DIR, ".agents", "skills"), { recursive: true });
 
-    // when
-    const claudeDirectories = findProjectClaudeSkillDirs(childDir)
-    const agentsDirectories = findProjectAgentsSkillDirs(childDir)
+		// when
+		const claudeDirectories = findProjectClaudeSkillDirs(childDir);
+		const agentsDirectories = findProjectAgentsSkillDirs(childDir);
 
-    // then
-    expect(claudeDirectories).toEqual([canonicalPath(join(projectDir, ".claude", "skills"))])
-    expect(agentsDirectories).toEqual([canonicalPath(join(TEST_DIR, ".agents", "skills"))])
-  })
+		// then
+		expect(claudeDirectories).toEqual([
+			canonicalPath(join(projectDir, ".claude", "skills")),
+		]);
+		expect(agentsDirectories).toEqual([]);
+	});
 
-  it("#given a stop directory #when finding ancestor dirs #then it does not scan beyond the stop boundary", () => {
-    // given
-    const projectDir = join(TEST_DIR, "project")
-    const childDir = join(projectDir, "apps", "cli")
-    mkdirSync(join(projectDir, ".opencode", "skills"), { recursive: true })
-    mkdirSync(join(TEST_DIR, ".opencode", "skills"), { recursive: true })
+	it("#given a stop directory #when finding ancestor dirs #then it does not scan beyond the stop boundary", () => {
+		// given
+		const projectDir = join(TEST_DIR, "project");
+		const childDir = join(projectDir, "apps", "cli");
+		mkdirSync(join(projectDir, ".opencode", "skills"), { recursive: true });
+		mkdirSync(join(TEST_DIR, ".opencode", "skills"), { recursive: true });
 
-    // when
-    const directories = findProjectOpencodeSkillDirs(childDir, projectDir)
+		// when
+		const directories = findProjectOpencodeSkillDirs(childDir, projectDir);
 
-    // then
-    expect(directories).toEqual([canonicalPath(join(projectDir, ".opencode", "skills"))])
-  })
-})
+		// then
+		expect(directories).toEqual([
+			canonicalPath(join(projectDir, ".opencode", "skills")),
+		]);
+	});
+
+	it("#given a non-git project root marker #when finding project opencode skill dirs #then it stops before outside ancestors", () => {
+		// given
+		const workspaceDir = join(TEST_DIR, "workspace");
+		const projectDir = join(workspaceDir, "project");
+		const childDir = join(projectDir, "apps", "cli");
+		mkdirSync(childDir, { recursive: true });
+		mkdirSync(join(projectDir, ".opencode", "skills"), { recursive: true });
+		mkdirSync(join(workspaceDir, ".opencode", "skills"), { recursive: true });
+		mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+
+		// when
+		const directories = findProjectOpencodeSkillDirs(childDir);
+
+		// then
+		expect(directories).toEqual([
+			canonicalPath(join(projectDir, ".opencode", "skills")),
+		]);
+	});
+
+	it("#given nested workspace package root outside a nearer project boundary #when finding project opencode skill dirs #then it stops at the nearer boundary", () => {
+		// given
+		const workspaceDir = join(TEST_DIR, "workspace");
+		const projectDir = join(workspaceDir, "project");
+		const childDir = join(projectDir, "apps", "cli");
+		mkdirSync(childDir, { recursive: true });
+		mkdirSync(join(projectDir, ".opencode", "skills"), { recursive: true });
+		mkdirSync(join(workspaceDir, ".opencode", "skills"), { recursive: true });
+		mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+		writeFileSync(join(workspaceDir, "package.json"), "{}");
+
+		// when
+		const directories = findProjectOpencodeSkillDirs(childDir, undefined);
+
+		// then
+		expect(directories).toEqual([
+			canonicalPath(join(projectDir, ".opencode", "skills")),
+		]);
+	});
+
+	it("#given temp workspace root boundary without inner markers #when finding project opencode skill dirs #then it stops before temp ancestors", () => {
+		// given
+		const workspaceDir = join(TEST_DIR, "workspace");
+		const childDir = join(workspaceDir, "project", "apps", "cli");
+		mkdirSync(childDir, { recursive: true });
+		mkdirSync(join(workspaceDir, ".opencode", "skills"), { recursive: true });
+		mkdirSync(join(TEST_DIR, ".opencode", "skills"), { recursive: true });
+
+		// when
+		const directories = findProjectOpencodeSkillDirs(childDir);
+
+		// then
+		expect(directories).toEqual([
+			canonicalPath(join(workspaceDir, ".opencode", "skills")),
+		]);
+	});
+
+	it("#given git worktree root with a nearer nested project boundary #when finding project opencode skill dirs #then the nearer boundary wins", () => {
+		// given
+		const workspaceDir = join(TEST_DIR, "workspace-git");
+		const projectDir = join(workspaceDir, "packages", "app");
+		const childDir = join(projectDir, "src");
+		mkdirSync(childDir, { recursive: true });
+		execFileSync("git", ["init"], {
+			cwd: workspaceDir,
+			stdio: ["ignore", "ignore", "ignore"],
+		});
+		mkdirSync(join(workspaceDir, ".opencode", "skills"), { recursive: true });
+		mkdirSync(join(projectDir, ".opencode", "skills"), { recursive: true });
+		mkdirSync(join(projectDir, ".claude", "rules"), { recursive: true });
+
+		// when
+		const directories = findProjectOpencodeSkillDirs(childDir);
+
+		// then
+		expect(directories).toEqual([
+			canonicalPath(join(projectDir, ".opencode", "skills")),
+		]);
+	});
+
+	it("#given git worktree with nested package project marker only #when finding project opencode skill dirs #then repo root skills remain visible", () => {
+		// given
+		const workspaceDir = join(TEST_DIR, "workspace-package-git");
+		const projectDir = join(workspaceDir, "packages", "app");
+		const childDir = join(projectDir, "src");
+		mkdirSync(childDir, { recursive: true });
+		execFileSync("git", ["init"], {
+			cwd: workspaceDir,
+			stdio: ["ignore", "ignore", "ignore"],
+		});
+		mkdirSync(join(workspaceDir, ".opencode", "skills"), { recursive: true });
+		writeFileSync(join(projectDir, "package.json"), "{}");
+
+		// when
+		const directories = findProjectOpencodeSkillDirs(childDir);
+
+		// then
+		expect(directories).toEqual([
+			canonicalPath(join(workspaceDir, ".opencode", "skills")),
+		]);
+	});
+});

--- a/src/shared/project-discovery-dirs.ts
+++ b/src/shared/project-discovery-dirs.ts
@@ -1,101 +1,212 @@
-import { execFileSync } from "node:child_process"
-import { existsSync, realpathSync } from "node:fs"
-import { dirname, join, resolve } from "node:path"
+import * as childProcess from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+const PROJECT_BOUNDARY_MARKERS = [
+	".opencode",
+	".claude",
+	".agents",
+	".sisyphus",
+] as const;
 
 function normalizePath(path: string): string {
-  const resolvedPath = resolve(path)
-  if (!existsSync(resolvedPath)) {
-    return resolvedPath
-  }
+	const resolvedPath = resolve(path);
+	if (!existsSync(resolvedPath)) {
+		return resolvedPath;
+	}
 
-  try {
-    return realpathSync(resolvedPath)
-  } catch {
-    return resolvedPath
-  }
+	try {
+		return realpathSync(resolvedPath);
+	} catch {
+		return resolvedPath;
+	}
 }
 
 function findAncestorDirectories(
-  startDirectory: string,
-  targetPaths: ReadonlyArray<ReadonlyArray<string>>,
-  stopDirectory?: string,
+	startDirectory: string,
+	targetPaths: ReadonlyArray<ReadonlyArray<string>>,
+	stopDirectory?: string,
 ): string[] {
-  const directories: string[] = []
-  const seen = new Set<string>()
-  let currentDirectory = normalizePath(startDirectory)
-  const resolvedStopDirectory = stopDirectory ? normalizePath(stopDirectory) : undefined
+	const directories: string[] = [];
+	const seen = new Set<string>();
+	let currentDirectory = normalizePath(startDirectory);
+	const resolvedStopDirectory = stopDirectory
+		? normalizePath(stopDirectory)
+		: undefined;
+	const resolvedHomeDirectory = normalizePath(homedir());
 
-  while (true) {
-    for (const targetPath of targetPaths) {
-      const candidateDirectory = join(currentDirectory, ...targetPath)
-      if (!existsSync(candidateDirectory) || seen.has(candidateDirectory)) {
-        continue
-      }
+	while (true) {
+		if (!resolvedStopDirectory && currentDirectory === resolvedHomeDirectory) {
+			return directories;
+		}
 
-      seen.add(candidateDirectory)
-      directories.push(candidateDirectory)
-    }
+		for (const targetPath of targetPaths) {
+			const candidateDirectory = join(currentDirectory, ...targetPath);
+			if (!existsSync(candidateDirectory) || seen.has(candidateDirectory)) {
+				continue;
+			}
 
-    if (resolvedStopDirectory === currentDirectory) {
-      return directories
-    }
+			seen.add(candidateDirectory);
+			directories.push(candidateDirectory);
+		}
 
-    const parentDirectory = dirname(currentDirectory)
-    if (parentDirectory === currentDirectory) {
-      return directories
-    }
+		if (!resolvedStopDirectory && existsSync(join(currentDirectory, ".git"))) {
+			return directories;
+		}
 
-    currentDirectory = normalizePath(parentDirectory)
-  }
+		if (resolvedStopDirectory === currentDirectory) {
+			return directories;
+		}
+
+		const parentDirectory = dirname(currentDirectory);
+		if (parentDirectory === currentDirectory) {
+			return directories;
+		}
+
+		currentDirectory = normalizePath(parentDirectory);
+	}
 }
 
 function detectWorktreePath(directory: string): string | undefined {
-  try {
-    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
-      cwd: directory,
-      encoding: "utf-8",
-      timeout: 5000,
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim()
-  } catch {
-    return undefined
-  }
+	try {
+		return childProcess
+			.execFileSync("git", ["rev-parse", "--show-toplevel"], {
+				cwd: directory,
+				encoding: "utf-8",
+				timeout: 5000,
+				stdio: ["pipe", "pipe", "pipe"],
+			})
+			.trim();
+	} catch {
+		return undefined;
+	}
 }
 
-export function findProjectClaudeSkillDirs(startDirectory: string, stopDirectory?: string): string[] {
-  return findAncestorDirectories(
-    startDirectory,
-    [[".claude", "skills"]],
-    stopDirectory ?? detectWorktreePath(startDirectory),
-  )
+function hasProjectBoundaryMarker(directory: string): boolean {
+	return PROJECT_BOUNDARY_MARKERS.some((marker) =>
+		existsSync(join(directory, marker)),
+	);
 }
 
-export function findProjectAgentsSkillDirs(startDirectory: string, stopDirectory?: string): string[] {
-  return findAncestorDirectories(
-    startDirectory,
-    [[".agents", "skills"]],
-    stopDirectory ?? detectWorktreePath(startDirectory),
-  )
+function findNearestProjectBoundary(directory: string): string | undefined {
+	let currentDirectory = normalizePath(directory);
+
+	while (true) {
+		if (hasProjectBoundaryMarker(currentDirectory)) {
+			return currentDirectory;
+		}
+
+		const parentDirectory = dirname(currentDirectory);
+		if (parentDirectory === currentDirectory) {
+			return undefined;
+		}
+
+		currentDirectory = normalizePath(parentDirectory);
+	}
 }
 
-export function findProjectOpencodeSkillDirs(startDirectory: string, stopDirectory?: string): string[] {
-  return findAncestorDirectories(
-    startDirectory,
-    [
-      [".opencode", "skills"],
-      [".opencode", "skill"],
-    ],
-    stopDirectory ?? detectWorktreePath(startDirectory),
-  )
+function detectTempWorkspaceRoot(directory: string): string | undefined {
+	const normalizedTempDir = normalizePath(tmpdir());
+	let currentDirectory = normalizePath(directory);
+
+	while (true) {
+		const parentDirectory = dirname(currentDirectory);
+		if (parentDirectory === normalizedTempDir) {
+			return currentDirectory;
+		}
+
+		if (parentDirectory === currentDirectory) {
+			return undefined;
+		}
+
+		currentDirectory = normalizePath(parentDirectory);
+	}
 }
 
-export function findProjectOpencodeCommandDirs(startDirectory: string, stopDirectory?: string): string[] {
-  return findAncestorDirectories(
-    startDirectory,
-    [
-      [".opencode", "commands"],
-      [".opencode", "command"],
-    ],
-    stopDirectory ?? detectWorktreePath(startDirectory),
-  )
+function isNestedBoundary(
+	root: string | undefined,
+	boundary: string | undefined,
+): boolean {
+	if (!root || !boundary || root === boundary) {
+		return false;
+	}
+
+	const relativePath = relative(root, boundary);
+	return (
+		relativePath !== "" &&
+		!relativePath.startsWith("..") &&
+		!isAbsolute(relativePath)
+	);
+}
+
+function resolveDiscoveryStopDirectory(
+	startDirectory: string,
+): string | undefined {
+	const tempWorkspaceRoot = detectTempWorkspaceRoot(startDirectory);
+	const nearestBoundary = findNearestProjectBoundary(startDirectory);
+	const worktreeRoot = detectWorktreePath(startDirectory);
+
+	if (isNestedBoundary(worktreeRoot, nearestBoundary)) {
+		return nearestBoundary;
+	}
+
+	if (worktreeRoot) {
+		return worktreeRoot;
+	}
+
+	if (nearestBoundary) {
+		return nearestBoundary;
+	}
+	return tempWorkspaceRoot ?? undefined;
+}
+
+export function findProjectClaudeSkillDirs(
+	startDirectory: string,
+	stopDirectory?: string,
+): string[] {
+	return findAncestorDirectories(
+		startDirectory,
+		[[".claude", "skills"]],
+		stopDirectory ?? resolveDiscoveryStopDirectory(startDirectory),
+	);
+}
+
+export function findProjectAgentsSkillDirs(
+	startDirectory: string,
+	stopDirectory?: string,
+): string[] {
+	return findAncestorDirectories(
+		startDirectory,
+		[[".agents", "skills"]],
+		stopDirectory ?? resolveDiscoveryStopDirectory(startDirectory),
+	);
+}
+
+export function findProjectOpencodeSkillDirs(
+	startDirectory: string,
+	stopDirectory?: string,
+): string[] {
+	return findAncestorDirectories(
+		startDirectory,
+		[
+			[".opencode", "skills"],
+			[".opencode", "skill"],
+		],
+		stopDirectory ?? resolveDiscoveryStopDirectory(startDirectory),
+	);
+}
+
+export function findProjectOpencodeCommandDirs(
+	startDirectory: string,
+	stopDirectory?: string,
+): string[] {
+	return findAncestorDirectories(
+		startDirectory,
+		[
+			[".opencode", "commands"],
+			[".opencode", "command"],
+		],
+		stopDirectory ?? resolveDiscoveryStopDirectory(startDirectory),
+	);
 }

--- a/src/shared/skill-path-resolver.ts
+++ b/src/shared/skill-path-resolver.ts
@@ -1,27 +1,32 @@
-import { join } from "path"
+import { join } from "path";
 
 function looksLikeFilePath(path: string): boolean {
-	if (path.endsWith("/")) return true
-	const lastSegment = path.split("/").pop() ?? ""
-	return /\.[a-zA-Z0-9]+$/.test(lastSegment)
+	if (path.endsWith("/")) return true;
+	const lastSegment = path.split("/").pop() ?? "";
+	return /\.[a-zA-Z0-9]+$/.test(lastSegment);
 }
 
 /**
  * Resolves @path references in skill content to absolute paths.
  *
  * Matches @references that contain at least one slash (e.g., @scripts/search.py, @data/)
- * to avoid false positives with decorators (@param), JSDoc tags (@ts-ignore), etc.
+ * to avoid false positives with decorators (@param), JSDoc tags (@ts-expect-error), etc.
  * Also skips npm scoped packages (@scope/package) by requiring a file extension or trailing slash.
  *
  * Email addresses are excluded since they have alphanumeric characters before @.
  */
-export function resolveSkillPathReferences(content: string, basePath: string): string {
-	const normalizedBase = basePath.endsWith("/") ? basePath.slice(0, -1) : basePath
+export function resolveSkillPathReferences(
+	content: string,
+	basePath: string,
+): string {
+	const normalizedBase = basePath.endsWith("/")
+		? basePath.slice(0, -1)
+		: basePath;
 	return content.replace(
-		/(?<![a-zA-Z0-9])@([a-zA-Z0-9_-]+\/[a-zA-Z0-9_.\-\/]*)/g,
+		/(?<![a-zA-Z0-9])@([a-zA-Z0-9_-]+\/[a-zA-Z0-9_.\-/]*)/g,
 		(match, relativePath: string) => {
-			if (!looksLikeFilePath(relativePath)) return match
-			return join(normalizedBase, relativePath)
-		}
-	)
+			if (!looksLikeFilePath(relativePath)) return match;
+			return join(normalizedBase, relativePath).replace(/\\/g, "/");
+		},
+	);
 }

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -1,132 +1,203 @@
-import { tool, type PluginInput, type ToolDefinition } from "@opencode-ai/plugin"
-import { ALLOWED_AGENTS, CALL_OMO_AGENT_DESCRIPTION } from "./constants"
-import type { AllowedAgentType, CallOmoAgentArgs, ToolContextWithMetadata } from "./types"
-import type { BackgroundManager } from "../../features/background-agent"
-import type { CategoriesConfig, AgentOverrides } from "../../config/schema"
-import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
-import type { FallbackEntry } from "../../shared/model-requirements"
-import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
-import { getAgentConfigKey } from "../../shared/agent-display-names"
-import { normalizeModelFormat } from "../../shared/model-format-normalizer"
-import { normalizeFallbackModels } from "../../shared/model-resolver"
-import { buildFallbackChainFromModels } from "../../shared/fallback-chain-from-models"
-import { log } from "../../shared"
-import { executeBackground } from "./background-executor"
-import { executeSync } from "./sync-executor"
+import {
+	type PluginInput,
+	type ToolDefinition,
+	tool,
+} from "@opencode-ai/plugin";
+import type { AgentOverrides, CategoriesConfig } from "../../config/schema";
+import type { BackgroundManager } from "../../features/background-agent";
+import { log } from "../../shared";
+import { getAgentConfigKey } from "../../shared/agent-display-names";
+import { buildFallbackChainFromModels } from "../../shared/fallback-chain-from-models";
+import { normalizeModelFormat } from "../../shared/model-format-normalizer";
+import type { FallbackEntry } from "../../shared/model-requirements";
+import { AGENT_MODEL_REQUIREMENTS } from "../../shared/model-requirements";
+import type { DelegatedModelConfig } from "../../shared/model-resolution-types";
+import { normalizeFallbackModels } from "../../shared/model-resolver";
+import { executeBackground } from "./background-executor";
+import { ALLOWED_AGENTS, CALL_OMO_AGENT_DESCRIPTION } from "./constants";
+import { executeSync } from "./sync-executor";
+import type {
+	AllowedAgentType,
+	CallOmoAgentArgs,
+	ToolContextWithMetadata,
+} from "./types";
 
 function resolveModelAndFallbackChain(args: {
-  subagentType: string
-  agentOverrides?: AgentOverrides
-  userCategories?: CategoriesConfig
-}): { model: DelegatedModelConfig | undefined; fallbackChain: FallbackEntry[] | undefined } {
-  const { subagentType, agentOverrides, userCategories } = args
-  const agentConfigKey = getAgentConfigKey(subagentType)
-  const agentRequirement = AGENT_MODEL_REQUIREMENTS[agentConfigKey]
+	subagentType: string;
+	agentOverrides?: AgentOverrides;
+	userCategories?: CategoriesConfig;
+}): {
+	model: DelegatedModelConfig | undefined;
+	fallbackChain: FallbackEntry[] | undefined;
+} {
+	const { subagentType, agentOverrides, userCategories } = args;
+	const agentConfigKey = getAgentConfigKey(subagentType);
+	const agentRequirement = AGENT_MODEL_REQUIREMENTS[agentConfigKey];
 
-  const agentOverride = agentOverrides?.[agentConfigKey as keyof AgentOverrides]
-    ?? (agentOverrides
-      ? Object.entries(agentOverrides).find(([key]) => key.toLowerCase() === agentConfigKey)?.[1]
-      : undefined)
+	const agentOverride =
+		agentOverrides?.[agentConfigKey as keyof AgentOverrides] ??
+		(agentOverrides
+			? Object.entries(agentOverrides).find(
+					([key]) => key.toLowerCase() === agentConfigKey,
+				)?.[1]
+			: undefined);
 
-  let model: DelegatedModelConfig | undefined
-  if (agentOverride?.model) {
-    const normalized = normalizeModelFormat(agentOverride.model)
-    if (normalized) {
-      model = agentOverride.variant ? { ...normalized, variant: agentOverride.variant } : normalized
-      log("[call_omo_agent] Resolved model override from agent config", {
-        agent: subagentType,
-        model: agentOverride.model,
-        variant: agentOverride.variant,
-      })
-    }
-  }
+	let model: DelegatedModelConfig | undefined;
+	if (agentOverride?.model) {
+		const normalized = normalizeModelFormat(agentOverride.model);
+		if (normalized) {
+			model = agentOverride.variant
+				? { ...normalized, variant: agentOverride.variant }
+				: normalized;
+			log("[call_omo_agent] Resolved model override from agent config", {
+				agent: subagentType,
+				model: agentOverride.model,
+				variant: agentOverride.variant,
+			});
+		}
+	}
 
-  const normalizedFallbackModels = normalizeFallbackModels(
-    agentOverride?.fallback_models
-    ?? (agentOverride?.category ? userCategories?.[agentOverride.category]?.fallback_models : undefined)
-  )
-  const defaultProviderID = model?.providerID
-    ?? agentRequirement?.fallbackChain?.[0]?.providers?.[0]
-    ?? "opencode"
-  const configuredFallbackChain = buildFallbackChainFromModels(normalizedFallbackModels, defaultProviderID)
+	const normalizedFallbackModels = normalizeFallbackModels(
+		agentOverride?.fallback_models ??
+			(agentOverride?.category
+				? userCategories?.[agentOverride.category]?.fallback_models
+				: undefined),
+	);
+	const defaultProviderID =
+		model?.providerID ??
+		agentRequirement?.fallbackChain?.[0]?.providers?.[0] ??
+		"opencode";
+	const configuredFallbackChain = buildFallbackChainFromModels(
+		normalizedFallbackModels,
+		defaultProviderID,
+	);
 
-  return {
-    model,
-    fallbackChain: configuredFallbackChain ?? agentRequirement?.fallbackChain,
-  }
+	return {
+		model,
+		fallbackChain: configuredFallbackChain ?? agentRequirement?.fallbackChain,
+	};
 }
 
 export function createCallOmoAgent(
-  ctx: PluginInput,
-  backgroundManager: BackgroundManager,
-  disabledAgents: string[] = [],
-  agentOverrides?: AgentOverrides,
-  userCategories?: CategoriesConfig,
+	ctx: PluginInput,
+	backgroundManager: BackgroundManager,
+	disabledAgents: string[] = [],
+	agentOverrides?: AgentOverrides,
+	userCategories?: CategoriesConfig,
 ): ToolDefinition {
-  const agentDescriptions = ALLOWED_AGENTS.map(
-    (name) => `- ${name}: Specialized agent for ${name} tasks`
-  ).join("\n")
-  const description = CALL_OMO_AGENT_DESCRIPTION.replace("{agents}", agentDescriptions)
+	const agentDescriptions = ALLOWED_AGENTS.map(
+		(name) => `- ${name}: Specialized agent for ${name} tasks`,
+	).join("\n");
+	const description = CALL_OMO_AGENT_DESCRIPTION.replace(
+		"{agents}",
+		agentDescriptions,
+	);
 
-  return tool({
-    description,
-    args: {
-      description: tool.schema.string().describe("A short (3-5 words) description of the task"),
-      prompt: tool.schema.string().describe("The task for the agent to perform"),
-      subagent_type: tool.schema
-        .string()
-        .describe("The type of specialized agent to use for this task (explore or librarian only)"),
-      run_in_background: tool.schema
-        .boolean()
-        .describe("REQUIRED. true: run asynchronously (use background_output to get results), false: run synchronously and wait for completion"),
-      session_id: tool.schema.string().describe("Existing Task session to continue").optional(),
-    },
-    async execute(args: CallOmoAgentArgs, toolContext) {
-      const toolCtx = toolContext as ToolContextWithMetadata
-      log(`[call_omo_agent] Starting with agent: ${args.subagent_type}, background: ${args.run_in_background}`)
+	return tool({
+		description,
+		args: {
+			description: tool.schema
+				.string()
+				.describe("A short (3-5 words) description of the task"),
+			prompt: tool.schema
+				.string()
+				.describe("The task for the agent to perform"),
+			subagent_type: tool.schema
+				.string()
+				.describe(
+					"The type of specialized agent to use for this task (explore or librarian only)",
+				),
+			run_in_background: tool.schema
+				.boolean()
+				.describe(
+					"REQUIRED. true: run asynchronously (use background_output to get results), false: run synchronously and wait for completion",
+				),
+			session_id: tool.schema
+				.string()
+				.describe("Existing Task session to continue")
+				.optional(),
+		},
+		async execute(args: CallOmoAgentArgs, toolContext) {
+			const toolCtx = toolContext as ToolContextWithMetadata;
+			log(
+				`[call_omo_agent] Starting with agent: ${args.subagent_type}, background: ${args.run_in_background}`,
+			);
 
-      // Case-insensitive agent validation - allows "Explore", "EXPLORE", "explore" etc.
-      if (
-        !ALLOWED_AGENTS.some(
-          (name) => name.toLowerCase() === args.subagent_type.toLowerCase(),
-        )
-      ) {
-        return `Error: Invalid agent type "${args.subagent_type}". Only ${ALLOWED_AGENTS.join(", ")} are allowed.`
-      }
+			// Case-insensitive agent validation - allows "Explore", "EXPLORE", "explore" etc.
+			if (
+				!ALLOWED_AGENTS.some(
+					(name) => name.toLowerCase() === args.subagent_type.toLowerCase(),
+				)
+			) {
+				return `Error: Invalid agent type "${args.subagent_type}". Only ${ALLOWED_AGENTS.join(", ")} are allowed.`;
+			}
 
-      const normalizedAgent = args.subagent_type.toLowerCase() as AllowedAgentType
-      args = { ...args, subagent_type: normalizedAgent }
+			const normalizedAgent =
+				args.subagent_type.toLowerCase() as AllowedAgentType;
+			args = { ...args, subagent_type: normalizedAgent };
 
-      // Check if agent is disabled
-      if (disabledAgents.some((disabled) => disabled.toLowerCase() === normalizedAgent)) {
-        return `Error: Agent "${normalizedAgent}" is disabled via disabled_agents configuration. Remove it from disabled_agents in your oh-my-opencode.json to use it.`
-      }
+			// Check if agent is disabled
+			if (
+				disabledAgents.some(
+					(disabled) => disabled.toLowerCase() === normalizedAgent,
+				)
+			) {
+				return `Error: Agent "${normalizedAgent}" is disabled via disabled_agents configuration. Remove it from disabled_agents in your oh-my-openagent.jsonc to use it.`;
+			}
 
-      const { model: resolvedModel, fallbackChain } = resolveModelAndFallbackChain({
-        subagentType: args.subagent_type,
-        agentOverrides,
-        userCategories,
-      })
+			const { model: resolvedModel, fallbackChain } =
+				resolveModelAndFallbackChain({
+					subagentType: args.subagent_type,
+					agentOverrides,
+					userCategories,
+				});
 
-      if (args.run_in_background) {
-        if (args.session_id) {
-          return `Error: session_id is not supported in background mode. Use run_in_background=false to continue an existing session.`
-        }
-        return await executeBackground(args, toolCtx, backgroundManager, ctx.client, fallbackChain, resolvedModel)
-      }
+			if (args.run_in_background) {
+				if (args.session_id) {
+					return `Error: session_id is not supported in background mode. Use run_in_background=false to continue an existing session.`;
+				}
+				return await executeBackground(
+					args,
+					toolCtx,
+					backgroundManager,
+					ctx.client,
+					fallbackChain,
+					resolvedModel,
+				);
+			}
 
-      if (!args.session_id) {
-        let spawnReservation: Awaited<ReturnType<BackgroundManager["reserveSubagentSpawn"]>> | undefined
-        try {
-          spawnReservation = await backgroundManager.reserveSubagentSpawn(toolCtx.sessionID)
-          return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, spawnReservation, resolvedModel)
-        } catch (error) {
-          spawnReservation?.rollback()
-          return `Error: ${error instanceof Error ? error.message : String(error)}`
-        }
-      }
+			if (!args.session_id) {
+				let spawnReservation:
+					| Awaited<ReturnType<BackgroundManager["reserveSubagentSpawn"]>>
+					| undefined;
+				try {
+					spawnReservation = await backgroundManager.reserveSubagentSpawn(
+						toolCtx.sessionID,
+					);
+					return await executeSync(
+						args,
+						toolCtx,
+						ctx,
+						undefined,
+						fallbackChain,
+						spawnReservation,
+						resolvedModel,
+					);
+				} catch (error) {
+					spawnReservation?.rollback();
+					return `Error: ${error instanceof Error ? error.message : String(error)}`;
+				}
+			}
 
-      return await executeSync(args, toolCtx, ctx, undefined, fallbackChain, undefined, resolvedModel)
-    },
-  })
+			return await executeSync(
+				args,
+				toolCtx,
+				ctx,
+				undefined,
+				fallbackChain,
+				undefined,
+				resolvedModel,
+			);
+		},
+	});
 }

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -1,266 +1,321 @@
-import type { ModelFallbackInfo } from "../../features/task-toast-manager/types"
-import type { DelegateTaskArgs } from "./types"
-import type { ExecutorContext } from "./executor-types"
-import type { FallbackEntry } from "../../shared/model-requirements"
-import { mergeCategories } from "../../shared/merge-categories"
-import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent"
-import { resolveCategoryConfig } from "./categories"
-import { parseModelString } from "./model-string-parser"
-import { CATEGORY_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
-import { normalizeFallbackModels, flattenToFallbackModelStrings } from "../../shared/model-resolver"
-import { buildFallbackChainFromModels, findMostSpecificFallbackEntry } from "../../shared/fallback-chain-from-models"
-import { getAvailableModelsForDelegateTask } from "./available-models"
-import { resolveModelForDelegateTask } from "./model-selection"
+import type { CategoryConfig } from "../../config/schema";
+import type { ModelFallbackInfo } from "../../features/task-toast-manager/types";
+import {
+	buildFallbackChainFromModels,
+	findMostSpecificFallbackEntry,
+} from "../../shared/fallback-chain-from-models";
+import { mergeCategories } from "../../shared/merge-categories";
+import type { FallbackEntry } from "../../shared/model-requirements";
+import { CATEGORY_MODEL_REQUIREMENTS } from "../../shared/model-requirements";
+import {
+	flattenToFallbackModelStrings,
+	normalizeFallbackModels,
+} from "../../shared/model-resolver";
+import { getAvailableModelsForDelegateTask } from "./available-models";
+import { resolveCategoryConfig } from "./categories";
+import type { ExecutorContext } from "./executor-types";
+import { resolveModelForDelegateTask } from "./model-selection";
+import { parseModelString } from "./model-string-parser";
+import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent";
+import type { DelegatedModelConfig, DelegateTaskArgs } from "./types";
 
-import type { CategoryConfig } from "../../config/schema"
-import type { DelegatedModelConfig } from "./types"
-
-function applyCategoryParams(base: DelegatedModelConfig, config: CategoryConfig): DelegatedModelConfig {
-  const result = { ...base }
-  if (config.temperature !== undefined) result.temperature = config.temperature
-  if (config.top_p !== undefined) result.top_p = config.top_p
-  if (config.maxTokens !== undefined) result.maxTokens = config.maxTokens
-  if (config.reasoningEffort !== undefined) result.reasoningEffort = config.reasoningEffort
-  if (config.thinking !== undefined) result.thinking = config.thinking
-  return result
+function applyCategoryParams(
+	base: DelegatedModelConfig,
+	config: CategoryConfig,
+): DelegatedModelConfig {
+	const result = { ...base };
+	if (config.temperature !== undefined) result.temperature = config.temperature;
+	if (config.top_p !== undefined) result.top_p = config.top_p;
+	if (config.maxTokens !== undefined) result.maxTokens = config.maxTokens;
+	if (config.reasoningEffort !== undefined)
+		result.reasoningEffort = config.reasoningEffort;
+	if (config.thinking !== undefined) result.thinking = config.thinking;
+	return result;
 }
 
 export interface CategoryResolutionResult {
-  agentToUse: string
-  categoryModel: DelegatedModelConfig | undefined
-  categoryPromptAppend: string | undefined
-  maxPromptTokens?: number
-  modelInfo: ModelFallbackInfo | undefined
-  actualModel: string | undefined
-  isUnstableAgent: boolean
-  fallbackChain?: FallbackEntry[]  // For runtime retry on model errors
-  error?: string
+	agentToUse: string;
+	categoryModel: DelegatedModelConfig | undefined;
+	categoryPromptAppend: string | undefined;
+	maxPromptTokens?: number;
+	modelInfo: ModelFallbackInfo | undefined;
+	actualModel: string | undefined;
+	isUnstableAgent: boolean;
+	fallbackChain?: FallbackEntry[]; // For runtime retry on model errors
+	error?: string;
 }
 
 export async function resolveCategoryExecution(
-  args: DelegateTaskArgs,
-  executorCtx: ExecutorContext,
-  inheritedModel: string | undefined,
-  systemDefaultModel: string | undefined
+	args: DelegateTaskArgs,
+	executorCtx: ExecutorContext,
+	inheritedModel: string | undefined,
+	systemDefaultModel: string | undefined,
 ): Promise<CategoryResolutionResult> {
-  const { client, userCategories, sisyphusJuniorModel } = executorCtx
+	const { client, userCategories, sisyphusJuniorModel } = executorCtx;
 
-  const availableModels = await getAvailableModelsForDelegateTask(client)
+	const availableModels = await getAvailableModelsForDelegateTask(client);
 
-  const categoryName = args.category!
-  const enabledCategories = mergeCategories(userCategories)
-  const categoryExists = enabledCategories[categoryName] !== undefined
+	const categoryName = args.category!;
+	const enabledCategories = mergeCategories(userCategories);
+	const categoryExists = enabledCategories[categoryName] !== undefined;
 
-  const resolved = resolveCategoryConfig(categoryName, {
-    userCategories,
-    inheritedModel,
-    systemDefaultModel,
-    availableModels,
-  })
+	const resolved = resolveCategoryConfig(categoryName, {
+		userCategories,
+		inheritedModel,
+		systemDefaultModel,
+		availableModels,
+	});
 
-  if (!resolved) {
-    const requirement = CATEGORY_MODEL_REQUIREMENTS[categoryName]
-    const allCategoryNames = Object.keys(enabledCategories).join(", ")
+	if (!resolved) {
+		const requirement = CATEGORY_MODEL_REQUIREMENTS[categoryName];
+		const allCategoryNames = Object.keys(enabledCategories).join(", ");
 
-    if (categoryExists && requirement?.requiresModel) {
-      return {
-        agentToUse: "",
-        categoryModel: undefined,
-        categoryPromptAppend: undefined,
-        maxPromptTokens: undefined,
-        modelInfo: undefined,
-        actualModel: undefined,
-        isUnstableAgent: false,
-        error: `Category "${categoryName}" requires model "${requirement.requiresModel}" which is not available.
+		if (categoryExists && requirement?.requiresModel) {
+			return {
+				agentToUse: "",
+				categoryModel: undefined,
+				categoryPromptAppend: undefined,
+				maxPromptTokens: undefined,
+				modelInfo: undefined,
+				actualModel: undefined,
+				isUnstableAgent: false,
+				error: `Category "${categoryName}" requires model "${requirement.requiresModel}" which is not available.
 
 To use this category:
 1. Connect a provider with this model: ${requirement.requiresModel}
-2. Or configure an alternative model in your oh-my-opencode.json for this category
+2. Or configure an alternative model in your oh-my-openagent.jsonc for this category
 
 Available categories: ${allCategoryNames}`,
-      }
-    }
+			};
+		}
 
-    return {
-      agentToUse: "",
-      categoryModel: undefined,
-      categoryPromptAppend: undefined,
-      maxPromptTokens: undefined,
-      modelInfo: undefined,
-      actualModel: undefined,
-      isUnstableAgent: false,
-      error: `Unknown category: "${categoryName}". Available: ${allCategoryNames}`,
-    }
-  }
+		return {
+			agentToUse: "",
+			categoryModel: undefined,
+			categoryPromptAppend: undefined,
+			maxPromptTokens: undefined,
+			modelInfo: undefined,
+			actualModel: undefined,
+			isUnstableAgent: false,
+			error: `Unknown category: "${categoryName}". Available: ${allCategoryNames}`,
+		};
+	}
 
-  const requirement = CATEGORY_MODEL_REQUIREMENTS[args.category!]
-  const normalizedConfiguredFallbackModels = normalizeFallbackModels(resolved.config.fallback_models)
-  let actualModel: string | undefined
-  let modelInfo: ModelFallbackInfo | undefined
-  let categoryModel: DelegatedModelConfig | undefined
-  let isModelResolutionSkipped = false
-  let fallbackEntry: FallbackEntry | undefined
-  let matchedFallback = false
+	const requirement = CATEGORY_MODEL_REQUIREMENTS[args.category!];
+	const normalizedConfiguredFallbackModels = normalizeFallbackModels(
+		resolved.config.fallback_models,
+	);
+	let actualModel: string | undefined;
+	let modelInfo: ModelFallbackInfo | undefined;
+	let categoryModel: DelegatedModelConfig | undefined;
+	let isModelResolutionSkipped = false;
+	let fallbackEntry: FallbackEntry | undefined;
+	let matchedFallback = false;
 
-  const overrideModel = sisyphusJuniorModel
-  const explicitCategoryModel = userCategories?.[args.category!]?.model
+	const overrideModel = sisyphusJuniorModel;
+	const explicitCategoryModel = userCategories?.[args.category!]?.model;
 
-  if (!requirement) {
-    // Precedence: explicit category model > sisyphus-junior default > category resolved model
-    // This keeps `sisyphus-junior.model` useful as a global default while allowing
-    // per-category overrides via `categories[category].model`.
-    actualModel = explicitCategoryModel ?? overrideModel ?? resolved.model
-    if (actualModel) {
-      modelInfo = explicitCategoryModel || overrideModel
-        ? { model: actualModel, type: "user-defined", source: "override" }
-        : { model: actualModel, type: "system-default", source: "system-default" }
-      const parsedModel = parseModelString(actualModel)
-      const variantToUse = userCategories?.[args.category!]?.variant ?? resolved.config.variant
-      categoryModel = parsedModel
-        ? applyCategoryParams({ ...parsedModel, variant: variantToUse }, resolved.config)
-        : undefined
-    }
-  } else {
-    const resolution = resolveModelForDelegateTask({
-      userModel: explicitCategoryModel ?? overrideModel,
-      userFallbackModels: flattenToFallbackModelStrings(normalizedConfiguredFallbackModels),
-      categoryDefaultModel: resolved.model,
-      isUserConfiguredCategoryModel: resolved.isUserConfiguredModel,
-      fallbackChain: requirement.fallbackChain,
-      availableModels,
-      systemDefaultModel,
-    })
+	if (!requirement) {
+		// Precedence: explicit category model > sisyphus-junior default > category resolved model
+		// This keeps `sisyphus-junior.model` useful as a global default while allowing
+		// per-category overrides via `categories[category].model`.
+		actualModel = explicitCategoryModel ?? overrideModel ?? resolved.model;
+		if (actualModel) {
+			modelInfo =
+				explicitCategoryModel || overrideModel
+					? { model: actualModel, type: "user-defined", source: "override" }
+					: {
+							model: actualModel,
+							type: "system-default",
+							source: "system-default",
+						};
+			const parsedModel = parseModelString(actualModel);
+			const variantToUse =
+				userCategories?.[args.category!]?.variant ?? resolved.config.variant;
+			categoryModel = parsedModel
+				? applyCategoryParams(
+						{ ...parsedModel, variant: variantToUse },
+						resolved.config,
+					)
+				: undefined;
+		}
+	} else {
+		const resolution = resolveModelForDelegateTask({
+			userModel: explicitCategoryModel ?? overrideModel,
+			userFallbackModels: flattenToFallbackModelStrings(
+				normalizedConfiguredFallbackModels,
+			),
+			categoryDefaultModel: resolved.model,
+			isUserConfiguredCategoryModel: resolved.isUserConfiguredModel,
+			fallbackChain: requirement.fallbackChain,
+			availableModels,
+			systemDefaultModel,
+		});
 
-    if (resolution && "skipped" in resolution) {
-      isModelResolutionSkipped = true
-      const userModelOverride = explicitCategoryModel ?? overrideModel
-      if (userModelOverride) {
-        actualModel = userModelOverride
-        const parsedModel = parseModelString(actualModel)
-        const variantToUse = userCategories?.[args.category!]?.variant ?? resolved.config.variant
-        categoryModel = parsedModel
-          ? applyCategoryParams({ ...parsedModel, variant: variantToUse }, resolved.config)
-          : undefined
-        modelInfo = { model: actualModel, type: "user-defined", source: "override" }
-      }
-    } else if (resolution) {
-      const {
-        model: resolvedModel,
-        variant: resolvedVariant,
-        fallbackEntry: resolvedFallbackEntry,
-        matchedFallback: resolvedMatchedFallback,
-      } = resolution
-      fallbackEntry = resolvedFallbackEntry
-      matchedFallback = resolvedMatchedFallback === true
-      actualModel = resolvedModel
+		if (resolution && "skipped" in resolution) {
+			isModelResolutionSkipped = true;
+			const userModelOverride = explicitCategoryModel ?? overrideModel;
+			if (userModelOverride) {
+				actualModel = userModelOverride;
+				const parsedModel = parseModelString(actualModel);
+				const variantToUse =
+					userCategories?.[args.category!]?.variant ?? resolved.config.variant;
+				categoryModel = parsedModel
+					? applyCategoryParams(
+							{ ...parsedModel, variant: variantToUse },
+							resolved.config,
+						)
+					: undefined;
+				modelInfo = {
+					model: actualModel,
+					type: "user-defined",
+					source: "override",
+				};
+			}
+		} else if (resolution) {
+			const {
+				model: resolvedModel,
+				variant: resolvedVariant,
+				fallbackEntry: resolvedFallbackEntry,
+				matchedFallback: resolvedMatchedFallback,
+			} = resolution;
+			fallbackEntry = resolvedFallbackEntry;
+			matchedFallback = resolvedMatchedFallback === true;
+			actualModel = resolvedModel;
 
-      if (!parseModelString(actualModel)) {
-        return {
-          agentToUse: "",
-          categoryModel: undefined,
-          categoryPromptAppend: undefined,
-          maxPromptTokens: undefined,
-          modelInfo: undefined,
-          actualModel: undefined,
-          isUnstableAgent: false,
-          error: `Invalid model format "${actualModel}". Expected "provider/model" format (e.g., "anthropic/claude-sonnet-4-6").`,
-        }
-      }
+			if (!parseModelString(actualModel)) {
+				return {
+					agentToUse: "",
+					categoryModel: undefined,
+					categoryPromptAppend: undefined,
+					maxPromptTokens: undefined,
+					modelInfo: undefined,
+					actualModel: undefined,
+					isUnstableAgent: false,
+					error: `Invalid model format "${actualModel}". Expected "provider/model" format (e.g., "anthropic/claude-sonnet-4-6").`,
+				};
+			}
 
-      const type: "user-defined" | "inherited" | "category-default" | "system-default" =
-        (explicitCategoryModel || overrideModel)
-          ? "user-defined"
-          : (systemDefaultModel && actualModel === systemDefaultModel)
-              ? "system-default"
-              : "category-default"
+			const type:
+				| "user-defined"
+				| "inherited"
+				| "category-default"
+				| "system-default" =
+				explicitCategoryModel || overrideModel
+					? "user-defined"
+					: systemDefaultModel && actualModel === systemDefaultModel
+						? "system-default"
+						: "category-default";
 
-      const source: "override" | "category-default" | "system-default" =
-        type === "user-defined"
-          ? "override"
-          : type === "system-default"
-              ? "system-default"
-              : "category-default"
+			const source: "override" | "category-default" | "system-default" =
+				type === "user-defined"
+					? "override"
+					: type === "system-default"
+						? "system-default"
+						: "category-default";
 
-      modelInfo = { model: actualModel, type, source }
+			modelInfo = { model: actualModel, type, source };
 
-      const parsedModel = parseModelString(actualModel)
-      const variantToUse = userCategories?.[args.category!]?.variant ?? resolvedVariant ?? resolved.config.variant
-      categoryModel = parsedModel
-        ? applyCategoryParams({ ...parsedModel, variant: variantToUse }, resolved.config)
-        : undefined
-    }
-  }
+			const parsedModel = parseModelString(actualModel);
+			const variantToUse =
+				userCategories?.[args.category!]?.variant ??
+				resolvedVariant ??
+				resolved.config.variant;
+			categoryModel = parsedModel
+				? applyCategoryParams(
+						{ ...parsedModel, variant: variantToUse },
+						resolved.config,
+					)
+				: undefined;
+		}
+	}
 
-  if (!categoryModel && actualModel) {
-    const parsedModel = parseModelString(actualModel)
-    categoryModel = parsedModel ?? undefined
-  }
-  const categoryPromptAppend = resolved.promptAppend || undefined
+	if (!categoryModel && actualModel) {
+		const parsedModel = parseModelString(actualModel);
+		categoryModel = parsedModel ?? undefined;
+	}
+	const categoryPromptAppend = resolved.promptAppend || undefined;
 
-  if (!categoryModel && !actualModel && !isModelResolutionSkipped) {
-    const categoryNames = Object.keys(enabledCategories)
-    return {
-      agentToUse: "",
-      categoryModel: undefined,
-      categoryPromptAppend: undefined,
-      maxPromptTokens: undefined,
-      modelInfo: undefined,
-      actualModel: undefined,
-      isUnstableAgent: false,
-      error: `Model not configured for category "${args.category}".
+	if (!categoryModel && !actualModel && !isModelResolutionSkipped) {
+		const categoryNames = Object.keys(enabledCategories);
+		return {
+			agentToUse: "",
+			categoryModel: undefined,
+			categoryPromptAppend: undefined,
+			maxPromptTokens: undefined,
+			modelInfo: undefined,
+			actualModel: undefined,
+			isUnstableAgent: false,
+			error: `Model not configured for category "${args.category}".
 
 Configure in one of:
 1. OpenCode: Set "model" in opencode.json
-2. Oh-My-OpenCode: Set category model in oh-my-opencode.json
+2. Oh-My-OpenCode: Set category model in oh-my-openagent.jsonc
 3. Provider: Connect a provider with available models
 
 Current category: ${args.category}
 Available categories: ${categoryNames.join(", ")}`,
-    }
-  }
+		};
+	}
 
-  const resolvedModel = actualModel?.toLowerCase()
-  const isUnstableAgent = resolved.config.is_unstable_agent ?? (resolvedModel ? resolvedModel.includes("gemini") || resolvedModel.includes("minimax") || resolvedModel.includes("kimi") : false)
+	const resolvedModel = actualModel?.toLowerCase();
+	const isUnstableAgent =
+		resolved.config.is_unstable_agent ??
+		(resolvedModel
+			? resolvedModel.includes("gemini") ||
+				resolvedModel.includes("minimax") ||
+				resolvedModel.includes("kimi")
+			: false);
 
-  const defaultProviderID = categoryModel?.providerID
-    ?? parseModelString(actualModel ?? "")?.providerID
-    ?? "opencode"
-  const configuredFallbackChain = buildFallbackChainFromModels(
-    normalizedConfiguredFallbackModels,
-    defaultProviderID,
-  )
+	const defaultProviderID =
+		categoryModel?.providerID ??
+		parseModelString(actualModel ?? "")?.providerID ??
+		"opencode";
+	const configuredFallbackChain = buildFallbackChainFromModels(
+		normalizedConfiguredFallbackModels,
+		defaultProviderID,
+	);
 
-  // Only promote fallback-only settings when resolution actually selected a fallback model.
-  const effectiveEntry = matchedFallback && categoryModel
-    ? (
-        fallbackEntry
-        ?? (configuredFallbackChain
-          ? findMostSpecificFallbackEntry(categoryModel.providerID, categoryModel.modelID, configuredFallbackChain)
-          : undefined)
-      )
-    : undefined
+	// Only promote fallback-only settings when resolution actually selected a fallback model.
+	const effectiveEntry =
+		matchedFallback && categoryModel
+			? (fallbackEntry ??
+				(configuredFallbackChain
+					? findMostSpecificFallbackEntry(
+							categoryModel.providerID,
+							categoryModel.modelID,
+							configuredFallbackChain,
+						)
+					: undefined))
+			: undefined;
 
-  if (categoryModel && effectiveEntry) {
-    categoryModel = {
-      ...categoryModel,
-      variant: userCategories?.[args.category!]?.variant ?? effectiveEntry.variant ?? categoryModel.variant,
-      reasoningEffort: effectiveEntry.reasoningEffort ?? categoryModel.reasoningEffort,
-      temperature: effectiveEntry.temperature ?? categoryModel.temperature,
-      top_p: effectiveEntry.top_p ?? categoryModel.top_p,
-      maxTokens: effectiveEntry.maxTokens ?? categoryModel.maxTokens,
-      thinking: effectiveEntry.thinking ?? categoryModel.thinking,
-    }
-  }
+	if (categoryModel && effectiveEntry) {
+		categoryModel = {
+			...categoryModel,
+			variant:
+				userCategories?.[args.category!]?.variant ??
+				effectiveEntry.variant ??
+				categoryModel.variant,
+			reasoningEffort:
+				effectiveEntry.reasoningEffort ?? categoryModel.reasoningEffort,
+			temperature: effectiveEntry.temperature ?? categoryModel.temperature,
+			top_p: effectiveEntry.top_p ?? categoryModel.top_p,
+			maxTokens: effectiveEntry.maxTokens ?? categoryModel.maxTokens,
+			thinking: effectiveEntry.thinking ?? categoryModel.thinking,
+		};
+	}
 
-  return {
-    agentToUse: SISYPHUS_JUNIOR_AGENT,
-    categoryModel,
-    categoryPromptAppend,
-    maxPromptTokens: resolved.config.max_prompt_tokens,
-    modelInfo,
-    actualModel,
-    isUnstableAgent,
-    // Don't use hardcoded fallback chain when resolution was skipped (cold cache)
-    fallbackChain: configuredFallbackChain ?? (isModelResolutionSkipped ? undefined : requirement?.fallbackChain),
-  }
+	return {
+		agentToUse: SISYPHUS_JUNIOR_AGENT,
+		categoryModel,
+		categoryPromptAppend,
+		maxPromptTokens: resolved.config.max_prompt_tokens,
+		modelInfo,
+		actualModel,
+		isUnstableAgent,
+		// Don't use hardcoded fallback chain when resolution was skipped (cold cache)
+		fallbackChain:
+			configuredFallbackChain ??
+			(isModelResolutionSkipped ? undefined : requirement?.fallbackChain),
+	};
 }

--- a/src/tools/lsp/lsp-client-wrapper.ts
+++ b/src/tools/lsp/lsp-client-wrapper.ts
@@ -1,115 +1,128 @@
-import { extname, resolve } from "path"
-import { fileURLToPath } from "node:url"
-import { existsSync, statSync } from "fs"
+import { fileURLToPath } from "node:url";
+import { existsSync, statSync } from "fs";
+import { extname, resolve } from "path";
 
-import { LSPClient, lspManager } from "./client"
-import { findServerForExtension } from "./config"
-import type { ServerLookupResult } from "./types"
+import { type LSPClient, lspManager } from "./client";
+import { findServerForExtension } from "./config";
+import type { ServerLookupResult } from "./types";
 
 export function isDirectoryPath(filePath: string): boolean {
-  if (!existsSync(filePath)) {
-    return false
-  }
-  return statSync(filePath).isDirectory()
+	if (!existsSync(filePath)) {
+		return false;
+	}
+	return statSync(filePath).isDirectory();
 }
 
 export function uriToPath(uri: string): string {
-  return fileURLToPath(uri)
+	return fileURLToPath(uri);
 }
 
 export function findWorkspaceRoot(filePath: string): string {
-  let dir = resolve(filePath)
+	let dir = resolve(filePath);
 
-  if (!existsSync(dir) || !isDirectoryPath(dir)) {
-    dir = require("path").dirname(dir)
-  }
+	if (!existsSync(dir) || !isDirectoryPath(dir)) {
+		dir = require("path").dirname(dir);
+	}
 
-  const markers = [".git", "package.json", "pyproject.toml", "Cargo.toml", "go.mod", "pom.xml", "build.gradle"]
+	const markers = [
+		".git",
+		"package.json",
+		"pyproject.toml",
+		"Cargo.toml",
+		"go.mod",
+		"pom.xml",
+		"build.gradle",
+	];
 
-  let prevDir = ""
-  while (dir !== prevDir) {
-    for (const marker of markers) {
-      if (existsSync(require("path").join(dir, marker))) {
-        return dir
-      }
-    }
-    prevDir = dir
-    dir = require("path").dirname(dir)
-  }
+	let prevDir = "";
+	while (dir !== prevDir) {
+		for (const marker of markers) {
+			if (existsSync(require("path").join(dir, marker))) {
+				return dir;
+			}
+		}
+		prevDir = dir;
+		dir = require("path").dirname(dir);
+	}
 
-  return require("path").dirname(resolve(filePath))
+	return require("path").dirname(resolve(filePath));
 }
 
-export function formatServerLookupError(result: Exclude<ServerLookupResult, { status: "found" }>): string {
-  if (result.status === "not_installed") {
-    const { server, installHint } = result
-    return [
-      `LSP server '${server.id}' is configured but NOT INSTALLED.`,
-      ``,
-      `Command not found: ${server.command[0]}`,
-      ``,
-      `To install:`,
-      `  ${installHint}`,
-      ``,
-      `Supported extensions: ${server.extensions.join(", ")}`,
-      ``,
-      `After installation, the server will be available automatically.`,
-      `Run 'LspServers' tool to verify installation status.`,
-    ].join("\n")
-  }
+export function formatServerLookupError(
+	result: Exclude<ServerLookupResult, { status: "found" }>,
+): string {
+	if (result.status === "not_installed") {
+		const { server, installHint } = result;
+		return [
+			`LSP server '${server.id}' is configured but NOT INSTALLED.`,
+			``,
+			`Command not found: ${server.command[0]}`,
+			``,
+			`To install:`,
+			`  ${installHint}`,
+			``,
+			`Supported extensions: ${server.extensions.join(", ")}`,
+			``,
+			`After installation, the server will be available automatically.`,
+			`Run 'LspServers' tool to verify installation status.`,
+		].join("\n");
+	}
 
-  return [
-    `No LSP server configured for extension: ${result.extension}`,
-    ``,
-    `Available servers: ${result.availableServers.slice(0, 10).join(", ")}${result.availableServers.length > 10 ? "..." : ""}`,
-    ``,
-    `To add a custom server, configure 'lsp' in oh-my-opencode.json:`,
-    `  {`,
-    `    "lsp": {`,
-    `      "my-server": {`,
-    `        "command": ["my-lsp", "--stdio"],`,
-    `        "extensions": ["${result.extension}"]`,
-    `      }`,
-    `    }`,
-    `  }`,
-  ].join("\n")
+	return [
+		`No LSP server configured for extension: ${result.extension}`,
+		``,
+		`Available servers: ${result.availableServers.slice(0, 10).join(", ")}${result.availableServers.length > 10 ? "..." : ""}`,
+		``,
+		`To add a custom server, configure 'lsp' in oh-my-openagent.jsonc:`,
+		`  {`,
+		`    "lsp": {`,
+		`      "my-server": {`,
+		`        "command": ["my-lsp", "--stdio"],`,
+		`        "extensions": ["${result.extension}"]`,
+		`      }`,
+		`    }`,
+		`  }`,
+	].join("\n");
 }
 
-export async function withLspClient<T>(filePath: string, fn: (client: LSPClient) => Promise<T>): Promise<T> {
-  const absPath = resolve(filePath)
+export async function withLspClient<T>(
+	filePath: string,
+	fn: (client: LSPClient) => Promise<T>,
+): Promise<T> {
+	const absPath = resolve(filePath);
 
-  if (isDirectoryPath(absPath)) {
-    throw new Error(
-      `Directory paths are not supported by this LSP tool. ` +
-        `Use lsp_diagnostics with the 'extension' parameter for directory diagnostics.`
-    )
-  }
+	if (isDirectoryPath(absPath)) {
+		throw new Error(
+			`Directory paths are not supported by this LSP tool. ` +
+				`Use lsp_diagnostics with the 'extension' parameter for directory diagnostics.`,
+		);
+	}
 
-  const ext = extname(absPath)
-  const result = findServerForExtension(ext)
+	const ext = extname(absPath);
+	const result = findServerForExtension(ext);
 
-  if (result.status !== "found") {
-    throw new Error(formatServerLookupError(result))
-  }
+	if (result.status !== "found") {
+		throw new Error(formatServerLookupError(result));
+	}
 
-  const server = result.server
-  const root = findWorkspaceRoot(absPath)
-  const client = await lspManager.getClient(root, server)
+	const server = result.server;
+	const root = findWorkspaceRoot(absPath);
+	const client = await lspManager.getClient(root, server);
 
-  try {
-    return await fn(client)
-  } catch (e) {
-    if (e instanceof Error && e.message.includes("timeout")) {
-      const isInitializing = lspManager.isServerInitializing(root, server.id)
-      if (isInitializing) {
-        throw new Error(
-          `LSP server is still initializing. Please retry in a few seconds. ` +
-            `Original error: ${e.message}`
-        )
-      }
-    }
-    throw e
-  } finally {
-    lspManager.releaseClient(root, server.id)
-  }
+	try {
+		return await fn(client);
+	} catch (e) {
+		if (e instanceof Error && e.message.includes("timeout")) {
+			const isInitializing = lspManager.isServerInitializing(root, server.id);
+			if (isInitializing) {
+				throw new Error(
+					`LSP server is still initializing. Please retry in a few seconds. ` +
+						`Original error: ${e.message}`,
+				);
+			}
+		}
+		throw e;
+	} finally {
+		lspManager.releaseClient(root, server.id);
+	}
 }

--- a/src/tools/lsp/server-config-loader.test.ts
+++ b/src/tools/lsp/server-config-loader.test.ts
@@ -1,21 +1,25 @@
-import { describe, it, expect } from "bun:test"
-import { writeFileSync, unlinkSync, mkdirSync, rmSync } from "fs"
-import { join } from "path"
-import { tmpdir } from "os"
-import { loadJsonFile, getConfigPaths, getMergedServers } from "./server-config-loader"
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, unlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+	getConfigPaths,
+	getMergedServers,
+	loadJsonFile,
+} from "./server-config-loader";
 
 describe("loadJsonFile", () => {
-  it("parses JSONC config files with comments correctly", () => {
-    // given
-    const testData = {
-      lsp: {
-        typescript: {
-          command: ["tsserver"],
-          extensions: [".ts", ".tsx"]
-        }
-      }
-    }
-    const jsoncContent = `{
+	it("parses JSONC config files with comments correctly", () => {
+		// given
+		const testData = {
+			lsp: {
+				typescript: {
+					command: ["tsserver"],
+					extensions: [".ts", ".tsx"],
+				},
+			},
+		};
+		const jsoncContent = `{
   // LSP configuration for TypeScript
   "lsp": {
     "typescript": {
@@ -23,28 +27,31 @@ describe("loadJsonFile", () => {
       "extensions": [".ts", ".tsx"] // TypeScript extensions
     }
   }
-}`
-    const tempPath = join(tmpdir(), "test-config.jsonc")
-    writeFileSync(tempPath, jsoncContent, "utf-8")
+}`;
+		const tempPath = join(tmpdir(), "test-config.jsonc");
+		writeFileSync(tempPath, jsoncContent, "utf-8");
 
-    // when
-    const result = loadJsonFile<typeof testData>(tempPath)
+		// when
+		const result = loadJsonFile<typeof testData>(tempPath);
 
-    // then
-    expect(result).toEqual(testData)
+		// then
+		expect(result).toEqual(testData);
 
-    // cleanup
-    unlinkSync(tempPath)
-  })
+		// cleanup
+		unlinkSync(tempPath);
+	});
 
-  it("discovers JSONC-only user config (oh-my-opencode.jsonc)", () => {
-    const originalEnv = process.env.OPENCODE_CONFIG_DIR
-    const tempBase = join(tmpdir(), `omo-test-user-jsonc-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    try {
-      mkdirSync(tempBase, { recursive: true })
-      process.env.OPENCODE_CONFIG_DIR = tempBase
+	it("discovers JSONC-only user config (oh-my-opencode.jsonc)", () => {
+		const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+		const tempBase = join(
+			tmpdir(),
+			`omo-test-user-jsonc-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		try {
+			mkdirSync(tempBase, { recursive: true });
+			process.env.OPENCODE_CONFIG_DIR = tempBase;
 
-      const userJsonc = `{
+			const userJsonc = `{
   // user jsonc config
   "lsp": {
     "user-jsonc": {
@@ -52,28 +59,33 @@ describe("loadJsonFile", () => {
       "extensions": [".ujs"]
     }
   }
-}`
-      const userPath = join(tempBase, "oh-my-opencode.jsonc")
-      writeFileSync(userPath, userJsonc, "utf-8")
+}`;
+			const userPath = join(tempBase, "oh-my-opencode.jsonc");
+			writeFileSync(userPath, userJsonc, "utf-8");
 
-      const servers = getMergedServers()
-      const found = servers.find(s => s.id === "user-jsonc" && s.source === "user")
-      expect(found !== undefined).toBe(true)
-    } finally {
-      if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR
-      else process.env.OPENCODE_CONFIG_DIR = originalEnv
-      rmSync(tempBase, { recursive: true, force: true })
-    }
-  })
+			const servers = getMergedServers();
+			const found = servers.find(
+				(s) => s.id === "user-jsonc" && s.source === "user",
+			);
+			expect(found !== undefined).toBe(true);
+		} finally {
+			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+			else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+			rmSync(tempBase, { recursive: true, force: true });
+		}
+	});
 
-  it("discovers JSONC-only opencode config (opencode.jsonc)", () => {
-    const originalEnv = process.env.OPENCODE_CONFIG_DIR
-    const tempBase = join(tmpdir(), `omo-test-oc-jsonc-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    try {
-      mkdirSync(tempBase, { recursive: true })
-      process.env.OPENCODE_CONFIG_DIR = tempBase
+	it("discovers JSONC-only opencode config (opencode.jsonc)", () => {
+		const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+		const tempBase = join(
+			tmpdir(),
+			`omo-test-oc-jsonc-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		try {
+			mkdirSync(tempBase, { recursive: true });
+			process.env.OPENCODE_CONFIG_DIR = tempBase;
 
-      const opencodeJsonc = `{
+			const opencodeJsonc = `{
   // opencode jsonc config
   "lsp": {
     "opencode-jsonc": {
@@ -81,26 +93,31 @@ describe("loadJsonFile", () => {
       "extensions": [".ocjs"]
     }
   }
-}`
-      const opencodePath = join(tempBase, "opencode.jsonc")
-      writeFileSync(opencodePath, opencodeJsonc, "utf-8")
+}`;
+			const opencodePath = join(tempBase, "opencode.jsonc");
+			writeFileSync(opencodePath, opencodeJsonc, "utf-8");
 
-      const servers = getMergedServers()
-      const found = servers.find(s => s.id === "opencode-jsonc" && s.source === "opencode")
-      expect(found !== undefined).toBe(true)
-    } finally {
-      if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR
-      else process.env.OPENCODE_CONFIG_DIR = originalEnv
-      rmSync(tempBase, { recursive: true, force: true })
-    }
-  })
+			const servers = getMergedServers();
+			const found = servers.find(
+				(s) => s.id === "opencode-jsonc" && s.source === "opencode",
+			);
+			expect(found !== undefined).toBe(true);
+		} finally {
+			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+			else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+			rmSync(tempBase, { recursive: true, force: true });
+		}
+	});
 
-  it("discovers JSONC-only project config (.opencode/oh-my-opencode.jsonc)", () => {
-    const originalCwd = process.cwd()
-    const tempProject = join(tmpdir(), `omo-test-project-jsonc-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    try {
-      mkdirSync(join(tempProject, ".opencode"), { recursive: true })
-      const projectJsonc = `{
+	it("discovers JSONC-only project config (.opencode/oh-my-opencode.jsonc)", () => {
+		const originalCwd = process.cwd();
+		const tempProject = join(
+			tmpdir(),
+			`omo-test-project-jsonc-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		try {
+			mkdirSync(join(tempProject, ".opencode"), { recursive: true });
+			const projectJsonc = `{
   // project jsonc config
   "lsp": {
     "project-jsonc": {
@@ -108,36 +125,45 @@ describe("loadJsonFile", () => {
       "extensions": [".pjs"]
     }
   }
-}`
-      const projectPath = join(tempProject, ".opencode", "oh-my-opencode.jsonc")
-      writeFileSync(projectPath, projectJsonc, "utf-8")
+}`;
+			const projectPath = join(
+				tempProject,
+				".opencode",
+				"oh-my-opencode.jsonc",
+			);
+			writeFileSync(projectPath, projectJsonc, "utf-8");
 
-      process.chdir(tempProject)
-      const servers = getMergedServers()
-      const found = servers.find(s => s.id === "project-jsonc" && s.source === "project")
-      expect(found !== undefined).toBe(true)
-    } finally {
-      process.chdir(originalCwd)
-      rmSync(tempProject, { recursive: true, force: true })
-    }
-  })
+			process.chdir(tempProject);
+			const servers = getMergedServers();
+			const found = servers.find(
+				(s) => s.id === "project-jsonc" && s.source === "project",
+			);
+			expect(found !== undefined).toBe(true);
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(tempProject, { recursive: true, force: true });
+		}
+	});
 
-  it("prefers .jsonc over .json when both exist for same config id", () => {
-    const originalEnv = process.env.OPENCODE_CONFIG_DIR
-    const tempBase = join(tmpdir(), `omo-test-precedence-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    try {
-      mkdirSync(tempBase, { recursive: true })
-      process.env.OPENCODE_CONFIG_DIR = tempBase
+	it("prefers .jsonc over .json when both exist for same config id", () => {
+		const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+		const tempBase = join(
+			tmpdir(),
+			`omo-test-precedence-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		try {
+			mkdirSync(tempBase, { recursive: true });
+			process.env.OPENCODE_CONFIG_DIR = tempBase;
 
-      const jsonContent = `{
+			const jsonContent = `{
   "lsp": {
     "conflict": {
       "command": ["from-json"],
       "extensions": [".j"]
     }
   }
-}`
-      const jsoncContent = `{
+}`;
+			const jsoncContent = `{
   // jsonc should take precedence
   "lsp": {
     "conflict": {
@@ -145,17 +171,142 @@ describe("loadJsonFile", () => {
       "extensions": [".jc"]
     }
   }
-}`
-      writeFileSync(join(tempBase, "oh-my-opencode.json"), jsonContent, "utf-8")
-      writeFileSync(join(tempBase, "oh-my-opencode.jsonc"), jsoncContent, "utf-8")
+}`;
+			writeFileSync(
+				join(tempBase, "oh-my-opencode.json"),
+				jsonContent,
+				"utf-8",
+			);
+			writeFileSync(
+				join(tempBase, "oh-my-opencode.jsonc"),
+				jsoncContent,
+				"utf-8",
+			);
 
-      const servers = getMergedServers()
-      const found = servers.find(s => s.id === "conflict" && s.source === "user")
-      expect(found?.command && Array.isArray(found.command) && found.command[0] === "from-jsonc").toBe(true)
-    } finally {
-      if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR
-      else process.env.OPENCODE_CONFIG_DIR = originalEnv
-      rmSync(tempBase, { recursive: true, force: true })
-    }
-  })
-})
+			const servers = getMergedServers();
+			const found = servers.find(
+				(s) => s.id === "conflict" && s.source === "user",
+			);
+			expect(
+				found?.command &&
+					Array.isArray(found.command) &&
+					found.command[0] === "from-jsonc",
+			).toBe(true);
+		} finally {
+			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+			else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+			rmSync(tempBase, { recursive: true, force: true });
+		}
+	});
+
+	it("prefers canonical user config over legacy user config", () => {
+		const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+		const tempBase = join(
+			tmpdir(),
+			`omo-test-user-canonical-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		try {
+			mkdirSync(tempBase, { recursive: true });
+			process.env.OPENCODE_CONFIG_DIR = tempBase;
+
+			writeFileSync(
+				join(tempBase, "oh-my-opencode.jsonc"),
+				'{\n  "lsp": {\n    "legacy-user": {\n      "command": ["legacy-user-cmd"],\n      "extensions": [".lu"]\n    }\n  }\n}',
+				"utf-8",
+			);
+			writeFileSync(
+				join(tempBase, "oh-my-openagent.jsonc"),
+				'{\n  "lsp": {\n    "canonical-user": {\n      "command": ["canonical-user-cmd"],\n      "extensions": [".cu"]\n    }\n  }\n}',
+				"utf-8",
+			);
+
+			const servers = getMergedServers();
+			expect(
+				servers.find(
+					(s) => s.id === "canonical-user" && s.source === "user",
+				) !== undefined,
+			).toBe(true);
+			expect(servers.some((s) => s.id === "legacy-user")).toBe(false);
+		} finally {
+			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+			else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+			rmSync(tempBase, { recursive: true, force: true });
+		}
+	});
+
+	it("prefers canonical project config over legacy project config", () => {
+		const originalCwd = process.cwd();
+		const tempProject = join(
+			tmpdir(),
+			`omo-test-project-canonical-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		try {
+			mkdirSync(join(tempProject, ".opencode"), { recursive: true });
+			writeFileSync(
+				join(tempProject, ".opencode", "oh-my-opencode.jsonc"),
+				'{\n  "lsp": {\n    "legacy-project": {\n      "command": ["legacy-project-cmd"],\n      "extensions": [".lp"]\n    }\n  }\n}',
+				"utf-8",
+			);
+			writeFileSync(
+				join(tempProject, ".opencode", "oh-my-openagent.jsonc"),
+				'{\n  "lsp": {\n    "canonical-project": {\n      "command": ["canonical-project-cmd"],\n      "extensions": [".cp"]\n    }\n  }\n}',
+				"utf-8",
+			);
+
+			process.chdir(tempProject);
+			const servers = getMergedServers();
+			expect(
+				servers.find(
+					(s) => s.id === "canonical-project" && s.source === "project",
+				) !== undefined,
+			).toBe(true);
+			expect(servers.some((s) => s.id === "legacy-project")).toBe(false);
+		} finally {
+			process.chdir(originalCwd);
+			rmSync(tempProject, { recursive: true, force: true });
+		}
+	});
+
+	it("prefers project canonical config over user canonical config", () => {
+		const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+		const originalCwd = process.cwd();
+		const tempBase = join(
+			tmpdir(),
+			`omo-test-layer-precedence-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		const tempProject = join(
+			tmpdir(),
+			`omo-test-layer-project-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		try {
+			mkdirSync(tempBase, { recursive: true });
+			mkdirSync(join(tempProject, ".opencode"), { recursive: true });
+			process.env.OPENCODE_CONFIG_DIR = tempBase;
+
+			writeFileSync(
+				join(tempBase, "oh-my-openagent.jsonc"),
+				'{\n  "lsp": {\n    "shared-precedence": {\n      "command": ["user-cmd"],\n      "extensions": [".sp"]\n    }\n  }\n}',
+				"utf-8",
+			);
+			writeFileSync(
+				join(tempProject, ".opencode", "oh-my-openagent.jsonc"),
+				'{\n  "lsp": {\n    "shared-precedence": {\n      "command": ["project-cmd"],\n      "extensions": [".sp"]\n    }\n  }\n}',
+				"utf-8",
+			);
+
+			process.chdir(tempProject);
+			const servers = getMergedServers();
+			const found = servers.find((s) => s.id === "shared-precedence");
+			expect(found?.source).toBe("project");
+			expect(
+				Array.isArray(found?.command) && found?.command[0] === "project-cmd",
+			).toBe(true);
+		} finally {
+			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+			else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+			process.chdir(originalCwd);
+			rmSync(tempBase, { recursive: true, force: true });
+			rmSync(tempProject, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/tools/lsp/server-config-loader.test.ts
+++ b/src/tools/lsp/server-config-loader.test.ts
@@ -268,6 +268,36 @@ describe("loadJsonFile", () => {
 		}
 	});
 
+	it("falls back to legacy user config when canonical user config has a non-object root", () => {
+		const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+		const tempBase = join(
+			tmpdir(),
+			`omo-test-user-nonobject-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		try {
+			mkdirSync(tempBase, { recursive: true });
+			process.env.OPENCODE_CONFIG_DIR = tempBase;
+
+			writeFileSync(join(tempBase, "oh-my-openagent.jsonc"), "null", "utf-8");
+			writeFileSync(
+				join(tempBase, "oh-my-opencode.jsonc"),
+				'{\n  "lsp": {\n    "legacy-user-nonobject": {\n      "command": ["legacy-user-nonobject-cmd"],\n      "extensions": [".lun"]\n    }\n  }\n}',
+				"utf-8",
+			);
+
+			const servers = getMergedServers();
+			const found = servers.find(
+				(s) => s.id === "legacy-user-nonobject" && s.source === "user",
+			);
+			expect(found !== undefined).toBe(true);
+			expect(found?.command?.[0]).toBe("legacy-user-nonobject-cmd");
+		} finally {
+			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+			else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+			rmSync(tempBase, { recursive: true, force: true });
+		}
+	});
+
 	it("prefers canonical project config over legacy project config", () => {
 		const originalCwd = process.cwd();
 		const tempProject = join(

--- a/src/tools/lsp/server-config-loader.test.ts
+++ b/src/tools/lsp/server-config-loader.test.ts
@@ -234,6 +234,40 @@ describe("loadJsonFile", () => {
 		}
 	});
 
+	it("falls back to legacy user config when canonical user config is malformed", () => {
+		const originalEnv = process.env.OPENCODE_CONFIG_DIR;
+		const tempBase = join(
+			tmpdir(),
+			`omo-test-user-fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		try {
+			mkdirSync(tempBase, { recursive: true });
+			process.env.OPENCODE_CONFIG_DIR = tempBase;
+
+			writeFileSync(
+				join(tempBase, "oh-my-openagent.jsonc"),
+				"{ invalid jsonc",
+				"utf-8",
+			);
+			writeFileSync(
+				join(tempBase, "oh-my-opencode.jsonc"),
+				'{\n  "lsp": {\n    "legacy-user-fallback": {\n      "command": ["legacy-user-fallback-cmd"],\n      "extensions": [".luf"]\n    }\n  }\n}',
+				"utf-8",
+			);
+
+			const servers = getMergedServers();
+			const found = servers.find(
+				(s) => s.id === "legacy-user-fallback" && s.source === "user",
+			);
+			expect(found !== undefined).toBe(true);
+			expect(found?.command?.[0]).toBe("legacy-user-fallback-cmd");
+		} finally {
+			if (originalEnv === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+			else process.env.OPENCODE_CONFIG_DIR = originalEnv;
+			rmSync(tempBase, { recursive: true, force: true });
+		}
+	});
+
 	it("prefers canonical project config over legacy project config", () => {
 		const originalCwd = process.cwd();
 		const tempProject = join(

--- a/src/tools/lsp/server-config-loader.ts
+++ b/src/tools/lsp/server-config-loader.ts
@@ -1,116 +1,127 @@
-import { existsSync, readFileSync } from "fs"
-import { join } from "path"
-
-import { BUILTIN_SERVERS } from "./constants"
-import type { ResolvedServer } from "./types"
-import { getOpenCodeConfigDir } from "../../shared"
-import { parseJsonc, detectConfigFile, detectPluginConfigFile } from "../../shared/jsonc-parser"
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { getOpenCodeConfigDir } from "../../shared";
+import {
+	detectConfigFile,
+	parseJsonc,
+	readFirstValidPluginConfigFile,
+} from "../../shared/jsonc-parser";
+import { BUILTIN_SERVERS } from "./constants";
+import type { ResolvedServer } from "./types";
 
 interface LspEntry {
-  disabled?: boolean
-  command?: string[]
-  extensions?: string[]
-  priority?: number
-  env?: Record<string, string>
-  initialization?: Record<string, unknown>
+	disabled?: boolean;
+	command?: string[];
+	extensions?: string[];
+	priority?: number;
+	env?: Record<string, string>;
+	initialization?: Record<string, unknown>;
 }
 
 interface ConfigJson {
-  lsp?: Record<string, LspEntry>
+	lsp?: Record<string, LspEntry>;
 }
 
-type ConfigSource = "project" | "user" | "opencode"
+type ConfigSource = "project" | "user" | "opencode";
 
 interface ServerWithSource extends ResolvedServer {
-  source: ConfigSource
+	source: ConfigSource;
 }
 
 export function loadJsonFile<T>(path: string): T | null {
-  if (!existsSync(path)) return null
-  try {
-    return parseJsonc(readFileSync(path, "utf-8")) as T
-  } catch {
-    return null
-  }
+	if (!existsSync(path)) return null;
+	try {
+		return parseJsonc(readFileSync(path, "utf-8")) as T;
+	} catch {
+		return null;
+	}
 }
 
-export function getConfigPaths(): { project: string; user: string; opencode: string } {
-  const cwd = process.cwd()
-  const configDir = getOpenCodeConfigDir({ binary: "opencode" })
-  return {
-    project: detectPluginConfigFile(join(cwd, ".opencode")).path,
-    user: detectPluginConfigFile(configDir).path,
-    opencode: detectConfigFile(join(configDir, "opencode")).path,
-  }
+export function getConfigPaths(): {
+	project: string;
+	user: string;
+	opencode: string;
+} {
+	const cwd = process.cwd();
+	const configDir = getOpenCodeConfigDir({ binary: "opencode" });
+	return {
+		project: readFirstValidPluginConfigFile(join(cwd, ".opencode")).path,
+		user: readFirstValidPluginConfigFile(configDir).path,
+		opencode: detectConfigFile(join(configDir, "opencode")).path,
+	};
 }
 
 export function loadAllConfigs(): Map<ConfigSource, ConfigJson> {
-  const paths = getConfigPaths()
-  const configs = new Map<ConfigSource, ConfigJson>()
+	const paths = getConfigPaths();
+	const configs = new Map<ConfigSource, ConfigJson>();
 
-  const project = loadJsonFile<ConfigJson>(paths.project)
-  if (project) configs.set("project", project)
+	const project = loadJsonFile<ConfigJson>(paths.project);
+	if (project) configs.set("project", project);
 
-  const user = loadJsonFile<ConfigJson>(paths.user)
-  if (user) configs.set("user", user)
+	const user = loadJsonFile<ConfigJson>(paths.user);
+	if (user) configs.set("user", user);
 
-  const opencode = loadJsonFile<ConfigJson>(paths.opencode)
-  if (opencode) configs.set("opencode", opencode)
+	const opencode = loadJsonFile<ConfigJson>(paths.opencode);
+	if (opencode) configs.set("opencode", opencode);
 
-  return configs
+	return configs;
 }
 
 export function getMergedServers(): ServerWithSource[] {
-  const configs = loadAllConfigs()
-  const servers: ServerWithSource[] = []
-  const disabled = new Set<string>()
-  const seen = new Set<string>()
+	const configs = loadAllConfigs();
+	const servers: ServerWithSource[] = [];
+	const disabled = new Set<string>();
+	const seen = new Set<string>();
 
-  const sources: ConfigSource[] = ["project", "user", "opencode"]
+	const sources: ConfigSource[] = ["project", "user", "opencode"];
 
-  for (const source of sources) {
-    const config = configs.get(source)
-    if (!config?.lsp) continue
+	for (const source of sources) {
+		const config = configs.get(source);
+		if (!config?.lsp) continue;
 
-    for (const [id, entry] of Object.entries(config.lsp)) {
-      if (entry.disabled) {
-        disabled.add(id)
-        continue
-      }
+		for (const [id, entry] of Object.entries(config.lsp)) {
+			if (entry.disabled) {
+				disabled.add(id);
+				continue;
+			}
 
-      if (seen.has(id)) continue
-      if (!entry.command || !entry.extensions) continue
+			if (seen.has(id)) continue;
+			if (!entry.command || !entry.extensions) continue;
 
-      servers.push({
-        id,
-        command: entry.command,
-        extensions: entry.extensions,
-        priority: entry.priority ?? 0,
-        env: entry.env,
-        initialization: entry.initialization,
-        source,
-      })
-      seen.add(id)
-    }
-  }
+			servers.push({
+				id,
+				command: entry.command,
+				extensions: entry.extensions,
+				priority: entry.priority ?? 0,
+				env: entry.env,
+				initialization: entry.initialization,
+				source,
+			});
+			seen.add(id);
+		}
+	}
 
-  for (const [id, config] of Object.entries(BUILTIN_SERVERS)) {
-    if (disabled.has(id) || seen.has(id)) continue
+	for (const [id, config] of Object.entries(BUILTIN_SERVERS)) {
+		if (disabled.has(id) || seen.has(id)) continue;
 
-    servers.push({
-      id,
-      command: config.command,
-      extensions: config.extensions,
-      priority: -100,
-      source: "opencode",
-    })
-  }
+		servers.push({
+			id,
+			command: config.command,
+			extensions: config.extensions,
+			priority: -100,
+			source: "opencode",
+		});
+	}
 
-  return servers.sort((a, b) => {
-    if (a.source !== b.source) {
-      const order: Record<ConfigSource, number> = { project: 0, user: 1, opencode: 2 }
-      return order[a.source] - order[b.source]
-    }
-    return b.priority - a.priority
-  })
+	return servers.sort((a, b) => {
+		if (a.source !== b.source) {
+			const order: Record<ConfigSource, number> = {
+				project: 0,
+				user: 1,
+				opencode: 2,
+			};
+			return order[a.source] - order[b.source];
+		}
+		return b.priority - a.priority;
+	});
 }

--- a/src/tools/task/task-list.test.ts
+++ b/src/tools/task/task-list.test.ts
@@ -1,335 +1,349 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test"
-import { createTaskList } from "./task-list"
-import { writeJsonAtomic } from "../../features/claude-tasks/storage"
-import type { TaskObject } from "./types"
-import { join } from "path"
-import { existsSync, rmSync } from "fs"
-
-const testProjectDir = "/tmp/task-list-test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, rmSync } from "fs";
+import { join } from "path";
+import { writeJsonAtomic } from "../../features/claude-tasks/storage";
+import { createTaskList } from "./task-list";
+import type { TaskObject } from "./types";
 
 describe("createTaskList", () => {
-  let taskDir: string
+	let testProjectDir: string;
+	let taskDir: string;
 
-  beforeEach(() => {
-    taskDir = join(testProjectDir, ".sisyphus/tasks")
-    if (existsSync(taskDir)) {
-      rmSync(taskDir, { recursive: true })
-    }
-  })
+	beforeEach(() => {
+		testProjectDir = join(
+			process.cwd(),
+			`.test-task-list-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		taskDir = join(testProjectDir, ".sisyphus", "tasks");
+		if (existsSync(testProjectDir)) {
+			rmSync(testProjectDir, { recursive: true, force: true });
+		}
+	});
 
-  afterEach(() => {
-    if (existsSync(taskDir)) {
-      rmSync(taskDir, { recursive: true })
-    }
-  })
+	afterEach(() => {
+		if (existsSync(testProjectDir)) {
+			rmSync(testProjectDir, { recursive: true, force: true });
+		}
+	});
 
-  it("returns empty array when no tasks exist", async () => {
-    //#given
-    const config = {
-      sisyphus: {
-        tasks: {
-          storage_path: join(testProjectDir, ".sisyphus/tasks"),
-          claude_code_compat: false,
-        },
-      },
-    }
-    const tool = createTaskList(config)
+	it("returns empty array when no tasks exist", async () => {
+		//#given
+		const config = {
+			sisyphus: {
+				tasks: {
+					storage_path: join(testProjectDir, ".sisyphus/tasks"),
+					claude_code_compat: false,
+				},
+			},
+		};
+		const tool = createTaskList(config);
 
-    //#when
-    const result = await tool.execute({}, { sessionID: "test-session" })
+		//#when
+		const result = await tool.execute({}, { sessionID: "test-session" });
 
-    //#then
-    const parsed = JSON.parse(result)
-    expect(parsed.tasks).toEqual([])
-  })
+		//#then
+		const parsed = JSON.parse(result);
+		expect(parsed.tasks).toEqual([]);
+	});
 
-  it("excludes completed tasks by default", async () => {
-    //#given
-    const task1: TaskObject = {
-      id: "T-1",
-      subject: "Active task",
-      description: "Should be included",
-      status: "pending",
-      blocks: [],
-      blockedBy: [],
-      threadID: "test-session",
-    }
-    const task2: TaskObject = {
-      id: "T-2",
-      subject: "Completed task",
-      description: "Should be excluded",
-      status: "completed",
-      blocks: [],
-      blockedBy: [],
-      threadID: "test-session",
-    }
+	it("excludes completed tasks by default", async () => {
+		//#given
+		const task1: TaskObject = {
+			id: "T-1",
+			subject: "Active task",
+			description: "Should be included",
+			status: "pending",
+			blocks: [],
+			blockedBy: [],
+			threadID: "test-session",
+		};
+		const task2: TaskObject = {
+			id: "T-2",
+			subject: "Completed task",
+			description: "Should be excluded",
+			status: "completed",
+			blocks: [],
+			blockedBy: [],
+			threadID: "test-session",
+		};
 
-    writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task1)
-    writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-2.json"), task2)
+		writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task1);
+		writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-2.json"), task2);
 
-    const config = {
-      sisyphus: {
-        tasks: {
-          storage_path: join(testProjectDir, ".sisyphus/tasks"),
-          claude_code_compat: false,
-        },
-      },
-    }
-    const tool = createTaskList(config)
+		const config = {
+			sisyphus: {
+				tasks: {
+					storage_path: join(testProjectDir, ".sisyphus/tasks"),
+					claude_code_compat: false,
+				},
+			},
+		};
+		const tool = createTaskList(config);
 
-    //#when
-    const result = await tool.execute({}, { sessionID: "test-session" })
+		//#when
+		const result = await tool.execute({}, { sessionID: "test-session" });
 
-    //#then
-    const parsed = JSON.parse(result)
-    expect(parsed.tasks).toHaveLength(1)
-    expect(parsed.tasks[0].id).toBe("T-1")
-  })
+		//#then
+		const parsed = JSON.parse(result);
+		expect(parsed.tasks).toHaveLength(1);
+		expect(parsed.tasks[0].id).toBe("T-1");
+	});
 
-  it("excludes deleted tasks by default", async () => {
-    //#given
-    const task1: TaskObject = {
-      id: "T-1",
-      subject: "Active task",
-      description: "Should be included",
-      status: "pending",
-      blocks: [],
-      blockedBy: [],
-      threadID: "test-session",
-    }
-    const task2: TaskObject = {
-      id: "T-2",
-      subject: "Deleted task",
-      description: "Should be excluded",
-      status: "deleted",
-      blocks: [],
-      blockedBy: [],
-      threadID: "test-session",
-    }
+	it("excludes deleted tasks by default", async () => {
+		//#given
+		const task1: TaskObject = {
+			id: "T-1",
+			subject: "Active task",
+			description: "Should be included",
+			status: "pending",
+			blocks: [],
+			blockedBy: [],
+			threadID: "test-session",
+		};
+		const task2: TaskObject = {
+			id: "T-2",
+			subject: "Deleted task",
+			description: "Should be excluded",
+			status: "deleted",
+			blocks: [],
+			blockedBy: [],
+			threadID: "test-session",
+		};
 
-    writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task1)
-    writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-2.json"), task2)
+		writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task1);
+		writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-2.json"), task2);
 
-     const config = {
-       sisyphus: {
-         tasks: {
-           storage_path: join(testProjectDir, ".sisyphus/tasks"),
-           claude_code_compat: false,
-         },
-       },
-     }
-     const tool = createTaskList(config)
+		const config = {
+			sisyphus: {
+				tasks: {
+					storage_path: join(testProjectDir, ".sisyphus/tasks"),
+					claude_code_compat: false,
+				},
+			},
+		};
+		const tool = createTaskList(config);
 
-     //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+		//#when
+		const result = await tool.execute({}, { sessionID: "test-session" });
 
-     //#then
-     const parsed = JSON.parse(result)
-     expect(parsed.tasks).toHaveLength(1)
-     expect(parsed.tasks[0].id).toBe("T-1")
-   })
+		//#then
+		const parsed = JSON.parse(result);
+		expect(parsed.tasks).toHaveLength(1);
+		expect(parsed.tasks[0].id).toBe("T-1");
+	});
 
-   it("returns summary format with id, subject, status, owner, blockedBy", async () => {
-    //#given
-    const task: TaskObject = {
-      id: "T-1",
-      subject: "Test task",
-      description: "This is a long description that should not be included",
-      status: "in_progress",
-      owner: "sisyphus",
-      blocks: [],
-      blockedBy: ["T-2"],
-      threadID: "test-session",
-    }
+	it("returns summary format with id, subject, status, owner, blockedBy", async () => {
+		//#given
+		const task: TaskObject = {
+			id: "T-1",
+			subject: "Test task",
+			description: "This is a long description that should not be included",
+			status: "in_progress",
+			owner: "sisyphus",
+			blocks: [],
+			blockedBy: ["T-2"],
+			threadID: "test-session",
+		};
 
-    writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task)
+		writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task);
 
-     const config = {
-       sisyphus: {
-         tasks: {
-           storage_path: join(testProjectDir, ".sisyphus/tasks"),
-           claude_code_compat: false,
-         },
-       },
-     }
-     const tool = createTaskList(config)
+		const config = {
+			sisyphus: {
+				tasks: {
+					storage_path: join(testProjectDir, ".sisyphus/tasks"),
+					claude_code_compat: false,
+				},
+			},
+		};
+		const tool = createTaskList(config);
 
-     //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+		//#when
+		const result = await tool.execute({}, { sessionID: "test-session" });
 
-     //#then
-     const parsed = JSON.parse(result)
-     expect(parsed.tasks).toHaveLength(1)
-     const summary = parsed.tasks[0]
-    expect(summary).toHaveProperty("id")
-    expect(summary).toHaveProperty("subject")
-    expect(summary).toHaveProperty("status")
-    expect(summary).toHaveProperty("owner")
-    expect(summary).toHaveProperty("blockedBy")
-    expect(summary).not.toHaveProperty("description")
-    expect(summary.id).toBe("T-1")
-    expect(summary.subject).toBe("Test task")
-    expect(summary.status).toBe("in_progress")
-    expect(summary.owner).toBe("sisyphus")
-    expect(summary.blockedBy).toEqual(["T-2"])
-  })
+		//#then
+		const parsed = JSON.parse(result);
+		expect(parsed.tasks).toHaveLength(1);
+		const summary = parsed.tasks[0];
+		expect(summary).toHaveProperty("id");
+		expect(summary).toHaveProperty("subject");
+		expect(summary).toHaveProperty("status");
+		expect(summary).toHaveProperty("owner");
+		expect(summary).toHaveProperty("blockedBy");
+		expect(summary).not.toHaveProperty("description");
+		expect(summary.id).toBe("T-1");
+		expect(summary.subject).toBe("Test task");
+		expect(summary.status).toBe("in_progress");
+		expect(summary.owner).toBe("sisyphus");
+		expect(summary.blockedBy).toEqual(["T-2"]);
+	});
 
-  it("filters blockedBy to only include unresolved (non-completed) blockers", async () => {
-    //#given
-    const blockerCompleted: TaskObject = {
-      id: "T-blocker-completed",
-      subject: "Completed blocker",
-      description: "",
-      status: "completed",
-      blocks: [],
-      blockedBy: [],
-      threadID: "test-session",
-    }
-    const blockerPending: TaskObject = {
-      id: "T-blocker-pending",
-      subject: "Pending blocker",
-      description: "",
-      status: "pending",
-      blocks: [],
-      blockedBy: [],
-      threadID: "test-session",
-    }
-    const mainTask: TaskObject = {
-      id: "T-main",
-      subject: "Main task",
-      description: "",
-      status: "pending",
-      blocks: [],
-      blockedBy: ["T-blocker-completed", "T-blocker-pending"],
-      threadID: "test-session",
-    }
+	it("filters blockedBy to only include unresolved (non-completed) blockers", async () => {
+		//#given
+		const blockerCompleted: TaskObject = {
+			id: "T-blocker-completed",
+			subject: "Completed blocker",
+			description: "",
+			status: "completed",
+			blocks: [],
+			blockedBy: [],
+			threadID: "test-session",
+		};
+		const blockerPending: TaskObject = {
+			id: "T-blocker-pending",
+			subject: "Pending blocker",
+			description: "",
+			status: "pending",
+			blocks: [],
+			blockedBy: [],
+			threadID: "test-session",
+		};
+		const mainTask: TaskObject = {
+			id: "T-main",
+			subject: "Main task",
+			description: "",
+			status: "pending",
+			blocks: [],
+			blockedBy: ["T-blocker-completed", "T-blocker-pending"],
+			threadID: "test-session",
+		};
 
-    writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-blocker-completed.json"), blockerCompleted)
-    writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-blocker-pending.json"), blockerPending)
-    writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-main.json"), mainTask)
+		writeJsonAtomic(
+			join(testProjectDir, ".sisyphus/tasks", "T-blocker-completed.json"),
+			blockerCompleted,
+		);
+		writeJsonAtomic(
+			join(testProjectDir, ".sisyphus/tasks", "T-blocker-pending.json"),
+			blockerPending,
+		);
+		writeJsonAtomic(
+			join(testProjectDir, ".sisyphus/tasks", "T-main.json"),
+			mainTask,
+		);
 
-     const config = {
-       sisyphus: {
-         tasks: {
-           storage_path: join(testProjectDir, ".sisyphus/tasks"),
-           claude_code_compat: false,
-         },
-       },
-     }
-     const tool = createTaskList(config)
+		const config = {
+			sisyphus: {
+				tasks: {
+					storage_path: join(testProjectDir, ".sisyphus/tasks"),
+					claude_code_compat: false,
+				},
+			},
+		};
+		const tool = createTaskList(config);
 
-     //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+		//#when
+		const result = await tool.execute({}, { sessionID: "test-session" });
 
-     //#then
-     const parsed = JSON.parse(result)
-     const mainTaskSummary = parsed.tasks.find((t: { id: string }) => t.id === "T-main")
-    expect(mainTaskSummary.blockedBy).toEqual(["T-blocker-pending"])
-  })
+		//#then
+		const parsed = JSON.parse(result);
+		const mainTaskSummary = parsed.tasks.find(
+			(t: { id: string }) => t.id === "T-main",
+		);
+		expect(mainTaskSummary.blockedBy).toEqual(["T-blocker-pending"]);
+	});
 
-   it("includes all active statuses (pending, in_progress)", async () => {
-     //#given
-     const task1: TaskObject = {
-       id: "T-1",
-       subject: "Pending task",
-       description: "",
-       status: "pending",
-       blocks: [],
-       blockedBy: [],
-       threadID: "test-session",
-     }
-     const task2: TaskObject = {
-       id: "T-2",
-       subject: "In progress task",
-       description: "",
-       status: "in_progress",
-       blocks: [],
-       blockedBy: [],
-       threadID: "test-session",
-     }
+	it("includes all active statuses (pending, in_progress)", async () => {
+		//#given
+		const task1: TaskObject = {
+			id: "T-1",
+			subject: "Pending task",
+			description: "",
+			status: "pending",
+			blocks: [],
+			blockedBy: [],
+			threadID: "test-session",
+		};
+		const task2: TaskObject = {
+			id: "T-2",
+			subject: "In progress task",
+			description: "",
+			status: "in_progress",
+			blocks: [],
+			blockedBy: [],
+			threadID: "test-session",
+		};
 
-     writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task1)
-     writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-2.json"), task2)
+		writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task1);
+		writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-2.json"), task2);
 
-     const config = {
-       sisyphus: {
-         tasks: {
-           storage_path: join(testProjectDir, ".sisyphus/tasks"),
-           claude_code_compat: false,
-         },
-       },
-     }
-     const tool = createTaskList(config)
+		const config = {
+			sisyphus: {
+				tasks: {
+					storage_path: join(testProjectDir, ".sisyphus/tasks"),
+					claude_code_compat: false,
+				},
+			},
+		};
+		const tool = createTaskList(config);
 
-     //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+		//#when
+		const result = await tool.execute({}, { sessionID: "test-session" });
 
-     //#then
-     const parsed = JSON.parse(result)
-     expect(parsed.tasks).toHaveLength(2)
-   })
+		//#then
+		const parsed = JSON.parse(result);
+		expect(parsed.tasks).toHaveLength(2);
+	});
 
-   it("handles tasks with no blockedBy gracefully", async () => {
-     //#given
-     const task: TaskObject = {
-       id: "T-1",
-       subject: "Task with no blockers",
-       description: "",
-       status: "pending",
-       blocks: [],
-       blockedBy: [],
-       threadID: "test-session",
-     }
+	it("handles tasks with no blockedBy gracefully", async () => {
+		//#given
+		const task: TaskObject = {
+			id: "T-1",
+			subject: "Task with no blockers",
+			description: "",
+			status: "pending",
+			blocks: [],
+			blockedBy: [],
+			threadID: "test-session",
+		};
 
-     writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task)
+		writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task);
 
-     const config = {
-       sisyphus: {
-         tasks: {
-           storage_path: join(testProjectDir, ".sisyphus/tasks"),
-           claude_code_compat: false,
-         },
-       },
-     }
-     const tool = createTaskList(config)
+		const config = {
+			sisyphus: {
+				tasks: {
+					storage_path: join(testProjectDir, ".sisyphus/tasks"),
+					claude_code_compat: false,
+				},
+			},
+		};
+		const tool = createTaskList(config);
 
-     //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+		//#when
+		const result = await tool.execute({}, { sessionID: "test-session" });
 
-     //#then
-     const parsed = JSON.parse(result)
-     expect(parsed.tasks[0].blockedBy).toEqual([])
-   })
+		//#then
+		const parsed = JSON.parse(result);
+		expect(parsed.tasks[0].blockedBy).toEqual([]);
+	});
 
-   it("handles missing blocker tasks gracefully", async () => {
-     //#given
-     const task: TaskObject = {
-       id: "T-1",
-       subject: "Task with missing blocker",
-       description: "",
-       status: "pending",
-       blocks: [],
-       blockedBy: ["T-missing"],
-       threadID: "test-session",
-     }
+	it("handles missing blocker tasks gracefully", async () => {
+		//#given
+		const task: TaskObject = {
+			id: "T-1",
+			subject: "Task with missing blocker",
+			description: "",
+			status: "pending",
+			blocks: [],
+			blockedBy: ["T-missing"],
+			threadID: "test-session",
+		};
 
-     writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task)
+		writeJsonAtomic(join(testProjectDir, ".sisyphus/tasks", "T-1.json"), task);
 
-     const config = {
-       sisyphus: {
-         tasks: {
-           storage_path: join(testProjectDir, ".sisyphus/tasks"),
-           claude_code_compat: false,
-         },
-       },
-     }
-     const tool = createTaskList(config)
+		const config = {
+			sisyphus: {
+				tasks: {
+					storage_path: join(testProjectDir, ".sisyphus/tasks"),
+					claude_code_compat: false,
+				},
+			},
+		};
+		const tool = createTaskList(config);
 
-     //#when
-     const result = await tool.execute({}, { sessionID: "test-session" })
+		//#when
+		const result = await tool.execute({}, { sessionID: "test-session" });
 
-     //#then
-     const parsed = JSON.parse(result)
-     expect(parsed.tasks[0].blockedBy).toEqual(["T-missing"])
-   })
-})
+		//#then
+		const parsed = JSON.parse(result);
+		expect(parsed.tasks[0].blockedBy).toEqual(["T-missing"]);
+	});
+});


### PR DESCRIPTION
## Summary
- finish the u49 canonical contract / doctor / schema / LSP alignment work
- complete y87 OMO stabilization and boundary discovery fixes
- include the supporting regressions required to keep the branch green

## Verification
- bun test
- node ./node_modules/typescript/bin/tsc --noEmit
- manual build pipeline:
  - bun build src/index.ts --outdir dist --target bun --format esm --external @ast-grep/napi
  - node ./node_modules/typescript/bin/tsc --emitDeclarationOnly
  - bun build src/cli/index.ts --outdir dist/cli --target bun --format esm --external @ast-grep/napi
  - bun run script/build-schema.ts

## Beads
- u49
- y87

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `oh-my-openagent.jsonc` the canonical config across runtime, installer, doctor, and docs, with safe legacy fallback. Also stabilizes OMO behavior and fixes edge cases to keep the branch green.

- **Refactors**
  - Prefer `oh-my-openagent.jsonc` over legacy across runtime, installer, LSP, and doctor; warn on legacy use and coexistence; block migration when canonical exists; fall back to legacy if canonical is invalid.
  - Unify config loading for doctor/LSP and align model resolution with runtime; update schema generator to add `git_master` defaults and remove it from required.
  - Improve cross-platform path handling (Windows normalization), `opencode` binary resolution, file-write guard behavior, and background task polling; expand and deflake tests.

- **Migration**
  - Move config to `.opencode/oh-my-openagent.jsonc` (user: `~/.config/opencode/oh-my-openagent.jsonc`); legacy `oh-my-opencode.json[c]` still loads with warnings.
  - In `opencode.json`, set the plugin entry to `"oh-my-openagent"`; `"oh-my-opencode"` remains supported with a warning.
  - Run `bunx oh-my-opencode doctor` to detect legacy files, coexistence, or multiple canonical files.

<sup>Written for commit 47a88676e79f5f0d5ffd0abf469c77758c053476. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

