### PR TITLE
fix(multimodal-looker): explicitly instruct agent to use Read tool for PDFs (fixes #2998)

### DIFF
--- a/src/agents/multimodal-looker.ts
+++ b/src/agents/multimodal-looker.ts
@@ -38,9 +38,13 @@ When NOT to use you:
 
 How you work:
 1. Receive a file path and a goal describing what to extract
-2. Read and analyze the file deeply
-3. Return ONLY the relevant extracted information
-4. The main agent never processes the raw file - you save context tokens
+2. ALWAYS call the Read tool on the file path first - it handles PDFs, images, and all file types
+3. Analyze the content returned by the Read tool
+4. Return ONLY the relevant extracted information
+5. The main agent never processes the raw file - you save context tokens
+
+CRITICAL: You MUST use the Read tool to access files. Do NOT claim you cannot read a file type.
+The Read tool supports PDFs (returns extracted text and page images), images, and all text formats.
 
 For PDFs: extract text, structure, tables, data from specific sections
 For images: describe layouts, UI elements, text, diagrams, charts

--- a/src/agents/multimodal-looker.ts
+++ b/src/agents/multimodal-looker.ts
@@ -38,13 +38,14 @@ When NOT to use you:
 
 How you work:
 1. Receive a file path and a goal describing what to extract
-2. ALWAYS call the Read tool on the file path first - it handles PDFs, images, and all file types
-3. Analyze the content returned by the Read tool
+2. If the Read tool is available in your tool set, call it on the file path first — it handles PDFs, images, and all file types
+3. If file content is already provided as an attachment (no Read tool available), analyze the attached content directly
 4. Return ONLY the relevant extracted information
-5. The main agent never processes the raw file - you save context tokens
+5. The main agent never processes the raw file — you save context tokens
 
-CRITICAL: You MUST use the Read tool to access files. Do NOT claim you cannot read a file type.
+When the Read tool is available, use it to access files. Do NOT claim you cannot read a file type.
 The Read tool supports PDFs (returns extracted text and page images), images, and all text formats.
+When file content is provided as an attachment instead, skip the Read step and analyze the content directly.
 
 For PDFs: extract text, structure, tables, data from specific sections
 For images: describe layouts, UI elements, text, diagrams, charts


### PR DESCRIPTION
## Summary
- Update Multimodal-Looker agent prompt to explicitly instruct it to use the Read tool for PDF files.

## Problem
The Multimodal-Looker agent fails to read PDF files, claiming the model doesn't support PDF parsing. The root cause is that the agent's prompt says "Read and analyze the file deeply" without explicitly telling the agent to call the Read tool. The model reasons about the file without actually invoking the tool, then incorrectly claims it cannot read PDFs.

The Read tool already supports PDFs (returns extracted text and page images as file attachments), and users confirmed that `look_at` (which uses the same Read tool internally) works fine for PDFs.

## Fix
Updated the agent prompt to:
1. Explicitly instruct the agent to ALWAYS call the Read tool first
2. Added a CRITICAL instruction that the Read tool handles PDFs, images, and all file types
3. Clarified the workflow steps to make tool usage mandatory rather than implied

## Changes
| File | Change |
|------|--------|
| `src/agents/multimodal-looker.ts` | Updated prompt: explicit Read tool usage instructions for PDFs |

Fixes #2998

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Multimodal-Looker prompt to call the `Read` tool for PDFs and other files when available, and analyze provided attachments directly when not. Ensures PDFs are parsed and keeps `look_at` workflow compatibility. Fixes #2998.

- **Bug Fixes**
  - Prompt now: call `Read` first if it's in the toolset (supports PDFs, images, all file types); if content is attached, skip `Read` and analyze the attachment.
  - Prevents false “unsupported file type” claims and avoids reasoning over raw files; agent extracts only relevant info from `Read` output or attachments.

<sup>Written for commit 959801c6ba4b0574aa63d6cde150a473fe24df00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

