### PR TITLE
fix: resolve agent display names before promptAsync injection

### DIFF
--- a/src/hooks/todo-continuation-enforcer/continuation-injection.test.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.test.ts
@@ -40,7 +40,7 @@ describe("injectContinuation", () => {
     })
 
     // then
-    expect(capturedAgent).toBe("sisyphus")
+    expect(capturedAgent).toBe("Sisyphus - Ultraworker")
   })
 
   test("inherits tools from resolved message info when reinjecting", async () => {

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -16,7 +16,7 @@ import { log } from "../../shared/logger"
 import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 import {
   getAgentConfigKey,
-  normalizeAgentForPromptKey,
+  normalizeAgentForPrompt,
 } from "../../shared/agent-display-names"
 
 import {
@@ -126,7 +126,7 @@ export async function injectContinuation(args: {
     tools = tools ?? previousMessage?.tools
   }
 
-  const promptAgent = normalizeAgentForPromptKey(agentName)
+  const promptAgent = normalizeAgentForPrompt(agentName)
 
   if (promptAgent && skipAgents.some(s => getAgentConfigKey(s) === getAgentConfigKey(promptAgent))) {
     log(`[${HOOK_NAME}] Skipped: agent in skipAgents list`, { sessionID, agent: agentName })


### PR DESCRIPTION
## Problem

`injectContinuation()` passes config keys (e.g. `"sisyphus"`) to `promptAsync`,
but the OpenCode runtime registers agents under display names
(e.g. `"Sisyphus - Ultraworker"`). The lookup fails, the session errors, goes
idle, and the enforcer retries — creating an infinite error loop that freezes the
session after all sub-agents complete.

```
[todo-continuation-enforcer] Injecting continuation agent:"sisyphus"
[auto-compact] session.error: Agent not found: "sisyphus".
  Available agents: Sisyphus (Ultraworker), ...
```

## Root Cause

`continuation-injection.ts` imports `normalizeAgentForPromptKey` (returns config
keys) instead of `normalizeAgentForPrompt` (returns display names). The correct
function already exists in `agent-display-names.ts` — this is a one-import fix.

## Changes

- `continuation-injection.ts`: swap `normalizeAgentForPromptKey` →
  `normalizeAgentForPrompt`
- `continuation-injection.test.ts`: update assertion to expect display name

## Testing

- Reproduced on v3.15.3 with multi-agent session (Sisyphus + background agents)
- Verified fix resolves the freeze loop
- `bun run typecheck` should pass (import/usage types unchanged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent lookup during continuation injection by resolving display names before calling `promptAsync`. Prevents “Agent not found” errors and the enforcer retry loop that froze sessions.

- **Bug Fixes**
  - Use `normalizeAgentForPrompt` instead of `normalizeAgentForPromptKey` in `continuation-injection.ts` to pass the runtime display name (e.g., “Sisyphus - Ultraworker”).
  - Update test to expect the display name in `continuation-injection.test.ts`.

<sup>Written for commit 1a592b0ff9befb0f33d39671e9d0c2c9b279cfdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

