### PR TITLE
fix: normalize runtime agent names in delegate-task

### DIFF
--- a/src/tools/delegate-task/subagent-resolver.ts
+++ b/src/tools/delegate-task/subagent-resolver.ts
@@ -107,7 +107,13 @@ Create the work plan directly - that's your job as the planning agent.`,
       }
     }
 
-    agentToUse = matchedAgent.name
+    const runtimeSafeAgentName = getAgentConfigKey(matchedAgent.name)
+    const canonicalDisplayName = getAgentDisplayName(runtimeSafeAgentName).replace(/^\u200B+/, "")
+    const isKnownBuiltinAgent =
+      canonicalDisplayName.toLowerCase() === matchedAgent.name.toLowerCase()
+      || runtimeSafeAgentName === matchedAgent.name.toLowerCase()
+
+    agentToUse = isKnownBuiltinAgent ? runtimeSafeAgentName : matchedAgent.name
 
     const agentConfigKey = getAgentConfigKey(agentToUse)
     const agentOverride = agentOverrides?.[agentConfigKey as keyof typeof agentOverrides]

--- a/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
@@ -683,7 +683,7 @@ describe("resolveSubagentExecution - agent name sanitization", () => {
 
     //#then
     expect(result.error).toBeUndefined()
-    expect(result.agentToUse).toBe("Hephaestus - Deep Agent")
+    expect(result.agentToUse).toBe("hephaestus")
     cacheSpy.mockRestore()
   })
 
@@ -726,6 +726,27 @@ describe("resolveSubagentExecution - agent name sanitization", () => {
     //#then
     expect(result.error).toBeUndefined()
     expect(result.agentToUse).toBe("explore")
+    cacheSpy.mockRestore()
+  })
+
+  test("resolves builtin display names to runtime-safe config keys", async () => {
+    //#given
+    const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
+      models: {},
+      connected: [],
+      updatedAt: "2026-03-03T00:00:00.000Z",
+    })
+    const args = createBaseArgs({ subagent_type: "Sisyphus - Ultraworker" })
+    const executorCtx = createExecutorContext(async () => ([
+      { name: "Sisyphus - Ultraworker", mode: "subagent", model: "openai/gpt-5.3-codex" },
+    ]))
+
+    //#when
+    const result = await resolveSubagentExecution(args, executorCtx, "oracle", "deep")
+
+    //#then
+    expect(result.error).toBeUndefined()
+    expect(result.agentToUse).toBe("sisyphus")
     cacheSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary

- Fix delegate-task subagent resolution so builtin agent display names are normalized to runtime-safe config keys before prompt/session delegation.
- Prevent `Agent not found` failures caused by passing UI display names such as `Sisyphus - Ultraworker` into the runtime.
- Add regression coverage for builtin display-name resolution.

## Changes

- Updated `src/tools/delegate-task/subagent-resolver.ts`
  - When a builtin agent is matched by display name, it now resolves to the runtime-safe config key (for example `sisyphus`) instead of forwarding the display label.
  - Custom/unknown agent names are still preserved as-is.
- Updated `src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts`
  - Adjusted the existing builtin display-name expectation from display label to config key.
  - Added a regression test for `Sisyphus - Ultraworker` resolving to `sisyphus`.

## Screenshots

Not applicable.

## Testing

```bash
bun test src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
bun run typecheck
bun run build
```

## Related Issues

Reproduction observed locally while running `omo-plan-draft` / delegation flows:

```text
Port range exhausted, attaching to existing server on 4096
Session: ses_2901f6719ffeHZcN5g5w5nGMtJ
[session.error] Agent not found: "Sisyphus - Ultraworker". Available agents: Sisyphus (Ultraworker), Hephaestus (Deep Agent), Metis (Plan Consultant), Momus (Plan Critic), Prometheus (Plan Builder), Sisyphus-Junior, explore, general, librarian, multimodal-looker, oracle, plan, Atlas (Plan Executor)
[session.error] UnknownError
Session ended with error: UnknownError
Check if todos were completed before the error.
```

Root cause:
- Oh My OpenAgent keeps UI/display names like `Sisyphus - Ultraworker`.
- Runtime delegation expects canonical/runtime-safe names such as `sisyphus` or the runtime-registered agent name.
- `subagent-resolver.ts` was forwarding `matchedAgent.name` directly, which leaked display names into runtime agent calls.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize built-in agent display names to runtime-safe config keys in delegate-task to prevent “Agent not found” errors during delegation. Fixes cases like “Sisyphus - Ultraworker” resolving to “sisyphus”.

- **Bug Fixes**
  - Map matched built-in display names to config keys via `getAgentConfigKey`; leave custom/unknown names unchanged.
  - Updated tests to expect config keys and added a regression test for “Sisyphus - Ultraworker” -> “sisyphus”.

<sup>Written for commit ed91510d527c16332ff6da7154d5daf41ec5edfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

