### PR TITLE
fix: resolve agent display names before promptAsync injection

### DIFF
--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -19,7 +19,7 @@ import { log } from "../../shared/logger"
 import { isSqliteBackend } from "../../shared/opencode-storage-detection"
 import {
   getAgentConfigKey,
-  normalizeAgentForPromptKey,
+  normalizeAgentForPrompt,
 } from "../../shared/agent-display-names"
 
 import {
@@ -129,7 +129,7 @@ export async function injectContinuation(args: {
     tools = tools ?? previousMessage?.tools
   }
 
-  const promptAgent = normalizeAgentForPromptKey(agentName)
+  const promptAgent = normalizeAgentForPrompt(agentName)
   const launchAgent = resolveRegisteredAgentName(agentName)
 
   if (promptAgent && skipAgents.some(s => getAgentConfigKey(s) === getAgentConfigKey(promptAgent))) {


### PR DESCRIPTION
## Problem

`injectContinuation()` passes config keys (e.g. `"sisyphus"`) to `promptAsync`,
but the OpenCode runtime registers agents under display names
(e.g. `"Sisyphus - Ultraworker"`). The lookup fails, the session errors, goes
idle, and the enforcer retries — creating an infinite error loop that freezes the
session after all sub-agents complete.

```
[todo-continuation-enforcer] Injecting continuation agent:"sisyphus"
[auto-compact] session.error: Agent not found: "sisyphus".
  Available agents: Sisyphus (Ultraworker), ...
```

## Root Cause

`continuation-injection.ts` imports `normalizeAgentForPromptKey` (returns config
keys) instead of `normalizeAgentForPrompt` (returns display names). The correct
function already exists in `agent-display-names.ts` — this is a one-import fix.

## Changes

- `continuation-injection.ts`: swap `normalizeAgentForPromptKey` →
  `normalizeAgentForPrompt`

## Testing

- Reproduced on v3.15.3 with multi-agent session (Sisyphus + background agents)
- Verified fix resolves the freeze loop
- `bun run typecheck` should pass (import/usage types unchanged)

---

> Recreated from #3211 which was closed when the fork was temporarily privatized.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes continuation injection by resolving agent display names before calling promptAsync, preventing “Agent not found” errors and the enforcer retry loop that freezes sessions.

- **Bug Fixes**
  - Use normalizeAgentForPrompt instead of normalizeAgentForPromptKey in continuation-injection.ts.
  - Aligns prompt agent names with registered display names (e.g., “Sisyphus - Ultraworker”).

<sup>Written for commit 589c9fcd124a280b9127655da92d2b56f6175233. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

