### PR TITLE
docs(git-master): make language handling generic (incl. Japanese examples)

### DIFF
--- a/src/features/builtin-skills/git-master/SKILL.md
+++ b/src/features/builtin-skills/git-master/SKILL.md
@@ -527,7 +527,7 @@ IF style == SHORT:
 
 **VALIDATION before each commit:**
 1. Does message match detected style?
-2. Does language match detected language?
+2. Does message use the repository's dominant language/script profile (from Phase 1.1)?
 3. Is it similar to examples from git log?
 
 If ANY check fails -> REWRITE message.

--- a/src/features/builtin-skills/git-master/SKILL.md
+++ b/src/features/builtin-skills/git-master/SKILL.md
@@ -18,9 +18,9 @@ Analyze the user's request to determine operation mode:
 
 | User Request Pattern | Mode | Jump To |
 |---------------------|------|---------|
-| "commit", "커밋", changes to commit | `COMMIT` | Phase 0-6 (existing) |
-| "rebase", "리베이스", "squash", "cleanup history" | `REBASE` | Phase R1-R4 |
-| "find when", "who changed", "언제 바뀌었", "git blame", "bisect" | `HISTORY_SEARCH` | Phase H1-H3 |
+| Commit intent in any language (e.g., "commit", "커밋", "コミット") | `COMMIT` | Phase 0-6 (existing) |
+| Rebase/squash intent in any language (e.g., "rebase", "리베이스", "リベース") | `REBASE` | Phase R1-R4 |
+| History lookup intent in any language (e.g., "find when", "언제 바뀌었", "いつ追加") | `HISTORY_SEARCH` | Phase H1-H3 |
 | "smart rebase", "rebase onto" | `REBASE` | Phase R1-R4 |
 
 **CRITICAL**: Don't default to COMMIT mode. Parse the actual request.
