### PR TITLE
docs(readme): add Russian telemetry/legal section

### DIFF
--- a/README.ru.md
+++ b/README.ru.md
@@ -101,6 +101,10 @@ https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/refs/heads/dev/do
 curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/refs/heads/dev/docs/guide/installation.md
 ```
 
+**Примечание**: Используйте опубликованное имя пакета и бинарника `oh-my-opencode`. Внутри `opencode.json` слой совместимости теперь предпочитает точку входа плагина `oh-my-openagent`, в то время как устаревшие записи `oh-my-opencode` все еще загружаются с предупреждением. Файлы конфигурации плагина по-прежнему часто используют `oh-my-opencode.json` или `oh-my-opencode.jsonc`, и как устаревшие, так и переименованные базовые имена распознаются во время переходного периода.
+
+Анонимная телеметрия включена по умолчанию для улучшения надежности установки и работы. Она использует PostHog с хешированным идентификатором установки, никогда не используя исходное имя хоста, и может быть отключена с помощью `OMO_SEND_ANONYMOUS_TELEMETRY=0` или `OMO_DISABLE_POSTHOG=1`. См. [Политику конфиденциальности](docs/legal/privacy-policy.md) и [Условия обслуживания](docs/legal/terms-of-service.md).
+
 ------
 
 ## Пропустите этот README


### PR DESCRIPTION
## Summary
- Added Russian translation of telemetry and legal information section
- Matches English README content added in commit 630f5b79

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Russian telemetry/legal section to `README.ru.md` to match the English README and keep docs consistent. It explains default anonymous PostHog telemetry, how to opt out via `OMO_SEND_ANONYMOUS_TELEMETRY=0` or `OMO_DISABLE_POSTHOG=1`, links to privacy/terms, and notes the `oh-my-opencode`/`oh-my-openagent` naming compatibility.

<sup>Written for commit 3673b962662d5418a28ccf447850ceece1a7542e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

