### PR TITLE
refactor: simplify nullish guards and remove dead no-op paths

### DIFF
--- a/src/cli/config-manager/add-plugin-to-opencode-config.ts
+++ b/src/cli/config-manager/add-plugin-to-opencode-config.ts
@@ -79,11 +79,7 @@ export async function addPluginToOpenCodeConfig(currentVersion: string): Promise
 
     const normalizedPlugins = [...otherPlugins]
 
-    if (canonicalEntries.length > 0 || legacyEntries.length > 0) {
-      normalizedPlugins.push(pluginEntry)
-    } else {
-      normalizedPlugins.push(pluginEntry)
-    }
+    normalizedPlugins.push(pluginEntry)
 
     config.plugin = normalizedPlugins
 

--- a/src/cli/config-manager/parse-opencode-config-file.test.ts
+++ b/src/cli/config-manager/parse-opencode-config-file.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { parseOpenCodeConfigFileWithError } from "./parse-opencode-config-file"
+
+describe("parseOpenCodeConfigFileWithError", () => {
+  const tempDirectories: string[] = []
+
+  afterEach(() => {
+    for (const directory of tempDirectories.splice(0)) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  test("#given a valid object config #when parsing the file #then it returns the parsed config", () => {
+    // given
+    const directory = mkdtempSync(join(tmpdir(), "omo-parse-config-"))
+    tempDirectories.push(directory)
+    const filePath = join(directory, "opencode.json")
+    writeFileSync(filePath, '{"plugin": ["oh-my-openagent"]}\n', "utf-8")
+
+    // when
+    const result = parseOpenCodeConfigFileWithError(filePath)
+
+    // then
+    expect(result).toEqual({
+      config: { plugin: ["oh-my-openagent"] },
+    })
+  })
+
+  test("#given a null config payload #when parsing the file #then it returns a null parse error", () => {
+    // given
+    const directory = mkdtempSync(join(tmpdir(), "omo-parse-config-"))
+    tempDirectories.push(directory)
+    const filePath = join(directory, "opencode.json")
+    writeFileSync(filePath, "null\n", "utf-8")
+
+    // when
+    const result = parseOpenCodeConfigFileWithError(filePath)
+
+    // then
+    expect(result).toEqual({
+      config: null,
+      error: `Config file parsed to null/undefined: ${filePath}. Ensure it contains valid JSON.`,
+    })
+  })
+})

--- a/src/cli/config-manager/parse-opencode-config-file.ts
+++ b/src/cli/config-manager/parse-opencode-config-file.ts
@@ -30,7 +30,7 @@ export function parseOpenCodeConfigFileWithError(path: string): ParseConfigResul
 
     const config = parseJsonc<OpenCodeConfig>(content)
 
-    if (config === null || config === undefined) {
+    if (config == null) {
       return { config: null, error: `Config file parsed to null/undefined: ${path}. Ensure it contains valid JSON.` }
     }
 

--- a/src/config/schema/dynamic-context-pruning.ts
+++ b/src/config/schema/dynamic-context-pruning.ts
@@ -1,9 +1,7 @@
 import { z } from "zod"
 
 export const DynamicContextPruningConfigSchema = z.object({
-  /** Enable dynamic context pruning (default: false) */
   enabled: z.boolean().default(false),
-  /** Notification level: off, minimal, or detailed (default: detailed) */
   notification: z.enum(["off", "minimal", "detailed"]).default("detailed"),
   /** Turn protection - prevent pruning recent tool outputs */
   turn_protection: z

--- a/src/config/schema/ralph-loop.ts
+++ b/src/config/schema/ralph-loop.ts
@@ -1,9 +1,7 @@
 import { z } from "zod"
 
 export const RalphLoopConfigSchema = z.object({
-  /** Enable ralph loop functionality (default: false - opt-in feature) */
   enabled: z.boolean().default(false),
-  /** Default max iterations if not specified in command (default: 100) */
   default_max_iterations: z.number().min(1).max(1000).default(100),
   /** Custom state file directory relative to project root (default: .opencode/) */
   state_dir: z.string().optional(),

--- a/src/config/schema/start-work.ts
+++ b/src/config/schema/start-work.ts
@@ -1,7 +1,6 @@
 import { z } from "zod"
 
 export const StartWorkConfigSchema = z.object({
-  /** Enable auto-commit after each atomic task completion (default: true) */
   auto_commit: z.boolean().default(true),
 })
 

--- a/src/features/background-agent/loop-detector.test.ts
+++ b/src/features/background-agent/loop-detector.test.ts
@@ -112,6 +112,20 @@ describe("loop-detector", () => {
       expect(result).toBe("read")
     })
 
+    test("#given nullish inputs #when signatures are created #then null and undefined behave the same", () => {
+      // given
+      const undefinedInput = undefined
+      const nullInput = null
+
+      // when
+      const undefinedResult = createToolCallSignature("read", undefinedInput)
+      const nullResult = createToolCallSignature("read", nullInput)
+
+      // then
+      expect(undefinedResult).toBe("read")
+      expect(nullResult).toBe(undefinedResult)
+    })
+
     test("#given tool with empty object input #when signature created #then returns bare tool name", () => {
       const result = createToolCallSignature("read", {})
 
@@ -257,6 +271,25 @@ describe("loop-detector", () => {
         const result = detectRepetitiveToolUse(window)
 
         expect(result).toEqual({ triggered: false })
+      })
+    })
+
+    describe("#given nullish tool inputs", () => {
+      test("#when recorded #then null and undefined produce the same unknown-input window", () => {
+        // given
+        const settings = resolveCircuitBreakerSettings()
+
+        // when
+        const undefinedWindow = recordToolCall(undefined, "read", settings, undefined)
+        const nullWindow = recordToolCall(undefined, "read", settings, null)
+
+        // then
+        expect(undefinedWindow).toEqual(nullWindow)
+        expect(undefinedWindow).toEqual({
+          lastSignature: "read::__unknown-input__",
+          consecutiveCount: 1,
+          threshold: settings.consecutiveThreshold,
+        })
       })
     })
   })

--- a/src/features/background-agent/loop-detector.ts
+++ b/src/features/background-agent/loop-detector.ts
@@ -36,7 +36,7 @@ export function recordToolCall(
   settings: CircuitBreakerSettings,
   toolInput?: Record<string, unknown> | null
 ): ToolCallWindow {
-  if (toolInput === undefined || toolInput === null) {
+  if (toolInput == null) {
     return {
       lastSignature: `${toolName}::__unknown-input__`,
       consecutiveCount: 1,
@@ -78,7 +78,7 @@ export function createToolCallSignature(
   toolName: string,
   toolInput?: Record<string, unknown> | null
 ): string {
-  if (toolInput === undefined || toolInput === null) {
+  if (toolInput == null) {
     return toolName
   }
   if (Object.keys(toolInput).length === 0) {

--- a/src/features/background-agent/loop-detector.ts
+++ b/src/features/background-agent/loop-detector.ts
@@ -62,7 +62,7 @@ export function recordToolCall(
 }
 
 function sortObject(obj: unknown): unknown {
-  if (obj === null || obj === undefined) return obj
+  if (obj == null) return obj
   if (typeof obj !== "object") return obj
   if (Array.isArray(obj)) return obj.map(sortObject)
 

--- a/src/features/claude-code-mcp-loader/env-expander.ts
+++ b/src/features/claude-code-mcp-loader/env-expander.ts
@@ -35,7 +35,7 @@ export function expandEnvVars(value: string, options: ExpandEnvVarsOptions = {})
 }
 
 export function expandEnvVarsInObject<T>(obj: T, options: ExpandEnvVarsOptions = {}): T {
-  if (obj === null || obj === undefined) return obj
+  if (obj == null) return obj
   if (typeof obj === "string") return expandEnvVars(obj, options) as T
   if (Array.isArray(obj)) {
     return obj.map((item) => expandEnvVarsInObject(item, options)) as T

--- a/src/features/claude-code-plugin-loader/plugin-path-resolver.test.ts
+++ b/src/features/claude-code-plugin-loader/plugin-path-resolver.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+
+import { resolvePluginPath, resolvePluginPaths } from "./plugin-path-resolver"
+
+describe("resolvePluginPath", () => {
+  test("#given a plugin root placeholder #when resolving the path #then it replaces the placeholder", () => {
+    // given
+    const path = "${CLAUDE_PLUGIN_ROOT}/dist/index.js"
+
+    // when
+    const result = resolvePluginPath(path, "/tmp/plugin-root")
+
+    // then
+    expect(result).toBe("/tmp/plugin-root/dist/index.js")
+  })
+})
+
+describe("resolvePluginPaths", () => {
+  test("#given a nested object #when resolving paths #then it rewrites every nested string path", () => {
+    // given
+    const value = {
+      command: "node",
+      args: ["${CLAUDE_PLUGIN_ROOT}/server.js"],
+      nested: {
+        config: "${CLAUDE_PLUGIN_ROOT}/config.json",
+      },
+    }
+
+    // when
+    const result = resolvePluginPaths(value, "/tmp/plugin-root")
+
+    // then
+    expect(result).toEqual({
+      command: "node",
+      args: ["/tmp/plugin-root/server.js"],
+      nested: {
+        config: "/tmp/plugin-root/config.json",
+      },
+    })
+  })
+
+  test("#given nullish input #when resolving paths #then it returns the same nullish value", () => {
+    // given
+    const nullValue = null
+    const undefinedValue = undefined
+
+    // when
+    const nullResult = resolvePluginPaths(nullValue, "/tmp/plugin-root")
+    const undefinedResult = resolvePluginPaths(undefinedValue, "/tmp/plugin-root")
+
+    // then
+    expect(nullResult).toBeNull()
+    expect(undefinedResult).toBeUndefined()
+  })
+})

--- a/src/features/claude-code-plugin-loader/plugin-path-resolver.ts
+++ b/src/features/claude-code-plugin-loader/plugin-path-resolver.ts
@@ -5,7 +5,7 @@ export function resolvePluginPath(path: string, pluginRoot: string): string {
 }
 
 export function resolvePluginPaths<T>(obj: T, pluginRoot: string): T {
-  if (obj === null || obj === undefined) return obj
+  if (obj == null) return obj
   if (typeof obj === "string") {
     return resolvePluginPath(obj, pluginRoot) as T
   }

--- a/src/hooks/directory-agents-injector/hook.ts
+++ b/src/hooks/directory-agents-injector/hook.ts
@@ -16,8 +16,10 @@ interface ToolExecuteOutput {
   metadata: unknown;
 }
 
-interface ToolExecuteBeforeOutput {
-  args: unknown;
+interface DirectoryAgentsInjectorHook {
+  "tool.execute.before"?: (input: ToolExecuteInput, output: { args: unknown }) => Promise<void>;
+  "tool.execute.after": (input: ToolExecuteInput, output: ToolExecuteOutput) => Promise<void>;
+  event: (input: EventInput) => Promise<void>;
 }
 
 interface EventInput {
@@ -30,7 +32,7 @@ interface EventInput {
 export function createDirectoryAgentsInjectorHook(
   ctx: PluginInput,
   modelCacheState?: { anthropicContext1MEnabled: boolean },
-) {
+): DirectoryAgentsInjectorHook {
   const sessionCaches = new Map<string, Set<string>>();
   const truncator = createDynamicTruncator(ctx, modelCacheState);
 
@@ -48,14 +50,6 @@ export function createDirectoryAgentsInjectorHook(
       });
       return;
     }
-  };
-
-  const toolExecuteBefore = async (
-    input: ToolExecuteInput,
-    output: ToolExecuteBeforeOutput,
-  ): Promise<void> => {
-    void input;
-    void output;
   };
 
   const eventHandler = async ({ event }: EventInput) => {
@@ -80,7 +74,6 @@ export function createDirectoryAgentsInjectorHook(
   };
 
   return {
-    "tool.execute.before": toolExecuteBefore,
     "tool.execute.after": toolExecuteAfter,
     event: eventHandler,
   };

--- a/src/hooks/directory-readme-injector/hook.ts
+++ b/src/hooks/directory-readme-injector/hook.ts
@@ -16,8 +16,10 @@ interface ToolExecuteOutput {
   metadata: unknown;
 }
 
-interface ToolExecuteBeforeOutput {
-  args: unknown;
+interface DirectoryReadmeInjectorHook {
+  "tool.execute.before"?: (input: ToolExecuteInput, output: { args: unknown }) => Promise<void>;
+  "tool.execute.after": (input: ToolExecuteInput, output: ToolExecuteOutput) => Promise<void>;
+  event: (input: EventInput) => Promise<void>;
 }
 
 interface EventInput {
@@ -30,7 +32,7 @@ interface EventInput {
 export function createDirectoryReadmeInjectorHook(
   ctx: PluginInput,
   modelCacheState?: { anthropicContext1MEnabled: boolean },
-) {
+): DirectoryReadmeInjectorHook {
   const sessionCaches = new Map<string, Set<string>>();
   const truncator = createDynamicTruncator(ctx, modelCacheState);
 
@@ -48,14 +50,6 @@ export function createDirectoryReadmeInjectorHook(
       });
       return;
     }
-  };
-
-  const toolExecuteBefore = async (
-    input: ToolExecuteInput,
-    output: ToolExecuteBeforeOutput,
-  ): Promise<void> => {
-    void input;
-    void output;
   };
 
   const eventHandler = async ({ event }: EventInput) => {
@@ -80,7 +74,6 @@ export function createDirectoryReadmeInjectorHook(
   };
 
   return {
-    "tool.execute.before": toolExecuteBefore,
     "tool.execute.after": toolExecuteAfter,
     event: eventHandler,
   };

--- a/src/plugin/chat-params.ts
+++ b/src/plugin/chat-params.ts
@@ -1,4 +1,3 @@
-import { normalizeSDKResponse } from "../shared/normalize-sdk-response"
 import { getSessionPromptParams } from "../shared/session-prompt-params-state"
 import { getModelCapabilities, resolveCompatibleModelSettings } from "../shared"
 
@@ -58,8 +57,6 @@ function buildChatParamsInput(raw: unknown): ChatParamsHookInput | null {
       ? model.id
       : undefined
   const providerId = provider.id
-  const variant = message.variant
-
   if (typeof providerID !== "string") return null
   if (typeof modelID !== "string") return null
   if (typeof providerId !== "string") return null
@@ -71,7 +68,6 @@ function buildChatParamsInput(raw: unknown): ChatParamsHookInput | null {
     provider: { id: providerId },
     message,
     rawMessage: message,
-    ...(typeof variant === "string" ? {} : {}),
   }
 }
 

--- a/src/shared/normalize-sdk-response.ts
+++ b/src/shared/normalize-sdk-response.ts
@@ -7,7 +7,7 @@ export function normalizeSDKResponse<TData>(
   fallback: TData,
   options?: NormalizeSDKResponseOptions,
 ): TData {
-  if (response === null || response === undefined) {
+  if (response == null) {
     return fallback
   }
 
@@ -17,7 +17,7 @@ export function normalizeSDKResponse<TData>(
 
   if (typeof response === "object" && "data" in response) {
     const data = (response as { data?: unknown }).data
-    if (data !== null && data !== undefined) {
+    if (data != null) {
       return data as TData
     }
 


### PR DESCRIPTION
## Summary
- simplify several nullish guards and remove dead no-op paths without changing runtime behavior
- add focused tests for config parsing and plugin path resolution to lock in the helper behavior touched by the cleanup
- remove redundant schema default comments and keep the branch rebased on the latest `dev`

## Testing
- `bun test`
- `bun run typecheck`
- `bun run build`
- `bun run script/run-ci-tests.ts`

## Review
- Goal/constraints review: PASS
- Code quality review: PASS with only non-blocking nitpicks
- Security review: PASS
- QA review: PASS
- Context mining: PASS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes nullish handling and removes dead no-op paths across config, hooks, and helpers. Adds tests to lock behavior; no runtime behavior change.

- **Refactors**
  - Replace verbose null guards with `== null` / `!= null` in config parsing, env/path resolvers, loop detector, and SDK response normalization.
  - Remove no-op `tool.execute.before` handlers and tighten hook return types for directory injector hooks.
  - Simplify plugin addition logic and drop unused code in chat params; remove redundant schema default comments.
  - Add focused tests for `parseOpenCodeConfigFileWithError`, plugin path resolution, and loop detector nullish behavior.

<sup>Written for commit 141798efed411f874b126ce8afff411b3e6f3a0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

