### PR TITLE
feat(model-requirements): add glm-5.1 to agent fallback chains (fixes #3210)

### DIFF
--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -41,6 +41,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       },
       { providers: ["openai", "github-copilot", "opencode", "vercel"], model: "gpt-5.4", variant: "medium" },
       { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5" },
+      { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5.1" },
       { providers: ["opencode"], model: "big-pickle" },
     ],
     requiresAnyModel: true,
@@ -73,6 +74,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "max",
       },
       { providers: ["opencode-go", "vercel"], model: "glm-5" },
+      { providers: ["opencode-go", "vercel"], model: "glm-5.1" },
     ],
   },
   librarian: {
@@ -113,6 +115,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["opencode-go", "vercel"], model: "glm-5" },
+      { providers: ["opencode-go", "vercel"], model: "glm-5.1" },
       {
         providers: ["google", "github-copilot", "opencode", "vercel"],
         model: "gemini-3.1-pro",
@@ -132,6 +135,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["opencode-go", "vercel"], model: "glm-5" },
+      { providers: ["opencode-go", "vercel"], model: "glm-5.1" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
     ],
   },
@@ -153,6 +157,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["opencode-go", "vercel"], model: "glm-5" },
+      { providers: ["opencode-go", "vercel"], model: "glm-5.1" },
     ],
   },
   atlas: {
@@ -191,12 +196,14 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5" },
+      { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5.1" },
       {
         providers: ["anthropic", "github-copilot", "opencode", "vercel"],
         model: "claude-opus-4-6",
         variant: "max",
       },
       { providers: ["opencode-go", "vercel"], model: "glm-5" },
+      { providers: ["opencode-go", "vercel"], model: "glm-5.1" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
     ],
   },
@@ -218,6 +225,7 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "max",
       },
       { providers: ["opencode-go", "vercel"], model: "glm-5" },
+      { providers: ["opencode-go", "vercel"], model: "glm-5.1" },
     ],
   },
   deep: {
@@ -305,8 +313,10 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "high",
       },
       { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5" },
+      { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5.1" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
       { providers: ["opencode-go", "vercel"], model: "glm-5" },
+      { providers: ["opencode-go", "vercel"], model: "glm-5.1" },
       { providers: ["opencode", "vercel"], model: "kimi-k2.5" },
       {
         providers: [


### PR DESCRIPTION
## Summary
- add `glm-5.1` next to existing `glm-5` fallback entries in shared agent and category model requirements
- keep the existing GLM fallback ordering intact while making GLM-5.1 available to the same providers

## Verification
- checked `src/cli/model-fallback.ts` and confirmed it consumes the shared fallback requirements without needing code changes
- attempted `bun run build`, `bun install --frozen-lockfile && bun run build`, and `bunx tsc --noEmit src/shared/model-requirements.ts`; this workspace is currently missing installable dependencies / has install issues in the environment, so local build verification could not complete

Fixes #3210

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `glm-5.1` to agent and category model fallback chains, enabling the same providers to use the new GLM variant while keeping fallback order unchanged. Addresses #3210 by adding `glm-5.1` for `zai-coding-plan`, `opencode`, `opencode-go`, and `vercel` with no other code changes.

<sup>Written for commit 23357b5b14bcc2422340a9fadc7caf785db312d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

