### PR TITLE
fix(hooks): add proactive tool_use/tool_result pair validator (fixes #3014)

### DIFF
--- a/src/config/schema/hooks.ts
+++ b/src/config/schema/hooks.ts
@@ -25,6 +25,7 @@ export const HookNameSchema = z.enum([
   "interactive-bash-session",
 
   "thinking-block-validator",
+  "tool-result-pair-validator",
   "ralph-loop",
   "category-skill-reminder",
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -26,6 +26,7 @@ export { createNonInteractiveEnvHook } from "./non-interactive-env";
 export { createInteractiveBashSessionHook } from "./interactive-bash-session";
 
 export { createThinkingBlockValidatorHook } from "./thinking-block-validator";
+export { createToolResultPairValidatorHook } from "./tool-result-pair-validator";
 export { createCategorySkillReminderHook } from "./category-skill-reminder";
 export { createRalphLoopHook, type RalphLoopHook } from "./ralph-loop";
 export { createNoSisyphusGptHook } from "./no-sisyphus-gpt";

--- a/src/hooks/tool-result-pair-validator/hook.ts
+++ b/src/hooks/tool-result-pair-validator/hook.ts
@@ -1,0 +1,128 @@
+/**
+ * Proactive Tool Result Pair Validator Hook
+ *
+ * Prevents "tool_use ids were found without tool_result blocks" errors
+ * by validating tool_use/tool_result pairing BEFORE sending to the API.
+ *
+ * When compaction or context-window-limit-recovery removes a user message
+ * containing tool_result while keeping the assistant message with tool_use,
+ * the Anthropic API rejects the request. This hook detects orphaned tool_use
+ * blocks and injects synthetic tool_result parts to restore valid pairing.
+ *
+ * Runs as the LAST step in experimental.chat.messages.transform,
+ * after context-injector and thinking-block-validator.
+ */
+
+import type { Message, Part } from "@opencode-ai/sdk"
+import { log } from "../../shared/logger"
+
+interface MessageWithParts {
+  info: Message
+  parts: Part[]
+}
+
+type MessagesTransformHook = {
+  "experimental.chat.messages.transform"?: (
+    input: Record<string, never>,
+    output: { messages: MessageWithParts[] }
+  ) => Promise<void>
+}
+
+function isValidToolCallID(id: unknown): id is string {
+  return typeof id === "string" && /^(toolu_|call_)/.test(id)
+}
+
+function extractToolUseIdsFromAssistant(parts: Part[]): string[] {
+  if (!parts || parts.length === 0) return []
+
+  const ids: string[] = []
+  for (const part of parts) {
+    const type = (part as { type: string }).type
+    if (type !== "tool" && type !== "tool_use") continue
+
+    const callID =
+      (part as { callID?: unknown }).callID ??
+      (part as { id?: unknown }).id
+    if (isValidToolCallID(callID)) {
+      ids.push(callID)
+    }
+  }
+  return ids
+}
+
+function extractToolResultIdsFromUser(parts: Part[]): Set<string> {
+  if (!parts || parts.length === 0) return new Set()
+
+  const ids = new Set<string>()
+  for (const part of parts) {
+    const type = (part as { type: string }).type
+    if (type !== "tool" && type !== "tool_result") continue
+
+    const callID =
+      (part as { callID?: unknown }).callID ??
+      (part as { tool_use_id?: unknown }).tool_use_id
+    if (typeof callID === "string" && callID.length > 0) {
+      ids.add(callID)
+    }
+  }
+  return ids
+}
+
+function createSyntheticToolResultPart(toolUseId: string): Part {
+  return {
+    type: "tool_result",
+    tool_use_id: toolUseId,
+    content: "[tool result unavailable - recovered by tool-result-pair-validator]",
+  } as Part
+}
+
+export function createToolResultPairValidatorHook(): MessagesTransformHook {
+  return {
+    "experimental.chat.messages.transform": async (_input, output) => {
+      const { messages } = output
+      if (!messages || messages.length === 0) return
+
+      for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i]
+        if (msg.info.role !== "assistant") continue
+
+        const toolUseIds = extractToolUseIdsFromAssistant(msg.parts)
+        if (toolUseIds.length === 0) continue
+
+        const nextMsg = messages[i + 1]
+        const isNextUser = nextMsg?.info.role === "user"
+
+        if (!isNextUser) {
+          const syntheticParts = toolUseIds.map(createSyntheticToolResultPart)
+          const syntheticMessage: MessageWithParts = {
+            info: {
+              id: `synthetic_tool_result_${i}_${Date.now()}`,
+              role: "user",
+            } as Message,
+            parts: syntheticParts,
+          }
+
+          messages.splice(i + 1, 0, syntheticMessage)
+          log("[tool-result-pair-validator] Injected synthetic user message", {
+            afterIndex: i,
+            toolUseIds,
+          })
+          continue
+        }
+
+        const existingResultIds = extractToolResultIdsFromUser(nextMsg.parts)
+        const missingIds = toolUseIds.filter((id) => !existingResultIds.has(id))
+
+        if (missingIds.length > 0) {
+          for (const id of missingIds) {
+            nextMsg.parts.push(createSyntheticToolResultPart(id))
+          }
+          log("[tool-result-pair-validator] Injected missing tool_result parts", {
+            messageIndex: i + 1,
+            missingIds,
+          })
+        }
+      }
+    },
+  }
+}

--- a/src/hooks/tool-result-pair-validator/index.ts
+++ b/src/hooks/tool-result-pair-validator/index.ts
@@ -1,0 +1,1 @@
+export { createToolResultPairValidatorHook } from "./hook"

--- a/src/plugin/hooks/create-transform-hooks.ts
+++ b/src/plugin/hooks/create-transform-hooks.ts
@@ -5,6 +5,7 @@ import {
   createClaudeCodeHooksHook,
   createKeywordDetectorHook,
   createThinkingBlockValidatorHook,
+  createToolResultPairValidatorHook,
 } from "../../hooks"
 import {
   contextCollector,
@@ -17,6 +18,7 @@ export type TransformHooks = {
   keywordDetector: ReturnType<typeof createKeywordDetectorHook> | null
   contextInjectorMessagesTransform: ReturnType<typeof createContextInjectorMessagesTransformHook>
   thinkingBlockValidator: ReturnType<typeof createThinkingBlockValidatorHook> | null
+  toolResultPairValidator: ReturnType<typeof createToolResultPairValidatorHook> | null
 }
 
 export function createTransformHooks(args: {
@@ -63,10 +65,19 @@ export function createTransformHooks(args: {
       )
     : null
 
+  const toolResultPairValidator = isHookEnabled("tool-result-pair-validator")
+    ? safeCreateHook(
+        "tool-result-pair-validator",
+        () => createToolResultPairValidatorHook(),
+        { enabled: safeHookEnabled },
+      )
+    : null
+
   return {
     claudeCodeHooks,
     keywordDetector,
     contextInjectorMessagesTransform,
     thinkingBlockValidator,
+    toolResultPairValidator,
   }
 }

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -20,5 +20,9 @@ export function createMessagesTransformHandler(args: {
     await args.hooks.thinkingBlockValidator?.[
       "experimental.chat.messages.transform"
     ]?.(input, output)
+
+    await args.hooks.toolResultPairValidator?.[
+      "experimental.chat.messages.transform"
+    ]?.(input, output)
   }
 }


### PR DESCRIPTION
## Summary
- Add a proactive tool_use/tool_result pair validator as the final step in the `experimental.chat.messages.transform` pipeline to prevent API rejection errors in Plan mode.

## Problem
When compaction or context-window-limit-recovery removes a user message containing `tool_result` while keeping the preceding assistant message with `tool_use`, the Anthropic API rejects the request with:

```
messages.N: 'tool_use' ids were found without 'tool_result' blocks immediately after
```

The existing `session-recovery` hook handles this REACTIVELY (after the API error), but: the orphaned `tool_use` persists in the message history, causing the error on EVERY subsequent API call. Recovery only fixes the current failing message, not historical orphans.

## Fix
New `tool-result-pair-validator` hook that runs as the LAST step in `experimental.chat.messages.transform` (after context-injector and thinking-block-validator):

1. Scans all assistant messages for `tool_use` parts
2. Checks the next message has matching `tool_result` parts (handles both internal `type: "tool"` with `callID` and API `type: "tool_use"`/`type: "tool_result"` formats)
3. If tool_results are missing, injects synthetic cancelled tool_result parts
4. If no user message follows the assistant message, splices in a synthetic user message

This prevents the API error entirely — proactive instead of reactive.

## Changes
| File | Change |
|------|--------|
| `src/hooks/tool-result-pair-validator/hook.ts` | New hook: scans and fixes orphaned tool_use/tool_result pairs |
| `src/hooks/tool-result-pair-validator/index.ts` | Barrel export |
| `src/hooks/index.ts` | Export new hook factory |
| `src/config/schema/hooks.ts` | Register `tool-result-pair-validator` hook name |
| `src/plugin/hooks/create-transform-hooks.ts` | Create and wire the hook with `safeCreateHook` |
| `src/plugin/messages-transform.ts` | Run validator as the final transform step |

## Design Decisions
- **Runs LAST in the transform pipeline**: Validates the final message state after all other transforms (context injection, thinking block validation) have run
- **Handles both internal and API Part formats**: Checks `callID`, `id`, and `tool_use_id` fields to cover both OpenCode internal format and Anthropic API format
- **Configurable**: Can be disabled via `disabled_hooks: ["tool-result-pair-validator"]`
- **Follows existing patterns**: Same factory pattern, hook type, and registration flow as `thinking-block-validator`

Fixes #3014

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Anthropic API errors by validating and repairing `tool_use`/`tool_result` pairs before requests. Fixes #3014.

- **Bug Fixes**
  - Added `tool-result-pair-validator` as the last step in `experimental.chat.messages.transform` to ensure every assistant `tool_use` has a matching `tool_result` in the next user message.
  - Injects synthetic `tool_result` parts (and a synthetic user message when needed) to fix orphans caused by compaction or context-window recovery, preventing repeated API rejections.
  - Supports internal `type: "tool"`/`callID` and Anthropic `type: "tool_use"`/`type: "tool_result"` formats; can be disabled via `disabled_hooks: ["tool-result-pair-validator"]` and is wired into the transform pipeline.

<sup>Written for commit d65f036e2c0e06ba860dd76b134c328e26721a3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

