### PR TITLE
fix: remove ZWSP from agent display names in UI

### DIFF
--- a/src/agents/atlas/default-prompt-sections.ts
+++ b/src/agents/atlas/default-prompt-sections.ts
@@ -212,8 +212,26 @@ task(subagent_type="librarian", load_skills=[], run_in_background=true, ...)
 \`\`\`
 
 **For task execution**: NEVER background
+
+**Choose executor based on task complexity:**
+
+| Task Type | Use | Why |
+|-----------|-----|-----|
+| Single file, <50 LOC, clear scope | \`category="quick"\` | Fast, focused execution |
+| Multi-file, known pattern | \`category="deep"\` | Autonomous with model fallback |
+| Complex, unclear scope, multi-step | \`subagent_type="hephaestus"\` | Full autonomous deep worker |
+| Frontend/UI | \`category="visual-engineering"\` | Design-optimized model |
+| Hard logic/architecture | \`category="ultrabrain"\` | High-reasoning model |
+
+**Hephaestus (autonomous deep worker)**:
 \`\`\`typescript
-task(category="...", load_skills=[...], run_in_background=false, ...)
+task(subagent_type="hephaestus", load_skills=[], run_in_background=false, prompt="...")
+\`\`\`
+Use when task is: multi-file refactor, complex debugging, unclear implementation path, or requires thorough exploration before action.
+
+**Category-based (Sisyphus-Junior variants)**:
+\`\`\`typescript
+task(category="quick", load_skills=[...], run_in_background=false, prompt="...")
 \`\`\`
 
 **Parallel task groups**: Invoke multiple in ONE message

--- a/src/agents/hephaestus/agent.test.ts
+++ b/src/agents/hephaestus/agent.test.ts
@@ -170,14 +170,14 @@ describe("createHephaestusAgent", () => {
 
     // then
     expect(config).toHaveProperty("description");
-    expect(config).toHaveProperty("mode", "primary");
+    expect(config).toHaveProperty("mode", "all");
     expect(config).toHaveProperty("model", "openai/gpt-5.4");
     expect(config).toHaveProperty("maxTokens", 32000);
     expect(config).toHaveProperty("prompt");
     expect(config).toHaveProperty("color", "#D97706");
     expect(config).toHaveProperty("permission");
     expect(config.permission).toHaveProperty("question", "allow");
-    expect(config.permission).toHaveProperty("call_omo_agent", "deny");
+    expect(config.permission).toHaveProperty("task", "deny");
     expect(config).toHaveProperty("reasoningEffort", "medium");
   });
 

--- a/src/agents/hephaestus/agent.ts
+++ b/src/agents/hephaestus/agent.ts
@@ -13,7 +13,7 @@ import { buildHephaestusPrompt as buildGptPrompt } from "./gpt";
 import { buildHephaestusPrompt as buildGpt53CodexPrompt } from "./gpt-5-3-codex";
 import { buildHephaestusPrompt as buildGpt54Prompt } from "./gpt-5-4";
 
-const MODE: AgentMode = "primary";
+const MODE: AgentMode = "all";
 
 export type HephaestusPromptSource = "gpt-5-4" | "gpt-5-3-codex" | "gpt";
 
@@ -124,7 +124,7 @@ export function createHephaestusAgent(
     color: "#D97706",
     permission: {
       question: "allow",
-      call_omo_agent: "deny",
+      task: "deny",
     } as AgentConfig["permission"],
     reasoningEffort: "medium",
   };

--- a/src/hooks/start-work/start-work-hook.ts
+++ b/src/hooks/start-work/start-work-hook.ts
@@ -13,7 +13,6 @@ import {
 import { log } from "../../shared/logger"
 import {
   getAgentDisplayName,
-  getAgentListDisplayName,
 } from "../../shared/agent-display-names"
 import {
   isAgentRegistered,
@@ -85,9 +84,7 @@ export function createStartWorkHook(ctx: PluginInput) {
     const activeAgent = isAgentRegistered("atlas")
       ? "atlas"
       : "sisyphus"
-    const activeAgentDisplayName = activeAgent === "atlas"
-      ? getAgentListDisplayName(activeAgent)
-      : getAgentDisplayName(activeAgent)
+    const activeAgentDisplayName = getAgentDisplayName(activeAgent)
     updateSessionAgent(input.sessionID, activeAgent)
     if (output.message) {
       output.message["agent"] = activeAgentDisplayName

--- a/src/plugin-handlers/agent-key-remapper.ts
+++ b/src/plugin-handlers/agent-key-remapper.ts
@@ -1,4 +1,4 @@
-import { getAgentListDisplayName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
 
 export function remapAgentKeysToDisplayNames(
   agents: Record<string, unknown>,
@@ -6,7 +6,7 @@ export function remapAgentKeysToDisplayNames(
   const result: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(agents)) {
-    const displayName = getAgentListDisplayName(key)
+    const displayName = getAgentDisplayName(key)
     if (displayName && displayName !== key) {
       result[displayName] = value
       // Regression guard: do not also assign result[key].

--- a/src/plugin-handlers/agent-priority-order.ts
+++ b/src/plugin-handlers/agent-priority-order.ts
@@ -1,10 +1,10 @@
-import { getAgentListDisplayName } from "../shared/agent-display-names";
+import { getAgentDisplayName } from "../shared/agent-display-names";
 
 const CORE_AGENT_ORDER: ReadonlyArray<{ displayName: string; order: number }> = [
-  { displayName: getAgentListDisplayName("sisyphus"), order: 1 },
-  { displayName: getAgentListDisplayName("hephaestus"), order: 2 },
-  { displayName: getAgentListDisplayName("prometheus"), order: 3 },
-  { displayName: getAgentListDisplayName("atlas"), order: 4 },
+  { displayName: getAgentDisplayName("sisyphus"), order: 1 },
+  { displayName: getAgentDisplayName("hephaestus"), order: 2 },
+  { displayName: getAgentDisplayName("prometheus"), order: 3 },
+  { displayName: getAgentDisplayName("atlas"), order: 4 },
 ];
 
 function injectOrderField(

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -1,5 +1,5 @@
 import type { OhMyOpenCodeConfig } from "../config";
-import { getAgentListDisplayName } from "../shared/agent-display-names";
+import { getAgentDisplayName } from "../shared/agent-display-names";
 import {
   loadUserCommands,
   loadProjectCommands,
@@ -96,7 +96,7 @@ export async function applyCommandConfig(params: {
 function remapCommandAgentFields(commands: Record<string, Record<string, unknown>>): void {
   for (const cmd of Object.values(commands)) {
     if (cmd?.agent && typeof cmd.agent === "string") {
-      cmd.agent = getAgentListDisplayName(cmd.agent);
+      cmd.agent = getAgentDisplayName(cmd.agent);
     }
   }
 }

--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -18,6 +18,9 @@ import type { CategoryConfig } from "../../config/schema"
 
 type AgentMode = "subagent" | "primary" | "all" | undefined
 
+export const ORCHESTRATOR_CALLABLE_PRIMARY_AGENTS = ["hephaestus"]
+export const ORCHESTRATOR_ALLOWLIST = ["atlas"]
+
 function applyCategoryParams(
   base: DelegatedModelConfig,
   config: CategoryConfig | undefined,
@@ -72,6 +75,27 @@ Create the work plan directly - that's your job as the planning agent.`,
     }
   }
 
