### PR TITLE
fix(stop-continuation): clear chat.message fallback stop state before work resumes

### DIFF
--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -17,6 +17,18 @@ import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/s
 type ChatMessagePart = { type: string; text?: string; [key: string]: unknown }
 type ChatMessageHandlerOutput = { message: Record<string, unknown>; parts: ChatMessagePart[] }
 
+function createStartWorkTemplateOutput(): ChatMessageHandlerOutput {
+  return {
+    message: {},
+    parts: [
+      {
+        type: "text",
+        text: `<session-context>context</session-context>\nYou are starting a Sisyphus work session.`,
+      },
+    ],
+  }
+}
+
 function createStopContinuationGuardMock(isStopped: boolean) {
   const clearCalls: string[] = []
   const isStoppedCalls: string[] = []
@@ -248,10 +260,7 @@ describe("createChatMessageHandler - stop continuation clearing for raw slash fa
       },
     }
     const handler = createChatMessageHandler(args)
-    const output: ChatMessageHandlerOutput = {
-      message: {},
-      parts: [{ type: "text", text: "/start-work" }],
-    }
+    const output = createStartWorkTemplateOutput()
 
     // when
     await handler(createMockInput("sisyphus"), output)
@@ -322,6 +331,31 @@ describe("createChatMessageHandler - stop continuation clearing for raw slash fa
     expect(stopContinuationGuard.clearCalls).toEqual(["test-session"])
   })
 
