### PR TITLE
fix(anthropic-effort): skip effort injection for Haiku models

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -3,6 +3,13 @@ import { log, normalizeModelID } from "../../shared"
 const OPUS_PATTERN = /claude-.*opus/i
 const INTERNAL_SKIP_AGENTS = new Set(["title", "summary", "compaction"])
 
+/**
+ * Models that do not support the effort parameter.
+ * Haiku is a "small" model used for title generation, summaries, etc.
+ * These models return API errors when effort is passed.
+ */
+const EFFORT_UNSUPPORTED_PATTERN = /claude-.*haiku/i
+
 function isClaudeProvider(providerID: string, modelID: string): boolean {
   if (["anthropic", "google-vertex-anthropic", "opencode"].includes(providerID)) return true
   if (providerID === "github-copilot" && modelID.toLowerCase().includes("claude")) return true
@@ -12,6 +19,15 @@ function isClaudeProvider(providerID: string, modelID: string): boolean {
 function isOpusModel(modelID: string): boolean {
   const normalized = normalizeModelID(modelID)
   return OPUS_PATTERN.test(normalized)
+}
+
+/**
+ * Check if the model does not support effort parameter.
+ * Haiku and other small/lite models don't support extended thinking.
+ */
+function isEffortUnsupportedModel(modelID: string): boolean {
+  const normalized = normalizeModelID(modelID)
+  return EFFORT_UNSUPPORTED_PATTERN.test(normalized)
 }
 
 function shouldSkipForInternalAgent(agentName: string | undefined): boolean {
@@ -59,6 +75,7 @@ export function createAnthropicEffortHook() {
       if (message.variant !== "max") return
       if (!isClaudeProvider(model.providerID, model.modelID)) return
       if (shouldSkipForInternalAgent(agent?.name)) return
+      if (isEffortUnsupportedModel(model.modelID)) return
       if (output.options.effort !== undefined) return
 
       const opus = isOpusModel(model.modelID)

--- a/src/hooks/anthropic-effort/index.test.ts
+++ b/src/hooks/anthropic-effort/index.test.ts
@@ -147,6 +147,32 @@ describe("createAnthropicEffortHook", () => {
 
       expect(output.options.effort).toBeUndefined()
     })
+
+    describe("#given models that do not support effort parameter", () => {
+      const unsupportedModels = [
+        "claude-haiku-4-5",
+        "claude-3-haiku",
+        "claude-3-5-haiku",
+        "claude-haiku-4.5",
+        "anthropic/claude-haiku-4-5",
+      ] as const
+
+      for (const modelID of unsupportedModels) {
+        it(`skips effort injection for ${modelID} (does not support effort)`, async () => {
+          // given - haiku model with variant max
+          const hook = createAnthropicEffortHook()
+          const { input, output } = createMockParams({ modelID })
+
+          // when
+          await hook["chat.params"](input, output)
+
+          // then - effort should NOT be injected
+          expect(output.options.effort).toBeUndefined()
+          // variant should remain unchanged (not mutated)
+          expect(input.message.variant).toBe("max")
+        })
+      }
+    })
   })
 
   describe("existing options", () => {


### PR DESCRIPTION
## Summary

Fixes #3308

The `anthropic-effort` hook was injecting the `effort` parameter into all Claude API calls when `message.variant === 'max'`, including calls to Haiku models used by the title agent. Haiku does not support the effort parameter, causing API rejection with error: "This model does not support the effort parameter."

## Root Cause

The hook checked `message.variant` (which retains 'max' from the session's user message) but didn't account for the target model's capability. While opencode's `llm.ts` correctly skips variant for small models (`input.small`), this hook would re-inject effort.

## Solution

Added explicit model-level detection for effort-unsupported models (Haiku pattern). This complements the existing agent name check (`title`, `summary`, `compaction`) by adding a model capability check.

## Changes

- `src/hooks/anthropic-effort/hook.ts`: Added `EFFORT_UNSUPPORTED_PATTERN` and `isEffortUnsupportedModel()` to skip effort injection for Haiku models
- `src/hooks/anthropic-effort/index.test.ts`: Added test cases for Haiku model skip behavior

## Testing

```bash
bun test src/hooks/anthropic-effort/index.test.ts
# 17 pass, 0 fail
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip injecting `effort` for Claude Haiku models in the `anthropic-effort` hook to prevent API errors and restore title/summary/compaction calls. Fixes #3308.

- **Bug Fixes**
  - Added `EFFORT_UNSUPPORTED_PATTERN` and `isEffortUnsupportedModel()` to detect Haiku models and skip `effort` even when `message.variant === 'max'`.
  - Kept internal agent skip and added model capability check to avoid re-injection.
  - Added tests covering common Haiku model IDs.

<sup>Written for commit d9eb86bb7109b63dfbff730c08a64ce94a7cb447. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

