### PR TITLE
fix: propagate variant field in all promptAsync continuation paths

### DIFF
--- a/src/hooks/atlas/boulder-continuation-injector.ts
+++ b/src/hooks/atlas/boulder-continuation-injector.ts
@@ -70,11 +70,17 @@ export async function injectBoulderContinuation(input: {
     const promptContext = await resolveRecentPromptContextForSession(ctx, sessionID)
     const inheritedTools = resolveInheritedPromptTools(sessionID, promptContext.tools)
 
-		await ctx.client.session.promptAsync({
+		const launchModel = promptContext.model
+        ? { providerID: promptContext.model.providerID, modelID: promptContext.model.modelID }
+        : undefined
+    const launchVariant = promptContext.model?.variant
+
+    await ctx.client.session.promptAsync({
 			path: { id: sessionID },
 			body: {
 				agent: normalizeAgentForPrompt(continuationAgent) ?? continuationAgent,
-				...(promptContext.model !== undefined ? { model: promptContext.model } : {}),
+				...(launchModel ? { model: launchModel } : {}),
+				...(launchVariant ? { variant: launchVariant } : {}),
 				...(inheritedTools ? { tools: inheritedTools } : {}),
         parts: [createInternalAgentTextPart(prompt)],
       },

--- a/src/hooks/atlas/recent-model-resolver.ts
+++ b/src/hooks/atlas/recent-model-resolver.ts
@@ -31,7 +31,7 @@ export async function resolveRecentPromptContextForSession(
       const model = info?.model
       const tools = normalizePromptTools(info?.tools)
       if (model?.providerID && model?.modelID) {
-        return { model: { providerID: model.providerID, modelID: model.modelID }, tools }
+        return { model: { providerID: model.providerID, modelID: model.modelID, ...(model.variant ? { variant: model.variant } : {}) }, tools }
       }
 
       if (info?.providerID && info?.modelID) {
@@ -54,7 +54,7 @@ export async function resolveRecentPromptContextForSession(
   if (!model?.providerID || !model?.modelID) {
     return { tools }
   }
-  return { model: { providerID: model.providerID, modelID: model.modelID }, tools }
+  return { model: { providerID: model.providerID, modelID: model.modelID, ...(model.variant ? { variant: model.variant } : {}) }, tools }
 }
 
 export async function resolveRecentModelForSession(

--- a/src/hooks/atlas/types.ts
+++ b/src/hooks/atlas/types.ts
@@ -2,7 +2,7 @@ import type { AgentOverrides } from "../../config"
 import type { BackgroundManager } from "../../features/background-agent"
 import type { TopLevelTaskRef } from "../../features/boulder-state"
 
-export type ModelInfo = { providerID: string; modelID: string }
+export type ModelInfo = { providerID: string; modelID: string; variant?: string }
 
 export interface AtlasHookOptions {
   directory: string

--- a/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -11,7 +11,7 @@ import {
 
 type MessageInfo = {
 	agent?: string
-	model?: { providerID: string; modelID: string }
+	model?: { providerID: string; modelID: string; variant?: string }
 	modelID?: string
 	providerID?: string
 	tools?: Record<string, boolean | "allow" | "deny" | "ask">
@@ -28,7 +28,7 @@ export async function injectContinuationPrompt(
 	},
 ): Promise<void> {
 	let agent: string | undefined
-	let model: { providerID: string; modelID: string } | undefined
+	let model: { providerID: string; modelID: string; variant?: string } | undefined
 	let tools: Record<string, boolean | "allow" | "deny" | "ask"> | undefined
 	const sourceSessionID = options.inheritFromSessionID ?? options.sessionID
 
@@ -62,6 +62,7 @@ export async function injectContinuationPrompt(
 				? {
 					providerID: currentMessage.model.providerID,
 					modelID: currentMessage.model.modelID,
+					...(currentMessage.model.variant ? { variant: currentMessage.model.variant } : {}),
 				}
 				: undefined
 		tools = currentMessage?.tools
@@ -69,11 +70,17 @@ export async function injectContinuationPrompt(
 
 	const inheritedTools = resolveInheritedPromptTools(sourceSessionID, tools)
 
+	const launchModel = model
+		? { providerID: model.providerID, modelID: model.modelID }
+		: undefined
+	const launchVariant = model?.variant
+
 	await ctx.client.session.promptAsync({
 		path: { id: options.sessionID },
 		body: {
 			...(agent !== undefined ? { agent } : {}),
-			...(model !== undefined ? { model } : {}),
+			...(launchModel ? { model: launchModel } : {}),
+			...(launchVariant ? { variant: launchVariant } : {}),
 			...(inheritedTools ? { tools: inheritedTools } : {}),
 			parts: [createInternalAgentTextPart(options.prompt)],
 		},

--- a/src/hooks/session-recovery/resume.ts
+++ b/src/hooks/session-recovery/resume.ts
@@ -27,12 +27,18 @@ export function extractResumeConfig(userMessage: MessageData | undefined, sessio
 export async function resumeSession(client: Client, config: ResumeConfig): Promise<boolean> {
   try {
     const inheritedTools = resolveInheritedPromptTools(config.sessionID, config.tools)
+    const launchModel = config.model
+      ? { providerID: config.model.providerID, modelID: config.model.modelID }
+      : undefined
+    const launchVariant = config.model?.variant
+
     await client.session.promptAsync({
       path: { id: config.sessionID },
       body: {
         parts: [createInternalAgentTextPart(RECOVERY_RESUME_TEXT)],
         agent: config.agent,
-        model: config.model,
+        ...(launchModel ? { model: launchModel } : {}),
+        ...(launchVariant ? { variant: launchVariant } : {}),
         ...(inheritedTools ? { tools: inheritedTools } : {}),
       },
     })

--- a/src/hooks/session-recovery/types.ts
+++ b/src/hooks/session-recovery/types.ts
@@ -73,6 +73,7 @@ export interface MessageData {
     model?: {
       providerID: string
       modelID: string
+      variant?: string
     }
     system?: string
     tools?: Record<string, boolean>
@@ -94,6 +95,7 @@ export interface ResumeConfig {
   model?: {
     providerID: string
     modelID: string
+    variant?: string
   }
   tools?: Record<string, boolean>
 }

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -159,11 +159,17 @@ ${todoList}`
 
     const inheritedTools = resolveInheritedPromptTools(sessionID, tools)
 
+    const launchModel = model
+      ? { providerID: model.providerID, modelID: model.modelID }
+      : undefined
+    const launchVariant = model?.variant
+
     await ctx.client.session.promptAsync({
       path: { id: sessionID },
       body: {
         agent: agentName,
-        ...(model !== undefined ? { model } : {}),
+        ...(launchModel ? { model: launchModel } : {}),
+        ...(launchVariant ? { variant: launchVariant } : {}),
         ...(inheritedTools ? { tools: inheritedTools } : {}),
         parts: [createInternalAgentTextPart(prompt)],
       },

--- a/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
+++ b/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
@@ -29,7 +29,7 @@ type BabysitterContext = {
         body: {
           parts: Array<{ type: "text"; text: string }>
           agent?: string
-          model?: { providerID: string; modelID: string }
+          model?: { providerID: string; modelID: string; variant?: string }
           tools?: Record<string, boolean>
         }
         query?: { directory?: string }
@@ -39,7 +39,7 @@ type BabysitterContext = {
         body: {
           parts: Array<{ type: "text"; text: string }>
           agent?: string
-          model?: { providerID: string; modelID: string }
+          model?: { providerID: string; modelID: string; variant?: string }
           tools?: Record<string, boolean>
         }
         query?: { directory?: string }
@@ -57,9 +57,9 @@ type BabysitterOptions = {
 async function resolveMainSessionTarget(
   ctx: BabysitterContext,
   sessionID: string
-): Promise<{ agent?: string; model?: { providerID: string; modelID: string }; tools?: Record<string, boolean> }> {
+): Promise<{ agent?: string; model?: { providerID: string; modelID: string; variant?: string }; tools?: Record<string, boolean> }> {
   let agent = getSessionAgent(sessionID)
-  let model: { providerID: string; modelID: string } | undefined
+  let model: { providerID: string; modelID: string; variant?: string } | undefined
   let tools: Record<string, boolean> | undefined
 
   try {
@@ -152,11 +152,17 @@ export function createUnstableAgentBabysitterHook(ctx: BabysitterContext, option
       const { agent, model, tools } = await resolveMainSessionTarget(ctx, mainSessionID)
 
       try {
+        const launchModel = model
+          ? { providerID: model.providerID, modelID: model.modelID }
+          : undefined
+        const launchVariant = model?.variant
+
         await ctx.client.session.promptAsync({
           path: { id: mainSessionID },
           body: {
             ...(agent ? { agent } : {}),
-            ...(model ? { model } : {}),
+            ...(launchModel ? { model: launchModel } : {}),
+            ...(launchVariant ? { variant: launchVariant } : {}),
             ...(tools ? { tools } : {}),
             parts: [createInternalAgentTextPart(reminder)],
           },


### PR DESCRIPTION
## Summary
Fixes #3081 — the `variant` field (controlling reasoning intensity: low/medium/high/max) was silently dropped in all 5 hook-based continuation paths.

## Root Cause
`manager.ts` correctly splits `variant` from the model object and passes it as a top-level body field:
```ts
const launchModel = { providerID, modelID }
const launchVariant = input.model?.variant
// body: { model: launchModel, variant: launchVariant, ... }
```

But all 5 continuation hooks either:
1. Didn't extract variant at all (boulder, babysitter)
2. Included variant inside the `model` object instead of top-level (todo-continuation, session-recovery)
3. Stripped variant during model extraction (ralph-loop fallback, recent-model-resolver)

## Fix
Applied the same pattern from `manager.ts` to all 5 continuation paths:
```ts
const launchModel = model ? { providerID: model.providerID, modelID: model.modelID } : undefined
const launchVariant = model?.variant
// body: { ...(launchModel ? { model: launchModel } : {}), ...(launchVariant ? { variant: launchVariant } : {}), ... }
```

Also updated type definitions to include `variant?: string` in ModelInfo across atlas, session-recovery, and unstable-agent-babysitter.

## Changed Files (8)
| File | Change |
|------|--------|
| `boulder-continuation-injector.ts` | Extract variant, pass top-level |
| `continuation-prompt-injector.ts` (ralph-loop) | Extract variant, pass top-level, fix fallback path |
| `continuation-injection.ts` (todo) | Extract variant from model, pass top-level |
| `unstable-agent-babysitter-hook.ts` | Extract variant, pass top-level, update types |
| `resume.ts` (session-recovery) | Extract variant, pass top-level |
| `types.ts` (atlas) | Add `variant?: string` to ModelInfo |
| `types.ts` (session-recovery) | Add `variant?: string` to MessageData + ResumeConfig |
| `recent-model-resolver.ts` | Preserve variant in model extraction |

## Tests
- Hook tests: **325 pass, 0 fail**
- Full suite: **4758 pass / 63 fail** (63 are pre-existing on dev, 0 new failures)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures sessions keep their chosen reasoning intensity by passing the `variant` field as a top-level value in all hook-based `promptAsync` continuations. Fixes #3081 to prevent `variant` from being dropped and reverting to default during automatic continuations.

- **Bug Fixes**
  - Split `variant` out of `model` and send it top-level in boulder, ralph-loop, todo-continuation, session-recovery, and unstable-agent-babysitter paths.
  - Preserve `variant` when resolving recent models and stored messages; updated types to include `variant` where missing.

<sup>Written for commit 74c26919f04c16a2f6c005f29d193b1c3823eb72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

