### PR TITLE
fix: normalize legacy default_agent values before display name resolution

### DIFF
--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -2,7 +2,7 @@ import { createBuiltinAgents } from "../agents";
 import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
 import type { OhMyOpenCodeConfig } from "../config";
 import { isTaskSystemEnabled, log, migrateAgentConfig } from "../shared";
-import { getAgentDisplayName } from "../shared/agent-display-names";
+import { getAgentDisplayName, normalizeAgentForPrompt } from "../shared/agent-display-names";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { registerAgentName } from "../features/claude-code-session-state";
 import {
@@ -159,7 +159,7 @@ export async function applyAgentConfig(params: {
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
     if (configuredDefaultAgent) {
       (params.config as { default_agent?: string }).default_agent =
-        getAgentDisplayName(configuredDefaultAgent);
+        normalizeAgentForPrompt(configuredDefaultAgent) ?? getAgentDisplayName("sisyphus");
     } else {
       (params.config as { default_agent?: string }).default_agent =
         getAgentDisplayName("sisyphus");


### PR DESCRIPTION
## Summary

Follow-up to 9532440 which removed ZWSP from agent config keys but left `configuredDefaultAgent` unnormalized. This handles legacy `default_agent` values that `getAgentDisplayName()` alone leaves unchanged.

## Problem

After 9532440 landed, `getAgentDisplayName(configuredDefaultAgent)` still fails for:
- **Legacy parenthesized names**: `"Sisyphus (Ultraworker)"` passes through unchanged, missing the `"Sisyphus - Ultraworker"` agent key
- **ZWSP-prefixed values**: old stored values like `"\u200BSisyphus - Ultraworker"` also pass through unchanged

## Fix

Replace `getAgentDisplayName(configuredDefaultAgent)` with `normalizeAgentForPrompt(configuredDefaultAgent)`, which already exists in the codebase and handles all legacy formats:

| Input | `getAgentDisplayName` (before) | `normalizeAgentForPrompt` (after) |
|---|---|---|
| `"sisyphus"` | `"Sisyphus - Ultraworker"` ✓ | `"Sisyphus - Ultraworker"` ✓ |
| `"Sisyphus - Ultraworker"` | `"Sisyphus - Ultraworker"` ✓ | `"Sisyphus - Ultraworker"` ✓ |
| `"Sisyphus (Ultraworker)"` | `"Sisyphus (Ultraworker)"` ✗ | `"Sisyphus - Ultraworker"` ✓ |
| `"\u200BSisyphus - Ultraworker"` | `"\u200BSisyphus..."` ✗ | `"Sisyphus - Ultraworker"` ✓ |
| `"My-Custom-Agent"` | `"My-Custom-Agent"` ✓ | `"My-Custom-Agent"` ✓ |

1 file changed, 2 insertions, 2 deletions.

## Testing

- `bun run typecheck` — passes
- `bun run build` — passes

Fixes #3220
Relates to #3238, #3281