### PR TITLE
docs(configuration): add sisyphus-junior to agent list

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -146,7 +146,7 @@ Here's a practical starting configuration:
 
 ### Agents
 
-Override built-in agent settings. Available agents: `sisyphus`, `hephaestus`, `prometheus`, `oracle`, `librarian`, `explore`, `multimodal-looker`, `metis`, `momus`, `atlas`.
+Override built-in agent settings. Available agents: `sisyphus`, `hephaestus`, `prometheus`, `oracle`, `librarian`, `explore`, `multimodal-looker`, `metis`, `momus`, `atlas`, `sisyphus-junior`.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Added sisyphus-junior to the documented agent list
- Now correctly lists all 11 agents per agent-names.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `sisyphus-junior` to the available agents list in the configuration docs, aligning the docs with the current set of 11 built-in agents.

<sup>Written for commit e223ab208fb49afd8ae909bc9acff8ba9e3f00ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