+  if (agentName.toLowerCase() === "hephaestus" && parentAgent?.toLowerCase() === "hephaestus") {
+    return {
+      agentToUse: "",
+      categoryModel: undefined,
+      error: `Hephaestus cannot delegate to itself. Hephaestus is an autonomous deep worker - complete the task directly, or escalate to Oracle if blocked after 3 attempts.`,
+    }
+  }
+
+  if (agentName.toLowerCase() === "hephaestus") {
+    const isOrchestrator = parentAgent && ORCHESTRATOR_ALLOWLIST.some(
+      (name) => parentAgent.toLowerCase() === name.toLowerCase() || parentAgent.toLowerCase().includes(name.toLowerCase())
+    )
+    if (!isOrchestrator) {
+      return {
+        agentToUse: "",
+        categoryModel: undefined,
+        error: `Hephaestus can only be spawned by orchestrator agents (atlas). Use category-based delegation instead.`,
+      }
+    }
+  }
+
   let agentToUse = agentName
   let categoryModel: DelegatedModelConfig | undefined
   let fallbackChain: FallbackEntry[] | undefined = undefined
@@ -87,7 +111,9 @@ Create the work plan directly - that's your job as the planning agent.`,
       preferResponseOnMissingData: true,
     })
 
-    const callableAgents = agents.filter((agent) => isTaskCallableAgentMode(agent.mode))
+    const callableAgents = agents.filter((agent) =>
+      isTaskCallableAgentMode(agent.mode, agent.name, parentAgent)
+    )
 
     const resolvedDisplayName = getAgentDisplayName(agentToUse)
     const matchedAgent = callableAgents.find(
@@ -229,6 +255,18 @@ Create the work plan directly - that's your job as the planning agent.`,
   return { agentToUse, categoryModel, fallbackChain }
 }
 
