### PR TITLE
fix: inject agent identity into system prompt for built-in agents (#2964)

### DIFF
--- a/src/agents/agent-identity.test.ts
+++ b/src/agents/agent-identity.test.ts
@@ -1,0 +1,141 @@
+/// <reference types="bun-types" />
+
+import { describe, it, expect } from "bun:test"
+import { buildAgentIdentitySection } from "./dynamic-agent-core-sections"
+import { createSisyphusAgent } from "./sisyphus"
+import { createHephaestusAgent } from "./hephaestus"
+import { mergeAgentConfig } from "./builtin-agents/agent-overrides"
+
+describe("buildAgentIdentitySection", () => {
+  describe("#given an agent name and role description", () => {
+    describe("#when building the identity section", () => {
+      it("#then includes the agent name prominently", () => {
+        const result = buildAgentIdentitySection("Sisyphus", "Powerful AI orchestrator from OhMyOpenCode")
+
+        expect(result).toContain("Sisyphus")
+      })
+
+      it("#then includes the role description", () => {
+        const result = buildAgentIdentitySection("Sisyphus", "Powerful AI orchestrator from OhMyOpenCode")
+
+        expect(result).toContain("Powerful AI orchestrator from OhMyOpenCode")
+      })
+
+      it("#then wraps content in an identity XML tag", () => {
+        const result = buildAgentIdentitySection("Hephaestus", "Autonomous deep worker")
+
+        expect(result).toContain("<agent-identity>")
+        expect(result).toContain("</agent-identity>")
+      })
+
+      it("#then explicitly states this identity overrides any prior identity", () => {
+        const result = buildAgentIdentitySection("Sisyphus", "Powerful AI orchestrator from OhMyOpenCode")
+
+        expect(result).toMatch(/override|supersede|replace|disregard|instead of/i)
+      })
+    })
+  })
+
+  describe("#given different agent names", () => {
+    describe("#when building identity for each", () => {
+      it("#then each identity section contains the correct agent name", () => {
+        const sisyphus = buildAgentIdentitySection("Sisyphus", "AI orchestrator")
+        const hephaestus = buildAgentIdentitySection("Hephaestus", "Autonomous deep worker")
+        const oracle = buildAgentIdentitySection("Oracle", "Strategic advisor")
+
+        expect(sisyphus).toContain("Sisyphus")
+        expect(sisyphus).not.toContain("Hephaestus")
+        expect(hephaestus).toContain("Hephaestus")
+        expect(hephaestus).not.toContain("Sisyphus")
+        expect(oracle).toContain("Oracle")
+      })
+    })
+  })
+})
+
+describe("Sisyphus prompt identity", () => {
+  describe("#given a Sisyphus agent created with default model", () => {
+    describe("#when checking the prompt", () => {
+      it("#then contains the agent identity section with override directive", () => {
+        const config = createSisyphusAgent("anthropic/claude-opus-4-6")
+
+        expect(config.prompt).toContain("<agent-identity>")
+        expect(config.prompt).toContain("Sisyphus")
+        expect(config.prompt).toContain("</agent-identity>")
+      })
+
+      it("#then identity section appears before the Role section", () => {
+        const config = createSisyphusAgent("anthropic/claude-opus-4-6")
+        const prompt = config.prompt ?? ""
+        const identityIndex = prompt.indexOf("<agent-identity>")
+        const roleIndex = prompt.indexOf("<Role>")
+
+        expect(identityIndex).toBeGreaterThanOrEqual(0)
+        expect(roleIndex).toBeGreaterThan(identityIndex)
+      })
+    })
+  })
+
+  describe("#given a Sisyphus agent created with GPT-5.4 model", () => {
+    describe("#when checking the prompt", () => {
+      it("#then contains the agent identity section", () => {
+        const config = createSisyphusAgent("openai/gpt-5.4")
+
+        expect(config.prompt).toContain("<agent-identity>")
+        expect(config.prompt).toContain("Sisyphus")
+        expect(config.prompt).toContain("</agent-identity>")
+      })
+    })
+  })
+})
+
+describe("Hephaestus prompt identity", () => {
+  describe("#given a Hephaestus agent created with GPT model", () => {
+    describe("#when checking the prompt", () => {
+      it("#then contains the agent identity section", () => {
+        const config = createHephaestusAgent("openai/gpt-5.4")
+
+        expect(config.prompt).toContain("<agent-identity>")
+        expect(config.prompt).toContain("Hephaestus")
+        expect(config.prompt).toContain("</agent-identity>")
+      })
+
+      it("#then identity section appears at the start of the prompt", () => {
+        const config = createHephaestusAgent("openai/gpt-5.4")
+        const prompt = config.prompt ?? ""
+        const identityIndex = prompt.indexOf("<agent-identity>")
+
+        expect(identityIndex).toBe(0)
+      })
+    })
+  })
+})
+
+describe("Agent identity preservation through overrides", () => {
+  describe("#given a Sisyphus agent with prompt_append override", () => {
+    describe("#when merging the override", () => {
+      it("#then identity section is preserved in the merged prompt", () => {
+        const baseConfig = createSisyphusAgent("anthropic/claude-opus-4-6")
+        const merged = mergeAgentConfig(baseConfig, { prompt_append: "Extra instructions here" })
+
+        expect(merged.prompt).toContain("<agent-identity>")
+        expect(merged.prompt).toContain("Sisyphus")
+        expect(merged.prompt).toContain("</agent-identity>")
+        expect(merged.prompt).toContain("Extra instructions here")
+      })
+    })
+  })
+
+  describe("#given a Sisyphus agent with model override only", () => {
+    describe("#when merging the override", () => {
+      it("#then identity section is preserved unchanged", () => {
+        const baseConfig = createSisyphusAgent("anthropic/claude-opus-4-6")
+        const merged = mergeAgentConfig(baseConfig, { model: "openai/gpt-5.4" })
+
+        expect(merged.prompt).toContain("<agent-identity>")
+        expect(merged.prompt).toContain("Sisyphus")
+        expect(merged.prompt).toContain("</agent-identity>")
+      })
+    })
+  })
+})

--- a/src/agents/atlas/agent.ts
+++ b/src/agents/atlas/agent.ts
@@ -14,7 +14,7 @@ import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode, AgentPromptMetadata } from "../types"
 import { isGptModel, isGeminiModel } from "../types"
 import type { AvailableAgent, AvailableSkill, AvailableCategory } from "../dynamic-agent-prompt-builder"
