### PR TITLE
fix(models): mark gpt-4.1-mini and gpt-4.1-nano as supporting tool calls

### DIFF
--- a/src/generated/model-capabilities.generated.json
+++ b/src/generated/model-capabilities.generated.json
@@ -12113,7 +12113,7 @@
       "family": "gpt-nano",
       "reasoning": false,
       "temperature": true,
-      "toolCall": false,
+      "toolCall": true,
       "modalities": {
         "input": [
           "text",
@@ -12274,7 +12274,7 @@
       "family": "gpt-mini",
       "reasoning": false,
       "temperature": true,
-      "toolCall": false,
+      "toolCall": true,
       "modalities": {
         "input": [
           "text",

--- a/src/shared/model-capabilities-bundled-snapshot.test.ts
+++ b/src/shared/model-capabilities-bundled-snapshot.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+
+import { getBundledModelCapabilitiesSnapshot, getModelCapabilities } from "./model-capabilities"
+
+describe("bundled model capabilities snapshot", () => {
+  test("keeps GPT-4.1 OpenAI variants marked as supporting tool calls", () => {
+    // given
+    const bundledSnapshot = getBundledModelCapabilitiesSnapshot()
+    const modelIDs = [
+      "openai/gpt-4.1",
+      "openai/gpt-4.1-mini",
+      "openai/gpt-4.1-nano",
+    ]
+
+    // when
+    const results = modelIDs.map((modelID) =>
+      getModelCapabilities({
+        providerID: "openai",
+        modelID,
+        bundledSnapshot,
+      }),
+    )
+
+    // then
+    for (const result of results) {
+      expect(result.toolCall).toBe(true)
+      expect(result.diagnostics).toMatchObject({
+        resolutionMode: "snapshot-backed",
+        snapshot: { source: "bundled-snapshot" },
+        toolCall: { source: "bundled-snapshot" },
+      })
+    }
+  })
+})


### PR DESCRIPTION
Fixes #2923 — gpt-4.1-mini and gpt-4.1-nano were incorrectly marked as toolCall:false in the bundled model capabilities snapshot.

**Changes:**
- Set toolCall:true for gpt-nano and gpt-mini families in generated snapshot
- Added snapshot test verifying openai/gpt-4.1, gpt-4.1-mini, gpt-4.1-nano all have toolCall:true

**Tests:** 1 pass, 0 fail (new snapshot test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correctly marks `gpt-4.1-mini` and `gpt-4.1-nano` as supporting tool calls in the bundled model capabilities. Fixes #2923 so tool calls are enabled for these models.

- **Bug Fixes**
  - Set "toolCall": true for `gpt-nano` and `gpt-mini` families in `src/generated/model-capabilities.generated.json`.
  - Added a snapshot test to lock `openai/gpt-4.1`, `openai/gpt-4.1-mini`, and `openai/gpt-4.1-nano` to tool-call support with snapshot-backed diagnostics.

<sup>Written for commit 156c1f4aeba0f96e6a585be4b15990da25b36353. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

