### PR TITLE
fix(context-limit): use known GA context limits for claude-4-6 models (fixes #3450)

### DIFF
--- a/src/shared/context-limit-resolver.ts
+++ b/src/shared/context-limit-resolver.ts
@@ -23,6 +23,16 @@ function supportsCachedAnthropicLimit(modelID: string): boolean {
   return /^claude-(opus|sonnet)-4(?:-|\.)6(?:-high)?$/.test(modelID)
 }
 
+const KNOWN_GA_CONTEXT_LIMITS: Record<string, number> = {
+  "claude-opus-4-6": 680_000,
+  "claude-sonnet-4-6": 680_000,
+}
+
+function getKnownGAContextLimit(modelID: string): number | undefined {
+  const normalized = modelID.replace(/-high$/, "")
+  return KNOWN_GA_CONTEXT_LIMITS[normalized]
+}
+
 export function resolveActualContextLimit(
   providerID: string,
   modelID: string,
@@ -35,7 +45,7 @@ export function resolveActualContextLimit(
     const cachedLimit = modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`)
     if (cachedLimit && supportsCachedAnthropicLimit(modelID)) return cachedLimit
 
-    return DEFAULT_ANTHROPIC_ACTUAL_LIMIT
+    return getKnownGAContextLimit(modelID) ?? DEFAULT_ANTHROPIC_ACTUAL_LIMIT
   }
 
   return modelCacheState?.modelContextLimitsCache?.get(`${providerID}/${modelID}`) ?? null


### PR DESCRIPTION
## Summary
- Add built-in 680K context limit for GA claude-opus-4-6 and claude-sonnet-4-6 instead of falling back to 200K when the model cache is empty

## Problem
When the Anthropic provider config lacks explicit `models.*.limit.context` entries, the `modelContextLimitsCache` has no entry for GA 4.6 models. `resolveActualContextLimit` then falls through to `DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000`, which is far below the actual 680K GA limit. This causes premature compaction and context truncation.

## Fix
Added a `KNOWN_GA_CONTEXT_LIMITS` lookup that returns 680K for `claude-opus-4-6` and `claude-sonnet-4-6` (including `-high` variants). When the model cache has no entry and the 1M beta is not active, the function now checks known GA limits before falling back to the 200K default.

## Changes
| File | Change |
|------|--------|
| `src/shared/context-limit-resolver.ts` | Add `KNOWN_GA_CONTEXT_LIMITS` map and `getKnownGAContextLimit()` helper; use as intermediate fallback before 200K default |

Fixes #3450

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the known 680K context limit for GA `claude-opus-4-6` and `claude-sonnet-4-6` (including `-high`) instead of falling back to 200K when cache/config are missing. Prevents early context truncation and aligns with GA limits. Fixes #3450.

- **Bug Fixes**
  - Added a `KNOWN_GA_CONTEXT_LIMITS` lookup and helper to return 680K for GA 4.6 models before the 200K default.
  - Applies when no `models.*.limit.context` is set and the Anthropic model cache has no entry.

<sup>Written for commit 393fd7fe70f467f8598b9edf76b9ae27d2192f5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

