### PR TITLE
fix: Update toast titles from OhMyOpenCode to OhMyOpenAgent

### DIFF
--- a/src/hooks/auto-update-checker/hook/update-toasts.ts
+++ b/src/hooks/auto-update-checker/hook/update-toasts.ts
@@ -9,7 +9,7 @@ export async function showUpdateAvailableToast(
   await ctx.client.tui
     .showToast({
       body: {
-        title: `OhMyOpenCode ${latestVersion}`,
+        title: `OhMyOpenAgent ${latestVersion}`,
         message: getToastMessage(true, latestVersion),
         variant: "info" as const,
         duration: 8000,
@@ -23,7 +23,7 @@ export async function showAutoUpdatedToast(ctx: PluginInput, oldVersion: string,
   await ctx.client.tui
     .showToast({
       body: {
-        title: "OhMyOpenCode Updated!",
+        title: "OhMyOpenAgent Updated!",
         message: `v${oldVersion} → v${newVersion}\nRestart OpenCode to apply.`,
         variant: "success" as const,
         duration: 8000,


### PR DESCRIPTION
## Summary

fix: Update toast titles from OhMyOpenCode to OhMyOpenAgent

- 

## Changes

fix: Update toast titles from OhMyOpenCode to OhMyOpenAgent

- 


## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the “update available” and “updated” toast titles from OhMyOpenCode to OhMyOpenAgent to match current branding and avoid confusion.

<sup>Written for commit c414b47b2ed63a72449857bc8982998f524821a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

