### PR TITLE
fix: use in-process flag instead of existsSync for cache availability

### DIFF
--- a/src/shared/connected-providers-cache.ts
+++ b/src/shared/connected-providers-cache.ts
@@ -2,6 +2,10 @@ import { log } from "./logger"
 import * as dataPath from "./data-path"
 import { createJsonFileCacheStore } from "./json-file-cache-store"
 
+// Track if provider models cache has been successfully written in the current process
+// This helps in sandbox environments where filesystem state may not persist across contexts
+let providerModelsCacheWrittenInCurrentProcess = false
+
 const CONNECTED_PROVIDERS_CACHE_FILE = "connected-providers.json"
 const PROVIDER_MODELS_CACHE_FILE = "provider-models.json"
 
@@ -84,6 +88,12 @@ export function createConnectedProvidersCacheStore(
 	}
 
 	function hasProviderModelsCache(): boolean {
+		// First check if we've written the cache in the current process
+		// This handles sandbox environments where filesystem state may not persist across contexts
+		if (providerModelsCacheWrittenInCurrentProcess) {
+			return true
+		}
+		// Fall back to the store's has() method (which also checks in-memory state)
 		return providerModelsCacheStore.has()
 	}
 
@@ -92,6 +102,7 @@ export function createConnectedProvidersCacheStore(
 			...data,
 			updatedAt: new Date().toISOString(),
 		})
+		providerModelsCacheWrittenInCurrentProcess = true
 	}
 
 	async function updateConnectedProvidersCache(client: {
@@ -161,6 +172,7 @@ export function createConnectedProvidersCacheStore(
 	function _resetMemCacheForTesting(): void {
 		connectedProvidersCacheStore.resetMemory()
 		providerModelsCacheStore.resetMemory()
+		providerModelsCacheWrittenInCurrentProcess = false
 	}
 
 	return {

--- a/src/shared/json-file-cache-store.ts
+++ b/src/shared/json-file-cache-store.ts
@@ -27,6 +27,7 @@ export function createJsonFileCacheStore<TValue>(
 	options: JsonFileCacheStoreOptions<TValue>,
 ): JsonFileCacheStore<TValue> {
 	let memoryValue: TValue | null | undefined
+	let writtenInCurrentProcess = false
 
 	function getCacheFilePath(): string {
 		return join(options.getCacheDir(), options.filename)
@@ -67,6 +68,17 @@ export function createJsonFileCacheStore<TValue>(
 	}
 
 	function has(): boolean {
+		// First check if we have a valid in-memory cache value
+		// This handles sandbox environments where existsSync may fail across contexts
+		if (memoryValue !== undefined && memoryValue !== null) {
+			return true
+		}
+		// Check if we've written to this cache in the current process
+		// This helps in sandbox environments where filesystem state may not persist across contexts
+		if (writtenInCurrentProcess) {
+			return true
+		}
+		// Fall back to filesystem check
 		return existsSync(getCacheFilePath())
 	}
 
@@ -77,6 +89,7 @@ export function createJsonFileCacheStore<TValue>(
 		try {
 			writeFileSync(cacheFile, options.serialize?.(value) ?? JSON.stringify(value, null, 2))
 			memoryValue = value
+			writtenInCurrentProcess = true
 			log(`[${options.logPrefix}] ${options.cacheLabel} written`, options.describe(value))
 		} catch (error) {
 			log(`[${options.logPrefix}] Error writing ${toLogLabel(options.cacheLabel)}`, {
@@ -87,6 +100,7 @@ export function createJsonFileCacheStore<TValue>(
 
 	function resetMemory(): void {
 		memoryValue = undefined
+		writtenInCurrentProcess = false
 	}
 
 	return {


### PR DESCRIPTION
## Summary

- Fixes spurious "Model Cache Not Found" toast warnings that fire on every first message when running as an OpenCode plugin
- Root cause: `existsSync()` is unreliable across different Bun sandbox hook contexts (config vs chat.message) because each runs in an isolated virtual filesystem
- Adds `writtenInCurrentProcess` flags to `json-file-cache-store` and `connected-providers-cache` so cache availability is tracked at the process level instead of relying solely on filesystem checks

Closes #3412

## Changes

### `src/shared/json-file-cache-store.ts`
- Added `writtenInCurrentProcess` closure-level boolean flag
- `write()` sets flag to `true` on successful write
- `has()` uses three-tier check: `memoryValue → writtenInCurrentProcess → existsSync()`
- `resetMemory()` resets the flag

### `src/shared/connected-providers-cache.ts`
- Added `providerModelsCacheWrittenInCurrentProcess` module-level flag
- `writeProviderModelsCache()` sets flag on successful write
- `hasProviderModelsCache()` checks flag before delegating to store's `has()`
- `_resetMemCacheForTesting()` resets the flag

## Testing

- All 5450+ existing tests pass
- TypeScript typecheck passes
- Build succeeds (`bun run build`)
- `connected-providers-cache.test.ts` (7 tests) passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes spurious "Model Cache Not Found" toasts by tracking cache writes in-process instead of relying on `existsSync` in Bun sandbox contexts. Addresses Linear #3412 and stops first-message warnings in the OpenCode plugin.

- **Bug Fixes**
  - Added in-process flags: `writtenInCurrentProcess` in `json-file-cache-store` and a module-level flag in `connected-providers-cache` to track successful writes.
  - Updated `has()` to check memory → in-process flag → filesystem, with `write()` setting the flag and reset methods clearing it.
  - Prevents false negatives when hook contexts use isolated virtual filesystems.

<sup>Written for commit 177c51b64086ae43c03534a77b13cc5e81892fff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

