### PR TITLE
docs: fix Sisyphus Tasks config reference to match actual schema

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -435,13 +435,14 @@ Sisyphus agents can also be customized under `agents` using their names: `Sisyph
 
 ### Sisyphus Tasks
 
-Enable the Sisyphus Tasks system for cross-session task tracking.
+File-based task persistence with dependency tracking, used for cross-session task management. The task system is controlled by `experimental.task_system` (defaults to `true` since v3.14). When enabled, `TodoWrite`/`TodoRead` are intercepted and replaced with the Task tools (`task_create`, `task_get`, `task_list`, `task_update`).
+
+The `sisyphus.tasks` section configures **storage options** only:
 
 ```json
 {
   "sisyphus": {
     "tasks": {
-      "enabled": false,
       "storage_path": ".sisyphus/tasks",
       "claude_code_compat": false
     }
@@ -451,9 +452,17 @@ Enable the Sisyphus Tasks system for cross-session task tracking.
 
 | Option               | Default           | Description                                |
 | -------------------- | ----------------- | ------------------------------------------ |
-| `enabled`            | `false`           | Enable Sisyphus Tasks system               |
 | `storage_path`       | `.sisyphus/tasks` | Storage path (relative to project root)    |
+| `task_list_id`       | -                 | Force task list ID (alternative to env `ULTRAWORK_TASK_LIST_ID`) |
 | `claude_code_compat` | `false`           | Enable Claude Code path compatibility mode |
+
+To disable the task system entirely, set `experimental.task_system` to `false`:
+
+```json
+{
+  "experimental": { "task_system": false }
+}
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixes the `Sisyphus Tasks` section in `docs/reference/configuration.md` which documented a nonexistent `enabled` field defaulting to `false`
- Aligns the docs with the actual `SisyphusTasksConfigSchema` and `experimental.task_system` toggle

## Problem

The documentation stated:

```json
{
  "sisyphus": {
    "tasks": {
      "enabled": false,
      ...
    }
  }
}
```

| Option | Default | Description |
|--------|---------|-------------|
| `enabled` | `false` | Enable Sisyphus Tasks system |

This is wrong on two counts:

1. **The `enabled` field does not exist** in [`SisyphusTasksConfigSchema`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/config/schema/sisyphus.ts) -- the schema only has `storage_path`, `task_list_id`, and `claude_code_compat`
2. **The task system actually defaults to `true`** (since v3.14) via [`experimental.task_system`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/plugin/tool-registry.ts#L178-L179), not `false`

This caused confusion since users reading the docs would believe the task system is off by default when it is actually on.

## Changes

- Removed the phantom `enabled` field from the JSON example and options table
- Added the `task_list_id` option that exists in the schema but was missing from docs
- Clarified that `sisyphus.tasks` configures **storage options only**, not the on/off toggle
- Added a pointer to `experimental.task_system` as the actual enable/disable mechanism
- Added a brief description of what the task system does (replaces `TodoWrite`/`TodoRead` with `task_create`, `task_get`, `task_list`, `task_update`)

## Evidence

- Schema: [`src/config/schema/sisyphus.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/config/schema/sisyphus.ts) -- no `enabled` field
- Toggle: [`src/plugin/tool-registry.ts#L178-179`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/plugin/tool-registry.ts#L178-L179) -- `experimental?.task_system ?? true`
- Hook: [`src/hooks/tasks-todowrite-disabler/hook.ts#L12`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/hooks/tasks-todowrite-disabler/hook.ts#L12) -- same default


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Sisyphus Tasks config docs to match the real schema and default behavior. Prevents confusion by pointing to `experimental.task_system` (defaults to `true`) as the actual toggle.

- **Bug Fixes**
  - Removed nonexistent `enabled` field from example and options table.
  - Added missing `task_list_id` from `SisyphusTasksConfigSchema`.
  - Clarified `sisyphus.tasks` controls storage only; toggle lives at `experimental.task_system`.
  - Briefly explained tool interception (`TodoWrite`/`TodoRead` → `task_create`/`task_get`/`task_list`/`task_update`) and showed how to disable.

<sup>Written for commit dc41de9a4e4b48d2bdc565418aadc3cec3f3add7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

