### PR TITLE
fix(mcp): prioritize OpenCode user MCP config over Claude Code .mcp.json (fixes #2946)

### DIFF
--- a/src/plugin-handlers/mcp-config-handler.ts
+++ b/src/plugin-handlers/mcp-config-handler.ts
@@ -40,8 +40,8 @@ export async function applyMcpConfig(params: {
 
   const merged = {
     ...createBuiltinMcps(disabledMcps, params.pluginConfig),
-    ...(userMcp ?? {}),
     ...mcpResult.servers,
+    ...(userMcp ?? {}),
     ...params.pluginComponents.mcpServers,
   } as Record<string, McpEntry>;
 


### PR DESCRIPTION
## Summary
- Swap MCP merge order so OpenCode user config takes precedence over Claude Code .mcp.json entries.

## Problem
When both OpenCode config and Claude Code's .mcp.json define an MCP server with the same name, the Claude Code version silently overrides the OpenCode user config. The merge order in `mcp-config-handler.ts` spreads `userMcp` before `mcpResult.servers`, so Claude Code entries win on name collisions.

## Fix
Swapped the spread order: Claude Code MCPs are now spread first, then OpenCode user MCPs override them. This gives users explicit control -- their OpenCode-specific config always wins over Claude Code defaults.

New priority (lowest to highest): builtin -> Claude Code .mcp.json -> OpenCode user config -> plugin MCPs.

## Changes
| File | Change |
|------|--------|
| `src/plugin-handlers/mcp-config-handler.ts` | Swap `userMcp` and `mcpResult.servers` spread order |

Fixes #2946

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure OpenCode user MCP config overrides Claude Code .mcp.json entries on name collisions. Swaps merge order in MCP config merging so user settings take precedence.

- **Bug Fixes**
  - Update `src/plugin-handlers/mcp-config-handler.ts` to set precedence: builtin -> Claude Code .mcp.json -> OpenCode user config -> plugin MCPs.

<sup>Written for commit 8832dd05ae1a55bd9ea65f576096368913c3f055. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

