### PR TITLE
fix(call-omo-agent): guard undefined subagent_type in session title (fixes #1948)

### DIFF
--- a/src/tools/call-omo-agent/session-creator.ts
+++ b/src/tools/call-omo-agent/session-creator.ts
@@ -38,7 +38,7 @@ export async function createOrGetSession(
     const createResult = await ctx.client.session.create({
       body: {
         parentID: toolContext.sessionID,
-        title: `${args.description} (@${args.subagent_type} subagent)`,
+        title: `${args.description} (@${args.subagent_type ?? "agent"} subagent)`,
       } as Record<string, unknown>,
       query: {
         directory: parentDirectory,

--- a/src/tools/call-omo-agent/subagent-session-creator.ts
+++ b/src/tools/call-omo-agent/subagent-session-creator.ts
@@ -39,7 +39,7 @@ export async function resolveOrCreateSessionId(
 
 	const body = {
 		parentID: toolContext.sessionID,
-		title: `${args.description} (@${args.subagent_type} subagent)`,
+		title: `${args.description} (@${args.subagent_type ?? "agent"} subagent)`,
 	}
 
 	const createResult = await ctx.client.session.create({


### PR DESCRIPTION
## Summary
- Add nullish coalescing guard for `subagent_type` in session title generation to prevent `titlecase(undefined)` crash

## Problem
When a model calls `task()` or `call_omo_agent()` without providing `subagent_type`, the undefined value is interpolated into the session title string (`@undefined subagent`). OpenCode's runtime then calls `titlecase(info.input.subagent_type)` which throws `TypeError: undefined is not an object` because `titlecase()` lacks a null guard.

## Fix
Added `?? "agent"` fallback in both `session-creator.ts` and `subagent-session-creator.ts` so the title gracefully degrades to `@agent subagent` instead of `@undefined subagent`, preventing the upstream crash.

## Changes
| File | Change |
|------|--------|
| `src/tools/call-omo-agent/session-creator.ts` | Guard `args.subagent_type` with `?? "agent"` fallback |
| `src/tools/call-omo-agent/subagent-session-creator.ts` | Guard `args.subagent_type` with `?? "agent"` fallback |

Fixes #1948

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crash in session title generation by guarding undefined `subagent_type`; we now default to "agent" so `task()` and `call_omo_agent()` calls without a type produce `@agent subagent` titles instead of throwing.

<sup>Written for commit 5cdbf0fca3b8f09a9b05b66213112d0bbafc4031. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

