### PR TITLE
Double displayed context window counts

### DIFF
--- a/src/hooks/context-window-monitor.model-context-limits.test.ts
+++ b/src/hooks/context-window-monitor.model-context-limits.test.ts
@@ -86,8 +86,8 @@ describe("context-window-monitor modelContextLimitsCache", () => {
 
     // then
     expect(output.output).toContain("context remaining")
-    expect(output.output).toContain("262,144-token context window")
-    expect(output.output).toContain("[Context Status: 72.5% used (190,000/262,144 tokens), 27.5% remaining]")
+    expect(output.output).toContain("524,288-token context window")
+    expect(output.output).toContain("[Context Status: 72.5% used (380,000/524,288 tokens), 27.5% remaining]")
     expect(output.output).not.toContain("1,000,000")
   })
 
@@ -217,7 +217,7 @@ describe("context-window-monitor modelContextLimitsCache", () => {
 
         // then — 360K/500K = 72%, above 70% threshold, uses cached 500K limit
         expect(output.output).toContain("context remaining")
-        expect(output.output).toContain("500,000-token context window")
+        expect(output.output).toContain("1,000,000-token context window")
       })
     })
   })
@@ -262,7 +262,7 @@ describe("context-window-monitor modelContextLimitsCache", () => {
 
         // then
         expect(output.output).toContain("context remaining")
-        expect(output.output).toContain("200,000-token context window")
+        expect(output.output).toContain("400,000-token context window")
       })
     })
   })

--- a/src/hooks/context-window-monitor.test.ts
+++ b/src/hooks/context-window-monitor.test.ts
@@ -106,7 +106,7 @@ describe("context-window-monitor", () => {
   // #given token usage exceeds 70% threshold
   // #when tool.execute.after is called
   // #then context reminder should be appended to output
-  it("should append context reminder when usage exceeds threshold", async () => {
+  it("should append context reminder with doubled displayed counts when usage exceeds threshold", async () => {
     const hook = createContextWindowMonitorHook(ctx as never)
     const sessionID = "ses_high_usage"
 

--- a/src/hooks/context-window-monitor.test.ts
+++ b/src/hooks/context-window-monitor.test.ts
@@ -138,6 +138,8 @@ describe("context-window-monitor", () => {
     )
 
     expect(output.output).toContain("context remaining")
+    expect(output.output).toContain("400,000-token context window")
+    expect(output.output).toContain("[Context Status: 80.0% used (320,000/400,000 tokens), 20.0% remaining]")
     expect(ctx.client.session.messages).not.toHaveBeenCalled()
   })
 

--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -6,13 +6,14 @@ import {
 import { createSystemDirective, SystemDirectiveTypes } from "../shared/system-directive"
 
 const CONTEXT_WARNING_THRESHOLD = 0.70
+const DISPLAY_TOKEN_COUNT_MULTIPLIER = 2
 
-function toDisplayedTokenCount(actualTokenCount: number): number {
-  return actualTokenCount * 2
+function toDisplayTokenCount(actualTokenCount: number): number {
+  return actualTokenCount * DISPLAY_TOKEN_COUNT_MULTIPLIER
 }
 
 function createContextReminder(actualLimit: number): string {
-  const limitTokens = toDisplayedTokenCount(actualLimit).toLocaleString()
+  const limitTokens = toDisplayTokenCount(actualLimit).toLocaleString()
 
   return `${createSystemDirective(SystemDirectiveTypes.CONTEXT_WINDOW_MONITOR)}
 
@@ -71,8 +72,8 @@ export function createContextWindowMonitorHook(
 
     const usedPct = (actualUsagePercentage * 100).toFixed(1)
     const remainingPct = ((1 - actualUsagePercentage) * 100).toFixed(1)
-    const usedTokens = toDisplayedTokenCount(totalInputTokens).toLocaleString()
-    const limitTokens = toDisplayedTokenCount(actualLimit).toLocaleString()
+    const usedTokens = toDisplayTokenCount(totalInputTokens).toLocaleString()
+    const limitTokens = toDisplayTokenCount(actualLimit).toLocaleString()
 
     output.output += `\n\n${createContextReminder(actualLimit)}
 [Context Status: ${usedPct}% used (${usedTokens}/${limitTokens} tokens), ${remainingPct}% remaining]`

--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -7,8 +7,12 @@ import { createSystemDirective, SystemDirectiveTypes } from "../shared/system-di
 
 const CONTEXT_WARNING_THRESHOLD = 0.70
 
+function toDisplayedTokenCount(actualTokenCount: number): number {
+  return actualTokenCount * 2
+}
+
 function createContextReminder(actualLimit: number): string {
-  const limitTokens = actualLimit.toLocaleString()
+  const limitTokens = toDisplayedTokenCount(actualLimit).toLocaleString()
 
   return `${createSystemDirective(SystemDirectiveTypes.CONTEXT_WINDOW_MONITOR)}
 
@@ -67,8 +71,8 @@ export function createContextWindowMonitorHook(
 
     const usedPct = (actualUsagePercentage * 100).toFixed(1)
     const remainingPct = ((1 - actualUsagePercentage) * 100).toFixed(1)
-    const usedTokens = totalInputTokens.toLocaleString()
-    const limitTokens = actualLimit.toLocaleString()
+    const usedTokens = toDisplayedTokenCount(totalInputTokens).toLocaleString()
+    const limitTokens = toDisplayedTokenCount(actualLimit).toLocaleString()
 
     output.output += `\n\n${createContextReminder(actualLimit)}
 [Context Status: ${usedPct}% used (${usedTokens}/${limitTokens} tokens), ${remainingPct}% remaining]`


### PR DESCRIPTION
## Summary
Display doubled token counts in the context window monitor while keeping the actual warning threshold unchanged.

## Changes
- double the user-facing context window limit display in the monitor reminder
- double the displayed used token count in the context status line
- update monitor tests to assert the new displayed values

## Testing
- `bun run typecheck` ✅
- `bun test` ✅
- `bun run build` ✅

## Related Issues
- None

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Double the user-facing context window token counts in the reminder and status line, using a display multiplier while keeping the 70% warning threshold unchanged. Updated tests and expectations (including cached limit scenarios) to assert doubled limits and used tokens.

<sup>Written for commit 5b3541f7aadd4bc58679af2c8f1bc905d5e655cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

