### PR TITLE
docs(cli): add --vercel-ai-gateway flag

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,6 +57,7 @@ bunx oh-my-opencode install
 | `--zai-coding-plan <no\|yes>` | Z.ai Coding Plan subscription |
 | `--kimi-for-coding <no\|yes>` | Kimi for Coding subscription |
 | `--opencode-go <no\|yes>` | OpenCode Go subscription |
+| `--vercel-ai-gateway <no\|yes>` | Vercel AI Gateway: no, yes (default: no) |
 | `--skip-auth` | Skip authentication setup hints |
 
 Anonymous telemetry uses PostHog with a hashed installation identifier. Disable it with `OMO_SEND_ANONYMOUS_TELEMETRY=0` or `OMO_DISABLE_POSTHOG=1`. See [Privacy Policy](../legal/privacy-policy.md).


### PR DESCRIPTION
## Summary
- Added documentation for the new `--vercel-ai-gateway` install flag
- Synced with cli-program.ts source of truth

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `--vercel-ai-gateway <no|yes>` to the CLI install docs, aligned with `cli-program.ts` (default: no) so users can opt into Vercel AI Gateway during setup.

<sup>Written for commit c91db2eb3081db709447367532921d832921c5d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

