### PR TITLE
fix(delegate-task): isPlanFamily false-positive on display names

### DIFF
--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -191,7 +191,7 @@ describe("sisyphus-task", () => {
       expect(result).toBe(false)
     })
 
-    test("returns true for 'planner' (matches via includes('plan'))", () => {
+    test("returns false for 'planner' (no longer matches via substring)", () => {
       //#given / #when
       const result = isPlanAgent("planner")
 
@@ -252,6 +252,19 @@ describe("sisyphus-task", () => {
       expect(PLAN_AGENT_NAMES).toEqual(["plan"])
     })
   })
+
+    test("returns false for non-plan agent display names (regression: isPlanAgent substring false-positive)", () => {
+      //#given / #when / #then
+      expect(isPlanAgent("Atlas (Plan Executor)")).toBe(false)
+      expect(isPlanAgent("Momus (Plan Critic)")).toBe(false)
+      expect(isPlanAgent("Metis (Plan Consultant)")).toBe(false)
+    })
+
+    test("returns true for 'Plan' display name casing variations", () => {
+      //#given / #when / #then
+      expect(isPlanAgent("Plan")).toBe(true)
+      expect(isPlanAgent("PLAN")).toBe(true)
+    })
 
   describe("isPlanFamily", () => {
     test("returns true for 'plan'", () => {

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -261,6 +261,13 @@ describe("sisyphus-task", () => {
       expect(result).toBe(true)
     })
 
+    test("returns false for non-plan-family agent display names", () => {
+      //#given / #when / #then
+      expect(isPlanFamily("Momus (Plan Critic)")).toBe(false)
+      expect(isPlanFamily("Metis (Plan Consultant)")).toBe(false)
+      expect(isPlanFamily("Atlas (Plan Executor)")).toBe(false)
+    })
+
     test("returns true for 'prometheus'", () => {
       //#given / #when
       const result = isPlanFamily("prometheus")


### PR DESCRIPTION
## Summary
- Replace naive `.includes(name)` with `getAgentConfigKey()` normalization + exact match
- Fixes Prometheus unable to delegate to Momus/Metis/Atlas (display names contained Plan)
- Adds regression tests for display name inputs

Fixes #3312

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix false positives in `isPlanFamily` and `isPlanAgent` by normalizing names via `getAgentConfigKey()` and switching to exact matches (no substring). Unblocks Prometheus delegation to Momus/Metis/Atlas; updates tests (`'planner'` now returns false) and adds regression coverage for display-name false-positives and case-insensitive `'Plan'`; fixes #3312.

<sup>Written for commit 32c038da7ec5b68442034389e791556d040c85ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

