### PR TITLE
Revert tmux default isolation to inline

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -6002,7 +6002,7 @@
           "minimum": 20
         },
         "isolation": {
-          "default": "session",
+          "default": "inline",
           "type": "string",
           "enum": [
             "inline",

--- a/src/config/schema/tmux.test.ts
+++ b/src/config/schema/tmux.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+import { TmuxConfigSchema, TmuxIsolationSchema } from "./tmux"
+
+describe("TmuxIsolationSchema", () => {
+  describe('#given all supported isolation values', () => {
+    test('#when parsed #then it accepts inline, window, and session', () => {
+      expect(TmuxIsolationSchema.parse("inline")).toBe("inline")
+      expect(TmuxIsolationSchema.parse("window")).toBe("window")
+      expect(TmuxIsolationSchema.parse("session")).toBe("session")
+    })
+  })
+})
+
+describe("TmuxConfigSchema", () => {
+  describe('#given tmux isolation is omitted', () => {
+    test('#when parsed #then default isolation is inline', () => {
+      const result = TmuxConfigSchema.parse({})
+
+      expect(result.isolation).toBe("inline")
+    })
+  })
+})

--- a/src/config/schema/tmux.ts
+++ b/src/config/schema/tmux.ts
@@ -20,7 +20,7 @@ export const TmuxConfigSchema = z.object({
   main_pane_size: z.number().min(20).max(80).default(60),
   main_pane_min_width: z.number().min(40).default(120),
   agent_pane_min_width: z.number().min(20).default(40),
-  isolation: TmuxIsolationSchema.default("session"),
+  isolation: TmuxIsolationSchema.default("inline"),
 })
 
 export type TmuxConfig = z.infer<typeof TmuxConfigSchema>

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     main_pane_size: pluginConfig.tmux?.main_pane_size ?? 60,
     main_pane_min_width: pluginConfig.tmux?.main_pane_min_width ?? 120,
     agent_pane_min_width: pluginConfig.tmux?.agent_pane_min_width ?? 40,
-    isolation: pluginConfig.tmux?.isolation ?? "session",
+    isolation: pluginConfig.tmux?.isolation ?? "inline",
   }
 
   const modelCacheState = createModelCacheState()


### PR DESCRIPTION
## Summary
- revert the default tmux isolation to `inline` so patch upgrades preserve the pre-3.14.1 behavior
- keep `window` and `session` available, while adding a regression test for the safe default
- regenerate the published config schema so docs match runtime defaults

## Testing
- `bun run typecheck`
- `bun test`
- `bun run build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted the default `tmux` isolation to `inline` to preserve pre-3.14.1 behavior and avoid unexpected session-level isolation. Docs schema updated and tests added to guard the default.

- **Bug Fixes**
  - Set `tmux.isolation` default back to `inline` in schema and plugin fallback.
  - Kept `window` and `session` valid; added tests for allowed values and the default.
  - Regenerated `assets/oh-my-opencode.schema.json` so docs match runtime defaults.

<sup>Written for commit 6722b395ea5b6db240122dc19bb5f54c90fb9339. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

