### PR TITLE
fix(migration): skip backup when config content is unchanged (fixes #3222)

### DIFF
--- a/src/shared/migration/config-migration.ts
+++ b/src/shared/migration/config-migration.ts
@@ -142,6 +142,29 @@ export function migrateConfigFile(
   }
 
   if (needsWrite) {
+    // Verify the config file content actually changed before creating a
+    // backup and rewriting.  Several migration paths set needsWrite=true
+    // without altering the config body (e.g. stripping an already-absent
+    // _migrations field, or recording sidecar-only state).  Without this
+    // guard the plugin creates a new .bak.<timestamp> file on every
+    // startup even when the config is already up-to-date (#3222).
+    const newContent = JSON.stringify(copy, null, 2) + "\n"
+    let existingContent: string | undefined
+    try {
+      existingContent = fs.readFileSync(configPath, "utf-8")
+    } catch {
+      // File unreadable -- proceed with write to recover.
+    }
+    if (existingContent !== undefined && existingContent === newContent) {
+      // Config file is already up-to-date. Apply in-memory mutations
+      // (e.g. stripped _migrations) without touching the filesystem.
+      for (const key of Object.keys(rawConfig)) {
+        delete rawConfig[key]
+      }
+      Object.assign(rawConfig, copy)
+      return false
+    }
+
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
     const backupPath = `${configPath}.bak.${timestamp}`
     let backupSucceeded = false

--- a/src/shared/migration/config-migration.ts
+++ b/src/shared/migration/config-migration.ts
@@ -11,6 +11,7 @@ export function migrateConfigFile(
   rawConfig: Record<string, unknown>
 ): boolean {
   const copy = structuredClone(rawConfig)
+  const originalSnapshot = JSON.stringify(rawConfig)
   let needsWrite = false
 
   // Load previously applied migrations from BOTH the legacy in-config
@@ -142,22 +143,15 @@ export function migrateConfigFile(
   }
 
   if (needsWrite) {
-    // Verify the config file content actually changed before creating a
-    // backup and rewriting.  Several migration paths set needsWrite=true
-    // without altering the config body (e.g. stripping an already-absent
+    // Verify the config body actually changed before creating a backup and
+    // rewriting.  Several migration paths set needsWrite=true without
+    // altering the config body (e.g. stripping an already-absent
     // _migrations field, or recording sidecar-only state).  Without this
     // guard the plugin creates a new .bak.<timestamp> file on every
     // startup even when the config is already up-to-date (#3222).
-    const newContent = JSON.stringify(copy, null, 2) + "\n"
-    let existingContent: string | undefined
-    try {
-      existingContent = fs.readFileSync(configPath, "utf-8")
-    } catch {
-      // File unreadable -- proceed with write to recover.
-    }
-    if (existingContent !== undefined && existingContent === newContent) {
-      // Config file is already up-to-date. Apply in-memory mutations
-      // (e.g. stripped _migrations) without touching the filesystem.
+    if (JSON.stringify(copy) === originalSnapshot) {
+      // Config body is identical after all migrations ran. Apply in-memory
+      // mutations (e.g. stripped _migrations) without touching the filesystem.
       for (const key of Object.keys(rawConfig)) {
         delete rawConfig[key]
       }


### PR DESCRIPTION
## Summary
- Prevent unnecessary `.bak.<timestamp>` backup files on every startup when no config changes are needed

## Problem
`migrateConfigFile()` sets `needsWrite=true` in several code paths that update migration tracking state (sidecar writes, stripping legacy `_migrations` field) without actually changing the config file body. When `needsWrite` is true, a backup file is unconditionally created and the config is rewritten, even when the output is identical to the existing file. This causes a new `.bak.<timestamp>` file to accumulate on every OpenCode startup.

## Fix
Added a content comparison before the backup/write block. The function now reads the existing config file content and compares it against the serialized migration output. If they are identical, the function applies in-memory mutations (e.g. stripped `_migrations`) and returns `false` without touching the filesystem. Backup and rewrite only occur when the config content has actually changed.

## Changes
| File | Change |
|------|--------|
| `src/shared/migration/config-migration.ts` | Add content comparison guard before backup creation |

Fixes #3222

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip creating `.bak.<timestamp>` files and rewrites during config migration when the migrated output matches the original in-memory config. This prevents backup sprawl on startup and avoids unnecessary disk I/O.

- **Bug Fixes**
  - Compare the serialized migrated config to an `originalSnapshot` of `rawConfig` (in-memory) before backup/write.
  - If identical, mutate `rawConfig` in memory and return; only create a backup and rewrite when content changes.

<sup>Written for commit dc622439855617ad5669ffac60bc92c6654d248e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

