### PR TITLE
fix: skip thinking param injection for GLM models in sisyphus-junior

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oh-my-opencode",
   "version": "3.14.0",
   "description": "The Best AI Agent Harness - Batteries-Included OpenCode Plugin with Multi-Model Orchestration, Parallel Background Agents, and Crafted LSP/AST Tools",
-  "main": "dist/index.js",
+  "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
   "bin": {

--- a/src/agents/sisyphus-junior/agent.ts
+++ b/src/agents/sisyphus-junior/agent.ts
@@ -12,7 +12,7 @@
 
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode } from "../types"
-import { isGptModel, isGeminiModel } from "../types"
+import { isGlmModel, isGptModel, isGeminiModel } from "../types"
 import type { AgentOverrideConfig } from "../../config/schema"
 import {
   createAgentToolRestrictions,
@@ -121,6 +121,10 @@ export function createSisyphusJuniorAgentWithOverrides(
 
   if (isGptModel(model)) {
     return { ...base, reasoningEffort: "medium" } as AgentConfig
+  }
+
+  if (isGlmModel(model)) {
+    return base as AgentConfig
   }
 
   return {

--- a/src/agents/sisyphus-junior/index.test.ts
+++ b/src/agents/sisyphus-junior/index.test.ts
@@ -143,6 +143,44 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
     })
   })
 
+  describe("reasoning configuration", () => {
+    test("#given GPT model #when agent is created #then uses reasoningEffort", () => {
+      // given
+      const override = { model: "openai/gpt-5.4" }
+
+      // when
+      const result = createSisyphusJuniorAgentWithOverrides(override)
+
+      // then
+      expect(result.reasoningEffort).toBe("medium")
+      expect(result.thinking).toBeUndefined()
+    })
+
+    test("#given Claude model #when agent is created #then injects thinking", () => {
+      // given
+      const override = { model: "anthropic/claude-sonnet-4-6" }
+
+      // when
+      const result = createSisyphusJuniorAgentWithOverrides(override)
+
+      // then
+      expect(result.reasoningEffort).toBeUndefined()
+      expect(result.thinking).toEqual({ type: "enabled", budgetTokens: 32000 })
+    })
+
+    test("#given GLM reasoning model #when agent is created #then skips injected thinking", () => {
+      // given
+      const override = { model: "z-ai/glm-5" }
+
+      // when
+      const result = createSisyphusJuniorAgentWithOverrides(override)
+
+      // then
+      expect(result.reasoningEffort).toBeUndefined()
+      expect(result.thinking).toBeUndefined()
+    })
+  })
+
   describe("tool safety (task blocked, call_omo_agent allowed)", () => {
     test("task remains blocked, call_omo_agent is allowed via tools format", () => {
       // given

--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { isGptModel, isGeminiModel, isGpt5_4Model, isMiniMaxModel } from "./types";
+import { isGptModel, isGeminiModel, isGlmModel, isGpt5_4Model, isMiniMaxModel } from "./types";
 
 describe("isGpt5_4Model", () => {
   test("detects gpt-5.4 models", () => {
@@ -98,6 +98,26 @@ describe("isMiniMaxModel", () => {
     expect(isMiniMaxModel("anthropic/claude-opus-4-6")).toBe(false);
     expect(isMiniMaxModel("google/gemini-3.1-pro")).toBe(false);
     expect(isMiniMaxModel("opencode-go/kimi-k2.5")).toBe(false);
+  });
+});
+
+describe("isGlmModel", () => {
+  test("#given GLM models with provider prefix #then returns true", () => {
+    expect(isGlmModel("z-ai/glm-5")).toBe(true);
+    expect(isGlmModel("opencode/glm-5")).toBe(true);
+    expect(isGlmModel("opencode-go/glm-5-turbo")).toBe(true);
+    expect(isGlmModel("opencode/glm-4.6v")).toBe(true);
+  });
+
+  test("#given GLM models without provider prefix #then returns true", () => {
+    expect(isGlmModel("glm-5")).toBe(true);
+    expect(isGlmModel("glm-5-turbo")).toBe(true);
+  });
+
+  test("#given non-GLM models #then returns false", () => {
+    expect(isGlmModel("openai/gpt-5.4")).toBe(false);
+    expect(isGlmModel("anthropic/claude-opus-4-6")).toBe(false);
+    expect(isGlmModel("google/gemini-3.1-pro")).toBe(false);
   });
 });
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -96,6 +96,11 @@ export function isMiniMaxModel(model: string): boolean {
   return modelName.includes("minimax");
 }
 
+export function isGlmModel(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase();
+  return modelName.includes("glm");
+}
+
 export function isGeminiModel(model: string): boolean {
   if (GEMINI_PROVIDERS.some((prefix) => model.startsWith(prefix))) return true;
 


### PR DESCRIPTION
Fixes #2967

## Problem
GLM-5 has native reasoning built-in. When sisyphus-junior injects `thinking: { type: 'enabled', budgetTokens: 32000 }` for non-GPT models, GLM-5 returns a 400 error due to the unsupported param conflict.

## Fix
- Add `isGlmModel()` helper to `types.ts` (matches `glm` in model name after extracting provider prefix)
- Early return in `createSisyphusJuniorAgentWithOverrides` for GLM models — returns base config without `thinking` or `reasoningEffort`
- Mirrors the existing pattern for GPT models (`isGptModel` → `reasoningEffort`) and Gemini models

## Tests
- `isGlmModel`: provider-prefixed (`z-ai/glm-5`, `opencode/glm-5`), bare (`glm-5`), and negative cases
- Reasoning config: GPT gets `reasoningEffort`, Claude gets `thinking`, GLM gets neither

## Note
Same pattern exists in `sisyphus.ts`, `oracle.ts`, `momus.ts`, and `metis.ts` — they also inject `thinking` for non-GPT models without a GLM check. Scoped this PR to sisyphus-junior per the issue; follow-up PR can address the others.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip injecting `thinking` for GLM models in `sisyphus-junior` to avoid 400s from GLM-5’s native reasoning and satisfy Linear 2967. Adds `isGlmModel()` with an early return; also corrects the `package.json` main path.

- **Bug Fixes**
  - Add `isGlmModel()` and return the base config for GLM models (no `thinking` or `reasoningEffort`) in `createSisyphusJuniorAgentWithOverrides`.
  - Fix `package.json` main to `./dist/index.js` for proper plugin loading.

<sup>Written for commit 71c60e1be4cc0b69da43b600eb593cfaaf275a81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

