### PR TITLE
fix(agent-usage-reminder): cap reminders at 3 to reduce token waste (fixes #2994)

### DIFF
--- a/src/hooks/agent-usage-reminder/hook.ts
+++ b/src/hooks/agent-usage-reminder/hook.ts
@@ -41,6 +41,8 @@ const ORCHESTRATOR_AGENTS = new Set([
   "prometheus",
 ]);
 
+const MAX_REMINDERS = 3;
+
 function isOrchestratorAgent(agentName: string): boolean {
   return ORCHESTRATOR_AGENTS.has(getAgentConfigKey(agentName));
 }
@@ -99,6 +101,10 @@ export function createAgentUsageReminderHook(_ctx: PluginInput) {
     const state = getOrCreateState(sessionID);
 
     if (state.agentUsed) {
+      return;
+    }
+
+    if (state.reminderCount >= MAX_REMINDERS) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Cap agent usage reminder injections at 3 per session to prevent token waste from repeated blocks.

## Problem
The `agent-usage-reminder` hook appends a ~250-token reminder to every target tool output (grep, read, bash, etc.) until the user delegates to an agent. In sessions with 30-50 tool calls before delegation, this adds 7.5-12.5K tokens of duplicated content. The hook already tracks `reminderCount` via `state.reminderCount++` but never checks it as a limit.

## Fix
Added a `MAX_REMINDERS = 3` constant and a guard `if (state.reminderCount >= MAX_REMINDERS) return` before appending the reminder. After 3 reminders, the hook stops injecting even if the user hasn't delegated yet. This preserves the educational nudge while preventing context exhaustion.

Note: the `category-skill-reminder` hook already has a one-shot guard (`reminderShown`). This fix aligns the agent-usage-reminder with the same deduplication pattern.

## Changes
| File | Change |
|------|--------|
| `src/hooks/agent-usage-reminder/hook.ts` | Add `MAX_REMINDERS = 3` constant and guard check before injection |

Fixes #2994

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit agent usage reminders to 3 per session to stop repeated 250‑token blocks and reduce token waste in long sessions. Fixes #2994.

<sup>Written for commit 8d784ceccf7005b11e209c52c747f1b6365d90c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

