### PR TITLE
fix: propagate project skills to background task sessions (#2687)

### DIFF
--- a/src/tools/delegate-task/prompt-builder.test.ts
+++ b/src/tools/delegate-task/prompt-builder.test.ts
@@ -1,0 +1,125 @@
+declare const require: (name: string) => unknown
+const { describe, test, expect } = require("bun:test") as {
+  describe: (name: string, fn: () => void) => void
+  test: (name: string, fn: () => void) => void
+  expect: (value: unknown) => {
+    toBe: (expected: unknown) => void
+    toContain: (expected: string) => void
+    toBeUndefined: () => void
+    toBeDefined: () => void
+    not: {
+      toContain: (expected: string) => void
+      toBeUndefined: () => void
+    }
+  }
+}
+
+import { buildSystemContent } from "./prompt-builder"
+import type { AvailableSkill, AvailableCategory } from "../../agents/dynamic-agent-prompt-builder"
+
+describe("prompt-builder", () => {
+  describe("buildSystemContent", () => {
+    describe("#given non-plan agent with availableSkills", () => {
+      test("#when availableSkills contains project-level skills #then system content includes available_skills section", () => {
+        // given
+        const availableSkills: AvailableSkill[] = [
+          { name: "git-master", description: "Git workflow automation", location: "plugin" },
+          { name: "my-project-skill", description: "Project-specific deployment", location: "project" },
+        ]
+        const availableCategories: AvailableCategory[] = [
+          { name: "quick", description: "Trivial tasks", model: "openai/gpt-5.4-mini" },
+        ]
+
+        // when
+        const result = buildSystemContent({
+          agentName: "sisyphus-junior",
+          availableSkills,
+          availableCategories,
+        })
+
+        // then
+        expect(result).toBeDefined()
+        expect(result).toContain("my-project-skill")
+        expect(result).toContain("git-master")
+      })
+
+      test("#when agent is explore #then system content includes available_skills section", () => {
+        // given
+        const availableSkills: AvailableSkill[] = [
+          { name: "code-review", description: "Review code quality", location: "project" },
+        ]
+
+        // when
+        const result = buildSystemContent({
+          agentName: "explore",
+          availableSkills,
+        })
+
+        // then
+        expect(result).toBeDefined()
+        expect(result).toContain("code-review")
+      })
+
+      test("#when availableSkills is empty #then system content does not include available_skills section", () => {
+        // given
+        const availableSkills: AvailableSkill[] = []
+
+        // when
+        const result = buildSystemContent({
+          agentName: "sisyphus-junior",
+          availableSkills,
+          categoryPromptAppend: "some category context",
+        })
+
+        // then
+        expect(result).toBeDefined()
+        expect(result).not.toContain("available_skills")
+      })
+    })
+
+    describe("#given plan agent with availableSkills", () => {
+      test("#when availableSkills provided #then system content includes plan agent prepend with skills", () => {
+        // given
+        const availableSkills: AvailableSkill[] = [
+          { name: "git-master", description: "Git workflow automation", location: "plugin" },
+        ]
+        const availableCategories: AvailableCategory[] = [
+          { name: "quick", description: "Trivial tasks", model: "openai/gpt-5.4-mini" },
+        ]
+
+        // when
+        const result = buildSystemContent({
+          agentName: "plan",
+          availableSkills,
+          availableCategories,
+        })
+
+        // then
+        expect(result).toBeDefined()
+        expect(result).toContain("git-master")
+        expect(result).toContain("AVAILABLE SKILLS")
+      })
+    })
+
+    describe("#given non-plan agent with agentsContext override", () => {
+      test("#when agentsContext is provided #then it takes precedence and skills section is appended", () => {
+        // given
+        const availableSkills: AvailableSkill[] = [
+          { name: "deploy-skill", description: "Deployment automation", location: "project" },
+        ]
+
+        // when
+        const result = buildSystemContent({
+          agentName: "sisyphus-junior",
+          agentsContext: "Custom agent context here",
+          availableSkills,
+        })
+
+        // then
+        expect(result).toBeDefined()
+        expect(result).toContain("Custom agent context here")
+        expect(result).toContain("deploy-skill")
+      })
+    })
+  })
+})

--- a/src/tools/delegate-task/prompt-builder.ts
+++ b/src/tools/delegate-task/prompt-builder.ts
@@ -1,4 +1,5 @@
 import type { BuildSystemContentInput } from "./types"
+import type { AvailableSkill } from "../../agents/dynamic-agent-prompt-builder"
 import { buildPlanAgentSystemPrepend, isPlanAgent } from "./constants"
 import { buildSystemContentWithTokenLimit } from "./token-limiter"
 
@@ -19,6 +20,22 @@ function buildPlanAgentPromptAppend(tddEnabled: boolean): string {
 ${TDD_LINE}`
   }
   return PLAN_AGENT_PROMPT_BASE
+}
+
+function buildAvailableSkillsSection(skills: AvailableSkill[]): string {
+  if (skills.length === 0) {
+    return ""
+  }
+
+  const rows = skills
+    .map((s) => `- \`${s.name}\`: ${s.description || s.name}`)
+    .join("\n")
+
+  return `<available_skills>
+Skills provide specialized instructions. Load via load_skills parameter when delegating tasks.
+
+${rows}
+</available_skills>`
 }
 
 function usesFreeOrLocalModel(model: { providerID: string; modelID: string; variant?: string } | undefined): boolean {
@@ -51,9 +68,19 @@ export function buildSystemContent(input: BuildSystemContentInput): string | und
     availableSkills,
   } = input
 
-  const planAgentPrepend = isPlanAgent(agentName)
+  const isPlan = isPlanAgent(agentName)
+  const planAgentPrepend = isPlan
     ? buildPlanAgentSystemPrepend(availableCategories, availableSkills)
     : ""
+
+  const skillsSection = !isPlan
+    ? buildAvailableSkillsSection(availableSkills ?? [])
+    : ""
+
+  const baseAgentsContext = agentsContext ?? planAgentPrepend
+  const effectiveAgentsContext = !isPlan && skillsSection
+    ? [baseAgentsContext, skillsSection].filter(Boolean).join("\n\n")
+    : baseAgentsContext
 
   const effectiveMaxPromptTokens = maxPromptTokens
     ?? (usesFreeOrLocalModel(model) ? FREE_OR_LOCAL_PROMPT_TOKEN_LIMIT : undefined)
@@ -63,7 +90,7 @@ export function buildSystemContent(input: BuildSystemContentInput): string | und
       skillContent,
       skillContents,
       categoryPromptAppend,
-      agentsContext: agentsContext ?? planAgentPrepend,
+      agentsContext: effectiveAgentsContext,
       planAgentPrepend,
     },
     effectiveMaxPromptTokens


### PR DESCRIPTION
Closes #2687. Project-level skills from .opencode/skills/ now included in delegated session prompts. 5007 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates project-level skills from `.opencode/skills/` into delegated background task session prompts so agents can load and use them. Fixes #2687.

- **Bug Fixes**
  - Append `available_skills` to non-plan agent prompts; plan agents keep existing prepend behavior.
  - Respect `agentsContext` overrides and append skills after the custom context; omit the section when no skills exist.
  - Add tests for plan and non-plan agents, empty skills, and overrides.

<sup>Written for commit 2465205356bacb40efa1b3d7a54dbafb7e77e4a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

