### PR TITLE
fix(skill): use existing 'review-work' skill name in tool examples (fixes #3285)

### DIFF
--- a/src/tools/skill/constants.ts
+++ b/src/tools/skill/constants.ts
@@ -8,7 +8,7 @@ Skills and commands provide specialized knowledge and step-by-step guidance.
 Use this when a task matches an available skill's or command's description.
 
 **How to use:**
-- Call with a skill name: name='code-review'
+- Call with a skill name: name='review-work'
 - Call with a command name (without leading slash): name='publish'
 - The tool will return detailed instructions with your context applied.
 `

--- a/src/tools/skill/tools.ts
+++ b/src/tools/skill/tools.ts
@@ -104,7 +104,7 @@ export function createSkillTool(options: SkillLoadOptions = {}): ToolDefinition 
       return cachedDescription ?? TOOL_DESCRIPTION_PREFIX
     },
     args: {
-      name: tool.schema.string().describe("The skill or command name (e.g., 'code-review' or 'publish'). Use without leading slash for commands."),
+      name: tool.schema.string().describe("The skill or command name (e.g., 'review-work' or 'publish'). Use without leading slash for commands."),
       user_message: tool.schema
         .string()
         .optional()


### PR DESCRIPTION
## Summary
- Replace non-existent 'code-review' example with actual 'review-work' skill name in tool schema

## Problem
The skill tool's description and argument schema reference 'code-review' as an example skill name, but this skill does not exist. Users who follow the example get an error. The actual built-in review skill is named 'review-work'.

## Fix
Updated both references from 'code-review' to 'review-work'.

## Changes
| File | Change |
|------|--------|
| `src/tools/skill/constants.ts` | Update example in TOOL_DESCRIPTION_PREFIX |
| `src/tools/skill/tools.ts` | Update example in argument schema description |

Fixes #3285

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the non-existent 'code-review' example with the correct 'review-work' skill name in the skill tool description and argument schema to prevent usage errors. Fixes #3285.

<sup>Written for commit b076923652e9113716cc19c085d72664e4ed44bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

