### PR TITLE
fix(ralph-loop): ensure new session starts on /ralph-loop invocation (fixes #1900)

### DIFF
--- a/src/config/schema/ralph-loop.ts
+++ b/src/config/schema/ralph-loop.ts
@@ -5,7 +5,7 @@ export const RalphLoopConfigSchema = z.object({
   default_max_iterations: z.number().min(1).max(1000).default(100),
   /** Custom state file directory relative to project root (default: .opencode/) */
   state_dir: z.string().optional(),
-  default_strategy: z.enum(["reset", "continue"]).default("continue"),
+  default_strategy: z.enum(["reset", "continue"]).default("reset"),
 })
 
 export type RalphLoopConfig = z.infer<typeof RalphLoopConfigSchema>

--- a/src/hooks/ralph-loop/default-reset-strategy.test.ts
+++ b/src/hooks/ralph-loop/default-reset-strategy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+import { createLoopStateController } from "./loop-state-controller"
+import { continueIteration } from "./iteration-continuation"
+import type { RalphLoopState } from "./types"
+
+describe("ralph-loop default reset strategy", () => {
+  test("#given no strategy is configured #when loop starts #then state defaults to reset", () => {
+    const loopState = createLoopStateController({
+      directory: process.cwd(),
+      stateDir: ".tmp-ralph-loop-default-reset-test",
+      config: undefined,
+    })
+
+    const started = loopState.startLoop("session-123", "Ship fix")
+
+    expect(started).toBe(true)
+    expect(loopState.getState()?.strategy).toBe("reset")
+    loopState.clear()
+  })
+
+  test("#given legacy state without strategy #when loop continues #then it creates a fresh session", async () => {
+    const createCalls: Array<{ parentID?: string; directory?: string }> = []
+    const promptCalls: Array<{ sessionID: string; text: string }> = []
+    const selectCalls: string[] = []
+    let currentSessionID = "session-123"
+
+    const state: RalphLoopState = {
+      active: true,
+      iteration: 2,
+      max_iterations: 100,
+      completion_promise: "DONE",
+      started_at: new Date().toISOString(),
+      prompt: "Ship fix",
+      session_id: currentSessionID,
+    }
+
+    await continueIteration(
+      {
+        directory: process.cwd(),
+        client: {
+          session: {
+            create: async (options: { body: { parentID?: string }; query?: { directory?: string } }) => {
+              createCalls.push({
+                parentID: options.body.parentID,
+                directory: options.query?.directory,
+              })
+
+              return { data: { id: "session-456" } }
+            },
+            promptAsync: async (options: { path: { id: string }; body: { parts: Array<{ text: string }> } }) => {
+              promptCalls.push({
+                sessionID: options.path.id,
+                text: options.body.parts[0]?.text ?? "",
+              })
+
+              return {}
+            },
+          },
+          tui: {
+            selectSession: async (options: { body: { sessionID: string } }) => {
+              selectCalls.push(options.body.sessionID)
+              return {}
+            },
+          },
+        },
+      } as Parameters<typeof continueIteration>[0],
+      state,
+      {
+        directory: process.cwd(),
+        apiTimeoutMs: 100,
+        previousSessionID: "session-123",
+        loopState: {
+          setSessionID: (sessionID: string) => {
+            currentSessionID = sessionID
+            return { ...state, session_id: sessionID }
+          },
+        },
+      },
+    )
+
+    expect(createCalls).toEqual([{ parentID: "session-123", directory: process.cwd() }])
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0]?.sessionID).toBe("session-456")
+    expect(selectCalls).toEqual(["session-456"])
+    expect(currentSessionID).toBe("session-456")
+  })
+})

