### PR TITLE
fix(cli): replace subscription upsell with informational note (fixes #3069)

### DIFF
--- a/src/cli/cli-installer.ts
+++ b/src/cli/cli-installer.ts
@@ -87,17 +87,10 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
   printBox(formatConfigSummary(config), isUpdate ? "Updated Configuration" : "Installation Complete")
 
   if (!config.hasClaude) {
-    console.log()
-    console.log(color.bgRed(color.white(color.bold(" CRITICAL WARNING "))))
-    console.log()
-    console.log(color.red(color.bold("  Sisyphus agent is STRONGLY optimized for Claude Opus 4.5.")))
-    console.log(color.red("  Without Claude, you may experience significantly degraded performance:"))
-    console.log(color.dim("    • Reduced orchestration quality"))
-    console.log(color.dim("    • Weaker tool selection and delegation"))
-    console.log(color.dim("    • Less reliable task completion"))
-    console.log()
-    console.log(color.yellow("  Consider subscribing to Claude Pro/Max for the best experience."))
-    console.log()
+    printInfo(
+      "Note: Sisyphus agent performs best with Claude Opus 4.5+. " +
+        "Other models work but may have reduced orchestration quality.",
+    )
   }
 
   if (

--- a/src/cli/tui-installer.ts
+++ b/src/cli/tui-installer.ts
@@ -63,17 +63,10 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
   spinner.stop(`Config written to ${color.cyan(omoResult.configPath)}`)
 
   if (!config.hasClaude) {
-    console.log()
-    console.log(color.bgRed(color.white(color.bold(" CRITICAL WARNING "))))
-    console.log()
-    console.log(color.red(color.bold("  Sisyphus agent is STRONGLY optimized for Claude Opus 4.5.")))
-    console.log(color.red("  Without Claude, you may experience significantly degraded performance:"))
-    console.log(color.dim("    • Reduced orchestration quality"))
-    console.log(color.dim("    • Weaker tool selection and delegation"))
-    console.log(color.dim("    • Less reliable task completion"))
-    console.log()
-    console.log(color.yellow("  Consider subscribing to Claude Pro/Max for the best experience."))
-    console.log()
+    p.log.info(
+      `${color.bold("Note:")} Sisyphus agent performs best with Claude Opus 4.5+.\n` +
+        `Other models work but may have reduced orchestration quality.`,
+    )
   }
 
   if (!config.hasClaude && !config.hasOpenAI && !config.hasGemini && !config.hasCopilot && !config.hasOpencodeZen) {


### PR DESCRIPTION
## Summary
- Replace the CRITICAL WARNING subscription upsell during install with a neutral informational note.

## Problem
Users running `bunx oh-my-opencode install` without Claude see an alarming `CRITICAL WARNING` banner with red text and subscription promotion text (`Consider subscribing to Claude Pro/Max`). This is overly promotional and misleading since the plugin works well with non-Claude models (Kimi K2.5, GPT-5.4, GLM-5).

## Fix
Replaced the CRITICAL WARNING block in both `tui-installer.ts` and `cli-installer.ts` with a concise informational note, matching the text the maintainer approved in the issue:

> Note: Sisyphus agent performs best with Claude Opus 4.5+.
> Other models work but may have reduced orchestration quality.

No banner, no red text, no subscription mentions.

## Changes
| File | Change |
|------|--------|
| `src/cli/tui-installer.ts` | Replace CRITICAL WARNING block with `p.log.info()` note |
| `src/cli/cli-installer.ts` | Replace CRITICAL WARNING block with `printInfo()` note |

Fixes #3069

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the install-time “CRITICAL WARNING” subscription upsell with a neutral note when Claude isn’t configured across CLI and TUI installers, fixing #3069.

- **Bug Fixes**
  - Show this note instead of the banner/promo: “Note: Sisyphus agent performs best with Claude Opus 4.5+. Other models work but may have reduced orchestration quality.”
  - Implemented in `src/cli/cli-installer.ts` (via `printInfo`) and `src/cli/tui-installer.ts` (via `p.log.info`).

<sup>Written for commit 2f10ff46058ff98ca79a1d7b56d5342c3478ba4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

