### PR TITLE
fix(ci): isolate model-resolver and prometheus-config tests from mock.module contamination

### DIFF
--- a/src/plugin-handlers/prometheus-agent-config-builder.test.ts
+++ b/src/plugin-handlers/prometheus-agent-config-builder.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test, spyOn, afterEach, beforeEach } from "bun:test";
+import { describe, expect, test, spyOn, afterEach, beforeEach, mock } from "bun:test";
+
+// Isolate from other tests that mock.module the logger (CI cross-contamination fix)
+mock.module("../shared/logger", () => ({ log: (..._args: unknown[]) => {} }))
+
 import { buildPrometheusAgentConfig } from "./prometheus-agent-config-builder";
 import * as shared from "../shared";
 import * as categoryResolver from "./category-config-resolver";

--- a/src/shared/model-resolver.test.ts
+++ b/src/shared/model-resolver.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test, spyOn, beforeEach, afterEach, mock } from "bun:test"
+
+// Isolate from other tests that mock.module the logger (CI cross-contamination fix)
+mock.module("./logger", () => ({ log: (..._args: unknown[]) => {} }))
+
 import { resolveModel, resolveModelWithFallback, type ModelResolutionInput, type ExtendedModelResolutionInput, type ModelResolutionResult, type ModelSource } from "./model-resolver"
 import * as logger from "./logger"
 import * as connectedProvidersCache from "./connected-providers-cache"


### PR DESCRIPTION
## Summary

Fixes the flaky CI failure where `resolveModelWithFallback` (41 tests) and `buildPrometheusAgentConfig` (5 tests) pass locally but randomly fail in CI's shared test batch.

## Root cause

Both files use `spyOn(shared, 'log')` to intercept logger calls. But they don't own the logger module. When other test files in the same `bun test` process call `mock.module('../shared/logger', ...)`, the import cache is poisoned — the spy targets a stale module binding and `mock.calls` stays empty.

`run-ci-tests.ts` auto-detects files containing `mock.module(` and runs them in isolated `bun test` processes. But these two files didn't use `mock.module` directly (they used `spyOn`), so they ran in the shared batch where any mock.module'd logger from an isolated test could contaminate them via Bun's module cache.

## Fix

Add a lightweight `mock.module` call at the top of each file:

```typescript
mock.module('../shared/logger', () => ({ log: (..._args: unknown[]) => {} }))
```

This causes `run-ci-tests.ts` to auto-detect and isolate them, giving each file its own clean module instance.

## Validation

```
bun run script/run-ci-tests.ts → 4437 pass / 0 fail (shared) + isolated targets all green
bun run typecheck → clean
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky CI by isolating two test files from logger mock contamination. Adds a no-op `mock.module` for the shared logger so `run-ci-tests.ts` runs them in separate `bun test` processes.

**Bug Fixes**
- `src/shared/model-resolver.test.ts`: add `mock.module("./logger", () => ({ log: () => {} }))` to isolate logger.
- `src/plugin-handlers/prometheus-agent-config-builder.test.ts`: add `mock.module("../shared/logger", () => ({ log: () => {} }))`.
- Ensures `spyOn` targets the correct logger instance and prevents stale bindings from other tests that mock the logger.

<sup>Written for commit 6943b6d4d8b631c0290a31c95c8f0d999902c68e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

