### PR TITLE
fix(non-interactive-env): use detectShellType() instead of hardcoded unix (fixes #2344)

### DIFF
--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
-import { log, buildEnvPrefix, detectShellType } from "../../shared"
+import { log, buildEnvPrefix } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -52,8 +52,10 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
       // for git commands to prevent interactive prompts.
 
-      const shellType = detectShellType()
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
+      // Always use unix-style prefix: this hook only processes Bash tool commands
+      // (guarded by the tool check above), so the prefix must be bash-compatible
+      // regardless of the host OS shell (e.g., PowerShell on Windows).
+      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
       
       // Check if the command already starts with the prefix to avoid stacking.
       // This maintains the non-interactive behavior and makes the operation idempotent.

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -1,6 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
-import { log, buildEnvPrefix } from "../../shared"
+import { log, buildEnvPrefix, detectShellType } from "../../shared"
 
 export * from "./constants"
 export * from "./detector"
@@ -52,7 +52,8 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
       // for git commands to prevent interactive prompts.
 
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
+      const shellType = detectShellType()
+      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
       
       // Check if the command already starts with the prefix to avoid stacking.
       // This maintains the non-interactive behavior and makes the operation idempotent.


### PR DESCRIPTION
## Summary
- Replace hardcoded `"unix"` shell type with `detectShellType()` in `non-interactive-env` hook to fix Windows compatibility.

## Problem
`non-interactive-env-hook.ts` line 55 hardcodes `buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")` regardless of the actual OS. On Windows, this generates `export VAR=value;` syntax that is invalid for `cmd.exe` and PowerShell, causing all git commands to fail with `'export' is not recognized`.

The codebase already has `detectShellType()` in `src/shared/shell-env.ts` that correctly detects Unix/PowerShell/cmd and `buildEnvPrefix()` already handles all three shell types. The hook just wasn't using the detection.

## Fix
Import `detectShellType` from shared and call it at runtime instead of hardcoding `"unix"`. On Windows with PowerShell, this generates `$env:VAR='value';` syntax. On Windows with cmd.exe, this generates `set VAR="value" &&` syntax. On Unix, behavior is unchanged.

## Changes
| File | Change |
|------|--------|
| `src/hooks/non-interactive-env/non-interactive-env-hook.ts` | Import `detectShellType`, call it instead of hardcoded `"unix"` |

Fixes #2344

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows failures in the non-interactive env hook by always using a Bash-compatible env prefix for Bash tool commands. Prevents invalid `export` lines from reaching PowerShell/cmd while keeping Unix behavior unchanged. Fixes #2344.

- **Bug Fixes**
  - Force `buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")` in `non-interactive-env` and document the Bash-only scope.
  - Hook applies only to Bash tool commands, so PowerShell/cmd no longer receive invalid syntax.

<sup>Written for commit dda953df64cf1893f961da6776afa3297c9f1e98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