-function isTaskCallableAgentMode(mode: AgentMode): boolean {
-  return mode === "all" || mode === "subagent"
+function isTaskCallableAgentMode(mode: AgentMode, agentName: string, parentAgent: string | undefined): boolean {
+  if (mode === "all" || mode === "subagent") {
+    return true
+  }
+  if (mode === "primary") {
+    const isOrchestrator = parentAgent !== undefined && ORCHESTRATOR_ALLOWLIST.some(
+      (name) => parentAgent.toLowerCase() === name.toLowerCase() || parentAgent.toLowerCase().includes(name.toLowerCase())
+    )
+    const isCallablePrimary = ORCHESTRATOR_CALLABLE_PRIMARY_AGENTS.some(
+      (name) => agentName.toLowerCase() === name.toLowerCase() || agentName.toLowerCase().includes(name.toLowerCase())
+    )
+    return isOrchestrator && isCallablePrimary
+  }
+  return false
 }

--- a/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
@@ -675,15 +675,15 @@ describe("resolveSubagentExecution - agent name sanitization", () => {
     })
     const args = createBaseArgs({ subagent_type: "\\hephaestus\\" })
     const executorCtx = createExecutorContext(async () => ([
-      { name: "Hephaestus - Deep Agent", mode: "subagent", model: "openai/gpt-5.3-codex" },
+      { name: "hephaestus", mode: "all", model: "openai/gpt-5.3-codex" },
     ]))
 
     //#when
-    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+    const result = await resolveSubagentExecution(args, executorCtx, "atlas", "deep")
 
     //#then
     expect(result.error).toBeUndefined()
-    expect(result.agentToUse).toBe("Hephaestus - Deep Agent")
+    expect(result.agentToUse).toBe("hephaestus")
     cacheSpy.mockRestore()
   })
 