@@ -107,18 +107,18 @@ git log --oneline $(git merge-base HEAD main 2>/dev/null || git merge-base HEAD 
 <style_detection>
 **THIS PHASE HAS MANDATORY OUTPUT** - You MUST print the analysis result before moving to Phase 2.
 
-### 1.1 Language Detection
+### 1.1 Language Profile Detection
 
 ```
 Count from git log -30:
-- Korean characters: N commits
-- English only: M commits
-- Mixed: K commits
+- Dominant language/script patterns: N commits
+- Secondary language/script patterns: M commits
+- Mixed/ambiguous: K commits
 
 DECISION:
-- If Korean >= 50% -> KOREAN
-- If English >= 50% -> ENGLISH  
-- If Mixed -> Use MAJORITY language
+- Preserve the dominant repository language pattern in commit messages
+- If multiple languages are common, follow the nearest recent examples for the same module
+- Never restrict output to specific languages; support any language used by the repo (e.g., Japanese, Korean, English, etc.)
 ```
 
 ### 1.2 Commit Style Classification
@@ -151,9 +151,9 @@ STYLE DETECTION RESULT
 ======================
 Analyzed: 30 commits from git log
 
-Language: [KOREAN | ENGLISH]
-  - Korean commits: N (X%)
-  - English commits: M (Y%)
+Language profile: [DOMINANT_LANGUAGE_OR_SCRIPT]
+  - Dominant pattern: N (X%)
+  - Secondary pattern: M (Y%)
 
 Style: [SEMANTIC | PLAIN | SENTENCE | SHORT]
   - Semantic (feat:, fix:, etc): N (X%)
@@ -165,7 +165,7 @@ Reference examples from repo:
   2. "actual commit message from log"
   3. "actual commit message from log"
 
-All commits will follow: [LANGUAGE] + [STYLE]
+All commits will follow: [DOMINANT_LANGUAGE_OR_SCRIPT] + [STYLE]
 ```
 
 **IF YOU SKIP THIS OUTPUT, YOUR COMMITS WILL BE WRONG. STOP AND REDO.**
@@ -507,17 +507,19 @@ git log -1 --oneline
 **Based on COMMIT_CONFIG from Phase 1:**
 
 ```
-IF style == SEMANTIC AND language == KOREAN:
-  -> "feat: 로그인 기능 추가"
-  
-IF style == SEMANTIC AND language == ENGLISH:
-  -> "feat: add login feature"
-  
-IF style == PLAIN AND language == KOREAN:
-  -> "로그인 기능 추가"
-  
-IF style == PLAIN AND language == ENGLISH:
-  -> "Add login feature"
+IF style == SEMANTIC:
+  -> Use a semantic prefix + repository language message
+  -> Examples:
+     - "feat: add login feature"
+     - "feat: ログイン機能を追加"
+     - "feat: 로그인 기능 추가"
+
+IF style == PLAIN:
+  -> Use plain repository language message without semantic prefix
+  -> Examples:
+     - "Add login feature"
+     - "ログイン機能を追加"
+     - "로그인 기능 추가"
   
 IF style == SHORT:
   -> "format" / "type fix" / "lint"
@@ -589,7 +591,7 @@ NEXT STEPS:
 | If git log shows... | Use this style |
 |---------------------|----------------|
 | `feat: xxx`, `fix: yyy` | SEMANTIC |
-| `Add xxx`, `Fix yyy`, `xxx 추가` | PLAIN |
+| `Add xxx`, `Fix yyy`, `xxx 추가`, `xxxを追加` | PLAIN |
 | `format`, `lint`, `typo` | SHORT |
 | Full sentences | SENTENCE |
 | Mix of above | Use MAJORITY (not semantic by default) |
@@ -691,16 +693,16 @@ USER REQUEST -> STRATEGY:
 "squash commits" / "cleanup" / "정리"
   -> INTERACTIVE_SQUASH
 
-"rebase on main" / "update branch" / "메인에 리베이스"
+"rebase on main" intent in any language (e.g., "update branch", "메인에 리베이스", "mainにリベース")
   -> REBASE_ONTO_BASE
 
 "autosquash" / "apply fixups"
   -> AUTOSQUASH
 
-"reorder commits" / "커밋 순서"
+"reorder commits" intent in any language (e.g., "커밋 순서", "コミット順を並べ替え")
   -> INTERACTIVE_REORDER
 
-"split commit" / "커밋 분리"
+"split commit" intent in any language (e.g., "커밋 분리", "コミット分割")
   -> INTERACTIVE_EDIT
 ```
 </rebase_context>
@@ -850,12 +852,12 @@ NEXT STEPS:
 
 | User Request | Search Type | Tool |
 |--------------|-------------|------|
-| "when was X added" / "X가 언제 추가됐어" | PICKAXE | `git log -S` |
+| "when was X added" in any language (e.g., "X가 언제 추가됐어", "Xはいつ追加された") | PICKAXE | `git log -S` |
 | "find commits changing X pattern" | REGEX | `git log -G` |
-| "who wrote this line" / "이 줄 누가 썼어" | BLAME | `git blame` |
-| "when did bug start" / "버그 언제 생겼어" | BISECT | `git bisect` |
-| "history of file" / "파일 히스토리" | FILE_LOG | `git log -- path` |
-| "find deleted code" / "삭제된 코드 찾기" | PICKAXE_ALL | `git log -S --all` |
+| "who wrote this line" in any language (e.g., "이 줄 누가 썼어", "この行を書いたのは誰") | BLAME | `git blame` |
+| "when did bug start" in any language (e.g., "버그 언제 생겼어", "バグはいつ入った") | BISECT | `git bisect` |
+| "history of file" in any language (e.g., "파일 히스토리", "ファイル履歴") | FILE_LOG | `git log -- path` |
+| "find deleted code" in any language (e.g., "삭제된 코드 찾기", "削除されたコードを探す") | PICKAXE_ALL | `git log -S --all` |
 
 ### H1.2 Extract Search Parameters
 

--- a/src/features/builtin-skills/skills/git-master-sections/commit-workflow.ts
+++ b/src/features/builtin-skills/skills/git-master-sections/commit-workflow.ts
@@ -35,18 +35,18 @@ git log --oneline $(git merge-base HEAD main 2>/dev/null || git merge-base HEAD 
 <style_detection>
 **THIS PHASE HAS MANDATORY OUTPUT** - You MUST print the analysis result before moving to Phase 2.
 
-### 1.1 Language Detection
+### 1.1 Language Profile Detection
 
 \`\`\`
 Count from git log -30:
-- Korean characters: N commits
-- English only: M commits
-- Mixed: K commits
+- Dominant language/script patterns: N commits
+- Secondary language/script patterns: M commits
+- Mixed/ambiguous: K commits
 
 DECISION:
-- If Korean >= 50% -> KOREAN
-- If English >= 50% -> ENGLISH  
-- If Mixed -> Use MAJORITY language
+- Preserve the dominant repository language pattern in commit messages
+- If multiple languages are common, follow the nearest recent examples for the same module
+- Never restrict output to specific languages; support any language used by the repo (e.g., Japanese, Korean, English, etc.)
 \`\`\`
 
 ### 1.2 Commit Style Classification
@@ -79,9 +79,9 @@ STYLE DETECTION RESULT
 ======================
 Analyzed: 30 commits from git log
 
-Language: [KOREAN | ENGLISH]
-  - Korean commits: N (X%)
-  - English commits: M (Y%)
+Language profile: [DOMINANT_LANGUAGE_OR_SCRIPT]
+  - Dominant pattern: N (X%)
+  - Secondary pattern: M (Y%)
 
 Style: [SEMANTIC | PLAIN | SENTENCE | SHORT]
   - Semantic (feat:, fix:, etc): N (X%)
@@ -93,7 +93,7 @@ Reference examples from repo:
   2. "actual commit message from log"
   3. "actual commit message from log"
 
-All commits will follow: [LANGUAGE] + [STYLE]
+All commits will follow: [DOMINANT_LANGUAGE_OR_SCRIPT] + [STYLE]
 \`\`\`
 
 **IF YOU SKIP THIS OUTPUT, YOUR COMMITS WILL BE WRONG. STOP AND REDO.**
@@ -435,17 +435,19 @@ git log -1 --oneline
 **Based on COMMIT_CONFIG from Phase 1:**
 
 \`\`\`
-IF style == SEMANTIC AND language == KOREAN:
-  -> "feat: 로그인 기능 추가"
-  
-IF style == SEMANTIC AND language == ENGLISH:
-  -> "feat: add login feature"
-  
-IF style == PLAIN AND language == KOREAN:
-  -> "로그인 기능 추가"
-  
-IF style == PLAIN AND language == ENGLISH:
-  -> "Add login feature"
+IF style == SEMANTIC:
+  -> Use a semantic prefix + repository language message
+  -> Examples:
+     - "feat: add login feature"
+     - "feat: ログイン機能を追加"
+     - "feat: 로그인 기능 추가"
+
+IF style == PLAIN:
+  -> Use plain repository language message without semantic prefix
+  -> Examples:
+     - "Add login feature"
+     - "ログイン機能を追加"
+     - "로그인 기능 추가"
   
 IF style == SHORT:
   -> "format" / "type fix" / "lint"

--- a/src/features/builtin-skills/skills/git-master-sections/commit-workflow.ts
+++ b/src/features/builtin-skills/skills/git-master-sections/commit-workflow.ts
@@ -455,7 +455,7 @@ IF style == SHORT:
 
 **VALIDATION before each commit:**
 1. Does message match detected style?
-2. Does language match detected language?
+2. Does message use the repository's dominant language/script profile (from Phase 1.1)?
 3. Is it similar to examples from git log?
 
 If ANY check fails -> REWRITE message.

--- a/src/features/builtin-skills/skills/git-master-sections/history-search-workflow.ts
+++ b/src/features/builtin-skills/skills/git-master-sections/history-search-workflow.ts
@@ -7,12 +7,12 @@ export const GIT_MASTER_HISTORY_SEARCH_WORKFLOW_SECTION = `## HISTORY SEARCH MOD
 
 | User Request | Search Type | Tool |
 |--------------|-------------|------|
-| "when was X added" / "X가 언제 추가됐어" | PICKAXE | \`git log -S\` |
+| "when was X added" in any language (e.g., "X가 언제 추가됐어", "Xはいつ追加された") | PICKAXE | \`git log -S\` |
 | "find commits changing X pattern" | REGEX | \`git log -G\` |
-| "who wrote this line" / "이 줄 누가 썼어" | BLAME | \`git blame\` |
-| "when did bug start" / "버그 언제 생겼어" | BISECT | \`git bisect\` |
-| "history of file" / "파일 히스토리" | FILE_LOG | \`git log -- path\` |
-| "find deleted code" / "삭제된 코드 찾기" | PICKAXE_ALL | \`git log -S --all\` |
+| "who wrote this line" in any language (e.g., "이 줄 누가 썼어", "この行を書いたのは誰") | BLAME | \`git blame\` |
+| "when did bug start" in any language (e.g., "버그 언제 생겼어", "バグはいつ入った") | BISECT | \`git bisect\` |
+| "history of file" in any language (e.g., "파일 히스토리", "ファイル履歴") | FILE_LOG | \`git log -- path\` |
+| "find deleted code" in any language (e.g., "삭제된 코드 찾기", "削除されたコードを探す") | PICKAXE_ALL | \`git log -S --all\` |
 
 ### H1.2 Extract Search Parameters
 

--- a/src/features/builtin-skills/skills/git-master-sections/overview.ts
+++ b/src/features/builtin-skills/skills/git-master-sections/overview.ts
@@ -13,9 +13,9 @@ Analyze the user's request to determine operation mode:
 
 | User Request Pattern | Mode | Jump To |
 |---------------------|------|---------|
-| "commit", "커밋", changes to commit | \`COMMIT\` | Phase 0-6 (existing) |
-| "rebase", "리베이스", "squash", "cleanup history" | \`REBASE\` | Phase R1-R4 |
-| "find when", "who changed", "언제 바뀌었", "git blame", "bisect" | \`HISTORY_SEARCH\` | Phase H1-H3 |
+| Commit intent in any language (e.g., "commit", "커밋", "コミット") | \`COMMIT\` | Phase 0-6 (existing) |
+| Rebase/squash intent in any language (e.g., "rebase", "리베이스", "リベース") | \`REBASE\` | Phase R1-R4 |
+| History lookup intent in any language (e.g., "find when", "언제 바뀌었", "いつ追加") | \`HISTORY_SEARCH\` | Phase H1-H3 |
 | "smart rebase", "rebase onto" | \`REBASE\` | Phase R1-R4 |
 
 **CRITICAL**: Don't default to COMMIT mode. Parse the actual request.

--- a/src/features/builtin-skills/skills/git-master-sections/quick-reference.ts
+++ b/src/features/builtin-skills/skills/git-master-sections/quick-reference.ts
@@ -5,7 +5,7 @@ export const GIT_MASTER_QUICK_REFERENCE_SECTION = `## Quick Reference
 | If git log shows... | Use this style |
 |---------------------|----------------|
 | \`feat: xxx\`, \`fix: yyy\` | SEMANTIC |
-| \`Add xxx\`, \`Fix yyy\`, \`xxx 추가\` | PLAIN |
+| \`Add xxx\`, \`Fix yyy\`, \`xxx 추가\`, \`xxxを追加\` | PLAIN |
 | \`format\`, \`lint\`, \`typo\` | SHORT |
 | Full sentences | SENTENCE |
 | Mix of above | Use MAJORITY (not semantic by default) |

--- a/src/features/builtin-skills/skills/git-master-sections/rebase-workflow.ts
+++ b/src/features/builtin-skills/skills/git-master-sections/rebase-workflow.ts
@@ -30,19 +30,19 @@ git stash list
 \`\`\`
 USER REQUEST -> STRATEGY:
 
-"squash commits" / "cleanup" / "정리"
+"squash commits" intent in any language (e.g., "cleanup", "정리", "履歴整理")
   -> INTERACTIVE_SQUASH
 
-"rebase on main" / "update branch" / "메인에 리베이스"
+"rebase on main" intent in any language (e.g., "update branch", "메인에 리베이스", "mainにリベース")
   -> REBASE_ONTO_BASE
 
 "autosquash" / "apply fixups"
   -> AUTOSQUASH
 
-"reorder commits" / "커밋 순서"
+"reorder commits" intent in any language (e.g., "커밋 순서", "コミット順を並べ替え")
   -> INTERACTIVE_REORDER
 
-"split commit" / "커밋 분리"
+"split commit" intent in any language (e.g., "커밋 분리", "コミット分割")
   -> INTERACTIVE_EDIT
 \`\`\`
 </rebase_context>


### PR DESCRIPTION
## Summary

The `git-master` skill had English/Korean-centric wording throughout its language detection and commit message guidance, making it unclear whether other languages (e.g., Japanese) are supported. This PR makes all language-related guidance fully language-agnostic.

Fixes #3097

## Changes

- **Mode detection triggers**: replaced hardcoded Korean examples with generic "any language" phrasing, adding Japanese examples alongside existing ones
- **Language profile detection** (Phase 1.1): removed binary Korean/English detection logic; replaced with language-agnostic "dominant language pattern" approach that works for any repository language
- **Commit message generation** (Phase 5.4): removed KOREAN/ENGLISH branching; now shows multilingual examples (English, Japanese, Korean) as illustrative only
- **History search triggers**: added Japanese example phrases alongside Korean ones
- **Rebase mode triggers**: added Japanese example phrases alongside Korean ones
- **Quick reference cheat sheet**: added Japanese example (`xxxを追加`) alongside Korean (`xxx 추가`)
- Synced `src/features/builtin-skills/git-master/SKILL.md` to match all section-template changes

## Testing

- `bun test src/features/opencode-skill-loader/git-master-template-injection.test.ts` — 10 pass ✅
- `bun run typecheck` ✅
- `bun run build` ✅