### PR TITLE
docs(readme): add Chinese telemetry/legal section

### DIFF
--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -116,6 +116,10 @@ https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/refs/heads/dev/do
 curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/refs/heads/dev/docs/guide/installation.md
 ```
 
+**注意**：请使用已发布的包名和二进制名 `oh-my-opencode`。在 `opencode.json` 中，兼容性层现在优先使用插件入口 `oh-my-openagent`，而旧的 `oh-my-opencode` 条目仍会加载并显示警告。插件配置文件通常仍使用 `oh-my-opencode.json` 或 `oh-my-opencode.jsonc`，在过渡期间新旧两种文件名都会被识别。
+
+匿名遥测默认开启，用于帮助提升安装和运行时的可靠性。它使用 PostHog，并采用哈希化的安装标识符，绝不会使用原始主机名，可通过 `OMO_SEND_ANONYMOUS_TELEMETRY=0` 或 `OMO_DISABLE_POSTHOG=1` 禁用。详见 [隐私政策](docs/legal/privacy-policy.md) 和 [服务条款](docs/legal/terms-of-service.md)。
+
 ---
 
 ## 跳过这个 README 吧


### PR DESCRIPTION
## Summary
- Added Chinese translation of telemetry and legal information section
- Matches English README content added in commit 630f5b79

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Chinese translation for the telemetry and legal section in the README to match the English version. Also clarifies naming and compatibility: use package/binary `oh-my-opencode`, plugin entry `oh-my-openagent`, both old/new config filenames are supported; and documents disabling anonymous telemetry with `OMO_SEND_ANONYMOUS_TELEMETRY=0` or `OMO_DISABLE_POSTHOG=1` with links to privacy and terms.

<sup>Written for commit 23d0a0dca38d9903a6e540ea7b5e15e983643b6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

