### PR TITLE
fix(anthropic-effort): skip effort injection for Haiku models

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -62,11 +62,11 @@ export function createAnthropicEffortHook() {
     ): Promise<void> => {
       const { agent, model, message } = input
       if (!model?.modelID || !model?.providerID) return
+      if (isEffortUnsupportedModel(model.modelID)) return
       if (message.variant !== "max") return
       if (!isClaudeProvider(model.providerID, model.modelID)) return
       if (shouldSkipForInternalAgent(agent?.name)) return
       if (output.options.effort !== undefined) return
-      if (isEffortUnsupportedModel(model.modelID)) return
 
       const opus = isOpusModel(model.modelID)
       const clamped = clampVariant(message.variant, opus)

--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -1,6 +1,7 @@
 import { log, normalizeModelID } from "../../shared"
 
 const OPUS_PATTERN = /claude-.*opus/i
+const EFFORT_UNSUPPORTED_PATTERN = /claude-.*haiku/i
 const INTERNAL_SKIP_AGENTS = new Set(["title", "summary", "compaction"])
 
 function isClaudeProvider(providerID: string, modelID: string): boolean {
@@ -12,6 +13,11 @@ function isClaudeProvider(providerID: string, modelID: string): boolean {
 function isOpusModel(modelID: string): boolean {
   const normalized = normalizeModelID(modelID)
   return OPUS_PATTERN.test(normalized)
+}
+
+function isEffortUnsupportedModel(modelID: string): boolean {
+  const normalized = normalizeModelID(modelID)
+  return EFFORT_UNSUPPORTED_PATTERN.test(normalized)
 }
 
 function shouldSkipForInternalAgent(agentName: string | undefined): boolean {
@@ -60,6 +66,7 @@ export function createAnthropicEffortHook() {
       if (!isClaudeProvider(model.providerID, model.modelID)) return
       if (shouldSkipForInternalAgent(agent?.name)) return
       if (output.options.effort !== undefined) return
+      if (isEffortUnsupportedModel(model.modelID)) return
 
       const opus = isOpusModel(model.modelID)
       const clamped = clampVariant(message.variant, opus)

--- a/src/hooks/anthropic-effort/index.test.ts
+++ b/src/hooks/anthropic-effort/index.test.ts
@@ -147,6 +147,30 @@ describe("createAnthropicEffortHook", () => {
 
       expect(output.options.effort).toBeUndefined()
     })
+
+    describe("#given haiku models (effort unsupported)", () => {
+      const haikuModels = [
+        "claude-haiku-4-5",
+        "claude-haiku-4.6",
+        "claude-haiku",
+        "claude-haiku-20240307",
+      ]
+
+      for (const modelID of haikuModels) {
+        it(`skips effort injection for ${modelID}`, async () => {
+          // given
+          const hook = createAnthropicEffortHook()
+          const { input, output } = createMockParams({ modelID })
+
+          // when
+          await hook["chat.params"](input, output)
+
+          // then
+          expect(output.options.effort).toBeUndefined()
+          expect(input.message.variant).toBe("max")
+        })
+      }
+    })
   })
 
   describe("existing options", () => {


### PR DESCRIPTION
## Summary

Fixes #3308

The `anthropic-effort` hook was injecting the `effort` parameter into all Claude API calls when `message.variant === 'max'`, including calls to Haiku models. Haiku does not support the effort parameter, causing API rejection with error: "This model does not support the effort parameter."

## Root Cause

The hook checked `message.variant` but didn't account for the target model's capability. Haiku models (used by title agent) don't support extended thinking/effort parameters.

## Solution

Added `EFFORT_UNSUPPORTED_PATTERN` and `isEffortUnsupportedModel()` to detect and skip effort injection for Haiku models.

## Changes

- `src/hooks/anthropic-effort/hook.ts`: Added Haiku detection pattern and skip logic
- `src/hooks/anthropic-effort/index.test.ts`: Added test cases for Haiku model skip behavior

## Testing

```bash
bun test src/hooks/anthropic-effort/index.test.ts
# 16 pass, 0 fail
```

---
*This fix was implemented by droid (Factory AI) via use-droid skill*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip injecting the `effort` parameter for Claude Haiku models in the `anthropic-effort` hook. Prevents API errors and restores reliable title generation.

- **Bug Fixes**
  - Detect `claude-.*haiku` via `EFFORT_UNSUPPORTED_PATTERN` and `isEffortUnsupportedModel()` and bypass effort injection.
  - Run the Haiku skip check immediately after model validation (before the variant check) to ensure a reliable early return.
  - Add tests for multiple Haiku model IDs to confirm the skip behavior.

<sup>Written for commit 522f8aab6c5339818bc20da8f5264ddc9cb53963. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

