### PR TITLE
fix(grep): handle Windows drive-letter paths and CRLF in parseOutput

### DIFF
--- a/src/tools/grep/cli.ts
+++ b/src/tools/grep/cli.ts
@@ -102,7 +102,8 @@ function parseOutput(output: string, filesOnly = false): GrepMatch[] {
   const matches: GrepMatch[] = []
   const lines = output.split("\n")
 
-  for (const line of lines) {
+  for (let line of lines) {
+    line = line.replace(/\r$/, "")
     if (!line.trim()) continue
 
     if (filesOnly) {
@@ -115,7 +116,8 @@ function parseOutput(output: string, filesOnly = false): GrepMatch[] {
       continue
     }
 
-    const match = line.match(/^(.+?):(\d+):(.*)$/)
+    // Handle Windows drive-letter paths (e.g. C:\path\file.ts:42:content)
+    const match = line.match(/^([A-Za-z]:[\\\/].*?|.+?):(\d+):(.*)$/)
     if (match) {
       matches.push({
         file: match[1],
@@ -134,10 +136,11 @@ function parseCountOutput(output: string): CountResult[] {
   const results: CountResult[] = []
   const lines = output.split("\n")
 
-  for (const line of lines) {
+  for (let line of lines) {
+    line = line.replace(/\r$/, "")
     if (!line.trim()) continue
 
-    const match = line.match(/^(.+?):(\d+)$/)
+    const match = line.match(/^([A-Za-z]:[\\\/].*?|.+?):(\d+)$/)
     if (match) {
       results.push({
         file: match[1],


### PR DESCRIPTION
## Summary

Fixes grep tool `content` and `count` output modes always returning "No matches found" on Windows.

Closes #2962

## Root Cause (two issues)

### 1. Drive-letter regex failure

ripgrep outputs paths like `C:\path\file.ts:42:content`. The regex `^(.+?):(\d+):(.*)$` matches `C` as the file group (lazy `.+?` stops at the first `:`), then `\d+` fails on `\path\...`.

### 2. CRLF line endings (missed by PR #2976)

ripgrep outputs `\r\n` on Windows. After `split("\n")`, each line retains a trailing `\r`. The `$` anchor in the regex does not match before `\r`, so every line fails.

**PR #2976 addressed issue 1 with `--path-separator=/`, but this flag gets expanded by MSYS2/Git Bash into a full path (`C:/Program Files/Git/`), causing a separate rg error. It also did not address issue 2.**

## Fix

- Update `parseOutput` and `parseCountOutput` regexes to handle drive-letter prefixes: `^([A-Za-z]:[\\/].*?|.+?):(\d+):(.*)$`
- Strip trailing `\r` from each line before matching: `line.replace(/\r$/, "")`
- No `--path-separator` flag (avoids MSYS2 expansion issue)

## Why this doesn't break Linux/Mac

- The `\r` strip is a no-op when `\r` is absent
- The regex uses an alternative `([A-Za-z]:[\\/].*?|.+?)` — when no drive letter exists, it falls back to the original `.+?` behavior

## Testing

Verified on Windows 11 + Git Bash + ripgrep 15.1.0 + oh-my-openagent 3.16.0:

| Mode | Before | After |
|------|--------|-------|
| `content` | "No matches found" | Correct matches with file, line, text |
| `count` | Working | Working |
| `files_with_matches` | Working | Working |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows parsing in the grep tool so `content` and `count` modes return correct matches instead of "No matches found" by handling drive-letter paths and CRLF line endings.

- **Bug Fixes**
  - Strip trailing `\r` from each output line before matching.
  - Update `parseOutput` and `parseCountOutput` regexes to support `C:\...` paths.
  - Remove `--path-separator` usage to avoid MSYS2/Git Bash path expansion.

<sup>Written for commit b0b19f30b946fa75ea696663b1f85cb4dba61b13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

