### PR TITLE
docs(examples): fix schema URLs to use oh-my-openagent

### DIFF
--- a/docs/examples/coding-focused.jsonc
+++ b/docs/examples/coding-focused.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/dev/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   // Optimized for intensive coding sessions.
   // Prioritizes deep implementation agents and fast feedback loops.

--- a/docs/examples/default.jsonc
+++ b/docs/examples/default.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/dev/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   // Balanced defaults for general development.
   // Tuned for reliability across diverse tasks without overspending.

--- a/docs/examples/planning-focused.jsonc
+++ b/docs/examples/planning-focused.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-opencode/dev/assets/oh-my-opencode.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   // Optimized for strategic planning, architecture, and complex project design.
   // Prioritizes deep thinking agents and thorough analysis before execution.


### PR DESCRIPTION
## Summary

Fixes schema URLs in example config files to use the correct oh-my-openagent repository name instead of the old oh-my-opencode.

## Changes

- docs/examples/default.jsonc
- docs/examples/coding-focused.jsonc
- docs/examples/planning-focused.jsonc

## Validation

All three example files now pass schema validation with the correct URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `$schema` URLs in example configs to point to the `oh-my-openagent` repository instead of `oh-my-opencode`. Restores correct schema validation and editor IntelliSense in `default.jsonc`, `coding-focused.jsonc`, and `planning-focused.jsonc`.

<sup>Written for commit cbd7dac3ba30745cddff171e009259726031aed6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

