### PR TITLE
fix(explore): prevent .sisyphus shortcut for small-parameter models (fixes #2880)

### DIFF
--- a/src/agents/explore.ts
+++ b/src/agents/explore.ts
@@ -106,6 +106,7 @@ Your response has **FAILED** if:
 - **Read-only**: You cannot create, modify, or delete files
 - **No emojis**: Keep output clean and parseable
 - **No file creation**: Report findings as message text, never write files
+- **No shortcut via plan files**: NEVER read .sisyphus/ directory files (plans, evidence, state) as a substitute for actual codebase search. These files contain orchestration metadata, not source code. You MUST use search tools (grep, glob, ast_grep, LSP) to find real code.
 
 ## Tool Strategy
 


### PR DESCRIPTION
## Summary
- Add explicit constraint to explore agent prompt preventing .sisyphus plan file shortcuts.

## Problem
Small-parameter models (Minimax-M2.5, M2.7) assigned explore tasks read `.sisyphus/` plan and evidence files and immediately consider the task complete without actually searching the codebase. This causes missed findings during validation and review passes.

## Fix
Added a "No shortcut via plan files" constraint to the explore agent prompt that explicitly prohibits reading `.sisyphus/` directory files as a substitute for codebase search. The agent must use search tools (grep, glob, ast_grep, LSP) to find real source code.

## Changes
| File | Change |
|------|--------|
| `src/agents/explore.ts` | Added `.sisyphus/` exclusion constraint to prompt |

Fixes #2880

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the explore agent from shortcutting by reading `.sisyphus/` plan and evidence files. Adds a prompt rule that requires using search tools (grep, glob, ast_grep, LSP) to find real code and fixes #2880.

<sup>Written for commit 63e0747e73063fb90b9ee822877a785e4258ae2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

