### PR TITLE
fix(agents): replace ZWSP sort prefixes with runtime sort shim (#3259)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+import { installAgentSortShim } from "./shared/agent-sort-shim"
+
+installAgentSortShim()
+
 import { initConfigContext } from "./cli/config-manager/config-context"
 import type { Plugin } from "@opencode-ai/plugin"
 

--- a/src/plugin-handlers/agent-key-remapper.test.ts
+++ b/src/plugin-handlers/agent-key-remapper.test.ts
@@ -82,7 +82,7 @@ describe("remapAgentKeysToDisplayNames", () => {
     expect(result["sisyphus"]).toBeUndefined()
   })
 
-  it("keeps the four core agents in canonical order under opencode name sorting", () => {
+  it("remaps all four core agents to their display names", () => {
     // given
     const result = remapAgentKeysToDisplayNames({
       atlas: {},
@@ -92,14 +92,12 @@ describe("remapAgentKeysToDisplayNames", () => {
     })
 
     // when
-    const sortedNames = Object.keys(result).sort()
+    const names = Object.keys(result)
 
     // then
-    expect(sortedNames).toEqual([
-      getAgentListDisplayName("sisyphus"),
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("atlas"),
-    ])
+    expect(names).toContain(getAgentDisplayName("sisyphus"))
+    expect(names).toContain(getAgentDisplayName("hephaestus"))
+    expect(names).toContain(getAgentDisplayName("prometheus"))
+    expect(names).toContain(getAgentDisplayName("atlas"))
   })
 })

--- a/src/plugin-handlers/agent-key-remapper.ts
+++ b/src/plugin-handlers/agent-key-remapper.ts
@@ -1,4 +1,4 @@
-import { getAgentListDisplayName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
 
 export function remapAgentKeysToDisplayNames(
   agents: Record<string, unknown>,
@@ -6,7 +6,7 @@ export function remapAgentKeysToDisplayNames(
   const result: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(agents)) {
-    const displayName = getAgentListDisplayName(key)
+    const displayName = getAgentDisplayName(key)
     if (displayName && displayName !== key) {
       result[displayName] = value
       // Regression guard: do not also assign result[key].

--- a/src/plugin-handlers/agent-priority-order.ts
+++ b/src/plugin-handlers/agent-priority-order.ts
@@ -1,10 +1,10 @@
-import { getAgentListDisplayName } from "../shared/agent-display-names";
+import { getAgentDisplayName } from "../shared/agent-display-names";
 
 const CORE_AGENT_ORDER: ReadonlyArray<{ displayName: string; order: number }> = [
-  { displayName: getAgentListDisplayName("sisyphus"), order: 1 },
-  { displayName: getAgentListDisplayName("hephaestus"), order: 2 },
-  { displayName: getAgentListDisplayName("prometheus"), order: 3 },
-  { displayName: getAgentListDisplayName("atlas"), order: 4 },
+  { displayName: getAgentDisplayName("sisyphus"), order: 1 },
+  { displayName: getAgentDisplayName("hephaestus"), order: 2 },
+  { displayName: getAgentDisplayName("prometheus"), order: 3 },
+  { displayName: getAgentDisplayName("atlas"), order: 4 },
 ];
 
 function injectOrderField(

--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -189,11 +189,11 @@ describe("getAgentConfigKey", () => {
 })
 
 describe("getAgentListDisplayName", () => {
-  it("applies invisible stable-sort prefixes to the core agent list", () => {
-    expect(getAgentListDisplayName("sisyphus")).toBe("\u200BSisyphus - Ultraworker")
-    expect(getAgentListDisplayName("hephaestus")).toBe("\u200B\u200BHephaestus - Deep Agent")
-    expect(getAgentListDisplayName("prometheus")).toBe("\u200B\u200B\u200BPrometheus - Plan Builder")
-    expect(getAgentListDisplayName("atlas")).toBe("\u200B\u200B\u200B\u200BAtlas - Plan Executor")
+  it("returns clean display names without ZWSP prefixes", () => {
+    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentListDisplayName("hephaestus")).toBe("Hephaestus - Deep Agent")
+    expect(getAgentListDisplayName("prometheus")).toBe("Prometheus - Plan Builder")
+    expect(getAgentListDisplayName("atlas")).toBe("Atlas - Plan Executor")
   })
 
   it("keeps non-core agents unprefixed for list display", () => {

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -27,10 +27,10 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
 }
 
 const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {
-  sisyphus: "\u200B",
-  hephaestus: "\u200B\u200B",
-  prometheus: "\u200B\u200B\u200B",
-  atlas: "\u200B\u200B\u200B\u200B",
+  sisyphus: "",
+  hephaestus: "",
+  prometheus: "",
+  atlas: "",
 }
 
 export function stripAgentListSortPrefix(agentName: string): string {

--- a/src/shared/agent-sort-shim.test.ts
+++ b/src/shared/agent-sort-shim.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll } from "bun:test"
+import { installAgentSortShim } from "./agent-sort-shim"
+
+beforeAll(() => {
+  installAgentSortShim()
+})
+
+describe("installAgentSortShim", () => {
+  it("#given agent objects with known names #when toSorted with name comparator #then returns priority order", () => {
+    const agents = [
+      { name: "Atlas - Plan Executor", native: false },
+      { name: "Prometheus - Plan Builder", native: false },
+      { name: "Hephaestus - Deep Agent", native: false },
+      { name: "Sisyphus - Ultraworker", native: false },
+    ]
+
+    const sorted = agents.toSorted((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+
+    expect(sorted.map((a) => a.name)).toEqual([
+      "Sisyphus - Ultraworker",
+      "Hephaestus - Deep Agent",
+      "Prometheus - Plan Builder",
+      "Atlas - Plan Executor",
+    ])
+  })
+
+  it("#given mixed known and unknown agents #when toSorted #then ranked agents first then unknowns by fallback", () => {
+    const agents = [
+      { name: "build", native: true },
+      { name: "Atlas - Plan Executor", native: false },
+      { name: "Sisyphus - Ultraworker", native: false },
+      { name: "plan", native: true },
+    ]
+
+    const sorted = agents.toSorted((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+
+    expect(sorted.map((a) => a.name)).toEqual([
+      "Sisyphus - Ultraworker",
+      "Atlas - Plan Executor",
+      "build",
+      "plan",
+    ])
+  })
+
+  it("#given plain string array #when toSorted #then not intercepted", () => {
+    const strs = ["zebra", "apple", "mango"]
+
+    const sorted = strs.toSorted()
+
+    expect(sorted).toEqual(["apple", "mango", "zebra"])
+  })
+
+  it("#given agent objects #when sort (in-place) #then also applies priority order", () => {
+    const agents = [
+      { name: "Atlas - Plan Executor" },
+      { name: "Sisyphus - Ultraworker" },
+      { name: "Hephaestus - Deep Agent" },
+    ]
+
+    agents.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+
+    expect(agents.map((a) => a.name)).toEqual([
+      "Sisyphus - Ultraworker",
+      "Hephaestus - Deep Agent",
+      "Atlas - Plan Executor",
+    ])
+  })
+
+  it("#given number array #when sort #then not intercepted", () => {
+    const nums = [3, 1, 2]
+
+    nums.sort((a, b) => a - b)
+
+    expect(nums).toEqual([1, 2, 3])
+  })
+})

--- a/src/shared/agent-sort-shim.test.ts
+++ b/src/shared/agent-sort-shim.test.ts
@@ -29,17 +29,37 @@ describe("installAgentSortShim", () => {
       { name: "build", native: true },
       { name: "Atlas - Plan Executor", native: false },
       { name: "Sisyphus - Ultraworker", native: false },
-      { name: "plan", native: true },
+      { name: "Hephaestus - Deep Agent", native: false },
     ]
 
     const sorted = agents.toSorted((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
 
     expect(sorted.map((a) => a.name)).toEqual([
       "Sisyphus - Ultraworker",
+      "Hephaestus - Deep Agent",
       "Atlas - Plan Executor",
       "build",
-      "plan",
     ])
+  })
+
+  it("#given array with only one known agent #when toSorted #then not intercepted", () => {
+    const agents = [
+      { name: "build", native: true },
+      { name: "Sisyphus - Ultraworker", native: false },
+      { name: "plan", native: true },
+    ]
+
+    const sorted = agents.toSorted((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+
+    expect(sorted.map((a) => a.name)).toEqual(["Sisyphus - Ultraworker", "build", "plan"])
+  })
+
+  it("#given array with non-object elements #when toSorted #then not intercepted", () => {
+    const mixed = [{ name: "Sisyphus - Ultraworker" }, null, "string", 42]
+
+    const sorted = mixed.toSorted(() => 0)
+
+    expect(sorted).toHaveLength(4)
   })
 
   it("#given plain string array #when toSorted #then not intercepted", () => {

--- a/src/shared/agent-sort-shim.ts
+++ b/src/shared/agent-sort-shim.ts
@@ -32,29 +32,27 @@ for (let i = 0; i < PRIORITY_ORDER.length; i++) {
 
 const UNRANKED = 9999
 
-function isAgentArray(arr: unknown[]): arr is AgentLike[] {
+function isAgentArray(arr: unknown[]): boolean {
+  let knownCount = 0
   for (let i = 0; i < arr.length; i++) {
     const item = arr[i]
-    if (
-      item != null &&
-      typeof item === "object" &&
-      "name" in item &&
-      typeof (item as AgentLike).name === "string" &&
-      AGENT_RANK[(item as AgentLike).name] !== undefined
-    ) {
-      return true
-    }
+    if (item == null || typeof item !== "object" || !("name" in item)) return false
+    const name = (item as AgentLike).name
+    if (typeof name !== "string") return false
+    if (AGENT_RANK[name] !== undefined) knownCount++
   }
-  return false
+  return knownCount >= 2
 }
 
 function agentComparator(
-  a: AgentLike,
-  b: AgentLike,
-  fallback?: (a: AgentLike, b: AgentLike) => number,
+  a: unknown,
+  b: unknown,
+  fallback?: (a: unknown, b: unknown) => number,
 ): number {
-  const ra = AGENT_RANK[a.name] ?? UNRANKED
-  const rb = AGENT_RANK[b.name] ?? UNRANKED
+  const aName = a != null && typeof a === "object" && "name" in a ? (a as AgentLike).name : undefined
+  const bName = b != null && typeof b === "object" && "name" in b ? (b as AgentLike).name : undefined
+  const ra = (aName !== undefined ? AGENT_RANK[aName] : undefined) ?? UNRANKED
+  const rb = (bName !== undefined ? AGENT_RANK[bName] : undefined) ?? UNRANKED
   if (ra !== rb) return ra - rb
   return fallback ? fallback(a, b) : 0
 }
@@ -64,7 +62,7 @@ export function installAgentSortShim(): void {
   Array.prototype.toSorted = function (this: unknown[], compareFn?: (a: unknown, b: unknown) => number) {
     if (this.length >= 2 && isAgentArray(this)) {
       return origToSorted.call(this, (a: unknown, b: unknown) =>
-        agentComparator(a as AgentLike, b as AgentLike, compareFn as (a: AgentLike, b: AgentLike) => number),
+        agentComparator(a, b, compareFn),
       )
     }
     return origToSorted.call(this, compareFn)
@@ -74,7 +72,7 @@ export function installAgentSortShim(): void {
   Array.prototype.sort = function (this: unknown[], compareFn?: (a: unknown, b: unknown) => number) {
     if (this.length >= 2 && isAgentArray(this)) {
       return origSort.call(this, (a: unknown, b: unknown) =>
-        agentComparator(a as AgentLike, b as AgentLike, compareFn as (a: AgentLike, b: AgentLike) => number),
+        agentComparator(a, b, compareFn),
       )
     }
     return origSort.call(this, compareFn)

--- a/src/shared/agent-sort-shim.ts
+++ b/src/shared/agent-sort-shim.ts
@@ -1,0 +1,82 @@
+// Temporary shim: patches Array.prototype.toSorted/.sort to enforce agent
+// picker order. OpenCode 1.4.x ignores the `order` field (sst/opencode#19127)
+// and ZWSP prefixes cause TUI rendering artifacts (#3259).
+// Remove once OpenCode ships `order` field support.
+
+import { AGENT_DISPLAY_NAMES } from "./agent-display-names"
+
+interface AgentLike {
+  name: string
+  [key: string]: unknown
+}
+
+const AGENT_RANK: Record<string, number> = {}
+const PRIORITY_ORDER = [
+  "sisyphus",
+  "hephaestus",
+  "prometheus",
+  "atlas",
+  "sisyphus-junior",
+  "metis",
+  "momus",
+  "athena",
+  "athena-junior",
+]
+
+for (let i = 0; i < PRIORITY_ORDER.length; i++) {
+  const displayName = AGENT_DISPLAY_NAMES[PRIORITY_ORDER[i]]
+  if (displayName) {
+    AGENT_RANK[displayName] = i + 1
+  }
+}
+
+const UNRANKED = 9999
+
+function isAgentArray(arr: unknown[]): arr is AgentLike[] {
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i]
+    if (
+      item != null &&
+      typeof item === "object" &&
+      "name" in item &&
+      typeof (item as AgentLike).name === "string" &&
+      AGENT_RANK[(item as AgentLike).name] !== undefined
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+function agentComparator(
+  a: AgentLike,
+  b: AgentLike,
+  fallback?: (a: AgentLike, b: AgentLike) => number,
+): number {
+  const ra = AGENT_RANK[a.name] ?? UNRANKED
+  const rb = AGENT_RANK[b.name] ?? UNRANKED
+  if (ra !== rb) return ra - rb
+  return fallback ? fallback(a, b) : 0
+}
+
+export function installAgentSortShim(): void {
+  const origToSorted = Array.prototype.toSorted
+  Array.prototype.toSorted = function (this: unknown[], compareFn?: (a: unknown, b: unknown) => number) {
+    if (this.length >= 2 && isAgentArray(this)) {
+      return origToSorted.call(this, (a: unknown, b: unknown) =>
+        agentComparator(a as AgentLike, b as AgentLike, compareFn as (a: AgentLike, b: AgentLike) => number),
+      )
+    }
+    return origToSorted.call(this, compareFn)
+  } as typeof Array.prototype.toSorted
+
+  const origSort = Array.prototype.sort
+  Array.prototype.sort = function (this: unknown[], compareFn?: (a: unknown, b: unknown) => number) {
+    if (this.length >= 2 && isAgentArray(this)) {
+      return origSort.call(this, (a: unknown, b: unknown) =>
+        agentComparator(a as AgentLike, b as AgentLike, compareFn as (a: AgentLike, b: AgentLike) => number),
+      )
+    }
+    return origSort.call(this, compareFn)
+  } as typeof Array.prototype.sort
+}


### PR DESCRIPTION
## Summary

Fixes #3259. Replaces ZWSP (U+200B) sort prefixes with a runtime `Array.prototype.toSorted`/`.sort` shim that enforces agent picker order without invisible characters.

## Problem

ZWSP prefixes in `AGENT_LIST_SORT_PREFIXES` cause TUI rendering artifacts: `Bun.stringWidth()` returns 0 for ZWSP but terminals (WezTerm, Ghostty) render it as 1-cell wide, producing a visible gap in the status bar. This was reported in #3259 and confirmed across multiple terminal emulators.

#3260 attempted to fix this by removing ZWSP entirely, but was reverted in #3265 because OpenCode 1.4.x does not honor the `order` field (sst/opencode#19127) and falls back to alphabetical sorting, breaking the agent picker order.

## Root Cause Analysis

OpenCode 1.4.x sorts agents via remeda `sortBy()` which delegates to `Array.prototype.toSorted` using `<`/`>` string comparison on `.name`. This is *not* `localeCompare` — it's raw operator comparison. The `order` field injected by `reorderAgentsByPriority()` is silently ignored.

## Solution

- **Clear ZWSP prefixes** to empty strings (no more invisible characters)
- **Add `agent-sort-shim.ts`** that monkey-patches `Array.prototype.toSorted` and `.sort` with a narrow interceptor: only arrays where at least one element has a `.name` matching a known agent display name are reordered by a rank map. All other sort operations are untouched.
- **Install the shim at module load time** in `src/index.ts` (before any OpenCode code runs)
- **Migrate callers** from `getAgentListDisplayName` → `getAgentDisplayName` in `agent-key-remapper.ts` and `agent-priority-order.ts`

### Why this approach

| Approach | Sort ✓ | Render ✓ | Notes |
|---|---|---|---|
| ZWSP prefixes | ✓ | ✗ | Width mismatch between Bun.stringWidth (0) and terminal (1) |
| U+2060 WORD JOINER | ✓ | ✗ | Same width mismatch |
| U+00AD SOFT HYPHEN | ✓ | ✗ | Same issue |
| ANSI escape prefixes | ✓ | ✗ | Corrupted going through config pipeline |
| Remove prefixes only | ✗ | ✓ | Alphabetical order (A→H→P→S) |
| **Runtime sort shim** | **✓** | **✓** | No invisible chars, narrow monkey-patch |

## Cleanup

Remove `installAgentSortShim()` once OpenCode ships `order` field support (sst/opencode#19127).

## Tests

- `agent-sort-shim.test.ts` — 5 new tests: priority order via toSorted, mixed known/unknown agents, plain string arrays unaffected, in-place sort, number arrays unaffected
- `agent-display-names.test.ts` — updated: expects clean names without ZWSP
- `agent-key-remapper.test.ts` — updated: no longer asserts ZWSP-dependent sort order
- `agent-priority-order.test.ts` — passes unchanged
- `bun run typecheck` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced ZWSP-based sort prefixes with a runtime sort shim to preserve agent picker order and remove the visible gap in the TUI. The shim intercepts `Array.prototype.toSorted`/`sort` only for agent arrays under strict checks; other sorts are untouched.

- **Bug Fixes**
  - Removed ZWSP from `AGENT_LIST_SORT_PREFIXES`; display names are clean.
  - Added `src/shared/agent-sort-shim.ts` to enforce rank-based agent order when sorting by `.name`.
  - Tightened interception: array must be all objects with `.name` and include 2+ known agent names; single-match, mixed-type, and string/number arrays are not intercepted.
  - Installed the shim at startup in `src/index.ts`.
  - Migrated callers from `getAgentListDisplayName` to `getAgentDisplayName`.
  - Added/updated tests for priority ordering, single-match arrays, mixed types, in-place sort, and clean names.

<sup>Written for commit ad1d9c9a3f3588c5599485a80bcbfc84f324974b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

