### PR TITLE
docs(contributing): update tool/hook counts and version references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ oh-my-opencode/
 │   ├── config/          # Zod v4 schema system
 │   ├── shared/          # Cross-cutting utilities
 │   ├── cli/             # CLI: install, run, doctor, mcp-oauth (Commander.js)
-│   ├── plugin/          # 10 OpenCode hook handlers + hook composition
+│   ├── plugin/          # 10 OpenCode hook handlers + 52 hook composition
 │   └── plugin-handlers/ # 6-phase config loading pipeline
 ├── packages/            # Monorepo: comment-checker, opencode-sdk
 └── dist/                # Build output (ESM + .d.ts)


### PR DESCRIPTION
## Summary
- Removed hardcoded TypeScript 5.7.3+ version pin
- Removed OpenCode 1.0.150+ prerequisite
- Updated hook count: 52 hooks across 55 modules
- Updated tool count: 26 tools across 16 directories
- Updated hook handlers: 10 OpenCode hook handlers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `TypeScript 5.7.3+` and `OpenCode 1.0.150+` prerequisites and updated CONTRIBUTING to reflect current project stats. The plugin section now notes 10 `OpenCode` hook handlers + 52 hook composition and documents 52 hooks across 55 modules and 26 tools across 16 directories.

<sup>Written for commit 0cb0a6c01d48bd2f6e222494537fcc8610f72ca3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

