### PR TITLE
Classify quota/billing message-only errors as non-retryable

### DIFF
--- a/src/shared/model-error-classifier.test.ts
+++ b/src/shared/model-error-classifier.test.ts
@@ -171,6 +171,107 @@ describe("model-error-classifier", () => {
     //#then
     expect(result).toBe(true)
   })
+
+  describe("#given message-only errors with quota/billing language", () => {
+    test("#when message contains 'quota' #then classifies as non-retryable", () => {
+      //#given
+      const error = { message: "You have exceeded your quota for this billing period" }
+
+      //#when
+      const result = shouldRetryError(error)
+
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("#when message contains 'quota will reset after' #then classifies as non-retryable", () => {
+      //#given
+      const error = { message: "Request failed: quota will reset after 2026-04-10" }
+
+      //#when
+      const result = shouldRetryError(error)
+
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("#when message contains 'usage limit' #then classifies as non-retryable", () => {
+      //#given
+      const error = { message: "Your usage limit has been reached for today" }
+
+      //#when
+      const result = shouldRetryError(error)
+
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("#when message contains 'insufficient' #then classifies as non-retryable", () => {
+      //#given
+      const error = { message: "Insufficient credits to complete request" }
+
+      //#when
+      const result = shouldRetryError(error)
+
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("#when message contains 'free usage' #then classifies as non-retryable", () => {
+      //#given
+      const error = { message: "Free usage exceeded, please upgrade your plan" }
+
+      //#when
+      const result = shouldRetryError(error)
+
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("#when message contains 'credit' #then classifies as non-retryable", () => {
+      //#given
+      const error = { message: "Not enough credit remaining on your account" }
+
+      //#when
+      const result = shouldRetryError(error)
+
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("#when message contains 'balance' #then classifies as non-retryable", () => {
+      //#given
+      const error = { message: "Your account balance is too low" }
+
+      //#when
+      const result = shouldRetryError(error)
+
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("#when message contains 'usage exceeded' #then classifies as non-retryable", () => {
+      //#given
+      const error = { message: "API usage exceeded for this billing cycle" }
+
+      //#when
+      const result = shouldRetryError(error)
+
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("#when error has unknown name and quota message #then stop pattern takes precedence", () => {
+      //#given
+      const error = { name: "UnknownProviderError", message: "quota exceeded for model" }
+
+      //#when
+      const result = shouldRetryError(error)
+
+      //#then
+      expect(result).toBe(false)
+    })
+  })
 })
 
 export {}

--- a/src/shared/model-error-classifier.ts
+++ b/src/shared/model-error-classifier.ts
@@ -34,20 +34,31 @@ const NON_RETRYABLE_ERROR_NAMES = new Set([
 ])
 
 /**
+ * Message patterns that indicate a non-retryable billing/quota error.
+ * Checked before RETRYABLE_MESSAGE_PATTERNS so that message-only errors
+ * containing quota/credit language are correctly classified as STOP.
+ */
+const STOP_MESSAGE_PATTERNS = [
+  "quota",
+  "usage limit",
+  "insufficient",
+  "free usage",
+  "usage exceeded",
+  "credit",
+  "balance",
+]
+
+/**
  * Message patterns that indicate a retryable error even without a known error name.
  */
 const RETRYABLE_MESSAGE_PATTERNS = [
   "rate_limit",
   "rate limit",
-  "quota",
-  "quota will reset after",
-  "usage limit has been reached",
   "all credentials for model",
   "cooling down",
   "exhausted your capacity",
   "not found",
   "unavailable",
-  "insufficient",
   "too many requests",
   "over limit",
   "overloaded",
@@ -63,10 +74,6 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   "timeout",
   "service unavailable",
   "internal_server_error",
-  "free usage",
-  "usage exceeded",
-  "credit",
-  "balance",
   "temporarily unavailable",
   "try again",
   "503",
@@ -123,6 +130,11 @@ export function isRetryableModelError(error: ErrorInfo): boolean {
   const msg = error.message?.toLowerCase() ?? ""
   if (hasProviderAutoRetrySignal(msg)) {
     return true
+  }
+  // Check stop message patterns before retryable patterns so that
+  // billing/quota messages without a known error name are not retried
+  if (STOP_MESSAGE_PATTERNS.some((pattern) => msg.includes(pattern))) {
+    return false
   }
   return RETRYABLE_MESSAGE_PATTERNS.some((pattern) => msg.includes(pattern))
 }


### PR DESCRIPTION
## Summary

- Add `STOP_MESSAGE_PATTERNS` to catch billing/quota errors that lack a known error name, preventing them from being incorrectly classified as retryable via `RETRYABLE_MESSAGE_PATTERNS`

## Changes

- Extract quota/billing-related patterns (`quota`, `usage limit`, `insufficient`, `free usage`, `usage exceeded`, `credit`, `balance`) from `RETRYABLE_MESSAGE_PATTERNS` into a new `STOP_MESSAGE_PATTERNS` array
- Add a stop-pattern check in `isRetryableModelError()` before the retryable message pattern fallback, so message-only errors containing billing language return `false`
- Add 9 tests covering message-only quota/billing errors and the precedence of stop patterns over retryable patterns

## Testing

```bash
bun run typecheck
bun test src/shared/model-error-classifier.test.ts
```

All 23 tests pass (14 existing + 9 new). Typecheck and build clean.

## Related Issues

Closes #3126

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies quota and billing message-only errors as non-retryable to stop futile retries. Fixes misclassification when providers return only billing text without a known error name.

- **Bug Fixes**
  - Added STOP_MESSAGE_PATTERNS for billing/quota terms and removed them from RETRYABLE_MESSAGE_PATTERNS.
  - In isRetryableModelError(), check stop patterns before retryable message patterns.
  - Added 9 tests covering message-only billing cases and precedence. Closes #3126.

<sup>Written for commit 6edd5c55b2134b0c75df6033912673710580ee4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

