### PR TITLE
fix(skill-loader): coerce numeric frontmatter command names to strings

### DIFF
--- a/src/features/opencode-skill-loader/loaded-skill-from-path.ts
+++ b/src/features/opencode-skill-loader/loaded-skill-from-path.ts
@@ -25,7 +25,7 @@ export async function loadSkillFromPath(options: {
     const mcpJsonMcp = await loadMcpJsonFromDir(options.resolvedPath)
     const mcpConfig = mcpJsonMcp || frontmatterMcp
 
-    const baseName = data.name || options.defaultName
+    const baseName = data.name == null ? options.defaultName : String(data.name)
     const skillName = namePrefix ? `${namePrefix}/${baseName}` : baseName
     const originalDescription = data.description || ""
     const isOpencodeSource = options.scope === "opencode" || options.scope === "opencode-project"

--- a/src/features/opencode-skill-loader/loader.test.ts
+++ b/src/features/opencode-skill-loader/loader.test.ts
@@ -100,6 +100,34 @@ This is a simple skill.
       }
     })
 
+    it("coerces numeric frontmatter names to strings", async () => {
+      // given
+      const skillContent = `---
+name: 12306
+description: Numeric skill name
+---
+This skill name should still load.
+`
+      createTestSkill("12306", skillContent)
+
+      // when
+      const { discoverSkills } = await import("./loader")
+      const originalCwd = process.cwd()
+      process.chdir(TEST_DIR)
+
+      try {
+        const skills = await discoverSkills({ includeClaudeCodePaths: false })
+        const skill = skills.find(s => s.name === "12306")
+
+        // then
+        expect(skill).toBeDefined()
+        expect(typeof skill?.name).toBe("string")
+        expect(skill?.definition.name).toBe("12306")
+      } finally {
+        process.chdir(originalCwd)
+      }
+    })
+
     it("preserves env var placeholders without expansion", async () => {
       // given
       const skillContent = `---


### PR DESCRIPTION
## Summary
- Prevent crash when YAML frontmatter `name` field is a number (e.g., `name: 12306`)

## Problem
YAML parses numeric-looking `name` values as numbers, not strings. The existing code `data.name || options.defaultName` treats truthy numbers correctly but passes them as `number` type downstream, which causes type errors when the name is used as a string key in Maps or object properties.

## Fix
Changed `data.name || options.defaultName` to `data.name == null ? options.defaultName : String(data.name)`. This coerces any non-null frontmatter name to a string while still falling back to `defaultName` when name is absent.

## Changes
| File | Change |
|------|--------|
| `src/features/opencode-skill-loader/loaded-skill-from-path.ts` | Null-check + String() coercion for frontmatter name |
| `src/features/opencode-skill-loader/loader.test.ts` | Add test for numeric frontmatter name (`name: 12306`) |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash in the skill loader when the YAML frontmatter name is numeric. Non-null names are coerced to strings while preserving the default-name fallback; a test covers numeric names.

<sup>Written for commit 3750265ff72f89782ea4143a9143b91c5f1eda49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

