### PR TITLE
feat(preemptive-compaction): add compaction_model config option (fixes #828)

### DIFF
--- a/src/config/schema/experimental.ts
+++ b/src/config/schema/experimental.ts
@@ -1,10 +1,15 @@
 import { z } from "zod"
 import { DynamicContextPruningConfigSchema } from "./dynamic-context-pruning"
 
+const PreemptiveCompactionConfigSchema = z.object({
+  threshold: z.number().min(0).max(1).optional(),
+  model: z.string().optional(),
+})
+
 export const ExperimentalConfigSchema = z.object({
   aggressive_truncation: z.boolean().optional(),
   auto_resume: z.boolean().optional(),
-  preemptive_compaction: z.boolean().optional(),
+  preemptive_compaction: z.union([z.boolean(), PreemptiveCompactionConfigSchema]).optional(),
   truncate_all_tool_outputs: z.boolean().optional(),
   /** Dynamic context pruning configuration */
   dynamic_context_pruning: DynamicContextPruningConfigSchema.optional(),

--- a/src/hooks/preemptive-compaction.test.ts
+++ b/src/hooks/preemptive-compaction.test.ts
@@ -172,6 +172,88 @@ describe("preemptive-compaction", () => {
     expect(ctx.client.session.summarize).toHaveBeenCalled()
   })
 
+  it("should use configured compaction model override when set", async () => {
+    const hook = createPreemptiveCompactionHook(ctx as never, {
+      experimental: {
+        preemptive_compaction: {
+          model: "openrouter/openai/gpt-5-mini",
+        },
+      },
+    })
+    const sessionID = "ses_model_override"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            finish: true,
+            tokens: {
+              input: 170000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_model_override" },
+      { title: "", output: "test", metadata: null },
+    )
+
+    expect(ctx.client.session.summarize).toHaveBeenCalledWith({
+      path: { id: sessionID },
+      body: { providerID: "openrouter", modelID: "openai/gpt-5-mini", auto: true },
+      query: { directory: "/tmp/test" },
+    })
+  })
+
+  it("should respect object threshold config", async () => {
+    const hook = createPreemptiveCompactionHook(ctx as never, {
+      experimental: {
+        preemptive_compaction: {
+          threshold: 0.95,
+        },
+      },
+    })
+    const sessionID = "ses_threshold_override"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            finish: true,
+            tokens: {
+              input: 170000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_threshold_override" },
+      { title: "", output: "test", metadata: null },
+    )
+
+    expect(ctx.client.session.summarize).not.toHaveBeenCalled()
+  })
+
   it("should trigger compaction for google-vertex-anthropic provider", async () => {
     //#given google-vertex-anthropic usage above threshold
     const hook = createPreemptiveCompactionHook(ctx as never, {} as never)

--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -28,6 +28,46 @@ interface CachedCompactionState {
   tokens: TokenInfo
 }
 
+function resolvePreemptiveCompactionConfig(pluginConfig: OhMyOpenCodeConfig): {
+  model?: string
+  threshold: number
+} {
+  const preemptiveCompactionConfig = pluginConfig.experimental?.preemptive_compaction
+  const threshold = typeof preemptiveCompactionConfig === "object" && preemptiveCompactionConfig !== null
+    ? preemptiveCompactionConfig.threshold ?? PREEMPTIVE_COMPACTION_THRESHOLD
+    : PREEMPTIVE_COMPACTION_THRESHOLD
+
+  return {
+    threshold,
+    model:
+      typeof preemptiveCompactionConfig === "object" && preemptiveCompactionConfig !== null
+        ? preemptiveCompactionConfig.model
+        : undefined,
+  }
+}
+
+function resolvePreemptiveCompactionModel(args: {
+  pluginConfig: OhMyOpenCodeConfig
+  sessionID: string
+  providerID: string
+  modelID: string
+  configuredModel?: string
+}): { providerID: string; modelID: string } {
+  const { configuredModel, modelID, pluginConfig, providerID, sessionID } = args
+
+  if (configuredModel) {
+    const modelParts = configuredModel.split("/")
+    if (modelParts.length >= 2) {
+      return {
+        providerID: modelParts[0],
+        modelID: modelParts.slice(1).join("/"),
+      }
+    }
+  }
+
+  return resolveCompactionModel(pluginConfig, sessionID, providerID, modelID)
+}
+
 async function withTimeout<TValue>(
   promise: Promise<TValue>,
   timeoutMs: number,
@@ -71,6 +111,7 @@ export function createPreemptiveCompactionHook(
   const compactedSessions = new Set<string>()
   const lastCompactionTime = new Map<string, number>()
   const tokenCache = new Map<string, CachedCompactionState>()
+  const preemptiveCompactionConfig = resolvePreemptiveCompactionConfig(pluginConfig)
 
   const postCompactionMonitor = createPostCompactionDegradationMonitor({
     client: ctx.client,
@@ -109,18 +150,19 @@ export function createPreemptiveCompactionHook(
 
     const totalInputTokens = (cached.tokens.input ?? 0) + (cached.tokens.cache?.read ?? 0)
     const usageRatio = totalInputTokens / actualLimit
-    if (usageRatio < PREEMPTIVE_COMPACTION_THRESHOLD || !cached.modelID) return
+    if (usageRatio < preemptiveCompactionConfig.threshold || !cached.modelID) return
 
     compactionInProgress.add(sessionID)
     lastCompactionTime.set(sessionID, Date.now())
 
     try {
-      const { providerID: targetProviderID, modelID: targetModelID } = resolveCompactionModel(
+      const { providerID: targetProviderID, modelID: targetModelID } = resolvePreemptiveCompactionModel({
         pluginConfig,
         sessionID,
-        cached.providerID,
-        cached.modelID,
-      )
+        providerID: cached.providerID,
+        modelID: cached.modelID,
+        configuredModel: preemptiveCompactionConfig.model,
+      })
 
       await withTimeout(
         ctx.client.session.summarize({
@@ -143,7 +185,7 @@ export function createPreemptiveCompactionHook(
       ctx.client.tui.showToast({
         body: {
           title: "Preemptive compaction failed",
-          message: `Context window is above ${Math.round(PREEMPTIVE_COMPACTION_THRESHOLD * 100)}% and auto-compaction could not run. The session may grow large. Error: ${String(error)}`,
+          message: `Context window is above ${Math.round(preemptiveCompactionConfig.threshold * 100)}% and auto-compaction could not run. The session may grow large. Error: ${String(error)}`,
           variant: "warning",
           duration: 10000,
         },


### PR DESCRIPTION
## Summary
- add object config support for `experimental.preemptive_compaction` with optional `threshold` and `model`
- let the preemptive compaction hook use a configured summarization model while keeping the existing conversation-model fallback
- cover the new model override and object threshold behavior with hook tests

## Problem
The preemptive compaction hook currently summarizes with the active conversation model. When that session runs on Claude thinking models, the summarize request can fail with a 400 because the compaction payload is not compatible with the thinking API.

## Fix
This change allows users to set `experimental.preemptive_compaction.model` to a different provider/model pair for compaction runs. When no override is configured, the hook keeps the existing behavior and falls back to the conversation model and existing compaction resolver logic.

## Changes
| File | Change |
|------|--------|
| `src/config/schema/experimental.ts` | Extend `preemptive_compaction` to accept an object with optional `threshold` and `model` |
| `src/hooks/preemptive-compaction.ts` | Read the object config, apply optional threshold override, and pass the configured model to summarize when set |
| `src/hooks/preemptive-compaction.test.ts` | Add coverage for configured model override and object threshold behavior |

Fixes #828

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `experimental.preemptive_compaction` object config with `threshold` and `model`, so compaction can use a dedicated summarize model and avoid 400s on Claude thinking models. Fixes #828.

- **New Features**
  - Support boolean or object config for `experimental.preemptive_compaction` (`threshold`, `model`).
  - Hook uses configured model for summarize; falls back to conversation model.
  - Tests cover model override and threshold behavior.

<sup>Written for commit b7e643b21daae6a39d0d1aa10598eda850003c1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

