### PR TITLE
fix(ock): suppress OMO workflow ownership in bead-first repos

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -1,312 +1,352 @@
 import { createBuiltinAgents } from "../agents";
 import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
 import type { OhMyOpenCodeConfig } from "../config";
-import { isTaskSystemEnabled, log, migrateAgentConfig } from "../shared";
-import { AGENT_NAME_MAP } from "../shared/migration";
-import { getAgentDisplayName } from "../shared/agent-display-names";
+import {
+	loadProjectAgents,
+	loadUserAgents,
+} from "../features/claude-code-agent-loader";
 import { registerAgentName } from "../features/claude-code-session-state";
 import {
-  discoverConfigSourceSkills,
-  discoverGlobalAgentsSkills,
-  discoverOpencodeGlobalSkills,
-  discoverOpencodeProjectSkills,
-  discoverProjectAgentsSkills,
-  discoverProjectClaudeSkills,
-  discoverUserClaudeSkills,
+	discoverConfigSourceSkills,
+	discoverGlobalAgentsSkills,
+	discoverOpencodeGlobalSkills,
+	discoverOpencodeProjectSkills,
+	discoverProjectAgentsSkills,
+	discoverProjectClaudeSkills,
+	discoverUserClaudeSkills,
 } from "../features/opencode-skill-loader";
-import { loadProjectAgents, loadUserAgents } from "../features/claude-code-agent-loader";
-import type { PluginComponents } from "./plugin-components-loader";
-import { reorderAgentsByPriority } from "./agent-priority-order";
+import {
+	isTaskSystemEnabledForDirectory,
+	log,
+	migrateAgentConfig,
+} from "../shared";
+import { getAgentDisplayName } from "../shared/agent-display-names";
+import { AGENT_NAME_MAP } from "../shared/migration";
 import { remapAgentKeysToDisplayNames } from "./agent-key-remapper";
 import {
-  createProtectedAgentNameSet,
-  filterProtectedAgentOverrides,
+	createProtectedAgentNameSet,
+	filterProtectedAgentOverrides,
 } from "./agent-override-protection";
-import { buildPrometheusAgentConfig } from "./prometheus-agent-config-builder";
+import { reorderAgentsByPriority } from "./agent-priority-order";
 import { buildPlanDemoteConfig } from "./plan-model-inheritance";
+import type { PluginComponents } from "./plugin-components-loader";
+import { buildPrometheusAgentConfig } from "./prometheus-agent-config-builder";
 
 type AgentConfigRecord = Record<string, Record<string, unknown> | undefined> & {
-  build?: Record<string, unknown>;
-  plan?: Record<string, unknown>;
+	build?: Record<string, unknown>;
+	plan?: Record<string, unknown>;
 };
 
