### PR TITLE
fix(auto-update): use semantic version comparison instead of string e…

### DIFF
--- a/src/hooks/auto-update-checker/checker/check-for-update.ts
+++ b/src/hooks/auto-update-checker/checker/check-for-update.ts
@@ -1,4 +1,5 @@
 import { log } from "../../../shared/logger"
+import { compareVersions } from "../../../shared/opencode-version"
 import type { UpdateCheckResult } from "../types"
 import { extractChannel } from "../version-channel"
 import { isLocalDevMode } from "./local-dev-path"
@@ -55,7 +56,7 @@ export async function checkForUpdate(directory: string): Promise<UpdateCheckResu
     }
   }
 
-  const needsUpdate = currentVersion !== latestVersion
+  const needsUpdate = compareVersions(currentVersion, latestVersion) !== 0
   log(
     `[auto-update-checker] Current: ${currentVersion}, Latest (${channel}): ${latestVersion}, NeedsUpdate: ${needsUpdate}`
   )


### PR DESCRIPTION
…quality

The update checker was using strict string comparison (===) to compare current and latest versions. This caused false-positive update notifications when versions were semantically equal but had different string representations (e.g., with/without 'v' prefix, different formatting).

Changed to use compareVersions() which properly parses and compares semver versions, handling 'v' prefixes and other variations correctly.

Fixes: incorrect 'v3.17.2 available' notifications when already on latest version

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect update prompts by switching the auto-update checker to semantic version comparison. Replaces string equality with `compareVersions`, correctly handling 'v' prefixes and other semver variations.

<sup>Written for commit 003e45abeda78c77c0c90eaf10d866d2e9e06283. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

