### PR TITLE
fix(background-agent): retry with fallback agent on Agent not found

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1,5 +1,6 @@
 
 import type { PluginInput } from "@opencode-ai/plugin"
+import { isAgentNotFoundError } from "./spawner"
 import type {
   BackgroundTask,
   LaunchInput,
@@ -546,32 +547,54 @@ export class BackgroundManager {
       applySessionPromptParams(sessionID, input.model)
     }
 
+    const FALLBACK_AGENT = "general"
+
+    const promptBody = {
+      agent: input.agent,
+      ...(launchModel ? { model: launchModel } : {}),
+      ...(launchVariant ? { variant: launchVariant } : {}),
+      system: input.skillContent,
+      tools: (() => {
+        const tools = {
+          task: false,
+          call_omo_agent: true,
+          question: false,
+          ...getAgentToolRestrictions(input.agent),
+        }
+        setSessionTools(sessionID, tools)
+        return tools
+      })(),
+      parts: [createInternalAgentTextPart(input.prompt)],
+    }
+
     promptWithModelSuggestionRetry(this.client, {
       path: { id: sessionID },
-      body: {
-        agent: input.agent,
-        ...(launchModel ? { model: launchModel } : {}),
-        ...(launchVariant ? { variant: launchVariant } : {}),
-        system: input.skillContent,
-        tools: (() => {
-          const tools = {
-            task: false,
-            call_omo_agent: true,
-            question: false,
-            ...getAgentToolRestrictions(input.agent),
-          }
-          setSessionTools(sessionID, tools)
-          return tools
-        })(),
-        parts: [createInternalAgentTextPart(input.prompt)],
-      },
+      body: promptBody,
     }).catch(async (error) => {
+      // Retry with fallback agent if the original agent was unregistered (e.g., after a model switch)
+      if (isAgentNotFoundError(error) && input.agent !== FALLBACK_AGENT) {
+        log("[background-agent] Agent not found, retrying with fallback agent", {
+          original: input.agent,
+          fallback: FALLBACK_AGENT,
+          taskId: task.id,
+        })
+        try {
+          await promptWithModelSuggestionRetry(this.client, {
+            path: { id: sessionID },
+            body: { ...promptBody, agent: FALLBACK_AGENT },
+          })
+          return
+        } catch (retryError) {
+          log("[background-agent] Fallback agent also failed:", retryError)
+        }
+      }
+
       log("[background-agent] promptAsync error:", error)
       const existingTask = this.findBySession(sessionID)
       if (existingTask) {
         existingTask.status = "interrupt"
         const errorMessage = error instanceof Error ? error.message : String(error)
-        if (errorMessage.includes("agent.name") || errorMessage.includes("undefined")) {
+        if (errorMessage.includes("agent.name") || errorMessage.includes("undefined") || isAgentNotFoundError(error)) {
           existingTask.error = `Agent "${input.agent}" not found. Make sure the agent is registered in your opencode.json or provided by a plugin.`
         } else {
           existingTask.error = errorMessage

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1,6 +1,6 @@
 
 import type { PluginInput } from "@opencode-ai/plugin"
-import { isAgentNotFoundError } from "./spawner"
+import { isAgentNotFoundError, FALLBACK_AGENT, buildFallbackBody } from "./spawner"
 import type {
   BackgroundTask,
   LaunchInput,
@@ -547,8 +547,6 @@ export class BackgroundManager {
       applySessionPromptParams(sessionID, input.model)
     }
 
-    const FALLBACK_AGENT = "general"
-
     const promptBody = {
       agent: input.agent,
       ...(launchModel ? { model: launchModel } : {}),
@@ -579,10 +577,13 @@ export class BackgroundManager {
           taskId: task.id,
         })
         try {
+          const fallbackBody = buildFallbackBody(promptBody, FALLBACK_AGENT)
+          setSessionTools(sessionID, fallbackBody.tools as Record<string, boolean>)
           await promptWithModelSuggestionRetry(this.client, {
             path: { id: sessionID },
-            body: { ...promptBody, agent: FALLBACK_AGENT },
+            body: fallbackBody,
           })
+          task.agent = FALLBACK_AGENT
           return
         } catch (retryError) {
           log("[background-agent] Fallback agent also failed:", retryError)
@@ -1224,6 +1225,16 @@ export class BackgroundManager {
     errorMessage: string | undefined
   }): Promise<void> {
     const { task, errorInfo, errorMessage, errorName } = args
+
+    // Agent-not-found errors are handled by the prompt catch block with agent fallback.
+    // Do not also trigger model fallback retry — that would race with the agent retry.
+    if (isAgentNotFoundError({ message: errorInfo.message } as Error)) {
+      log("[background-agent] Skipping session.error fallback for agent-not-found (handled by prompt catch)", {
+        taskId: task.id,
+        errorMessage: errorInfo.message?.slice(0, 100),
+      })
+      return
+    }
 
     if (await this.tryFallbackRetry(task, errorInfo, "session.error")) {
       return

--- a/src/features/background-agent/spawner.test.ts
+++ b/src/features/background-agent/spawner.test.ts
@@ -6,6 +6,184 @@ import {
   getSessionPromptParams,
 } from "../../shared/session-prompt-params-state"
 
+describe("background-agent spawner agent-not-found fallback", () => {
+  afterEach(() => {
+    clearSessionPromptParams("session-fallback")
+  })
+
+  test("retries with 'general' agent when promptAsync fails with Agent not found", async () => {
+    //#given
+    const promptCalls: any[] = []
+    let callCount = 0
+
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/tmp/test" } }),
+        create: async () => ({ data: { id: "session-fallback" } }),
+        promptAsync: async (args: any) => {
+          callCount++
+          promptCalls.push({ body: { ...args.body }, path: { ...args.path } })
+          if (callCount === 1) {
+            throw new Error('Agent not found: "Sisyphus-Junior". Available agents: build, explore, general, plan')
+          }
+          return { data: {} }
+        },
+      },
+    } as any
+
+    const onTaskError = mock(() => {})
+
+    const task = createTask({
+      description: "Implement feature",
+      prompt: "Please implement the break-even analysis",
+      agent: "Sisyphus-Junior",
+      parentSessionID: "ses_parent",
+      parentMessageID: "msg_parent",
+    })
+
+    const item = {
+      task,
+      input: {
+        description: task.description,
+        prompt: task.prompt,
+        agent: task.agent,
+        parentSessionID: task.parentSessionID,
+        parentMessageID: task.parentMessageID,
+        parentModel: task.parentModel,
+        parentAgent: task.parentAgent,
+        model: task.model,
+      },
+    }
+
+    const ctx = {
+      client,
+      directory: "/tmp/test",
+      concurrencyManager: { release: () => {} },
+      tmuxEnabled: false,
+      onTaskError,
+    }
+
+    //#when
+    await startTask(item as any, ctx as any)
+
+    // Wait for the fire-and-forget prompt chain to settle
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    //#then
+    // Should have called promptAsync twice: once with original agent, once with fallback
+    expect(promptCalls).toHaveLength(2)
+    expect(promptCalls[0].body.agent).toBe("Sisyphus-Junior")
+    expect(promptCalls[1].body.agent).toBe("general")
+    // Original prompt content preserved in fallback
+    expect(promptCalls[1].body.parts).toEqual(promptCalls[0].body.parts)
+    // Task should not have errored
+    expect(onTaskError).not.toHaveBeenCalled()
+  })
+
+  test("does not retry for non-agent-not-found errors", async () => {
+    //#given
+    const promptCalls: any[] = []
+
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/tmp/test" } }),
+        create: async () => ({ data: { id: "session-fallback" } }),
+        promptAsync: async (args: any) => {
+          promptCalls.push(args)
+          throw new Error("Connection timeout")
+        },
+      },
+    } as any
+
+    const onTaskError = mock(() => {})
+
+    const task = createTask({
+      description: "Implement feature",
+      prompt: "Do work",
+      agent: "Sisyphus-Junior",
+      parentSessionID: "ses_parent",
+      parentMessageID: "msg_parent",
+    })
+
+    const item = {
+      task,
+      input: {
+        description: task.description,
+        prompt: task.prompt,
+        agent: task.agent,
+        parentSessionID: task.parentSessionID,
+        parentMessageID: task.parentMessageID,
+      },
+    }
+
+    const ctx = {
+      client,
+      directory: "/tmp/test",
+      concurrencyManager: { release: () => {} },
+      tmuxEnabled: false,
+      onTaskError,
+    }
+
+    //#when
+    await startTask(item as any, ctx as any)
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    //#then
+    // Only one attempt — no retry for non-agent errors
+    expect(promptCalls).toHaveLength(1)
+    expect(onTaskError).toHaveBeenCalled()
+  })
+
+  test("calls onTaskError if fallback agent also fails", async () => {
+    //#given
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/tmp/test" } }),
+        create: async () => ({ data: { id: "session-fallback" } }),
+        promptAsync: async () => {
+          throw new Error('Agent not found: "Sisyphus-Junior". Available agents: build, explore, general, plan')
+        },
+      },
+    } as any
+
+    const onTaskError = mock(() => {})
+
+    const task = createTask({
+      description: "Implement feature",
+      prompt: "Do work",
+      agent: "Sisyphus-Junior",
+      parentSessionID: "ses_parent",
+      parentMessageID: "msg_parent",
+    })
+
+    const item = {
+      task,
+      input: {
+        description: task.description,
+        prompt: task.prompt,
+        agent: task.agent,
+        parentSessionID: task.parentSessionID,
+        parentMessageID: task.parentMessageID,
+      },
+    }
+
+    const ctx = {
+      client,
+      directory: "/tmp/test",
+      concurrencyManager: { release: () => {} },
+      tmuxEnabled: false,
+      onTaskError,
+    }
+
+    //#when
+    await startTask(item as any, ctx as any)
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    //#then
+    expect(onTaskError).toHaveBeenCalled()
+  })
+})
+
 describe("background-agent spawner fallback model promotion", () => {
   afterEach(() => {
     clearSessionPromptParams("session-123")

--- a/src/features/background-agent/spawner.test.ts
+++ b/src/features/background-agent/spawner.test.ts
@@ -144,11 +144,13 @@ describe("background-agent spawner agent-not-found fallback", () => {
 
   test("calls onTaskError if fallback agent also fails", async () => {
     //#given
+    let callCount = 0
     const client = {
       session: {
         get: async () => ({ data: { directory: "/tmp/test" } }),
         create: async () => ({ data: { id: "session-fallback" } }),
         promptAsync: async () => {
+          callCount++
           throw new Error('Agent not found: "Sisyphus-Junior". Available agents: build, explore, general, plan')
         },
       },
@@ -188,7 +190,134 @@ describe("background-agent spawner agent-not-found fallback", () => {
     await new Promise(resolve => setTimeout(resolve, 50))
 
     //#then
+    // Verify retry was attempted (2 calls: original + fallback)
+    expect(callCount).toBe(2)
     expect(onTaskError).toHaveBeenCalled()
+  })
+
+  test("retries on agent.name/undefined error variant", async () => {
+    //#given
+    const promptCalls: any[] = []
+    let callCount = 0
+
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/tmp/test" } }),
+        create: async () => ({ data: { id: "session-fallback" } }),
+        promptAsync: async (args: any) => {
+          callCount++
+          promptCalls.push({ body: { ...args.body } })
+          if (callCount === 1) {
+            throw new Error("Cannot read properties of undefined (reading 'agent.name')")
+          }
+          return { data: {} }
+        },
+      },
+    } as any
+
+    const onTaskError = mock(() => {})
+
+    const task = createTask({
+      description: "Test task",
+      prompt: "Do work",
+      agent: "Sisyphus-Junior",
+      parentSessionID: "ses_parent",
+      parentMessageID: "msg_parent",
+    })
+
+    const item = {
+      task,
+      input: {
+        description: task.description,
+        prompt: task.prompt,
+        agent: task.agent,
+        parentSessionID: task.parentSessionID,
+        parentMessageID: task.parentMessageID,
+        parentModel: task.parentModel,
+        parentAgent: task.parentAgent,
+        model: task.model,
+      },
+    }
+
+    const ctx = {
+      client,
+      directory: "/tmp/test",
+      concurrencyManager: { release: () => {} },
+      tmuxEnabled: false,
+      onTaskError,
+    }
+
+    //#when
+    await startTask(item as any, ctx as any)
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    //#then
+    expect(promptCalls).toHaveLength(2)
+    expect(promptCalls[0].body.agent).toBe("Sisyphus-Junior")
+    expect(promptCalls[1].body.agent).toBe("general")
+    expect(onTaskError).not.toHaveBeenCalled()
+  })
+
+  test("detects agent error from plain object with message field", async () => {
+    //#given
+    const promptCalls: any[] = []
+    let callCount = 0
+
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/tmp/test" } }),
+        create: async () => ({ data: { id: "session-fallback" } }),
+        promptAsync: async (args: any) => {
+          callCount++
+          promptCalls.push({ body: { ...args.body } })
+          if (callCount === 1) {
+            throw { message: 'Agent not found: "Custom-Agent"', name: "UnknownError" }
+          }
+          return { data: {} }
+        },
+      },
+    } as any
+
+    const onTaskError = mock(() => {})
+
+    const task = createTask({
+      description: "Test task",
+      prompt: "Do work",
+      agent: "Custom-Agent",
+      parentSessionID: "ses_parent",
+      parentMessageID: "msg_parent",
+    })
+
+    const item = {
+      task,
+      input: {
+        description: task.description,
+        prompt: task.prompt,
+        agent: task.agent,
+        parentSessionID: task.parentSessionID,
+        parentMessageID: task.parentMessageID,
+        parentModel: task.parentModel,
+        parentAgent: task.parentAgent,
+        model: task.model,
+      },
+    }
+
+    const ctx = {
+      client,
+      directory: "/tmp/test",
+      concurrencyManager: { release: () => {} },
+      tmuxEnabled: false,
+      onTaskError,
+    }
+
+    //#when
+    await startTask(item as any, ctx as any)
+    await new Promise(resolve => setTimeout(resolve, 50))
+
+    //#then
+    expect(promptCalls).toHaveLength(2)
+    expect(promptCalls[1].body.agent).toBe("general")
+    expect(onTaskError).not.toHaveBeenCalled()
   })
 })
 

--- a/src/features/background-agent/spawner.test.ts
+++ b/src/features/background-agent/spawner.test.ts
@@ -76,6 +76,14 @@ describe("background-agent spawner agent-not-found fallback", () => {
     expect(promptCalls[1].body.agent).toBe("general")
     // Original prompt content preserved in fallback
     expect(promptCalls[1].body.parts).toEqual(promptCalls[0].body.parts)
+    // Tool restrictions recomputed for fallback agent (general has no restrictions)
+    expect(promptCalls[1].body.tools).toEqual({
+      task: false,
+      call_omo_agent: true,
+      question: false,
+    })
+    // Task agent identity updated to reflect fallback
+    expect(task.agent).toBe("general")
     // Task should not have errored
     expect(onTaskError).not.toHaveBeenCalled()
   })

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -11,8 +11,19 @@ import type { ConcurrencyManager } from "./concurrency"
 export const FALLBACK_AGENT = "general"
 
 export function isAgentNotFoundError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.includes("Agent not found")
+  const message =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+        ? error.message
+        : typeof error === "object" && error !== null && typeof (error as { message?: unknown }).message === "string"
+          ? (error as { message: string }).message
+          : String(error)
+  return (
+    message.includes("Agent not found") ||
+    message.includes("agent.name") ||
+    (message.includes("agent") && message.includes("undefined"))
+  )
 }
 
 export function buildFallbackBody(

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -8,6 +8,13 @@ import { getTaskToastManager } from "../task-toast-manager"
 import { isInsideTmux } from "../../shared/tmux"
 import type { ConcurrencyManager } from "./concurrency"
 
+const FALLBACK_AGENT = "general"
+
+export function isAgentNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes("Agent not found")
+}
+
 export interface SpawnerContext {
   client: OpencodeClient
   directory: string
@@ -138,22 +145,42 @@ export async function startTask(
 
   applySessionPromptParams(sessionID, input.model)
 
+  const promptBody = {
+    agent: input.agent,
+    ...(launchModel ? { model: launchModel } : {}),
+    ...(launchVariant ? { variant: launchVariant } : {}),
+    system: input.skillContent,
+    tools: {
+      task: false,
+      call_omo_agent: true,
+      question: false,
+      ...getAgentToolRestrictions(input.agent),
+    },
+    parts: [createInternalAgentTextPart(input.prompt)],
+  }
+
   promptWithModelSuggestionRetry(client, {
     path: { id: sessionID },
-    body: {
-      agent: input.agent,
-      ...(launchModel ? { model: launchModel } : {}),
-      ...(launchVariant ? { variant: launchVariant } : {}),
-      system: input.skillContent,
-      tools: {
-        task: false,
-        call_omo_agent: true,
-        question: false,
-        ...getAgentToolRestrictions(input.agent),
-      },
-      parts: [createInternalAgentTextPart(input.prompt)],
-    },
-  }).catch((error) => {
+    body: promptBody,
+  }).catch(async (error) => {
+    if (isAgentNotFoundError(error) && input.agent !== FALLBACK_AGENT) {
+      log("[background-agent] Agent not found, retrying with fallback agent", {
+        original: input.agent,
+        fallback: FALLBACK_AGENT,
+        taskId: task.id,
+      })
+      try {
+        await promptWithModelSuggestionRetry(client, {
+          path: { id: sessionID },
+          body: { ...promptBody, agent: FALLBACK_AGENT },
+        })
+        return
+      } catch (retryError) {
+        log("[background-agent] Fallback agent also failed:", retryError)
+        onTaskError(task, retryError instanceof Error ? retryError : new Error(String(retryError)))
+        return
+      }
+    }
     log("[background-agent] promptAsync error:", error)
     onTaskError(task, error instanceof Error ? error : new Error(String(error)))
   })
@@ -228,21 +255,41 @@ export async function resumeTask(
 
   applySessionPromptParams(task.sessionID, task.model)
 
+  const resumeBody = {
+    agent: task.agent,
+    ...(resumeModel ? { model: resumeModel } : {}),
+    ...(resumeVariant ? { variant: resumeVariant } : {}),
+    tools: {
+      task: false,
+      call_omo_agent: true,
+      question: false,
+      ...getAgentToolRestrictions(task.agent),
+    },
+    parts: [createInternalAgentTextPart(input.prompt)],
+  }
+
   client.session.promptAsync({
     path: { id: task.sessionID },
-    body: {
-      agent: task.agent,
-      ...(resumeModel ? { model: resumeModel } : {}),
-      ...(resumeVariant ? { variant: resumeVariant } : {}),
-      tools: {
-        task: false,
-        call_omo_agent: true,
-        question: false,
-        ...getAgentToolRestrictions(task.agent),
-      },
-      parts: [createInternalAgentTextPart(input.prompt)],
-    },
-  }).catch((error) => {
+    body: resumeBody,
+  }).catch(async (error) => {
+    if (isAgentNotFoundError(error) && task.agent !== FALLBACK_AGENT) {
+      log("[background-agent] Resume agent not found, retrying with fallback agent", {
+        original: task.agent,
+        fallback: FALLBACK_AGENT,
+        taskId: task.id,
+      })
+      try {
+        await client.session.promptAsync({
+          path: { id: task.sessionID! },
+          body: { ...resumeBody, agent: FALLBACK_AGENT },
+        })
+        return
+      } catch (retryError) {
+        log("[background-agent] Resume fallback agent also failed:", retryError)
+        onTaskError(task, retryError instanceof Error ? retryError : new Error(String(retryError)))
+        return
+      }
+    }
     log("[background-agent] resume prompt error:", error)
     onTaskError(task, error instanceof Error ? error : new Error(String(error)))
   })

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -21,8 +21,7 @@ export function isAgentNotFoundError(error: unknown): boolean {
           : String(error)
   return (
     message.includes("Agent not found") ||
-    message.includes("agent.name") ||
-    (message.includes("agent") && message.includes("undefined"))
+    message.includes("agent.name")
   )
 }
 

--- a/src/features/background-agent/spawner.ts
+++ b/src/features/background-agent/spawner.ts
@@ -8,11 +8,27 @@ import { getTaskToastManager } from "../task-toast-manager"
 import { isInsideTmux } from "../../shared/tmux"
 import type { ConcurrencyManager } from "./concurrency"
 
-const FALLBACK_AGENT = "general"
+export const FALLBACK_AGENT = "general"
 
 export function isAgentNotFoundError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
   return message.includes("Agent not found")
+}
+
+export function buildFallbackBody(
+  originalBody: Record<string, unknown>,
+  fallbackAgent: string,
+): Record<string, unknown> {
+  return {
+    ...originalBody,
+    agent: fallbackAgent,
+    tools: {
+      task: false,
+      call_omo_agent: true,
+      question: false,
+      ...getAgentToolRestrictions(fallbackAgent),
+    },
+  }
 }
 
 export interface SpawnerContext {
@@ -172,8 +188,9 @@ export async function startTask(
       try {
         await promptWithModelSuggestionRetry(client, {
           path: { id: sessionID },
-          body: { ...promptBody, agent: FALLBACK_AGENT },
+          body: buildFallbackBody(promptBody, FALLBACK_AGENT),
         })
+        task.agent = FALLBACK_AGENT
         return
       } catch (retryError) {
         log("[background-agent] Fallback agent also failed:", retryError)
@@ -279,10 +296,11 @@ export async function resumeTask(
         taskId: task.id,
       })
       try {
-        await client.session.promptAsync({
+        await promptWithModelSuggestionRetry(client, {
           path: { id: task.sessionID! },
-          body: { ...resumeBody, agent: FALLBACK_AGENT },
+          body: buildFallbackBody(resumeBody, FALLBACK_AGENT),
         })
+        task.agent = FALLBACK_AGENT
         return
       } catch (retryError) {
         log("[background-agent] Resume fallback agent also failed:", retryError)


### PR DESCRIPTION
## Summary

- When a model/mode switch happens while a background task is in-flight, the oh-my-openagent agent registry can be rebuilt without custom agents (e.g., `Sisyphus-Junior`). The opencode SDK then rejects the `promptAsync` call with `Agent not found: "Sisyphus-Junior". Available agents: build, explore, general, plan`, killing the background task.
- This PR adds retry logic: when `promptAsync` fails with "Agent not found", the spawner retries with the `"general"` agent (always available in opencode). The original prompt, model, and skill content are preserved — only the agent routing changes.
- Fixes both the `spawner.ts` (`startTask`/`resumeTask`) and `manager.ts` (inline launch) code paths.
- Improves the error message detection in `manager.ts` to recognize `"Agent not found"` alongside the existing `"agent.name"`/`"undefined"` checks.

## Reproduction

1. Configure `sisyphus-junior` in `oh-my-openagent.json`
2. Start a background task that dispatches to `Sisyphus-Junior`
3. Switch model or leave ultrawork mode while the task is pending/running
4. Background task fails: `Agent not found: "Sisyphus-Junior". Available agents: build, explore, general, plan`

## Changes

| File | Change |
|------|--------|
| `spawner.ts` | Added `isAgentNotFoundError()` helper. Added retry-with-fallback in `startTask` and `resumeTask`. |
| `manager.ts` | Added same retry-with-fallback in inline launch path. Improved error detection pattern. |
| `spawner.test.ts` | 3 new tests: successful fallback, no retry for non-agent errors, error propagation when fallback also fails. |

## Test plan

- [x] Existing 400 background-agent tests pass
- [x] Existing 296 delegate-task/call-omo-agent/agent-config tests pass
- [x] 3 new tests cover: successful fallback to `"general"`, no retry for unrelated errors, error propagation when fallback fails
- [ ] Manual: switch model while background task running → task should recover via `"general"` agent

## Related issues

- Fixes #2052 (Sisyphus_Junior not found when restarted by Todo System)
- Related to #2875 (Agent not found: "atlas" - key mismatch) — closed but same class of bug
- Related to #2882 (runtime-fallback retry fails with Agent not found) — closed but same class of bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries background prompts with the fallback `general` agent when the requested agent is missing, so background tasks don’t fail after model/mode switches in `oh-my-openagent`/`opencode`. Prompt, model, and skill content are preserved; only the agent changes with correct tool restrictions.

- **Bug Fixes**
  - Retry with `general` on agent-not-found in `spawner.ts` (`startTask`, `resumeTask` via `promptWithModelSuggestionRetry`) and `manager.ts`; set `task.agent` to `general` on success.
  - Recompute fallback tool restrictions via `buildFallbackBody` (applied in both spawner and manager); centralize with `FALLBACK_AGENT`; tighten detection with `isAgentNotFoundError` to handle "Agent not found", `agent.name`, and plain-object `.message` errors (removed broad agent+undefined pattern).
  - Prevent double-retry by skipping model fallback in `handleSessionErrorEvent` when agent-not-found is already handled; tests cover success, no retry on other errors, fallback failure (verifies two attempts), and the refined detection variants.

<sup>Written for commit f8d086ded1bbd71300cc676326ef15512b824a09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

