### PR TITLE
fix: add oh-my-openagent bin alias for renamed package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "bin": {
-    "oh-my-opencode": "bin/oh-my-opencode.js"
+    "oh-my-opencode": "bin/oh-my-opencode.js",
+    "oh-my-openagent": "bin/oh-my-opencode.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Fixes #3482

After the package rename from `oh-my-opencode` to `oh-my-openagent`, the `bin` field in `package.json` only had the old `oh-my-opencode` entry. Users installing via `npm install -g oh-my-openagent` could not invoke `oh-my-openagent` from the command line.

**Fix:** Add `oh-my-openagent` as a second bin alias pointing to the same `bin/oh-my-opencode.js` entry point. Both `oh-my-opencode` and `oh-my-openagent` now work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `oh-my-openagent` CLI alias so global installs expose the command after the rename. Both `oh-my-opencode` and `oh-my-openagent` now point to `bin/oh-my-opencode.js` (fixes #3482).

<sup>Written for commit fec50c5d850bee956dc4a47d8ff6f89905516eca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

