### PR TITLE
fix(command-discovery): skip non-directory .claude/commands path

### DIFF
--- a/src/tools/slashcommand/command-discovery.test.ts
+++ b/src/tools/slashcommand/command-discovery.test.ts
@@ -267,3 +267,52 @@ Use nested command.
     expect(startWorkCommand?.metadata.agent).toBe("atlas")
   })
 })
+
+describe("non-directory commands path", () => {
+  let testDir: string
+  let savedEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "omo-cmd-file-"))
+    savedEnv = {
+      CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+      OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
+    }
+    process.env.CLAUDE_CONFIG_DIR = join(testDir, "claude-config")
+    process.env.OPENCODE_CONFIG_DIR = join(testDir, "opencode-config")
+    mkdirSync(join(testDir, "claude-config"), { recursive: true })
+    mkdirSync(join(testDir, "opencode-config"), { recursive: true })
+  })
+
+  afterEach(() => {
+    Object.entries(savedEnv).forEach(([k, v]) => {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    })
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it("#given .claude/commands is a file #when discoverCommandsSync runs #then returns without crashing", () => {
+    const projectDir = join(testDir, "project")
+    mkdirSync(join(projectDir, ".claude"), { recursive: true })
+    writeFileSync(join(projectDir, ".claude", "commands"), "")  // file, not directory
+
+    // Should not throw
+    const commands = discoverCommandsSync(projectDir)
+    expect(commands).toBeInstanceOf(Array)
+  })
+
+  it("#given .claude/commands is a directory #when discoverCommandsSync runs #then discovers commands normally", () => {
+    const projectDir = join(testDir, "project")
+    mkdirSync(join(projectDir, ".claude", "commands"), { recursive: true })
+    writeFileSync(
+      join(projectDir, ".claude", "commands", "test-cmd.md"),
+      "---\ndescription: Test\n---\nTest command content.\n",
+    )
+
+    const commands = discoverCommandsSync(projectDir)
+    const testCmd = commands.find((c) => c.name === "test-cmd")
+    expect(testCmd).toBeDefined()
+    expect(testCmd?.content).toContain("Test command content.")
+  })
+})

--- a/src/tools/slashcommand/command-discovery.ts
+++ b/src/tools/slashcommand/command-discovery.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from "fs"
+import { existsSync, readdirSync, readFileSync, statSync } from "fs"
 import { basename, join } from "path"
 import {
   parseFrontmatter,
@@ -9,7 +9,7 @@ import {
 } from "../../shared"
 import type { CommandFrontmatter } from "../../features/claude-code-command-loader/types"
 import { isMarkdownFile } from "../../shared/file-utils"
-import { getClaudeConfigDir } from "../../shared"
+import { getClaudeConfigDir, log } from "../../shared"
 import { loadBuiltinCommands } from "../../features/builtin-commands"
 import type { CommandInfo, CommandMetadata, CommandScope } from "./types"
 
@@ -26,6 +26,10 @@ function discoverCommandsFromDir(
   prefix = "",
 ): CommandInfo[] {
   if (!existsSync(commandsDir)) return []
+  if (!statSync(commandsDir).isDirectory()) {
+    log(`[command-discovery] Skipping non-directory path: ${commandsDir}`)
+    return []
+  }
 
   const entries = readdirSync(commandsDir, { withFileTypes: true })
   const commands: CommandInfo[] = []


### PR DESCRIPTION
## Problem

When `.claude/commands` exists as a file instead of a directory, `readdirSync` throws `ENOTDIR` and crashes command discovery, stalling OMO initialization. Users see the UI fall back to Build/Plan only with no clear error.

## Reproduction

```bash
mkdir -p .claude
touch .claude/commands  # file, not directory
opencode  # stalls, agents unavailable
```

Confirmed: `existsSync` returns `true` for the file, then `readdirSync` throws `ENOTDIR`.

## Fix

Added `statSync().isDirectory()` guard after the `existsSync` check in `discoverCommandsFromDir`. Non-directory paths are skipped with a warning log.

## Tests

- Added test: file-as-commands-dir returns empty array without crashing
- Added test: directory-as-commands-dir still discovers commands normally
- All 10 command-discovery tests pass
- `tsc --noEmit` clean

Fixes #3010

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash when `.claude/commands` is a file by skipping non-directory paths during command discovery. OMO now initializes correctly and agents load instead of falling back to Build/Plan. Fixes #3010.

- **Bug Fixes**
  - Guard with `statSync().isDirectory()` and skip non-directory `.claude/commands`, with a warning log.
  - Added tests for file path (no crash) and directory path (commands discovered).
  - All command-discovery tests pass; typecheck clean.

<sup>Written for commit bb85e40a787443003d205d338a3ea047b3e5ce3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

