### PR TITLE
Fix HTTP hook HTTPS enforcement gaps

### DIFF
--- a/src/hooks/claude-code-hooks/execute-http-hook-security.test.ts
+++ b/src/hooks/claude-code-hooks/execute-http-hook-security.test.ts
@@ -41,7 +41,7 @@ describe("executeHttpHook TLS security", () => {
       const result = await executeHttpHook(hook, "{}")
 
       expect(result.exitCode).toBe(1)
-      expect(result.stderr).toContain("HTTP hook URL must use HTTPS in production")
+      expect(result.stderr).toContain("HTTP hook URL must use HTTPS")
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
@@ -52,7 +52,7 @@ describe("executeHttpHook TLS security", () => {
       const result = await executeHttpHook(hook, "{}")
 
       expect(result.exitCode).toBe(1)
-      expect(result.stderr).toContain("HTTP hook URL must use HTTPS in production")
+      expect(result.stderr).toContain("HTTP hook URL must use HTTPS")
       expect(mockFetch).not.toHaveBeenCalled()
     })
 
@@ -108,14 +108,15 @@ describe("executeHttpHook TLS security", () => {
       process.env = { ...originalEnv, NODE_ENV: "development" }
     })
 
-    it("#when hook uses remote http:// URL #then allows execution", async () => {
+    it("#when hook uses remote http:// URL #then rejects with exit code 1", async () => {
       const { executeHttpHook } = await import("./execute-http-hook")
       const hook: HookHttp = { type: "http", url: "http://example.com/hooks" }
 
       const result = await executeHttpHook(hook, "{}")
 
-      expect(result.exitCode).toBe(0)
-      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain("HTTP hook URL must use HTTPS")
+      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it("#when hook uses http://localhost #then allows execution", async () => {
@@ -150,6 +151,59 @@ describe("executeHttpHook TLS security", () => {
       expect(mockLog).toHaveBeenCalledWith("HTTP hook URL uses insecure protocol", {
         url: "http://example.com/hooks",
       })
+    })
+
+    it("#when hook uses http://[::1] #then allows execution", async () => {
+      const { executeHttpHook } = await import("./execute-http-hook")
+      const hook: HookHttp = { type: "http", url: "http://[::1]:8080/hooks" }
+
+      const result = await executeHttpHook(hook, "{}")
+
+      expect(result.exitCode).toBe(0)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("#given NODE_ENV is unset", () => {
+    beforeEach(() => {
+      process.env = { ...originalEnv }
+      delete process.env.NODE_ENV
+    })
+
+    it("#when hook uses remote http:// URL #then rejects with exit code 1", async () => {
+      const { executeHttpHook } = await import("./execute-http-hook")
+      const hook: HookHttp = { type: "http", url: "http://example.com/hooks" }
+
+      const result = await executeHttpHook(hook, "{}")
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain("HTTP hook URL must use HTTPS")
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("#given redirect downgrade protection", () => {
+    beforeEach(() => {
+      process.env = { ...originalEnv, NODE_ENV: "production" }
+    })
+
+    it("#when hook uses https:// URL #then fetch uses manual redirect handling", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response("redirect", { status: 302, statusText: "Found" }))
+      )
+      const { executeHttpHook } = await import("./execute-http-hook")
+      const hook: HookHttp = { type: "http", url: "https://example.com/hooks" }
+
+      const result = await executeHttpHook(hook, "{}")
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain("HTTP hook returned status 302")
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://example.com/hooks",
+        expect.objectContaining({
+          redirect: "manual",
+        })
+      )
     })
   })
 

--- a/src/hooks/claude-code-hooks/execute-http-hook.ts
+++ b/src/hooks/claude-code-hooks/execute-http-hook.ts
@@ -4,13 +4,10 @@ import { log } from "../../shared"
 
 const DEFAULT_HTTP_HOOK_TIMEOUT_S = 30
 const ALLOWED_SCHEMES = new Set(["http:", "https:"])
-
-function isProduction(): boolean {
-  return process.env.NODE_ENV === "production"
-}
+const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"])
 
 function isLocalhost(url: URL): boolean {
-  return url.hostname === "localhost" || url.hostname === "127.0.0.1"
+  return LOCALHOST_HOSTNAMES.has(url.hostname)
 }
 
 function isPlainHttp(url: URL): boolean {
@@ -68,10 +65,10 @@ export async function executeHttpHook(
 
   if (isPlainHttp(parsed)) {
     log("HTTP hook URL uses insecure protocol", { url: hook.url })
-    if (isProduction() && !isLocalhost(parsed)) {
+    if (!isLocalhost(parsed)) {
       return {
         exitCode: 1,
-        stderr: "HTTP hook URL must use HTTPS in production. Plain HTTP is only allowed for localhost/127.0.0.1.",
+        stderr: "HTTP hook URL must use HTTPS. Plain HTTP is only allowed for localhost, 127.0.0.1, and ::1.",
       }
     }
   }
@@ -84,6 +81,7 @@ export async function executeHttpHook(
       method: "POST",
       headers,
       body: stdin,
+      redirect: "manual",
       signal: AbortSignal.timeout(timeoutS * 1000),
     })
 


### PR DESCRIPTION
## Summary
Tighten HTTP hook transport enforcement so non-loopback remote hooks always require HTTPS, even when `NODE_ENV` is unset or non-production.
Block redirect-based protocol downgrade attempts and preserve local development exceptions for `localhost`, `127.0.0.1`, and IPv6 loopback.

## Changes
- add TDD coverage for unset `NODE_ENV`, redirect downgrade handling, and `http://[::1]` localhost allowance
- reject all non-loopback plain HTTP hook URLs regardless of environment and keep warning logs for blocked URLs
- set `redirect: "manual"` on hook fetches to avoid following HTTPS-to-HTTP redirects

## Testing
- `bun run typecheck` ✅
- `bun test` ✅
- `bun run build` ✅

## Related Issues
- N/A


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces HTTPS for all non-loopback HTTP hooks in every environment and blocks HTTPS-to-HTTP redirect downgrades. Local development remains allowed for `localhost`, `127.0.0.1`, and `::1`.

- **Bug Fixes**
  - Reject plain HTTP for remote hooks regardless of `NODE_ENV`; allow `localhost`, `127.0.0.1`, `::1`/`[::1]`.
  - Use fetch with `redirect: "manual"` and surface 3xx to prevent HTTPS→HTTP downgrades.
  - Add tests for unset `NODE_ENV`, redirect handling, and IPv6 loopback; update error message and keep warning logs.

<sup>Written for commit 3eb1430a43ffe20987edd935c07887fd003b96e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

