### PR TITLE
docs(readme): add Japanese telemetry/legal section

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -115,6 +115,10 @@ https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/refs/heads/dev/do
 curl -s https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/refs/heads/dev/docs/guide/installation.md
 ```
 
+**注記**: 公開されているパッケージおよびバイナリ名は `oh-my-opencode` を使用してください。`opencode.json` 内では、互換性レイヤーがプラグインエントリ `oh-my-openagent` を優先しますが、従来の `oh-my-opencode` エントリも警告付きで読み込まれます。プラグイン設定ファイルは依然として `oh-my-opencode.json` または `oh-my-opencode.jsonc` を使用するのが一般的で、移行期間中は従来のファイル名と改名後のファイル名の両方が認識されます。
+
+匿名のテレメトリは、インストールとランタイムの信頼性向上のためにデフォルトで有効になっています。これは PostHog を使用し、生のホスト名ではなくハッシュ化されたインストール識別子を使用します。無効化するには `OMO_SEND_ANONYMOUS_TELEMETRY=0` または `OMO_DISABLE_POSTHOG=1` を設定してください。[プライバシーポリシー](docs/legal/privacy-policy.md)と[利用規約](docs/legal/terms-of-service.md)をご覧ください。
+
 ---
 
 ## このREADMEをスキップする


### PR DESCRIPTION
## Summary
- Added Japanese translation of telemetry and legal information section
- Matches English README content added in commit 630f5b79

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Japanese telemetry/legal section to `README.ja.md` to match the English README. Clarifies `oh-my-opencode` vs `oh-my-openagent` naming, default anonymous telemetry via PostHog (hashed install ID), opt-out env vars (`OMO_SEND_ANONYMOUS_TELEMETRY=0`, `OMO_DISABLE_POSTHOG=1`), and links to privacy/terms.

<sup>Written for commit 0ece66e361839e2b3dcbebf1a8ab7085db070068. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

