### PR TITLE
fix(preemptive-compaction): notify user on failure and reduce timeout

### DIFF
--- a/src/hooks/preemptive-compaction.test.ts
+++ b/src/hooks/preemptive-compaction.test.ts
@@ -284,8 +284,55 @@ describe("preemptive-compaction", () => {
     //#then
     expect(logMock).toHaveBeenCalledWith("[preemptive-compaction] Compaction failed", {
       sessionID,
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
       error: String(summarizeError),
     })
+  })
+
+  // #given compaction fails
+  // #when tool.execute.after completes the catch block
+  // #then should show a warning toast explaining the failure to the user
+  it("should show a warning toast when preemptive compaction fails", async () => {
+    //#given
+    const hook = createPreemptiveCompactionHook(ctx as never, {} as never)
+    const sessionID = "ses_toast_on_failure"
+    const summarizeError = new Error("upstream rate limited")
+    ctx.client.session.summarize.mockRejectedValueOnce(summarizeError)
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            finish: true,
+            tokens: {
+              input: 170000,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    //#when
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_toast" },
+      { title: "", output: "test", metadata: null },
+    )
+
+    //#then
+    expect(ctx.client.tui.showToast).toHaveBeenCalledTimes(1)
+    const toastCall = ctx.client.tui.showToast.mock.calls[0]?.[0]
+    expect(toastCall?.body?.title).toBe("Preemptive compaction failed")
+    expect(toastCall?.body?.variant).toBe("warning")
+    expect(String(toastCall?.body?.message)).toContain("upstream rate limited")
   })
 
   // #given compaction fails
@@ -475,6 +522,8 @@ describe("preemptive-compaction", () => {
       expect(ctx.client.session.summarize).toHaveBeenCalledTimes(1)
       expect(logMock).toHaveBeenCalledWith("[preemptive-compaction] Compaction failed", {
         sessionID,
+        providerID: "anthropic",
+        modelID: "claude-sonnet-4-6",
         error: expect.stringContaining("Compaction summarize timed out"),
       })
 

--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -8,7 +8,7 @@ import {
 import { resolveCompactionModel } from "./shared/compaction-model-resolver"
 import { createPostCompactionDegradationMonitor } from "./preemptive-compaction-degradation-monitor"
 
-const PREEMPTIVE_COMPACTION_TIMEOUT_MS = 120_000
+const PREEMPTIVE_COMPACTION_TIMEOUT_MS = 60_000
 const PREEMPTIVE_COMPACTION_THRESHOLD = 0.78
 const PREEMPTIVE_COMPACTION_COOLDOWN_MS = 60_000
 
@@ -134,7 +134,25 @@ export function createPreemptiveCompactionHook(
 
       compactedSessions.add(sessionID)
     } catch (error) {
-      log("[preemptive-compaction] Compaction failed", { sessionID, error: String(error) })
+      log("[preemptive-compaction] Compaction failed", {
+        sessionID,
+        providerID: cached.providerID,
+        modelID: cached.modelID,
+        error: String(error),
+      })
+      ctx.client.tui.showToast({
+        body: {
+          title: "Preemptive compaction failed",
+          message: `Context window is above ${Math.round(PREEMPTIVE_COMPACTION_THRESHOLD * 100)}% and auto-compaction could not run. The session may grow large. Error: ${String(error)}`,
+          variant: "warning",
+          duration: 10000,
+        },
+      }).catch((toastError: unknown) => {
+        log("[preemptive-compaction] Failed to show toast", {
+          sessionID,
+          toastError: String(toastError),
+        })
+      })
     } finally {
       compactionInProgress.delete(sessionID)
     }


### PR DESCRIPTION
## Summary

Fix 'stuck at 80% context' reports. Users (david_66 on Discord) described sessions becoming unresponsive when the preemptive compaction threshold was crossed. Root causes in `src/hooks/preemptive-compaction.ts`:

1. **120s perceived hang.** `PREEMPTIVE_COMPACTION_TIMEOUT_MS` was 120 seconds. While `session.summarize()` is in flight, `tool.execute.after` short-circuits via the `compactionInProgress` guard, so a hung summarize call blocks the session for two full minutes before giving up. From the user's chair this is indistinguishable from a crash.

2. **Silent failure.** On failure (timeout or exception), only a `log()` line was emitted. The user got zero signal about why their session was unresponsive or why auto-compaction never ran, so a transient upstream error could silently leave them well above the threshold.

## Fix

- Reduce `PREEMPTIVE_COMPACTION_TIMEOUT_MS` from 120s → 60s. Still generous for the upstream, but caps the worst-case perceived hang at one minute.
- Show a `warning`-variant toast via `ctx.client.tui.showToast` whenever the catch block fires. Includes the underlying error string so the user can decide whether to retry, run `/compact` manually, or swap providers.
- Include `providerID`/`modelID` in the `Compaction failed` log entry so real-world failures are easier to correlate to a specific compaction target model.

## Test coverage

- Existing failure-path assertions (`should log summarize errors instead of swallowing them`, `should clear in-progress lock when summarize times out`) updated to match the new log shape (`providerID`/`modelID` included).
- New test: `should show a warning toast when preemptive compaction fails` — verifies the toast title, variant, and that the error message surfaces to the user.

```
bun test src/hooks/preemptive-compaction
→ 20 pass / 0 fail / 30 expect() calls

bun run typecheck
→ clean
```

## Related

- Discord report: https://discord.com/channels/1452487457085063218/1490536332961906829/1491345441399505037
- Confirmed by @code-yeongyu as 'it is a bug' in the same thread.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce preemptive compaction timeout to 60s and show a warning toast on failure to prevent sessions feeling “stuck” near the 78% context threshold.

- **Bug Fixes**
  - Cut `PREEMPTIVE_COMPACTION_TIMEOUT_MS` from 120s to 60s to cap perceived stalls.
  - Show a `warning` toast via `ctx.client.tui.showToast` with the error message when compaction fails.
  - Log `providerID` and `modelID` with compaction failures for easier debugging.
  - Tests: added toast notification test and updated failure-path assertions.

<sup>Written for commit 1ea0ee4319e3129183749fc7bdb96ec46fa35fbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

