### PR TITLE
fix(test): update atlas test to expect task_id parameter instead of session_id

### DIFF
--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -957,7 +957,8 @@ session_id: ses_untrusted_999
       const updatedState = readBoulderState(TEST_DIR)
       expect(updatedState?.task_sessions?.["todo:1"]).toBeUndefined()
       expect(output.output).not.toContain('task(session_id="ses_untrusted_999"')
-      expect(output.output).toContain('task(session_id="<session_id>"')
+      expect(output.output).not.toContain('task(task_id="ses_untrusted_999"')
+      expect(output.output).toContain('task(task_id="<session_id>"')
 
       cleanupMessageStorage(sessionID)
     })


### PR DESCRIPTION
Fixes the pre-existing CI failure on dev.

`verification-reminders.ts` was updated to use `task(task_id=...)` format but the test `should ignore extracted session ids that are outside the active boulder lineage` still expected the old `task(session_id=...)` format.

This test has been failing on every dev CI run since the refactor. One-line fix: update the assertion to match the current parameter name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing dev CI test by updating the Atlas test to expect `task(task_id=...)` instead of `task(session_id=...)`. Aligns the assertion with the refactor in `verification-reminders.ts`.

- **Bug Fixes**
  - Updated test “should ignore extracted session ids that are outside the active boulder lineage” to assert absence/presence using `task_id` instead of `session_id`.

<sup>Written for commit 91ebffa9da32dd97340f4ef76e330fc63983c552. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

