### PR TITLE
fix(install): add plugin cache compat for OpenCode 1.3.14

### DIFF
--- a/src/cli/cli-installer.test.ts
+++ b/src/cli/cli-installer.test.ts
@@ -3,6 +3,43 @@ import * as configManager from "./config-manager"
 import { runCliInstaller } from "./cli-installer"
 import type { InstallArgs } from "./types"
 
+function createCacheRepairResult(
+  status: "healthy" | "repaired" | "failed",
+  success: boolean
+) {
+  const location = {
+    entry: "oh-my-openagent",
+    source: "npm" as const,
+    packageName: "oh-my-openagent",
+    cacheDir: "/tmp/opencode/packages/oh-my-openagent",
+    cachePackagePath: "/tmp/opencode/packages/oh-my-openagent/package.json",
+    cacheLockfilePath: "/tmp/opencode/packages/oh-my-openagent/package-lock.json",
+    installedPackageJsonPath: "/tmp/opencode/packages/oh-my-openagent/node_modules/oh-my-openagent/package.json",
+  }
+
+  return {
+    success,
+    status,
+    attempted: status !== "healthy",
+    initialInspection: {
+      entry: "oh-my-openagent",
+      status: success ? "corrupt" : "missing",
+      location,
+      requiredPaths: [],
+      missingPaths: [],
+    },
+    finalInspection: {
+      entry: "oh-my-openagent",
+      status: success ? "healthy" : "corrupt",
+      location,
+      requiredPaths: [],
+      missingPaths: success ? [] : [location.cacheLockfilePath],
+    },
+    attempts: [],
+    error: success ? undefined : "Cache repair failed",
+  }
+}
+
 describe("runCliInstaller", () => {
   const mockConsoleLog = mock(() => {})
   const mockConsoleError = mock(() => {})
@@ -40,11 +77,13 @@ describe("runCliInstaller", () => {
       spyOn(configManager, "addPluginToOpenCodeConfig").mockResolvedValue({
         success: true,
         configPath: "/tmp/opencode.jsonc",
+        pluginEntry: "oh-my-openagent",
       }),
       spyOn(configManager, "writeOmoConfig").mockReturnValue({
         success: true,
         configPath: "/tmp/oh-my-opencode.jsonc",
       }),
+      spyOn(configManager, "repairPluginCache").mockResolvedValue(createCacheRepairResult("repaired", true)),
     ]
 
     const args: InstallArgs = {
@@ -63,6 +102,119 @@ describe("runCliInstaller", () => {
 
     //#then
     expect(result).toBe(0)
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+  })
+
+  it("repairs the plugin cache after registration when OpenCode is installed", async () => {
+    //#given
+    const addPluginSpy = spyOn(configManager, "addPluginToOpenCodeConfig").mockResolvedValue({
+      success: true,
+      configPath: "/tmp/opencode.jsonc",
+      pluginEntry: "oh-my-openagent@latest",
+    })
+    const writeConfigSpy = spyOn(configManager, "writeOmoConfig").mockReturnValue({
+      success: true,
+      configPath: "/tmp/oh-my-opencode.jsonc",
+    })
+    const repairSpy = spyOn(configManager, "repairPluginCache").mockResolvedValue(
+      createCacheRepairResult("repaired", true)
+    )
+    const restoreSpies = [
+      spyOn(configManager, "detectCurrentConfig").mockReturnValue({
+        isInstalled: false,
+        hasClaude: true,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+      }),
+      spyOn(configManager, "isOpenCodeInstalled").mockResolvedValue(true),
+      spyOn(configManager, "getOpenCodeVersion").mockResolvedValue("1.3.14"),
+      addPluginSpy,
+      writeConfigSpy,
+      repairSpy,
+    ]
+    const args: InstallArgs = {
+      tui: false,
+      claude: "yes",
+      openai: "no",
+      gemini: "no",
+      copilot: "no",
+      opencodeZen: "no",
+      zaiCodingPlan: "no",
+      kimiForCoding: "no",
+    }
+
+    //#when
+    const result = await runCliInstaller(args, "3.4.0")
+
+    //#then
+    expect(result).toBe(0)
+    expect(addPluginSpy).toHaveBeenCalled()
+    expect(writeConfigSpy).toHaveBeenCalled()
+    expect(repairSpy).toHaveBeenCalledWith("oh-my-openagent@latest")
+
+    for (const spy of restoreSpies) {
+      spy.mockRestore()
+    }
+  })
+
+  it("warns on cache repair failure without aborting installation", async () => {
+    //#given
+    const repairSpy = spyOn(configManager, "repairPluginCache").mockResolvedValue(
+      createCacheRepairResult("failed", false)
+    )
+    const restoreSpies = [
+      spyOn(configManager, "detectCurrentConfig").mockReturnValue({
+        isInstalled: false,
+        hasClaude: true,
+        isMax20: false,
+        hasOpenAI: false,
+        hasGemini: false,
+        hasCopilot: false,
+        hasOpencodeZen: false,
+        hasZaiCodingPlan: false,
+        hasKimiForCoding: false,
+        hasOpencodeGo: false,
+      }),
+      spyOn(configManager, "isOpenCodeInstalled").mockResolvedValue(true),
+      spyOn(configManager, "getOpenCodeVersion").mockResolvedValue("1.3.14"),
+      spyOn(configManager, "addPluginToOpenCodeConfig").mockResolvedValue({
+        success: true,
+        configPath: "/tmp/opencode.jsonc",
+        pluginEntry: "oh-my-openagent",
+      }),
+      spyOn(configManager, "writeOmoConfig").mockReturnValue({
+        success: true,
+        configPath: "/tmp/oh-my-opencode.jsonc",
+      }),
+      repairSpy,
+    ]
+    const args: InstallArgs = {
+      tui: false,
+      claude: "yes",
+      openai: "no",
+      gemini: "no",
+      copilot: "no",
+      opencodeZen: "no",
+      zaiCodingPlan: "no",
+      kimiForCoding: "no",
+    }
+
+    //#when
+    const result = await runCliInstaller(args, "3.4.0")
+
+    //#then
+    expect(result).toBe(0)
+    expect(repairSpy).toHaveBeenCalledWith("oh-my-openagent")
+    expect(mockConsoleLog.mock.calls.flat().join("\n")).toContain("could not be repaired automatically")
 
     for (const spy of restoreSpies) {
       spy.mockRestore()

--- a/src/cli/cli-installer.ts
+++ b/src/cli/cli-installer.ts
@@ -1,11 +1,16 @@
+import { existsSync } from "node:fs"
+
 import color from "picocolors"
 import { PLUGIN_NAME } from "../shared"
 import type { InstallArgs } from "./types"
 import {
   addPluginToOpenCodeConfig,
   detectCurrentConfig,
+  getConfigDir,
+  getOpenCodePackagesCacheRootPath,
   getOpenCodeVersion,
   isOpenCodeInstalled,
+  repairPluginCache,
   writeOmoConfig,
 } from "./config-manager"
 import {
@@ -22,6 +27,16 @@ import {
   printWarning,
   validateNonTuiArgs,
 } from "./install-validators"
+
+function printPluginCacheRepairWarning(cacheDir: string, error?: string): void {
+  printWarning("OpenCode plugin cache could not be repaired automatically.")
+  printInfo(`Cache directory: ${cacheDir}`)
+  printInfo(`Manual cleanup: rm -rf "${cacheDir}"`)
+  printInfo(`Then rerun: bunx ${PLUGIN_NAME} install`)
+  if (error) {
+    printInfo(`Details: ${error}`)
+  }
+}
 
 export async function runCliInstaller(args: InstallArgs, version: string): Promise<number> {
   const validation = validateNonTuiArgs(args)
@@ -43,6 +58,9 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
   const isUpdate = detected.isInstalled
 
   printHeader(isUpdate)
+
+  const hadConfigDir = existsSync(getConfigDir())
+  const hadPackagesCacheDir = existsSync(getOpenCodePackagesCacheRootPath())
 
   const totalSteps = 4
   let step = 1
@@ -83,6 +101,28 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
     return 1
   }
   printSuccess(`Config written ${SYMBOLS.arrow} ${color.dim(omoResult.configPath)}`)
+
+  printStep(step++, totalSteps, "Priming OpenCode plugin cache...")
+  const pluginEntry = pluginResult.pluginEntry
+  const shouldRepairCache = Boolean(pluginEntry) && (installed || hadConfigDir || hadPackagesCacheDir)
+
+  if (!pluginEntry) {
+    printInfo("Skipped cache priming because the plugin entry could not be resolved.")
+  } else if (!shouldRepairCache) {
+    printInfo("Skipped cache priming until OpenCode creates its cache workspace.")
+  } else {
+    const cacheRepair = await repairPluginCache(pluginEntry)
+    const cacheDir = cacheRepair.finalInspection.location.cacheDir
+
+    if (cacheRepair.status === "skipped") {
+      printInfo("Skipped cache priming for local plugin entries.")
+    } else if (cacheRepair.success) {
+      const verb = cacheRepair.status === "repaired" ? "repaired" : "verified"
+      printSuccess(`Plugin cache ${verb} ${SYMBOLS.arrow} ${color.dim(cacheDir ?? "unknown cache path")}`)
+    } else {
+      printPluginCacheRepairWarning(cacheDir ?? "unknown cache path", cacheRepair.error)
+    }
+  }
 
   printBox(formatConfigSummary(config), isUpdate ? "Updated Configuration" : "Installation Complete")
 

--- a/src/cli/config-manager.ts
+++ b/src/cli/config-manager.ts
@@ -2,12 +2,31 @@ export type { ConfigContext } from "./config-manager/config-context"
 export {
   initConfigContext,
   getConfigContext,
+  getConfigDir,
   resetConfigContext,
 } from "./config-manager/config-context"
 
 export { fetchNpmDistTags } from "./config-manager/npm-dist-tags"
 export { getPluginNameWithVersion } from "./config-manager/plugin-name-with-version"
 export { addPluginToOpenCodeConfig } from "./config-manager/add-plugin-to-opencode-config"
+export {
+  getOpenCodeCacheRootPath,
+  getOpenCodePackagesCacheRootPath,
+  getPackageNameFromPluginEntry,
+  isLocalPluginEntry,
+  resolvePluginCacheLocation,
+} from "./config-manager/plugin-cache-entry"
+export type { PluginCacheLocation } from "./config-manager/plugin-cache-entry"
+export { inspectPluginCache } from "./config-manager/plugin-cache-health"
+export type {
+  PluginCacheInspection,
+  PluginCacheStatus,
+} from "./config-manager/plugin-cache-health"
+export { repairPluginCache } from "./config-manager/plugin-cache-repair"
+export type {
+  PluginCacheRepairAttempt,
+  PluginCacheRepairResult,
+} from "./config-manager/plugin-cache-repair"
 
 export { generateOmoConfig } from "./config-manager/generate-omo-config"
 export { writeOmoConfig } from "./config-manager/write-omo-config"

--- a/src/cli/config-manager/add-plugin-to-opencode-config.ts
+++ b/src/cli/config-manager/add-plugin-to-opencode-config.ts
@@ -26,7 +26,7 @@ export async function addPluginToOpenCodeConfig(currentVersion: string): Promise
     if (format === "none") {
       const config: OpenCodeConfig = { plugin: [pluginEntry] }
       writeFileSync(path, JSON.stringify(config, null, 2) + "\n")
-      return { success: true, configPath: path }
+      return { success: true, configPath: path, pluginEntry }
     }
 
     const parseResult = parseOpenCodeConfigFileWithError(path)
@@ -54,14 +54,18 @@ export async function addPluginToOpenCodeConfig(currentVersion: string): Promise
 
     const normalizedPlugins = [...otherPlugins]
 
+    let finalPluginEntry = pluginEntry
+
     if (canonicalEntries.length > 0) {
-      normalizedPlugins.push(canonicalEntries[0])
+      finalPluginEntry = canonicalEntries[0]
+      normalizedPlugins.push(finalPluginEntry)
     } else if (legacyEntries.length > 0) {
       const versionMatch = legacyEntries[0].match(/@(.+)$/)
       const preservedVersion = versionMatch ? versionMatch[1] : null
-      normalizedPlugins.push(preservedVersion ? `${PLUGIN_NAME}@${preservedVersion}` : pluginEntry)
+      finalPluginEntry = preservedVersion ? `${PLUGIN_NAME}@${preservedVersion}` : pluginEntry
+      normalizedPlugins.push(finalPluginEntry)
     } else {
-      normalizedPlugins.push(pluginEntry)
+      normalizedPlugins.push(finalPluginEntry)
     }
 
     config.plugin = normalizedPlugins
@@ -76,14 +80,14 @@ export async function addPluginToOpenCodeConfig(currentVersion: string): Promise
         const newContent = content.replace(pluginArrayRegex, `$1[\n    ${formattedPlugins}\n  ]`)
         writeFileSync(path, newContent)
       } else {
-        const newContent = content.replace(/(\{)/, `$1\n  "plugin": ["${pluginEntry}"],`)
+        const newContent = content.replace(/(\{)/, `$1\n  "plugin": ["${finalPluginEntry}"],`)
         writeFileSync(path, newContent)
       }
     } else {
       writeFileSync(path, JSON.stringify(config, null, 2) + "\n")
     }
 
-    return { success: true, configPath: path }
+    return { success: true, configPath: path, pluginEntry: finalPluginEntry }
   } catch (err) {
     return {
       success: false,

--- a/src/cli/config-manager/plugin-cache-entry.test.ts
+++ b/src/cli/config-manager/plugin-cache-entry.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { join } from "node:path"
+
+import {
+  getPackageNameFromPluginEntry,
+  getOpenCodePackagesCacheRootPath,
+  isLocalPluginEntry,
+  resolvePluginCacheLocation,
+} from "./plugin-cache-entry"
+
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME
+
+afterEach(() => {
+  if (originalXdgCacheHome === undefined) {
+    delete process.env.XDG_CACHE_HOME
+  } else {
+    process.env.XDG_CACHE_HOME = originalXdgCacheHome
+  }
+})
+
+describe("plugin cache entry", () => {
+  it("derives the cache path for a bare canonical package entry", () => {
+    //#given
+    process.env.XDG_CACHE_HOME = "/tmp/omo-cache-entry-bare"
+
+    //#when
+    const location = resolvePluginCacheLocation("oh-my-openagent")
+
+    //#then
+    expect(location.source).toBe("npm")
+    expect(location.packageName).toBe("oh-my-openagent")
+    expect(location.cacheDir).toBe(join(getOpenCodePackagesCacheRootPath(), "oh-my-openagent"))
+  })
+
+  it("derives the cache path for a tagged canonical package entry", () => {
+    //#given
+    process.env.XDG_CACHE_HOME = "/tmp/omo-cache-entry-tagged"
+
+    //#when
+    const location = resolvePluginCacheLocation("oh-my-openagent@latest")
+
+    //#then
+    expect(location.packageName).toBe("oh-my-openagent")
+    expect(location.cacheDir).toBe(join(getOpenCodePackagesCacheRootPath(), "oh-my-openagent@latest"))
+  })
+
+  it("derives the cache path for an exact version entry", () => {
+    //#given
+    process.env.XDG_CACHE_HOME = "/tmp/omo-cache-entry-versioned"
+
+    //#when
+    const location = resolvePluginCacheLocation("oh-my-openagent@1.2.3")
+
+    //#then
+    expect(location.packageName).toBe("oh-my-openagent")
+    expect(location.cacheDir).toBe(join(getOpenCodePackagesCacheRootPath(), "oh-my-openagent@1.2.3"))
+  })
+
+  it("derives the cache path for a legacy package entry", () => {
+    //#given
+    process.env.XDG_CACHE_HOME = "/tmp/omo-cache-entry-legacy"
+
+    //#when
+    const location = resolvePluginCacheLocation("oh-my-opencode@3.0.0")
+
+    //#then
+    expect(location.packageName).toBe("oh-my-opencode")
+    expect(location.installedPackageJsonPath).toBe(
+      join(getOpenCodePackagesCacheRootPath(), "oh-my-opencode@3.0.0", "node_modules", "oh-my-opencode", "package.json"),
+    )
+  })
+
+  it("marks file entries as local and skips cache resolution", () => {
+    //#given
+    const entry = "file:///tmp/oh-my-openagent"
+
+    //#when
+    const location = resolvePluginCacheLocation(entry)
+
+    //#then
+    expect(isLocalPluginEntry(entry)).toBe(true)
+    expect(getPackageNameFromPluginEntry(entry)).toBeNull()
+    expect(location.source).toBe("local")
+    expect(location.cacheDir).toBeNull()
+  })
+})

--- a/src/cli/config-manager/plugin-cache-entry.ts
+++ b/src/cli/config-manager/plugin-cache-entry.ts
@@ -1,0 +1,73 @@
+import { join } from "node:path"
+import { homedir } from "node:os"
+
+const WINDOWS_ABSOLUTE_PATH_REGEX = /^[A-Za-z]:[\\/]/
+
+export type PluginEntrySource = "npm" | "local"
+
+export interface PluginCacheLocation {
+  entry: string
+  source: PluginEntrySource
+  packageName: string | null
+  cacheDir: string | null
+  cachePackagePath: string | null
+  cacheLockfilePath: string | null
+  installedPackageJsonPath: string | null
+}
+
+export function getOpenCodeCacheRootPath(): string {
+  const cacheHome = process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache")
+  return join(cacheHome, "opencode")
+}
+
+export function getOpenCodePackagesCacheRootPath(): string {
+  return join(getOpenCodeCacheRootPath(), "packages")
+}
+
+export function isLocalPluginEntry(entry: string): boolean {
+  return (
+    entry.startsWith("file://")
+    || entry.startsWith(".")
+    || entry.startsWith("/")
+    || WINDOWS_ABSOLUTE_PATH_REGEX.test(entry)
+  )
+}
+
+export function getPackageNameFromPluginEntry(entry: string): string | null {
+  if (isLocalPluginEntry(entry)) {
+    return null
+  }
+
+  const lastAt = entry.lastIndexOf("@")
+  return lastAt > 0 ? entry.slice(0, lastAt) : entry
+}
+
+function buildInstalledPackageJsonPath(cacheDir: string, packageName: string): string {
+  return join(cacheDir, "node_modules", ...packageName.split("/"), "package.json")
+}
+
+export function resolvePluginCacheLocation(entry: string): PluginCacheLocation {
+  const packageName = getPackageNameFromPluginEntry(entry)
+  if (!packageName) {
+    return {
+      entry,
+      source: "local",
+      packageName: null,
+      cacheDir: null,
+      cachePackagePath: null,
+      cacheLockfilePath: null,
+      installedPackageJsonPath: null,
+    }
+  }
+
+  const cacheDir = join(getOpenCodePackagesCacheRootPath(), entry)
+  return {
+    entry,
+    source: "npm",
+    packageName,
+    cacheDir,
+    cachePackagePath: join(cacheDir, "package.json"),
+    cacheLockfilePath: join(cacheDir, "package-lock.json"),
+    installedPackageJsonPath: buildInstalledPackageJsonPath(cacheDir, packageName),
+  }
+}

--- a/src/cli/config-manager/plugin-cache-health.ts
+++ b/src/cli/config-manager/plugin-cache-health.ts
@@ -1,0 +1,54 @@
+import { existsSync } from "node:fs"
+
+import {
+  resolvePluginCacheLocation,
+  type PluginCacheLocation,
+} from "./plugin-cache-entry"
+
+export type PluginCacheStatus = "healthy" | "missing" | "corrupt" | "local"
+
+export interface PluginCacheInspection {
+  entry: string
+  status: PluginCacheStatus
+  location: PluginCacheLocation
+  requiredPaths: string[]
+  missingPaths: string[]
+}
+
+function getRequiredPaths(location: PluginCacheLocation): string[] {
+  return [
+    location.cachePackagePath,
+    location.cacheLockfilePath,
+    location.installedPackageJsonPath,
+  ].filter((pathValue): pathValue is string => Boolean(pathValue))
+}
+
+export function inspectPluginCache(entry: string): PluginCacheInspection {
+  const location = resolvePluginCacheLocation(entry)
+  if (location.source === "local") {
+    return {
+      entry,
+      status: "local",
+      location,
+      requiredPaths: [],
+      missingPaths: [],
+    }
+  }
+
+  const requiredPaths = getRequiredPaths(location)
+  const missingPaths = requiredPaths.filter((pathValue) => !existsSync(pathValue))
+  const cacheDirExists = location.cacheDir ? existsSync(location.cacheDir) : false
+  const status = !cacheDirExists
+    ? "missing"
+    : missingPaths.length === 0
+      ? "healthy"
+      : "corrupt"
+
+  return {
+    entry,
+    status,
+    location,
+    requiredPaths,
+    missingPaths,
+  }
+}

--- a/src/cli/config-manager/plugin-cache-repair.test.ts
+++ b/src/cli/config-manager/plugin-cache-repair.test.ts
@@ -1,0 +1,197 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+import * as spawnHelpers from "../../shared/spawn-with-windows-hide"
+import { getPackageNameFromPluginEntry, resolvePluginCacheLocation } from "./plugin-cache-entry"
+import { repairPluginCache } from "./plugin-cache-repair"
+
+type CreateProcOptions = {
+  exitCode?: number | null
+  stdout?: string
+  stderr?: string
+}
+
+function createProc(options: CreateProcOptions = {}): ReturnType<typeof spawnHelpers.spawnWithWindowsHide> {
+  const exitCode = options.exitCode ?? 0
+
+  return {
+    exited: Promise.resolve(exitCode),
+    exitCode,
+    stdout: new Blob([options.stdout ?? ""]).stream(),
+    stderr: new Blob([options.stderr ?? ""]).stream(),
+    kill: () => {},
+  } satisfies ReturnType<typeof spawnHelpers.spawnWithWindowsHide>
+}
+
+function writeJson(filePath: string, value: Record<string, unknown>): void {
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n", "utf-8")
+}
+
+function writeHealthyCache(entry: string, version = "1.2.3"): void {
+  const location = resolvePluginCacheLocation(entry)
+  const packageName = getPackageNameFromPluginEntry(entry)
+
+  if (!location.cacheDir || !location.cachePackagePath || !location.cacheLockfilePath || !location.installedPackageJsonPath || !packageName) {
+    throw new Error(`Could not resolve cache location for ${entry}`)
+  }
+
+  writeJson(location.cachePackagePath, {
+    name: "opencode-plugin-cache",
+    private: true,
+    dependencies: {
+      [packageName]: version,
+    },
+  })
+  writeJson(location.cacheLockfilePath, { name: "opencode-plugin-cache", lockfileVersion: 3 })
+  writeJson(location.installedPackageJsonPath, {
+    name: packageName,
+    version,
+  })
+}
+
+describe("repairPluginCache", () => {
+  const originalXdgCacheHome = process.env.XDG_CACHE_HOME
+  let tempCacheHome = ""
+  let spawnWithWindowsHideSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    tempCacheHome = mkdtempSync(join(tmpdir(), "omo-plugin-cache-repair-"))
+    process.env.XDG_CACHE_HOME = tempCacheHome
+    spawnWithWindowsHideSpy = spyOn(spawnHelpers, "spawnWithWindowsHide")
+  })
+
+  afterEach(() => {
+    spawnWithWindowsHideSpy.mockRestore()
+
+    if (originalXdgCacheHome === undefined) {
+      delete process.env.XDG_CACHE_HOME
+    } else {
+      process.env.XDG_CACHE_HOME = originalXdgCacheHome
+    }
+
+    rmSync(tempCacheHome, { recursive: true, force: true })
+  })
+
+  it("returns a healthy no-op result when the cache is already complete", async () => {
+    //#given
+    writeHealthyCache("oh-my-openagent")
+
+    //#when
+    const result = await repairPluginCache("oh-my-openagent")
+
+    //#then
+    expect(result.success).toBe(true)
+    expect(result.status).toBe("healthy")
+    expect(result.attempted).toBe(false)
+    expect(spawnWithWindowsHideSpy).not.toHaveBeenCalled()
+  })
+
+  it("repairs a cache that is missing the package lockfile", async () => {
+    //#given
+    writeHealthyCache("oh-my-openagent")
+    const location = resolvePluginCacheLocation("oh-my-openagent")
+    unlinkSync(location.cacheLockfilePath!)
+    writeFileSync(join(location.cacheDir!, "stale.txt"), "stale", "utf-8")
+
+    spawnWithWindowsHideSpy.mockImplementation((command, options) => {
+      writeHealthyCache("oh-my-openagent")
+      return createProc({ stdout: command.join(" ") })
+    })
+
+    //#when
+    const result = await repairPluginCache("oh-my-openagent")
+
+    //#then
+    expect(result.success).toBe(true)
+    expect(result.status).toBe("repaired")
+    expect(result.attempts[0]?.tool).toBe("npm")
+    expect(result.attempts[0]?.verified).toBe(true)
+    expect(existsSync(join(location.cacheDir!, "stale.txt"))).toBe(false)
+  })
+
+  it("repairs a cache that is missing node_modules", async () => {
+    //#given
+    writeHealthyCache("oh-my-openagent")
+    rmSync(join(resolvePluginCacheLocation("oh-my-openagent").cacheDir!, "node_modules"), { recursive: true, force: true })
+
+    spawnWithWindowsHideSpy.mockImplementation((_command, _options) => {
+      writeHealthyCache("oh-my-openagent")
+      return createProc()
+    })
+
+    //#when
+    const result = await repairPluginCache("oh-my-openagent")
+
+    //#then
+    expect(result.success).toBe(true)
+    expect(result.status).toBe("repaired")
+    expect(result.attempts).toHaveLength(1)
+    expect(result.attempts[0]?.tool).toBe("npm")
+  })
+
+  it("falls back to bun when npm is unavailable", async () => {
+    //#given
+    spawnWithWindowsHideSpy.mockImplementation((command, _options) => {
+      if (command[0] === "npm") {
+        throw new Error("npm not found")
+      }
+
+      writeHealthyCache("oh-my-openagent@latest")
+      return createProc()
+    })
+
+    //#when
+    const result = await repairPluginCache("oh-my-openagent@latest")
+
+    //#then
+    expect(result.success).toBe(true)
+    expect(result.status).toBe("repaired")
+    expect(result.attempts).toHaveLength(2)
+    expect(result.attempts[0]?.tool).toBe("npm")
+    expect(result.attempts[0]?.error).toContain("npm not found")
+    expect(result.attempts[1]?.tool).toBe("bun")
+    expect(result.attempts[1]?.verified).toBe(true)
+  })
+
+  it("returns a clear failure when both npm and bun are unavailable", async () => {
+    //#given
+    spawnWithWindowsHideSpy.mockImplementation((command, _options) => {
+      throw new Error(`${command[0]} not found`)
+    })
+
+    //#when
+    const result = await repairPluginCache("oh-my-openagent")
+
+    //#then
+    expect(result.success).toBe(false)
+    expect(result.status).toBe("failed")
+    expect(result.attempts).toHaveLength(2)
+    expect(result.error).toContain("bun not found")
+  })
+
+  it("skips local file plugin entries", async () => {
+    //#given
+    const entry = "file:///tmp/oh-my-openagent"
+
+    //#when
+    const result = await repairPluginCache(entry)
+
+    //#then
+    expect(result.success).toBe(true)
+    expect(result.status).toBe("skipped")
+    expect(result.attempted).toBe(false)
+    expect(spawnWithWindowsHideSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/config-manager/plugin-cache-repair.ts
+++ b/src/cli/config-manager/plugin-cache-repair.ts
@@ -1,0 +1,190 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+
+import { spawnWithWindowsHide } from "../../shared/spawn-with-windows-hide"
+import {
+  inspectPluginCache,
+  type PluginCacheInspection,
+} from "./plugin-cache-health"
+
+const CACHE_WORKSPACE_NAME = "opencode-plugin-cache"
+
+type RepairTool = "npm" | "bun"
+
+export interface PluginCacheRepairAttempt {
+  tool: RepairTool
+  command: string[]
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  error?: string
+  verified: boolean
+}
+
+export interface PluginCacheRepairResult {
+  success: boolean
+  status: "skipped" | "healthy" | "repaired" | "failed"
+  attempted: boolean
+  initialInspection: PluginCacheInspection
+  finalInspection: PluginCacheInspection
+  attempts: PluginCacheRepairAttempt[]
+  error?: string
+}
+
+function createWorkspacePackageJson(): string {
+  return JSON.stringify(
+    {
+      name: CACHE_WORKSPACE_NAME,
+      private: true,
+    },
+    null,
+    2,
+  ) + "\n"
+}
+
+function prepareWorkspace(cacheDir: string, packageJsonPath: string): void {
+  mkdirSync(cacheDir, { recursive: true })
+  writeFileSync(packageJsonPath, createWorkspacePackageJson(), "utf-8")
+}
+
+async function readStream(stream: ReadableStream<Uint8Array> | undefined): Promise<string> {
+  if (!stream) {
+    return ""
+  }
+
+  return new Response(stream).text()
+}
+
+async function runInstallAttempt(
+  tool: RepairTool,
+  entry: string,
+  workspaceDir: string,
+): Promise<Omit<PluginCacheRepairAttempt, "verified">> {
+  const command = tool === "npm" ? ["npm", "install", entry] : ["bun", "add", entry]
+
+  try {
+    const proc = spawnWithWindowsHide(command, {
+      cwd: workspaceDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    const stdoutPromise = readStream(proc.stdout)
+    const stderrPromise = readStream(proc.stderr)
+
+    await proc.exited
+
+    return {
+      tool,
+      command,
+      exitCode: proc.exitCode,
+      stdout: await stdoutPromise,
+      stderr: await stderrPromise,
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return {
+      tool,
+      command,
+      exitCode: null,
+      stdout: "",
+      stderr: "",
+      error: message,
+    }
+  }
+}
+
+function createFailureResult(
+  initialInspection: PluginCacheInspection,
+  finalInspection: PluginCacheInspection,
+  attempts: PluginCacheRepairAttempt[],
+  error: string,
+): PluginCacheRepairResult {
+  return {
+    success: false,
+    status: "failed",
+    attempted: attempts.length > 0,
+    initialInspection,
+    finalInspection,
+    attempts,
+    error,
+  }
+}
+
+export async function repairPluginCache(entry: string): Promise<PluginCacheRepairResult> {
+  const initialInspection = inspectPluginCache(entry)
+  if (initialInspection.status === "local") {
+    return {
+      success: true,
+      status: "skipped",
+      attempted: false,
+      initialInspection,
+      finalInspection: initialInspection,
+      attempts: [],
+    }
+  }
+
+  if (initialInspection.status === "healthy") {
+    return {
+      success: true,
+      status: "healthy",
+      attempted: false,
+      initialInspection,
+      finalInspection: initialInspection,
+      attempts: [],
+    }
+  }
+
+  const location = initialInspection.location
+  if (!location.cacheDir || !location.cachePackagePath) {
+    return createFailureResult(
+      initialInspection,
+      initialInspection,
+      [],
+      "Plugin cache location could not be resolved.",
+    )
+  }
+
+  if (initialInspection.status === "corrupt" && location.cacheDir) {
+    rmSync(location.cacheDir, { recursive: true, force: true })
+  }
+
+  const attempts: PluginCacheRepairAttempt[] = []
+  const tools: RepairTool[] = ["npm", "bun"]
+
+  for (const tool of tools) {
+    rmSync(location.cacheDir, { recursive: true, force: true })
+    prepareWorkspace(location.cacheDir, location.cachePackagePath)
+
+    const attempt = await runInstallAttempt(tool, entry, location.cacheDir)
+    const inspection = inspectPluginCache(entry)
+    attempts.push({
+      ...attempt,
+      verified: inspection.status === "healthy",
+    })
+
+    if (inspection.status === "healthy") {
+      return {
+        success: true,
+        status: "repaired",
+        attempted: true,
+        initialInspection,
+        finalInspection: inspection,
+        attempts,
+      }
+    }
+  }
+
+  const finalInspection = inspectPluginCache(entry)
+  const lastAttempt = attempts.at(-1)
+  const lastError = lastAttempt?.error
+  const missingSummary = finalInspection.missingPaths.length > 0
+    ? `Missing: ${finalInspection.missingPaths.join(", ")}.`
+    : "Cache verification failed after reinstall."
+
+  return createFailureResult(
+    initialInspection,
+    finalInspection,
+    attempts,
+    lastError ? `Cache repair failed: ${lastError}` : missingSummary,
+  )
+}

--- a/src/cli/doctor/checks/system-loaded-version.test.ts
+++ b/src/cli/doctor/checks/system-loaded-version.test.ts
@@ -130,6 +130,61 @@ describe("system loaded version", () => {
       expect(loadedVersion.expectedVersion).toBe("4.5.6")
       expect(loadedVersion.loadedVersion).toBe("4.5.6")
     })
+
+    it("prefers the per-plugin package cache when a plugin entry is provided", () => {
+      //#given
+      const configDir = createTemporaryDirectory("omo-config-")
+      const cacheHome = createTemporaryDirectory("omo-cache-home-")
+      const cacheDir = join(cacheHome, "opencode")
+      const packageCacheDir = join(cacheDir, "packages", "oh-my-openagent@latest")
+
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      process.env.XDG_CACHE_HOME = cacheHome
+
+      writeJson(join(configDir, "package.json"), {
+        dependencies: { [PACKAGE_NAME]: "1.2.3" },
+      })
+      writeJson(join(configDir, "node_modules", PACKAGE_NAME, "package.json"), {
+        version: "1.2.3",
+      })
+      writeJson(join(packageCacheDir, "package.json"), {
+        dependencies: { [PACKAGE_NAME]: "9.9.9" },
+      })
+      writeJson(join(packageCacheDir, "node_modules", PACKAGE_NAME, "package.json"), {
+        version: "9.9.9",
+      })
+
+      //#when
+      const loadedVersion = getLoadedPluginVersion("oh-my-openagent@latest")
+
+      //#then
+      expect(loadedVersion.cacheDir).toBe(packageCacheDir)
+      expect(loadedVersion.expectedVersion).toBe("9.9.9")
+      expect(loadedVersion.loadedVersion).toBe("9.9.9")
+    })
+
+    it("resolves legacy package cache installs using the legacy package directory", () => {
+      //#given
+      const cacheHome = createTemporaryDirectory("omo-legacy-cache-home-")
+      const packageCacheDir = join(cacheHome, "opencode", "packages", "oh-my-opencode@3.0.0")
+
+      process.env.XDG_CACHE_HOME = cacheHome
+
+      writeJson(join(packageCacheDir, "package.json"), {
+        dependencies: { "oh-my-opencode": "3.0.0" },
+      })
+      writeJson(join(packageCacheDir, "node_modules", "oh-my-opencode", "package.json"), {
+        version: "3.0.0",
+      })
+
+      //#when
+      const loadedVersion = getLoadedPluginVersion("oh-my-opencode@3.0.0")
+
+      //#then
+      expect(loadedVersion.cacheDir).toBe(packageCacheDir)
+      expect(loadedVersion.expectedVersion).toBe("3.0.0")
+      expect(loadedVersion.loadedVersion).toBe("3.0.0")
+    })
   })
 
   describe("getSuggestedInstallTag", () => {

--- a/src/cli/doctor/checks/system-loaded-version.ts
+++ b/src/cli/doctor/checks/system-loaded-version.ts
@@ -6,6 +6,10 @@ import { getLatestVersion } from "../../../hooks/auto-update-checker/checker"
 import { extractChannel } from "../../../hooks/auto-update-checker"
 import { PACKAGE_NAME } from "../constants"
 import { getOpenCodeCacheDir, getOpenCodeConfigPaths, parseJsonc } from "../../../shared"
+import {
+  getPackageNameFromPluginEntry,
+  resolvePluginCacheLocation,
+} from "../../config-manager/plugin-cache-entry"
 
 interface PackageJsonShape {
   version?: string
@@ -18,6 +22,13 @@ export interface LoadedVersionInfo {
   installedPackagePath: string
   expectedVersion: string | null
   loadedVersion: string | null
+}
+
+interface InstallCandidate {
+  cacheDir: string
+  cachePackagePath: string
+  installedPackagePath: string
+  packageName: string
 }
 
 function getPlatformDefaultCacheDir(platform: NodeJS.Platform = process.platform): string {
@@ -58,31 +69,38 @@ function normalizeVersion(value: string | undefined): string | null {
   return match?.[0] ?? null
 }
 
-export function getLoadedPluginVersion(): LoadedVersionInfo {
+function createInstallCandidate(cacheDir: string, packageName: string): InstallCandidate {
+  return {
+    cacheDir,
+    cachePackagePath: join(cacheDir, "package.json"),
+    installedPackagePath: join(cacheDir, "node_modules", ...packageName.split("/"), "package.json"),
+    packageName,
+  }
+}
+
+export function getLoadedPluginVersion(pluginEntry: string | null = null): LoadedVersionInfo {
   const configPaths = getOpenCodeConfigPaths({ binary: "opencode" })
   const configDir = resolveExistingDir(configPaths.configDir)
   const cacheDir = resolveExistingDir(resolveOpenCodeCacheDir())
+  const packageName = getPackageNameFromPluginEntry(pluginEntry ?? PACKAGE_NAME) ?? PACKAGE_NAME
+  const packageCacheLocation = pluginEntry ? resolvePluginCacheLocation(pluginEntry) : null
+  const packageCacheCandidate = packageCacheLocation?.source === "npm" && packageCacheLocation.cacheDir
+    ? createInstallCandidate(resolveExistingDir(packageCacheLocation.cacheDir), packageName)
+    : null
   const candidates = [
-    {
-      cacheDir: configDir,
-      cachePackagePath: join(configDir, "package.json"),
-      installedPackagePath: join(configDir, "node_modules", PACKAGE_NAME, "package.json"),
-    },
-    {
-      cacheDir,
-      cachePackagePath: join(cacheDir, "package.json"),
-      installedPackagePath: join(cacheDir, "node_modules", PACKAGE_NAME, "package.json"),
-    },
-  ]
+    packageCacheCandidate,
+    createInstallCandidate(configDir, packageName),
+    createInstallCandidate(cacheDir, packageName),
+  ].filter((candidate): candidate is InstallCandidate => Boolean(candidate))
 
   const selectedCandidate = candidates.find((candidate) => existsSync(candidate.installedPackagePath)) ?? candidates[0]
 
-  const { cacheDir: selectedDir, cachePackagePath, installedPackagePath } = selectedCandidate
+  const { cacheDir: selectedDir, cachePackagePath, installedPackagePath, packageName: selectedPackageName } = selectedCandidate
 
   const cachePackage = readPackageJson(cachePackagePath)
   const installedPackage = readPackageJson(installedPackagePath)
 
-  const expectedVersion = normalizeVersion(cachePackage?.dependencies?.[PACKAGE_NAME])
+  const expectedVersion = normalizeVersion(cachePackage?.dependencies?.[selectedPackageName])
   const loadedVersion = normalizeVersion(installedPackage?.version)
 
   return {

--- a/src/cli/doctor/checks/system-plugin.ts
+++ b/src/cli/doctor/checks/system-plugin.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs"
 
 import { LEGACY_PLUGIN_NAME, PLUGIN_NAME, getOpenCodeConfigPaths, parseJsonc } from "../../../shared"
+import { isLocalPluginEntry } from "../../config-manager/plugin-cache-entry"
 
 export interface PluginInfo {
   registered: boolean
@@ -44,7 +45,10 @@ function findPluginEntry(entries: string[]): { entry: string; isLocalDev: boolea
     if (entry === LEGACY_PLUGIN_NAME || entry.startsWith(`${LEGACY_PLUGIN_NAME}@`)) {
       return { entry, isLocalDev: false }
     }
-    if (entry.startsWith("file://") && (entry.includes(PLUGIN_NAME) || entry.includes(LEGACY_PLUGIN_NAME))) {
+    if (
+      isLocalPluginEntry(entry)
+      && (entry.includes(PLUGIN_NAME) || entry.includes(LEGACY_PLUGIN_NAME))
+    ) {
       return { entry, isLocalDev: true }
     }
   }

--- a/src/cli/doctor/checks/system.test.ts
+++ b/src/cli/doctor/checks/system.test.ts
@@ -26,15 +26,32 @@ const mockGetLoadedPluginVersion = mock(() => ({
 }))
 const mockGetLatestPluginVersion = mock(async (_currentVersion: string | null) => null as string | null)
 const mockGetSuggestedInstallTag = mock(() => "latest")
+const mockInspectPluginCache = mock(() => ({
+  entry: "oh-my-openagent",
+  status: "healthy" as const,
+  location: {
+    entry: "oh-my-openagent",
+    source: "npm" as const,
+    packageName: "oh-my-openagent",
+    cacheDir: "/Users/test/.cache/opencode/packages/oh-my-openagent",
+    cachePackagePath: "/tmp/package.json",
+    cacheLockfilePath: "/tmp/package-lock.json",
+    installedPackageJsonPath: "/tmp/node_modules/oh-my-openagent/package.json",
+  },
+  requiredPaths: [],
+  missingPaths: [],
+}))
 
 const realSystemBinary = require("./system-binary")
 const realSystemPlugin = require("./system-plugin")
 const realSystemLoadedVersion = require("./system-loaded-version")
+const realPluginCacheHealth = require("../../config-manager/plugin-cache-health")
 
 afterAll(() => {
   mock.module("./system-binary", () => realSystemBinary)
   mock.module("./system-plugin", () => realSystemPlugin)
   mock.module("./system-loaded-version", () => realSystemLoadedVersion)
+  mock.module("../../config-manager/plugin-cache-health", () => realPluginCacheHealth)
   mock.restore()
 })
 
@@ -55,6 +72,10 @@ async function importFreshSystemModule(): Promise<SystemModule> {
     getSuggestedInstallTag: mockGetSuggestedInstallTag,
   }))
 
+  mock.module("../../config-manager/plugin-cache-health", () => ({
+    inspectPluginCache: mockInspectPluginCache,
+  }))
+
   return import(`./system?test=${Date.now()}-${Math.random()}`)
 }
 
@@ -67,6 +88,7 @@ describe("system check", () => {
     mockGetLoadedPluginVersion.mockReset()
     mockGetLatestPluginVersion.mockReset()
     mockGetSuggestedInstallTag.mockReset()
+    mockInspectPluginCache.mockReset()
 
     mockFindOpenCodeBinary.mockResolvedValue({ path: "/usr/local/bin/opencode" })
     mockGetOpenCodeVersion.mockResolvedValue("1.0.200")
@@ -88,6 +110,21 @@ describe("system check", () => {
     })
     mockGetLatestPluginVersion.mockResolvedValue(null)
     mockGetSuggestedInstallTag.mockReturnValue("latest")
+    mockInspectPluginCache.mockReturnValue({
+      entry: "oh-my-openagent",
+      status: "healthy",
+      location: {
+        entry: "oh-my-openagent",
+        source: "npm",
+        packageName: "oh-my-openagent",
+        cacheDir: "/Users/test/.cache/opencode/packages/oh-my-openagent",
+        cachePackagePath: "/tmp/package.json",
+        cacheLockfilePath: "/tmp/package-lock.json",
+        installedPackageJsonPath: "/tmp/node_modules/oh-my-openagent/package.json",
+      },
+      requiredPaths: [],
+      missingPaths: [],
+    })
   })
 
   describe("#given cache directory contains spaces", () => {
@@ -213,6 +250,66 @@ describe("system check", () => {
 
       //#then
       expect(result.issues.some((issue) => issue.title === "Using legacy package name")).toBe(false)
+    })
+  })
+
+  describe("#given OpenCode 1.3.14 expects a package cache workspace", () => {
+    it("adds an error when the registered package cache is missing", async () => {
+      //#given
+      mockGetOpenCodeVersion.mockResolvedValue("1.3.14")
+      mockInspectPluginCache.mockReturnValue({
+        entry: "oh-my-openagent@latest",
+        status: "missing",
+        location: {
+          entry: "oh-my-openagent@latest",
+          source: "npm",
+          packageName: "oh-my-openagent",
+          cacheDir: "/Users/test/.cache/opencode/packages/oh-my-openagent@latest",
+          cachePackagePath: "/tmp/package.json",
+          cacheLockfilePath: "/tmp/package-lock.json",
+          installedPackageJsonPath: "/tmp/node_modules/oh-my-openagent/package.json",
+        },
+        requiredPaths: [],
+        missingPaths: ["/tmp/package-lock.json"],
+      })
+      const { checkSystem } = await importFreshSystemModule()
+
+      //#when
+      const result = await checkSystem()
+
+      //#then
+      const cacheIssue = result.issues.find((issue) => issue.title === "Plugin package cache is missing or incomplete")
+      expect(cacheIssue?.severity).toBe("error")
+      expect(cacheIssue?.fix).toContain("OpenCode 1.3.14 requires a populated plugin cache workspace")
+      expect(cacheIssue?.fix).toContain(`Run: bunx ${PLUGIN_NAME} install`)
+      expect(cacheIssue?.fix).toContain('/Users/test/.cache/opencode/packages/oh-my-openagent@latest')
+    })
+
+    it("does not report a cache error when the package cache is healthy", async () => {
+      //#given
+      mockGetOpenCodeVersion.mockResolvedValue("1.3.14")
+      mockInspectPluginCache.mockReturnValue({
+        entry: "oh-my-openagent",
+        status: "healthy",
+        location: {
+          entry: "oh-my-openagent",
+          source: "npm",
+          packageName: "oh-my-openagent",
+          cacheDir: "/Users/test/.cache/opencode/packages/oh-my-openagent",
+          cachePackagePath: "/tmp/package.json",
+          cacheLockfilePath: "/tmp/package-lock.json",
+          installedPackageJsonPath: "/tmp/node_modules/oh-my-openagent/package.json",
+        },
+        requiredPaths: [],
+        missingPaths: [],
+      })
+      const { checkSystem } = await importFreshSystemModule()
+
+      //#when
+      const result = await checkSystem()
+
+      //#then
+      expect(result.issues.some((issue) => issue.title === "Plugin package cache is missing or incomplete")).toBe(false)
     })
   })
 })

--- a/src/cli/doctor/checks/system.ts
+++ b/src/cli/doctor/checks/system.ts
@@ -5,8 +5,11 @@ import type { CheckResult, DoctorIssue, SystemInfo } from "../types"
 import { findOpenCodeBinary, getOpenCodeVersion, compareVersions } from "./system-binary"
 import { getPluginInfo } from "./system-plugin"
 import { getLatestPluginVersion, getLoadedPluginVersion, getSuggestedInstallTag } from "./system-loaded-version"
+import { inspectPluginCache } from "../../config-manager/plugin-cache-health"
 import { parseJsonc } from "../../../shared"
 import { PLUGIN_NAME, LEGACY_PLUGIN_NAME } from "../../../shared/plugin-identity"
+
+const PACKAGE_CACHE_REQUIRED_VERSION = "1.3.14"
 
 function isConfigValid(configPath: string | null): boolean {
   if (!configPath) return true
@@ -32,9 +35,30 @@ function buildMessage(status: CheckResult["status"], issues: DoctorIssue[]): str
   return `${issues.length} system warning(s) detected`
 }
 
+function usesPackageCache(opencodeVersion: string | null): boolean {
+  if (!opencodeVersion) {
+    return false
+  }
+
+  return compareVersions(opencodeVersion, PACKAGE_CACHE_REQUIRED_VERSION)
+}
+
+function buildPackageCacheFix(opencodeVersion: string | null, cacheDir: string | null): string {
+  const steps = [`Run: bunx ${PLUGIN_NAME} install`]
+  if (cacheDir) {
+    steps.push(`If it still fails, remove "${cacheDir}" and rerun the installer`)
+  }
+
+  if (opencodeVersion?.startsWith(PACKAGE_CACHE_REQUIRED_VERSION)) {
+    steps.unshift(`OpenCode ${PACKAGE_CACHE_REQUIRED_VERSION} requires a populated plugin cache workspace`)
+  }
+
+  return steps.join(". ")
+}
+
 export async function gatherSystemInfo(): Promise<SystemInfo> {
   const [binaryInfo, pluginInfo] = await Promise.all([findOpenCodeBinary(), Promise.resolve(getPluginInfo())])
-  const loadedInfo = getLoadedPluginVersion()
+  const loadedInfo = getLoadedPluginVersion(pluginInfo.entry)
 
   const opencodeVersion = binaryInfo ? await getOpenCodeVersion(binaryInfo.path) : null
   const pluginVersion = pluginInfo.pinnedVersion ?? loadedInfo.expectedVersion ?? loadedInfo.loadedVersion
@@ -53,7 +77,7 @@ export async function gatherSystemInfo(): Promise<SystemInfo> {
 
 export async function checkSystem(): Promise<CheckResult> {
   const [systemInfo, pluginInfo] = await Promise.all([gatherSystemInfo(), Promise.resolve(getPluginInfo())])
-  const loadedInfo = getLoadedPluginVersion()
+  const loadedInfo = getLoadedPluginVersion(pluginInfo.entry)
   const latestVersion = await getLatestPluginVersion(systemInfo.loadedVersion)
   const installTag = getSuggestedInstallTag(systemInfo.loadedVersion)
   const issues: DoctorIssue[] = []
@@ -103,6 +127,30 @@ export async function checkSystem(): Promise<CheckResult> {
         fix: `Update your opencode.json plugin entry: "${pluginInfo.entry}" → "${suggestedEntry}"`,
         severity: "warning",
         affects: ["plugin loading"],
+      })
+    }
+  }
+
+  if (
+    pluginInfo.registered
+    && pluginInfo.entry
+    && !pluginInfo.isLocalDev
+    && usesPackageCache(systemInfo.opencodeVersion)
+  ) {
+    const packageCache = inspectPluginCache(pluginInfo.entry)
+
+    if (packageCache.status === "missing" || packageCache.status === "corrupt") {
+      const missingPaths = packageCache.missingPaths.length > 0
+        ? ` Missing: ${packageCache.missingPaths.join(", ")}.`
+        : ""
+
+      issues.push({
+        title: "Plugin package cache is missing or incomplete",
+        description:
+          `OpenCode expects a plugin cache workspace at "${packageCache.location.cacheDir}".${missingPaths}`,
+        fix: buildPackageCacheFix(systemInfo.opencodeVersion, packageCache.location.cacheDir),
+        severity: "error",
+        affects: ["plugin loading", "all agents"],
       })
     }
   }

--- a/src/cli/tui-installer.ts
+++ b/src/cli/tui-installer.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs"
+
 import * as p from "@clack/prompts"
 import color from "picocolors"
 import { PLUGIN_NAME } from "../shared"
@@ -5,12 +7,25 @@ import type { InstallArgs } from "./types"
 import {
   addPluginToOpenCodeConfig,
   detectCurrentConfig,
+  getConfigDir,
+  getOpenCodePackagesCacheRootPath,
   getOpenCodeVersion,
   isOpenCodeInstalled,
+  repairPluginCache,
   writeOmoConfig,
 } from "./config-manager"
 import { detectedToInitialValues, formatConfigSummary, SYMBOLS } from "./install-validators"
 import { promptInstallConfig } from "./tui-install-prompts"
+
+function printPluginCacheRepairWarning(cacheDir: string, error?: string): void {
+  p.log.warn("OpenCode plugin cache could not be repaired automatically.")
+  p.log.info(`Cache directory: ${cacheDir}`)
+  p.log.info(`Manual cleanup: rm -rf "${cacheDir}"`)
+  p.log.info(`Then rerun: bunx ${PLUGIN_NAME} install`)
+  if (error) {
+    p.log.info(`Details: ${error}`)
+  }
+}
 
 export async function runTuiInstaller(args: InstallArgs, version: string): Promise<number> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
@@ -20,6 +35,8 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
 
   const detected = detectCurrentConfig()
   const isUpdate = detected.isInstalled
+  const hadConfigDir = existsSync(getConfigDir())
+  const hadPackagesCacheDir = existsSync(getOpenCodePackagesCacheRootPath())
 
   p.intro(color.bgMagenta(color.white(isUpdate ? " oMoMoMoMo... Update " : " oMoMoMoMo... ")))
 
@@ -61,6 +78,29 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
     return 1
   }
   spinner.stop(`Config written to ${color.cyan(omoResult.configPath)}`)
+
+  spinner.start("Priming OpenCode plugin cache")
+  const pluginEntry = pluginResult.pluginEntry
+  const shouldRepairCache = Boolean(pluginEntry) && (installed || hadConfigDir || hadPackagesCacheDir)
+
+  if (!pluginEntry) {
+    spinner.stop("Skipped cache priming because the plugin entry could not be resolved")
+  } else if (!shouldRepairCache) {
+    spinner.stop("Skipped cache priming until OpenCode creates its cache workspace")
+  } else {
+    const cacheRepair = await repairPluginCache(pluginEntry)
+    const cacheDir = cacheRepair.finalInspection.location.cacheDir ?? "unknown cache path"
+
+    if (cacheRepair.status === "skipped") {
+      spinner.stop("Skipped cache priming for local plugin entries")
+    } else if (cacheRepair.success) {
+      const verb = cacheRepair.status === "repaired" ? "repaired" : "verified"
+      spinner.stop(`Plugin cache ${verb} at ${color.cyan(cacheDir)}`)
+    } else {
+      spinner.stop("Automatic cache repair failed")
+      printPluginCacheRepairWarning(cacheDir, cacheRepair.error)
+    }
+  }
 
   if (!config.hasClaude) {
     console.log()

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -29,6 +29,7 @@ export interface InstallConfig {
 export interface ConfigMergeResult {
   success: boolean
   configPath: string
+  pluginEntry?: string
   error?: string
 }
 


### PR DESCRIPTION
**Problem**
OpenCode 1.3.14+ expects a populated plugin cache workspace at ~/.cache/opencode/packages/<entry>. Without it, plugins fail to load even when correctly registered in opencode.json.

**Solution**
Adds cache inspection, targeted repair with npm/bun fallback, and doctor detection for missing or corrupt cache entries.

**Changes**

1. plugin-cache-entry — resolves canonical cache paths, detects local vs npm entries
2. plugin-cache-health — inspects cache status (healthy / missing / corrupt / local)
3. plugin-cache-repair — idempotent, non-failing repair with npm → bun fallback
4. cli-installer — primes cache after config write; warns on failure, never aborts
5. doctor — flags missing/corrupt cache for OpenCode 1.3.14+, suggests targeted fix
6. system-loaded-version — made plugin-entry-aware

How to Test
```
bunx oh-my-opencode install
bunx oh-my-opencode doctor
```


closes #3125 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds plugin cache compatibility for OpenCode 1.3.14 by priming and repairing the per‑plugin cache at ~/.cache/opencode/packages/<entry> during install. Prevents plugin load failures and adds doctor checks with clear, actionable fixes.

- **Bug Fixes**
  - Installer and TUI prime/repair the per‑plugin cache after registration; gated until OpenCode or its cache workspace exists; non‑blocking with warnings; uses `npm` with `bun` fallback; skips local `file://`/path entries.
  - Doctor for 1.3.14+ inspects the per‑plugin package cache and reports missing/corrupt states with fix steps (rerun install or remove the cache dir). Version detection now prefers the per‑plugin cache using the resolved plugin entry and supports legacy `oh-my-opencode`.

- **New Features**
  - Adds cache utilities: `plugin-cache-entry`, `plugin-cache-health`, `plugin-cache-repair` (exported from `config-manager`), plus path helpers like `getConfigDir` and `getOpenCodePackagesCacheRootPath`.
  - Installer surfaces the resolved plugin entry and prints cache paths with manual cleanup commands when auto‑repair fails.

<sup>Written for commit ca251876e3f593eb5cce5b5bb5bc816e1e0c61a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

