### PR TITLE
fix(default-agent): use getAgentListDisplayName to include sorting prefix

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -3,7 +3,7 @@ import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junio
 import type { OhMyOpenCodeConfig } from "../config";
 import { isTaskSystemEnabled, log, migrateAgentConfig } from "../shared";
 import { AGENT_NAME_MAP } from "../shared/migration";
-import { getAgentDisplayName } from "../shared/agent-display-names";
+import { getAgentDisplayName, getAgentListDisplayName } from "../shared/agent-display-names";
 import { registerAgentName } from "../features/claude-code-session-state";
 import {
   discoverConfigSourceSkills,
@@ -159,10 +159,10 @@ export async function applyAgentConfig(params: {
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
     if (configuredDefaultAgent) {
       (params.config as { default_agent?: string }).default_agent =
-        getAgentDisplayName(configuredDefaultAgent);
+        getAgentListDisplayName(configuredDefaultAgent);
     } else {
       (params.config as { default_agent?: string }).default_agent =
-        getAgentDisplayName("sisyphus");
+        getAgentListDisplayName("sisyphus");
     }
 
     // Assembly order: Sisyphus -> Hephaestus -> Prometheus -> Atlas


### PR DESCRIPTION
# Bug: `default_agent` fails with "agent not found" due to zero-width prefix mismatch

## Summary

When `oh-my-openagent` is configured with `default_agent: "sisyphus"`, running `opencode run` fails with:
```
error: default agent "Sisyphus - Ultraworker" not found
```

The bug occurs because `default_agent` is set to the display name **without** zero-width sorting prefixes, but agent keys are remapped **with** these prefixes. OpenCode's agent lookup does exact string matching and fails.

## Steps to Reproduce

1. Install oh-my-openagent: `bun add oh-my-openagent@latest`
2. Configure with `default_agent: "sisyphus"` in `oh-my-openagent.json`
3. Run: `opencode run "Say hello!"`
4. Error: `default agent "Sisyphus - Ultraworker" not found`

## Root Cause

In `src/plugin-handlers/agent-config-handler.ts`:

```typescript
// default_agent is set WITHOUT zero-width prefix:
(params.config as { default_agent?: string }).default_agent =
  getAgentDisplayName(configuredDefaultAgent);  
// Result: "Sisyphus - Ultraworker"

// But agent keys are remapped WITH zero-width prefix:
params.config.agent = remapAgentKeysToDisplayNames(params.config.agent);
// Result: { "\u200BSisyphus - Ultraworker": {...}, ... }
```

When OpenCode looks up `"Sisyphus - Ultraworker"` in the agents object, it finds `"\u200BSisyphus - Ultraworker"` (with zero-width space `\u200B`) → mismatch!

The zero-width prefixes are intentional for UI sorting order (see `AGENT_LIST_SORT_PREFIXES`), but `default_agent` should use the same prefixed form to match the remapped keys.

## Affected Versions

- v3.14.0 - v3.16.0+ (likely present since agent key remapping was introduced)
- The v3.14.0 changelog mentions "Agent键别名保留" fixing related issues, but `default_agent` was not included in that fix

## Suggested Fix

**File:** `src/plugin-handlers/agent-config-handler.ts`

**Lines:** ~107-111

```diff
  if (isSisyphusEnabled && builtinAgents.sisyphus) {
    if (configuredDefaultAgent) {
-     (params.config as { default_agent?: string }).default_agent =
-       getAgentDisplayName(configuredDefaultAgent);
+     (params.config as { default_agent?: string }).default_agent =
+       getAgentListDisplayName(configuredDefaultAgent);
    } else {
-     (params.config as { default_agent?: string }).default_agent =
-       getAgentDisplayName("sisyphus");
+     (params.config as { default_agent?: string }).default_agent =
+       getAgentListDisplayName("sisyphus");
    }
```

This ensures `default_agent` includes the same zero-width sorting prefix as the remapped agent keys, allowing OpenCode's agent lookup to succeed.

## Workaround

Until fixed, users can work around this by:

1. **Set via environment variable:**
   ```bash
   OPENCODE_DEFAULT_AGENT=build opencode run "Say hello!"
   ```

2. **Use pure mode (no plugins):**
   ```bash
   opencode run "Say hello!" --pure
   ```

3. **Use the oh-my-opencode CLI wrapper:**
   ```bash
   bunx oh-my-opencode run "Say hello!"
   ```
   (Note: this also has the same underlying bug but may handle it differently)

## Additional Context

- Zero-width sorting prefixes are defined in `AGENT_LIST_SORT_PREFIXES` for UI ordering
- The `getAgentDisplayName()` function returns plain display names
- The `getAgentListDisplayName()` function adds the sorting prefix
- Related: v3.14.0 fixed similar issues in `atlas/boulder-continuation-injector.ts` and `features/claude-code-session-state/state.ts`

## Labels

`bug`, `good first issue`, `regression`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes "agent not found" when a default agent is set. We now use getAgentListDisplayName to include the zero-width sorting prefix so `default_agent` matches remapped agent keys.

<sup>Written for commit 5c6b0b07b0c4f3d35797867f22d3b8e4d23a66a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

