### PR TITLE
fix(ci): isolate model-resolution-pipeline test to prevent mock contamination

### DIFF
--- a/src/shared/model-resolution-pipeline.test.ts
+++ b/src/shared/model-resolution-pipeline.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import { resolveModelPipeline } from "./model-resolution-pipeline"
+
+// Force test-runner isolation: files that import mock.module are auto-detected
+// by run-ci-tests.ts and executed in their own bun process so they cannot be
+// contaminated by (or contaminate) mock.module calls in other test files.
+mock.module("./logger", () => ({
+  log: () => {},
+}))
 
 describe("resolveModelPipeline", () => {
   test("does not return unused explicit user config metadata in override result", () => {


### PR DESCRIPTION
Same pattern as #3243 — the `resolveModelPipeline > does not return unused explicit user config metadata in override result` test failed **3 times today** on CI (twice blocking v3.16.1 publish, once on dev push) while always passing locally. Root cause: `mock.module` calls in sibling test files leak into this file's module scope when bun runs them in the same process. Adding `mock.module('./logger', ...)` triggers auto-isolation by `run-ci-tests.ts`.

1 file, 8 lines added, 1 deleted. Unblocks the publish.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates the model-resolution-pipeline test by importing `mock.module` with a no-op `./logger` mock. This makes `run-ci-tests.ts` run the file in its own process, preventing cross-file mock leakage and fixing the CI flake that blocked the v3.16.1 publish.

<sup>Written for commit 7a1f121fdd1d27604c6f99a60f616f72593139fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

