### PR TITLE
refactor(plugin): remove AI slop and clean comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,14 +21,12 @@ import { startTmuxCheck } from "./tools"
 let activePluginDispose: PluginDispose | null = null
 
 const OhMyOpenCodePlugin: Plugin = async (ctx) => {
-  // Initialize config context for plugin runtime (prevents warnings from hooks)
   initConfigContext("opencode", null)
   log("[OhMyOpenCodePlugin] ENTRY - plugin loading", {
     directory: ctx.directory,
   })
   logLegacyPluginStartupWarning()
 
-  // Detect conflicting skill plugins (e.g., opencode-skills)
   const skillPluginCheck = detectExternalSkillPlugin(ctx.directory)
   if (skillPluginCheck.detected && skillPluginCheck.pluginName) {
     console.warn(getSkillPluginConflictWarning(skillPluginCheck.pluginName))
@@ -126,7 +124,4 @@ export type {
   BuiltinCommandName,
 } from "./config"
 
-// NOTE: Do NOT export functions from main index.ts!
-// OpenCode treats ALL exports as plugin instances and calls them.
-// Config error utilities are available via "./shared/config-errors" for internal use only.
 export type { ConfigLoadError } from "./shared/config-errors"

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -38,7 +38,6 @@ export async function applyCommandConfig(params: {
   const includeClaudeCommands = params.pluginConfig.claude_code?.commands ?? true;
   const includeClaudeSkills = params.pluginConfig.claude_code?.skills ?? true;
 
-  // Detect conflicting skill plugins
   const externalSkillPlugin = detectExternalSkillPlugin(params.ctx.directory);
   if (includeClaudeSkills && externalSkillPlugin.detected) {
     log(getSkillPluginConflictWarning(externalSkillPlugin.pluginName!));

--- a/src/plugin-handlers/mcp-config-handler.ts
+++ b/src/plugin-handlers/mcp-config-handler.ts
@@ -6,6 +6,10 @@ import { log } from "../shared";
 
 type McpEntry = Record<string, unknown>;
 
+function isDisabledMcpEntry(value: unknown): value is McpEntry & { enabled: false } {
+  return typeof value === "object" && value !== null && (value as McpEntry).enabled === false;
+}
+
 function captureUserDisabledMcps(
   userMcp: Record<string, unknown> | undefined
 ): Set<string> {
@@ -13,12 +17,7 @@ function captureUserDisabledMcps(
   if (!userMcp) return disabled;
 
   for (const [name, value] of Object.entries(userMcp)) {
-    if (
-      value &&
-      typeof value === "object" &&
-      "enabled" in value &&
-      (value as McpEntry).enabled === false
-    ) {
+    if (isDisabledMcpEntry(value)) {
       disabled.add(name);
     }
   }

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -153,8 +153,6 @@ export function createSessionHooks(args: {
     }
   }
 
-  // Model fallback hook (configurable via model_fallback config + disabled_hooks)
-  // This handles automatic model switching when model errors occur
   const isModelFallbackConfigEnabled = pluginConfig.model_fallback ?? false
   const modelFallback = isModelFallbackConfigEnabled && isHookEnabled("model-fallback")
     ? safeHook("model-fallback", () =>

--- a/src/plugin/normalize-tool-arg-schemas.ts
+++ b/src/plugin/normalize-tool-arg-schemas.ts
@@ -41,7 +41,6 @@ export function normalizeToolArgSchemas<TDefinition extends Pick<ToolDefinition,
   return toolDefinition
 }
 
-// Schema keywords unsupported by Gemini — strip them from MCP tool schemas
 const UNSUPPORTED_SCHEMA_KEYWORDS = new Set(["contentEncoding", "contentMediaType"])
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/plugin/ultrawork-db-model-override.test.ts
+++ b/src/plugin/ultrawork-db-model-override.test.ts
@@ -126,7 +126,7 @@ describe("scheduleDeferredModelOverride", () => {
   })
 
   test("should fall back to setTimeout when message never appears", async () => {
-    //#given — no message inserted
+    //#given no message inserted
 
     //#when
     const { scheduleDeferredModelOverride } = await import("./ultrawork-db-model-override")


### PR DESCRIPTION
Removes AI slop from plugin handlers, plugin-handlers, and root src entry point comments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed verbose comments across plugin files and added a small type guard for MCP config parsing. No behavior changes; this improves readability and clarity.

- **Refactors**
  - Added `isDisabledMcpEntry` helper in MCP config handler to detect disabled entries.
  - Removed redundant comments in `src/index.ts`, handlers, hooks, and schema utils.
  - Cleaned a test comment in `ultrawork-db-model-override.test.ts`.

<sup>Written for commit 66cc823ff33a870169fe8ea06f9833bf3061390a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

