### PR TITLE
fix(background-agent): queue fallback notification when parent notification delivery fails (fixes #2627)

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1704,8 +1704,11 @@ export class BackgroundManager {
       await this.enqueueNotificationForParent(task.parentSessionID, () => this.notifyParentSession(task))
       log(`[background-agent] Task completed via ${source}:`, task.id)
     } catch (err) {
-      log("[background-agent] Error in notifyParentSession:", { taskId: task.id, error: err })
-      // Concurrency already released, notification failed but task is complete
+      log("[background-agent] Error in notifyParentSession, queuing fallback:", { taskId: task.id, error: err })
+      this.queuePendingNotification(
+        task.parentSessionID,
+        `[Background task completed] "${task.description}" (agent: ${task.agent ?? "unknown"}) finished but notification delivery failed. Use background_output to retrieve the result.\n\nSession ID: ${task.sessionID}\nTask ID: ${task.id}`,
+      )
     }
 
     return true


### PR DESCRIPTION
## Summary
- Queue a fallback pending notification when direct parent session notification fails after task completion

## Problem
Parent sessions get permanently stuck showing "waiting for background agents" when notification delivery fails. In `tryCompleteTask`, the task status is atomically set to `completed` before the parent notification is sent. If `notifyParentSession` throws (timeout, transient error), the parent session never learns the task finished. Since `pollRunningTasks` skips non-running tasks, no retry is attempted and the parent hangs indefinitely.

## Fix
When `notifyParentSession` fails, the catch block now calls `queuePendingNotification` to inject a fallback notification into the parent session's next chat message. This ensures the parent always learns about task completion, even if the direct notification mechanism fails.

## Changes
| File | Change |
|------|--------|
| `src/features/background-agent/manager.ts` | Queue fallback pending notification in `tryCompleteTask` catch block instead of silently dropping the error |

Fixes #2627

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures parent sessions always learn when a background task completes by queuing a fallback notification if direct delivery fails. Prevents sessions from getting stuck on "waiting for background agents" (fixes #2627).

- **Bug Fixes**
  - In `tryCompleteTask`, catch `notifyParentSession` errors and call `queuePendingNotification` to inject a completion message into the parent’s next chat.

<sup>Written for commit 80e47921c655f5e8efeccf7799974fc558df766a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

