### PR TITLE
fix(package): sync platform binary package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,17 +78,17 @@
     "typescript": "^5.7.3"
   },
   "optionalDependencies": {
-    "oh-my-opencode-darwin-arm64": "3.14.0",
-    "oh-my-opencode-darwin-x64": "3.14.0",
-    "oh-my-opencode-darwin-x64-baseline": "3.14.0",
-    "oh-my-opencode-linux-arm64": "3.14.0",
-    "oh-my-opencode-linux-arm64-musl": "3.14.0",
-    "oh-my-opencode-linux-x64": "3.14.0",
-    "oh-my-opencode-linux-x64-baseline": "3.14.0",
-    "oh-my-opencode-linux-x64-musl": "3.14.0",
-    "oh-my-opencode-linux-x64-musl-baseline": "3.14.0",
-    "oh-my-opencode-windows-x64": "3.14.0",
-    "oh-my-opencode-windows-x64-baseline": "3.14.0"
+    "oh-my-opencode-darwin-arm64": "3.14.1",
+    "oh-my-opencode-darwin-x64": "3.14.1",
+    "oh-my-opencode-darwin-x64-baseline": "3.14.1",
+    "oh-my-opencode-linux-arm64": "3.14.1",
+    "oh-my-opencode-linux-arm64-musl": "3.14.1",
+    "oh-my-opencode-linux-x64": "3.14.1",
+    "oh-my-opencode-linux-x64-baseline": "3.14.1",
+    "oh-my-opencode-linux-x64-musl": "3.14.1",
+    "oh-my-opencode-linux-x64-musl-baseline": "3.14.1",
+    "oh-my-opencode-windows-x64": "3.14.1",
+    "oh-my-opencode-windows-x64-baseline": "3.14.1"
   },
   "overrides": {
     "@opencode-ai/sdk": "^1.2.24"

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-arm64",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (darwin-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/darwin-x64-baseline/package.json
+++ b/packages/darwin-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-x64-baseline",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (darwin-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-darwin-x64",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (darwin-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/linux-arm64-musl/package.json
+++ b/packages/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-arm64-musl",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-arm64-musl)",
   "license": "MIT",
   "repository": {

--- a/packages/linux-arm64/package.json
+++ b/packages/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-arm64",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-arm64)",
   "license": "MIT",
   "repository": {

--- a/packages/linux-x64-baseline/package.json
+++ b/packages/linux-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-baseline",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/linux-x64-musl-baseline/package.json
+++ b/packages/linux-x64-musl-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-musl-baseline",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-musl-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/linux-x64-musl/package.json
+++ b/packages/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64-musl",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64-musl)",
   "license": "MIT",
   "repository": {

--- a/packages/linux-x64/package.json
+++ b/packages/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-linux-x64",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (linux-x64)",
   "license": "MIT",
   "repository": {

--- a/packages/windows-x64-baseline/package.json
+++ b/packages/windows-x64-baseline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-x64-baseline",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (windows-x64-baseline, no AVX2)",
   "license": "MIT",
   "repository": {

--- a/packages/windows-x64/package.json
+++ b/packages/windows-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-opencode-windows-x64",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Platform-specific binary for oh-my-opencode (windows-x64)",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- sync root optional platform binary dependency versions with the current package version
- update all platform package manifests from 3.14.0 to 3.14.1
- keep the dev branch version surface aligned with the publish workflow expectations

## Validation
- verified the root package version, optionalDependencies, and all platform package versions now match locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync all platform binary package versions to 3.14.1 across the repo to prevent install mismatches and keep dev in line with the publish workflow.

- **Dependencies**
  - Bumped root `optionalDependencies` for all `oh-my-opencode-*` platform binaries from 3.14.0 to 3.14.1.
  - Updated each platform package `package.json` to 3.14.1 (darwin, linux, windows; including baseline and musl variants).

<sup>Written for commit ccd4312a5745917c7ff8917f4c5314d1b70969d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

