### PR TITLE
fix(stop-continuation): persist stop state across user messages (#3276)

### DIFF
--- a/src/hooks/stop-continuation-guard/hook.ts
+++ b/src/hooks/stop-continuation-guard/hook.ts
@@ -100,10 +100,16 @@ export function createStopContinuationGuardHook(
   }: {
     sessionID?: string
   }): Promise<void> => {
-    if (sessionID && stoppedSessions.has(sessionID)) {
-      clear(sessionID)
-      log(`[${HOOK_NAME}] Cleared stop state on new user message`, { sessionID })
-    }
+    // Intentionally no-op: stop state should persist across user messages.
+    // Previously this cleared the stop on any new user message, but that caused
+    // /stop-continuation to be ineffective — the user's very next message
+    // (including normal chat) would re-enable continuation.
+    //
+    // Stop state is now only cleared by:
+    // 1. /start-work (or /ulw-loop, /ralph-loop) via explicit clear() call
+    // 2. session.deleted event
+    // 3. Future /resume-continuation command
+    void sessionID
   }
 
   return {

--- a/src/hooks/stop-continuation-guard/index.test.ts
+++ b/src/hooks/stop-continuation-guard/index.test.ts
@@ -162,7 +162,7 @@ describe("stop-continuation-guard", () => {
     expect(guard.isStopped(session2)).toBe(false)
   })
 
-  test("should clear stopped state on new user message (chat.message)", async () => {
+  test("should NOT clear stopped state on new user message (chat.message)", async () => {
     // given - a session that was stopped
     const guard = createStopContinuationGuardHook(createMockPluginInput())
     const sessionID = "test-session-4"
@@ -172,7 +172,38 @@ describe("stop-continuation-guard", () => {
     // when - user sends a new message
     await guard["chat.message"]({ sessionID })
 
-    // then - stop state should be cleared (one-time only)
+    // then - stop state should persist (not cleared by user messages)
+    // Stop is only cleared by explicit work-starting commands (/start-work, /ralph-loop, /ulw-loop)
+    // or session deletion. This prevents /stop-continuation from being ineffective.
+    expect(guard.isStopped(sessionID)).toBe(true)
+  })
+
+  test("should persist stop state across multiple user messages", async () => {
+    // given - a session that was stopped
+    const guard = createStopContinuationGuardHook(createMockPluginInput())
+    const sessionID = "test-session-persist"
+    guard.stop(sessionID)
+
+    // when - user sends multiple messages
+    await guard["chat.message"]({ sessionID })
+    await guard["chat.message"]({ sessionID })
+    await guard["chat.message"]({ sessionID })
+
+    // then - stop state remains active
+    expect(guard.isStopped(sessionID)).toBe(true)
+  })
+
+  test("should clear stop state only via explicit clear() call", () => {
+    // given - a session that was stopped
+    const guard = createStopContinuationGuardHook(createMockPluginInput())
+    const sessionID = "test-session-explicit-clear"
+    guard.stop(sessionID)
+    expect(guard.isStopped(sessionID)).toBe(true)
+
+    // when - clear is called (simulating /start-work or /ralph-loop)
+    guard.clear(sessionID)
+
+    // then - stop state is cleared
     expect(guard.isStopped(sessionID)).toBe(false)
   })
 

--- a/src/plugin/tool-execute-before.ts
+++ b/src/plugin/tool-execute-before.ts
@@ -184,6 +184,19 @@ export function createToolExecuteBeforeHandler(args: {
           sessionID,
         })
       }
+
+      // Clear stop state when user explicitly resumes work via work-starting commands.
+      // This ensures /stop-continuation persists until the user intentionally restarts.
+      const workStartingCommands = ["start-work", "ralph-loop", "ulw-loop"]
+      if (workStartingCommands.includes(command ?? "") && sessionID) {
+        if (hooks.stopContinuationGuard?.isStopped(sessionID)) {
+          hooks.stopContinuationGuard.clear(sessionID)
+          log("[stop-continuation] Stop state cleared by work-starting command", {
+            sessionID,
+            command,
+          })
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

`/stop-continuation` was ineffective — continuation prompts kept appearing after the command was acknowledged by the agent.

## Root Cause

The `stop-continuation-guard` hook cleared its stopped state on **every `chat.message` event** (i.e., any user message). So:

1. User sends `/stop-continuation` → `stop(sessionID)` called ✓
2. Model acknowledges → goes idle → continuation correctly skipped ✓
3. User sends any new message (normal chat) → `chat.message` fires → `clear(sessionID)` 💥
4. Next idle → `isContinuationStopped` returns false → continuation resumes 💀

The design intent was 'clear stop on next user message = user resumed work.' But users expect `/stop-continuation` to persist until they explicitly restart via `/start-work`, `/ralph-loop`, or `/ulw-loop`.

## Fix

- **`stop-continuation-guard` `chat.message`**: No longer clears the stop state on user messages
- **`tool-execute-before`**: Work-starting commands (`/start-work`, `/ralph-loop`, `/ulw-loop`) now explicitly call `clear(sessionID)` to resume continuation
- **Tests**: 12 pass (3 new), 125 related tests pass, 0 regressions

## Behavioral Change

| Scenario | Before | After |
|---|---|---|
| `/stop-continuation` then chat normally | Continuation resumes on next message | Continuation stays stopped |
| `/stop-continuation` then `/start-work` | Continuation resumes | Continuation resumes (same) |
| `/stop-continuation` then `/ralph-loop` | Continuation resumes | Continuation resumes (same) |
| Session deleted | Stop cleared | Stop cleared (same) |

3 files, +56 −6 lines.

Closes #3276

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/stop-continuation` persist across user messages so continuation doesn’t restart unintentionally. Continuation now resumes only when the user runs `/start-work`, `/ralph-loop`, or `/ulw-loop`.

- **Bug Fixes**
  - `stop-continuation-guard` no longer clears the stop state on `chat.message`.
  - `tool-execute-before` explicitly clears the stop state on work-starting commands.
  - Tests added/updated to ensure stop persists across multiple messages and only explicit resume clears it.

<sup>Written for commit ab515b77d0a90252e85b1f044d2672b9523cc2e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

