### PR TITLE
fix(grep): handle Windows drive-letter paths in parseOutput regex

### DIFF
--- a/src/tools/grep/cli.ts
+++ b/src/tools/grep/cli.ts
@@ -23,6 +23,9 @@ function buildRgArgs(options: GrepOptions): string[] {
     `--max-filesize=${options.maxFilesize ?? DEFAULT_MAX_FILESIZE}`,
     `--max-count=${Math.min(options.maxCount ?? DEFAULT_MAX_COUNT, DEFAULT_MAX_COUNT)}`,
     `--max-columns=${Math.min(options.maxColumns ?? DEFAULT_MAX_COLUMNS, DEFAULT_MAX_COLUMNS)}`,
+    // Normalize path separators to forward slashes on Windows so the
+    // parseOutput regex doesn't break on drive-letter colons (e.g. C:\...)
+    "--path-separator=/",
   ]
 
   if (options.context !== undefined && options.context > 0) {
@@ -95,7 +98,8 @@ function buildArgs(options: GrepOptions, backend: GrepBackend): string[] {
   return backend === "rg" ? buildRgArgs(options) : buildGrepArgs(options)
 }
 
-function parseOutput(output: string, filesOnly = false): GrepMatch[] {
+/** @internal Exported for testing only */
+export function parseOutput(output: string, filesOnly = false): GrepMatch[] {
   if (!output.trim()) return []
 
   const matches: GrepMatch[] = []
@@ -114,7 +118,8 @@ function parseOutput(output: string, filesOnly = false): GrepMatch[] {
       continue
     }
 
-    const match = line.match(/^(.+?):(\d+):(.*)$/)
+    // Handle optional Windows drive letter (e.g. C:/path/file.ts:42:content)
+    const match = line.match(/^([A-Za-z]:\/.*?|.+?):(\d+):(.*)$/)
     if (match) {
       matches.push({
         file: match[1],
@@ -127,7 +132,8 @@ function parseOutput(output: string, filesOnly = false): GrepMatch[] {
   return matches
 }
 
-function parseCountOutput(output: string): CountResult[] {
+/** @internal Exported for testing only */
+export function parseCountOutput(output: string): CountResult[] {
   if (!output.trim()) return []
 
   const results: CountResult[] = []
@@ -136,7 +142,8 @@ function parseCountOutput(output: string): CountResult[] {
   for (const line of lines) {
     if (!line.trim()) continue
 
-    const match = line.match(/^(.+?):(\d+)$/)
+    // Handle optional Windows drive letter (e.g. C:/path/file.ts:42)
+    const match = line.match(/^([A-Za-z]:\/.*?|.+?):(\d+)$/)
     if (match) {
       results.push({
         file: match[1],

--- a/src/tools/grep/parse-output.test.ts
+++ b/src/tools/grep/parse-output.test.ts
@@ -1,0 +1,101 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+import { parseOutput, parseCountOutput } from "./cli"
+
+describe("parseOutput", () => {
+  describe("#given Unix-style paths", () => {
+    test("#then parses file, line, and text correctly", () => {
+      const output = "/home/user/project/src/index.ts:42:const foo = 'bar'"
+      const matches = parseOutput(output)
+      expect(matches).toEqual([
+        { file: "/home/user/project/src/index.ts", line: 42, text: "const foo = 'bar'" },
+      ])
+    })
+
+    test("#then handles multiple matches", () => {
+      const output = [
+        "src/a.ts:1:line one",
+        "src/b.ts:20:line two",
+      ].join("\n")
+      const matches = parseOutput(output)
+      expect(matches).toHaveLength(2)
+      expect(matches[0]).toEqual({ file: "src/a.ts", line: 1, text: "line one" })
+      expect(matches[1]).toEqual({ file: "src/b.ts", line: 20, text: "line two" })
+    })
+  })
+
+  describe("#given Windows drive-letter paths with forward slashes (--path-separator=/)", () => {
+    test("#then parses the full drive-letter path correctly", () => {
+      const output = "C:/Users/dev/project/src/index.ts:42:const foo = 'bar'"
+      const matches = parseOutput(output)
+      expect(matches).toEqual([
+        { file: "C:/Users/dev/project/src/index.ts", line: 42, text: "const foo = 'bar'" },
+      ])
+    })
+
+    test("#then handles multiple Windows paths", () => {
+      const output = [
+        "D:/work/repo/file.cpp:10:#include <stdio.h>",
+        "D:/work/repo/main.cpp:25:int main() {",
+      ].join("\n")
+      const matches = parseOutput(output)
+      expect(matches).toHaveLength(2)
+      expect(matches[0]).toEqual({ file: "D:/work/repo/file.cpp", line: 10, text: "#include <stdio.h>" })
+      expect(matches[1]).toEqual({ file: "D:/work/repo/main.cpp", line: 25, text: "int main() {" })
+    })
+  })
+
+  describe("#given text containing colons", () => {
+    test("#then captures full text after line number", () => {
+      const output = "src/config.ts:5:const url = 'http://localhost:3000'"
+      const matches = parseOutput(output)
+      expect(matches).toEqual([
+        { file: "src/config.ts", line: 5, text: "const url = 'http://localhost:3000'" },
+      ])
+    })
+  })
+
+  describe("#given filesOnly mode", () => {
+    test("#then returns file paths with line 0 and empty text", () => {
+      const output = "src/a.ts\nsrc/b.ts\n"
+      const matches = parseOutput(output, true)
+      expect(matches).toEqual([
+        { file: "src/a.ts", line: 0, text: "" },
+        { file: "src/b.ts", line: 0, text: "" },
+      ])
+    })
+  })
+
+  describe("#given empty output", () => {
+    test("#then returns empty array", () => {
+      expect(parseOutput("")).toEqual([])
+      expect(parseOutput("  \n  ")).toEqual([])
+    })
+  })
+})
+
+describe("parseCountOutput", () => {
+  describe("#given Unix-style paths", () => {
+    test("#then parses file and count correctly", () => {
+      const output = "src/index.ts:5"
+      const results = parseCountOutput(output)
+      expect(results).toEqual([{ file: "src/index.ts", count: 5 }])
+    })
+  })
+
+  describe("#given Windows drive-letter paths", () => {
+    test("#then parses the full drive-letter path correctly", () => {
+      const output = "C:/Users/dev/project/src/index.ts:12"
+      const results = parseCountOutput(output)
+      expect(results).toEqual([{ file: "C:/Users/dev/project/src/index.ts", count: 12 }])
+    })
+  })
+
+  describe("#given empty output", () => {
+    test("#then returns empty array", () => {
+      expect(parseCountOutput("")).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
Closes #2962. Adds --path-separator=/ to rg args and updates parseOutput/parseCountOutput regex to handle drive letters. 10 new tests, all 21 grep tests pass, tsc clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows grep parsing so matches and counts return correctly. Closes #2962.

- **Bug Fixes**
  - Add `--path-separator=/` to `rg` args to normalize Windows paths.
  - Update `parseOutput` and `parseCountOutput` regex to handle drive-letter paths (e.g., `C:/...`).
  - Export parsers for tests and add coverage for Windows/Unix paths, colons in text, files-only mode, and empty output. All grep tests pass.

<sup>Written for commit 2a7789e07cffda63677e47cf69814d71af21e94f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

