### PR TITLE
fix(posthog): disable exception autocapture to stay within free tier

### DIFF
--- a/src/shared/posthog.ts
+++ b/src/shared/posthog.ts
@@ -155,7 +155,7 @@ export function getPostHogDistinctId(): string {
 
 export function createCliPostHog(): PostHogClient {
   return createPostHogClient("cli", {
-    enableExceptionAutocapture: true,
+    enableExceptionAutocapture: false,
     flushAt: 1,
     flushInterval: 0,
   })
@@ -163,7 +163,7 @@ export function createCliPostHog(): PostHogClient {
 
 export function createPluginPostHog(): PostHogClient {
   return createPostHogClient("plugin", {
-    enableExceptionAutocapture: true,
+    enableExceptionAutocapture: false,
     flushAt: 1,
     flushInterval: 0,
   })


### PR DESCRIPTION
## Problem

PostHog Error tracking exceeded 100K free tier limit — 188K events in just 5 days (4/10~4/15).

### Exception breakdown (5 days):
- `ProviderModelNotFoundError`: 75K (40%) — user config issues
- `NotFoundError`: 25K — session/file not found
- `No output generated`: 24K — stream errors
- `EPIPE/EOF/stream destroyed`: 40K — normal pipe closures
- `ENOSPC`: 3K — user disk space

Most of these are noise from user environments, not actionable bugs.

## Solution

Disable `enableExceptionAutocapture` in both CLI and plugin PostHog clients. Manual `captureException()` in `runner.ts` for critical run failures is preserved.

## Impact
- Error tracking: 188K/5d → ~0 (manual exceptions only)
- Projected monthly: stays within 100K free tier
- No loss of critical error visibility — `run_failed` events + manual `captureException` still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable PostHog automatic exception capture for CLI and plugin clients to reduce noisy error events and stay within the 100K free tier. Manual `captureException()` for critical run failures (and `run_failed` events) remains in place.

<sup>Written for commit 0764526acab5290ff564b99785e61dca49bdbd3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