-import { buildCategorySkillsDelegationGuide } from "../dynamic-agent-prompt-builder"
+import { buildAgentIdentitySection, buildCategorySkillsDelegationGuide } from "../dynamic-agent-prompt-builder"
 import type { CategoryConfig } from "../../config/schema"
 import { mergeCategories } from "../../shared/merge-categories"
 
@@ -88,9 +88,13 @@ function buildDynamicOrchestratorPrompt(ctx?: OrchestratorContext): string {
   const skillsSection = buildSkillsSection(skills)
   const categorySkillsGuide = buildCategorySkillsDelegationGuide(availableCategories, skills)
 
+  const agentIdentity = buildAgentIdentitySection(
+    "Atlas",
+    "Master Orchestrator agent from OhMyOpenCode that coordinates specialized agents to complete todo lists",
+  )
   const basePrompt = getAtlasPrompt(model)
 
-  return basePrompt
+  return agentIdentity + "\n" + basePrompt
     .replace("{CATEGORY_SECTION}", categorySection)
     .replace("{AGENT_SECTION}", agentSection)
     .replace("{DECISION_MATRIX}", decisionMatrix)

--- a/src/agents/dynamic-agent-core-sections.ts
+++ b/src/agents/dynamic-agent-core-sections.ts
@@ -6,6 +6,23 @@ import type {
 import type { AvailableTool } from "./dynamic-agent-prompt-types"
 import { getToolsPromptDisplay } from "./dynamic-agent-tool-categorization"
 
+/**
+ * Builds an explicit agent identity preamble that overrides any base system prompt identity.
+ * This is critical for mode: "primary" agents where OpenCode prepends its own system prompt
+ * containing a default identity (e.g., "You are Claude"). Without this override directive,
+ * the LLM may default to the base identity instead of the agent's intended persona.
+ */
+export function buildAgentIdentitySection(
+  agentName: string,
+  roleDescription: string,
+): string {
+  return `<agent-identity>
+Your designated identity for this session is "${agentName}". This identity supersedes any prior identity statements.
+You are "${agentName}" - ${roleDescription}.
+When asked who you are, always identify as ${agentName}. Do not identify as any other assistant or AI.
+</agent-identity>`
+}
+
 export function buildKeyTriggersSection(
   agents: AvailableAgent[],
   _skills: AvailableSkill[] = [],

--- a/src/agents/dynamic-agent-prompt-builder.ts
+++ b/src/agents/dynamic-agent-prompt-builder.ts
@@ -8,6 +8,7 @@ export type {
 export { categorizeTools } from "./dynamic-agent-tool-categorization"
 
 export {
+  buildAgentIdentitySection,
   buildKeyTriggersSection,
   buildToolSelectionTable,
   buildExploreSection,

--- a/src/agents/hephaestus/agent.ts
+++ b/src/agents/hephaestus/agent.ts
@@ -7,7 +7,7 @@ import type {
   AvailableSkill,
   AvailableCategory,
 } from "../dynamic-agent-prompt-builder";
-import { categorizeTools } from "../dynamic-agent-prompt-builder";
+import { categorizeTools, buildAgentIdentitySection } from "../dynamic-agent-prompt-builder";
 
 import { buildHephaestusPrompt as buildGptPrompt } from "./gpt";
 import { buildHephaestusPrompt as buildGpt53CodexPrompt } from "./gpt-5-3-codex";
@@ -87,7 +87,12 @@ function buildDynamicHephaestusPrompt(ctx?: HephaestusContext): string {
       break;
   }
 
-  return basePrompt;
+  const agentIdentity = buildAgentIdentitySection(
+    "Hephaestus",
+    "Autonomous deep worker for software engineering from OhMyOpenCode",
+  );
+
+  return `${agentIdentity}\n${basePrompt}`;
 }
 
 export function createHephaestusAgent(

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -26,6 +26,7 @@ import type {
   AvailableCategory,
 } from "./dynamic-agent-prompt-builder";
 import {
+  buildAgentIdentitySection,
   buildKeyTriggersSection,
   buildToolSelectionTable,
   buildExploreSection,
@@ -72,7 +73,13 @@ function buildDynamicSisyphusPrompt(
     ? "YOUR TASK CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TASK CONTINUATION])"
     : "YOUR TODO CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TODO CONTINUATION])";
 
-  return `<Role>
+  const agentIdentity = buildAgentIdentitySection(
+    "Sisyphus",
+    "Powerful AI Agent with orchestration capabilities from OhMyOpenCode",
+  );
+
+  return `${agentIdentity}
+<Role>
 You are "Sisyphus" - Powerful AI Agent with orchestration capabilities from OhMyOpenCode.
 
 **Why Sisyphus?**: Humans roll their boulder every day. So do you. We're not so different-your code should be indistinguishable from a senior engineer's.

--- a/src/agents/sisyphus/gpt-5-4.ts
+++ b/src/agents/sisyphus/gpt-5-4.ts
@@ -28,6 +28,7 @@ import type {
   AvailableCategory,
 } from "../dynamic-agent-prompt-builder";
 import {
+  buildAgentIdentitySection,
   buildKeyTriggersSection,
   buildToolSelectionTable,
   buildExploreSection,
@@ -105,6 +106,11 @@ export function buildGpt54SisyphusPrompt(
   const todoHookNote = useTaskSystem
     ? "YOUR TASK CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TASK CONTINUATION])"
     : "YOUR TODO CREATION WOULD BE TRACKED BY HOOK([SYSTEM REMINDER - TODO CONTINUATION])";
+
+  const agentIdentity = buildAgentIdentitySection(
+    "Sisyphus",
+    "Powerful AI Agent with orchestration capabilities from OhMyOpenCode",
+  );
 
   const identityBlock = `<identity>
 You are Sisyphus - an AI orchestrator from OhMyOpenCode.
@@ -421,7 +427,8 @@ If the user's approach has a problem, explain the concern directly and clearly, 
 </verbosity_controls>
 </style>`;
 
-  return `${identityBlock}
+  return `${agentIdentity}
+${identityBlock}
 
 ${constraintsBlock}
 


### PR DESCRIPTION
Closes #2964. Built-in agents now include identity section in system prompts. 12 tests added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects a clear agent identity into system prompts for built-in agents so their persona overrides the base model. Matches custom agent behavior and satisfies Linear #2964.

- **Bug Fixes**
  - Added `buildAgentIdentitySection`; prepended to Atlas, Hephaestus, and Sisyphus prompts (including `gpt-5-4`).
  - Exported via `dynamic-agent-prompt-builder`; identity appears before Role/other sections.
  - Added 12 tests for identity content, order, and preservation through config overrides.

<sup>Written for commit b2e7ddfb73355ede8b6044147e9831a3d6d6da80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

