### PR TITLE
docs(overview): update model-role claims and complete category list

### DIFF
--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -66,7 +66,7 @@ User Request
     └─→ [Category-based agents] — Specialized by task type
 ```
 
-When Sisyphus delegates to a subagent, it doesn't pick a model name. It picks a **category** — `visual-engineering`, `ultrabrain`, `quick`, `deep`. The category automatically maps to the right model. You touch nothing.
+When Sisyphus delegates to a subagent, it doesn't pick a model name. It picks a **category** — `visual-engineering`, `ultrabrain`, `deep`, `artistry`, `quick`, `unspecified-low`, `unspecified-high`, `writing`. The category automatically maps to the right model. You touch nothing.
 
 For a deep dive into how agents collaborate, see the [Orchestration System Guide](./orchestration.md).
 
@@ -83,11 +83,10 @@ Sisyphus is your main orchestrator. He plans, delegates to specialists, and driv
 **Recommended models:**
 
 - **Claude Opus 4.6** — Best overall experience. Sisyphus was built with Claude-optimized prompts.
-- **Claude Sonnet 4.6** — Good balance of capability and cost.
 - **Kimi K2.5** — Great Claude-like alternative. Many users run this combo exclusively.
 - **GLM 5** — Solid option, especially via Z.ai.
 
-Sisyphus still works best on Claude-family models, Kimi, and GLM. GPT-5.4 now has a dedicated prompt path, but older GPT models are still a poor fit and should route to Hephaestus instead.
+Sisyphus works best on Claude Opus 4.6, Kimi K2.5, and GLM 5. GPT-5.4 now has a dedicated prompt path, but older GPT models are still a poor fit and should route to Hephaestus instead.
 
 ### Hephaestus: The Legitimate Craftsman
 
@@ -101,7 +100,7 @@ Use Hephaestus when you need deep architectural reasoning, complex debugging acr
 
 - **Multi-model orchestration.** Pure Codex is single-model. OmO routes different tasks to different models automatically. GPT for deep reasoning. Gemini for frontend. GPT-5.4 Mini for speed. The right brain for the right job.
 - **Background agents.** Fire 5+ agents in parallel. Something Codex simply cannot do. While one agent writes code, another researches patterns, another checks documentation. Like a real dev team.
-- **Category system.** Tasks are routed by intent, not model name. `visual-engineering` gets Gemini. `ultrabrain` gets GPT-5.4. `quick` gets GPT-5.4 Mini. No manual juggling.
+- **Category system.** Tasks are routed by intent, not model name. `visual-engineering` gets Gemini. `ultrabrain` gets GPT-5.4 xhigh. `deep` gets GPT-5.4. `artistry` gets Gemini. `quick` gets GPT-5.4 Mini. `unspecified-low` gets fast cheap models. `unspecified-high` gets Claude Opus. `writing` gets prose-optimized models. No manual juggling.
 - **Accumulated wisdom.** Subagents learn from previous results. Conventions discovered in task 1 are passed to task 5. Mistakes made early aren't repeated. The system gets smarter as it works.
 
 ### Prometheus: The Strategic Planner
@@ -186,20 +185,32 @@ You can override specific agents or categories in your config:
   },
 
   "categories": {
-    // Frontend work: Gemini dominates visual tasks
+    // Frontend/UI work: Gemini dominates visual tasks
     "visual-engineering": {
       "model": "google/gemini-3.1-pro",
       "variant": "high",
     },
 
-    // General high-effort work
-    "unspecified-high": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
+    // Hard logic and architecture: GPT-5.4 xhigh
+    "ultrabrain": { "model": "openai/gpt-5.4", "variant": "xhigh" },
 
-    // Quick tasks: use GPT-5.4-mini (fast and cheap)
+    // Autonomous research and execution
+    "deep": { "model": "openai/gpt-5.4", "variant": "high" },
+
+    // Creative and design work
+    "artistry": { "model": "google/gemini-3.1-pro", "variant": "high" },
+
+    // Quick tasks: fast and cheap
     "quick": { "model": "openai/gpt-5.4-mini" },
 
-    // Deep reasoning: GPT-5.4
-    "ultrabrain": { "model": "openai/gpt-5.4", "variant": "xhigh" },
+    // Low-effort fallback: cheapest available
+    "unspecified-low": { "model": "openai/gpt-5.4-mini" },
+
+    // High-effort fallback: best available
+    "unspecified-high": { "model": "anthropic/claude-opus-4-6", "variant": "max" },
+
+    // Prose and documentation
+    "writing": { "model": "anthropic/claude-opus-4-6", "variant": "high" },
   },
 }
 ```
@@ -208,14 +219,14 @@ You can override specific agents or categories in your config:
 
 **Claude-like models** (instruction-following, structured output):
 
-- Claude Opus 4.6, Claude Sonnet 4.6, Claude Haiku 4.5
+- Claude Opus 4.6, Claude Haiku 4.5
 - Kimi K2.5 — behaves very similarly to Claude
 - GLM 5 — Claude-like behavior, good for broad tasks
 
 **GPT models** (explicit reasoning, principle-driven):
 
 - GPT-5.4 — deep coding powerhouse, required for Hephaestus and default for Oracle
-- GPT-5-Nano — ultra-cheap, fast utility tasks
+- GPT-5.4 Mini — fast and cheap utility tasks
 
 **Different-behavior models**:
 


### PR DESCRIPTION
## Summary
- Expanded category list from 4 to all 8 categories
- Removed Claude Sonnet 4.6 from Sisyphus recommended models
- Updated config example with all 8 category model mappings
- Fixed GPT-5-Nano → GPT-5.4 Mini

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Overview guide to cover all eight agent categories and align model-to-role claims with current routing. Also fixes model naming and recommendations.

- **Docs**
  - Expanded category list to all 8: `visual-engineering`, `ultrabrain`, `deep`, `artistry`, `quick`, `unspecified-low`, `unspecified-high`, `writing`.
  - Updated routing examples and config snippet with new mappings (e.g., `ultrabrain` → GPT-5.4 xhigh, `deep` → GPT-5.4, `quick` → GPT-5.4 Mini).
  - Removed Claude Sonnet 4.6 from Sisyphus recommendations; clarified best models are Claude Opus 4.6, Kimi K2.5, and GLM 5.
  - Fixed naming: GPT-5-Nano → GPT-5.4 Mini.

<sup>Written for commit 05e54444c50638737dd5e2225c5d1707b5d7ac0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

