### PR TITLE
fix(shell-env): check SHELL before PSModulePath for shell detection

### DIFF
--- a/src/shared/shell-env.test.ts
+++ b/src/shared/shell-env.test.ts
@@ -45,7 +45,8 @@ describe("shell-env", () => {
       expect(result).toBe("unix")
     })
 
-    test("#given PSModulePath is set #when detectShellType is called #then returns powershell", () => {
+    test("#given PSModulePath is set without SHELL #when detectShellType is called #then returns powershell", () => {
+      delete process.env.SHELL
       process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
       Object.defineProperty(process, "platform", { value: "win32" })
 
@@ -74,14 +75,24 @@ describe("shell-env", () => {
       expect(result).toBe("unix")
     })
 
-    test("#given PSModulePath takes priority over SHELL #when both are set #then returns powershell", () => {
+    test("#given SHELL takes priority over PSModulePath #when both are set #then returns unix", () => {
       process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
       process.env.SHELL = "/bin/bash"
       Object.defineProperty(process, "platform", { value: "win32" })
 
       const result = detectShellType()
 
-      expect(result).toBe("powershell")
+      expect(result).toBe("unix")
+    })
+
+    test("#given SHELL set to Git Bash on Windows with PSModulePath #when detectShellType is called #then returns unix", () => {
+      process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
+      process.env.SHELL = "C:\\Program Files\\Git\\bin\\bash.exe"
+      Object.defineProperty(process, "platform", { value: "win32" })
+
+      const result = detectShellType()
+
+      expect(result).toBe("unix")
     })
   })
 

--- a/src/shared/shell-env.ts
+++ b/src/shared/shell-env.ts
@@ -4,21 +4,25 @@ export type ShellType = "unix" | "powershell" | "cmd" | "csh"
  * Detect the current shell type based on environment variables.
  * 
  * Detection priority:
- * 1. PSModulePath → PowerShell
- * 2. SHELL env var → Unix shell
+ * 1. SHELL env var → Unix shell (explicit user choice takes precedence)
+ * 2. PSModulePath → PowerShell
  * 3. Platform fallback → win32: cmd, others: unix
+ * 
+ * Note: SHELL is checked before PSModulePath because on Windows, PSModulePath
+ * is always set by the system even when the active shell is Git Bash or WSL.
+ * An explicit SHELL variable indicates the user's chosen shell overrides that.
  */
 export function detectShellType(): ShellType {
-  if (process.env.PSModulePath) {
-    return "powershell"
-  }
-
   if (process.env.SHELL) {
     const shell = process.env.SHELL
     if (shell.includes("csh") || shell.includes("tcsh")) {
       return "csh"
     }
     return "unix"
+  }
+
+  if (process.env.PSModulePath) {
+    return "powershell"
   }
 
   return process.platform === "win32" ? "cmd" : "unix"


### PR DESCRIPTION
## Summary

- Reordered `detectShellType()` to check `SHELL` env var **before** `PSModulePath`
- On Windows, `PSModulePath` is always set by the system, causing the function to incorrectly return `"powershell"` even when the user has `SHELL` pointing to Git Bash or another Unix-like shell
- An explicit `SHELL` env var indicates the user's chosen shell and should take priority over the implicit `PSModulePath` heuristic

## Problem

When running OpenCode with oh-my-openagent on Windows with Git Bash (SHELL set), the plugin generated PowerShell env var syntax (`$env:VAR='value'`) instead of Unix syntax (`export VAR=value;`). This caused commands to fail silently or with syntax errors in bash shells.

Root cause: `detectShellType()` checked `PSModulePath` first. Since Windows always has this env var, it always returned `"powershell"` regardless of the user's actual shell preference.

## Fix

```typescript
// Before (buggy): PSModulePath checked first → always "powershell" on Windows
if (process.env.PSModulePath) return "powershell"
if (process.env.SHELL) ...

// After (fixed): SHELL checked first → respects user's explicit shell choice
if (process.env.SHELL) ...
if (process.env.PSModulePath) return "powershell"
```

## Testing

- Updated existing test: "PSModulePath takes priority" → "SHELL takes priority over PSModulePath → returns unix"
- Added new test: Git Bash path on Windows with PSModulePath should return "unix"
- Fixed PSModulePath-only test to explicitly `delete process.env.SHELL` (was leaking from system env)
- All 42 tests pass

Closes #3338

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches shell detection to check SHELL before PSModulePath so Windows users with Git Bash aren’t misidentified as PowerShell. This fixes incorrect env var syntax and bash errors. Fixes #3338.

- Bug Fixes
  - Prioritize SHELL over PSModulePath; fallbacks stay the same (win32 → cmd, others → unix).
  - Treat Git Bash paths (e.g., C:\Program Files\Git\bin\bash.exe) as unix.
  - Updated tests for precedence and Git Bash; clear SHELL in PSModulePath-only test.

<sup>Written for commit f5a95203a46a32968c1107571cd4b2061b49c6e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

