### PR TITLE
fix(skill-mcp): pass workspace directory as cwd to stdio MCP processes

### DIFF
--- a/src/features/skill-mcp-manager/stdio-client.ts
+++ b/src/features/skill-mcp-manager/stdio-client.ts
@@ -60,6 +60,7 @@ export async function createStdioClient(params: SkillMcpClientConnectionParams):
     args,
     env: mergedEnv,
     stderr: "ignore",
+    ...(info.directory ? { cwd: info.directory } : {}),
   })
 
   const client: McpClient = stdioClientDependencies.createClient(

--- a/src/features/skill-mcp-manager/types.ts
+++ b/src/features/skill-mcp-manager/types.ts
@@ -24,6 +24,7 @@ export interface SkillMcpClientInfo {
   skillName: string
   sessionID: string
   scope?: SkillScope | "local"
+  directory?: string
 }
 
 export interface SkillMcpServerContext {

--- a/src/tools/skill-mcp/tools.test.ts
+++ b/src/tools/skill-mcp/tools.test.ts
@@ -192,6 +192,32 @@ describe("skill_mcp tool", () => {
         {},
       )
     })
+
+    it("passes toolContext.directory to the manager", async () => {
+      // given
+      loadedSkills = [
+        createMockSkillWithMcp("test-skill", {
+          "test-server": { command: "echo", args: ["test"] },
+        }),
+      ]
+      const callToolSpy = spyOn(manager, "callTool").mockResolvedValue({ content: [] } as never)
+      const tool = createSkillMcpTool({
+        manager,
+        getLoadedSkills: () => loadedSkills,
+        getSessionID: () => "session-1",
+      })
+
+      // when
+      await tool.execute({ mcp_name: "test-server", tool_name: "some-tool" }, mockContext)
+
+      // then
+      expect(callToolSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ directory: "/test" }),
+        expect.any(Object),
+        "some-tool",
+        {},
+      )
+    })
   })
 })
 

--- a/src/tools/skill-mcp/tools.ts
+++ b/src/tools/skill-mcp/tools.ts
@@ -167,6 +167,7 @@ export function createSkillMcpTool(options: SkillMcpToolOptions): ToolDefinition
         skillName: found.skill.name,
         sessionID,
         scope: found.skill.scope,
+        directory: toolContext.directory,
       }
 
       const context: SkillMcpServerContext = {


### PR DESCRIPTION
## Summary

- Pass `toolContext.directory` through `SkillMcpClientInfo` to `StdioClientTransport`'s `cwd` parameter so that stdio MCP child processes inherit the correct workspace directory instead of `process.cwd()`

## Problem

In OpenCode web multi-workspace mode, skill_mcp spawned stdio child processes used `process.cwd()` (the directory where `opencode web` was started) rather than the session's workspace directory. This meant MCP servers that rely on the working directory (e.g., file-based databases, linters) would operate on the wrong project.

OpenCode's built-in MCP correctly passes `Instance.directory` as `cwd` to its `StdioClientTransport`. This PR brings skill-embedded MCPs to parity.

## Changes

- `SkillMcpClientInfo` type: added optional `directory` field
- `tools.ts`: populate `directory` from `toolContext.directory`
- `stdio-client.ts`: conditionally pass `cwd` to `StdioClientTransport` when `directory` is present

## Test plan

- [x] Existing 110 tests pass (0 regressions)
- [x] New test: verifies `toolContext.directory` is forwarded to manager via `SkillMcpClientInfo`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the session’s workspace directory to stdio MCP child processes as `cwd` so servers run against the correct project. Fixes multi-workspace mode where processes inherited `process.cwd()`.

- **Bug Fixes**
  - Add optional `directory` to `SkillMcpClientInfo`.
  - Set it from `toolContext.directory` and pass as `cwd` to `StdioClientTransport` when present.
  - Add test confirming the directory is forwarded to the manager.

<sup>Written for commit df172ac3d51b59f0de95f9db40adbf1a6fe2cbef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