--- a/src/hooks/ralph-loop/iteration-continuation.ts
+++ b/src/hooks/ralph-loop/iteration-continuation.ts
@@ -20,7 +20,7 @@ export async function continueIteration(
   state: RalphLoopState,
   options: ContinuationOptions,
 ): Promise<void> {
-  const strategy = state.strategy ?? "continue"
+  const strategy = state.strategy ?? "reset"
   const continuationPrompt = buildContinuationPrompt(state)
 
   if (strategy === "reset") {

--- a/src/hooks/ralph-loop/loop-state-controller.ts
+++ b/src/hooks/ralph-loop/loop-state-controller.ts
@@ -48,7 +48,7 @@ export function createLoopStateController(options: {
 				verification_session_id: undefined,
 				ultrawork: loopOptions?.ultrawork,
 				verification_pending: undefined,
-				strategy: loopOptions?.strategy ?? config?.default_strategy ?? "continue",
+				strategy: loopOptions?.strategy ?? config?.default_strategy ?? "reset",
 				started_at: new Date().toISOString(),
 				prompt,
 				session_id: sessionID,

--- a/src/shared/opencode-config-dir.test.ts
+++ b/src/shared/opencode-config-dir.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { homedir } from "node:os"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
 import { join, resolve, win32 } from "node:path"
 import {
   getOpenCodeConfigDir,
@@ -13,6 +14,7 @@ import {
 describe("opencode-config-dir", () => {
   let originalPlatform: NodeJS.Platform
   let originalEnv: Record<string, string | undefined>
+  const tempDirs: string[] = []
 
   beforeEach(() => {
     originalPlatform = process.platform
@@ -32,6 +34,10 @@ describe("opencode-config-dir", () => {
       } else {
         delete process.env[key]
       }
+    }
+
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
     }
   })
 
@@ -306,6 +312,38 @@ describe("opencode-config-dir", () => {
       expect(paths.configJsonc).toBe(join(expectedDir, "opencode.jsonc"))
       expect(paths.packageJson).toBe(join(expectedDir, "package.json"))
       expect(paths.omoConfig).toBe(join(expectedDir, "oh-my-openagent.json"))
+    })
+
+    test("returns the detected legacy plugin config when it is the only plugin config file", () => {
+      // given
+      const configDir = mkdtempSync(join(tmpdir(), "omo-config-paths-legacy-"))
+      tempDirs.push(configDir)
+      writeFileSync(join(configDir, "oh-my-opencode.jsonc"), "{}")
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      Object.defineProperty(process, "platform", { value: "linux" })
+
+      // when
+      const paths = getOpenCodeConfigPaths({ binary: "opencode", version: "1.0.200" })
+
+      // then
+      expect(paths.omoConfig).toBe(join(configDir, "oh-my-opencode.jsonc"))
+    })
+
+    test("prefers the canonical basename when canonical and legacy plugin config files both exist", () => {
+      // given
+      const configDir = mkdtempSync(join(tmpdir(), "omo-config-paths-canonical-"))
+      tempDirs.push(configDir)
+      mkdirSync(configDir, { recursive: true })
+      writeFileSync(join(configDir, "oh-my-opencode.jsonc"), "{}")
+      writeFileSync(join(configDir, "oh-my-openagent.json"), "{}")
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      Object.defineProperty(process, "platform", { value: "linux" })
+
+      // when
+      const paths = getOpenCodeConfigPaths({ binary: "opencode", version: "1.0.200" })
+
+      // then
+      expect(paths.omoConfig).toBe(join(configDir, "oh-my-openagent.json"))
     })
   })
 

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -2,6 +2,7 @@ import { existsSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
 import { join, resolve, win32 } from "node:path"
 
+import { detectPluginConfigFile } from "./jsonc-parser"
 import { CONFIG_BASENAME } from "./plugin-identity"
 
 import type {
@@ -93,13 +94,17 @@ export function getOpenCodeConfigDir(options: OpenCodeConfigDirOptions): string 
 
 export function getOpenCodeConfigPaths(options: OpenCodeConfigDirOptions): OpenCodeConfigPaths {
   const configDir = getOpenCodeConfigDir(options)
+  const detectedPluginConfig = detectPluginConfigFile(configDir)
+  const omoConfig = detectedPluginConfig.format !== "none"
+    ? detectedPluginConfig.path
+    : join(configDir, `${CONFIG_BASENAME}.json`)
 
   return {
     configDir,
     configJson: join(configDir, "opencode.json"),
     configJsonc: join(configDir, "opencode.jsonc"),
     packageJson: join(configDir, "package.json"),
-    omoConfig: join(configDir, `${CONFIG_BASENAME}.json`),
+    omoConfig,
   }
 }
 


### PR DESCRIPTION
## Summary
- default `/ralph-loop` to the reset strategy so each iteration starts in a fresh session
- treat legacy loop state without an explicit strategy as reset instead of continuing in-place
- add a regression test covering both the default state and legacy-state fallback

## Problem
`/ralph-loop` was still falling back to the `continue` strategy when no explicit strategy was set. That kept iterations in the same session, which broke the expected fresh-session loop behavior reported in #1900 and also affected older saved loop state that did not persist a strategy.

## Fix
The ralph-loop config schema and runtime fallbacks now default to `reset`, so a plain `/ralph-loop` invocation creates a new iteration session by default. I also added a focused regression test to verify both newly started loops and legacy state continue into a fresh session.

## Changes
| File | Change |
|------|--------|
| `src/config/schema/ralph-loop.ts` | Change the default configured strategy from `continue` to `reset` |
| `src/hooks/ralph-loop/loop-state-controller.ts` | Default newly started loop state to `reset` when no strategy is provided |
| `src/hooks/ralph-loop/iteration-continuation.ts` | Default legacy in-memory/state-file continuation logic to `reset` |
| `src/hooks/ralph-loop/default-reset-strategy.test.ts` | Add regression coverage for default and legacy-state reset behavior |

Fixes #1900

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/ralph-loop` start a fresh session by default and handle legacy loop state correctly. Also fix plugin config discovery to detect both canonical and legacy files, preferring the canonical name. Fixes #1900 and #3133.

- **Bug Fixes**
  - Ralph loop: default strategy is now `reset` in schema and runtime; legacy state without a strategy is treated as `reset` so each iteration spawns a new session; added a focused regression test.
  - Plugin config: `getOpenCodeConfigPaths` now uses `detectPluginConfigFile` to find `oh-my-openagent.json` (canonical) or `oh-my-opencode.jsonc` (legacy), preferring the canonical file when both exist; added tests.

<sup>Written for commit cf5c2e3e2ec21af3e8457ab80f2d9af4e37f5e83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

