### PR TITLE
fix(skill): resolve namespaced skills by short name

### DIFF
--- a/src/tools/skill/tools.test.ts
+++ b/src/tools/skill/tools.test.ts
@@ -670,3 +670,58 @@ describe("skill tool - nativeSkills integration", () => {
     expect(result).toContain("External plugin skill body")
   })
 })
+
+describe("skill tool - short name resolution", () => {
+  it("resolves namespaced skill by short name when unambiguous", async () => {
+    // given
+    const loadedSkills = [createMockSkill("superpowers/systematic-debugging")]
+    const tool = createSkillTool({ skills: loadedSkills })
+
+    // when
+    const result = await tool.execute({ name: "systematic-debugging" }, mockContext)
+
+    // then
+    expect(result).toContain("superpowers/systematic-debugging")
+  })
+
+  it("still resolves by exact full name", async () => {
+    // given
+    const loadedSkills = [createMockSkill("superpowers/systematic-debugging")]
+    const tool = createSkillTool({ skills: loadedSkills })
+
+    // when
+    const result = await tool.execute({ name: "superpowers/systematic-debugging" }, mockContext)
+
+    // then
+    expect(result).toContain("superpowers/systematic-debugging")
+  })
+
+  it("does not resolve short name when ambiguous (multiple matches)", async () => {
+    // given
+    const loadedSkills = [
+      createMockSkill("superpowers/debugging"),
+      createMockSkill("utils/debugging"),
+    ]
+    const tool = createSkillTool({ skills: loadedSkills })
+
+    // when / then — should not resolve (ambiguous), should suggest both
+    await expect(tool.execute({ name: "debugging" }, mockContext)).rejects.toThrow(
+      "not found"
+    )
+  })
+
+  it("prefers exact match over short name match", async () => {
+    // given — "debugging" exists as both exact and as part of a namespace
+    const loadedSkills = [
+      createMockSkill("debugging"),
+      createMockSkill("superpowers/debugging"),
+    ]
+    const tool = createSkillTool({ skills: loadedSkills })
+
+    // when
+    const result = await tool.execute({ name: "debugging" }, mockContext)
+
+    // then — should match "debugging" exactly, not "superpowers/debugging"
+    expect(result).toContain("## Skill: debugging")
+  })
+})

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -324,7 +324,19 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
       const requestedName = args.name.replace(/^\//, "")
 
       // Check skills first (exact match, case-insensitive)
-      const matchedSkill = skills.find(s => s.name.toLowerCase() === requestedName.toLowerCase())
+      let matchedSkill = skills.find(s => s.name.toLowerCase() === requestedName.toLowerCase())
+
+      // Fallback: try matching by short name (basename) for namespaced skills
+      // e.g. "systematic-debugging" matches "superpowers/systematic-debugging"
+      if (!matchedSkill) {
+        const shortNameMatches = skills.filter(s => {
+          const parts = s.name.split("/")
+          return parts.length > 1 && parts[parts.length - 1].toLowerCase() === requestedName.toLowerCase()
+        })
+        if (shortNameMatches.length === 1) {
+          matchedSkill = shortNameMatches[0]
+        }
+      }
 
       if (matchedSkill) {
         if (matchedSkill.definition.agent && (!ctx?.agent || matchedSkill.definition.agent !== ctx.agent)) {


### PR DESCRIPTION
## Problem

Skills with namespaced names (e.g. `superpowers/systematic-debugging`) are shown to users by their short name (`systematic-debugging`) in the skill listing. But invoking the short name fails with 'not found', because the resolver only accepts exact full-name matches.

## Reproduction

1. Have a namespaced skill installed (e.g. `superpowers/systematic-debugging`)
2. Call `systematic-debugging` via the skill tool
3. Error: `Skill 'systematic-debugging' not found. Did you mean: superpowers/systematic-debugging?`

## Fix

Added short-name fallback in `createSkillTool`: if exact match fails, try matching the basename of namespaced skills (the part after the last `/`). Only resolves when the match is unambiguous (single result).

**Priority rules:**
- Exact full-name match always wins
- Single short-name match resolves correctly
- Ambiguous short names (e.g. `superpowers/debugging` + `utils/debugging`) fall through to the existing error with suggestions

## Tests

4 new tests added:
- Resolves namespaced skill by short name when unambiguous
- Still resolves by exact full name
- Does not resolve when ambiguous (multiple matches)
- Prefers exact match over short name match

All 29 skill tool tests pass. `tsc --noEmit` clean.

Fixes #2971

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows invoking namespaced skills by short name to match what users see in listings. Adds a short-name fallback so `systematic-debugging` maps to `superpowers/systematic-debugging` when unambiguous, fixing #2971.

- **Bug Fixes**
  - Added short-name fallback in `createSkillTool`; resolves only when there’s a single namespaced match.
  - Exact full-name match still takes priority.
  - Ambiguous short names fall through to the existing error with suggestions.
  - Added 4 tests for unambiguous resolution, exact-match behavior, ambiguity, and priority.

<sup>Written for commit 2275d87a16e3d89847b7c1e241de2823f3b70a17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