-function getConfiguredDefaultAgent(config: Record<string, unknown>): string | undefined {
-  const defaultAgent = config.default_agent;
-  if (typeof defaultAgent !== "string") return undefined;
+function getConfiguredDefaultAgent(
+	config: Record<string, unknown>,
+): string | undefined {
+	const defaultAgent = config.default_agent;
+	if (typeof defaultAgent !== "string") return undefined;
 
-  const trimmedDefaultAgent = defaultAgent.trim();
-  return trimmedDefaultAgent.length > 0 ? trimmedDefaultAgent : undefined;
+	const trimmedDefaultAgent = defaultAgent.trim();
+	return trimmedDefaultAgent.length > 0 ? trimmedDefaultAgent : undefined;
 }
 
 export async function applyAgentConfig(params: {
-  config: Record<string, unknown>;
-  pluginConfig: OhMyOpenCodeConfig;
-  ctx: { directory: string; client?: any };
-  pluginComponents: PluginComponents;
+	config: Record<string, unknown>;
+	pluginConfig: OhMyOpenCodeConfig;
+	ctx: { directory: string; client?: any };
+	pluginComponents: PluginComponents;
 }): Promise<Record<string, unknown>> {
-  const migratedDisabledAgents = (params.pluginConfig.disabled_agents ?? []).map(
-    (agent) => {
-      return AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent;
-    },
-  ) as typeof params.pluginConfig.disabled_agents;
+	const migratedDisabledAgents = (
+		params.pluginConfig.disabled_agents ?? []
+	).map((agent) => {
+		return (
+			AGENT_NAME_MAP[agent.toLowerCase()] ?? AGENT_NAME_MAP[agent] ?? agent
+		);
+	}) as typeof params.pluginConfig.disabled_agents;
 
-  const includeClaudeSkillsForAwareness = params.pluginConfig.claude_code?.skills ?? true;
-  const [
-    discoveredConfigSourceSkills,
-    discoveredUserSkills,
-    discoveredProjectSkills,
-    discoveredProjectAgentsSkills,
-    discoveredOpencodeGlobalSkills,
-    discoveredOpencodeProjectSkills,
-    discoveredGlobalAgentsSkills,
-  ] = await Promise.all([
-    discoverConfigSourceSkills({
-      config: params.pluginConfig.skills,
-      configDir: params.ctx.directory,
-    }),
-    includeClaudeSkillsForAwareness ? discoverUserClaudeSkills() : Promise.resolve([]),
-    includeClaudeSkillsForAwareness
-       ? discoverProjectClaudeSkills(params.ctx.directory)
-       : Promise.resolve([]),
-    includeClaudeSkillsForAwareness
-      ? discoverProjectAgentsSkills(params.ctx.directory)
-      : Promise.resolve([]),
-    discoverOpencodeGlobalSkills(),
-    discoverOpencodeProjectSkills(params.ctx.directory),
-    includeClaudeSkillsForAwareness ? discoverGlobalAgentsSkills() : Promise.resolve([]),
-  ]);
+	const includeClaudeSkillsForAwareness =
+		params.pluginConfig.claude_code?.skills ?? true;
+	const [
+		discoveredConfigSourceSkills,
+		discoveredUserSkills,
+		discoveredProjectSkills,
+		discoveredProjectAgentsSkills,
+		discoveredOpencodeGlobalSkills,
+		discoveredOpencodeProjectSkills,
+		discoveredGlobalAgentsSkills,
+	] = await Promise.all([
+		discoverConfigSourceSkills({
+			config: params.pluginConfig.skills,
+			configDir: params.ctx.directory,
+		}),
+		includeClaudeSkillsForAwareness
+			? discoverUserClaudeSkills()
+			: Promise.resolve([]),
+		includeClaudeSkillsForAwareness
+			? discoverProjectClaudeSkills(params.ctx.directory)
+			: Promise.resolve([]),
+		includeClaudeSkillsForAwareness
+			? discoverProjectAgentsSkills(params.ctx.directory)
+			: Promise.resolve([]),
+		discoverOpencodeGlobalSkills(),
+		discoverOpencodeProjectSkills(params.ctx.directory),
+		includeClaudeSkillsForAwareness
+			? discoverGlobalAgentsSkills()
+			: Promise.resolve([]),
+	]);
 
-  const allDiscoveredSkills = [
-    ...discoveredConfigSourceSkills,
-    ...discoveredOpencodeProjectSkills,
-    ...discoveredProjectSkills,
-    ...discoveredProjectAgentsSkills,
-    ...discoveredOpencodeGlobalSkills,
-    ...discoveredUserSkills,
-    ...discoveredGlobalAgentsSkills,
-  ];
+	const allDiscoveredSkills = [
+		...discoveredConfigSourceSkills,
+		...discoveredOpencodeProjectSkills,
+		...discoveredProjectSkills,
+		...discoveredProjectAgentsSkills,
+		...discoveredOpencodeGlobalSkills,
+		...discoveredUserSkills,
+		...discoveredGlobalAgentsSkills,
+	];
 
-  const browserProvider =
-    params.pluginConfig.browser_automation_engine?.provider ?? "playwright";
-  const currentModel = params.config.model as string | undefined;
-  const disabledSkills = new Set<string>(params.pluginConfig.disabled_skills ?? []);
-  const useTaskSystem = isTaskSystemEnabled(params.pluginConfig);
-  const disableOmoEnv = params.pluginConfig.experimental?.disable_omo_env ?? false;
+	const browserProvider =
+		params.pluginConfig.browser_automation_engine?.provider ?? "playwright";
+	const currentModel = params.config.model as string | undefined;
+	const disabledSkills = new Set<string>(
+		params.pluginConfig.disabled_skills ?? [],
+	);
+	const useTaskSystem = isTaskSystemEnabledForDirectory(
+		params.pluginConfig,
+		params.ctx.directory,
+	);
+	const disableOmoEnv =
+		params.pluginConfig.experimental?.disable_omo_env ?? false;
 
-  const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
-  const userAgents = includeClaudeAgents ? loadUserAgents() : {};
-  const projectAgents = includeClaudeAgents ? loadProjectAgents(params.ctx.directory) : {};
-  const rawPluginAgents = params.pluginComponents.agents;
+	const includeClaudeAgents = params.pluginConfig.claude_code?.agents ?? true;
+	const userAgents = includeClaudeAgents ? loadUserAgents() : {};
+	const projectAgents = includeClaudeAgents
+		? loadProjectAgents(params.ctx.directory)
+		: {};
+	const rawPluginAgents = params.pluginComponents.agents;
 
-  const pluginAgents = Object.fromEntries(
-    Object.entries(rawPluginAgents).map(([key, value]) => [
-      key,
-      value ? migrateAgentConfig(value as Record<string, unknown>) : value,
-    ]),
-  );
+	const pluginAgents = Object.fromEntries(
+		Object.entries(rawPluginAgents).map(([key, value]) => [
+			key,
+			value ? migrateAgentConfig(value as Record<string, unknown>) : value,
+		]),
+	);
 
-  const configAgent = params.config.agent as AgentConfigRecord | undefined;
+	const configAgent = params.config.agent as AgentConfigRecord | undefined;
 
-  const customAgentSummaries = [
-    ...Object.entries(configAgent ?? {}),
-    ...Object.entries(userAgents),
-    ...Object.entries(projectAgents),
-    ...Object.entries(pluginAgents).filter(([, config]) => config !== undefined),
-  ]
-    .filter(([, config]) => config != null)
-    .map(([name, config]) => ({
-      name,
-      description: typeof (config as Record<string, unknown>)?.description === "string"
-        ? ((config as Record<string, unknown>).description as string)
-        : "",
-    }));
+	const customAgentSummaries = [
+		...Object.entries(configAgent ?? {}),
+		...Object.entries(userAgents),
+		...Object.entries(projectAgents),
+		...Object.entries(pluginAgents).filter(
+			([, config]) => config !== undefined,
+		),
+	]
+		.filter(([, config]) => config != null)
+		.map(([name, config]) => ({
+			name,
+			description:
+				typeof (config as Record<string, unknown>)?.description === "string"
+					? ((config as Record<string, unknown>).description as string)
+					: "",
+		}));
 
-  const builtinAgents = await createBuiltinAgents(
-    migratedDisabledAgents,
-    params.pluginConfig.agents,
-    params.ctx.directory,
-    currentModel,
-    params.pluginConfig.categories,
-    params.pluginConfig.git_master,
-    allDiscoveredSkills,
-    customAgentSummaries,
-    browserProvider,
-    currentModel,
-    disabledSkills,
-    useTaskSystem,
-    disableOmoEnv,
-  );
+	const builtinAgents = await createBuiltinAgents(
+		migratedDisabledAgents,
+		params.pluginConfig.agents,
+		params.ctx.directory,
+		currentModel,
+		params.pluginConfig.categories,
+		params.pluginConfig.git_master,
+		allDiscoveredSkills,
+		customAgentSummaries,
+		browserProvider,
+		currentModel,
+		disabledSkills,
+		useTaskSystem,
+		disableOmoEnv,
+	);
 
-  const disabledAgentNames = new Set(
-    (migratedDisabledAgents ?? []).map(a => a.toLowerCase())
-  );
+	const disabledAgentNames = new Set(
+		(migratedDisabledAgents ?? []).map((a) => a.toLowerCase()),
+	);
 
-  const filterDisabledAgents = (agents: Record<string, unknown>) =>
-    Object.fromEntries(
-      Object.entries(agents).filter(([name]) => !disabledAgentNames.has(name.toLowerCase()))
-    );
+	const filterDisabledAgents = (agents: Record<string, unknown>) =>
+		Object.fromEntries(
+			Object.entries(agents).filter(
+				([name]) => !disabledAgentNames.has(name.toLowerCase()),
+			),
+		);
 
-  const isSisyphusEnabled = params.pluginConfig.sisyphus_agent?.disabled !== true;
-  const builderEnabled =
-    params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? false;
-  const plannerEnabled = params.pluginConfig.sisyphus_agent?.planner_enabled ?? true;
-  const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
-  const shouldDemotePlan = plannerEnabled && replacePlan;
-  const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
+	const isSisyphusEnabled =
+		params.pluginConfig.sisyphus_agent?.disabled !== true;
+	const builderEnabled =
+		params.pluginConfig.sisyphus_agent?.default_builder_enabled ?? false;
+	const plannerEnabled =
+		params.pluginConfig.sisyphus_agent?.planner_enabled ?? true;
+	const replacePlan = params.pluginConfig.sisyphus_agent?.replace_plan ?? true;
+	const shouldDemotePlan = plannerEnabled && replacePlan;
+	const configuredDefaultAgent = getConfiguredDefaultAgent(params.config);
 
-  if (isSisyphusEnabled && builtinAgents.sisyphus) {
-    if (configuredDefaultAgent) {
-      (params.config as { default_agent?: string }).default_agent =
-        getAgentDisplayName(configuredDefaultAgent);
-    } else {
-      (params.config as { default_agent?: string }).default_agent =
-        getAgentDisplayName("sisyphus");
-    }
+	if (isSisyphusEnabled && builtinAgents.sisyphus) {
+		if (configuredDefaultAgent) {
+			(params.config as { default_agent?: string }).default_agent =
+				getAgentDisplayName(configuredDefaultAgent);
+		} else {
+			(params.config as { default_agent?: string }).default_agent =
+				getAgentDisplayName("sisyphus");
+		}
 
-    // Assembly order: Sisyphus -> Hephaestus -> Prometheus -> Atlas
-    const agentConfig: Record<string, unknown> = {
-      sisyphus: builtinAgents.sisyphus,
-    };
+		// Assembly order: Sisyphus -> Hephaestus -> Prometheus -> Atlas
+		const agentConfig: Record<string, unknown> = {
+			sisyphus: builtinAgents.sisyphus,
+		};
 
-    if (builtinAgents.hephaestus) {
-      agentConfig["hephaestus"] = builtinAgents.hephaestus;
-    }
+		if (builtinAgents.hephaestus) {
+			agentConfig["hephaestus"] = builtinAgents.hephaestus;
+		}
 
-    if (plannerEnabled) {
-      const prometheusOverride = params.pluginConfig.agents?.["prometheus"] as
-        | (Record<string, unknown> & { prompt_append?: string })
-        | undefined;
+		if (plannerEnabled) {
+			const prometheusOverride = params.pluginConfig.agents?.["prometheus"] as
+				| (Record<string, unknown> & { prompt_append?: string })
+				| undefined;
 
-      agentConfig["prometheus"] = await buildPrometheusAgentConfig({
-        configAgentPlan: configAgent?.plan,
-        pluginPrometheusOverride: prometheusOverride,
-        userCategories: params.pluginConfig.categories,
-        currentModel,
-        disabledTools: params.pluginConfig.disabled_tools,
-      });
-    }
+			agentConfig["prometheus"] = await buildPrometheusAgentConfig({
+				configAgentPlan: configAgent?.plan,
+				pluginPrometheusOverride: prometheusOverride,
+				userCategories: params.pluginConfig.categories,
+				currentModel,
+				disabledTools: params.pluginConfig.disabled_tools,
+			});
+		}
 
-    if (builtinAgents.atlas) {
-      agentConfig["atlas"] = builtinAgents.atlas;
-    }
+		if (builtinAgents.atlas) {
+			agentConfig["atlas"] = builtinAgents.atlas;
+		}
 
-    agentConfig["sisyphus-junior"] = createSisyphusJuniorAgentWithOverrides(
-      params.pluginConfig.agents?.["sisyphus-junior"],
-      (builtinAgents.atlas as { model?: string } | undefined)?.model,
-      useTaskSystem,
-    );
+		agentConfig["sisyphus-junior"] = createSisyphusJuniorAgentWithOverrides(
+			params.pluginConfig.agents?.["sisyphus-junior"],
+			(builtinAgents.atlas as { model?: string } | undefined)?.model,
+			useTaskSystem,
+		);
 
-    if (builderEnabled) {
-      const { name: _buildName, ...buildConfigWithoutName } =
-        configAgent?.build ?? {};
-      const migratedBuildConfig = migrateAgentConfig(
-        buildConfigWithoutName as Record<string, unknown>,
-      );
-      const override = params.pluginConfig.agents?.["OpenCode-Builder"];
-      const base = {
-        ...migratedBuildConfig,
-        description: `${(configAgent?.build?.description as string) ?? "Build agent"} (OpenCode default)`,
-      };
-      agentConfig["OpenCode-Builder"] = override ? { ...base, ...override } : base;
-    }
+		if (builderEnabled) {
+			const { name: _buildName, ...buildConfigWithoutName } =
+				configAgent?.build ?? {};
+			const migratedBuildConfig = migrateAgentConfig(
+				buildConfigWithoutName as Record<string, unknown>,
+			);
+			const override = params.pluginConfig.agents?.["OpenCode-Builder"];
+			const base = {
+				...migratedBuildConfig,
+				description: `${(configAgent?.build?.description as string) ?? "Build agent"} (OpenCode default)`,
+			};
+			agentConfig["OpenCode-Builder"] = override
+				? { ...base, ...override }
+				: base;
+		}
 
-    const filteredConfigAgents = configAgent
-      ? Object.fromEntries(
-          Object.entries(configAgent)
-            .filter(([key]) => {
-              if (key === "build") return false;
-              if (key === "plan" && shouldDemotePlan) return false;
-              if (key in builtinAgents) return false;
-              return true;
-            })
-            .map(([key, value]) => [
-              key,
-              value ? migrateAgentConfig(value as Record<string, unknown>) : value,
-            ]),
-        )
-      : {};
+		const filteredConfigAgents = configAgent
+			? Object.fromEntries(
+					Object.entries(configAgent)
+						.filter(([key]) => {
+							if (key === "build") return false;
+							if (key === "plan" && shouldDemotePlan) return false;
+							if (key in builtinAgents) return false;
+							return true;
+						})
+						.map(([key, value]) => [
+							key,
+							value
+								? migrateAgentConfig(value as Record<string, unknown>)
+								: value,
+						]),
+				)
+			: {};
 
-    const migratedBuild = configAgent?.build
-      ? migrateAgentConfig(configAgent.build as Record<string, unknown>)
-      : {};
+		const migratedBuild = configAgent?.build
+			? migrateAgentConfig(configAgent.build as Record<string, unknown>)
+			: {};
 
-    const planDemoteConfig = shouldDemotePlan
-      ? buildPlanDemoteConfig(
-          agentConfig["prometheus"] as Record<string, unknown> | undefined,
-          params.pluginConfig.agents?.plan as Record<string, unknown> | undefined,
-        )
-      : undefined;
+		const planDemoteConfig = shouldDemotePlan
+			? buildPlanDemoteConfig(
+					agentConfig["prometheus"] as Record<string, unknown> | undefined,
+					params.pluginConfig.agents?.plan as
+						| Record<string, unknown>
+						| undefined,
+				)
+			: undefined;
 
-    const protectedBuiltinAgentNames = createProtectedAgentNameSet([
-      ...Object.keys(agentConfig),
-      ...Object.keys(builtinAgents),
-    ]);
-    const filteredUserAgents = filterProtectedAgentOverrides(
-      userAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredProjectAgents = filterProtectedAgentOverrides(
-      projectAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredPluginAgents = filterProtectedAgentOverrides(
-      pluginAgents,
-      protectedBuiltinAgentNames,
-    );
+		const protectedBuiltinAgentNames = createProtectedAgentNameSet([
+			...Object.keys(agentConfig),
+			...Object.keys(builtinAgents),
+		]);
+		const filteredUserAgents = filterProtectedAgentOverrides(
+			userAgents,
+			protectedBuiltinAgentNames,
+		);
+		const filteredProjectAgents = filterProtectedAgentOverrides(
+			projectAgents,
+			protectedBuiltinAgentNames,
+		);
+		const filteredPluginAgents = filterProtectedAgentOverrides(
+			pluginAgents,
+			protectedBuiltinAgentNames,
+		);
 
-    params.config.agent = {
-      ...agentConfig,
-      ...Object.fromEntries(
-        Object.entries(builtinAgents).filter(
-          ([key]) => key !== "sisyphus" && key !== "hephaestus" && key !== "atlas",
-        ),
-      ),
-      ...filterDisabledAgents(filteredUserAgents),
-      ...filterDisabledAgents(filteredProjectAgents),
-      ...filterDisabledAgents(filteredPluginAgents),
-      ...filteredConfigAgents,
-      build: { ...migratedBuild, mode: "subagent", hidden: true },
-      ...(planDemoteConfig ? { plan: planDemoteConfig } : {}),
-    };
-  } else {
-    const protectedBuiltinAgentNames = createProtectedAgentNameSet(
-      Object.keys(builtinAgents),
-    );
-    const filteredUserAgents = filterProtectedAgentOverrides(
-      userAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredProjectAgents = filterProtectedAgentOverrides(
-      projectAgents,
-      protectedBuiltinAgentNames,
-    );
-    const filteredPluginAgents = filterProtectedAgentOverrides(
-      pluginAgents,
-      protectedBuiltinAgentNames,
-    );
+		params.config.agent = {
+			...agentConfig,
+			...Object.fromEntries(
+				Object.entries(builtinAgents).filter(
+					([key]) =>
+						key !== "sisyphus" && key !== "hephaestus" && key !== "atlas",
+				),
+			),
+			...filterDisabledAgents(filteredUserAgents),
+			...filterDisabledAgents(filteredProjectAgents),
+			...filterDisabledAgents(filteredPluginAgents),
+			...filteredConfigAgents,
+			build: { ...migratedBuild, mode: "subagent", hidden: true },
+			...(planDemoteConfig ? { plan: planDemoteConfig } : {}),
+		};
+	} else {
+		const protectedBuiltinAgentNames = createProtectedAgentNameSet(
+			Object.keys(builtinAgents),
+		);
+		const filteredUserAgents = filterProtectedAgentOverrides(
+			userAgents,
+			protectedBuiltinAgentNames,
+		);
+		const filteredProjectAgents = filterProtectedAgentOverrides(
+			projectAgents,
+			protectedBuiltinAgentNames,
+		);
+		const filteredPluginAgents = filterProtectedAgentOverrides(
+			pluginAgents,
+			protectedBuiltinAgentNames,
+		);
 
-    params.config.agent = {
-      ...builtinAgents,
-      ...filterDisabledAgents(filteredUserAgents),
-      ...filterDisabledAgents(filteredProjectAgents),
-      ...filterDisabledAgents(filteredPluginAgents),
-      ...configAgent,
-    };
-  }
+		params.config.agent = {
+			...builtinAgents,
+			...filterDisabledAgents(filteredUserAgents),
+			...filterDisabledAgents(filteredProjectAgents),
+			...filterDisabledAgents(filteredPluginAgents),
+			...configAgent,
+		};
+	}
 
-  if (params.config.agent) {
-    params.config.agent = remapAgentKeysToDisplayNames(
-      params.config.agent as Record<string, unknown>,
-    );
-    params.config.agent = reorderAgentsByPriority(
-      params.config.agent as Record<string, unknown>,
-    );
-  }
+	if (params.config.agent) {
+		params.config.agent = remapAgentKeysToDisplayNames(
+			params.config.agent as Record<string, unknown>,
+		);
+		params.config.agent = reorderAgentsByPriority(
+			params.config.agent as Record<string, unknown>,
+		);
+	}
 
-  const agentResult = params.config.agent as Record<string, unknown>;
-  for (const name of Object.keys(agentResult)) {
-    registerAgentName(name);
-  }
-  log("[config-handler] agents loaded", { agentKeys: Object.keys(agentResult) });
-  return agentResult;
+	const agentResult = params.config.agent as Record<string, unknown>;
+	for (const name of Object.keys(agentResult)) {
+		registerAgentName(name);
+	}
+	log("[config-handler] agents loaded", {
+		agentKeys: Object.keys(agentResult),
+	});
+	return agentResult;
 }

--- a/src/plugin-handlers/command-config-handler.ock.test.ts
+++ b/src/plugin-handlers/command-config-handler.ock.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { OhMyOpenCodeConfig } from "../config";
+import * as builtinCommands from "../features/builtin-commands";
+import { applyCommandConfig } from "./command-config-handler";
+import type { PluginComponents } from "./plugin-components-loader";
+
+const GIT_BIN = "/usr/bin/git";
+
+function createPluginComponents(): PluginComponents {
+	return {
+		commands: {},
+		skills: {},
+		agents: {},
+		mcpServers: {},
+		hooksConfigs: [],
+		plugins: [],
+		errors: [],
+	};
+}
+
+function createPluginConfig(): OhMyOpenCodeConfig {
+	return {};
+}
+
+function createOckProjectRoot(): string {
+	const projectRoot = mkdtempSync(
+		join(tmpdir(), "command-config-handler-ock-"),
+	);
+	execFileSync(GIT_BIN, ["init"], {
+		cwd: projectRoot,
+		stdio: ["ignore", "ignore", "ignore"],
+	});
+	mkdirSync(join(projectRoot, ".beads"), { recursive: true });
+	const commandDirectory = join(projectRoot, ".opencode", "command");
+	mkdirSync(commandDirectory, { recursive: true });
+
+	for (const commandName of ["create", "research", "start", "plan"]) {
+		writeFileSync(
+			join(commandDirectory, `${commandName}.md`),
+			`# ${commandName}\n`,
+			"utf-8",
+		);
+	}
+
+	return projectRoot;
+}
+
+describe("applyCommandConfig in OCK repos", () => {
+	const builtinCommandDefinitions = {
+		"start-work": {
+			name: "start-work",
+			description: "builtin",
+			template: "template",
+		},
+		"ralph-loop": {
+			name: "ralph-loop",
+			description: "builtin",
+			template: "template",
+		},
+		"ulw-loop": {
+			name: "ulw-loop",
+			description: "builtin",
+			template: "template",
+		},
+		"cancel-ralph": {
+			name: "cancel-ralph",
+			description: "builtin",
+			template: "template",
+		},
+		"stop-continuation": {
+			name: "stop-continuation",
+			description: "builtin",
+			template: "template",
+		},
+		refactor: {
+			name: "refactor",
+			description: "builtin",
+			template: "template",
+		},
+	};
+
+	let loadBuiltinCommandsSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		loadBuiltinCommandsSpy = spyOn(
+			builtinCommands,
+			"loadBuiltinCommands",
+		).mockReturnValue({});
+	});
+
+	afterEach(() => {
+		loadBuiltinCommandsSpy.mockRestore();
+	});
+
+	test("omits conflicting builtin workflow commands in OCK bead-first repos", async () => {
+		const projectRoot = createOckProjectRoot();
+		loadBuiltinCommandsSpy.mockReturnValue(builtinCommandDefinitions);
+
+		try {
+			const config: Record<string, unknown> = { command: {} };
+
+			await applyCommandConfig({
+				config,
+				pluginConfig: createPluginConfig(),
+				ctx: { directory: projectRoot },
+				pluginComponents: createPluginComponents(),
+			});
+
+			const commandConfig = config.command as Record<string, unknown>;
+			expect(commandConfig["start-work"]).toBeUndefined();
+			expect(commandConfig["ralph-loop"]).toBeUndefined();
+			expect(commandConfig["ulw-loop"]).toBeUndefined();
+			expect(commandConfig["cancel-ralph"]).toBeUndefined();
+			expect(commandConfig["stop-continuation"]).toBeUndefined();
+			expect(commandConfig.refactor).toBeDefined();
+		} finally {
+			rmSync(projectRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps builtin workflow commands in non-OCK repos", async () => {
+		const projectRoot = mkdtempSync(
+			join(tmpdir(), "command-config-handler-non-ock-"),
+		);
+		execFileSync(GIT_BIN, ["init"], {
+			cwd: projectRoot,
+			stdio: ["ignore", "ignore", "ignore"],
+		});
+		loadBuiltinCommandsSpy.mockReturnValue(builtinCommandDefinitions);
+
+		try {
+			const config: Record<string, unknown> = { command: {} };
+
+			await applyCommandConfig({
+				config,
+				pluginConfig: createPluginConfig(),
+				ctx: { directory: projectRoot },
+				pluginComponents: createPluginComponents(),
+			});
+
+			const commandConfig = config.command as Record<string, unknown>;
+			expect(commandConfig["start-work"]).toBeDefined();
+			expect(commandConfig["ralph-loop"]).toBeDefined();
+			expect(commandConfig["ulw-loop"]).toBeDefined();
+			expect(commandConfig["cancel-ralph"]).toBeDefined();
+			expect(commandConfig["stop-continuation"]).toBeDefined();
+			expect(commandConfig.refactor).toBeDefined();
+		} finally {
+			rmSync(projectRoot, { recursive: true, force: true });
+		}
+	});
+
+	test("keeps project-provided workflow commands even when builtin conflicts are filtered in OCK repos", async () => {
+		const projectRoot = createOckProjectRoot();
+		loadBuiltinCommandsSpy.mockReturnValue(builtinCommandDefinitions);
+
+		try {
+			const config: Record<string, unknown> = { command: {} };
+			const pluginComponents = createPluginComponents();
+
+			pluginComponents.commands = {
+				"start-work": {
+					name: "start-work",
+					description: "project command",
+					template: "project-template",
+				},
+			};
+
+			await applyCommandConfig({
+				config,
+				pluginConfig: createPluginConfig(),
+				ctx: { directory: projectRoot },
+				pluginComponents,
+			});
+
+			const commandConfig = config.command as Record<
+				string,
+				{ description?: string; template?: string }
+			>;
+			expect(commandConfig["start-work"]?.description).toBe("project command");
+			expect(commandConfig["start-work"]?.template).toBe("project-template");
+			expect(commandConfig["ralph-loop"]).toBeUndefined();
+		} finally {
+			rmSync(projectRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/plugin-handlers/command-config-handler.test.ts
+++ b/src/plugin-handlers/command-config-handler.test.ts
@@ -1,124 +1,198 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { OhMyOpenCodeConfig } from "../config";
 import * as builtinCommands from "../features/builtin-commands";
 import * as commandLoader from "../features/claude-code-command-loader";
 import * as skillLoader from "../features/opencode-skill-loader";
-import type { OhMyOpenCodeConfig } from "../config";
-import type { PluginComponents } from "./plugin-components-loader";
-import { applyCommandConfig } from "./command-config-handler";
 import { getAgentListDisplayName } from "../shared/agent-display-names";
+import { applyCommandConfig } from "./command-config-handler";
+import type { PluginComponents } from "./plugin-components-loader";
 
 function createPluginComponents(): PluginComponents {
-  return {
-    commands: {},
-    skills: {},
-    agents: {},
-    mcpServers: {},
-    hooksConfigs: [],
-    plugins: [],
-    errors: [],
-  };
+	return {
+		commands: {},
+		skills: {},
+		agents: {},
+		mcpServers: {},
+		hooksConfigs: [],
+		plugins: [],
+		errors: [],
+	};
 }
 
 function createPluginConfig(): OhMyOpenCodeConfig {
-  return {};
+	return {};
+}
+
+const GIT_BIN = "/usr/bin/git";
+
+function createNonOckProjectRoot(): string {
+	const projectRoot = mkdtempSync(
+		join(tmpdir(), "command-config-handler-non-ock-"),
+	);
+	execFileSync(GIT_BIN, ["init"], {
+		cwd: projectRoot,
+		stdio: ["ignore", "ignore", "ignore"],
+	});
+	return projectRoot;
 }
 
 describe("applyCommandConfig", () => {
-  let loadBuiltinCommandsSpy: ReturnType<typeof spyOn>;
-  let loadUserCommandsSpy: ReturnType<typeof spyOn>;
-  let loadProjectCommandsSpy: ReturnType<typeof spyOn>;
-  let loadOpencodeGlobalCommandsSpy: ReturnType<typeof spyOn>;
-  let loadOpencodeProjectCommandsSpy: ReturnType<typeof spyOn>;
-  let discoverConfigSourceSkillsSpy: ReturnType<typeof spyOn>;
-  let loadUserSkillsSpy: ReturnType<typeof spyOn>;
-  let loadProjectSkillsSpy: ReturnType<typeof spyOn>;
-  let loadOpencodeGlobalSkillsSpy: ReturnType<typeof spyOn>;
-  let loadOpencodeProjectSkillsSpy: ReturnType<typeof spyOn>;
-  let loadProjectAgentsSkillsSpy: ReturnType<typeof spyOn>;
-  let loadGlobalAgentsSkillsSpy: ReturnType<typeof spyOn>;
+	let loadBuiltinCommandsSpy: ReturnType<typeof spyOn>;
+	let loadUserCommandsSpy: ReturnType<typeof spyOn>;
+	let loadProjectCommandsSpy: ReturnType<typeof spyOn>;
+	let loadOpencodeGlobalCommandsSpy: ReturnType<typeof spyOn>;
+	let loadOpencodeProjectCommandsSpy: ReturnType<typeof spyOn>;
+	let discoverConfigSourceSkillsSpy: ReturnType<typeof spyOn>;
+	let loadUserSkillsSpy: ReturnType<typeof spyOn>;
+	let loadProjectSkillsSpy: ReturnType<typeof spyOn>;
+	let loadOpencodeGlobalSkillsSpy: ReturnType<typeof spyOn>;
+	let loadOpencodeProjectSkillsSpy: ReturnType<typeof spyOn>;
+	let loadProjectAgentsSkillsSpy: ReturnType<typeof spyOn>;
+	let loadGlobalAgentsSkillsSpy: ReturnType<typeof spyOn>;
 
-  beforeEach(() => {
-    loadBuiltinCommandsSpy = spyOn(builtinCommands, "loadBuiltinCommands").mockReturnValue({});
-    loadUserCommandsSpy = spyOn(commandLoader, "loadUserCommands").mockResolvedValue({});
-    loadProjectCommandsSpy = spyOn(commandLoader, "loadProjectCommands").mockResolvedValue({});
-    loadOpencodeGlobalCommandsSpy = spyOn(commandLoader, "loadOpencodeGlobalCommands").mockResolvedValue({});
-    loadOpencodeProjectCommandsSpy = spyOn(commandLoader, "loadOpencodeProjectCommands").mockResolvedValue({});
-    discoverConfigSourceSkillsSpy = spyOn(skillLoader, "discoverConfigSourceSkills").mockResolvedValue([]);
-    loadUserSkillsSpy = spyOn(skillLoader, "loadUserSkills").mockResolvedValue({});
-    loadProjectSkillsSpy = spyOn(skillLoader, "loadProjectSkills").mockResolvedValue({});
-    loadOpencodeGlobalSkillsSpy = spyOn(skillLoader, "loadOpencodeGlobalSkills").mockResolvedValue({});
-    loadOpencodeProjectSkillsSpy = spyOn(skillLoader, "loadOpencodeProjectSkills").mockResolvedValue({});
-    loadProjectAgentsSkillsSpy = spyOn(skillLoader, "loadProjectAgentsSkills").mockResolvedValue({});
-    loadGlobalAgentsSkillsSpy = spyOn(skillLoader, "loadGlobalAgentsSkills").mockResolvedValue({});
-  });
+	beforeEach(() => {
+		loadBuiltinCommandsSpy = spyOn(
+			builtinCommands,
+			"loadBuiltinCommands",
+		).mockReturnValue({});
+		loadUserCommandsSpy = spyOn(
+			commandLoader,
+			"loadUserCommands",
+		).mockResolvedValue({});
+		loadProjectCommandsSpy = spyOn(
+			commandLoader,
+			"loadProjectCommands",
+		).mockResolvedValue({});
+		loadOpencodeGlobalCommandsSpy = spyOn(
+			commandLoader,
+			"loadOpencodeGlobalCommands",
+		).mockResolvedValue({});
+		loadOpencodeProjectCommandsSpy = spyOn(
+			commandLoader,
+			"loadOpencodeProjectCommands",
+		).mockResolvedValue({});
+		discoverConfigSourceSkillsSpy = spyOn(
+			skillLoader,
+			"discoverConfigSourceSkills",
+		).mockResolvedValue([]);
+		loadUserSkillsSpy = spyOn(skillLoader, "loadUserSkills").mockResolvedValue(
+			{},
+		);
+		loadProjectSkillsSpy = spyOn(
+			skillLoader,
+			"loadProjectSkills",
+		).mockResolvedValue({});
+		loadOpencodeGlobalSkillsSpy = spyOn(
+			skillLoader,
+			"loadOpencodeGlobalSkills",
+		).mockResolvedValue({});
+		loadOpencodeProjectSkillsSpy = spyOn(
+			skillLoader,
+			"loadOpencodeProjectSkills",
+		).mockResolvedValue({});
+		loadProjectAgentsSkillsSpy = spyOn(
+			skillLoader,
+			"loadProjectAgentsSkills",
+		).mockResolvedValue({});
+		loadGlobalAgentsSkillsSpy = spyOn(
+			skillLoader,
+			"loadGlobalAgentsSkills",
+		).mockResolvedValue({});
+	});
 
-  afterEach(() => {
-    loadBuiltinCommandsSpy.mockRestore();
-    loadUserCommandsSpy.mockRestore();
-    loadProjectCommandsSpy.mockRestore();
-    loadOpencodeGlobalCommandsSpy.mockRestore();
-    loadOpencodeProjectCommandsSpy.mockRestore();
-    discoverConfigSourceSkillsSpy.mockRestore();
-    loadUserSkillsSpy.mockRestore();
-    loadProjectSkillsSpy.mockRestore();
-    loadOpencodeGlobalSkillsSpy.mockRestore();
-    loadOpencodeProjectSkillsSpy.mockRestore();
-    loadProjectAgentsSkillsSpy.mockRestore();
-    loadGlobalAgentsSkillsSpy.mockRestore();
-  });
+	afterEach(() => {
+		loadBuiltinCommandsSpy.mockRestore();
+		loadUserCommandsSpy.mockRestore();
+		loadProjectCommandsSpy.mockRestore();
+		loadOpencodeGlobalCommandsSpy.mockRestore();
+		loadOpencodeProjectCommandsSpy.mockRestore();
+		discoverConfigSourceSkillsSpy.mockRestore();
+		loadUserSkillsSpy.mockRestore();
+		loadProjectSkillsSpy.mockRestore();
+		loadOpencodeGlobalSkillsSpy.mockRestore();
+		loadOpencodeProjectSkillsSpy.mockRestore();
+		loadProjectAgentsSkillsSpy.mockRestore();
+		loadGlobalAgentsSkillsSpy.mockRestore();
+	});
 
-  test("includes .agents skills in command config", async () => {
-    // given
-    loadProjectAgentsSkillsSpy.mockResolvedValue({
-      "agents-project-skill": {
-        description: "(project - Skill) Agents project skill",
-        template: "template",
-      },
-    });
-    loadGlobalAgentsSkillsSpy.mockResolvedValue({
-      "agents-global-skill": {
-        description: "(user - Skill) Agents global skill",
-        template: "template",
-      },
-    });
-    const config: Record<string, unknown> = { command: {} };
+	test("includes .agents skills in command config", async () => {
+		// given
+		const projectRoot = createNonOckProjectRoot();
+		loadProjectAgentsSkillsSpy.mockResolvedValue({
+			"agents-project-skill": {
+				description: "(project - Skill) Agents project skill",
+				template: "template",
+			},
+		});
+		loadGlobalAgentsSkillsSpy.mockResolvedValue({
+			"agents-global-skill": {
+				description: "(user - Skill) Agents global skill",
+				template: "template",
+			},
+		});
+		const config: Record<string, unknown> = { command: {} };
 
-    // when
-    await applyCommandConfig({
-      config,
-      pluginConfig: createPluginConfig(),
-      ctx: { directory: "/tmp" },
-      pluginComponents: createPluginComponents(),
-    });
+		try {
+			// when
+			await applyCommandConfig({
+				config,
+				pluginConfig: createPluginConfig(),
+				ctx: { directory: projectRoot },
+				pluginComponents: createPluginComponents(),
+			});
 
-    // then
-    const commandConfig = config.command as Record<string, { description?: string }>;
-    expect(commandConfig["agents-project-skill"]?.description).toContain("Agents project skill");
-    expect(commandConfig["agents-global-skill"]?.description).toContain("Agents global skill");
-  });
+			// then
+			const commandConfig = config.command as Record<
+				string,
+				{ description?: string }
+			>;
+			expect(commandConfig["agents-project-skill"]?.description).toContain(
+				"Agents project skill",
+			);
+			expect(commandConfig["agents-global-skill"]?.description).toContain(
+				"Agents global skill",
+			);
+		} finally {
+			rmSync(projectRoot, { recursive: true, force: true });
+		}
+	});
 
-  test("remaps Atlas command agents to the list display name used by runtime agent lookup", async () => {
-    // given
-    loadBuiltinCommandsSpy.mockReturnValue({
-      "start-work": {
-        name: "start-work",
-        description: "(builtin) Start work",
-        template: "template",
-        agent: "atlas",
-      },
-    });
-    const config: Record<string, unknown> = { command: {} };
+	test("remaps Atlas command agents to the list display name used by runtime agent lookup", async () => {
+		// given
+		const projectRoot = createNonOckProjectRoot();
+		loadBuiltinCommandsSpy.mockReturnValue({
+			"start-work": {
+				name: "start-work",
+				description: "(builtin) Start work",
+				template: "template",
+				agent: "atlas",
+			},
+		});
+		const config: Record<string, unknown> = { command: {} };
 
-    // when
-    await applyCommandConfig({
-      config,
-      pluginConfig: createPluginConfig(),
-      ctx: { directory: "/tmp" },
-      pluginComponents: createPluginComponents(),
-    });
+		try {
+			// when
+			await applyCommandConfig({
+				config,
+				pluginConfig: createPluginConfig(),
+				ctx: { directory: projectRoot },
+				pluginComponents: createPluginComponents(),
+			});
 
-    // then
-    const commandConfig = config.command as Record<string, { agent?: string }>;
-    expect(commandConfig["start-work"]?.agent).toBe(getAgentListDisplayName("atlas"));
-  });
+			// then
+			const commandConfig = config.command as Record<
+				string,
+				{ agent?: string }
+			>;
+			expect(commandConfig["start-work"]?.agent).toBe(
+				getAgentListDisplayName("atlas"),
+			);
+		} finally {
+			rmSync(projectRoot, { recursive: true, force: true });
+		}
+	});
 });

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -1,102 +1,142 @@
 import type { OhMyOpenCodeConfig } from "../config";
-import { getAgentListDisplayName } from "../shared/agent-display-names";
-import {
-  loadUserCommands,
-  loadProjectCommands,
-  loadOpencodeGlobalCommands,
-  loadOpencodeProjectCommands,
-} from "../features/claude-code-command-loader";
 import { loadBuiltinCommands } from "../features/builtin-commands";
 import {
-  discoverConfigSourceSkills,
-  loadGlobalAgentsSkills,
-  loadProjectAgentsSkills,
-  loadUserSkills,
-  loadProjectSkills,
-  loadOpencodeGlobalSkills,
-  loadOpencodeProjectSkills,
-  skillsToCommandDefinitionRecord,
+	loadOpencodeGlobalCommands,
+	loadOpencodeProjectCommands,
+	loadProjectCommands,
+	loadUserCommands,
+} from "../features/claude-code-command-loader";
+import {
+	discoverConfigSourceSkills,
+	loadGlobalAgentsSkills,
+	loadOpencodeGlobalSkills,
+	loadOpencodeProjectSkills,
+	loadProjectAgentsSkills,
+	loadProjectSkills,
+	loadUserSkills,
+	skillsToCommandDefinitionRecord,
 } from "../features/opencode-skill-loader";
 import {
-  detectExternalSkillPlugin,
-  getSkillPluginConflictWarning,
-  log,
+	detectExternalSkillPlugin,
+	getSkillPluginConflictWarning,
+	isOckBeadFirstProject,
+	log,
 } from "../shared";
+import { getAgentListDisplayName } from "../shared/agent-display-names";
 import type { PluginComponents } from "./plugin-components-loader";
 
 export async function applyCommandConfig(params: {
-  config: Record<string, unknown>;
-  pluginConfig: OhMyOpenCodeConfig;
-  ctx: { directory: string };
-  pluginComponents: PluginComponents;
+	config: Record<string, unknown>;
+	pluginConfig: OhMyOpenCodeConfig;
+	ctx: { directory: string };
+	pluginComponents: PluginComponents;
 }): Promise<void> {
-  const builtinCommands = loadBuiltinCommands(params.pluginConfig.disabled_commands, {
-    useRegisteredAgents: true,
-  });
-  const systemCommands = (params.config.command as Record<string, unknown>) ?? {};
+	const beadFirstProject = isOckBeadFirstProject(params.ctx.directory);
+	const builtinCommands = filterBuiltinCommandsForOckRepo(
+		loadBuiltinCommands(params.pluginConfig.disabled_commands, {
+			useRegisteredAgents: true,
+		}),
+		beadFirstProject,
+	);
+	const systemCommands =
+		(params.config.command as Record<string, unknown>) ?? {};
 
-  const includeClaudeCommands = params.pluginConfig.claude_code?.commands ?? true;
-  const includeClaudeSkills = params.pluginConfig.claude_code?.skills ?? true;
+	const includeClaudeCommands =
+		params.pluginConfig.claude_code?.commands ?? true;
+	const includeClaudeSkills = params.pluginConfig.claude_code?.skills ?? true;
 
-  const externalSkillPlugin = detectExternalSkillPlugin(params.ctx.directory);
-  if (includeClaudeSkills && externalSkillPlugin.detected) {
-    log(getSkillPluginConflictWarning(externalSkillPlugin.pluginName!));
-  }
+	const externalSkillPlugin = detectExternalSkillPlugin(params.ctx.directory);
+	if (includeClaudeSkills && externalSkillPlugin.detected) {
+		log(getSkillPluginConflictWarning(externalSkillPlugin.pluginName!));
+	}
 
-  const [
-    configSourceSkills,
-    userCommands,
-    projectCommands,
-    opencodeGlobalCommands,
-    opencodeProjectCommands,
-    userSkills,
-    globalAgentsSkills,
-    projectSkills,
-    projectAgentsSkills,
-    opencodeGlobalSkills,
-    opencodeProjectSkills,
-  ] = await Promise.all([
-    discoverConfigSourceSkills({
-      config: params.pluginConfig.skills,
-      configDir: params.ctx.directory,
-    }),
-    includeClaudeCommands ? loadUserCommands() : Promise.resolve({}),
-    includeClaudeCommands ? loadProjectCommands(params.ctx.directory) : Promise.resolve({}),
-    loadOpencodeGlobalCommands(),
-    loadOpencodeProjectCommands(params.ctx.directory),
-    includeClaudeSkills ? loadUserSkills() : Promise.resolve({}),
-    includeClaudeSkills ? loadGlobalAgentsSkills() : Promise.resolve({}),
-    includeClaudeSkills ? loadProjectSkills(params.ctx.directory) : Promise.resolve({}),
-    includeClaudeSkills ? loadProjectAgentsSkills(params.ctx.directory) : Promise.resolve({}),
-    loadOpencodeGlobalSkills(),
-    loadOpencodeProjectSkills(params.ctx.directory),
-  ]);
+	const [
+		configSourceSkills,
+		userCommands,
+		projectCommands,
+		opencodeGlobalCommands,
+		opencodeProjectCommands,
+		userSkills,
+		globalAgentsSkills,
+		projectSkills,
+		projectAgentsSkills,
+		opencodeGlobalSkills,
+		opencodeProjectSkills,
+	] = await Promise.all([
+		discoverConfigSourceSkills({
+			config: params.pluginConfig.skills,
+			configDir: params.ctx.directory,
+		}),
+		includeClaudeCommands ? loadUserCommands() : Promise.resolve({}),
+		includeClaudeCommands
+			? loadProjectCommands(params.ctx.directory)
+			: Promise.resolve({}),
+		loadOpencodeGlobalCommands(),
+		loadOpencodeProjectCommands(params.ctx.directory),
+		includeClaudeSkills ? loadUserSkills() : Promise.resolve({}),
+		includeClaudeSkills ? loadGlobalAgentsSkills() : Promise.resolve({}),
+		includeClaudeSkills
+			? loadProjectSkills(params.ctx.directory)
+			: Promise.resolve({}),
+		includeClaudeSkills
+			? loadProjectAgentsSkills(params.ctx.directory)
+			: Promise.resolve({}),
+		loadOpencodeGlobalSkills(),
+		loadOpencodeProjectSkills(params.ctx.directory),
+	]);
 
-  params.config.command = {
-    ...builtinCommands,
-    ...skillsToCommandDefinitionRecord(configSourceSkills),
-    ...userCommands,
-    ...userSkills,
-    ...globalAgentsSkills,
-    ...opencodeGlobalCommands,
-    ...opencodeGlobalSkills,
-    ...systemCommands,
-    ...projectCommands,
-    ...projectSkills,
-    ...projectAgentsSkills,
-    ...opencodeProjectCommands,
-    ...opencodeProjectSkills,
-    ...params.pluginComponents.commands,
-    ...params.pluginComponents.skills,
-  };
+	params.config.command = {
+		...builtinCommands,
+		...skillsToCommandDefinitionRecord(configSourceSkills),
+		...userCommands,
+		...userSkills,
+		...globalAgentsSkills,
+		...opencodeGlobalCommands,
+		...opencodeGlobalSkills,
+		...systemCommands,
+		...projectCommands,
+		...projectSkills,
+		...projectAgentsSkills,
+		...opencodeProjectCommands,
+		...opencodeProjectSkills,
+		...params.pluginComponents.commands,
+		...params.pluginComponents.skills,
+	};
 
-  remapCommandAgentFields(params.config.command as Record<string, Record<string, unknown>>);
+	remapCommandAgentFields(
+		params.config.command as Record<string, Record<string, unknown>>,
+	);
 }
 
-function remapCommandAgentFields(commands: Record<string, Record<string, unknown>>): void {
-  for (const cmd of Object.values(commands)) {
-    if (cmd?.agent && typeof cmd.agent === "string") {
-      cmd.agent = getAgentListDisplayName(cmd.agent);
-    }
-  }
+const OCK_CONFLICTING_BUILTIN_COMMANDS = new Set([
+	"start-work",
+	"ralph-loop",
+	"ulw-loop",
+	"cancel-ralph",
+	"stop-continuation",
+]);
+
+function filterBuiltinCommandsForOckRepo(
+	commands: Record<string, unknown>,
+	beadFirstProject: boolean,
+): Record<string, unknown> {
+	if (!beadFirstProject) {
+		return commands;
+	}
+
+	return Object.fromEntries(
+		Object.entries(commands).filter(
+			([commandName]) => !OCK_CONFLICTING_BUILTIN_COMMANDS.has(commandName),
+		),
+	);
+}
+
+function remapCommandAgentFields(
+	commands: Record<string, Record<string, unknown>>,
+): void {
+	for (const cmd of Object.values(commands)) {
+		if (cmd?.agent && typeof cmd.agent === "string") {
+			cmd.agent = getAgentListDisplayName(cmd.agent);
+		}
+	}
 }

--- a/src/plugin-handlers/config-handler.ock.test.ts
+++ b/src/plugin-handlers/config-handler.ock.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import * as agents from "../agents";
+import type { OhMyOpenCodeConfig } from "../config";
+import * as builtinCommands from "../features/builtin-commands";
+import * as commandLoader from "../features/claude-code-command-loader";
+import * as mcpLoader from "../features/claude-code-mcp-loader";
+import * as pluginLoader from "../features/claude-code-plugin-loader";
+import * as skillLoader from "../features/opencode-skill-loader";
+import * as mcpModule from "../mcp";
+import * as shared from "../shared";
+import { createConfigHandler } from "./config-handler";
+
+function createPluginConfig(
+	overrides: Partial<OhMyOpenCodeConfig> = {},
+): OhMyOpenCodeConfig {
+	return {
+		git_master: {
+			commit_footer: true,
+			include_co_authored_by: true,
+			git_env_prefix: "GIT_MASTER=1",
+		},
+		...overrides,
+	};
+}
+
+function createOckProjectRoot(): string {
+	const projectRoot = mkdtempSync(join(tmpdir(), "config-handler-ock-"));
+	mkdirSync(join(projectRoot, ".git"), { recursive: true });
+	mkdirSync(join(projectRoot, ".beads"), { recursive: true });
+	const commandDirectory = join(projectRoot, ".opencode", "command");
+	mkdirSync(commandDirectory, { recursive: true });
+
+	for (const commandName of ["create", "research", "start", "plan"]) {
+		writeFileSync(
+			join(commandDirectory, `${commandName}.md`),
+			`# ${commandName}\n`,
+			"utf-8",
+		);
+	}
+
+	return projectRoot;
+}
+
+describe("createConfigHandler in OCK repos", () => {
+	beforeEach(() => {
+		spyOn(agents, "createBuiltinAgents" as any).mockResolvedValue({
+			atlas: { name: "atlas", prompt: "test", mode: "primary" },
+			sisyphus: { name: "sisyphus", prompt: "test", mode: "primary" },
+			hephaestus: { name: "hephaestus", prompt: "test", mode: "primary" },
+			prometheus: { name: "prometheus", prompt: "test", mode: "all" },
+			"sisyphus-junior": {
+				name: "sisyphus-junior",
+				prompt: "test",
+				mode: "subagent",
+			},
+		});
+		spyOn(commandLoader, "loadUserCommands" as any).mockResolvedValue({});
+		spyOn(commandLoader, "loadProjectCommands" as any).mockResolvedValue({});
+		spyOn(commandLoader, "loadOpencodeGlobalCommands" as any).mockResolvedValue(
+			{},
+		);
+		spyOn(
+			commandLoader,
+			"loadOpencodeProjectCommands" as any,
+		).mockResolvedValue({});
+		spyOn(builtinCommands, "loadBuiltinCommands" as any).mockReturnValue({
+			"start-work": {
+				name: "start-work",
+				description: "builtin",
+				template: "builtin-template",
+			},
+			refactor: {
+				name: "refactor",
+				description: "builtin",
+				template: "builtin-template",
+			},
+		});
+		spyOn(skillLoader, "loadUserSkills" as any).mockResolvedValue({});
+		spyOn(skillLoader, "loadProjectSkills" as any).mockResolvedValue({});
+		spyOn(skillLoader, "loadOpencodeGlobalSkills" as any).mockResolvedValue({});
+		spyOn(skillLoader, "loadOpencodeProjectSkills" as any).mockResolvedValue(
+			{},
+		);
+		spyOn(skillLoader, "loadProjectAgentsSkills" as any).mockResolvedValue({});
+		spyOn(skillLoader, "loadGlobalAgentsSkills" as any).mockResolvedValue({});
+		spyOn(skillLoader, "discoverConfigSourceSkills" as any).mockResolvedValue(
+			[],
+		);
+		spyOn(pluginLoader, "loadAllPluginComponents" as any).mockResolvedValue({
+			commands: {},
+			skills: {},
+			agents: {},
+			mcpServers: {},
+			hooksConfigs: [],
+			plugins: [],
+			errors: [],
+		});
+		spyOn(mcpLoader, "loadMcpConfigs" as any).mockResolvedValue({
+			servers: {},
+		});
+		spyOn(mcpLoader, "setAdditionalAllowedMcpEnvVars").mockImplementation(
+			() => {},
+		);
+		spyOn(mcpModule, "createBuiltinMcps" as any).mockReturnValue({});
+		spyOn(shared, "log" as any).mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		(agents.createBuiltinAgents as any)?.mockRestore?.();
+		(commandLoader.loadUserCommands as any)?.mockRestore?.();
+		(commandLoader.loadProjectCommands as any)?.mockRestore?.();
+		(commandLoader.loadOpencodeGlobalCommands as any)?.mockRestore?.();
+		(commandLoader.loadOpencodeProjectCommands as any)?.mockRestore?.();
+		(builtinCommands.loadBuiltinCommands as any)?.mockRestore?.();
+		(skillLoader.loadUserSkills as any)?.mockRestore?.();
+		(skillLoader.loadProjectSkills as any)?.mockRestore?.();
+		(skillLoader.loadOpencodeGlobalSkills as any)?.mockRestore?.();
+		(skillLoader.loadOpencodeProjectSkills as any)?.mockRestore?.();
+		(skillLoader.loadProjectAgentsSkills as any)?.mockRestore?.();
+		(skillLoader.loadGlobalAgentsSkills as any)?.mockRestore?.();
+		(skillLoader.discoverConfigSourceSkills as any)?.mockRestore?.();
+		(pluginLoader.loadAllPluginComponents as any)?.mockRestore?.();
+		(mcpLoader.loadMcpConfigs as any)?.mockRestore?.();
+		(mcpLoader.setAdditionalAllowedMcpEnvVars as any)?.mockRestore?.();
+		(mcpModule.createBuiltinMcps as any)?.mockRestore?.();
+		(shared.log as any)?.mockRestore?.();
+	});
+
+	test("suppresses conflicting builtins and task-system ownership together in OCK repos", async () => {
+		const projectRoot = createOckProjectRoot();
+
+		try {
+			const pluginConfig = createPluginConfig({
+				experimental: { task_system: true },
+			});
+			const config: Record<string, unknown> = {
+				model: "anthropic/claude-opus-4-6",
+				agent: {},
+				tools: {},
+				permission: {},
+				command: {},
+			};
+			const handler = createConfigHandler({
+				ctx: { directory: projectRoot },
+				pluginConfig,
+				modelCacheState: {
+					anthropicContext1MEnabled: false,
+					modelContextLimitsCache: new Map(),
+				},
+			});
+
+			await handler(config);
+
+			const commandConfig = config.command as Record<string, unknown>;
+			expect(commandConfig["start-work"]).toBeUndefined();
+			expect(commandConfig.refactor).toBeDefined();
+
+			const tools = config.tools as Record<string, unknown>;
+			expect(tools.todowrite).toBeUndefined();
+			expect(tools.todoread).toBeUndefined();
+
+			const agentConfig = config.agent as Record<
+				string,
+				{ permission?: Record<string, unknown> }
+			>;
+			const lastCreateBuiltinAgentsCall = (agents.createBuiltinAgents as any)
+				.mock.calls[(agents.createBuiltinAgents as any).mock.calls.length - 1];
+			expect(lastCreateBuiltinAgentsCall?.[11]).toBe(false);
+			expect(agentConfig.atlas?.permission?.todowrite).toBeUndefined();
+			expect(agentConfig.sisyphus?.permission?.todowrite).toBeUndefined();
+			expect(agentConfig.prometheus?.permission?.todowrite).toBeUndefined();
+		} finally {
+			rmSync(projectRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/plugin-handlers/config-handler.ts
+++ b/src/plugin-handlers/config-handler.ts
@@ -2,51 +2,57 @@ import type { OhMyOpenCodeConfig } from "../config";
 import { setAdditionalAllowedMcpEnvVars } from "../features/claude-code-mcp-loader";
 import type { ModelCacheState } from "../plugin-state";
 import { log } from "../shared";
+import { clearFormatterCache } from "../tools/hashline-edit/formatter-trigger";
 import { applyAgentConfig } from "./agent-config-handler";
 import { applyCommandConfig } from "./command-config-handler";
 import { applyMcpConfig } from "./mcp-config-handler";
-import { applyProviderConfig } from "./provider-config-handler";
 import { loadPluginComponents } from "./plugin-components-loader";
+import { applyProviderConfig } from "./provider-config-handler";
 import { applyToolConfig } from "./tool-config-handler";
-import { clearFormatterCache } from "../tools/hashline-edit/formatter-trigger"
 
 export { resolveCategoryConfig } from "./category-config-resolver";
 
 export interface ConfigHandlerDeps {
-  ctx: { directory: string; client?: any };
-  pluginConfig: OhMyOpenCodeConfig;
-  modelCacheState: ModelCacheState;
+	ctx: { directory: string; client?: any };
+	pluginConfig: OhMyOpenCodeConfig;
+	modelCacheState: ModelCacheState;
 }
 
 export function createConfigHandler(deps: ConfigHandlerDeps) {
-  const { ctx, pluginConfig, modelCacheState } = deps;
+	const { ctx, pluginConfig, modelCacheState } = deps;
 
-  return async (config: Record<string, unknown>) => {
-    const formatterConfig = config.formatter;
+	return async (config: Record<string, unknown>) => {
+		const formatterConfig = config.formatter;
 
-    setAdditionalAllowedMcpEnvVars(pluginConfig.mcp_env_allowlist ?? [])
-    applyProviderConfig({ config, modelCacheState });
-    clearFormatterCache()
+		setAdditionalAllowedMcpEnvVars(pluginConfig.mcp_env_allowlist ?? []);
+		applyProviderConfig({ config, modelCacheState });
+		clearFormatterCache();
 
-    const pluginComponents = await loadPluginComponents({ pluginConfig });
+		const pluginComponents = await loadPluginComponents({ pluginConfig });
 
-    const agentResult = await applyAgentConfig({
-      config,
-      pluginConfig,
-      ctx,
-      pluginComponents,
-    });
+		const agentResult = await applyAgentConfig({
+			config,
+			pluginConfig,
+			ctx,
+			pluginComponents,
+		});
 
-    applyToolConfig({ config, pluginConfig, agentResult });
-    await applyMcpConfig({ config, pluginConfig, pluginComponents });
-    await applyCommandConfig({ config, pluginConfig, ctx, pluginComponents });
+		applyToolConfig({
+			config,
+			pluginConfig,
+			agentResult,
+			directory: ctx.directory,
+		});
+		await applyMcpConfig({ config, pluginConfig, pluginComponents });
+		await applyCommandConfig({ config, pluginConfig, ctx, pluginComponents });
 
-    config.formatter = formatterConfig;
+		config.formatter = formatterConfig;
 
-    log("[config-handler] config handler applied", {
-      agentCount: Object.keys(agentResult).length,
-      commandCount: Object.keys((config.command as Record<string, unknown>) ?? {})
-        .length,
-    });
-  };
+		log("[config-handler] config handler applied", {
+			agentCount: Object.keys(agentResult).length,
+			commandCount: Object.keys(
+				(config.command as Record<string, unknown>) ?? {},
+			).length,
+		});
+	};
 }

--- a/src/plugin-handlers/tool-config-handler.ock.test.ts
+++ b/src/plugin-handlers/tool-config-handler.ock.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { OhMyOpenCodeConfig } from "../config";
+import { applyToolConfig } from "./tool-config-handler";
+
+const GIT_BIN = "/usr/bin/git";
+
+function createOckProjectRoot(): string {
+	const projectRoot = mkdtempSync(join(tmpdir(), "tool-config-handler-ock-"));
+	execFileSync(GIT_BIN, ["init"], {
+		cwd: projectRoot,
+		stdio: ["ignore", "ignore", "ignore"],
+	});
+	mkdirSync(join(projectRoot, ".beads"), { recursive: true });
+	const commandDirectory = join(projectRoot, ".opencode", "command");
+
+	for (const commandName of ["create", "research", "start", "plan"]) {
+		mkdirSync(commandDirectory, { recursive: true });
+		writeFileSync(
+			join(commandDirectory, `${commandName}.md`),
+			`# ${commandName}\n`,
+			"utf-8",
+		);
+	}
+
+	return projectRoot;
+}
+
+function createParams(directory: string) {
+	const agentResult: Record<string, { permission?: Record<string, unknown> }> =
+		{};
+	for (const agent of [
+		"atlas",
+		"sisyphus",
+		"hephaestus",
+		"prometheus",
+		"sisyphus-junior",
+	]) {
+		agentResult[agent] = { permission: {} };
+	}
+
+	return {
+		config: { tools: {}, permission: {} } as Record<string, unknown>,
+		pluginConfig: {
+			experimental: { task_system: true },
+		} as OhMyOpenCodeConfig,
+		agentResult: agentResult as Record<string, unknown>,
+		directory,
+	};
+}
+
+describe("applyToolConfig in OCK repos", () => {
+	it("does not deny todo tools in OCK repos even when task_system is enabled", () => {
+		const projectRoot = createOckProjectRoot();
+
+		try {
+			const params = createParams(projectRoot);
+
+			applyToolConfig(params);
+
+			const tools = params.config.tools as Record<string, unknown>;
+			expect(tools.todowrite).toBeUndefined();
+			expect(tools.todoread).toBeUndefined();
+
+			for (const agentName of [
+				"atlas",
+				"sisyphus",
+				"hephaestus",
+				"prometheus",
+				"sisyphus-junior",
+			]) {
+				const agent = params.agentResult[agentName] as {
+					permission: Record<string, unknown>;
+				};
+				expect(agent.permission.todowrite).toBeUndefined();
+				expect(agent.permission.todoread).toBeUndefined();
+			}
+		} finally {
+			rmSync(projectRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -1,132 +1,143 @@
 import type { OhMyOpenCodeConfig } from "../config";
-import { getAgentDisplayName, getAgentListDisplayName } from "../shared/agent-display-names";
-import { isTaskSystemEnabled } from "../shared";
+import { isTaskSystemEnabledForDirectory } from "../shared";
+import {
+	getAgentDisplayName,
+	getAgentListDisplayName,
+} from "../shared/agent-display-names";
 
 type AgentWithPermission = { permission?: Record<string, unknown> };
 
 function getConfigQuestionPermission(): string | null {
-  const configContent = process.env.OPENCODE_CONFIG_CONTENT;
-  if (!configContent) return null;
-  try {
-    const parsed = JSON.parse(configContent);
-    return parsed?.permission?.question ?? null;
-  } catch {
-    return null;
-  }
+	const configContent = process.env.OPENCODE_CONFIG_CONTENT;
+	if (!configContent) return null;
+	try {
+		const parsed = JSON.parse(configContent);
+		return parsed?.permission?.question ?? null;
+	} catch {
+		return null;
+	}
 }
 
-function agentByKey(agentResult: Record<string, unknown>, key: string): AgentWithPermission | undefined {
-  return (agentResult[getAgentListDisplayName(key)] ?? agentResult[getAgentDisplayName(key)] ?? agentResult[key]) as
-    | AgentWithPermission
-    | undefined;
+function agentByKey(
+	agentResult: Record<string, unknown>,
+	key: string,
+): AgentWithPermission | undefined {
+	return (agentResult[getAgentListDisplayName(key)] ??
+		agentResult[getAgentDisplayName(key)] ??
+		agentResult[key]) as AgentWithPermission | undefined;
 }
 
 export function applyToolConfig(params: {
-  config: Record<string, unknown>;
-  pluginConfig: OhMyOpenCodeConfig;
-  agentResult: Record<string, unknown>;
+	config: Record<string, unknown>;
+	pluginConfig: OhMyOpenCodeConfig;
+	agentResult: Record<string, unknown>;
+	directory?: string;
 }): void {
-  const taskSystemEnabled = isTaskSystemEnabled(params.pluginConfig)
-  const denyTodoTools = taskSystemEnabled
-    ? { todowrite: "deny", todoread: "deny" }
-    : {}
+	const taskSystemEnabled = isTaskSystemEnabledForDirectory(
+		params.pluginConfig,
+		params.directory,
+	);
+	const denyTodoTools = taskSystemEnabled
+		? { todowrite: "deny", todoread: "deny" }
+		: {};
 
-  const existingPermission = params.config.permission as Record<string, unknown> | undefined;
-  const skillDeniedByHost = existingPermission?.skill === "deny";
+	const existingPermission = params.config.permission as
+		| Record<string, unknown>
+		| undefined;
+	const skillDeniedByHost = existingPermission?.skill === "deny";
 
-  params.config.tools = {
-    ...(params.config.tools as Record<string, unknown>),
-    "grep_app_*": false,
-    LspHover: false,
-    LspCodeActions: false,
-    LspCodeActionResolve: false,
-    "task_*": false,
-    teammate: false,
-    ...(taskSystemEnabled
-      ? { todowrite: false, todoread: false }
-      : {}),
-    ...(skillDeniedByHost
-      ? { skill: false, skill_mcp: false }
-      : {}),
-  };
+	params.config.tools = {
+		...(params.config.tools as Record<string, unknown>),
+		"grep_app_*": false,
+		LspHover: false,
+		LspCodeActions: false,
+		LspCodeActionResolve: false,
+		"task_*": false,
+		teammate: false,
+		...(taskSystemEnabled ? { todowrite: false, todoread: false } : {}),
+		...(skillDeniedByHost ? { skill: false, skill_mcp: false } : {}),
+	};
 
-  const isCliRunMode = process.env.OPENCODE_CLI_RUN_MODE === "true";
-  const configQuestionPermission = getConfigQuestionPermission();
-  const isQuestionDisabledByPlugin = params.pluginConfig.disabled_tools?.includes("question") ?? false;
-  const questionPermission =
-    isQuestionDisabledByPlugin ? "deny" :
-    configQuestionPermission === "deny" ? "deny" :
-    isCliRunMode ? "deny" :
-    "allow";
+	const isCliRunMode = process.env.OPENCODE_CLI_RUN_MODE === "true";
+	const configQuestionPermission = getConfigQuestionPermission();
+	const isQuestionDisabledByPlugin =
+		params.pluginConfig.disabled_tools?.includes("question") ?? false;
+	const questionPermission = isQuestionDisabledByPlugin
+		? "deny"
+		: configQuestionPermission === "deny"
+			? "deny"
+			: isCliRunMode
+				? "deny"
+				: "allow";
 
-  const librarian = agentByKey(params.agentResult, "librarian");
-  if (librarian) {
-    librarian.permission = { ...librarian.permission, "grep_app_*": "allow" };
-  }
-  const looker = agentByKey(params.agentResult, "multimodal-looker");
-  if (looker) {
-    looker.permission = { ...looker.permission, task: "deny", look_at: "deny" };
-  }
-  const atlas = agentByKey(params.agentResult, "atlas");
-  if (atlas) {
-    atlas.permission = {
-      ...atlas.permission,
-      task: "allow",
-      call_omo_agent: "deny",
-      "task_*": "allow",
-      teammate: "allow",
-      ...denyTodoTools,
-    };
-  }
-  const sisyphus = agentByKey(params.agentResult, "sisyphus");
-  if (sisyphus) {
-    sisyphus.permission = {
-      ...sisyphus.permission,
-      call_omo_agent: "deny",
-      task: "allow",
-      question: questionPermission,
-      "task_*": "allow",
-      teammate: "allow",
-      ...denyTodoTools,
-    };
-  }
-  const hephaestus = agentByKey(params.agentResult, "hephaestus");
-  if (hephaestus) {
-    hephaestus.permission = {
-      ...hephaestus.permission,
-      call_omo_agent: "deny",
-      task: "allow",
-      question: questionPermission,
-      ...denyTodoTools,
-    };
-  }
-  const prometheus = agentByKey(params.agentResult, "prometheus");
-  if (prometheus) {
-    prometheus.permission = {
-      ...prometheus.permission,
-      call_omo_agent: "deny",
-      task: "allow",
-      question: questionPermission,
-      "task_*": "allow",
-      teammate: "allow",
-      ...denyTodoTools,
-    };
-  }
-  const junior = agentByKey(params.agentResult, "sisyphus-junior");
-  if (junior) {
-    junior.permission = {
-      ...junior.permission,
-      task: "allow",
-      "task_*": "allow",
-      teammate: "allow",
-      ...denyTodoTools,
-    };
-  }
+	const librarian = agentByKey(params.agentResult, "librarian");
+	if (librarian) {
+		librarian.permission = { ...librarian.permission, "grep_app_*": "allow" };
+	}
+	const looker = agentByKey(params.agentResult, "multimodal-looker");
+	if (looker) {
+		looker.permission = { ...looker.permission, task: "deny", look_at: "deny" };
+	}
+	const atlas = agentByKey(params.agentResult, "atlas");
+	if (atlas) {
+		atlas.permission = {
+			...atlas.permission,
+			task: "allow",
+			call_omo_agent: "deny",
+			"task_*": "allow",
+			teammate: "allow",
+			...denyTodoTools,
+		};
+	}
+	const sisyphus = agentByKey(params.agentResult, "sisyphus");
+	if (sisyphus) {
+		sisyphus.permission = {
+			...sisyphus.permission,
+			call_omo_agent: "deny",
+			task: "allow",
+			question: questionPermission,
+			"task_*": "allow",
+			teammate: "allow",
+			...denyTodoTools,
+		};
+	}
+	const hephaestus = agentByKey(params.agentResult, "hephaestus");
+	if (hephaestus) {
+		hephaestus.permission = {
+			...hephaestus.permission,
+			call_omo_agent: "deny",
+			task: "allow",
+			question: questionPermission,
+			...denyTodoTools,
+		};
+	}
+	const prometheus = agentByKey(params.agentResult, "prometheus");
+	if (prometheus) {
+		prometheus.permission = {
+			...prometheus.permission,
+			call_omo_agent: "deny",
+			task: "allow",
+			question: questionPermission,
+			"task_*": "allow",
+			teammate: "allow",
+			...denyTodoTools,
+		};
+	}
+	const junior = agentByKey(params.agentResult, "sisyphus-junior");
+	if (junior) {
+		junior.permission = {
+			...junior.permission,
+			task: "allow",
+			"task_*": "allow",
+			teammate: "allow",
+			...denyTodoTools,
+		};
+	}
 
-  params.config.permission = {
-    webfetch: "allow",
-    external_directory: "allow",
-    ...(params.config.permission as Record<string, unknown>),
-    task: "deny",
-  };
+	params.config.permission = {
+		webfetch: "allow",
+		external_directory: "allow",
+		...(params.config.permission as Record<string, unknown>),
+		task: "deny",
+	};
 }

--- a/src/plugin/hooks/create-tool-guard-hooks.ts
+++ b/src/plugin/hooks/create-tool-guard-hooks.ts
@@ -1,152 +1,200 @@
-import type { HookName, OhMyOpenCodeConfig } from "../../config"
-import type { ModelCacheState } from "../../plugin-state"
-import type { PluginContext } from "../types"
-
+import type { HookName, OhMyOpenCodeConfig } from "../../config";
 import {
-  createCommentCheckerHooks,
-  createToolOutputTruncatorHook,
-  createDirectoryAgentsInjectorHook,
-  createDirectoryReadmeInjectorHook,
-  createEmptyTaskResponseDetectorHook,
-  createRulesInjectorHook,
-  createTasksTodowriteDisablerHook,
-  createWriteExistingFileGuardHook,
-  createBashFileReadGuardHook,
-  createHashlineReadEnhancerHook,
-  createReadImageResizerHook,
-  createJsonErrorRecoveryHook,
-  createTodoDescriptionOverrideHook,
-  createWebFetchRedirectGuardHook,
-} from "../../hooks"
+	createBashFileReadGuardHook,
+	createCommentCheckerHooks,
+	createDirectoryAgentsInjectorHook,
+	createDirectoryReadmeInjectorHook,
+	createEmptyTaskResponseDetectorHook,
+	createHashlineReadEnhancerHook,
+	createJsonErrorRecoveryHook,
+	createReadImageResizerHook,
+	createRulesInjectorHook,
+	createTasksTodowriteDisablerHook,
+	createTodoDescriptionOverrideHook,
+	createToolOutputTruncatorHook,
+	createWebFetchRedirectGuardHook,
+	createWriteExistingFileGuardHook,
+} from "../../hooks";
+import type { ModelCacheState } from "../../plugin-state";
 import {
-  getOpenCodeVersion,
-  isOpenCodeVersionAtLeast,
-  log,
-  OPENCODE_NATIVE_AGENTS_INJECTION_VERSION,
-} from "../../shared"
-import { safeCreateHook } from "../../shared/safe-create-hook"
+	getOpenCodeVersion,
+	isOckBeadFirstProject,
+	isOpenCodeVersionAtLeast,
+	log,
+	OPENCODE_NATIVE_AGENTS_INJECTION_VERSION,
+} from "../../shared";
+import { safeCreateHook } from "../../shared/safe-create-hook";
+import type { PluginContext } from "../types";
 
 export type ToolGuardHooks = {
-  commentChecker: ReturnType<typeof createCommentCheckerHooks> | null
-  toolOutputTruncator: ReturnType<typeof createToolOutputTruncatorHook> | null
-  directoryAgentsInjector: ReturnType<typeof createDirectoryAgentsInjectorHook> | null
-  directoryReadmeInjector: ReturnType<typeof createDirectoryReadmeInjectorHook> | null
-  emptyTaskResponseDetector: ReturnType<typeof createEmptyTaskResponseDetectorHook> | null
-  rulesInjector: ReturnType<typeof createRulesInjectorHook> | null
-  tasksTodowriteDisabler: ReturnType<typeof createTasksTodowriteDisablerHook> | null
-  writeExistingFileGuard: ReturnType<typeof createWriteExistingFileGuardHook> | null
-  bashFileReadGuard: ReturnType<typeof createBashFileReadGuardHook> | null
-  hashlineReadEnhancer: ReturnType<typeof createHashlineReadEnhancerHook> | null
-  jsonErrorRecovery: ReturnType<typeof createJsonErrorRecoveryHook> | null
-  readImageResizer: ReturnType<typeof createReadImageResizerHook> | null
-  todoDescriptionOverride: ReturnType<typeof createTodoDescriptionOverrideHook> | null
-  webfetchRedirectGuard: ReturnType<typeof createWebFetchRedirectGuardHook> | null
-}
+	commentChecker: ReturnType<typeof createCommentCheckerHooks> | null;
+	toolOutputTruncator: ReturnType<typeof createToolOutputTruncatorHook> | null;
+	directoryAgentsInjector: ReturnType<
+		typeof createDirectoryAgentsInjectorHook
+	> | null;
+	directoryReadmeInjector: ReturnType<
+		typeof createDirectoryReadmeInjectorHook
+	> | null;
+	emptyTaskResponseDetector: ReturnType<
+		typeof createEmptyTaskResponseDetectorHook
+	> | null;
+	rulesInjector: ReturnType<typeof createRulesInjectorHook> | null;
+	tasksTodowriteDisabler: ReturnType<
+		typeof createTasksTodowriteDisablerHook
+	> | null;
+	writeExistingFileGuard: ReturnType<
+		typeof createWriteExistingFileGuardHook
+	> | null;
+	bashFileReadGuard: ReturnType<typeof createBashFileReadGuardHook> | null;
+	hashlineReadEnhancer: ReturnType<
+		typeof createHashlineReadEnhancerHook
+	> | null;
+	jsonErrorRecovery: ReturnType<typeof createJsonErrorRecoveryHook> | null;
+	readImageResizer: ReturnType<typeof createReadImageResizerHook> | null;
+	todoDescriptionOverride: ReturnType<
+		typeof createTodoDescriptionOverrideHook
+	> | null;
+	webfetchRedirectGuard: ReturnType<
+		typeof createWebFetchRedirectGuardHook
+	> | null;
+};
 
 export function createToolGuardHooks(args: {
-  ctx: PluginContext
-  pluginConfig: OhMyOpenCodeConfig
-  modelCacheState: ModelCacheState
-  isHookEnabled: (hookName: HookName) => boolean
-  safeHookEnabled: boolean
+	ctx: PluginContext;
+	pluginConfig: OhMyOpenCodeConfig;
+	modelCacheState: ModelCacheState;
+	isHookEnabled: (hookName: HookName) => boolean;
+	safeHookEnabled: boolean;
 }): ToolGuardHooks {
-  const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } = args
-  const safeHook = <T>(hookName: HookName, factory: () => T): T | null =>
-    safeCreateHook(hookName, factory, { enabled: safeHookEnabled })
+	const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } =
+		args;
+	const beadFirstProject = isOckBeadFirstProject(ctx.directory);
+	const safeHook = <T>(hookName: HookName, factory: () => T): T | null =>
+		safeCreateHook(hookName, factory, { enabled: safeHookEnabled });
 
-  const commentChecker = isHookEnabled("comment-checker")
-    ? safeHook("comment-checker", () => createCommentCheckerHooks(pluginConfig.comment_checker))
-    : null
+	const commentChecker = isHookEnabled("comment-checker")
+		? safeHook("comment-checker", () =>
+				createCommentCheckerHooks(pluginConfig.comment_checker),
+			)
+		: null;
 
-  const toolOutputTruncator = isHookEnabled("tool-output-truncator")
-    ? safeHook("tool-output-truncator", () =>
-        createToolOutputTruncatorHook(ctx, {
-          modelCacheState,
-          experimental: pluginConfig.experimental,
-        }))
-    : null
+	const toolOutputTruncator = isHookEnabled("tool-output-truncator")
+		? safeHook("tool-output-truncator", () =>
+				createToolOutputTruncatorHook(ctx, {
+					modelCacheState,
+					experimental: pluginConfig.experimental,
+				}),
+			)
+		: null;
 
-  let directoryAgentsInjector: ReturnType<typeof createDirectoryAgentsInjectorHook> | null = null
-  if (isHookEnabled("directory-agents-injector")) {
-    const currentVersion = getOpenCodeVersion()
-    const hasNativeSupport =
-      currentVersion !== null && isOpenCodeVersionAtLeast(OPENCODE_NATIVE_AGENTS_INJECTION_VERSION)
-    if (hasNativeSupport) {
-      log("directory-agents-injector auto-disabled due to native OpenCode support", {
-        currentVersion,
-        nativeVersion: OPENCODE_NATIVE_AGENTS_INJECTION_VERSION,
-      })
-    } else {
-      directoryAgentsInjector = safeHook("directory-agents-injector", () =>
-        createDirectoryAgentsInjectorHook(ctx, modelCacheState))
-    }
-  }
+	let directoryAgentsInjector: ReturnType<
+		typeof createDirectoryAgentsInjectorHook
+	> | null = null;
+	if (isHookEnabled("directory-agents-injector")) {
+		const currentVersion = getOpenCodeVersion();
+		const hasNativeSupport =
+			currentVersion !== null &&
+			isOpenCodeVersionAtLeast(OPENCODE_NATIVE_AGENTS_INJECTION_VERSION);
+		if (hasNativeSupport) {
+			log(
+				"directory-agents-injector auto-disabled due to native OpenCode support",
+				{
+					currentVersion,
+					nativeVersion: OPENCODE_NATIVE_AGENTS_INJECTION_VERSION,
+				},
+			);
+		} else {
+			directoryAgentsInjector = safeHook("directory-agents-injector", () =>
+				createDirectoryAgentsInjectorHook(ctx, modelCacheState),
+			);
+		}
+	}
 
-  const directoryReadmeInjector = isHookEnabled("directory-readme-injector")
-    ? safeHook("directory-readme-injector", () =>
-        createDirectoryReadmeInjectorHook(ctx, modelCacheState))
-    : null
+	const directoryReadmeInjector = isHookEnabled("directory-readme-injector")
+		? safeHook("directory-readme-injector", () =>
+				createDirectoryReadmeInjectorHook(ctx, modelCacheState),
+			)
+		: null;
 
-  const emptyTaskResponseDetector = isHookEnabled("empty-task-response-detector")
-    ? safeHook("empty-task-response-detector", () => createEmptyTaskResponseDetectorHook(ctx))
-    : null
+	const emptyTaskResponseDetector = isHookEnabled(
+		"empty-task-response-detector",
+	)
+		? safeHook("empty-task-response-detector", () =>
+				createEmptyTaskResponseDetectorHook(ctx),
+			)
+		: null;
 
-  const cc = pluginConfig.claude_code
-  const skipClaudeUserRules = cc?.hooks === false
-  const rulesInjector = isHookEnabled("rules-injector")
-    ? safeHook("rules-injector", () =>
-        createRulesInjectorHook(ctx, modelCacheState, {
-          skipClaudeUserRules,
-        }))
-    : null
+	const cc = pluginConfig.claude_code;
+	const skipClaudeUserRules = cc?.hooks === false;
+	const rulesInjector = isHookEnabled("rules-injector")
+		? safeHook("rules-injector", () =>
+				createRulesInjectorHook(ctx, modelCacheState, {
+					skipClaudeUserRules,
+				}),
+			)
+		: null;
 
-  const tasksTodowriteDisabler = isHookEnabled("tasks-todowrite-disabler")
-    ? safeHook("tasks-todowrite-disabler", () =>
-        createTasksTodowriteDisablerHook({ experimental: pluginConfig.experimental }))
-    : null
+	const tasksTodowriteDisabler =
+		!beadFirstProject && isHookEnabled("tasks-todowrite-disabler")
+			? safeHook("tasks-todowrite-disabler", () =>
+					createTasksTodowriteDisablerHook({
+						experimental: pluginConfig.experimental,
+					}),
+				)
+			: null;
 
-  const writeExistingFileGuard = isHookEnabled("write-existing-file-guard")
-    ? safeHook("write-existing-file-guard", () => createWriteExistingFileGuardHook(ctx))
-    : null
+	const writeExistingFileGuard = isHookEnabled("write-existing-file-guard")
+		? safeHook("write-existing-file-guard", () =>
+				createWriteExistingFileGuardHook(ctx),
+			)
+		: null;
 
-  const bashFileReadGuard = isHookEnabled("bash-file-read-guard")
-    ? safeHook("bash-file-read-guard", () => createBashFileReadGuardHook())
-    : null
+	const bashFileReadGuard = isHookEnabled("bash-file-read-guard")
+		? safeHook("bash-file-read-guard", () => createBashFileReadGuardHook())
+		: null;
 
-  const hashlineReadEnhancer = isHookEnabled("hashline-read-enhancer")
-    ? safeHook("hashline-read-enhancer", () => createHashlineReadEnhancerHook(ctx, { hashline_edit: { enabled: pluginConfig.hashline_edit ?? false } }))
-    : null
+	const hashlineReadEnhancer = isHookEnabled("hashline-read-enhancer")
+		? safeHook("hashline-read-enhancer", () =>
+				createHashlineReadEnhancerHook(ctx, {
+					hashline_edit: { enabled: pluginConfig.hashline_edit ?? false },
+				}),
+			)
+		: null;
 
-  const jsonErrorRecovery = isHookEnabled("json-error-recovery")
-    ? safeHook("json-error-recovery", () => createJsonErrorRecoveryHook(ctx))
-    : null
+	const jsonErrorRecovery = isHookEnabled("json-error-recovery")
+		? safeHook("json-error-recovery", () => createJsonErrorRecoveryHook(ctx))
+		: null;
 
-  const readImageResizer = isHookEnabled("read-image-resizer")
-    ? safeHook("read-image-resizer", () => createReadImageResizerHook(ctx))
-    : null
+	const readImageResizer = isHookEnabled("read-image-resizer")
+		? safeHook("read-image-resizer", () => createReadImageResizerHook(ctx))
+		: null;
 
-  const todoDescriptionOverride = isHookEnabled("todo-description-override")
-    ? safeHook("todo-description-override", () => createTodoDescriptionOverrideHook())
-    : null
+	const todoDescriptionOverride = isHookEnabled("todo-description-override")
+		? safeHook("todo-description-override", () =>
+				createTodoDescriptionOverrideHook(),
+			)
+		: null;
 
-  const webfetchRedirectGuard = isHookEnabled("webfetch-redirect-guard")
-    ? safeHook("webfetch-redirect-guard", () => createWebFetchRedirectGuardHook(ctx))
-    : null
+	const webfetchRedirectGuard = isHookEnabled("webfetch-redirect-guard")
+		? safeHook("webfetch-redirect-guard", () =>
+				createWebFetchRedirectGuardHook(ctx),
+			)
+		: null;
 
-  return {
-    commentChecker,
-    toolOutputTruncator,
-    directoryAgentsInjector,
-    directoryReadmeInjector,
-    emptyTaskResponseDetector,
-    rulesInjector,
-    tasksTodowriteDisabler,
-    writeExistingFileGuard,
-    bashFileReadGuard,
-    hashlineReadEnhancer,
-    jsonErrorRecovery,
-    readImageResizer,
-    todoDescriptionOverride,
-    webfetchRedirectGuard,
-  }
+	return {
+		commentChecker,
+		toolOutputTruncator,
+		directoryAgentsInjector,
+		directoryReadmeInjector,
+		emptyTaskResponseDetector,
+		rulesInjector,
+		tasksTodowriteDisabler,
+		writeExistingFileGuard,
+		bashFileReadGuard,
+		hashlineReadEnhancer,
+		jsonErrorRecovery,
+		readImageResizer,
+		todoDescriptionOverride,
+		webfetchRedirectGuard,
+	};
 }

--- a/src/plugin/tool-registry.test.ts
+++ b/src/plugin/tool-registry.test.ts
@@ -1,147 +1,190 @@
-import { describe, expect, test } from "bun:test"
-import { tool } from "@opencode-ai/plugin"
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { tool } from "@opencode-ai/plugin";
+import * as builtinCommands from "../features/builtin-commands";
+import { createToolRegistry, trimToolsToCap } from "./tool-registry";
+import type { ToolsRecord } from "./types";
 
-import type { ToolsRecord } from "./types"
-import { createToolRegistry, trimToolsToCap } from "./tool-registry"
+const GIT_BIN = "/usr/bin/git";
 
 const fakeTool = tool({
-  description: "test tool",
-  args: {},
-  async execute(): Promise<string> {
-    return "ok"
-  },
-})
+	description: "test tool",
+	args: {},
+	async execute(): Promise<string> {
+		return "ok";
+	},
+});
+
+const loadBuiltinCommandsSpy = spyOn(
+	builtinCommands,
+	"loadBuiltinCommands",
+).mockReturnValue({});
+
+const tempDirectories: string[] = [];
+
+function createNonOckProjectRoot(): string {
+	const projectRoot = mkdtempSync(join(tmpdir(), "tool-registry-non-ock-"));
+	tempDirectories.push(projectRoot);
+	execFileSync(GIT_BIN, ["init"], {
+		cwd: projectRoot,
+		stdio: ["ignore", "ignore", "ignore"],
+	});
+	return projectRoot;
+}
+
+afterEach(() => {
+	loadBuiltinCommandsSpy.mockReset();
+	loadBuiltinCommandsSpy.mockReturnValue({});
+	for (const tempDirectory of tempDirectories.splice(0)) {
+		rmSync(tempDirectory, { recursive: true, force: true });
+	}
+});
 
 describe("#given tool trimming prioritization", () => {
-  test("#when max_tools trims a hashline edit registration named edit #then edit is removed before higher-priority tools", () => {
-    const filteredTools = {
-      bash: fakeTool,
-      edit: fakeTool,
-      read: fakeTool,
-    } satisfies ToolsRecord
+	test("#when max_tools trims a hashline edit registration named edit #then edit is removed before higher-priority tools", () => {
+		const filteredTools = {
+			bash: fakeTool,
+			edit: fakeTool,
+			read: fakeTool,
+		} satisfies ToolsRecord;
 
-    trimToolsToCap(filteredTools, 2)
+		trimToolsToCap(filteredTools, 2);
 
-    expect(filteredTools).not.toHaveProperty("edit")
-    expect(filteredTools).toHaveProperty("bash")
-    expect(filteredTools).toHaveProperty("read")
-  })
-})
+		expect(filteredTools).not.toHaveProperty("edit");
+		expect(filteredTools).toHaveProperty("bash");
+		expect(filteredTools).toHaveProperty("read");
+	});
+});
 
 describe("#given task_system configuration", () => {
-  test("#when task_system is omitted #then task tools are not registered by default", () => {
-    const result = createToolRegistry({
-      ctx: { directory: "/tmp" } as Parameters<typeof createToolRegistry>[0]["ctx"],
-      pluginConfig: {},
-      managers: {
-        backgroundManager: {},
-        tmuxSessionManager: {},
-        skillMcpManager: {},
-      } as Parameters<typeof createToolRegistry>[0]["managers"],
-      skillContext: {
-        mergedSkills: [],
-        availableSkills: [],
-        browserProvider: "playwright",
-        disabledSkills: new Set(),
-      },
-      availableCategories: [],
-    })
+	test("#when task_system is omitted #then task tools are not registered by default", () => {
+		const projectRoot = createNonOckProjectRoot();
+		const result = createToolRegistry({
+			ctx: { directory: projectRoot } as Parameters<
+				typeof createToolRegistry
+			>[0]["ctx"],
+			pluginConfig: {},
+			managers: {
+				backgroundManager: {},
+				tmuxSessionManager: {},
+				skillMcpManager: {},
+			} as Parameters<typeof createToolRegistry>[0]["managers"],
+			skillContext: {
+				mergedSkills: [],
+				availableSkills: [],
+				browserProvider: "playwright",
+				disabledSkills: new Set(),
+			},
+			availableCategories: [],
+		});
 
-    expect(result.taskSystemEnabled).toBe(false)
-    expect(result.filteredTools).not.toHaveProperty("task_create")
-    expect(result.filteredTools).not.toHaveProperty("task_get")
-    expect(result.filteredTools).not.toHaveProperty("task_list")
-    expect(result.filteredTools).not.toHaveProperty("task_update")
-  })
+		expect(result.taskSystemEnabled).toBe(false);
+		expect(result.filteredTools).not.toHaveProperty("task_create");
+		expect(result.filteredTools).not.toHaveProperty("task_get");
+		expect(result.filteredTools).not.toHaveProperty("task_list");
+		expect(result.filteredTools).not.toHaveProperty("task_update");
+	});
 
-  test("#when task_system is enabled #then task tools are registered", () => {
-    const result = createToolRegistry({
-      ctx: { directory: "/tmp" } as Parameters<typeof createToolRegistry>[0]["ctx"],
-      pluginConfig: {
-        experimental: { task_system: true },
-      },
-      managers: {
-        backgroundManager: {},
-        tmuxSessionManager: {},
-        skillMcpManager: {},
-      } as Parameters<typeof createToolRegistry>[0]["managers"],
-      skillContext: {
-        mergedSkills: [],
-        availableSkills: [],
-        browserProvider: "playwright",
-        disabledSkills: new Set(),
-      },
-      availableCategories: [],
-    })
+	test("#when task_system is enabled #then task tools are registered", () => {
+		const projectRoot = createNonOckProjectRoot();
+		const result = createToolRegistry({
+			ctx: { directory: projectRoot } as Parameters<
+				typeof createToolRegistry
+			>[0]["ctx"],
+			pluginConfig: {
+				experimental: { task_system: true },
+			},
+			managers: {
+				backgroundManager: {},
+				tmuxSessionManager: {},
+				skillMcpManager: {},
+			} as Parameters<typeof createToolRegistry>[0]["managers"],
+			skillContext: {
+				mergedSkills: [],
+				availableSkills: [],
+				browserProvider: "playwright",
+				disabledSkills: new Set(),
+			},
+			availableCategories: [],
+		});
 
-    expect(result.taskSystemEnabled).toBe(true)
-    expect(result.filteredTools).toHaveProperty("task_create")
-    expect(result.filteredTools).toHaveProperty("task_get")
-    expect(result.filteredTools).toHaveProperty("task_list")
-    expect(result.filteredTools).toHaveProperty("task_update")
-  })
-})
+		expect(result.taskSystemEnabled).toBe(true);
+		expect(result.filteredTools).toHaveProperty("task_create");
+		expect(result.filteredTools).toHaveProperty("task_get");
+		expect(result.filteredTools).toHaveProperty("task_list");
+		expect(result.filteredTools).toHaveProperty("task_update");
+	});
+});
 
 describe("#given tmux integration is disabled", () => {
-  test("#when system tmux is available #then interactive_bash remains registered", () => {
-    const result = createToolRegistry({
-      ctx: { directory: "/tmp" } as Parameters<typeof createToolRegistry>[0]["ctx"],
-      pluginConfig: {
-        tmux: {
-          enabled: false,
-          layout: "main-vertical",
-          main_pane_size: 60,
-          main_pane_min_width: 120,
-          agent_pane_min_width: 40,
-          isolation: "inline",
-        },
-      },
-      managers: {
-        backgroundManager: {},
-        tmuxSessionManager: {},
-        skillMcpManager: {},
-      } as Parameters<typeof createToolRegistry>[0]["managers"],
-      skillContext: {
-        mergedSkills: [],
-        availableSkills: [],
-        browserProvider: "playwright",
-        disabledSkills: new Set(),
-      },
-      availableCategories: [],
-      interactiveBashEnabled: true,
-    })
+	test("#when system tmux is available #then interactive_bash remains registered", () => {
+		const projectRoot = createNonOckProjectRoot();
+		const result = createToolRegistry({
+			ctx: { directory: projectRoot } as Parameters<
+				typeof createToolRegistry
+			>[0]["ctx"],
+			pluginConfig: {
+				tmux: {
+					enabled: false,
+					layout: "main-vertical",
+					main_pane_size: 60,
+					main_pane_min_width: 120,
+					agent_pane_min_width: 40,
+					isolation: "inline",
+				},
+			},
+			managers: {
+				backgroundManager: {},
+				tmuxSessionManager: {},
+				skillMcpManager: {},
+			} as Parameters<typeof createToolRegistry>[0]["managers"],
+			skillContext: {
+				mergedSkills: [],
+				availableSkills: [],
+				browserProvider: "playwright",
+				disabledSkills: new Set(),
+			},
+			availableCategories: [],
+			interactiveBashEnabled: true,
+		});
 
-    expect(result.filteredTools).toHaveProperty("interactive_bash")
-  })
+		expect(result.filteredTools).toHaveProperty("interactive_bash");
+	});
 
-  test("#when system tmux is unavailable #then interactive_bash is not registered", () => {
-    const result = createToolRegistry({
-      ctx: { directory: "/tmp" } as Parameters<typeof createToolRegistry>[0]["ctx"],
-      pluginConfig: {
-        tmux: {
-          enabled: false,
-          layout: "main-vertical",
-          main_pane_size: 60,
-          main_pane_min_width: 120,
-          agent_pane_min_width: 40,
-          isolation: "inline",
-        },
-      },
-      managers: {
-        backgroundManager: {},
-        tmuxSessionManager: {},
-        skillMcpManager: {},
-      } as Parameters<typeof createToolRegistry>[0]["managers"],
-      skillContext: {
-        mergedSkills: [],
-        availableSkills: [],
-        browserProvider: "playwright",
-        disabledSkills: new Set(),
-      },
-      availableCategories: [],
-      interactiveBashEnabled: false,
-    })
+	test("#when system tmux is unavailable #then interactive_bash is not registered", () => {
+		const projectRoot = createNonOckProjectRoot();
+		const result = createToolRegistry({
+			ctx: { directory: projectRoot } as Parameters<
+				typeof createToolRegistry
+			>[0]["ctx"],
+			pluginConfig: {
+				tmux: {
+					enabled: false,
+					layout: "main-vertical",
+					main_pane_size: 60,
+					main_pane_min_width: 120,
+					agent_pane_min_width: 40,
+					isolation: "inline",
+				},
+			},
+			managers: {
+				backgroundManager: {},
+				tmuxSessionManager: {},
+				skillMcpManager: {},
+			} as Parameters<typeof createToolRegistry>[0]["managers"],
+			skillContext: {
+				mergedSkills: [],
+				availableSkills: [],
+				browserProvider: "playwright",
+				disabledSkills: new Set(),
+			},
+			availableCategories: [],
+			interactiveBashEnabled: false,
+		});
 
-    expect(result.filteredTools).not.toHaveProperty("interactive_bash")
-  })
-})
+		expect(result.filteredTools).not.toHaveProperty("interactive_bash");
+	});
+});

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -1,233 +1,253 @@
-import type { ToolDefinition } from "@opencode-ai/plugin"
-import type { SkillLoadOptions } from "../tools/skill/types"
-
-import type {
-  AvailableCategory,
-} from "../agents/dynamic-agent-prompt-builder"
-import type { OhMyOpenCodeConfig } from "../config"
-import { isInteractiveBashEnabled } from "../create-runtime-tmux-config"
-import type { PluginContext, ToolsRecord } from "./types"
-
+import type { ToolDefinition } from "@opencode-ai/plugin";
+import type { AvailableCategory } from "../agents/dynamic-agent-prompt-builder";
+import type { OhMyOpenCodeConfig } from "../config";
+import type { Managers } from "../create-managers";
+import { isInteractiveBashEnabled } from "../create-runtime-tmux-config";
+import { getMainSessionID } from "../features/claude-code-session-state";
+import { isTaskSystemEnabledForDirectory, log } from "../shared";
+import { filterDisabledTools } from "../shared/disabled-tools";
 import {
-  builtinTools,
-  createBackgroundTools,
-  createCallOmoAgent,
-  createLookAt,
-  createSkillMcpTool,
-  createSkillTool,
-  createGrepTools,
-  createGlobTools,
-  createAstGrepTools,
-  createSessionManagerTools,
-  createDelegateTask,
-  discoverCommandsSync,
-  interactive_bash,
-  createTaskCreateTool,
-  createTaskGetTool,
-  createTaskList,
-  createTaskUpdateTool,
-  createHashlineEditTool,
-} from "../tools"
-import { getMainSessionID } from "../features/claude-code-session-state"
-import { filterDisabledTools } from "../shared/disabled-tools"
-import { isTaskSystemEnabled, log } from "../shared"
-
-import type { Managers } from "../create-managers"
-import type { SkillContext } from "./skill-context"
-import { normalizeToolArgSchemas } from "./normalize-tool-arg-schemas"
+	builtinTools,
+	createAstGrepTools,
+	createBackgroundTools,
+	createCallOmoAgent,
+	createDelegateTask,
+	createGlobTools,
+	createGrepTools,
+	createHashlineEditTool,
+	createLookAt,
+	createSessionManagerTools,
+	createSkillMcpTool,
+	createSkillTool,
+	createTaskCreateTool,
+	createTaskGetTool,
+	createTaskList,
+	createTaskUpdateTool,
+	discoverCommandsSync,
+	interactive_bash,
+} from "../tools";
+import type { SkillLoadOptions } from "../tools/skill/types";
+import { normalizeToolArgSchemas } from "./normalize-tool-arg-schemas";
+import type { SkillContext } from "./skill-context";
+import type { PluginContext, ToolsRecord } from "./types";
 
 export type ToolRegistryResult = {
-  filteredTools: ToolsRecord
-  taskSystemEnabled: boolean
-}
+	filteredTools: ToolsRecord;
+	taskSystemEnabled: boolean;
+};
 
 const LOW_PRIORITY_TOOL_ORDER = [
-  "session_list",
-  "session_read",
-  "session_search",
-  "session_info",
-  "interactive_bash",
-  "look_at",
-  "call_omo_agent",
-  "task_create",
-  "task_get",
-  "task_list",
-  "task_update",
-  "background_output",
-  "background_cancel",
-  "edit",
-  "ast_grep_replace",
-  "ast_grep_search",
-  "glob",
-  "grep",
-  "skill_mcp",
-  "skill",
-  "task",
-  "lsp_rename",
-  "lsp_prepare_rename",
-  "lsp_find_references",
-  "lsp_goto_definition",
-  "lsp_symbols",
-  "lsp_diagnostics",
-] as const
+	"session_list",
+	"session_read",
+	"session_search",
+	"session_info",
+	"interactive_bash",
+	"look_at",
+	"call_omo_agent",
+	"task_create",
+	"task_get",
+	"task_list",
+	"task_update",
+	"background_output",
+	"background_cancel",
+	"edit",
+	"ast_grep_replace",
+	"ast_grep_search",
+	"glob",
+	"grep",
+	"skill_mcp",
+	"skill",
+	"task",
+	"lsp_rename",
+	"lsp_prepare_rename",
+	"lsp_find_references",
+	"lsp_goto_definition",
+	"lsp_symbols",
+	"lsp_diagnostics",
+] as const;
 
-export function trimToolsToCap(filteredTools: ToolsRecord, maxTools: number): void {
-  const toolNames = Object.keys(filteredTools)
-  if (toolNames.length <= maxTools) return
+export function trimToolsToCap(
+	filteredTools: ToolsRecord,
+	maxTools: number,
+): void {
+	const toolNames = Object.keys(filteredTools);
+	if (toolNames.length <= maxTools) return;
 
-  const removableToolNames = [
-    ...LOW_PRIORITY_TOOL_ORDER.filter((toolName) => toolNames.includes(toolName)),
-    ...toolNames
-      .filter((toolName) => !LOW_PRIORITY_TOOL_ORDER.includes(toolName as (typeof LOW_PRIORITY_TOOL_ORDER)[number]))
-      .sort(),
-  ]
+	const removableToolNames = [
+		...LOW_PRIORITY_TOOL_ORDER.filter((toolName) =>
+			toolNames.includes(toolName),
+		),
+		...toolNames
+			.filter(
+				(toolName) =>
+					!LOW_PRIORITY_TOOL_ORDER.includes(
+						toolName as (typeof LOW_PRIORITY_TOOL_ORDER)[number],
+					),
+			)
+			.sort(),
+	];
 
-  let currentCount = toolNames.length
-  let removed = 0
+	let currentCount = toolNames.length;
+	let removed = 0;
 
-  for (const toolName of removableToolNames) {
-    if (currentCount <= maxTools) break
-    if (!filteredTools[toolName]) continue
-    delete filteredTools[toolName]
-    currentCount -= 1
-    removed += 1
-  }
+	for (const toolName of removableToolNames) {
+		if (currentCount <= maxTools) break;
+		if (!filteredTools[toolName]) continue;
+		delete filteredTools[toolName];
+		currentCount -= 1;
+		removed += 1;
+	}
 
-  log(
-    `[tool-registry] Trimmed ${removed} tools to satisfy max_tools=${maxTools}. Final plugin tool count=${currentCount}.`,
-  )
+	log(
+		`[tool-registry] Trimmed ${removed} tools to satisfy max_tools=${maxTools}. Final plugin tool count=${currentCount}.`,
+	);
 }
 
 export function createToolRegistry(args: {
-  ctx: PluginContext
-  pluginConfig: OhMyOpenCodeConfig
-  managers: Pick<Managers, "backgroundManager" | "tmuxSessionManager" | "skillMcpManager">
-  skillContext: SkillContext
-  availableCategories: AvailableCategory[]
-  interactiveBashEnabled?: boolean
+	ctx: PluginContext;
+	pluginConfig: OhMyOpenCodeConfig;
+	managers: Pick<
+		Managers,
+		"backgroundManager" | "tmuxSessionManager" | "skillMcpManager"
+	>;
+	skillContext: SkillContext;
+	availableCategories: AvailableCategory[];
+	interactiveBashEnabled?: boolean;
 }): ToolRegistryResult {
-  const {
-    ctx,
-    pluginConfig,
-    managers,
-    skillContext,
-    availableCategories,
-    interactiveBashEnabled = isInteractiveBashEnabled(),
-  } = args
-  const backgroundTools = createBackgroundTools(managers.backgroundManager, ctx.client)
-  const callOmoAgent = createCallOmoAgent(
-    ctx,
-    managers.backgroundManager,
-    pluginConfig.disabled_agents ?? [],
-    pluginConfig.agents,
-    pluginConfig.categories,
-  )
+	const {
+		ctx,
+		pluginConfig,
+		managers,
+		skillContext,
+		availableCategories,
+		interactiveBashEnabled = isInteractiveBashEnabled(),
+	} = args;
+	const backgroundTools = createBackgroundTools(
+		managers.backgroundManager,
+		ctx.client,
+	);
+	const callOmoAgent = createCallOmoAgent(
+		ctx,
+		managers.backgroundManager,
+		pluginConfig.disabled_agents ?? [],
+		pluginConfig.agents,
+		pluginConfig.categories,
+	);
 
-  const isMultimodalLookerEnabled = !(pluginConfig.disabled_agents ?? []).some(
-    (agent) => agent.toLowerCase() === "multimodal-looker",
-  )
-  const lookAt = isMultimodalLookerEnabled ? createLookAt(ctx) : null
+	const isMultimodalLookerEnabled = !(pluginConfig.disabled_agents ?? []).some(
+		(agent) => agent.toLowerCase() === "multimodal-looker",
+	);
+	const lookAt = isMultimodalLookerEnabled ? createLookAt(ctx) : null;
 
-  const delegateTask = createDelegateTask({
-    manager: managers.backgroundManager,
-    client: ctx.client,
-    directory: ctx.directory,
-    userCategories: pluginConfig.categories,
-    agentOverrides: pluginConfig.agents,
-    gitMasterConfig: pluginConfig.git_master,
-    sisyphusJuniorModel: pluginConfig.agents?.["sisyphus-junior"]?.model,
-    browserProvider: skillContext.browserProvider,
-    disabledSkills: skillContext.disabledSkills,
-    availableCategories,
-    availableSkills: skillContext.availableSkills,
-    sisyphusAgentConfig: pluginConfig.sisyphus_agent,
-    syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
-    onSyncSessionCreated: async (event) => {
-      log("[index] onSyncSessionCreated callback", {
-        sessionID: event.sessionID,
-        parentID: event.parentID,
-        title: event.title,
-      })
-      await managers.tmuxSessionManager.onSessionCreated({
-        type: "session.created",
-        properties: {
-          info: {
-            id: event.sessionID,
-            parentID: event.parentID,
-            title: event.title,
-          },
-        },
-      })
-    },
-  })
+	const delegateTask = createDelegateTask({
+		manager: managers.backgroundManager,
+		client: ctx.client,
+		directory: ctx.directory,
+		userCategories: pluginConfig.categories,
+		agentOverrides: pluginConfig.agents,
+		gitMasterConfig: pluginConfig.git_master,
+		sisyphusJuniorModel: pluginConfig.agents?.["sisyphus-junior"]?.model,
+		browserProvider: skillContext.browserProvider,
+		disabledSkills: skillContext.disabledSkills,
+		availableCategories,
+		availableSkills: skillContext.availableSkills,
+		sisyphusAgentConfig: pluginConfig.sisyphus_agent,
+		syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
+		onSyncSessionCreated: async (event) => {
+			log("[index] onSyncSessionCreated callback", {
+				sessionID: event.sessionID,
+				parentID: event.parentID,
+				title: event.title,
+			});
+			await managers.tmuxSessionManager.onSessionCreated({
+				type: "session.created",
+				properties: {
+					info: {
+						id: event.sessionID,
+						parentID: event.parentID,
+						title: event.title,
+					},
+				},
+			});
+		},
+	});
 
-  const getSessionIDForMcp = (): string | undefined => getMainSessionID()
+	const getSessionIDForMcp = (): string | undefined => getMainSessionID();
 
-  const skillMcpTool = createSkillMcpTool({
-    manager: managers.skillMcpManager,
-    getLoadedSkills: () => skillContext.mergedSkills,
-    getSessionID: getSessionIDForMcp,
-  })
+	const skillMcpTool = createSkillMcpTool({
+		manager: managers.skillMcpManager,
+		getLoadedSkills: () => skillContext.mergedSkills,
+		getSessionID: getSessionIDForMcp,
+	});
 
-  const commands = discoverCommandsSync(ctx.directory, {
-    pluginsEnabled: pluginConfig.claude_code?.plugins ?? true,
-    enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
-  })
-  const skillTool = createSkillTool({
-    commands,
-    skills: skillContext.mergedSkills,
-    mcpManager: managers.skillMcpManager,
-    getSessionID: getSessionIDForMcp,
-    gitMasterConfig: pluginConfig.git_master,
-    browserProvider: skillContext.browserProvider,
-    nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
-  })
+	const commands = discoverCommandsSync(ctx.directory, {
+		pluginsEnabled: pluginConfig.claude_code?.plugins ?? true,
+		enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
+	});
+	const skillTool = createSkillTool({
+		commands,
+		skills: skillContext.mergedSkills,
+		mcpManager: managers.skillMcpManager,
+		getSessionID: getSessionIDForMcp,
+		gitMasterConfig: pluginConfig.git_master,
+		browserProvider: skillContext.browserProvider,
+		nativeSkills:
+			"skills" in ctx
+				? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills
+				: undefined,
+	});
 
-  const taskSystemEnabled = isTaskSystemEnabled(pluginConfig)
-  const taskToolsRecord: Record<string, ToolDefinition> = taskSystemEnabled
-    ? {
-        task_create: createTaskCreateTool(pluginConfig, ctx),
-        task_get: createTaskGetTool(pluginConfig),
-        task_list: createTaskList(pluginConfig),
-        task_update: createTaskUpdateTool(pluginConfig, ctx),
-      }
-    : {}
+	const taskSystemEnabled = isTaskSystemEnabledForDirectory(
+		pluginConfig,
+		ctx.directory,
+	);
+	const taskToolsRecord: Record<string, ToolDefinition> = taskSystemEnabled
+		? {
+				task_create: createTaskCreateTool(pluginConfig, ctx),
+				task_get: createTaskGetTool(pluginConfig),
+				task_list: createTaskList(pluginConfig),
+				task_update: createTaskUpdateTool(pluginConfig, ctx),
+			}
+		: {};
 
-  const hashlineEnabled = pluginConfig.hashline_edit ?? false
-  const hashlineToolsRecord: Record<string, ToolDefinition> = hashlineEnabled
-    ? { edit: createHashlineEditTool(ctx) }
-    : {}
+	const hashlineEnabled = pluginConfig.hashline_edit ?? false;
+	const hashlineToolsRecord: Record<string, ToolDefinition> = hashlineEnabled
+		? { edit: createHashlineEditTool(ctx) }
+		: {};
 
-  const allTools: Record<string, ToolDefinition> = {
-    ...builtinTools,
-    ...createGrepTools(ctx),
-    ...createGlobTools(ctx),
-    ...createAstGrepTools(ctx),
-    ...createSessionManagerTools(ctx),
-    ...backgroundTools,
-    call_omo_agent: callOmoAgent,
-    ...(lookAt ? { look_at: lookAt } : {}),
-    task: delegateTask,
-    skill_mcp: skillMcpTool,
-    skill: skillTool,
-    ...(interactiveBashEnabled ? { interactive_bash } : {}),
-    ...taskToolsRecord,
-    ...hashlineToolsRecord,
-  }
+	const allTools: Record<string, ToolDefinition> = {
+		...builtinTools,
+		...createGrepTools(ctx),
+		...createGlobTools(ctx),
+		...createAstGrepTools(ctx),
+		...createSessionManagerTools(ctx),
+		...backgroundTools,
+		call_omo_agent: callOmoAgent,
+		...(lookAt ? { look_at: lookAt } : {}),
+		task: delegateTask,
+		skill_mcp: skillMcpTool,
+		skill: skillTool,
+		...(interactiveBashEnabled ? { interactive_bash } : {}),
+		...taskToolsRecord,
+		...hashlineToolsRecord,
+	};
 
-  for (const toolDefinition of Object.values(allTools)) {
-    normalizeToolArgSchemas(toolDefinition)
-  }
+	for (const toolDefinition of Object.values(allTools)) {
+		normalizeToolArgSchemas(toolDefinition);
+	}
 
-  const filteredTools: ToolsRecord = filterDisabledTools(allTools, pluginConfig.disabled_tools)
+	const filteredTools: ToolsRecord = filterDisabledTools(
+		allTools,
+		pluginConfig.disabled_tools,
+	);
 
-  const maxTools = pluginConfig.experimental?.max_tools
-  if (maxTools) {
-    trimToolsToCap(filteredTools, maxTools)
-  }
+	const maxTools = pluginConfig.experimental?.max_tools;
+	if (maxTools) {
+		trimToolsToCap(filteredTools, maxTools);
+	}
 
-  return {
-    filteredTools,
-    taskSystemEnabled,
-  }
+	return {
+		filteredTools,
+		taskSystemEnabled,
+	};
 }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,76 +1,80 @@
-export * from "./frontmatter"
-export * from "./command-executor"
-export * from "./contains-path"
-export * from "./file-reference-resolver"
-export * from "./model-sanitizer"
-export * from "./logger"
-export * from "./snake-case"
-export * from "./tool-name"
-export * from "./pattern-matcher"
-export * from "./hook-disabled"
-export * from "./deep-merge"
-export * from "./file-utils"
-export * from "./dynamic-truncator"
-export * from "./data-path"
-export * from "./config-errors"
-export * from "./claude-config-dir"
-export * from "./jsonc-parser"
-export * from "./migration"
-export * from "./opencode-config-dir"
+export * from "./agent-tool-restrictions";
+export * from "./agent-variant";
+export * from "./binary-downloader";
+export * from "./claude-config-dir";
+export * from "./command-executor";
+export * from "./config-errors";
+export * from "./connected-providers-cache";
+export * from "./contains-path";
+export * from "./context-limit-resolver";
+export * from "./data-path";
+export * from "./deep-merge";
+export * from "./dynamic-truncator";
+export * from "./external-plugin-detector";
+export * from "./fallback-model-availability";
+export * from "./file-reference-resolver";
+export * from "./file-utils";
+export * from "./frontmatter";
+export * from "./git-worktree";
+export * from "./hook-disabled";
+export * from "./internal-initiator-marker";
+export * from "./jsonc-parser";
+export * from "./log-legacy-plugin-startup-warning";
+export * from "./logger";
+export * from "./migration";
+export * from "./model-availability";
+export * from "./model-capabilities";
+export * from "./model-capabilities-cache";
+export * from "./model-capability-heuristics";
+export { normalizeModel, normalizeModelID } from "./model-normalization";
+export * from "./model-requirements";
+export { resolveModelPipeline } from "./model-resolution-pipeline";
 export type {
-  OpenCodeBinaryType,
-  OpenCodeConfigDirOptions,
-  OpenCodeConfigPaths,
-} from "./opencode-config-dir-types"
-export * from "./opencode-version"
-export * from "./opencode-storage-detection"
-export * from "./permission-compat"
-export * from "./external-plugin-detector"
-export * from "./zip-extractor"
-export * from "./binary-downloader"
-export * from "./write-file-atomically"
-export * from "./agent-variant"
-export * from "./session-cursor"
-export * from "./shell-env"
-export * from "./system-directive"
-export * from "./agent-tool-restrictions"
-export * from "./model-requirements"
-export * from "./model-resolver"
-export { normalizeModel, normalizeModelID } from "./model-normalization"
-export { normalizeFallbackModels, flattenToFallbackModelStrings } from "./model-resolver"
-export { resolveModelPipeline } from "./model-resolution-pipeline"
+	ModelResolutionProvenance,
+	ModelResolutionRequest,
+	ModelResolutionResult,
+} from "./model-resolution-types";
+export * from "./model-resolver";
+export {
+	flattenToFallbackModelStrings,
+	normalizeFallbackModels,
+} from "./model-resolver";
+export * from "./model-sanitizer";
+export * from "./model-settings-compatibility";
+export * from "./model-suggestion-retry";
+export * from "./normalize-sdk-response";
+export * from "./ock-bead-first-project";
+export * from "./opencode-command-dirs";
+export * from "./opencode-config-dir";
 export type {
-  ModelResolutionRequest,
-  ModelResolutionProvenance,
-  ModelResolutionResult,
-} from "./model-resolution-types"
-export * from "./model-availability"
-export * from "./model-capabilities"
-export * from "./model-capabilities-cache"
-export * from "./model-capability-heuristics"
-export * from "./model-settings-compatibility"
-export * from "./fallback-model-availability"
-export * from "./connected-providers-cache"
-export * from "./context-limit-resolver"
-export * from "./session-utils"
-export * from "./tmux"
-export * from "./model-suggestion-retry"
-export * from "./opencode-server-auth"
-export * from "./opencode-http-api"
-export * from "./port-utils"
-export * from "./git-worktree"
-export * from "./safe-create-hook"
-export * from "./truncate-description"
-export * from "./opencode-storage-paths"
-export * from "./opencode-message-dir"
-export * from "./opencode-command-dirs"
-export * from "./project-discovery-dirs"
-export * from "./normalize-sdk-response"
-export * from "./session-directory-resolver"
-export * from "./prompt-tools"
-export * from "./internal-initiator-marker"
-export * from "./plugin-command-discovery"
-export { SessionCategoryRegistry } from "./session-category-registry"
-export * from "./plugin-identity"
-export * from "./log-legacy-plugin-startup-warning"
-export * from "./task-system-enabled"
+	OpenCodeBinaryType,
+	OpenCodeConfigDirOptions,
+	OpenCodeConfigPaths,
+} from "./opencode-config-dir-types";
+export * from "./opencode-http-api";
+export * from "./opencode-message-dir";
+export * from "./opencode-server-auth";
+export * from "./opencode-storage-detection";
+export * from "./opencode-storage-paths";
+export * from "./opencode-version";
+export * from "./pattern-matcher";
+export * from "./permission-compat";
+export * from "./plugin-command-discovery";
+export * from "./plugin-identity";
+export * from "./port-utils";
+export * from "./project-discovery-dirs";
+export * from "./prompt-tools";
+export * from "./safe-create-hook";
+export { SessionCategoryRegistry } from "./session-category-registry";
+export * from "./session-cursor";
+export * from "./session-directory-resolver";
+export * from "./session-utils";
+export * from "./shell-env";
+export * from "./snake-case";
+export * from "./system-directive";
+export * from "./task-system-enabled";
+export * from "./tmux";
+export * from "./tool-name";
+export * from "./truncate-description";
+export * from "./write-file-atomically";
+export * from "./zip-extractor";

--- a/src/shared/ock-bead-first-project.test.ts
+++ b/src/shared/ock-bead-first-project.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { isOckBeadFirstProject } from "./ock-bead-first-project";
+
+const OPTIONAL_WORKFLOW_COMMANDS = ["research", "start", "plan", "ship"];
+
+function writeCommand(directory: string, name: string): void {
+	mkdirSync(directory, { recursive: true });
+	writeFileSync(
+		join(directory, `${name}.md`),
+		`---\ndescription: ${name}\n---\n`,
+		"utf-8",
+	);
+}
+
+function createOckWorkflowRoot(rootDirectory: string): void {
+	mkdirSync(join(rootDirectory, ".git"), { recursive: true });
+	mkdirSync(join(rootDirectory, ".beads"), { recursive: true });
+	const commandDirectory = join(rootDirectory, ".opencode", "command");
+
+	writeCommand(commandDirectory, "create");
+	for (const commandName of OPTIONAL_WORKFLOW_COMMANDS) {
+		writeCommand(commandDirectory, commandName);
+	}
+}
+
+describe("isOckBeadFirstProject", () => {
+	const tempDirectories: string[] = [];
+
+	afterEach(() => {
+		for (const tempDirectory of tempDirectories) {
+			rmSync(tempDirectory, { force: true, recursive: true });
+		}
+		tempDirectories.length = 0;
+	});
+
+	it("returns true when nearest ancestor has .beads and OCK workflow commands", () => {
+		const tempDirectory = mkdtempSync(
+			join(tmpdir(), "ock-bead-first-project-"),
+		);
+		tempDirectories.push(tempDirectory);
+		const projectRoot = join(tempDirectory, "project");
+		const nestedDirectory = join(projectRoot, "apps", "desktop");
+
+		createOckWorkflowRoot(projectRoot);
+		mkdirSync(nestedDirectory, { recursive: true });
+
+		expect(isOckBeadFirstProject(nestedDirectory)).toBe(true);
+	});
+
+	it("returns false when only .opencode exists", () => {
+		const tempDirectory = mkdtempSync(
+			join(tmpdir(), "ock-bead-first-project-"),
+		);
+		tempDirectories.push(tempDirectory);
+		mkdirSync(join(tempDirectory, ".git"), { recursive: true });
+		const commandDirectory = join(tempDirectory, ".opencode", "command");
+
+		writeCommand(commandDirectory, "create");
+
+		expect(isOckBeadFirstProject(tempDirectory)).toBe(false);
+	});
+
+	it("returns false when only .beads exists", () => {
+		const tempDirectory = mkdtempSync(
+			join(tmpdir(), "ock-bead-first-project-"),
+		);
+		tempDirectories.push(tempDirectory);
+		mkdirSync(join(tempDirectory, ".git"), { recursive: true });
+
+		mkdirSync(join(tempDirectory, ".beads"), { recursive: true });
+
+		expect(isOckBeadFirstProject(tempDirectory)).toBe(false);
+	});
+
+	it("returns false without a git boundary even when OCK markers exist", () => {
+		const tempDirectory = mkdtempSync(
+			join(tmpdir(), "ock-bead-first-project-"),
+		);
+		tempDirectories.push(tempDirectory);
+
+		mkdirSync(join(tempDirectory, ".beads"), { recursive: true });
+		const commandDirectory = join(tempDirectory, ".opencode", "command");
+		writeCommand(commandDirectory, "create");
+		writeCommand(commandDirectory, "research");
+		writeCommand(commandDirectory, "start");
+		writeCommand(commandDirectory, "plan");
+
+		expect(isOckBeadFirstProject(tempDirectory)).toBe(false);
+	});
+
+	it("uses nearest matching ancestor inside nested directories", () => {
+		const tempDirectory = mkdtempSync(
+			join(tmpdir(), "ock-bead-first-project-"),
+		);
+		tempDirectories.push(tempDirectory);
+		const outerRoot = join(tempDirectory, "outer");
+		const innerRoot = join(outerRoot, "inner");
+		const nestedDirectory = join(innerRoot, "apps", "desktop");
+
+		mkdirSync(join(outerRoot, ".beads"), { recursive: true });
+		writeCommand(join(outerRoot, ".opencode", "command"), "create");
+		createOckWorkflowRoot(innerRoot);
+		mkdirSync(nestedDirectory, { recursive: true });
+
+		expect(isOckBeadFirstProject(nestedDirectory)).toBe(true);
+	});
+
+	it("returns false when only two optional workflow commands are present", () => {
+		const tempDirectory = mkdtempSync(
+			join(tmpdir(), "ock-bead-first-project-"),
+		);
+		tempDirectories.push(tempDirectory);
+		mkdirSync(join(tempDirectory, ".git"), { recursive: true });
+		mkdirSync(join(tempDirectory, ".beads"), { recursive: true });
+		const commandDirectory = join(tempDirectory, ".opencode", "command");
+
+		writeCommand(commandDirectory, "create");
+		writeCommand(commandDirectory, "research");
+		writeCommand(commandDirectory, "start");
+
+		expect(isOckBeadFirstProject(tempDirectory)).toBe(false);
+	});
+
+	it("returns true when pr.md is the third optional workflow command", () => {
+		const tempDirectory = mkdtempSync(
+			join(tmpdir(), "ock-bead-first-project-"),
+		);
+		tempDirectories.push(tempDirectory);
+		mkdirSync(join(tempDirectory, ".git"), { recursive: true });
+		mkdirSync(join(tempDirectory, ".beads"), { recursive: true });
+		const commandDirectory = join(tempDirectory, ".opencode", "command");
+
+		writeCommand(commandDirectory, "create");
+		writeCommand(commandDirectory, "research");
+		writeCommand(commandDirectory, "start");
+		writeCommand(commandDirectory, "pr");
+
+		expect(isOckBeadFirstProject(tempDirectory)).toBe(true);
+	});
+
+	it("returns true when canonical commands are under the plural commands alias", () => {
+		const tempDirectory = mkdtempSync(
+			join(tmpdir(), "ock-bead-first-project-"),
+		);
+		tempDirectories.push(tempDirectory);
+		mkdirSync(join(tempDirectory, ".git"), { recursive: true });
+		mkdirSync(join(tempDirectory, ".beads"), { recursive: true });
+		const commandDirectory = join(tempDirectory, ".opencode", "commands");
+
+		writeCommand(commandDirectory, "create");
+		writeCommand(commandDirectory, "research");
+		writeCommand(commandDirectory, "start");
+		writeCommand(commandDirectory, "plan");
+
+		expect(isOckBeadFirstProject(tempDirectory)).toBe(true);
+	});
+});

--- a/src/shared/ock-bead-first-project.ts
+++ b/src/shared/ock-bead-first-project.ts
@@ -1,0 +1,87 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { findProjectOpencodeCommandDirs } from "./project-discovery-dirs";
+
+const REQUIRED_COMMAND = "create.md";
+const OPTIONAL_WORKFLOW_COMMANDS = [
+	"research.md",
+	"start.md",
+	"plan.md",
+	"ship.md",
+	"pr.md",
+];
+
+function getProjectRoot(commandDirectory: string): string {
+	return dirname(dirname(commandDirectory));
+}
+
+function detectScanBoundary(startDirectory: string): string | undefined {
+	let currentDirectory = startDirectory;
+
+	while (true) {
+		if (existsSync(join(currentDirectory, ".git"))) {
+			return currentDirectory;
+		}
+
+		const parentDirectory = dirname(currentDirectory);
+		if (parentDirectory === currentDirectory) {
+			return undefined;
+		}
+
+		currentDirectory = parentDirectory;
+	}
+}
+
+function hasCanonicalOckWorkflowCommands(
+	commandDirectories: string[],
+): boolean {
+	const presentCommands = new Set<string>();
+
+	for (const commandDirectory of commandDirectories) {
+		if (existsSync(join(commandDirectory, REQUIRED_COMMAND))) {
+			presentCommands.add(REQUIRED_COMMAND);
+		}
+
+		for (const commandName of OPTIONAL_WORKFLOW_COMMANDS) {
+			if (existsSync(join(commandDirectory, commandName))) {
+				presentCommands.add(commandName);
+			}
+		}
+	}
+
+	const optionalCommandCount = OPTIONAL_WORKFLOW_COMMANDS.filter(
+		(commandName) => presentCommands.has(commandName),
+	).length;
+
+	return presentCommands.has(REQUIRED_COMMAND) && optionalCommandCount >= 3;
+}
+
+export function isOckBeadFirstProject(startDirectory: string): boolean {
+	const scanBoundary = detectScanBoundary(startDirectory);
+	if (!scanBoundary) {
+		return false;
+	}
+
+	const commandDirectories = findProjectOpencodeCommandDirs(
+		startDirectory,
+		scanBoundary,
+	);
+	const projectRoots = new Set(commandDirectories.map(getProjectRoot));
+
+	for (const projectRoot of projectRoots) {
+		const projectCommandDirectories = commandDirectories.filter(
+			(commandDirectory) => getProjectRoot(commandDirectory) === projectRoot,
+		);
+
+		if (!existsSync(join(projectRoot, ".beads"))) {
+			continue;
+		}
+
+		if (hasCanonicalOckWorkflowCommands(projectCommandDirectories)) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/shared/task-system-enabled.ts
+++ b/src/shared/task-system-enabled.ts
@@ -1,9 +1,21 @@
+import { isOckBeadFirstProject } from "./ock-bead-first-project";
+
 export interface TaskSystemConfig {
-  experimental?: {
-    task_system?: boolean
-  }
+	experimental?: {
+		task_system?: boolean;
+	};
 }
 
 export function isTaskSystemEnabled(config: TaskSystemConfig): boolean {
-  return config.experimental?.task_system ?? false
+	return config.experimental?.task_system ?? false;
+}
+
+export function isTaskSystemEnabledForDirectory(
+	config: TaskSystemConfig,
+	directory?: string,
+): boolean {
+	return (
+		isTaskSystemEnabled(config) &&
+		(!directory || !isOckBeadFirstProject(directory))
+	);
 }


### PR DESCRIPTION
## Summary
- add bead-first OCK repo detection with strict git-boundary behavior
- suppress conflicting builtin commands and OMO task-system ownership in OCK repos
- align agent prompt task-system instructions with actual OCK tool availability

## Verification
- bun test src/shared/ock-bead-first-project.test.ts src/plugin-handlers/command-config-handler.test.ts src/plugin-handlers/command-config-handler.ock.test.ts src/plugin-handlers/tool-config-handler.ock.test.ts src/plugin-handlers/config-handler.ock.test.ts src/plugin/tool-registry.test.ts src/plugin/hooks/create-tool-guard-hooks.test.ts src/features/claude-code-command-loader/loader.test.ts src/features/opencode-skill-loader/project-skill-discovery.test.ts src/features/claude-tasks/storage.test.ts src/features/claude-tasks/session-storage.test.ts src/hooks/tasks-todowrite-disabler/hook.test.ts
- bun run typecheck

## Manual QA
- verified non-git directories do not mis-detect as OCK bead-first projects
- verified OCK repos disable task-system tools, todo ownership hooks, and prompt-side task-system instructions
- verified non-OCK repos still expose task-system tools and hooks as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects OCK bead‑first repos and disables OMO task‑system ownership plus conflicting builtins inside them. Aligns prompts and tool availability with repo workflows; non‑OCK repos are unchanged.

- **Bug Fixes**
  - Add bead‑first detector with strict `.git` boundary; requires `.beads` and canonical `.opencode/command/create.md` (with optional workflow commands).
  - In OCK repos: disable task registry and todo‑ownership hooks, suppress conflicting builtin commands, and strip task‑system instructions from agent prompts.
  - Make task/command/tool loading directory‑aware via `isTaskSystemEnabledForDirectory`.
  - Add tests for OCK detection and command/tool/config handlers; confirmed non‑git directories and non‑OCK repos behave as before.

<sup>Written for commit 368d7c5a97d07c1a4324d3f6b54e5a177df7c496. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

