### PR TITLE
fix(non-interactive-env): always use unix-style env prefix for bash-only hook (fixes #2344)

### DIFF
--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -250,7 +250,7 @@ describe("non-interactive-env hook", () => {
       expect(cmd).toContain("; git commit")
     })
 
-    test("#given Windows with PowerShell env #when bash tool git command executes #then uses powershell syntax", async () => {
+    test("#given Windows with PowerShell env #when bash tool git command executes #then uses unix syntax because bash tool always runs in bash", async () => {
       process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
       Object.defineProperty(process, "platform", { value: "win32" })
 
@@ -265,14 +265,13 @@ describe("non-interactive-env hook", () => {
       )
 
       const cmd = output.args.command as string
-      expect(cmd).toStartWith("$env:")
+      expect(cmd).toStartWith("export ")
       expect(cmd).toContain("; git status")
-      expect(cmd).toContain("$env:GIT_EDITOR=':'")
-      expect(cmd).not.toContain("set ")
-      expect(cmd).not.toContain("export ")
+      expect(cmd).toContain("GIT_EDITOR=:")
+      expect(cmd).not.toContain("$env:")
     })
 
-    test("#given Windows without SHELL env #when bash tool git command executes #then uses powershell syntax", async () => {
+    test("#given Windows without SHELL env #when bash tool git command executes #then uses unix syntax because bash tool always runs in bash", async () => {
       delete process.env.PSModulePath
       delete process.env.SHELL
       Object.defineProperty(process, "platform", { value: "win32" })
@@ -288,11 +287,10 @@ describe("non-interactive-env hook", () => {
       )
 
       const cmd = output.args.command as string
-      expect(cmd).toStartWith("$env:")
+      expect(cmd).toStartWith("export ")
       expect(cmd).toContain("; git log")
-      expect(cmd).not.toContain("set ")
-      expect(cmd).toContain("$env:GIT_EDITOR=':'")
-      expect(cmd).not.toContain("export ")
+      expect(cmd).toContain("GIT_EDITOR=:")
+      expect(cmd).not.toContain("$env:")
     })
 
     test("#given Windows Git Bash environment #when git command executes #then uses detected shell syntax", async () => {
@@ -317,7 +315,7 @@ describe("non-interactive-env hook", () => {
       expect(cmd.length).toBeGreaterThan("git status".length)
     })
 
-    test("#given Windows platform #when chained git commands via bash tool #then uses powershell syntax", async () => {
+    test("#given Windows platform #when chained git commands via bash tool #then uses unix syntax because bash tool always runs in bash", async () => {
       delete process.env.PSModulePath
       delete process.env.SHELL
       Object.defineProperty(process, "platform", { value: "win32" })
@@ -333,10 +331,10 @@ describe("non-interactive-env hook", () => {
       )
 
       const cmd = output.args.command as string
-      expect(cmd).toStartWith("$env:")
+      expect(cmd).toStartWith("export ")
       expect(cmd).toContain("; git add file && git commit")
-      expect(cmd).toContain("$env:GIT_EDITOR=':'")
-      expect(cmd).not.toContain("export ")
+      expect(cmd).toContain("GIT_EDITOR=:")
+      expect(cmd).not.toContain("$env:")
     })
   })
 })

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -52,8 +52,10 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
       // for git commands to prevent interactive prompts.
 
-      const shellType = process.platform === "win32" ? "powershell" : "unix"
-      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
+      // Always use unix-style prefix: this hook only processes Bash tool commands
+      // (guarded by the tool check above), so the prefix must be bash-compatible
+      // regardless of the host OS shell (e.g., PowerShell on Windows).
+      const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, "unix")
       
       // Check if the command already starts with the prefix to avoid stacking.
       // This maintains the non-interactive behavior and makes the operation idempotent.


### PR DESCRIPTION
## Summary
- Always use unix-style env prefix for bash commands regardless of host OS shell.

## Problem
The `non-interactive-env` hook prepends environment variables to git commands run via the Bash tool. On Windows, `process.platform === "win32"` causes PowerShell-style prefixes (`$env:VAR=value`) to be generated, but the Bash tool always executes in a bash-compatible shell. This breaks git commands on Windows.

## Fix
Hardcode `"unix"` as the shell type for `buildEnvPrefix()` since this hook only processes Bash tool commands (guarded by `input.tool.toLowerCase() !== "bash"` on line 28). The env prefix must always be bash-compatible (`export VAR=value;`).

## Changes
| File | Change |
|------|--------|
| `src/hooks/non-interactive-env/non-interactive-env-hook.ts` | Replace platform-based shell detection with hardcoded `"unix"` |

Fixes #2344

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force a unix-style env prefix for all commands run by the `non-interactive-env` bash hook to fix broken git commands on Windows. Ensures bash-compatible env injection and fixes #2344.

- **Bug Fixes**
  - Always pass "unix" to buildEnvPrefix() for this hook, since it only handles `bash` tool commands.
  - Update Windows tests to expect unix-style prefixes and verify git commands no longer fail.

<sup>Written for commit 6749de972f162d475fefe4056d9ef76ef8f7d091. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

