### PR TITLE
docs(ollama): update issue status notation

### DIFF
--- a/docs/troubleshooting/ollama.md
+++ b/docs/troubleshooting/ollama.md
@@ -67,7 +67,7 @@ The proper fix requires Claude Code SDK to:
 3. Merge `tool_calls` from multiple lines
 4. Return a single merged response
 
-**Tracking**: https://github.com/code-yeongyu/oh-my-openagent/issues/1124
+**Tracking**: https://github.com/code-yeongyu/oh-my-openagent/issues/1124 (closed - documented workaround)
 
 ## Workaround Implementation
 
@@ -114,7 +114,7 @@ curl -s http://localhost:11434/api/chat \
 
 ## Related Issues
 
-- **oh-my-openagent**: https://github.com/code-yeongyu/oh-my-openagent/issues/1124
+- **oh-my-openagent**: https://github.com/code-yeongyu/oh-my-openagent/issues/1124 (closed - workaround documented)
 - **Ollama API Docs**: https://github.com/ollama/ollama/blob/main/docs/api.md
 
 ## Getting Help


### PR DESCRIPTION
## Summary
- Updated issue #1124 link to note closed status
- Verified workaround (stream: false) is still valid
- Verified model names (qwen3-coder, ministral-3:14b) are current

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marked the upstream `oh-my-openagent` issue as closed in the Ollama troubleshooting docs and confirmed the documented workaround (`stream: false`) is still valid. Updated both the Tracking and Related Issues links to reflect the closure.

<sup>Written for commit b57a79750f7f97dff393c2d4482b7241ce816d1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

