### PR TITLE
fix(plugin-config): ensure both legacy and renamed config files are discovered (fixes #3133)

### DIFF
--- a/src/shared/opencode-config-dir.test.ts
+++ b/src/shared/opencode-config-dir.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { homedir } from "node:os"
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
 import { join, resolve, win32 } from "node:path"
 import {
   getOpenCodeConfigDir,
@@ -13,6 +14,7 @@ import {
 describe("opencode-config-dir", () => {
   let originalPlatform: NodeJS.Platform
   let originalEnv: Record<string, string | undefined>
+  const tempDirs: string[] = []
 
   beforeEach(() => {
     originalPlatform = process.platform
@@ -32,6 +34,10 @@ describe("opencode-config-dir", () => {
       } else {
         delete process.env[key]
       }
+    }
+
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
     }
   })
 
@@ -306,6 +312,38 @@ describe("opencode-config-dir", () => {
       expect(paths.configJsonc).toBe(join(expectedDir, "opencode.jsonc"))
       expect(paths.packageJson).toBe(join(expectedDir, "package.json"))
       expect(paths.omoConfig).toBe(join(expectedDir, "oh-my-openagent.json"))
+    })
+
+    test("returns the detected legacy plugin config when it is the only plugin config file", () => {
+      // given
+      const configDir = mkdtempSync(join(tmpdir(), "omo-config-paths-legacy-"))
+      tempDirs.push(configDir)
+      writeFileSync(join(configDir, "oh-my-opencode.jsonc"), "{}")
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      Object.defineProperty(process, "platform", { value: "linux" })
+
+      // when
+      const paths = getOpenCodeConfigPaths({ binary: "opencode", version: "1.0.200" })
+
+      // then
+      expect(paths.omoConfig).toBe(join(configDir, "oh-my-opencode.jsonc"))
+    })
+
+    test("prefers the canonical basename when canonical and legacy plugin config files both exist", () => {
+      // given
+      const configDir = mkdtempSync(join(tmpdir(), "omo-config-paths-canonical-"))
+      tempDirs.push(configDir)
+      mkdirSync(configDir, { recursive: true })
+      writeFileSync(join(configDir, "oh-my-opencode.jsonc"), "{}")
+      writeFileSync(join(configDir, "oh-my-openagent.json"), "{}")
+      process.env.OPENCODE_CONFIG_DIR = configDir
+      Object.defineProperty(process, "platform", { value: "linux" })
+
+      // when
+      const paths = getOpenCodeConfigPaths({ binary: "opencode", version: "1.0.200" })
+
+      // then
+      expect(paths.omoConfig).toBe(join(configDir, "oh-my-openagent.json"))
     })
   })
 

--- a/src/shared/opencode-config-dir.ts
+++ b/src/shared/opencode-config-dir.ts
@@ -2,6 +2,7 @@ import { existsSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
 import { join, resolve, win32 } from "node:path"
 
+import { detectPluginConfigFile } from "./jsonc-parser"
 import { CONFIG_BASENAME } from "./plugin-identity"
 
 import type {
@@ -93,13 +94,17 @@ export function getOpenCodeConfigDir(options: OpenCodeConfigDirOptions): string 
 
 export function getOpenCodeConfigPaths(options: OpenCodeConfigDirOptions): OpenCodeConfigPaths {
   const configDir = getOpenCodeConfigDir(options)
+  const detectedPluginConfig = detectPluginConfigFile(configDir)
+  const omoConfig = detectedPluginConfig.format !== "none"
+    ? detectedPluginConfig.path
+    : join(configDir, `${CONFIG_BASENAME}.json`)
 
   return {
     configDir,
     configJson: join(configDir, "opencode.json"),
     configJsonc: join(configDir, "opencode.jsonc"),
     packageJson: join(configDir, "package.json"),
-    omoConfig: join(configDir, `${CONFIG_BASENAME}.json`),
+    omoConfig,
   }
 }
 


### PR DESCRIPTION
## Summary
- make shared plugin config path discovery resolve whichever `oh-my-openagent` or `oh-my-opencode` config file actually exists
- add regression coverage for legacy-only detection and canonical-over-legacy precedence in shared config path resolution

## Problem
Some code paths still treated the plugin config path as a fixed canonical `oh-my-openagent.json` fallback instead of resolving the active file on disk. That made discovery inconsistent when users only had a legacy `oh-my-opencode.json[c]` file or a `.jsonc` variant, even though the loader itself supports both basenames during the rename transition.

## Fix
Update `getOpenCodeConfigPaths()` to use `detectPluginConfigFile()` so shared path resolution consistently returns the real active plugin config file across old/new basenames and `.json`/`.jsonc` extensions. Add regression tests to lock in legacy fallback behavior and canonical-name precedence when both variants are present.

## Changes
| File | Change |
|------|--------|
| `src/shared/opencode-config-dir.ts` | Resolve `omoConfig` from detected plugin config files instead of a fixed canonical `.json` path |
| `src/shared/opencode-config-dir.test.ts` | Add regression tests for legacy-only detection and canonical precedence |

Fixes #3133

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure plugin config discovery resolves the actual file on disk, whether legacy `oh-my-opencode` or renamed `oh-my-openagent`, across `.json`/`.jsonc`. Canonical is preferred when both exist. Fixes #3133.

- **Bug Fixes**
  - Update `getOpenCodeConfigPaths()` to use `detectPluginConfigFile()` and set `omoConfig` to the detected path, preferring `oh-my-openagent` when both variants exist.
  - Add regression tests for legacy-only detection and canonical-over-legacy precedence.

<sup>Written for commit dacaeb4c560e3e2c0bbc4ec28e7846e6aaf53052. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

