### PR TITLE
Revert "fix(agents): remove ZWSP sort prefixes from display name helper (#3259)"

### DIFF
--- a/src/plugin-interface.test.ts
+++ b/src/plugin-interface.test.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto"
 import { createPluginInterface } from "./plugin-interface"
 import { createAutoSlashCommandHook } from "./hooks/auto-slash-command"
 import { createStartWorkHook } from "./hooks/start-work"
+import { getAgentListDisplayName } from "./shared/agent-display-names"
 import { readBoulderState } from "./features/boulder-state"
 import {
   _resetForTesting,

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -9,6 +9,7 @@ import { createAutoSlashCommandHook } from "../hooks/auto-slash-command"
 import { createStartWorkHook } from "../hooks/start-work"
 import { readBoulderState } from "../features/boulder-state"
 import { _resetForTesting, setMainSession, subagentSessions, registerAgentName, updateSessionAgent, getSessionAgent } from "../features/claude-code-session-state"
+import { getAgentListDisplayName } from "../shared/agent-display-names"
 import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state"
 
 type ChatMessagePart = { type: string; text?: string; [key: string]: unknown }
@@ -402,10 +403,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
     expect(getSessionModel("test-session")).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
   })
 
-  test("treats legacy ZWSP-prefixed agent names as explicit model overrides (GH-3259)", async () => {
-    // Users upgrading from v3.14.0-v3.16.0 may still have ZWSP-prefixed agent
-    // keys persisted in their session state. The handler must strip the
-    // prefix and resolve to the canonical display name.
+  test("treats prefixed list-display agent names as explicit model overrides", async () => {
     //#given
     setMainSession("test-session")
     setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" })
@@ -418,7 +416,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
       },
     })
     const handler = createChatMessageHandler(args)
-    const input = createMockInput("\u200B\u200B\u200BPrometheus - Plan Builder")
+    const input = createMockInput(getAgentListDisplayName("prometheus"))
     const output = createMockOutput()
 
     //#when

--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -183,46 +183,30 @@ describe("getAgentConfigKey", () => {
     expect(getAgentConfigKey("Sisyphus-Junior")).toBe("sisyphus-junior")
   })
 
-  it("resolves atlas even when a legacy ZWSP sort prefix is present on the stored key", () => {
-    // Users who installed v3.14.0 through v3.16.0 may have ZWSP-prefixed agent
-    // names baked into their config.agent keys. The resolver must still find
-    // the canonical config key after strip.
-    expect(getAgentConfigKey("\u200B\u200B\u200B\u200BAtlas - Plan Executor")).toBe("atlas")
+  it("resolves atlas even when the UI ordering prefix is present", () => {
+    expect(getAgentConfigKey(getAgentListDisplayName("atlas"))).toBe("atlas")
   })
 })
 
-describe("getAgentListDisplayName (deprecated alias, GH-3259)", () => {
-  it("returns plain display names without the legacy ZWSP sort prefix", () => {
-    // ZWSP prefixes were removed in #3242/#3259. This alias is retained for
-    // external callers that may still import it, but it now behaves
-    // identically to getAgentDisplayName.
-    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - Ultraworker")
-    expect(getAgentListDisplayName("hephaestus")).toBe("Hephaestus - Deep Agent")
-    expect(getAgentListDisplayName("prometheus")).toBe("Prometheus - Plan Builder")
-    expect(getAgentListDisplayName("atlas")).toBe("Atlas - Plan Executor")
+describe("getAgentListDisplayName", () => {
+  it("applies invisible stable-sort prefixes to the core agent list", () => {
+    expect(getAgentListDisplayName("sisyphus")).toBe("\u200BSisyphus - Ultraworker")
+    expect(getAgentListDisplayName("hephaestus")).toBe("\u200B\u200BHephaestus - Deep Agent")
+    expect(getAgentListDisplayName("prometheus")).toBe("\u200B\u200B\u200BPrometheus - Plan Builder")
+    expect(getAgentListDisplayName("atlas")).toBe("\u200B\u200B\u200B\u200BAtlas - Plan Executor")
   })
 
-  it("matches getAgentDisplayName for unknown agents", () => {
+  it("keeps non-core agents unprefixed for list display", () => {
     expect(getAgentListDisplayName("oracle")).toBe("oracle")
-  })
-
-  it("contains no zero-width characters in any core agent output (GH-3259)", () => {
-    const coreAgents = ["sisyphus", "hephaestus", "prometheus", "atlas"]
-    for (const agent of coreAgents) {
-      const result = getAgentListDisplayName(agent)
-      expect(result).not.toMatch(/[\u200B\u200C\u200D\uFEFF]/)
-    }
   })
 })
 
 describe("normalizeAgentForPrompt", () => {
-  it("strips legacy ZWSP sort prefixes from stored agent keys back to canonical display names", () => {
-    // Configs from v3.14.0-v3.16.0 may persist ZWSP-prefixed keys. The
-    // normalizer must restore the canonical name on read.
-    expect(normalizeAgentForPrompt("\u200BSisyphus - Ultraworker")).toBe("Sisyphus - Ultraworker")
-    expect(normalizeAgentForPrompt("\u200B\u200BHephaestus - Deep Agent")).toBe("Hephaestus - Deep Agent")
-    expect(normalizeAgentForPrompt("\u200B\u200B\u200BPrometheus - Plan Builder")).toBe("Prometheus - Plan Builder")
-    expect(normalizeAgentForPrompt("\u200B\u200B\u200B\u200BAtlas - Plan Executor")).toBe("Atlas - Plan Executor")
+  it("strips core UI ordering prefixes back to canonical display names", () => {
+    expect(normalizeAgentForPrompt(getAgentListDisplayName("sisyphus"))).toBe("Sisyphus - Ultraworker")
+    expect(normalizeAgentForPrompt(getAgentListDisplayName("hephaestus"))).toBe("Hephaestus - Deep Agent")
+    expect(normalizeAgentForPrompt(getAgentListDisplayName("prometheus"))).toBe("Prometheus - Plan Builder")
+    expect(normalizeAgentForPrompt(getAgentListDisplayName("atlas"))).toBe("Atlas - Plan Executor")
   })
 })
 

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -26,23 +26,13 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
   "council-member": "council-member",
 }
 
-/**
- * Strip the legacy zero-width-space sort prefix from an agent name.
- *
- * v3.14.0 through v3.16.0 prefixed the four core agents (Sisyphus,
- * Hephaestus, Prometheus, Atlas) with U+200B Zero Width Space characters
- * so they would sort ahead of user agents in the Tab cycle. Some terminal
- * emulators (Ghostty, certain Windows Terminal builds) render ZWSP as a
- * visible box or extra space, breaking the status bar layout (#3259), and
- * the prefixes also leaked through the plugin API and broke prompt_async
- * consumers (#3238).
- *
- * The prefixes are no longer injected anywhere (#3242 removed all call
- * sites and #3259 removed the constant table). This helper remains so
- * existing user configs that still have the ZWSP baked into their
- * `config.agent` keys from an older install continue to resolve
- * correctly after upgrading.
- */
+const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {
+  sisyphus: "\u200B",
+  hephaestus: "\u200B\u200B",
+  prometheus: "\u200B\u200B\u200B",
+  atlas: "\u200B\u200B\u200B\u200B",
+}
+
 export function stripAgentListSortPrefix(agentName: string): string {
   return agentName.replace(/^\u200B+/, "")
 }
@@ -68,20 +58,17 @@ export function getAgentDisplayName(configKey: string): string {
 }
 
 /**
- * @deprecated Use {@link getAgentDisplayName} directly.
- *
- * Historically this returned the display name with a ZWSP sort prefix
- * prepended so core agents would sort ahead of user agents in the Tab
- * cycle. The ZWSP prefixes caused visible rendering artifacts in some
- * terminals (#3259) and leaked into the plugin API surface (#3238), so
- * they were removed in #3242/#3259. This function is now a thin alias
- * over {@link getAgentDisplayName} that exists only for external
- * callers that may still import it. Sort ordering is now handled by
- * the `order` field injection in `reorderAgentsByPriority()` plus the
- * core-first insertion order in the same helper.
+ * @deprecated Do NOT use for config.agent keys or API-facing names.
+ * ZWSP prefixes leak into the /agent API response and break prompt_async consumers.
+ * Use getAgentDisplayName() instead. The `order` field injected by
+ * reorderAgentsByPriority() handles sort ordering without invisible characters.
+ * See: https://github.com/code-yeongyu/oh-my-openagent/issues/3238
  */
 export function getAgentListDisplayName(configKey: string): string {
-  return getAgentDisplayName(configKey)
+  const displayName = getAgentDisplayName(configKey)
+  const prefix = AGENT_LIST_SORT_PREFIXES[configKey.toLowerCase()]
+
+  return prefix ? `${prefix}${displayName}` : displayName
 }
 
 const REVERSE_DISPLAY_NAMES: Record<string, string> = Object.fromEntries(


### PR DESCRIPTION
Reverts #3260.

## Reason

#3260 removed the ZWSP sort prefixes from \`AGENT_LIST_SORT_PREFIXES\` on the assumption that the \`order\` field injected by \`reorderAgentsByPriority()\` would carry the sort weight forward. That assumption was wrong: OpenCode 1.4.x does NOT honor the \`order\` field yet (the upstream PR [sst/opencode#19127](https://github.com/sst/opencode/pull/19127) is still open). With ZWSP gone, OpenCode falls back to alphabetical sorting and the Tab cycle becomes:

  Atlas → Hephaestus → Prometheus → Sisyphus

instead of the intended:

  **Sisyphus → Hephaestus → Prometheus → Atlas**

Real-world impact: every user's agent picker order is wrong on the next dev build. This is a visible regression and trumps the cosmetic ZWSP rendering issue from #3259.

## Plan to re-fix #3259 properly

The visible-ZWSP-in-some-terminals issue from #3259 is real and still needs a fix, but it must NOT regress sort order. Options for a follow-up PR:

1. Wait for sst/opencode#19127 to land in an opencode release, then redo #3260
2. Use a different invisible-but-rendering-safe sort character (e.g. U+2060 WORD JOINER, which has better terminal compatibility than U+200B)
3. Pre-sort the \`config.agent\` insertion order so that even pure-alphabetical sorting downstream still respects priority via clever name rewrites (no, this is bad)

I'll open a follow-up tracking issue to pick one of these once the immediate regression is contained.

## Tests

- \`bun run typecheck\` → clean
- \`bun test src/shared/agent-display-names.test.ts src/plugin/chat-message.test.ts src/plugin-interface.test.ts\` → 46 pass, 0 fail (the original assertions for ZWSP-prefixed display names are restored)

## Apology

This is on me — I shipped #3260 without verifying against a live opencode 1.4.x build. The "no regression keep sorting" constraint was the explicit guidance and I missed it. Reverting now to restore correct order, then I'll figure out a non-regressing fix for #3259 separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore zero‑width‑space sort prefixes for core agents in the list UI to bring back correct ordering in OpenCode 1.4.x, which ignores the `order` field. This fixes the agent picker/tab order regression.

- Bug Fixes
  - Reintroduced stable‑sort prefixes via `AGENT_LIST_SORT_PREFIXES` in `getAgentListDisplayName()`.
  - Kept canonical names clean with `getAgentDisplayName()`; strip prefixes in `stripAgentListSortPrefix()` and `normalizeAgentForPrompt()`.
  - Updated tests and TUI handler to accept prefixed list names as explicit model overrides.

<sup>Written for commit 0d5b0874409cda6e56fef8a9d2f0b7488fd6eef9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

