### PR TITLE
fix: revert tmux default isolation to inline

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -6002,7 +6002,7 @@
           "minimum": 20
         },
         "isolation": {
-          "default": "session",
+          "default": "inline",
           "type": "string",
           "enum": [
             "inline",

--- a/src/config/schema/tmux.test.ts
+++ b/src/config/schema/tmux.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+import { TmuxConfigSchema, TmuxIsolationSchema } from "./tmux"
+
+describe("TmuxIsolationSchema", () => {
+  describe('#given all supported isolation values', () => {
+    test('#when parsed #then it accepts inline, window, and session', () => {
+      expect(TmuxIsolationSchema.parse("inline")).toBe("inline")
+      expect(TmuxIsolationSchema.parse("window")).toBe("window")
+      expect(TmuxIsolationSchema.parse("session")).toBe("session")
+    })
+  })
+})
+
+describe("TmuxConfigSchema", () => {
+  describe('#given tmux isolation is omitted', () => {
+    test('#when parsed #then default isolation is inline', () => {
+      const result = TmuxConfigSchema.parse({})
+
+      expect(result.isolation).toBe("inline")
+    })
+  })
+})

--- a/src/config/schema/tmux.ts
+++ b/src/config/schema/tmux.ts
@@ -20,7 +20,7 @@ export const TmuxConfigSchema = z.object({
   main_pane_size: z.number().min(20).max(80).default(60),
   main_pane_min_width: z.number().min(40).default(120),
   agent_pane_min_width: z.number().min(20).default(40),
-  isolation: TmuxIsolationSchema.default("session"),
+  isolation: TmuxIsolationSchema.default("inline"),
 })
 
 export type TmuxConfig = z.infer<typeof TmuxConfigSchema>

--- a/src/create-runtime-tmux-config.test.ts
+++ b/src/create-runtime-tmux-config.test.ts
@@ -1,0 +1,17 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+import { TmuxConfigSchema } from "./config/schema/tmux"
+import { createRuntimeTmuxConfig } from "./create-runtime-tmux-config"
+
+describe("createRuntimeTmuxConfig", () => {
+  describe("#given tmux isolation is omitted from plugin config", () => {
+    test("#when runtime tmux config is created #then it matches the schema default", () => {
+      const runtimeTmuxConfig = createRuntimeTmuxConfig({})
+      const schemaDefault = TmuxConfigSchema.parse({}).isolation
+
+      expect(runtimeTmuxConfig.isolation).toBe(schemaDefault)
+    })
+  })
+})

--- a/src/create-runtime-tmux-config.ts
+++ b/src/create-runtime-tmux-config.ts
@@ -1,0 +1,6 @@
+import type { OhMyOpenCodeConfig, TmuxConfig } from "./config"
+import { TmuxConfigSchema } from "./config/schema/tmux"
+
+export function createRuntimeTmuxConfig(pluginConfig: { tmux?: OhMyOpenCodeConfig["tmux"] }): TmuxConfig {
+  return TmuxConfigSchema.parse(pluginConfig.tmux ?? {})
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
     main_pane_size: pluginConfig.tmux?.main_pane_size ?? 60,
     main_pane_min_width: pluginConfig.tmux?.main_pane_min_width ?? 120,
     agent_pane_min_width: pluginConfig.tmux?.agent_pane_min_width ?? 40,
-    isolation: pluginConfig.tmux?.isolation ?? "session",
+    isolation: pluginConfig.tmux?.isolation ?? "inline",
   }
 
   const modelCacheState = createModelCacheState()

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type { HookName } from "./config"
 
 import { createHooks } from "./create-hooks"
 import { createManagers } from "./create-managers"
+import { createRuntimeTmuxConfig } from "./create-runtime-tmux-config"
 import { createTools } from "./create-tools"
 import { createPluginInterface } from "./plugin-interface"
 import { createPluginDispose, type PluginDispose } from "./plugin-dispose"
@@ -45,14 +46,7 @@ const OhMyOpenCodePlugin: Plugin = async (ctx) => {
 
   const firstMessageVariantGate = createFirstMessageVariantGate()
 
-  const tmuxConfig = {
-    enabled: pluginConfig.tmux?.enabled ?? false,
-    layout: pluginConfig.tmux?.layout ?? "main-vertical",
-    main_pane_size: pluginConfig.tmux?.main_pane_size ?? 60,
-    main_pane_min_width: pluginConfig.tmux?.main_pane_min_width ?? 120,
-    agent_pane_min_width: pluginConfig.tmux?.agent_pane_min_width ?? 40,
-    isolation: pluginConfig.tmux?.isolation ?? "inline",
-  }
+  const tmuxConfig = createRuntimeTmuxConfig(pluginConfig)
 
   const modelCacheState = createModelCacheState()
 


### PR DESCRIPTION
## Summary
Reverts tmux default isolation from "session" to "inline" to avoid breaking UX change in patch release.

## Changes
- Changed default isolation from "session" to "inline" in `src/config/schema/tmux.ts`
- Aligned runtime fallback in `src/index.ts`
- Added regression test in `src/config/schema/tmux.test.ts`
- Regenerated schema

## Testing
- `bun run typecheck` ✅
- `bun test` ✅
- `bun run build` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts tmux default isolation to "inline" and derives runtime config from schema defaults to prevent a breaking change and keep behavior consistent. Adds tests to lock in the defaults.

- **Bug Fixes**
  - Set default isolation to "inline" in schema; regenerated `assets/oh-my-opencode.schema.json`.
  - Introduced `createRuntimeTmuxConfig` to use schema defaults for runtime; updated `src/index.ts` to use it.
  - Added tests for isolation enum and default (`src/config/schema/tmux.test.ts`) and runtime parity with schema (`src/create-runtime-tmux-config.test.ts`).

<sup>Written for commit 6ca046c12b9e10afb0ba93ac0919d60c7c8564e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