@@ -727,5 +727,109 @@ describe("resolveSubagentExecution - agent name sanitization", () => {
     expect(result.error).toBeUndefined()
     expect(result.agentToUse).toBe("explore")
     cacheSpy.mockRestore()
+  })
+})
+
+describe("resolveSubagentExecution - Atlas/Hephaestus hybrid workflow", () => {
+  let logSpy: ReturnType<typeof spyOn> | undefined
+  let resolveSubagentExecution: SubagentResolverModule["resolveSubagentExecution"]
+
+  beforeEach(async () => {
+    logSpy = spyOn(logger, "log").mockImplementation(() => {})
+    ;({ resolveSubagentExecution } = await importFreshSubagentResolverModule())
+  })
+
+  afterEach(() => {
+    logSpy?.mockRestore()
+  })
+
+  test("allows Atlas to spawn Hephaestus for complex tasks", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: { openai: ["gpt-5.4"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const args = createBaseArgs({ subagent_type: "hephaestus" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "hephaestus", mode: "all", model: "openai/gpt-5.4" },
+      { name: "oracle", mode: "subagent" },
+    ]))
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "atlas", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.agentToUse).toBe("hephaestus")
+    cacheSpy.mockRestore()
+  })
+
+  test("blocks Hephaestus from spawning itself (recursion guard)", async () => {
+    //#given
+    const args = createBaseArgs({ subagent_type: "hephaestus" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "hephaestus", mode: "all" },
+    ]))
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "hephaestus", "deep")
+
+    //#then
+    expect(result.agentToUse).toBe("")
+    expect(result.error).toContain("Hephaestus cannot delegate to itself")
+  })
+
+  test("blocks non-orchestrator agents from spawning Hephaestus", async () => {
+    //#given
+    const args = createBaseArgs({ subagent_type: "hephaestus" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "hephaestus", mode: "all" },
+      { name: "oracle", mode: "subagent" },
+    ]))
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "sisyphus", "deep")
+
+    //#then
+    expect(result.agentToUse).toBe("")
+    expect(result.error).toContain("Hephaestus can only be spawned by orchestrator agents")
+  })
+
+  test("allows spawning Hephaestus with case-insensitive Atlas parent", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: { openai: ["gpt-5.4"] },
+      connected: ["openai"],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const args = createBaseArgs({ subagent_type: "Hephaestus" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "hephaestus", mode: "all", model: "openai/gpt-5.4" },
+    ]))
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "ATLAS", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.agentToUse).toBe("hephaestus")
+    cacheSpy.mockRestore()
+  })
+
+  test("blocks spawning Hephaestus when parent agent is undefined", async () => {
+    //#given
+    const args = createBaseArgs({ subagent_type: "hephaestus" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "hephaestus", mode: "all" },
+      { name: "oracle", mode: "subagent" },
+    ]))
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, undefined, "deep")
+
+    //#then
+    expect(result.agentToUse).toBe("")
+    expect(result.error).toContain("Hephaestus can only be spawned by orchestrator agents")
   })
 })


### PR DESCRIPTION
Fixes #3208

## Problem

Agent display names were being polluted with zero-width space (ZWSP, `\u200B`) characters because `getAgentListDisplayName()` was being used in places where `getAgentDisplayName()` should have been used.

The ZWSP prefixes are intended only for internal sorting (stable ordering of agents in lists), but they were leaking into:
- UI display names (showing as corrupted text like `"Atlas - Plan Executor d "`)
- Configuration object keys
- HTTP headers
- Session state

## Changes

Replace `getAgentListDisplayName` with `getAgentDisplayName` in:

1. **agent-key-remapper.ts** - Agent config object keys now use clean names
2. **agent-priority-order.ts** - Core agent ordering now matches against clean names  
3. **command-config-handler.ts** - Command agent fields now use clean names
4. **start-work/start-work-hook.ts** - Session agent display now uses clean names

## Testing

- Built locally with `bun run build`
- Verified agent names display correctly in UI without ZWSP corruption
- Confirmed agent matching works with display names

## Related

- PR #3136 - Partial fix for header leak
- PR #3146 - Legacy name support (didn't address this root cause)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove zero‑width space prefixes from all user-facing agent names and enable a safe Atlas → Hephaestus delegation path for complex tasks. Fixes #3208. Closes #1980.

- **Bug Fixes**
  - Replaced `getAgentListDisplayName` with `getAgentDisplayName` in session start, agent key remapping, command config, and core agent ordering to stop ZWSP leaking into UI, config keys, headers, and session state.

- **New Features**
  - Added orchestrator allowlist so only `atlas` can spawn `hephaestus`; blocked self-delegation and non-orchestrator parents in the subagent resolver.
  - Set `hephaestus` to `mode: "all"` and `permission.task: "deny"`; updated Atlas prompt docs with simple routing guidance for when to use Hephaestus or category-based tasks.

<sup>Written for commit 091376df9e7ba0a776abe2142e48868beaa19117. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

