### PR TITLE
Fix Claude user rule skipping for disabled hooks

### DIFF
--- a/src/plugin/hooks/create-tool-guard-hooks.test.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+import type { OhMyOpenCodeConfig } from "../../config"
+import type { ModelCacheState } from "../../plugin-state"
+import type { PluginContext } from "../types"
+
+const mockContext = {
+  directory: "/tmp",
+} as PluginContext
+
+const mockModelCacheState = {
+  anthropicContext1MEnabled: false,
+} satisfies ModelCacheState
+
+let capturedRulesInjectorOptions: { skipClaudeUserRules?: boolean } | undefined
+
+mock.module("../../hooks", () => ({
+  createCommentCheckerHooks: () => ({ name: "comment-checker" }),
+  createToolOutputTruncatorHook: () => ({ name: "tool-output-truncator" }),
+  createDirectoryAgentsInjectorHook: () => ({ name: "directory-agents-injector" }),
+  createDirectoryReadmeInjectorHook: () => ({ name: "directory-readme-injector" }),
+  createEmptyTaskResponseDetectorHook: () => ({ name: "empty-task-response-detector" }),
+  createRulesInjectorHook: (
+    _ctx: PluginContext,
+    _modelCacheState: ModelCacheState,
+    options?: { skipClaudeUserRules?: boolean },
+  ) => {
+    capturedRulesInjectorOptions = options
+    return { name: "rules-injector" }
+  },
+  createTasksTodowriteDisablerHook: () => ({ name: "tasks-todowrite-disabler" }),
+  createWriteExistingFileGuardHook: () => ({ name: "write-existing-file-guard" }),
+  createBashFileReadGuardHook: () => ({ name: "bash-file-read-guard" }),
+  createHashlineReadEnhancerHook: () => ({ name: "hashline-read-enhancer" }),
+  createReadImageResizerHook: () => ({ name: "read-image-resizer" }),
+  createJsonErrorRecoveryHook: () => ({ name: "json-error-recovery" }),
+  createTodoDescriptionOverrideHook: () => ({ name: "todo-description-override" }),
+  createWebFetchRedirectGuardHook: () => ({ name: "webfetch-redirect-guard" }),
+}))
+
+describe("createToolGuardHooks", () => {
+  beforeEach(() => {
+    capturedRulesInjectorOptions = undefined
+  })
+
+  it("skips Claude user rules when claude_code.hooks is false", async () => {
+    // given
+    const pluginConfig = {
+      claude_code: {
+        hooks: false,
+      },
+    } as OhMyOpenCodeConfig
+    const { createToolGuardHooks } = await import("./create-tool-guard-hooks")
+
+    // when
+    createToolGuardHooks({
+      ctx: mockContext,
+      pluginConfig,
+      modelCacheState: mockModelCacheState,
+      isHookEnabled: (hookName) => hookName === "rules-injector",
+      safeHookEnabled: true,
+    })
+
+    // then
+    expect(capturedRulesInjectorOptions).toEqual({ skipClaudeUserRules: true })
+  })
+})

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -92,14 +92,11 @@ export function createToolGuardHooks(args: {
     : null
 
   const cc = pluginConfig.claude_code
-  const claudeCodeDisabled = cc != null
-    && cc.hooks === false
-    && cc.skills === false
-    && cc.agents === false
+  const skipClaudeUserRules = cc?.hooks === false
   const rulesInjector = isHookEnabled("rules-injector")
     ? safeHook("rules-injector", () =>
         createRulesInjectorHook(ctx, modelCacheState, {
-          skipClaudeUserRules: claudeCodeDisabled ?? false,
+          skipClaudeUserRules,
         }))
     : null
 


### PR DESCRIPTION
## Summary
- Make `claude_code.hooks=false` skip loading `~/.claude/rules` without requiring `skills` or `agents` to also be disabled.
- Add a regression test that locks the tool-guard wiring to this hooks-only behavior.

## Testing
- `bun test src/plugin/hooks/create-tool-guard-hooks.test.ts`
- `bun run typecheck`
- `bun run build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `claude_code.hooks=false` skips loading `~/.claude/rules` without requiring `skills` or `agents` to be disabled. Aligns with Linear P2-15.

- **Bug Fixes**
  - Set `skipClaudeUserRules` based solely on `claude_code.hooks`.
  - Added a regression test to verify `rules-injector` receives `{ skipClaudeUserRules: true }` when hooks are disabled.

<sup>Written for commit 6dc21b3b7f650c3ef90cce1bf4cd18f705c3ae0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

