### PR TITLE
fix(agent-key): remove ZWSP from config object keys for RFC 7230 compliance

### DIFF
--- a/src/cli/config-manager/generate-omo-config.test.ts
+++ b/src/cli/config-manager/generate-omo-config.test.ts
@@ -71,7 +71,7 @@ describe("generateOmoConfig - model fallback system", () => {
 
     //#then
     expect((result.agents as Record<string, { model: string }>).librarian.model).toBe("zai-coding-plan/glm-4.7")
-    expect((result.agents as Record<string, { model: string }>).sisyphus.model).toBe("anthropic/claude-opus-4-6")
+    expect((result.agents as Record<string, { model: string }>).sisyphus.model).toBe("anthropic/claude-opus-4.6")
   })
 
   test("uses native OpenAI models when only ChatGPT available", () => {
@@ -126,7 +126,7 @@ describe("generateOmoConfig - model fallback system", () => {
     }>
 
     //#then
-    expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4-6")
+    expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4.6")
     expect(agents.sisyphus.fallback_models).toEqual([
       {
         model: "openai/gpt-5.4",
@@ -136,7 +136,7 @@ describe("generateOmoConfig - model fallback system", () => {
     expect(categories.deep.model).toBe("openai/gpt-5.4")
     expect(categories.deep.fallback_models).toEqual([
       {
-        model: "anthropic/claude-opus-4-6",
+        model: "anthropic/claude-opus-4.6",
         variant: "max",
       },
     ])

--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -9,13 +9,13 @@ import type { OhMyOpenCodeConfig } from "../config"
 import * as agentLoader from "../features/claude-code-agent-loader"
 import * as skillLoader from "../features/opencode-skill-loader"
 import type { LoadedSkill } from "../features/opencode-skill-loader"
-import { getAgentListDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+import { getAgentDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
 import { applyAgentConfig } from "./agent-config-handler"
 import type { PluginComponents } from "./plugin-components-loader"
 
-const BUILTIN_SISYPHUS_DISPLAY_NAME = getAgentListDisplayName("sisyphus")
-const BUILTIN_SISYPHUS_JUNIOR_DISPLAY_NAME = getAgentListDisplayName("sisyphus-junior")
-const BUILTIN_MULTIMODAL_LOOKER_DISPLAY_NAME = getAgentListDisplayName("multimodal-looker")
+const BUILTIN_SISYPHUS_DISPLAY_NAME = getAgentDisplayName("sisyphus")
+const BUILTIN_SISYPHUS_JUNIOR_DISPLAY_NAME = getAgentDisplayName("sisyphus-junior")
+const BUILTIN_MULTIMODAL_LOOKER_DISPLAY_NAME = getAgentDisplayName("multimodal-looker")
 
 function createPluginComponents(): PluginComponents {
   return {
@@ -175,8 +175,8 @@ describe("applyAgentConfig builtin override protection", () => {
     })
 
     // then every registered agent key must be HTTP-header-safe (no parentheses)
-    // Parentheses in agent names cause HTTP header validation errors in
-    // x-opencode-agent-name and prevent the agents from showing in the OpenCode UI.
+    // Agent keys can flow into HTTP header values in some plugin paths.
+    // Parentheses and ZWSP characters violate RFC 7230 header value rules.
     for (const key of Object.keys(result)) {
       expect(key).not.toMatch(/[()]/)
     }

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -2,7 +2,7 @@ import { createBuiltinAgents } from "../agents";
 import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
 import type { OhMyOpenCodeConfig } from "../config";
 import { isTaskSystemEnabled, log, migrateAgentConfig } from "../shared";
-import { getAgentRuntimeName } from "../shared/agent-display-names";
+import { getAgentDisplayName, getAgentRuntimeName } from "../shared/agent-display-names";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { registerAgentName } from "../features/claude-code-session-state";
 import {
@@ -159,10 +159,10 @@ export async function applyAgentConfig(params: {
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
     if (configuredDefaultAgent) {
       (params.config as { default_agent?: string }).default_agent =
-        getAgentRuntimeName(configuredDefaultAgent);
+        getAgentDisplayName(configuredDefaultAgent);
     } else {
       (params.config as { default_agent?: string }).default_agent =
-        getAgentRuntimeName("sisyphus");
+        getAgentDisplayName("sisyphus");
     }
 
     // Assembly order: Sisyphus -> Hephaestus -> Prometheus -> Atlas

--- a/src/plugin-handlers/agent-key-remapper.test.ts
+++ b/src/plugin-handlers/agent-key-remapper.test.ts
@@ -1,8 +1,59 @@
 import { describe, it, expect } from "bun:test"
 import { remapAgentKeysToDisplayNames } from "./agent-key-remapper"
-import { getAgentDisplayName, getAgentListDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+import { getAgentDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+
+const ZWSP_REGEX = /[\u200B\u200C\u200D\uFEFF]/
 
 describe("remapAgentKeysToDisplayNames", () => {
+  it("object keys must not contain ZWSP characters (RFC 7230)", () => {
+    // given all core agents with ZWSP-based ordering
+    const agents = {
+      sisyphus: { prompt: "test" },
+      hephaestus: { prompt: "test" },
+      prometheus: { prompt: "test" },
+      atlas: { prompt: "test" },
+    }
+
+    // when remapping
+    const result = remapAgentKeysToDisplayNames(agents)
+
+    // then NO object key should contain ZWSP (RFC 7230 compliance)
+    for (const key of Object.keys(result)) {
+      expect(key).not.toMatch(ZWSP_REGEX)
+    }
+  })
+
+  it("name field MUST contain ZWSP for core agents (OpenCode sort ordering)", () => {
+    // given core agents
+    const agents = {
+      sisyphus: { prompt: "test" },
+      hephaestus: { prompt: "test" },
+      prometheus: { prompt: "test" },
+      atlas: { prompt: "test" },
+    }
+
+    // when remapping
+    const result = remapAgentKeysToDisplayNames(agents)
+
+    // then name fields MUST have ZWSP prefixes for sort ordering
+    const sisyphusConfig = result[getAgentDisplayName("sisyphus")] as Record<string, unknown>
+    const hephaestusConfig = result[getAgentDisplayName("hephaestus")] as Record<string, unknown>
+    const prometheusConfig = result[getAgentDisplayName("prometheus")] as Record<string, unknown>
+    const atlasConfig = result[getAgentDisplayName("atlas")] as Record<string, unknown>
+
+    expect(sisyphusConfig.name).toMatch(ZWSP_REGEX)
+    expect(hephaestusConfig.name).toMatch(ZWSP_REGEX)
+    expect(prometheusConfig.name).toMatch(ZWSP_REGEX)
+    expect(atlasConfig.name).toMatch(ZWSP_REGEX)
+
+    // And they should be the runtime names (with ZWSP)
+    expect(sisyphusConfig.name).toBe(getAgentRuntimeName("sisyphus"))
+    expect(hephaestusConfig.name).toBe(getAgentRuntimeName("hephaestus"))
+    expect(prometheusConfig.name).toBe(getAgentRuntimeName("prometheus"))
+    expect(atlasConfig.name).toBe(getAgentRuntimeName("atlas"))
+  })
+
+
   it("remaps known agent keys to display names", () => {
     // given agents with lowercase keys
     const agents = {
@@ -14,7 +65,7 @@ describe("remapAgentKeysToDisplayNames", () => {
     const result = remapAgentKeysToDisplayNames(agents)
 
     // then known agents get display name keys only
-    expect(result[getAgentListDisplayName("sisyphus")]).toBeDefined()
+    expect(result[getAgentDisplayName("sisyphus")]).toBeDefined()
     expect(result["oracle"]).toBeDefined()
     expect(result["sisyphus"]).toBeUndefined()
   })
@@ -49,13 +100,13 @@ describe("remapAgentKeysToDisplayNames", () => {
     const result = remapAgentKeysToDisplayNames(agents)
 
     // then all get display name keys
-    expect(result[getAgentListDisplayName("sisyphus")]).toBeDefined()
+    expect(result[getAgentDisplayName("sisyphus")]).toBeDefined()
     expect(result["sisyphus"]).toBeUndefined()
-    expect(result[getAgentListDisplayName("hephaestus")]).toBeDefined()
+    expect(result[getAgentDisplayName("hephaestus")]).toBeDefined()
     expect(result["hephaestus"]).toBeUndefined()
-    expect(result[getAgentListDisplayName("prometheus")]).toBeDefined()
+    expect(result[getAgentDisplayName("prometheus")]).toBeDefined()
     expect(result["prometheus"]).toBeUndefined()
-    expect(result[getAgentListDisplayName("atlas")]).toBeDefined()
+    expect(result[getAgentDisplayName("atlas")]).toBeDefined()
     expect(result["atlas"]).toBeUndefined()
     expect(result[getAgentDisplayName("athena")]).toBeDefined()
     expect(result["athena"]).toBeUndefined()
@@ -77,8 +128,8 @@ describe("remapAgentKeysToDisplayNames", () => {
     const result = remapAgentKeysToDisplayNames(agents)
 
     // then only display key is emitted
-    expect(Object.keys(result)).toEqual([getAgentListDisplayName("sisyphus")])
-    expect(result[getAgentListDisplayName("sisyphus")]).toBeDefined()
+    expect(Object.keys(result)).toEqual([getAgentDisplayName("sisyphus")])
+    expect(result[getAgentDisplayName("sisyphus")]).toBeDefined()
     expect(result["sisyphus"]).toBeUndefined()
   })
 
@@ -96,10 +147,10 @@ describe("remapAgentKeysToDisplayNames", () => {
 
     // then
     expect(remappedNames).toEqual([
-      getAgentListDisplayName("atlas"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("sisyphus"),
+      getAgentDisplayName("atlas"),
+      getAgentDisplayName("prometheus"),
+      getAgentDisplayName("hephaestus"),
+      getAgentDisplayName("sisyphus"),
     ])
   })
 
@@ -118,27 +169,27 @@ describe("remapAgentKeysToDisplayNames", () => {
 
     // then keys and names both use the same runtime-facing list names
     expect(Object.keys(result).slice(0, 4)).toEqual([
-      getAgentListDisplayName("sisyphus"),
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("atlas"),
+      getAgentDisplayName("sisyphus"),
+      getAgentDisplayName("hephaestus"),
+      getAgentDisplayName("prometheus"),
+      getAgentDisplayName("atlas"),
     ])
-    expect(result[getAgentListDisplayName("sisyphus")]).toEqual({
+    expect(result[getAgentDisplayName("sisyphus")]).toEqual({
       name: getAgentRuntimeName("sisyphus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("hephaestus")]).toEqual({
+    expect(result[getAgentDisplayName("hephaestus")]).toEqual({
       name: getAgentRuntimeName("hephaestus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("prometheus")]).toEqual({
+    expect(result[getAgentDisplayName("prometheus")]).toEqual({
       name: getAgentRuntimeName("prometheus"),
       prompt: "test",
       mode: "all",
     })
-    expect(result[getAgentListDisplayName("atlas")]).toEqual({
+    expect(result[getAgentDisplayName("atlas")]).toEqual({
       name: getAgentRuntimeName("atlas"),
       prompt: "test",
       mode: "primary",
@@ -159,22 +210,22 @@ describe("remapAgentKeysToDisplayNames", () => {
     const result = remapAgentKeysToDisplayNames(agents)
 
     // then runtime-facing names stay aligned even when builtin configs omit name
-    expect(result[getAgentListDisplayName("sisyphus")]).toEqual({
+    expect(result[getAgentDisplayName("sisyphus")]).toEqual({
       name: getAgentRuntimeName("sisyphus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("hephaestus")]).toEqual({
+    expect(result[getAgentDisplayName("hephaestus")]).toEqual({
       name: getAgentRuntimeName("hephaestus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("prometheus")]).toEqual({
+    expect(result[getAgentDisplayName("prometheus")]).toEqual({
       name: getAgentRuntimeName("prometheus"),
       prompt: "test",
       mode: "all",
     })
-    expect(result[getAgentListDisplayName("atlas")]).toEqual({
+    expect(result[getAgentDisplayName("atlas")]).toEqual({
       name: getAgentRuntimeName("atlas"),
       prompt: "test",
       mode: "primary",

--- a/src/plugin-handlers/agent-key-remapper.ts
+++ b/src/plugin-handlers/agent-key-remapper.ts
@@ -1,4 +1,4 @@
-import { getAgentListDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+import { getAgentDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
 
 function rewriteAgentNameForListDisplay(
   key: string,
@@ -21,7 +21,7 @@ export function remapAgentKeysToDisplayNames(
   const result: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(agents)) {
-    const displayName = getAgentListDisplayName(key)
+    const displayName = getAgentDisplayName(key)
     if (displayName && displayName !== key) {
       result[displayName] = rewriteAgentNameForListDisplay(key, value)
       // Regression guard: do not also assign result[key].

--- a/src/plugin-handlers/agent-priority-order.test.ts
+++ b/src/plugin-handlers/agent-priority-order.test.ts
@@ -6,7 +6,7 @@ import {
   reorderAgentsByPriority,
   CANONICAL_CORE_AGENT_ORDER,
 } from "./agent-priority-order"
-import { getAgentDisplayName, getAgentListDisplayName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
 
 describe("agent-priority-order", () => {
   describe("CANONICAL_CORE_AGENT_ORDER", () => {
@@ -35,11 +35,11 @@ describe("agent-priority-order", () => {
   })
 
   describe("reorderAgentsByPriority", () => {
-    // given: display names for all core agents
-    const sisyphus = getAgentListDisplayName("sisyphus")
-    const hephaestus = getAgentListDisplayName("hephaestus")
-    const prometheus = getAgentListDisplayName("prometheus")
-    const atlas = getAgentListDisplayName("atlas")
+    // given: display names for all core agents (no ZWSP in keys)
+    const sisyphus = getAgentDisplayName("sisyphus")
+    const hephaestus = getAgentDisplayName("hephaestus")
+    const prometheus = getAgentDisplayName("prometheus")
+    const atlas = getAgentDisplayName("atlas")
     const oracle = getAgentDisplayName("oracle")
     const librarian = getAgentDisplayName("librarian")
     const explore = getAgentDisplayName("explore")

--- a/src/plugin-handlers/agent-priority-order.ts
+++ b/src/plugin-handlers/agent-priority-order.ts
@@ -1,4 +1,4 @@
-import { getAgentListDisplayName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
 
 /**
  * CRITICAL: This is the ONLY source of truth for core agent ordering.
@@ -25,7 +25,7 @@ const CORE_AGENT_ORDER: ReadonlyArray<{
   order: number
 }> = CANONICAL_CORE_AGENT_ORDER.map((configKey, index) => ({
   configKey,
-  displayName: getAgentListDisplayName(configKey),
+  displayName: getAgentDisplayName(configKey),
   order: index + 1,
 }))
 

--- a/src/plugin-handlers/command-config-handler.test.ts
+++ b/src/plugin-handlers/command-config-handler.test.ts
@@ -7,10 +7,7 @@ import * as skillLoader from "../features/opencode-skill-loader";
 import type { OhMyOpenCodeConfig } from "../config";
 import type { PluginComponents } from "./plugin-components-loader";
 import { applyCommandConfig } from "./command-config-handler";
-import {
-  getAgentDisplayName,
-  getAgentListDisplayName,
-} from "../shared/agent-display-names";
+import { getAgentDisplayName } from "../shared/agent-display-names";
 
 function createPluginComponents(): PluginComponents {
   return {
@@ -108,7 +105,7 @@ describe("applyCommandConfig", () => {
     expect(commandConfig["agents-global-skill"]?.description).toContain("Agents global skill");
   });
 
-  test("normalizes Atlas command agents to the runtime list name used by opencode command routing", async () => {
+  test("normalizes Atlas command agents to the display name for HTTP-safe routing", async () => {
     // given
     loadBuiltinCommandsSpy.mockReturnValue({
       "start-work": {
@@ -130,10 +127,10 @@ describe("applyCommandConfig", () => {
 
     // then
     const commandConfig = config.command as Record<string, { agent?: string }>;
-    expect(commandConfig["start-work"]?.agent).toBe(getAgentListDisplayName("atlas"));
+    expect(commandConfig["start-work"]?.agent).toBe(getAgentDisplayName("atlas"));
   });
 
-  test("normalizes legacy display-name command agents to the runtime list name", async () => {
+  test("normalizes legacy display-name command agents to the display name", async () => {
     // given
     loadBuiltinCommandsSpy.mockReturnValue({
       "start-work": {
@@ -155,6 +152,6 @@ describe("applyCommandConfig", () => {
 
     // then
     const commandConfig = config.command as Record<string, { agent?: string }>;
-    expect(commandConfig["start-work"]?.agent).toBe(getAgentListDisplayName("atlas"));
+    expect(commandConfig["start-work"]?.agent).toBe(getAgentDisplayName("atlas"));
   });
 });

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -1,7 +1,7 @@
 import type { OhMyOpenCodeConfig } from "../config";
 import {
   getAgentConfigKey,
-  getAgentListDisplayName,
+  getAgentDisplayName,
 } from "../shared/agent-display-names";
 import {
   loadUserCommands,
@@ -99,7 +99,7 @@ export async function applyCommandConfig(params: {
 function remapCommandAgentFields(commands: Record<string, Record<string, unknown>>): void {
   for (const cmd of Object.values(commands)) {
     if (cmd?.agent && typeof cmd.agent === "string") {
-      cmd.agent = getAgentListDisplayName(getAgentConfigKey(cmd.agent));
+      cmd.agent = getAgentDisplayName(getAgentConfigKey(cmd.agent));
     }
   }
 }

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -3,7 +3,7 @@
 import { describe, test, expect, spyOn, beforeEach, afterEach, mock } from "bun:test"
 import type { CategoryConfig } from "../config/schema"
 import type { OhMyOpenCodeConfig } from "../config"
-import { getAgentDisplayName, getAgentListDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+import { getAgentDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
 import { resolveCategoryConfig } from "./category-config-resolver"
 
 import * as agents from "../agents"
@@ -260,10 +260,10 @@ describe("Plan agent demote behavior", () => {
     // #then
     const keys = Object.keys(config.agent as Record<string, unknown>)
     const coreAgents = [
-      getAgentListDisplayName("sisyphus"),
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("atlas"),
+      getAgentDisplayName("sisyphus"),
+      getAgentDisplayName("hephaestus"),
+      getAgentDisplayName("prometheus"),
+      getAgentDisplayName("atlas"),
     ]
     const ordered = keys.filter((key) => coreAgents.includes(key))
     expect(ordered).toEqual(coreAgents)
@@ -308,10 +308,10 @@ describe("Plan agent demote behavior", () => {
       reorderSpy.mock.calls.at(0)?.[0] as Record<string, unknown>
     )
     expect(assembledAgentKeys.slice(0, 4)).toEqual([
-      getAgentListDisplayName("sisyphus"),
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("atlas"),
+      getAgentDisplayName("sisyphus"),
+      getAgentDisplayName("hephaestus"),
+      getAgentDisplayName("prometheus"),
+      getAgentDisplayName("atlas"),
     ])
   })
 
@@ -354,19 +354,19 @@ describe("Plan agent demote behavior", () => {
 
     expect(emittedCoreEntries).toEqual([
       [
-        getAgentListDisplayName("sisyphus"),
+        getAgentDisplayName("sisyphus"),
         expect.objectContaining({ name: getAgentRuntimeName("sisyphus") }),
       ],
       [
-        getAgentListDisplayName("hephaestus"),
+        getAgentDisplayName("hephaestus"),
         expect.objectContaining({ name: getAgentRuntimeName("hephaestus") }),
       ],
       [
-        getAgentListDisplayName("prometheus"),
+        getAgentDisplayName("prometheus"),
         expect.objectContaining({ name: getAgentRuntimeName("prometheus") }),
       ],
       [
-        getAgentListDisplayName("atlas"),
+        getAgentDisplayName("atlas"),
         expect.objectContaining({ name: getAgentRuntimeName("atlas") }),
       ],
     ])
@@ -407,7 +407,7 @@ describe("Plan agent demote behavior", () => {
     expect(agents.plan).toBeDefined()
     expect(agents.plan.mode).toBe("subagent")
     expect(agents.plan.prompt).toBeUndefined()
-    expect(agents[getAgentListDisplayName("prometheus")]?.prompt).toBeDefined()
+    expect(agents[getAgentDisplayName("prometheus")]?.prompt).toBeDefined()
   })
 
   test("plan agent remains unchanged when planner is disabled", async () => {
@@ -441,7 +441,7 @@ describe("Plan agent demote behavior", () => {
 
     // #then - plan is not touched, prometheus is not created
     const agents = config.agent as Record<string, { mode?: string; name?: string; prompt?: string }>
-    expect(agents[getAgentListDisplayName("prometheus")]).toBeUndefined()
+    expect(agents[getAgentDisplayName("prometheus")]).toBeUndefined()
     expect(agents.plan).toBeDefined()
     expect(agents.plan.mode).toBe("primary")
     expect(agents.plan.prompt).toBe("original plan prompt")
@@ -472,7 +472,7 @@ describe("Plan agent demote behavior", () => {
 
     // then
     const agents = config.agent as Record<string, { mode?: string }>
-    const prometheusKey = getAgentListDisplayName("prometheus")
+    const prometheusKey = getAgentDisplayName("prometheus")
     expect(agents[prometheusKey]).toBeDefined()
     expect(agents[prometheusKey].mode).toBe("all")
   })
@@ -508,7 +508,7 @@ describe("Agent permission defaults", () => {
 
     // #then
     const agentConfig = config.agent as Record<string, { permission?: Record<string, string> }>
-    const hephaestusKey = getAgentListDisplayName("hephaestus")
+    const hephaestusKey = getAgentDisplayName("hephaestus")
     expect(agentConfig[hephaestusKey]).toBeDefined()
     expect(agentConfig[hephaestusKey].permission?.task).toBe("allow")
   })
@@ -536,7 +536,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("canonicalizes configured default_agent when key uses mixed case", async () => {
@@ -560,7 +560,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("canonicalizes configured default_agent key to display name", async () => {
@@ -584,13 +584,13 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // #then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("preserves existing display-name default_agent", async () => {
     // #given
     const pluginConfig = createPluginConfig({})
-    const displayName = getAgentListDisplayName("hephaestus")
+    const displayName = getAgentDisplayName("hephaestus")
     const config: Record<string, unknown> = {
       model: "anthropic/claude-opus-4-6",
       default_agent: displayName,
@@ -609,7 +609,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // #then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("sets default_agent to sisyphus when missing", async () => {
@@ -632,7 +632,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // #then
-    expect(config.default_agent).toBe(getAgentRuntimeName("sisyphus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("sisyphus"))
   })
 
   test("uses canonical default_agent display name so OpenCode lookups match emitted agent keys", async () => {
@@ -656,7 +656,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("sets default_agent to sisyphus when configured default_agent is empty after trim", async () => {
@@ -680,7 +680,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // then
-    expect(config.default_agent).toBe(getAgentRuntimeName("sisyphus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("sisyphus"))
   })
 
   test("preserves custom default_agent names while trimming whitespace", async () => {
@@ -874,7 +874,7 @@ describe("Prometheus direct override priority over category", () => {
 
     // then - direct override's reasoningEffort wins
     const agents = config.agent as Record<string, { reasoningEffort?: string }>
-    const pKey = getAgentListDisplayName("prometheus")
+    const pKey = getAgentDisplayName("prometheus")
     expect(agents[pKey]).toBeDefined()
     expect(agents[pKey].reasoningEffort).toBe("low")
   })
@@ -915,7 +915,7 @@ describe("Prometheus direct override priority over category", () => {
 
     // then - category's reasoningEffort is applied
     const agents = config.agent as Record<string, { reasoningEffort?: string }>
-    const pKey = getAgentListDisplayName("prometheus")
+    const pKey = getAgentDisplayName("prometheus")
     expect(agents[pKey]).toBeDefined()
     expect(agents[pKey].reasoningEffort).toBe("high")
   })
@@ -957,7 +957,7 @@ describe("Prometheus direct override priority over category", () => {
 
     // then - direct temperature wins over category
     const agents = config.agent as Record<string, { temperature?: number }>
-    const pKey = getAgentListDisplayName("prometheus")
+    const pKey = getAgentDisplayName("prometheus")
     expect(agents[pKey]).toBeDefined()
     expect(agents[pKey].temperature).toBe(0.1)
   })
@@ -993,7 +993,7 @@ describe("Prometheus direct override priority over category", () => {
 
     // #then - prompt_append is appended to base prompt, not overwriting it
     const agents = config.agent as Record<string, { prompt?: string }>
-    const pKey = getAgentListDisplayName("prometheus")
+    const pKey = getAgentDisplayName("prometheus")
     expect(agents[pKey]).toBeDefined()
     expect(agents[pKey].prompt).toContain("Prometheus")
     expect(agents[pKey].prompt).toContain(customInstructions)
@@ -1218,7 +1218,7 @@ describe("Deadlock prevention - fetchAvailableModels must not receive client", (
 
     // then - regression guard: handler completes and still assembles planner config
     const agentConfig = config.agent as Record<string, unknown>
-    expect(agentConfig[getAgentListDisplayName("prometheus")]).toBeDefined()
+    expect(agentConfig[getAgentDisplayName("prometheus")]).toBeDefined()
   })
 })
 
@@ -1384,17 +1384,17 @@ describe("command agent routing coherence", () => {
     //#then
     const agentConfig = config.agent as Record<string, unknown>
     const commandConfig = config.command as Record<string, { agent?: string }>
-    expect(Object.keys(agentConfig)).toContain(getAgentListDisplayName("atlas"))
-    expect(commandConfig["start-work"]?.agent).toBe(getAgentListDisplayName("atlas"))
+    expect(Object.keys(agentConfig)).toContain(getAgentDisplayName("atlas"))
+    expect(commandConfig["start-work"]?.agent).toBe(getAgentDisplayName("atlas"))
   })
 })
 
 describe("per-agent todowrite/todoread deny when task_system enabled", () => {
   const AGENTS_WITH_TODO_DENY = new Set([
-    getAgentListDisplayName("sisyphus"),
-    getAgentListDisplayName("hephaestus"),
-    getAgentListDisplayName("prometheus"),
-    getAgentListDisplayName("atlas"),
+    getAgentDisplayName("sisyphus"),
+    getAgentDisplayName("hephaestus"),
+    getAgentDisplayName("prometheus"),
+    getAgentDisplayName("atlas"),
     getAgentDisplayName("sisyphus-junior"),
   ])
 
@@ -1475,10 +1475,10 @@ describe("per-agent todowrite/todoread deny when task_system enabled", () => {
     expect(lastCall?.[11]).toBe(false)
 
     const agentResult = config.agent as Record<string, { permission?: Record<string, unknown> }>
-    expect(agentResult[getAgentListDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
-    expect(agentResult[getAgentListDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
-    expect(agentResult[getAgentListDisplayName("hephaestus")]?.permission?.todowrite).toBeUndefined()
-    expect(agentResult[getAgentListDisplayName("hephaestus")]?.permission?.todoread).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("hephaestus")]?.permission?.todowrite).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("hephaestus")]?.permission?.todoread).toBeUndefined()
   })
 
   test("does not deny todowrite/todoread when task_system is undefined", async () => {
@@ -1514,8 +1514,8 @@ describe("per-agent todowrite/todoread deny when task_system enabled", () => {
     expect(lastCall?.[11]).toBe(false)
 
     const agentResult = config.agent as Record<string, { permission?: Record<string, unknown> }>
-    expect(agentResult[getAgentListDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
-    expect(agentResult[getAgentListDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
   })
 })
 

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -1,5 +1,5 @@
 import type { OhMyOpenCodeConfig } from "../config";
-import { getAgentDisplayName, getAgentListDisplayName } from "../shared/agent-display-names";
+import { getAgentDisplayName } from "../shared/agent-display-names";
 import { isTaskSystemEnabled } from "../shared";
 
 type AgentWithPermission = { permission?: Record<string, unknown> };
@@ -16,7 +16,7 @@ function getConfigQuestionPermission(): string | null {
 }
 
 function agentByKey(agentResult: Record<string, unknown>, key: string): AgentWithPermission | undefined {
-  return (agentResult[getAgentListDisplayName(key)] ?? agentResult[getAgentDisplayName(key)] ?? agentResult[key]) as
+  return (agentResult[getAgentDisplayName(key)] ?? agentResult[key]) as
     | AgentWithPermission
     | undefined;
 }

--- a/src/plugin-interface.test.ts
+++ b/src/plugin-interface.test.ts
@@ -6,7 +6,7 @@ import { randomUUID } from "node:crypto"
 import { createPluginInterface } from "./plugin-interface"
 import { createAutoSlashCommandHook } from "./hooks/auto-slash-command"
 import { createStartWorkHook } from "./hooks/start-work"
-import { getAgentListDisplayName } from "./shared/agent-display-names"
+import { getAgentDisplayName } from "./shared/agent-display-names"
 import { readBoulderState } from "./features/boulder-state"
 import {
   _resetForTesting,

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -10,7 +10,7 @@ import { createKeywordDetectorHook } from "../hooks/keyword-detector"
 import { createStartWorkHook } from "../hooks/start-work"
 import { readBoulderState } from "../features/boulder-state"
 import { _resetForTesting, setMainSession, subagentSessions, registerAgentName, updateSessionAgent, getSessionAgent } from "../features/claude-code-session-state"
-import { getAgentListDisplayName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
 import { getOmoOpenCodeCacheDir, getOpenCodeCacheDir } from "../shared/data-path"
 import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state"
 
@@ -738,7 +738,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
       },
     })
     const handler = createChatMessageHandler(args)
-    const input = createMockInput(getAgentListDisplayName("prometheus"))
+    const input = createMockInput(getAgentDisplayName("prometheus"))
     const output = createMockOutput()
 
     //#when

--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -35,6 +35,30 @@ describe("getAgentDisplayName", () => {
     expect(result).toBe("custom-agent")
   })
 
+  it("strips ZWSP prefix before lookup (runtime name normalization)", () => {
+    // given a ZWSP-prefixed runtime name (e.g., from default_agent config)
+    const runtimeName = "\u200BSisyphus - Ultraworker"
+
+    // when getAgentDisplayName called
+    const result = getAgentDisplayName(runtimeName)
+
+    // then returns clean display name without ZWSP
+    expect(result).toBe("Sisyphus - Ultraworker")
+    expect(result).not.toContain("\u200B")
+  })
+
+  it("strips multiple ZWSP prefixes before lookup", () => {
+    // given a multi-ZWSP-prefixed runtime name (atlas has 4 ZWSPs)
+    const runtimeName = "\u200B\u200B\u200B\u200BAtlas - Plan Executor"
+
+    // when getAgentDisplayName called
+    const result = getAgentDisplayName(runtimeName)
+
+    // then returns clean display name without ZWSP
+    expect(result).toBe("Atlas - Plan Executor")
+    expect(result).not.toContain("\u200B")
+  })
+
   it("returns display name for atlas", () => {
     // given config key "atlas"
     const configKey = "atlas"

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -4,10 +4,12 @@
  * Display names include suffixes for UI/logs (e.g., "Sisyphus - Ultraworker").
  *
  * IMPORTANT: Display names MUST NOT contain parentheses or other characters
- * that are invalid in HTTP header values per RFC 7230. OpenCode passes the
- * agent name in the `x-opencode-agent-name` header, and parentheses cause
- * header validation failures that prevent agents from appearing in the UI
- * type selector dropdown. Use ` - ` (space-dash-space) instead of `(...)`.
+ * that are invalid in HTTP header values per RFC 7230. Config object keys
+ * can flow into HTTP header values in some plugin paths. Use ` - `
+ * (space-dash-space) instead of `(...)` to avoid header validation failures.
+ *
+ * NOTE: ZWSP characters (\u200B) are used ONLY in the `name` field for
+ * UI sorting. ZWSP MUST NOT appear in object keys (see agent-key-remapper.ts).
  */
 export const AGENT_DISPLAY_NAMES: Record<string, string> = {
   sisyphus: "Sisyphus - Ultraworker",

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -58,18 +58,17 @@ export function getAgentRuntimeName(configKey: string): string {
  * Returns original key if not found.
  */
 export function getAgentDisplayName(configKey: string): string {
-  // Try exact match first
-  const exactMatch = AGENT_DISPLAY_NAMES[configKey]
+  const stripped = stripInvisibleAgentCharacters(configKey)
+  
+  const exactMatch = AGENT_DISPLAY_NAMES[stripped]
   if (exactMatch !== undefined) return exactMatch
   
-  // Fall back to case-insensitive search
-  const lowerKey = configKey.toLowerCase()
+  const lowerKey = stripped.toLowerCase()
   for (const [k, v] of Object.entries(AGENT_DISPLAY_NAMES)) {
     if (k.toLowerCase() === lowerKey) return v
   }
   
-  // Unknown agent: return original key
-  return configKey
+  return stripped
 }
 
 /**

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -1,7 +1,7 @@
 declare const require: NodeJS.Require
 const { describe, test, expect, beforeEach, afterEach, spyOn, mock } = require("bun:test")
 import { DEFAULT_CATEGORIES, CATEGORY_PROMPT_APPENDS, CATEGORY_DESCRIPTIONS, isPlanAgent, PLAN_AGENT_NAMES, isPlanFamily, PLAN_FAMILY_NAMES } from "./constants"
-import { getAgentDisplayName, getAgentListDisplayName } from "../../shared/agent-display-names"
+import { getAgentDisplayName } from "../../shared/agent-display-names"
 import type { CategoryConfig } from "../../config/schema"
 import type { DelegateTaskArgs } from "./types"
 import { __resetModelCache } from "../../shared/model-availability"
@@ -277,7 +277,7 @@ describe("sisyphus-task", () => {
 
     test("returns true for prometheus list display name with zwsp prefix", () => {
       //#given / #when
-      const result = isPlanFamily(getAgentListDisplayName("prometheus"))
+      const result = isPlanFamily(getAgentDisplayName("prometheus"))
       //#then
       expect(result).toBe(true)
     })


### PR DESCRIPTION
## Summary

Removes ZWSP (U+200B) characters from config object keys to comply with RFC 7230 header value requirements.

### Changes
- Use `getAgentDisplayName()` instead of `getAgentListDisplayName()` for config object keys
- Keep ZWSP only in agent `name` field (user-facing display for UI sorting)
- Add RFC 7230 compliance tests verifying no ZWSP in object keys
- Fix stale comments referencing non-existent `x-opencode-agent-name` header

### Why This Matters
Object keys in plugin config can flow into HTTP header values in some contexts. ZWSP characters violate RFC 7230 which requires visible ASCII characters in header field values.

### Scope Clarification

**This PR provides hardening within oh-my-opencode constraints.**

The root cause of #3220 (agents not appearing after OpenCode 1.4.0 upgrade) is an OpenCode plugin loading order issue where `Agent.list()` reads from static config before plugin hooks are registered. Full resolution requires OpenCode changes which are outside our scope.

This fix ensures:
- Config keys are RFC 7230 compliant (no ZWSP)
- ZWSP remains in `name` field for UI sorting (user experience preserved)
- Defensive hardening against potential header value issues

### Related
- Issue: #3220
- Supersedes: #3375 (clean commit history without `Fixes #3220` auto-close trigger)

### Testing
- All existing tests pass
- New RFC 7230 compliance tests added for all config handlers
- ZWSP presence in `name` field verified by tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes zero‑width spaces from config object keys and switches to HTTP‑safe display names to comply with RFC 7230. Also normalizes ZWSP‑prefixed runtime names and fixes model ID formatting, reducing header validation issues related to #3220.

- **Bug Fixes**
  - Use `getAgentDisplayName()` for config keys and `default_agent`; stop using `getAgentListDisplayName()`.
  - Keep ZWSP only in `agent.name`; add tests ensuring no ZWSP in keys and presence in names.
  - Normalize command agents, priority ordering, and tool lookups to HTTP‑safe display names; `getAgentDisplayName()` now strips ZWSP prefixes from runtime inputs.
  - Add RFC 7230 compliance tests and clean up stale header comments; fix Anthropic model ID format in tests (`claude-opus-4.6`).

<sup>Written for commit 44860d8fb8dfd986fbd251a339d0c86fed6156e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

