### PR TITLE
test: add regression tests for isPlanFamily, code-review->review-work, anthropic transform

### DIFF
--- a/src/tools/delegate-task/prompt-builder.test.ts
+++ b/src/tools/delegate-task/prompt-builder.test.ts
@@ -46,7 +46,7 @@ describe("prompt-builder", () => {
       test("#when agent is explore #then system content includes available_skills section", () => {
         // given
         const availableSkills: AvailableSkill[] = [
-          { name: "code-review", description: "Review code quality", location: "project" },
+          { name: "review-work", description: "Review code quality", location: "project" },
         ]
 
         // when
@@ -57,7 +57,7 @@ describe("prompt-builder", () => {
 
         // then
         expect(result).toBeDefined()
-        expect(result).toContain("code-review")
+        expect(result).toContain("review-work")
       })
 
       test("#when availableSkills is empty #then system content does not include available_skills section", () => {

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -289,6 +289,27 @@ describe("sisyphus-task", () => {
       expect(result).toBe(false)
     })
 
+    test("returns false for 'Momus (Plan Critic)' - no substring false-positive", () => {
+      //#given / #when
+      const result = isPlanFamily("Momus (Plan Critic)")
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("returns false for 'Momus - Plan Critic' - no substring false-positive", () => {
+      //#given / #when
+      const result = isPlanFamily("Momus - Plan Critic")
+      //#then
+      expect(result).toBe(false)
+    })
+
+    test("returns false for 'Metis - Plan Consultant' - no substring false-positive", () => {
+      //#given / #when
+      const result = isPlanFamily("Metis - Plan Consultant")
+      //#then
+      expect(result).toBe(false)
+    })
+
     test("returns false for undefined", () => {
       //#given / #when
       const result = isPlanFamily(undefined)


### PR DESCRIPTION
## Test-only changes

Adds regression tests and fixes test data for bugs that were already fixed in code but lacked test coverage:

### #3312: isPlanFamily() regression tests
- Added 3 test cases ensuring `isPlanFamily('Momus (Plan Critic)')`, `isPlanFamily('Momus - Plan Critic')`, and `isPlanFamily('Metis - Plan Consultant')` all return `false`
- Guards against future substring matching regressions

### #3285: Fix test data using old skill name
- `prompt-builder.test.ts` was still using `'code-review'` as example skill name
- Updated to `'review-work'` to match actual built-in skill name

**No production code changes.** Only test files modified.

Related: #3312, #3285, #3290

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests for `isPlanFamily()` to prevent substring false-positives and update test data to use `review-work` instead of `code-review` (covers #3312, #3285, #3290). No production code changes.

<sup>Written for commit e1b2f97bfdb0ad97af5399ae46311d2acd1e12de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

