### PR TITLE
fix: Update toast title from 'OhMyOpenCode' to 'OhMyOpenAgent'

### DIFF
--- a/src/hooks/auto-update-checker/hook/spinner-toast.ts
+++ b/src/hooks/auto-update-checker/hook/spinner-toast.ts
@@ -12,7 +12,7 @@ export async function showSpinnerToast(ctx: PluginInput, version: string, messag
     await ctx.client.tui
       .showToast({
         body: {
-          title: `${spinner} OhMyOpenCode ${version}`,
+          title: `${spinner} OhMyOpenAgent ${version}`,
           message,
           variant: "info" as const,
           duration: frameInterval + 50,


### PR DESCRIPTION
## Summary

- fix: Update toast title from 'OhMyOpenCode' to 'OhMyOpenAgent'

## Changes

fix: Update toast title from 'OhMyOpenCode' to 'OhMyOpenAgent'



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the auto-update spinner toast title to show "OhMyOpenAgent {version}" instead of "OhMyOpenCode", so users see the correct product name during update checks.

<sup>Written for commit 23031b2324b591203f6e67b253b8ada87896117e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

