### PR TITLE
fix(grep): handle CRLF line endings in ripgrep output parsing

### DIFF
--- a/src/tools/grep/cli.test.ts
+++ b/src/tools/grep/cli.test.ts
@@ -1,0 +1,110 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+import { parseOutput, parseCountOutput } from "./cli"
+
+describe("parseOutput", () => {
+  describe("#given LF line endings", () => {
+    test("#then parses content matches", () => {
+      const output = "src/foo.ts:10:  hello()\nsrc/foo.ts:20:  world()\n"
+
+      const matches = parseOutput(output)
+
+      expect(matches).toEqual([
+        { file: "src/foo.ts", line: 10, text: "  hello()" },
+        { file: "src/foo.ts", line: 20, text: "  world()" },
+      ])
+    })
+
+    test("#then parses files-only matches", () => {
+      const output = "src/foo.ts\nsrc/bar.ts\n"
+
+      const matches = parseOutput(output, true)
+
+      expect(matches).toEqual([
+        { file: "src/foo.ts", line: 0, text: "" },
+        { file: "src/bar.ts", line: 0, text: "" },
+      ])
+    })
+  })
+
+  describe("#given CRLF line endings", () => {
+    test("#then parses content matches", () => {
+      const output = "src/foo.ts:10:  hello()\r\nsrc/foo.ts:20:  world()\r\n"
+
+      const matches = parseOutput(output)
+
+      expect(matches).toEqual([
+        { file: "src/foo.ts", line: 10, text: "  hello()" },
+        { file: "src/foo.ts", line: 20, text: "  world()" },
+      ])
+    })
+
+    test("#then parses files-only matches", () => {
+      const output = "src/foo.ts\r\nsrc/bar.ts\r\n"
+
+      const matches = parseOutput(output, true)
+
+      expect(matches).toEqual([
+        { file: "src/foo.ts", line: 0, text: "" },
+        { file: "src/bar.ts", line: 0, text: "" },
+      ])
+    })
+
+    test("#then captured text has no trailing carriage return", () => {
+      const output = "file.py:10:  self.proxy = None\r\nfile.py:20:  proxy.start()\r\n"
+
+      const matches = parseOutput(output)
+
+      for (const m of matches) {
+        expect(m.text.endsWith("\r")).toBe(false)
+        expect(m.file.endsWith("\r")).toBe(false)
+      }
+      expect(matches).toHaveLength(2)
+    })
+  })
+
+  describe("#given empty output", () => {
+    test("#then returns empty array", () => {
+      expect(parseOutput("")).toEqual([])
+      expect(parseOutput("  \n  ")).toEqual([])
+      expect(parseOutput("  \r\n  ")).toEqual([])
+    })
+  })
+})
+
+describe("parseCountOutput", () => {
+  describe("#given LF line endings", () => {
+    test("#then parses count results", () => {
+      const output = "src/foo.ts:3\nsrc/bar.ts:1\n"
+
+      const results = parseCountOutput(output)
+
+      expect(results).toEqual([
+        { file: "src/foo.ts", count: 3 },
+        { file: "src/bar.ts", count: 1 },
+      ])
+    })
+  })
+
+  describe("#given CRLF line endings", () => {
+    test("#then parses count results", () => {
+      const output = "src/foo.ts:3\r\nsrc/bar.ts:1\r\n"
+
+      const results = parseCountOutput(output)
+
+      expect(results).toEqual([
+        { file: "src/foo.ts", count: 3 },
+        { file: "src/bar.ts", count: 1 },
+      ])
+    })
+  })
+
+  describe("#given empty output", () => {
+    test("#then returns empty array", () => {
+      expect(parseCountOutput("")).toEqual([])
+      expect(parseCountOutput("  \r\n  ")).toEqual([])
+    })
+  })
+})

--- a/src/tools/grep/cli.ts
+++ b/src/tools/grep/cli.ts
@@ -96,11 +96,11 @@ function buildArgs(options: GrepOptions, backend: GrepBackend): string[] {
   return backend === "rg" ? buildRgArgs(options) : buildGrepArgs(options)
 }
 
-function parseOutput(output: string, filesOnly = false): GrepMatch[] {
+export function parseOutput(output: string, filesOnly = false): GrepMatch[] {
   if (!output.trim()) return []
 
   const matches: GrepMatch[] = []
-  const lines = output.split("\n")
+  const lines = output.split(/\r?\n/)
 
   for (const line of lines) {
     if (!line.trim()) continue
@@ -128,11 +128,11 @@ function parseOutput(output: string, filesOnly = false): GrepMatch[] {
   return matches
 }
 
-function parseCountOutput(output: string): CountResult[] {
+export function parseCountOutput(output: string): CountResult[] {
   if (!output.trim()) return []
 
   const results: CountResult[] = []
-  const lines = output.split("\n")
+  const lines = output.split(/\r?\n/)
 
   for (const line of lines) {
     if (!line.trim()) continue


### PR DESCRIPTION
## Summary

- Fix `parseOutput` and `parseCountOutput` in `src/tools/grep/cli.ts` to handle CRLF (`\r\n`) line endings from ripgrep output
- Add unit tests for both parsers covering CRLF, LF, and empty-output cases

## Problem

When the Grep tool searches files with Windows-style CRLF line endings, ripgrep preserves the `\r` in its stdout. The parsers split on `"\n"` only, leaving a trailing `\r` on every line. This causes the content-mode regex `/^(.+?):(\d+):(.*)$/` to silently fail — the `$` anchor does not match before `\r` in JavaScript — so all matches are dropped and the tool returns "No matches found".

The `files_with_matches` mode was unaffected because it uses `line.trim()`, which strips `\r`. The `count` mode has the same latent bug in `parseCountOutput`.

### Reproduction

```
# Search a CRLF file in content mode → returns "No matches found"
grep(pattern="proxy", path="/path/to/crlf_file.py", output_mode="content")

# Same file in files_with_matches mode → works fine
grep(pattern="proxy", path="/path/to/crlf_file.py", output_mode="files_with_matches")
```

## Fix

Change `output.split("\n")` → `output.split(/\r?\n/)` in both `parseOutput` (line 103) and `parseCountOutput` (line 135). After proper splitting, the existing regexes work correctly with no further changes needed.

## Changes

| File | Change |
|------|--------|
| `src/tools/grep/cli.ts` | `split("\n")` → `split(/\r?\n/)` in `parseOutput` and `parseCountOutput`; export both functions for testability |
| `src/tools/grep/cli.test.ts` | New — 7 unit tests covering CRLF content, CRLF files-only, CRLF no-trailing-`\r`, CRLF count, LF content, LF files-only, and empty output |

## Testing

- Existing `result-formatter.test.ts` — 5/5 pass (no regressions)
- New `cli.test.ts` — all assertions verified (import currently blocked by unrelated missing `js-yaml` dependency in the test runner, logic verified independently)
- Manual reproduction confirmed: CRLF file now returns correct matches in content mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix parsing of ripgrep output with CRLF line endings so content and count modes return correct results on Windows. Adds tests covering CRLF, LF, and empty-output cases.

- **Bug Fixes**
  - Split lines with `/\r?\n/` in `parseOutput` and `parseCountOutput` in `src/tools/grep/cli.ts` to remove stray `\r`.
  - Export both functions and add `src/tools/grep/cli.test.ts` covering content, files-only, and count modes for CRLF/LF and empty output.
  - Resolves "No matches found" in content mode on CRLF files; count mode handles CRLF correctly.

<sup>Written for commit 697e44a8b76ab9b6c9ee80d14abcbcfd21b87c1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

