### PR TITLE
fix(agent-display): remove ZWSP from agent sort prefixes (fixes #3337)

### DIFF
--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -194,11 +194,11 @@ describe("getAgentConfigKey", () => {
 })
 
 describe("getAgentListDisplayName", () => {
-  it("applies invisible stable-sort prefixes to the core agent list", () => {
-    expect(getAgentListDisplayName("sisyphus")).toBe("\u200BSisyphus - Ultraworker")
-    expect(getAgentListDisplayName("hephaestus")).toBe("\u200B\u200BHephaestus - Deep Agent")
-    expect(getAgentListDisplayName("prometheus")).toBe("\u200B\u200B\u200BPrometheus - Plan Builder")
-    expect(getAgentListDisplayName("atlas")).toBe("\u200B\u200B\u200B\u200BAtlas - Plan Executor")
+  it("returns display names without invisible sort prefixes", () => {
+    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentListDisplayName("hephaestus")).toBe("Hephaestus - Deep Agent")
+    expect(getAgentListDisplayName("prometheus")).toBe("Prometheus - Plan Builder")
+    expect(getAgentListDisplayName("atlas")).toBe("Atlas - Plan Executor")
   })
 
   it("keeps non-core agents unprefixed for list display", () => {

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -27,10 +27,10 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
 }
 
 const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {
-  sisyphus: "\u200B",
-  hephaestus: "\u200B\u200B",
-  prometheus: "\u200B\u200B\u200B",
-  atlas: "\u200B\u200B\u200B\u200B",
+  sisyphus: "",
+  hephaestus: "",
+  prometheus: "",
+  atlas: "",
 }
 
 const INVISIBLE_AGENT_CHARACTERS_REGEX = /[\u200B\u200C\u200D\uFEFF]/g


### PR DESCRIPTION
## Summary
- Remove zero-width space (ZWSP) characters from agent list sort prefixes that cause display corruption in terminals

## Problem
Agent names display incorrectly in TUI on terminals that don't render ZWSP (`\u200B`) characters properly. The `AGENT_LIST_SORT_PREFIXES` map prepends 1-4 ZWSP characters to core agent display names for list ordering, but many terminals (WezTerm, Linux terminal emulators) render these as visible artifacts or truncate the agent name.

## Fix
Set all `AGENT_LIST_SORT_PREFIXES` values to empty strings. The invisible character stripping utilities (`stripInvisibleAgentCharacters`, `stripAgentListSortPrefix`) are preserved for backward compatibility with old sessions that may still contain ZWSP-prefixed names.

## Changes
| File | Change |
|------|--------|
| `src/shared/agent-display-names.ts` | Set ZWSP sort prefix values to empty strings |
| `src/shared/agent-display-names.test.ts` | Update test expectations for prefix-free display names |

Fixes #3337
Also resolves #3307 and #3347 (same root cause)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove zero‑width space sort prefixes from core agent display names to fix terminal rendering issues. Keeps stripping helpers for backward compatibility. Fixes #3337; also resolves #3307 and #3347.

- **Bug Fixes**
  - Set all sort prefixes to empty strings so names render correctly in TUIs.
  - Retain invisible-character stripping utilities for old ZWSP-prefixed sessions.
  - Update tests to expect prefix‑free display names.

<sup>Written for commit 7adbc44cd16237ae9a58d5ef9d43a1550621fb19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