+  test("does not clear stop state for ordinary stopped chat messages", async () => {
+    // given
+    const stopContinuationGuard = createStopContinuationGuardMock(true)
+    const startWorkCalls: string[] = []
+    const args = createMockHandlerArgs()
+    args.hooks.stopContinuationGuard = stopContinuationGuard.guard
+    args.hooks.startWork = {
+      "chat.message": async (input: { sessionID: string }) => {
+        startWorkCalls.push(input.sessionID)
+      },
+    }
+    const handler = createChatMessageHandler(args)
+
+    // when
+    await handler(createMockInput("sisyphus"), {
+      message: {},
+      parts: [{ type: "text", text: "continue helping with this bug" }],
+    })
+
+    // then
+    expect(startWorkCalls).toEqual(["test-session"])
+    expect(stopContinuationGuard.isStoppedCalls).toHaveLength(0)
+    expect(stopContinuationGuard.clearCalls).toHaveLength(0)
+  })
+
   test("does not clear stop state when the session was not stopped", async () => {
     // given
     const stopContinuationGuard = createStopContinuationGuardMock(false)
@@ -346,7 +380,7 @@ describe("createChatMessageHandler - stop continuation clearing for raw slash fa
     // when
     await handler(createMockInput("sisyphus"), {
       message: {},
-      parts: [{ type: "text", text: "/start-work" }],
+      parts: createStartWorkTemplateOutput().parts,
     })
     await handler(createMockInput("sisyphus"), {
       message: {},
@@ -368,8 +402,6 @@ describe("createChatMessageHandler - stop continuation clearing for raw slash fa
       { sessionID: "test-session", prompt: "continue", ultrawork: false },
     ])
     expect(stopContinuationGuard.isStoppedCalls).toEqual([
-      "test-session",
-      "test-session",
       "test-session",
       "test-session",
       "test-session",

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -17,6 +17,27 @@ import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/s
 type ChatMessagePart = { type: string; text?: string; [key: string]: unknown }
 type ChatMessageHandlerOutput = { message: Record<string, unknown>; parts: ChatMessagePart[] }
 
+function createStopContinuationGuardMock(isStopped: boolean) {
+  const clearCalls: string[] = []
+  const isStoppedCalls: string[] = []
+
+  return {
+    guard: {
+      "chat.message": async () => {},
+      stop: () => {},
+      isStopped: (sessionID: string) => {
+        isStoppedCalls.push(sessionID)
+        return isStopped
+      },
+      clear: (sessionID: string) => {
+        clearCalls.push(sessionID)
+      },
+    },
+    clearCalls,
+    isStoppedCalls,
+  }
+}
+
 function createMockHandlerArgs(overrides?: {
   pluginConfig?: Record<string, unknown>
   shouldOverride?: boolean
@@ -211,6 +232,149 @@ describe("createChatMessageHandler - /start-work integration", () => {
     expect(output.parts[0].text).toContain("Auto-Selected Plan")
     expect(output.parts[0].text).toContain("my-feature-plan")
     expect(readBoulderState(testDir)?.plan_name).toBe("my-feature-plan")
+  })
+})
+
+describe("createChatMessageHandler - stop continuation clearing for raw slash fallback", () => {
+  test("clears stop state before raw /start-work resumes work through chat.message", async () => {
+    // given
+    const stopContinuationGuard = createStopContinuationGuardMock(true)
+    const startWorkCalls: string[] = []
+    const args = createMockHandlerArgs()
+    args.hooks.stopContinuationGuard = stopContinuationGuard.guard
+    args.hooks.startWork = {
+      "chat.message": async (input: { sessionID: string }) => {
+        startWorkCalls.push(input.sessionID)
+      },
+    }
+    const handler = createChatMessageHandler(args)
+    const output: ChatMessageHandlerOutput = {
+      message: {},
+      parts: [{ type: "text", text: "/start-work" }],
+    }
+
+    // when
+    await handler(createMockInput("sisyphus"), output)
+
+    // then
+    expect(startWorkCalls).toEqual(["test-session"])
+    expect(stopContinuationGuard.isStoppedCalls).toEqual(["test-session"])
+    expect(stopContinuationGuard.clearCalls).toEqual(["test-session"])
+  })
+
+  test("clears stop state before raw /ulw-loop resumes work through chat.message", async () => {
+    // given
+    const stopContinuationGuard = createStopContinuationGuardMock(true)
+    const startLoopCalls: Array<{ sessionID: string; prompt: string; ultrawork: boolean }> = []
+    const args = createMockHandlerArgs()
+    args.hooks.stopContinuationGuard = stopContinuationGuard.guard
+    args.hooks.ralphLoop = {
+      startLoop: (sessionID: string, prompt: string, options?: { ultrawork?: boolean }) => {
+        startLoopCalls.push({ sessionID, prompt, ultrawork: options?.ultrawork === true })
+        return true
+      },
+      cancelLoop: () => true,
+    }
+    const handler = createChatMessageHandler(args)
+    const output: ChatMessageHandlerOutput = {
+      message: {},
+      parts: [{ type: "text", text: "/ulw-loop ship it" }],
+    }
+
+    // when
+    await handler(createMockInput("sisyphus"), output)
+
+    // then
+    expect(startLoopCalls).toEqual([
+      { sessionID: "test-session", prompt: "ship it", ultrawork: true },
+    ])
+    expect(stopContinuationGuard.isStoppedCalls).toEqual(["test-session"])
+    expect(stopContinuationGuard.clearCalls).toEqual(["test-session"])
+  })
+
+  test("clears stop state before raw /ralph-loop resumes work through chat.message", async () => {
+    // given
+    const stopContinuationGuard = createStopContinuationGuardMock(true)
+    const startLoopCalls: Array<{ sessionID: string; prompt: string; ultrawork: boolean }> = []
+    const args = createMockHandlerArgs()
+    args.hooks.stopContinuationGuard = stopContinuationGuard.guard
+    args.hooks.ralphLoop = {
+      startLoop: (sessionID: string, prompt: string, options?: { ultrawork?: boolean }) => {
+        startLoopCalls.push({ sessionID, prompt, ultrawork: options?.ultrawork === true })
+        return true
+      },
+      cancelLoop: () => true,
+    }
+    const handler = createChatMessageHandler(args)
+    const output: ChatMessageHandlerOutput = {
+      message: {},
+      parts: [{ type: "text", text: "/ralph-loop keep going" }],
+    }
+
+    // when
+    await handler(createMockInput("sisyphus"), output)
+
+    // then
+    expect(startLoopCalls).toEqual([
+      { sessionID: "test-session", prompt: "keep going", ultrawork: false },
+    ])
+    expect(stopContinuationGuard.isStoppedCalls).toEqual(["test-session"])
+    expect(stopContinuationGuard.clearCalls).toEqual(["test-session"])
+  })
+
+  test("does not clear stop state when the session was not stopped", async () => {
+    // given
+    const stopContinuationGuard = createStopContinuationGuardMock(false)
+    const startWorkCalls: string[] = []
+    const startLoopCalls: Array<{ sessionID: string; prompt: string; ultrawork: boolean }> = []
+    const args = createMockHandlerArgs()
+    args.hooks.stopContinuationGuard = stopContinuationGuard.guard
+    args.hooks.startWork = {
+      "chat.message": async (input: { sessionID: string }) => {
+        startWorkCalls.push(input.sessionID)
+      },
+    }
+    args.hooks.ralphLoop = {
+      startLoop: (sessionID: string, prompt: string, options?: { ultrawork?: boolean }) => {
+        startLoopCalls.push({ sessionID, prompt, ultrawork: options?.ultrawork === true })
+        return true
+      },
+      cancelLoop: () => true,
+    }
+    const handler = createChatMessageHandler(args)
+
+    // when
+    await handler(createMockInput("sisyphus"), {
+      message: {},
+      parts: [{ type: "text", text: "/start-work" }],
+    })
+    await handler(createMockInput("sisyphus"), {
+      message: {},
+      parts: [{ type: "text", text: "/ulw-loop continue" }],
+    })
+    await handler(createMockInput("sisyphus"), {
+      message: {},
+      parts: [{ type: "text", text: "/ralph-loop continue" }],
+    })
+
+    // then
+    expect(startWorkCalls).toEqual([
+      "test-session",
+      "test-session",
+      "test-session",
+    ])
+    expect(startLoopCalls).toEqual([
+      { sessionID: "test-session", prompt: "continue", ultrawork: true },
+      { sessionID: "test-session", prompt: "continue", ultrawork: false },
+    ])
+    expect(stopContinuationGuard.isStoppedCalls).toEqual([
+      "test-session",
+      "test-session",
+      "test-session",
+      "test-session",
+      "test-session",
+    ])
+    expect(stopContinuationGuard.clearCalls).toHaveLength(0)
   })
 })
 

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -1,7 +1,7 @@
 import type { OhMyOpenCodeConfig } from "../config"
 import type { PluginContext } from "./types"
 
-import { isModelCacheAvailable } from "../shared"
+import { isModelCacheAvailable, log } from "../shared"
 import { getAgentConfigKey } from "../shared/agent-display-names"
 import { getSessionModel, setSessionModel } from "../shared/session-model-state"
 import { getMainSessionID, setSessionAgent, subagentSessions } from "../features/claude-code-session-state"
@@ -125,6 +125,20 @@ function parseRawLoopSlashCommand(promptText: string): RawLoopCommand | null {
   return null
 }
 
+function clearStoppedContinuationBeforeWorkStart(
+  hooks: CreatedHooks,
+  sessionID: string,
+  command: "start-work" | "ralph-loop" | "ulw-loop"
+): void {
+  if (hooks.stopContinuationGuard?.isStopped(sessionID)) {
+    hooks.stopContinuationGuard.clear(sessionID)
+    log("[stop-continuation] Stop state cleared by chat.message work-starting command", {
+      sessionID,
+      command,
+    })
+  }
+}
+
 export function createChatMessageHandler(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
@@ -207,6 +221,7 @@ export function createChatMessageHandler(args: {
     await hooks.noSisyphusGpt?.["chat.message"]?.(input, output)
     await hooks.noHephaestusNonGpt?.["chat.message"]?.(input, output)
     if (hooks.startWork && isStartWorkHookOutput(output)) {
+      clearStoppedContinuationBeforeWorkStart(hooks, input.sessionID, "start-work")
       await hooks.startWork["chat.message"]?.(input, output)
     }
 
@@ -252,7 +267,9 @@ export function createChatMessageHandler(args: {
         const rawTask = taskMatch?.[1]?.trim() || rawLoopCommand?.args || ""
         const parsedArguments = parseRalphLoopArguments(rawTask)
         const ultrawork = isUlwLoopTemplate || rawLoopCommand?.command === "ulw-loop"
+        const command = ultrawork ? "ulw-loop" : "ralph-loop"
 
+        clearStoppedContinuationBeforeWorkStart(hooks, input.sessionID, command)
         hooks.ralphLoop.startLoop(input.sessionID, parsedArguments.prompt, {
           ultrawork,
           maxIterations: parsedArguments.maxIterations,

--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -26,6 +26,7 @@ export type ChatMessageInput = {
 type StartWorkHookOutput = { parts: Array<{ type: string; text?: string }> }
 
 type SessionModelOverride = { providerID: string; modelID: string }
+const START_WORK_TEMPLATE_MARKER = "You are starting a Sisyphus work session."
 
 type RawLoopCommand =
   | { command: "ralph-loop" | "ulw-loop"; args: string }
@@ -125,6 +126,23 @@ function parseRawLoopSlashCommand(promptText: string): RawLoopCommand | null {
   return null
 }
 
+function extractPromptText(parts: ChatMessagePart[]): string {
+  return (
+    parts
+      ?.filter((part) => part.type === "text" && part.text)
+      .map((part) => part.text)
+      .join("\n")
+      .trim() || ""
+  )
+}
+
+function isStartWorkFallbackTemplate(promptText: string): boolean {
+  return (
+    promptText.includes("<session-context>") &&
+    promptText.includes(START_WORK_TEMPLATE_MARKER)
+  )
+}
+
 function clearStoppedContinuationBeforeWorkStart(
   hooks: CreatedHooks,
   sessionID: string,
@@ -221,7 +239,10 @@ export function createChatMessageHandler(args: {
     await hooks.noSisyphusGpt?.["chat.message"]?.(input, output)
     await hooks.noHephaestusNonGpt?.["chat.message"]?.(input, output)
     if (hooks.startWork && isStartWorkHookOutput(output)) {
-      clearStoppedContinuationBeforeWorkStart(hooks, input.sessionID, "start-work")
+      const promptText = extractPromptText(output.parts)
+      if (isStartWorkFallbackTemplate(promptText)) {
+        clearStoppedContinuationBeforeWorkStart(hooks, input.sessionID, "start-work")
+      }
       await hooks.startWork["chat.message"]?.(input, output)
     }
 
@@ -241,12 +262,7 @@ export function createChatMessageHandler(args: {
 
     if (hooks.ralphLoop && output.message[NATIVE_LOOP_TRIGGERED_FLAG] !== true) {
       const parts = output.parts
-      const promptText =
-        parts
-          ?.filter((p) => p.type === "text" && p.text)
-          .map((p) => p.text)
-          .join("\n")
-          .trim() || ""
+      const promptText = extractPromptText(parts)
 
       const isRalphLoopTemplate =
         promptText.includes("You are starting a Ralph Loop") &&


### PR DESCRIPTION
## Summary
- Clear the persisted stop-continuation flag when raw `/start-work`, `/ulw-loop`, or `/ralph-loop` commands resume work through `chat.message` fallback paths.
- Keep continuation gates consistent with resumed work so Atlas, todo continuation, and retry logic are no longer left in a stopped state.

## Changes
- Add `chat-message` fallback stop-state clearing before `startWork` and raw Ralph loop startup paths.
- Add regression tests covering stopped and non-stopped sessions for raw `/start-work`, `/ulw-loop`, and `/ralph-loop` commands.

## Testing
- `bun run typecheck` ✅
- `bun test` ✅
- `bun run build` ✅

## Related Issues
- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clear the stop-continuation flag when work resumes via `chat.message` fallbacks so sessions don’t stay stuck, now scoped to the start-work fallback template. Applies to the `/start-work` fallback template and raw `/ulw-loop` or `/ralph-loop` commands; ordinary chat messages don’t clear the flag.

- **Bug Fixes**
  - Scope `/start-work` clearing to the fallback template (detects `<session-context>` and the start marker) and log the clear event.
  - Clear stop state before `/ulw-loop` and `/ralph-loop` when triggered via raw slash or template fallbacks; add tests covering stopped/non-stopped sessions and non-clearing for ordinary messages.

<sup>Written for commit c9461a908574c16408bbcf652d80d73ec2bfe608. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

