### PR TITLE
fix(skill): pass directory to getAllSkills and fix async test timing

### DIFF
--- a/src/tools/skill/async-description-refresh.test.ts
+++ b/src/tools/skill/async-description-refresh.test.ts
@@ -1,6 +1,9 @@
 /// <reference types="bun-types" />
 
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 import { createSkillTool } from "./tools"
 import type { LoadedSkill } from "../../features/opencode-skill-loader/types"
 
@@ -24,15 +27,26 @@ async function waitForRefresh(predicate: () => boolean): Promise<void> {
       return
     }
 
-    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    await new Promise<void>((resolve) => setTimeout(resolve, 50))
   }
 }
 
 describe("skill tool - async native skill description refresh", () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "skill-async-test-"))
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
   it("updates description after async native skills resolve", async () => {
     //#given
     let allCallCount = 0
     const tool = createSkillTool({
+      directory: testDir,
       skills: [createMockSkill("seeded-skill")],
       commands: [],
       nativeSkills: {

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -24,7 +24,7 @@ import {
   mergeNativeSkills,
 } from "./native-skills"
 
-export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition {
+export function createSkillTool(options: SkillLoadOptions): ToolDefinition {
   let cachedDescription: string | null = null
 
   const getSkills = async (): Promise<LoadedSkill[]> => {
@@ -32,6 +32,7 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
     const discovered = await getAllSkills({
       disabledSkills: options?.disabledSkills,
       browserProvider: options?.browserProvider,
+      directory: options.directory,
     })
     const allSkills = !options.skills
       ? discovered
@@ -184,4 +185,4 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
   })
 }
 
-export const skill: ToolDefinition = createSkillTool()
+export const skill: ToolDefinition = createSkillTool({ directory: process.cwd() })


### PR DESCRIPTION
## Summary

- Fix `createSkillTool()` to require `directory` parameter instead of defaulting to `{}`, which no longer satisfies the `SkillLoadOptions` interface after `directory` became required
- Pass `directory` through to `getAllSkills()` call inside the skill tool's `getSkills()` function
- Fix `async-description-refresh.test.ts` to use an isolated temp directory and increase poll interval (0ms -> 50ms) to account for real async I/O in skill discovery

## Problem

After `directory` was added as a required field on `SkillLoadOptions`, two issues appeared:

1. `createSkillTool(options: SkillLoadOptions = {})` — the default `{}` no longer satisfies the interface since `directory: string` is required. TypeScript reports `TS2741: Property 'directory' is missing`.

2. `getAllSkills()` inside the tool was not receiving `directory` from options, so skill discovery couldn't resolve project-level skills correctly.

3. The async description refresh test used `setTimeout(resolve, 0)` which was sufficient when `getAllSkills` had no real I/O, but now that it receives a directory and does filesystem discovery, 50ms intervals are needed for the async chain to complete.

## Changes

### `src/tools/skill/tools.ts`
- Remove default `= {}` from `createSkillTool` parameter (callers must pass options)
- Add `directory: options.directory` to the `getAllSkills()` call
- Standalone `skill` export uses `process.cwd()` as fallback directory

### `src/tools/skill/async-description-refresh.test.ts`
- Use `mkdtempSync` for isolated test directory (prevents real project skills from interfering)
- Increase poll interval from 0ms to 50ms in `waitForRefresh`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a `directory` in `createSkillTool`, pass it to `getAllSkills`, and set the default `skill` export to use `process.cwd()` to restore correct skill discovery. Stabilize the async refresh test with an isolated temp directory and a 50ms poll interval.

<sup>Written for commit 684c4e902e63b1402ffe2984d394a0f9cf790430. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

