### PR TITLE
fix(auto-update): align PACKAGE_NAME with published package name (#3129)

### DIFF
--- a/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
+++ b/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
@@ -3,8 +3,7 @@ import { spawnSync } from "node:child_process"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
-
-const PACKAGE_NAME = "oh-my-openagent"
+import { PACKAGE_NAME } from "../constants"
 
 type PluginEntryResult = {
   entry: string

--- a/src/hooks/auto-update-checker/constants.test.ts
+++ b/src/hooks/auto-update-checker/constants.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
 import { join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { getOpenCodeCacheDir } from "../../shared/data-path"
 
 describe("auto-update-checker constants", () => {
@@ -10,5 +12,18 @@ describe("auto-update-checker constants", () => {
     expect(INSTALLED_PACKAGE_JSON).toBe(
       join(getOpenCodeCacheDir(), "packages", "node_modules", PACKAGE_NAME, "package.json")
     )
+  })
+
+  it("PACKAGE_NAME matches the published package.json name", async () => {
+    // given the canonical package.json shipped with the plugin
+    const here = fileURLToPath(import.meta.url)
+    const repoPackageJsonPath = join(here, "..", "..", "..", "..", "package.json")
+    const repoPackageJson = JSON.parse(readFileSync(repoPackageJsonPath, "utf-8")) as { name: string }
+
+    // when the auto-update-checker constants are loaded
+    const { PACKAGE_NAME } = await import(`./constants?test=${Date.now()}`)
+
+    // then PACKAGE_NAME equals the actually published package name
+    expect(PACKAGE_NAME).toBe(repoPackageJson.name)
   })
 })

--- a/src/hooks/auto-update-checker/constants.ts
+++ b/src/hooks/auto-update-checker/constants.ts
@@ -3,7 +3,7 @@ import * as os from "node:os"
 import { getOpenCodeCacheDir } from "../../shared/data-path"
 import { getOpenCodeConfigDir } from "../../shared/opencode-config-dir"
 
-export const PACKAGE_NAME = "oh-my-openagent"
+export const PACKAGE_NAME = "oh-my-opencode"
 export const NPM_REGISTRY_URL = `https://registry.npmjs.org/-/package/${PACKAGE_NAME}/dist-tags`
 export const NPM_FETCH_TIMEOUT = 5000
 


### PR DESCRIPTION
## Summary

Fixes issue #3129 - aligns PACKAGE_NAME with the actual published package name for correct auto-update behavior.

## Changes
- Update PACKAGE_NAME to match published package name
- Ensures auto-update checks correct package registry entry

## Testing
- Verified auto-update detection works correctly
- All existing tests pass

Fixes #3129

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `PACKAGE_NAME` with the published package `oh-my-opencode` so auto-update checks the correct npm entry and the version toast shows the right version. Addresses #3129.

- **Bug Fixes**
  - Set `PACKAGE_NAME` in `constants.ts` to `oh-my-opencode`; updated tests to import it and added a check against the root `package.json`.
  - Ensures `NPM_REGISTRY_URL` points to the right dist-tags and fixes null results in auto-update detection.

<sup>Written for commit eb8d7191ff2e004f8bd42cd7c405a01d50960e4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

