### PR TITLE
docs(configuration): fix invalid JSON examples and schema issues

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -645,6 +645,9 @@ Auto-switches to backup models on API errors.
 
 ```json
 { "runtime_fallback": true }
+```
+
+```json
 { "runtime_fallback": false }
 ```
 
@@ -987,10 +990,12 @@ Install [`opencode-antigravity-auth`](https://github.com/NoeFabris/opencode-anti
 ```json
 {
   "agents": {
-    "explore": { "model": "ollama/qwen3-coder", "stream": false }
+    "explore": { "model": "ollama/qwen3-coder" }
   }
 }
 ```
+
+**Note:** The `stream` option should be configured in your OpenCode settings or via environment variables, not in the agent config. See [Ollama Troubleshooting](../troubleshooting/ollama.md) for details on disabling streaming.
 
 Common models: `ollama/qwen3-coder`, `ollama/ministral-3:14b`, `ollama/lfm2.5-thinking`
 


### PR DESCRIPTION
## Summary

Fixes invalid JSON examples and schema compliance issues in the configuration documentation.

## Changes

1. **Split two JSON objects into separate code blocks** (lines 647-648)
   - Two separate JSON objects in one code block is invalid JSON
   - Split into two separate fenced code blocks

2. **Remove 'stream' field from agent config** (line 990)
   - The 'stream' field does not exist in the agent schema
   - Added note about configuring streaming via OpenCode settings

## Validation

All JSON examples now pass schema validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix invalid JSON examples and align configuration docs with the agent schema. Examples now parse correctly and reflect how streaming is configured.

- **Bug Fixes**
  - Split two JSON objects into separate code blocks to ensure valid JSON.
  - Removed `stream` from agent config and added note to configure streaming via OpenCode settings or env variables.

<sup>Written for commit 2ebf146b84566e577571a105ec7a2962920a61e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

