### PR TITLE
refactor: replace em dashes with hyphens in test files and docs

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -3435,10 +3435,10 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
 
     getTaskMap(manager).set(task.id, task)
 
-    //#when — session is actively running
+    //#when - session is actively running
     await manager["checkAndInterruptStaleTasks"]({ "session-running": { type: "running" } })
 
-    //#then — task survives because session is running
+    //#then - task survives because session is running
     expect(task.status).toBe("running")
   })
 
@@ -3475,10 +3475,10 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
 
     getTaskMap(manager).set(task.id, task)
 
-    //#when — session is idle
+    //#when - session is idle
     await manager["checkAndInterruptStaleTasks"]({ "session-idle": { type: "idle" } })
 
-    //#then — killed because session is idle with stale lastUpdate
+    //#then - killed because session is idle with stale lastUpdate
     expect(task.status).toBe("cancelled")
     expect(task.error).toContain("Stale timeout")
   })
@@ -3512,15 +3512,15 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
 
     getTaskMap(manager).set(task.id, task)
 
-    //#when — session is running, lastUpdate 15min old
+    //#when - session is running, lastUpdate 15min old
     await manager["checkAndInterruptStaleTasks"]({ "session-long": { type: "running" } })
 
-    //#then — running sessions are NEVER stale-killed
+    //#then - running sessions are NEVER stale-killed
     expect(task.status).toBe("running")
   })
 
   test("should NOT interrupt running session with no progress (undefined lastUpdate)", async () => {
-    //#given — no progress at all, but session is running
+    //#given - no progress at all, but session is running
     const client = {
       session: {
         prompt: async () => ({}),
@@ -3546,10 +3546,10 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
 
     getTaskMap(manager).set(task.id, task)
 
-    //#when — session is running despite no progress
+    //#when - session is running despite no progress
     await manager["checkAndInterruptStaleTasks"]({ "session-rnp": { type: "running" } })
 
-    //#then — running sessions are NEVER killed
+    //#then - running sessions are NEVER killed
     expect(task.status).toBe("running")
   })
 
@@ -3585,10 +3585,10 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
 
     getTaskMap(manager).set(task.id, task)
 
-    //#when — no progress update for 15 minutes
+    //#when - no progress update for 15 minutes
     await manager["checkAndInterruptStaleTasks"]({})
 
-    //#then — killed because session gone from status registry
+    //#then - killed because session gone from status registry
     expect(task.status).toBe("cancelled")
     expect(task.error).toContain("session gone from status registry")
   })
@@ -3619,10 +3619,10 @@ describe("BackgroundManager.checkAndInterruptStaleTasks", () => {
 
     getTaskMap(manager).set(task.id, task)
 
-    //#when — only 5 min since start, within 10min session-gone timeout
+    //#when - only 5 min since start, within 10min session-gone timeout
     await manager["checkAndInterruptStaleTasks"]({})
 
-    //#then — task survives
+    //#then - task survives
     expect(task.status).toBe("running")
   })
 })

