### PR TITLE
docs(ollama): fix NDJSON code block language identifier

### DIFF
--- a/docs/troubleshooting/ollama.md
+++ b/docs/troubleshooting/ollama.md
@@ -16,7 +16,7 @@ This occurs when agents attempt tool calls (e.g., `explore` agent using `mcp_gre
 
 Ollama returns **NDJSON** (newline-delimited JSON) when `stream: true` is used in API requests:
 
-```json
+```ndjson
 {"message":{"tool_calls":[{"function":{"name":"read","arguments":{"filePath":"README.md"}}}]}, "done":false}
 {"message":{"content":""}, "done":true}
 ```


### PR DESCRIPTION
## Summary

Fixes the language identifier for NDJSON examples in the Ollama troubleshooting documentation.

## Changes

- Changed code block language from 'json' to 'ndjson' (lines 19-22)
- NDJSON contains multiple JSON objects which is not valid standard JSON
- Using 'ndjson' is more semantically correct and avoids validation errors

## Context

NDJSON (Newline Delimited JSON) is a format where each line is a valid JSON object, but the overall content is not a single valid JSON document. Marking it as 'json' causes validation tools to incorrectly flag it as invalid.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Ollama troubleshooting docs to label the streaming example as `ndjson` instead of `json`. This matches newline-delimited output and avoids false validation errors and incorrect highlighting.

<sup>Written for commit 0e8f5dd130c2195b21dfc3dfeefc74c9a9d11e0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

