### PR TITLE
fix(jsonc-parser): strip UTF-8 BOM before parsing

### DIFF
--- a/src/shared/jsonc-parser.test.ts
+++ b/src/shared/jsonc-parser.test.ts
@@ -139,6 +139,33 @@ describe("parseJsonc", () => {
     // then
     expect(() => parseJsonc(invalid)).toThrow()
   })
+
+  test("parses JSONC with UTF-8 BOM (Windows BOM files)", () => {
+    // given - JSON with UTF-8 BOM marker
+    const bom = "\uFEFF"
+    const jsonc = `${bom}{ "key": "value" }`
+
+    // when
+    const result = parseJsonc<{ key: string }>(jsonc)
+
+    // then
+    expect(result.key).toBe("value")
+  })
+
+  test("parses JSONC with BOM and comments", () => {
+    // given - JSONC with UTF-8 BOM and comments
+    const bom = "\uFEFF"
+    const jsonc = `${bom}{
+      // Windows editor saved with BOM
+      "key": "value"
+    }`
+
+    // when
+    const result = parseJsonc<{ key: string }>(jsonc)
+
+    // then
+    expect(result.key).toBe("value")
+  })
 })
 
 describe("parseJsoncSafe", () => {

--- a/src/shared/jsonc-parser.ts
+++ b/src/shared/jsonc-parser.ts
@@ -10,6 +10,9 @@ export interface JsoncParseResult<T> {
 }
 
 export function parseJsonc<T = unknown>(content: string): T {
+  // Strip UTF-8 BOM if present (Windows UTF-8 with BOM files)
+  content = content.replace(/^\uFEFF/, "")
+
   const errors: ParseError[] = []
   const result = parse(content, errors, {
     allowTrailingComma: true,


### PR DESCRIPTION
## Summary

Windows editors often save UTF-8 files with a BOM (Byte Order Mark). When this is present, jsonc-parser reports `InvalidSymbol at offset 0` because the BOM is not valid JSON/JSONC syntax.

This fix strips the BOM before parsing, resolving issue #3164 where Windows users report their opencode.jsonc file fails to parse even though it appears to start with a valid `{` character.

## Changes

- Added BOM stripping in `parseJsonc()` function (`src/shared/jsonc-parser.ts`)
- Added test cases for UTF-8 BOM files (with and without comments)

## Testing

- All 26 existing tests pass
- 2 new tests added for BOM handling:
  - `parses JSONC with UTF-8 BOM (Windows BOM files)`
  - `parses JSONC with BOM and comments`

Fixes #3164

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip the UTF-8 BOM in `parseJsonc()` before calling `jsonc-parser` to prevent "InvalidSymbol at offset 0" on Windows when files are saved with BOM. Add tests for BOM-only and BOM+comments; fixes #3164.

<sup>Written for commit daae6ed05b6fdda4ebb91795d890576efaef6e15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