--- a/src/features/background-agent/task-poller.test.ts
+++ b/src/features/background-agent/task-poller.test.ts
@@ -108,7 +108,7 @@ describe("checkAndInterruptStaleTasks", () => {
   })
 
   it("should interrupt tasks with NO progress.lastUpdate that exceeded messageStalenessTimeoutMs since startedAt", async () => {
-    //#given — task started 15 minutes ago, never received any progress update
+    //#given - task started 15 minutes ago, never received any progress update
     const task = createRunningTask({
       startedAt: new Date(Date.now() - 15 * 60 * 1000),
       progress: undefined,
@@ -162,7 +162,7 @@ describe("checkAndInterruptStaleTasks", () => {
   })
 
   it("should NOT interrupt tasks with NO progress.lastUpdate that are within messageStalenessTimeoutMs", async () => {
-    //#given — task started 5 minutes ago, default timeout is 10 minutes
+    //#given - task started 5 minutes ago, default timeout is 10 minutes
     const task = createRunningTask({
       startedAt: new Date(Date.now() - 5 * 60 * 1000),
       progress: undefined,
@@ -182,13 +182,13 @@ describe("checkAndInterruptStaleTasks", () => {
   })
 
   it("should use DEFAULT_MESSAGE_STALENESS_TIMEOUT_MS when messageStalenessTimeoutMs is not configured", async () => {
-    //#given — task started 65 minutes ago, no config for messageStalenessTimeoutMs
+    //#given - task started 65 minutes ago, no config for messageStalenessTimeoutMs
     const task = createRunningTask({
       startedAt: new Date(Date.now() - 65 * 60 * 1000),
       progress: undefined,
     })
 
-    //#when — default is 60 minutes (3_600_000ms)
+    //#when - default is 60 minutes (3_600_000ms)
     await checkAndInterruptStaleTasks({
       tasks: [task],
       client: mockClient as never,
@@ -203,7 +203,7 @@ describe("checkAndInterruptStaleTasks", () => {
   })
 
   it("should NOT interrupt task when session is running, even if lastUpdate exceeds stale timeout", async () => {
-    //#given — lastUpdate is 5min old but session is actively running
+    //#given - lastUpdate is 5min old but session is actively running
     const task = createRunningTask({
       startedAt: new Date(Date.now() - 300_000),
       progress: {
@@ -212,7 +212,7 @@ describe("checkAndInterruptStaleTasks", () => {
       },
     })
 
-    //#when — session status is "busy" (OpenCode's actual status for active LLM processing)
+    //#when - session status is "busy" (OpenCode's actual status for active LLM processing)
     await checkAndInterruptStaleTasks({
       tasks: [task],
       client: mockClient as never,
@@ -222,12 +222,12 @@ describe("checkAndInterruptStaleTasks", () => {
       sessionStatuses: { "ses-1": { type: "busy" } },
     })
 
-    //#then — task should survive because session is actively busy
+    //#then - task should survive because session is actively busy
     expect(task.status).toBe("running")
   })
 
   it("should NOT interrupt busy session task even with very old lastUpdate", async () => {
-    //#given — lastUpdate is 15min old, but session is still busy
+    //#given - lastUpdate is 15min old, but session is still busy
     const task = createRunningTask({
       startedAt: new Date(Date.now() - 900_000),
       progress: {
@@ -236,7 +236,7 @@ describe("checkAndInterruptStaleTasks", () => {
       },
     })
 
-    //#when — session busy, lastUpdate far exceeds any timeout
+    //#when - session busy, lastUpdate far exceeds any timeout
     await checkAndInterruptStaleTasks({
       tasks: [task],
       client: mockClient as never,
@@ -246,18 +246,18 @@ describe("checkAndInterruptStaleTasks", () => {
       sessionStatuses: { "ses-1": { type: "busy" } },
     })
 
-    //#then — busy sessions are NEVER stale-killed (babysitter + TTL prune handle these)
+    //#then - busy sessions are NEVER stale-killed (babysitter + TTL prune handle these)
     expect(task.status).toBe("running")
   })
 
   it("should NOT interrupt busy session even with no progress (undefined lastUpdate)", async () => {
-    //#given — task has no progress at all, but session is busy
+    //#given - task has no progress at all, but session is busy
     const task = createRunningTask({
       startedAt: new Date(Date.now() - 15 * 60 * 1000),
       progress: undefined,
     })
 
-    //#when — session is busy
+    //#when - session is busy
     await checkAndInterruptStaleTasks({
       tasks: [task],
       client: mockClient as never,
@@ -267,12 +267,12 @@ describe("checkAndInterruptStaleTasks", () => {
       sessionStatuses: { "ses-1": { type: "busy" } },
     })
 
-    //#then — task should survive because session is actively running
+    //#then - task should survive because session is actively running
     expect(task.status).toBe("running")
   })
 
   it("should interrupt task when session is idle and lastUpdate exceeds stale timeout", async () => {
-    //#given — lastUpdate is 5min old and session is idle
+    //#given - lastUpdate is 5min old and session is idle
     const task = createRunningTask({
       startedAt: new Date(Date.now() - 300_000),
       progress: {
@@ -281,7 +281,7 @@ describe("checkAndInterruptStaleTasks", () => {
       },
     })
 
-    //#when — session status is "idle"
+    //#when - session status is "idle"
     await checkAndInterruptStaleTasks({
       tasks: [task],
       client: mockClient as never,
@@ -291,13 +291,13 @@ describe("checkAndInterruptStaleTasks", () => {
       sessionStatuses: { "ses-1": { type: "idle" } },
     })
 
-    //#then — task should be killed because session is idle with stale lastUpdate
+    //#then - task should be killed because session is idle with stale lastUpdate
     expect(task.status).toBe("cancelled")
     expect(task.error).toContain("Stale timeout")
   })
 
   it("should NOT interrupt running session task even with very old lastUpdate", async () => {
-    //#given — lastUpdate is 15min old, but session is still running
+    //#given - lastUpdate is 15min old, but session is still running
     const task = createRunningTask({
       startedAt: new Date(Date.now() - 900_000),
       progress: {
@@ -306,7 +306,7 @@ describe("checkAndInterruptStaleTasks", () => {
       },
     })
 
-    //#when — session running, lastUpdate far exceeds any timeout
+    //#when - session running, lastUpdate far exceeds any timeout
     await checkAndInterruptStaleTasks({
       tasks: [task],
       client: mockClient as never,
@@ -316,12 +316,12 @@ describe("checkAndInterruptStaleTasks", () => {
       sessionStatuses: { "ses-1": { type: "running" } },
     })
 
-    //#then — running sessions are NEVER stale-killed (babysitter + TTL prune handle these)
+    //#then - running sessions are NEVER stale-killed (babysitter + TTL prune handle these)
     expect(task.status).toBe("running")
   })
 
   it("should NOT interrupt running session even with no progress (undefined lastUpdate)", async () => {
-    //#given — task has no progress at all, but session is running
+    //#given - task has no progress at all, but session is running
     const task = createRunningTask({
       startedAt: new Date(Date.now() - 15 * 60 * 1000),
       progress: undefined,

--- a/src/features/builtin-commands/commands.test.ts
+++ b/src/features/builtin-commands/commands.test.ts
@@ -103,7 +103,7 @@ describe("loadBuiltinCommands", () => {
   })
 })
 
-describe("loadBuiltinCommands — remove-ai-slops", () => {
+describe("loadBuiltinCommands - remove-ai-slops", () => {
   test("should include remove-ai-slops command in loaded commands", () => {
     //#given
     const disabledCommands: BuiltinCommandName[] = []

--- a/src/hooks/context-window-monitor.model-context-limits.test.ts
+++ b/src/hooks/context-window-monitor.model-context-limits.test.ts
@@ -173,7 +173,7 @@ describe("context-window-monitor modelContextLimitsCache", () => {
         const output = createOutput()
         await hook["tool.execute.after"]({ tool: "bash", sessionID, callID: "call_1" }, output)
 
-        // then — 160K/500K = 32%, well below 70% threshold
+        // then - 160K/500K = 32%, well below 70% threshold
         expect(output.output).toBe("original")
       })
     })

--- a/src/hooks/model-fallback/hook.test.ts
+++ b/src/hooks/model-fallback/hook.test.ts
@@ -400,7 +400,7 @@ describe("model fallback hook", () => {
     //#when
     await hook["chat.message"]?.({ sessionID }, output)
 
-    //#then — model name should be transformed from hyphen to dot notation
+    //#then - model name should be transformed from hyphen to dot notation
     expect(output.message["model"]).toEqual({
       providerID: "github-copilot",
       modelID: "claude-sonnet-4.6",

--- a/src/hooks/preemptive-compaction.test.ts
+++ b/src/hooks/preemptive-compaction.test.ts
@@ -601,7 +601,7 @@ describe("preemptive-compaction", () => {
     })
     const sessionID = "ses_kimi_limit"
 
-    // 180k total tokens — above 78% of 200k (156k) but below 78% of 256k (204k)
+    // 180k total tokens - above 78% of 200k (156k) but below 78% of 256k (204k)
     await hook.event({
       event: {
         type: "message.updated",
@@ -644,7 +644,7 @@ describe("preemptive-compaction", () => {
     })
     const sessionID = "ses_kimi_trigger"
 
-    // 210k total — above 78% of 256k (≈204k)
+    // 210k total - above 78% of 256k (≈204k)
     await hook.event({
       event: {
         type: "message.updated",

--- a/src/hooks/runtime-fallback/error-classifier.test.ts
+++ b/src/hooks/runtime-fallback/error-classifier.test.ts
@@ -134,7 +134,7 @@ describe("extractStatusCode", () => {
   })
 
   test("skips non-numeric status and finds deeper numeric statusCode", () => {
-    //#given — status is a string, but error.statusCode is numeric
+    //#given - status is a string, but error.statusCode is numeric
     const error = {
       status: "error",
       error: { statusCode: 429 },

--- a/src/tools/AGENTS.md
+++ b/src/tools/AGENTS.md
@@ -1,4 +1,4 @@
-# src/tools/ — 26 Tools Across 15 Directories
+# src/tools/ - 26 Tools Across 15 Directories
 
 **Generated:** 2026-03-06
 
@@ -38,7 +38,7 @@
 | `background_output` | `createBackgroundOutput` | task_id, block, timeout, full_session, include_thinking, message_limit, since_message_id, thinking_max_chars |
 | `background_cancel` | `createBackgroundCancel` | taskId, all |
 
-### LSP Refactoring (6) — Direct ToolDefinition
+### LSP Refactoring (6) - Direct ToolDefinition
 
 | Tool | Parameters |
 |------|------------|
@@ -81,7 +81,7 @@
 | `interactive_bash` | Direct | tmux_command |
 | `look_at` | `createLookAt` | file_path, image_data, goal |
 
-### Editing (1) — Conditional
+### Editing (1) - Conditional
 
 | Tool | Factory | Parameters |
 |------|---------|------------|


### PR DESCRIPTION
## Summary
- Replace em dashes with hyphens in 8 files (7 test files + AGENTS.md)
- No logic changes, text-only replacements in comments/descriptions
- Aligns with project convention: no em/en dashes in code

## Pre-publish review: V3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace em dashes with hyphens across tests and `src/tools/AGENTS.md` to match project style. Text-only cleanup; no behavior or test logic changes.

- **Refactors**
  - Updated 8 files (7 tests + `src/tools/AGENTS.md`) to use hyphens (-) instead of em dashes (—).
  - Changes limited to comments, test descriptions, and markdown headings.

<sup>Written for commit e860108b60b9984be380d428d23046dcfa4766d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

