### PR TITLE
fix: remove ZWSP sort prefix that leaks into x-opencode-agent-name header

### DIFF
--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -185,8 +185,8 @@ describe("getAgentListDisplayName", () => {
     expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus (Ultraworker)")
   })
 
-  it("applies invisible atlas sort prefix for list display", () => {
-    expect(getAgentListDisplayName("atlas")).toBe("\u200BAtlas (Plan Executor)")
+  it("returns atlas display name without sort prefix", () => {
+    expect(getAgentListDisplayName("atlas")).toBe("Atlas (Plan Executor)")
   })
 })
 

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -20,9 +20,7 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
   "council-member": "council-member",
 }
 
-const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {
-  atlas: "\u200B",
-}
+const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {}
 
 function stripAgentListSortPrefix(agentName: string): string {
   return agentName.replace(/^\u200B+/, "")


### PR DESCRIPTION
## Summary

- Removes the `\u200B` (zero-width space) entry from `AGENT_LIST_SORT_PREFIXES` for the Atlas agent
- Updates the corresponding test expectation

## Problem

`getAgentListDisplayName("atlas")` prepends a `\u200B` (U+200B, zero-width space) to the Atlas display name for UI sorting. This prefixed name flows through `agent-key-remapper.ts` into agent registration, and ultimately into the `x-opencode-agent-name` HTTP header — which rejects non-ASCII characters:

```
Header 'x-opencode-agent-name' has invalid value: '​Atlas (Plan Executor)'
```

## Why this is safe

The `\u200B` prefix alone cannot produce the correct agent order (Sisyphus → Hephaestus → Prometheus → Atlas). `agent-priority-order.ts` already handles ordering via explicit numeric `order` fields and JS object insertion order. The ZWSP was redundant.

## Changes

| File | Change |
|------|--------|
| `src/shared/agent-display-names.ts` | Empty `AGENT_LIST_SORT_PREFIXES` map |
| `src/shared/agent-display-names.test.ts` | Update test expectation for atlas |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the zero-width space prefix from the Atlas agent name to prevent non-ASCII from leaking into the `x-opencode-agent-name` header. Fixes invalid header errors while keeping agent ordering unchanged.

- **Bug Fixes**
  - Remove `\u200B` from `AGENT_LIST_SORT_PREFIXES` for Atlas and update the test.
  - Rely on `agent-priority-order.ts` for ordering; no impact on UI sort.

<sup>Written for commit b482e6c609802ebf420283b83bf13ef9ca6ab11d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

