### PR TITLE
fix: register custom user agents in delegate-task resolver (#2689)

### DIFF
--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -293,6 +293,81 @@ describe("applyAgentConfig builtin override protection", () => {
     expect(createSisyphusJuniorAgentSpy).toHaveBeenCalledWith(undefined, "openai/gpt-5.4", false)
   })
 
+  test("defaults mode to subagent for configAgent entries missing mode", async () => {
+    // given
+    const config = createBaseConfig()
+    ;(config as Record<string, unknown>).agent = {
+      "custom-reviewer": {
+        name: "custom-reviewer",
+        prompt: "Review code for security issues",
+        description: "Custom code reviewer",
+      },
+    }
+
+    // when
+    const result = await applyAgentConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    const customAgent = result["custom-reviewer"] as Record<string, unknown>
+    expect(customAgent).toBeDefined()
+    expect(customAgent.mode).toBe("subagent")
+  })
+
+  test("preserves explicit mode on configAgent entries", async () => {
+    // given
+    const config = createBaseConfig()
+    ;(config as Record<string, unknown>).agent = {
+      "custom-primary": {
+        name: "custom-primary",
+        prompt: "Primary agent",
+        mode: "primary",
+      },
+    }
+
+    // when
+    const result = await applyAgentConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    const customAgent = result["custom-primary"] as Record<string, unknown>
+    expect(customAgent).toBeDefined()
+    expect(customAgent.mode).toBe("primary")
+  })
+
+  test("defaults mode to subagent for plugin agents missing mode", async () => {
+    // given
+    const pluginComponents = createPluginComponents()
+    pluginComponents.agents = {
+      "plugin-worker": {
+        name: "plugin-worker",
+        prompt: "Do work",
+        description: "Plugin worker agent",
+      } as Record<string, unknown>,
+    }
+
+    // when
+    const result = await applyAgentConfig({
+      config: createBaseConfig(),
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents,
+    })
+
+    // then
+    const pluginAgent = result["plugin-worker"] as Record<string, unknown>
+    expect(pluginAgent).toBeDefined()
+    expect(pluginAgent.mode).toBe("subagent")
+  })
+
   test("includes project and global .agents skills in builtin agent awareness", async () => {
     // given
     const projectAgentsSkill = {

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -99,10 +99,12 @@ export async function applyAgentConfig(params: {
   const rawPluginAgents = params.pluginComponents.agents;
 
   const pluginAgents = Object.fromEntries(
-    Object.entries(rawPluginAgents).map(([key, value]) => [
-      key,
-      value ? migrateAgentConfig(value as Record<string, unknown>) : value,
-    ]),
+    Object.entries(rawPluginAgents).map(([key, value]) => {
+      if (!value) return [key, value];
+      const migrated = migrateAgentConfig(value as Record<string, unknown>);
+      if (!migrated.mode) migrated.mode = "subagent";
+      return [key, migrated];
+    }),
   );
 
   const configAgent = params.config.agent as AgentConfigRecord | undefined;
@@ -219,10 +221,12 @@ export async function applyAgentConfig(params: {
               if (key in builtinAgents) return false;
               return true;
             })
-            .map(([key, value]) => [
-              key,
-              value ? migrateAgentConfig(value as Record<string, unknown>) : value,
-            ]),
+            .map(([key, value]) => {
+              if (!value) return [key, value];
+              const migrated = migrateAgentConfig(value as Record<string, unknown>);
+              if (!migrated.mode) migrated.mode = "subagent";
+              return [key, migrated];
+            }),
         )
       : {};
 
@@ -285,12 +289,23 @@ export async function applyAgentConfig(params: {
       protectedBuiltinAgentNames,
     );
 
+    const defaultedConfigAgents = configAgent
+      ? Object.fromEntries(
+          Object.entries(configAgent).map(([key, value]) => {
+            if (!value) return [key, value];
+            const migrated = migrateAgentConfig(value as Record<string, unknown>);
+            if (!migrated.mode) migrated.mode = "subagent";
+            return [key, migrated];
+          }),
+        )
+      : {};
+
     params.config.agent = {
       ...builtinAgents,
       ...filterDisabledAgents(filteredUserAgents),
       ...filterDisabledAgents(filteredProjectAgents),
       ...filterDisabledAgents(filteredPluginAgents),
-      ...configAgent,
+      ...defaultedConfigAgents,
     };
   }
 


### PR DESCRIPTION
Closes #2689. Custom agents from ~/.config/opencode/agents/ now registered in task subagent registry. 5005 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes registration of custom agents in the delegate-task resolver by defaulting missing mode to subagent. Agents from ~/.config/opencode/agents/ and plugin agents without a mode now register as subagents and can receive delegated tasks.

- **Bug Fixes**
  - Default missing mode to subagent for config and plugin agents; preserve explicit mode when set.
  - Register user config agents from ~/.config/opencode/agents/ in the subagent registry and add tests for defaulting and mode preservation.

<sup>Written for commit fc009caaa18f8b80d4c163dbd0e9a9f0df2883d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

