### PR TITLE
docs: fix install guide model-matching link

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -460,7 +460,7 @@ Tell the user of following:
 
 3. **Need precision?** Press **Tab** to enter Prometheus (Planner) mode, create a work plan through an interview process, then run `/start-work` to execute it with full orchestration.
 
-4. You wanna have your own agent- catalog setup? I can read the [docs](docs/guide/agent-model-matching.md) and set up for you after interviewing!
+4. You wanna have your own agent- catalog setup? I can read the [docs](./agent-model-matching.md) and set up for you after interviewing!
 
 That's it. The agent will figure out the rest and handle everything automatically.
 


### PR DESCRIPTION
## Summary

- fix a broken relative link in `docs/guide/installation.md`
- point the install guide to the existing `agent-model-matching.md` file in the same directory

## Changes

- replace `docs/guide/agent-model-matching.md` with `./agent-model-matching.md` in the install guide so the link resolves correctly from the guide itself

## Related Issues

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the broken agent-model-matching link in `docs/guide/installation.md` by switching to `./agent-model-matching.md`. The link now works from the guide page in both GitHub and the built docs.

<sup>Written for commit b473593d5dfc94cf237f8f6c68d8791cb65f7f4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

