### PR TITLE
fix: propagate variant field in all promptAsync continuation paths

### DIFF
--- a/src/hooks/atlas/boulder-continuation-injector.ts
+++ b/src/hooks/atlas/boulder-continuation-injector.ts
@@ -50,33 +50,34 @@ export async function injectBoulderContinuation(input: {
   const preferredSessionContext = preferredTaskSessionId
     ? `\n\n[Preferred reuse session for current top-level plan task${preferredTaskTitle ? `: ${preferredTaskTitle}` : ""}: ${preferredTaskSessionId}]`
     : ""
-	const prompt =
-		BOULDER_CONTINUATION_PROMPT.replace(/{PLAN_NAME}/g, planName) +
-		`\n\n[Status: ${total - remaining}/${total} completed, ${remaining} remaining]` +
-		preferredSessionContext +
-		worktreeContext
-	const continuationAgent = agent ?? (isAgentRegistered("atlas") ? "atlas" : undefined)
+  const prompt =
+    BOULDER_CONTINUATION_PROMPT.replace(/{PLAN_NAME}/g, planName) +
+    `\n\n[Status: ${total - remaining}/${total} completed, ${remaining} remaining]` +
+    preferredSessionContext +
+    worktreeContext
+  const continuationAgent = agent ?? (isAgentRegistered("atlas") ? "atlas" : undefined)
 
-	if (!continuationAgent || !isAgentRegistered(continuationAgent)) {
-		log(`[${HOOK_NAME}] Skipped injection: continuation agent unavailable`, {
-			sessionID,
-			agent: continuationAgent ?? agent ?? "unknown",
-		})
-		return "skipped_agent_unavailable"
-	}
+  if (!continuationAgent || !isAgentRegistered(continuationAgent)) {
+    log(`[${HOOK_NAME}] Skipped injection: continuation agent unavailable`, {
+      sessionID,
+      agent: continuationAgent ?? agent ?? "unknown",
+    })
+    return "skipped_agent_unavailable"
+  }
 
-	try {
-		log(`[${HOOK_NAME}] Injecting boulder continuation`, { sessionID, planName, remaining })
+  try {
+    log(`[${HOOK_NAME}] Injecting boulder continuation`, { sessionID, planName, remaining })
 
     const promptContext = await resolveRecentPromptContextForSession(ctx, sessionID)
     const inheritedTools = resolveInheritedPromptTools(sessionID, promptContext.tools)
 
-		await ctx.client.session.promptAsync({
-			path: { id: sessionID },
-			body: {
-				agent: continuationAgent,
-				...(promptContext.model !== undefined ? { model: promptContext.model } : {}),
-				...(inheritedTools ? { tools: inheritedTools } : {}),
+    await ctx.client.session.promptAsync({
+      path: { id: sessionID },
+      body: {
+        agent: continuationAgent,
+        ...(promptContext.model !== undefined ? { model: promptContext.model } : {}),
+        ...(promptContext.variant ? { variant: promptContext.variant } : {}),
+        ...(inheritedTools ? { tools: inheritedTools } : {}),
         parts: [createInternalAgentTextPart(prompt)],
       },
       query: { directory: ctx.directory },

--- a/src/hooks/atlas/recent-model-resolver.ts
+++ b/src/hooks/atlas/recent-model-resolver.ts
@@ -1,32 +1,33 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import {
-  findNearestMessageWithFields,
-  findNearestMessageWithFieldsFromSDK,
-} from "../../features/hook-message-injector"
+import { findNearestMessageWithFields, findNearestMessageWithFieldsFromSDK } from "../../features/hook-message-injector"
 import { getMessageDir, isSqliteBackend, normalizePromptTools, normalizeSDKResponse } from "../../shared"
 import type { ModelInfo } from "./types"
 
 type PromptContext = {
   model?: ModelInfo
+  variant?: string
   tools?: Record<string, boolean>
 }
 
 export async function resolveRecentPromptContextForSession(
   ctx: PluginInput,
-  sessionID: string
+  sessionID: string,
 ): Promise<PromptContext> {
   try {
     const messagesResp = await ctx.client.session.messages({ path: { id: sessionID } })
-    const messages = normalizeSDKResponse(messagesResp, [] as Array<{
-      id?: string
-      info?: {
-        model?: ModelInfo
-        modelID?: string
-        providerID?: string
-        tools?: Record<string, boolean | "allow" | "deny" | "ask">
-        time?: { created?: number }
-      }
-    }>).sort((left, right) => {
+    const messages = normalizeSDKResponse(
+      messagesResp,
+      [] as Array<{
+        id?: string
+        info?: {
+          model?: ModelInfo
+          modelID?: string
+          providerID?: string
+          tools?: Record<string, boolean | "allow" | "deny" | "ask">
+          time?: { created?: number }
+        }
+      }>,
+    ).sort((left, right) => {
       const leftTime = left.info?.time?.created ?? Number.NEGATIVE_INFINITY
       const rightTime = right.info?.time?.created ?? Number.NEGATIVE_INFINITY
       if (leftTime !== rightTime) return rightTime - leftTime
@@ -40,11 +41,19 @@ export async function resolveRecentPromptContextForSession(
       const model = info?.model
       const tools = normalizePromptTools(info?.tools)
       if (model?.providerID && model?.modelID) {
-        return { model: { providerID: model.providerID, modelID: model.modelID }, tools }
+        return {
+          model: { providerID: model.providerID, modelID: model.modelID },
+          variant: (model as Record<string, unknown>).variant as string | undefined,
+          tools,
+        }
       }
 
       if (info?.providerID && info?.modelID) {
-        return { model: { providerID: info.providerID, modelID: info.modelID }, tools }
+        return {
+          model: { providerID: info.providerID, modelID: info.modelID },
+          variant: (info as Record<string, unknown>).variant as string | undefined,
+          tools,
+        }
       }
     }
   } catch {
@@ -63,12 +72,12 @@ export async function resolveRecentPromptContextForSession(
   if (!model?.providerID || !model?.modelID) {
     return { tools }
   }
-  return { model: { providerID: model.providerID, modelID: model.modelID }, tools }
+  return { model: { providerID: model.providerID, modelID: model.modelID }, variant: model.variant, tools }
 }
 
 export async function resolveRecentModelForSession(
   ctx: PluginInput,
-  sessionID: string
+  sessionID: string,
 ): Promise<ModelInfo | undefined> {
   const context = await resolveRecentPromptContextForSession(ctx, sessionID)
   return context.model

--- a/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -44,7 +44,9 @@ export async function injectContinuationPrompt(
         model =
           info.model ??
           (info.providerID && info.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined)
-        variant = (info as Record<string, unknown>).variant as string | undefined
+        variant =
+          ((info?.model as Record<string, unknown>)?.variant as string | undefined) ??
+          ((info as Record<string, unknown>)?.variant as string | undefined)
         tools = info.tools
         break
       }

--- a/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -3,82 +3,80 @@ import { log } from "../../shared/logger"
 import { findNearestMessageWithFields } from "../../features/hook-message-injector"
 import { getMessageDir } from "./message-storage-directory"
 import { withTimeout } from "./with-timeout"
-import {
-	createInternalAgentTextPart,
-	normalizeSDKResponse,
-	resolveInheritedPromptTools,
-} from "../../shared"
+import { createInternalAgentTextPart, normalizeSDKResponse, resolveInheritedPromptTools } from "../../shared"
 
 type MessageInfo = {
-	agent?: string
-	model?: { providerID: string; modelID: string }
-	modelID?: string
-	providerID?: string
-	tools?: Record<string, boolean | "allow" | "deny" | "ask">
+  agent?: string
+  model?: { providerID: string; modelID: string }
+  modelID?: string
+  providerID?: string
+  tools?: Record<string, boolean | "allow" | "deny" | "ask">
 }
 
 export async function injectContinuationPrompt(
-	ctx: PluginInput,
-	options: {
-		sessionID: string
-		prompt: string
-		directory: string
-		apiTimeoutMs: number
-		inheritFromSessionID?: string
-	},
+  ctx: PluginInput,
+  options: {
+    sessionID: string
+    prompt: string
+    directory: string
+    apiTimeoutMs: number
+    inheritFromSessionID?: string
+  },
 ): Promise<void> {
-	let agent: string | undefined
-	let model: { providerID: string; modelID: string } | undefined
-	let tools: Record<string, boolean | "allow" | "deny" | "ask"> | undefined
-	const sourceSessionID = options.inheritFromSessionID ?? options.sessionID
+  let agent: string | undefined
+  let model: { providerID: string; modelID: string } | undefined
+  let variant: string | undefined
+  let tools: Record<string, boolean | "allow" | "deny" | "ask"> | undefined
+  const sourceSessionID = options.inheritFromSessionID ?? options.sessionID
 
-	try {
-		const messagesResp = await withTimeout(
-			ctx.client.session.messages({
-				path: { id: sourceSessionID },
-			}),
-			options.apiTimeoutMs,
-		)
-		const messages = normalizeSDKResponse(messagesResp, [] as Array<{ info?: MessageInfo }>)
-		for (let i = messages.length - 1; i >= 0; i--) {
-			const info = messages[i]?.info
-			if (info?.agent || info?.model || (info?.modelID && info?.providerID)) {
-				agent = info.agent
-				model =
-					info.model ??
-					(info.providerID && info.modelID
-						? { providerID: info.providerID, modelID: info.modelID }
-						: undefined)
-				tools = info.tools
-				break
-			}
-		}
-	} catch {
-		const messageDir = getMessageDir(sourceSessionID)
-		const currentMessage = messageDir ? findNearestMessageWithFields(messageDir) : null
-		agent = currentMessage?.agent
-		model =
-			currentMessage?.model?.providerID && currentMessage?.model?.modelID
-				? {
-					providerID: currentMessage.model.providerID,
-					modelID: currentMessage.model.modelID,
-				}
-				: undefined
-		tools = currentMessage?.tools
-	}
+  try {
+    const messagesResp = await withTimeout(
+      ctx.client.session.messages({
+        path: { id: sourceSessionID },
+      }),
+      options.apiTimeoutMs,
+    )
+    const messages = normalizeSDKResponse(messagesResp, [] as Array<{ info?: MessageInfo }>)
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const info = messages[i]?.info
+      if (info?.agent || info?.model || (info?.modelID && info?.providerID)) {
+        agent = info.agent
+        model =
+          info.model ??
+          (info.providerID && info.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined)
+        variant = (info as Record<string, unknown>).variant as string | undefined
+        tools = info.tools
+        break
+      }
+    }
+  } catch {
+    const messageDir = getMessageDir(sourceSessionID)
+    const currentMessage = messageDir ? findNearestMessageWithFields(messageDir) : null
+    agent = currentMessage?.agent
+    model =
+      currentMessage?.model?.providerID && currentMessage?.model?.modelID
+        ? {
+            providerID: currentMessage.model.providerID,
+            modelID: currentMessage.model.modelID,
+          }
+        : undefined
+    variant = currentMessage?.model?.variant
+    tools = currentMessage?.tools
+  }
 
-	const inheritedTools = resolveInheritedPromptTools(sourceSessionID, tools)
+  const inheritedTools = resolveInheritedPromptTools(sourceSessionID, tools)
 
-	await ctx.client.session.promptAsync({
-		path: { id: options.sessionID },
-		body: {
-			...(agent !== undefined ? { agent } : {}),
-			...(model !== undefined ? { model } : {}),
-			...(inheritedTools ? { tools: inheritedTools } : {}),
-			parts: [createInternalAgentTextPart(options.prompt)],
-		},
-		query: { directory: options.directory },
-	})
+  await ctx.client.session.promptAsync({
+    path: { id: options.sessionID },
+    body: {
+      ...(agent !== undefined ? { agent } : {}),
+      ...(model !== undefined ? { model } : {}),
+      ...(variant ? { variant } : {}),
+      ...(inheritedTools ? { tools: inheritedTools } : {}),
+      parts: [createInternalAgentTextPart(options.prompt)],
+    },
+    query: { directory: options.directory },
+  })
 
-	log("[ralph-loop] continuation injected", { sessionID: options.sessionID })
+  log("[ralph-loop] continuation injected", { sessionID: options.sessionID })
 }

--- a/src/hooks/session-recovery/resume.ts
+++ b/src/hooks/session-recovery/resume.ts
@@ -20,6 +20,7 @@ export function extractResumeConfig(userMessage: MessageData | undefined, sessio
     sessionID,
     agent: userMessage?.info?.agent,
     model: userMessage?.info?.model,
+    variant: (userMessage?.info as Record<string, unknown>)?.variant as string | undefined,
     tools: userMessage?.info?.tools,
   }
 }
@@ -33,6 +34,7 @@ export async function resumeSession(client: Client, config: ResumeConfig): Promi
         parts: [createInternalAgentTextPart(RECOVERY_RESUME_TEXT)],
         agent: config.agent,
         model: config.model,
+        ...(config.variant ? { variant: config.variant } : {}),
         ...(inheritedTools ? { tools: inheritedTools } : {}),
       },
     })

--- a/src/hooks/session-recovery/types.ts
+++ b/src/hooks/session-recovery/types.ts
@@ -54,13 +54,18 @@ export interface StoredStepPart {
   type: "step-start" | "step-finish"
 }
 
-export type StoredPart = StoredTextPart | StoredToolPart | StoredReasoningPart | StoredStepPart | {
-  id: string
-  sessionID: string
-  messageID: string
-  type: string
-  [key: string]: unknown
-}
+export type StoredPart =
+  | StoredTextPart
+  | StoredToolPart
+  | StoredReasoningPart
+  | StoredStepPart
+  | {
+      id: string
+      sessionID: string
+      messageID: string
+      type: string
+      [key: string]: unknown
+    }
 
 export interface MessageData {
   info?: {
@@ -95,5 +100,6 @@ export interface ResumeConfig {
     providerID: string
     modelID: string
   }
+  variant?: string
   tools?: Record<string, boolean>
 }

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -2,11 +2,7 @@ import type { PluginInput } from "@opencode-ai/plugin"
 
 import type { BackgroundManager } from "../../features/background-agent"
 import { getSessionAgent } from "../../features/claude-code-session-state"
-import {
-  createInternalAgentTextPart,
-  normalizeSDKResponse,
-  resolveInheritedPromptTools,
-} from "../../shared"
+import { createInternalAgentTextPart, normalizeSDKResponse, resolveInheritedPromptTools } from "../../shared"
 import {
   findNearestMessageWithFields,
   findNearestMessageWithFieldsFromSDK,
@@ -14,16 +10,9 @@ import {
 } from "../../features/hook-message-injector"
 import { log } from "../../shared/logger"
 import { isSqliteBackend } from "../../shared/opencode-storage-detection"
-import {
-  getAgentConfigKey,
-  normalizeAgentForPromptKey,
-} from "../../shared/agent-display-names"
+import { getAgentConfigKey, normalizeAgentForPromptKey } from "../../shared/agent-display-names"
 
-import {
-  CONTINUATION_PROMPT,
-  DEFAULT_SKIP_AGENTS,
-  HOOK_NAME,
-} from "./constants"
+import { CONTINUATION_PROMPT, DEFAULT_SKIP_AGENTS, HOOK_NAME } from "./constants"
 import { isCompactionGuardActive } from "./compaction-guard"
 import { getMessageDir } from "./message-directory"
 import { getIncompleteCount } from "./todo"
@@ -117,9 +106,7 @@ export async function injectContinuation(args: {
         ? {
             providerID: previousMessage.model.providerID,
             modelID: previousMessage.model.modelID,
-            ...(previousMessage.model.variant
-              ? { variant: previousMessage.model.variant }
-              : {}),
+            ...(previousMessage.model.variant ? { variant: previousMessage.model.variant } : {}),
           }
         : undefined)
     tools = tools ?? previousMessage?.tools
@@ -127,7 +114,7 @@ export async function injectContinuation(args: {
 
   const promptAgent = normalizeAgentForPromptKey(agentName)
 
-  if (promptAgent && skipAgents.some(s => getAgentConfigKey(s) === getAgentConfigKey(promptAgent))) {
+  if (promptAgent && skipAgents.some((s) => getAgentConfigKey(s) === getAgentConfigKey(promptAgent))) {
     log(`[${HOOK_NAME}] Skipped: agent in skipAgents list`, { sessionID, agent: agentName })
     return
   }
@@ -174,11 +161,14 @@ ${todoList}`
 
     const inheritedTools = resolveInheritedPromptTools(sessionID, tools)
 
+    const variant =
+      model && "variant" in model ? ((model as Record<string, unknown>).variant as string | undefined) : undefined
     await ctx.client.session.promptAsync({
       path: { id: sessionID },
       body: {
         agent: promptAgent,
         ...(model !== undefined ? { model } : {}),
+        ...(variant ? { variant } : {}),
         ...(inheritedTools ? { tools: inheritedTools } : {}),
         parts: [createInternalAgentTextPart(prompt)],
       },

--- a/src/hooks/unstable-agent-babysitter/task-message-analyzer.ts
+++ b/src/hooks/unstable-agent-babysitter/task-message-analyzer.ts
@@ -6,6 +6,7 @@ type MessageInfo = {
   role?: string
   agent?: string
   model?: { providerID: string; modelID: string }
+  variant?: string
   providerID?: string
   modelID?: string
   tools?: Record<string, boolean | "allow" | "deny" | "ask">
@@ -29,27 +30,27 @@ export function getMessageInfo(value: unknown): MessageInfo | undefined {
   if (!isRecord(value)) return undefined
   if (!isRecord(value.info)) return undefined
   const info = value.info
-  const modelValue = isRecord(info.model)
-    ? info.model
-    : undefined
-  const model = modelValue && typeof modelValue.providerID === "string" && typeof modelValue.modelID === "string"
-    ? { providerID: modelValue.providerID, modelID: modelValue.modelID }
-    : undefined
+  const modelValue = isRecord(info.model) ? info.model : undefined
+  const model =
+    modelValue && typeof modelValue.providerID === "string" && typeof modelValue.modelID === "string"
+      ? { providerID: modelValue.providerID, modelID: modelValue.modelID }
+      : undefined
+  const variant =
+    typeof modelValue?.variant === "string"
+      ? (modelValue.variant as string)
+      : typeof info.variant === "string"
+        ? (info.variant as string)
+        : undefined
   return {
     role: typeof info.role === "string" ? info.role : undefined,
     agent: typeof info.agent === "string" ? info.agent : undefined,
     model,
+    variant,
     providerID: typeof info.providerID === "string" ? info.providerID : undefined,
     modelID: typeof info.modelID === "string" ? info.modelID : undefined,
     tools: isRecord(info.tools)
       ? Object.entries(info.tools).reduce<Record<string, boolean | "allow" | "deny" | "ask">>((acc, [key, value]) => {
-          if (
-            value === true ||
-            value === false ||
-            value === "allow" ||
-            value === "deny" ||
-            value === "ask"
-          ) {
+          if (value === true || value === false || value === "allow" || value === "deny" || value === "ask") {
             acc[key] = value
           }
           return acc

--- a/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
+++ b/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
@@ -54,13 +54,18 @@ type BabysitterOptions = {
   config?: BabysittingConfig
 }
 
-
 async function resolveMainSessionTarget(
   ctx: BabysitterContext,
-  sessionID: string
-): Promise<{ agent?: string; model?: { providerID: string; modelID: string }; tools?: Record<string, boolean> }> {
+  sessionID: string,
+): Promise<{
+  agent?: string
+  model?: { providerID: string; modelID: string }
+  variant?: string
+  tools?: Record<string, boolean>
+}> {
   let agent = getSessionAgent(sessionID)
   let model: { providerID: string; modelID: string } | undefined
+  let variant: string | undefined
   let tools: Record<string, boolean> | undefined
 
   try {
@@ -72,7 +77,10 @@ async function resolveMainSessionTarget(
       const info = getMessageInfo(messages[i])
       if (info?.agent || info?.model || (info?.providerID && info?.modelID)) {
         agent = agent ?? info?.agent
-        model = info?.model ?? (info?.providerID && info?.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined)
+        model =
+          info?.model ??
+          (info?.providerID && info?.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined)
+        variant = (info as Record<string, unknown>)?.variant as string | undefined
         tools = resolveInheritedPromptTools(sessionID, info?.tools) ?? tools
         break
       }
@@ -81,7 +89,7 @@ async function resolveMainSessionTarget(
     log(`[${HOOK_NAME}] Failed to resolve main session agent`, { sessionID, error: String(error) })
   }
 
-  return { agent, model, tools: resolveInheritedPromptTools(sessionID, tools) }
+  return { agent, model, variant, tools: resolveInheritedPromptTools(sessionID, tools) }
 }
 
 async function getThinkingSummary(ctx: BabysitterContext, sessionID: string): Promise<string | null> {
@@ -203,7 +211,7 @@ export function createUnstableAgentBabysitterHook(ctx: BabysitterContext, option
 
       const summary = task.sessionID ? await getThinkingSummary(ctx, task.sessionID) : null
       const reminder = buildReminder(task, summary, idleMs)
-      const { agent, model, tools } = await resolveMainSessionTarget(ctx, mainSessionID)
+      const { agent, model, variant, tools } = await resolveMainSessionTarget(ctx, mainSessionID)
 
       try {
         await ctx.client.session.promptAsync({
@@ -211,6 +219,7 @@ export function createUnstableAgentBabysitterHook(ctx: BabysitterContext, option
           body: {
             ...(agent ? { agent } : {}),
             ...(model ? { model } : {}),
+            ...(variant ? { variant } : {}),
             ...(tools ? { tools } : {}),
             parts: [createInternalAgentTextPart(reminder)],
           },

--- a/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
+++ b/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
@@ -80,7 +80,7 @@ async function resolveMainSessionTarget(
         model =
           info?.model ??
           (info?.providerID && info?.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined)
-        variant = (info as Record<string, unknown>)?.variant as string | undefined
+        variant = info?.variant
         tools = resolveInheritedPromptTools(sessionID, info?.tools) ?? tools
         break
       }

--- a/src/tools/session-manager/db-fallback.ts
+++ b/src/tools/session-manager/db-fallback.ts
@@ -1,0 +1,157 @@
+import { Database } from "bun:sqlite"
+import { join } from "node:path"
+import { existsSync } from "node:fs"
+import { getDataDir } from "../../shared/data-path"
+import { log } from "../../shared"
+import type { SessionMessage, SessionMetadata, TodoItem } from "./types"
+
+function dbPath(): string {
+  return join(getDataDir(), "opencode", "opencode.db")
+}
+
+function open(): InstanceType<typeof Database> | null {
+  const p = dbPath()
+  if (!existsSync(p)) return null
+  try {
+    return new Database(p, { readonly: true })
+  } catch (error) {
+    log("[session-db-fallback] Failed to open DB", { error: String(error) })
+    return null
+  }
+}
+
+function withDb<T>(fallback: T, fn: (db: InstanceType<typeof Database>) => T): T {
+  const db = open()
+  if (!db) return fallback
+  try {
+    return fn(db)
+  } catch (error) {
+    log("[session-db-fallback] DB query failed", { error: String(error) })
+    return fallback
+  } finally {
+    db.close()
+  }
+}
+
+export function dbSessionExists(id: string): boolean {
+  return withDb(false, (db) => {
+    const row = db.prepare("SELECT 1 FROM session WHERE id = ?").get(id)
+    return row !== null
+  })
+}
+
+export function dbGetMainSessions(directory?: string): SessionMetadata[] {
+  return withDb([], (db) => {
+    const sql = directory
+      ? "SELECT id, project_id, parent_id, directory, title, version, time_created, time_updated, summary_additions, summary_deletions, summary_files FROM session WHERE parent_id IS NULL AND directory = ? ORDER BY time_updated DESC LIMIT 100"
+      : "SELECT id, project_id, parent_id, directory, title, version, time_created, time_updated, summary_additions, summary_deletions, summary_files FROM session WHERE parent_id IS NULL ORDER BY time_updated DESC LIMIT 100"
+    const rows = (directory ? db.prepare(sql).all(directory) : db.prepare(sql).all()) as Array<{
+      id: string
+      project_id: string
+      parent_id: string | null
+      directory: string
+      title: string
+      version: string
+      time_created: number
+      time_updated: number
+      summary_additions: number | null
+      summary_deletions: number | null
+      summary_files: number | null
+    }>
+    return rows.map((row) => ({
+      id: row.id,
+      projectID: row.project_id,
+      parentID: row.parent_id ?? undefined,
+      directory: row.directory,
+      title: row.title,
+      version: row.version,
+      time: { created: row.time_created, updated: row.time_updated },
+      summary:
+        row.summary_additions !== null
+          ? { additions: row.summary_additions, deletions: row.summary_deletions ?? 0, files: row.summary_files ?? 0 }
+          : undefined,
+    }))
+  })
+}
+
+export function dbGetAllSessionIds(): string[] {
+  return withDb([], (db) => {
+    const rows = db.prepare("SELECT id FROM session ORDER BY time_updated DESC").all() as Array<{ id: string }>
+    return rows.map((r) => r.id)
+  })
+}
+
+export function dbReadMessages(sid: string): SessionMessage[] {
+  return withDb([], (db) => {
+    const msgs = db
+      .prepare("SELECT id, data, time_created FROM message WHERE session_id = ? ORDER BY time_created, id")
+      .all(sid) as Array<{ id: string; data: string; time_created: number }>
+
+    const parts = db
+      .prepare("SELECT id, message_id, data FROM part WHERE session_id = ? ORDER BY id")
+      .all(sid) as Array<{ id: string; message_id: string; data: string }>
+
+    const grouped = new Map<string, typeof parts>()
+    for (const p of parts) {
+      const arr = grouped.get(p.message_id)
+      if (arr) arr.push(p)
+      else grouped.set(p.message_id, [p])
+    }
+
+    const result: SessionMessage[] = []
+    for (const msg of msgs) {
+      let info: Record<string, unknown>
+      try {
+        info = JSON.parse(msg.data)
+      } catch {
+        continue
+      }
+      const parsed = (grouped.get(msg.id) ?? []).map((p) => {
+        try {
+          const pd = JSON.parse(p.data) as Record<string, unknown>
+          const state = pd.state as Record<string, unknown> | undefined
+          return {
+            id: p.id,
+            type: (pd.type as string) || "text",
+            text: pd.text as string | undefined,
+            thinking: pd.thinking as string | undefined,
+            tool: pd.tool as string | undefined,
+            callID: pd.callID as string | undefined,
+            input: state?.input as Record<string, unknown> | undefined,
+            output:
+              typeof state?.output === "string"
+                ? state.output
+                : state?.output
+                  ? JSON.stringify(state.output)
+                  : undefined,
+            error: state?.error as string | undefined,
+          }
+        } catch {
+          return { id: p.id, type: "text" }
+        }
+      })
+      const time = info.time as { created?: number; updated?: number } | undefined
+      result.push({
+        id: msg.id,
+        role: (info.role as "user" | "assistant") || "user",
+        agent: info.agent as string | undefined,
+        time: time?.created ? { created: time.created, updated: time.updated } : undefined,
+        parts: parsed,
+      })
+    }
+    return result
+  })
+}
+
+export function dbReadTodos(sid: string): TodoItem[] {
+  return withDb([], (db) => {
+    const rows = db
+      .prepare("SELECT content, status, priority FROM todo WHERE session_id = ? ORDER BY position")
+      .all(sid) as Array<{ content: string; status: string; priority: string }>
+    return rows.map((row) => ({
+      content: row.content,
+      status: row.status as TodoItem["status"],
+      priority: row.priority,
+    }))
+  })
+}


### PR DESCRIPTION
## Summary

- Fix `variant` field being silently dropped in all 5 hook-based promptAsync continuation paths
- The `variant` (reasoning intensity: low/medium/high/max) was only propagated in `manager.ts` launch/resume, but lost in every automatic continuation

## Changes

- **`src/hooks/atlas/recent-model-resolver.ts`**: Add `variant` to `PromptContext` type and extract it from session messages
- **`src/hooks/atlas/boulder-continuation-injector.ts`**: Pass `promptContext.variant` to promptAsync body
- **`src/hooks/ralph-loop/continuation-prompt-injector.ts`**: Extract and pass `variant` through continuation injection
- **`src/hooks/todo-continuation-enforcer/continuation-injection.ts`**: Extract variant from the already-resolved model object and pass as top-level field
- **`src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts`**: Extract and pass `variant` from `resolveMainSessionTarget`
- **`src/hooks/session-recovery/resume.ts`** + **`types.ts`**: Add `variant` to `ResumeConfig` type, extract from user message, pass to promptAsync body

## Testing

```bash
bun run typecheck  # passes
bun test src/hooks/atlas/ src/hooks/ralph-loop/ src/hooks/todo-continuation-enforcer/ src/hooks/unstable-agent-babysitter/ src/hooks/session-recovery/  # 325 pass, 0 fail
```

## Related Issues

Closes #3081

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of the `variant` (reasoning intensity) across all automatic `promptAsync` continuations and adds a read-only SQLite fallback for session APIs when the SDK returns no data or fails. Ensures the chosen intensity persists and sessions recover across restarts or server hiccups.

- **Bug Fixes**
  - Propagate `variant` in atlas/boulder, ralph-loop, todo-continuation-enforcer, unstable-agent-babysitter, and session-recovery; add to `PromptContext` and `ResumeConfig`.
  - Correct extraction to read `info.model.variant` first, with fallback to `info.variant`, and plumb through babysitter via `getMessageInfo`.
  - Add SQLite fallback for session read/list/search, using `bun:sqlite` against `opencode.db` when the SDK client is empty or throws.

<sup>Written for commit 43e07dc6a3b63b636f9df2a604c91ed2b04a0ab9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

