### PR TITLE
fix(config): allow disabling new built-in skills

### DIFF
--- a/src/config/schema/agent-names.test.ts
+++ b/src/config/schema/agent-names.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { OhMyOpenCodeConfigSchema } from "./oh-my-opencode-config"
+
+describe("OhMyOpenCodeConfigSchema disabled_skills", () => {
+  test("accepts review-work and ai-slop-remover", () => {
+    // given
+    const config = {
+      disabled_skills: ["review-work", "ai-slop-remover"],
+    }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(config)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.disabled_skills).toEqual([
+        "review-work",
+        "ai-slop-remover",
+      ])
+    }
+  })
+})

--- a/src/config/schema/agent-names.ts
+++ b/src/config/schema/agent-names.ts
@@ -20,6 +20,8 @@ export const BuiltinSkillNameSchema = z.enum([
   "dev-browser",
   "frontend-ui-ux",
   "git-master",
+  "review-work",
+  "ai-slop-remover",
 ])
 
 export const OverridableAgentNameSchema = z.enum([


### PR DESCRIPTION
## Summary
- Add review-work and ai-slop-remover to BuiltinSkillNameSchema
- Add regression test for disabled_skills config acceptance

## Testing
- `bun run typecheck` ✅
- `bun test src/config/ src/features/builtin-skills/` ✅
- `bun run build` ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow disabling the new built-in skills `review-work` and `ai-slop-remover` by adding them to `BuiltinSkillNameSchema`. Adds a regression test to ensure `disabled_skills` accepts these values.

<sup>Written for commit 8199adcb153e270f384389f0380be9f70582578d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

