### PR TITLE
fix(boulder-state): count only top-level checkboxes in getPlanProgress (fixes #3066)

### DIFF
--- a/src/features/boulder-state/storage.test.ts
+++ b/src/features/boulder-state/storage.test.ts
@@ -399,8 +399,8 @@ describe("boulder-state", () => {
       expect(progress.isComplete).toBe(false)
     })
 
-    test("should count space-indented unchecked checkbox", () => {
-      // given - plan file with a two-space indented checkbox
+    test("should not count space-indented unchecked checkbox", () => {
+      // given - plan file with a two-space indented checkbox (not top-level)
       const planPath = join(TEST_DIR, "space-indented-plan.md")
       writeFileSync(planPath, `# Plan
   - [ ] indented task
@@ -409,14 +409,14 @@ describe("boulder-state", () => {
       // when
       const progress = getPlanProgress(planPath)
 
-      // then
-      expect(progress.total).toBe(1)
+      // then - indented checkboxes are ignored to match readCurrentTopLevelTask semantics
+      expect(progress.total).toBe(0)
       expect(progress.completed).toBe(0)
       expect(progress.isComplete).toBe(false)
     })
 
-    test("should count tab-indented unchecked checkbox", () => {
-      // given - plan file with a tab-indented checkbox
+    test("should not count tab-indented unchecked checkbox", () => {
+      // given - plan file with a tab-indented checkbox (not top-level)
       const planPath = join(TEST_DIR, "tab-indented-plan.md")
       writeFileSync(planPath, `# Plan
 	- [ ] tab-indented task
@@ -425,13 +425,13 @@ describe("boulder-state", () => {
       // when
       const progress = getPlanProgress(planPath)
 
-      // then
-      expect(progress.total).toBe(1)
+      // then - indented checkboxes are ignored to match readCurrentTopLevelTask semantics
+      expect(progress.total).toBe(0)
       expect(progress.completed).toBe(0)
       expect(progress.isComplete).toBe(false)
     })
 
-    test("should count mixed top-level checked and indented unchecked checkboxes", () => {
+    test("should count only top-level checkbox and ignore indented unchecked checkbox", () => {
       // given - plan file with checked top-level and unchecked indented task
       const planPath = join(TEST_DIR, "mixed-indented-plan.md")
       writeFileSync(planPath, `# Plan
@@ -442,14 +442,14 @@ describe("boulder-state", () => {
       // when
       const progress = getPlanProgress(planPath)
 
-      // then
-      expect(progress.total).toBe(2)
+      // then - only the top-level checkbox is counted
+      expect(progress.total).toBe(1)
       expect(progress.completed).toBe(1)
-      expect(progress.isComplete).toBe(false)
+      expect(progress.isComplete).toBe(true)
     })
 
-    test("should count space-indented completed checkbox", () => {
-      // given - plan file with a two-space indented completed checkbox
+    test("should not count space-indented completed checkbox", () => {
+      // given - plan file with a two-space indented completed checkbox (not top-level)
       const planPath = join(TEST_DIR, "indented-completed-plan.md")
       writeFileSync(planPath, `# Plan
   - [x] indented completed task
@@ -458,10 +458,10 @@ describe("boulder-state", () => {
       // when
       const progress = getPlanProgress(planPath)
 
-      // then
-      expect(progress.total).toBe(1)
-      expect(progress.completed).toBe(1)
-      expect(progress.isComplete).toBe(true)
+      // then - indented checkboxes are ignored to match readCurrentTopLevelTask semantics
+      expect(progress.total).toBe(0)
+      expect(progress.completed).toBe(0)
+      expect(progress.isComplete).toBe(false)
     })
 
     test("should return isComplete true when all checked", () => {

--- a/src/features/boulder-state/storage.ts
+++ b/src/features/boulder-state/storage.ts
@@ -176,9 +176,11 @@ export function getPlanProgress(planPath: string): PlanProgress {
   try {
     const content = readFileSync(planPath, "utf-8")
     
-    // Match markdown checkboxes: - [ ] or - [x] or - [X]
-    const uncheckedMatches = content.match(/^\s*[-*]\s*\[\s*\]/gm) || []
-    const checkedMatches = content.match(/^\s*[-*]\s*\[[xX]\]/gm) || []
+    // Match only top-level markdown checkboxes (no leading whitespace).
+    // Nested checkboxes (e.g. under Acceptance Criteria) are excluded
+    // to align with readCurrentTopLevelTask() semantics.
+    const uncheckedMatches = content.match(/^[-*]\s*\[\s*\]/gm) || []
+    const checkedMatches = content.match(/^[-*]\s*\[[xX]\]/gm) || []
 
     const total = uncheckedMatches.length + checkedMatches.length
     const completed = checkedMatches.length


### PR DESCRIPTION
## Summary
- Fix `getPlanProgress()` to count only top-level checkboxes, aligning with `readCurrentTopLevelTask()` semantics.

## Problem
`getPlanProgress()` uses `^\s*[-*]\s*\[\s*\]` regex which matches checkboxes at **any** indentation level. This causes nested checkboxes (e.g. under Acceptance Criteria sections) to inflate the total count. A plan with 9 completed top-level tasks and 19 unchecked nested criteria shows as `9/28` instead of `9/9`.

Meanwhile, `readCurrentTopLevelTask()` in `top-level-task.ts` already correctly skips indented checkboxes (`if (uncheckedTaskMatch[1].length > 0) continue`). The two functions disagree on what constitutes a "task".

## Fix
Removed the `\s*` prefix from both checkbox regexes in `getPlanProgress()`. Now only checkboxes with no leading whitespace (top-level tasks) are counted, matching `readCurrentTopLevelTask()` behavior.

## Changes
| File | Change |
|------|--------|
| `src/features/boulder-state/storage.ts` | Changed regex from `^\s*[-*]` to `^[-*]` for both checked/unchecked patterns |

Fixes #3066

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3066 by counting only top-level checkboxes so nested items no longer affect plan progress. Aligns progress with how we read the current top-level task.

- **Bug Fixes**
  - Updated regex in src/features/boulder-state/storage.ts to require no leading whitespace for both checked and unchecked items; updated storage tests to assert space/tab-indented checkboxes are ignored and mixed cases count only the top-level item.

<sup>Written for commit cc88080e53f1b41adbb6bb27377a87f19bbe39e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

