### PR TITLE
fix(test): complete session_id→task_id migration in CI-breaking tests

### DIFF
--- a/src/agents/dynamic-agent-core-sections.ts
+++ b/src/agents/dynamic-agent-core-sections.ts
@@ -182,7 +182,7 @@ Multi-step task? **ALWAYS consult Plan Agent first.** Do NOT start implementatio
 
 - Single-file fix or trivial change → proceed directly
 - Anything else (2+ steps, unclear scope, architecture) → \`task(subagent_type="plan", ...)\` FIRST
-- Use \`session_id\` to resume the same Plan Agent - ask follow-up questions aggressively
+- Use \`task_id\` to resume the same Plan Agent - ask follow-up questions aggressively
 - If ANY part of the task is ambiguous, ask Plan Agent before guessing
 
 Plan Agent returns a structured work breakdown with parallel execution opportunities. Follow it.`

--- a/src/agents/dynamic-agent-prompt-builder.test.ts
+++ b/src/agents/dynamic-agent-prompt-builder.test.ts
@@ -244,7 +244,7 @@ describe("buildNonClaudePlannerSection", () => {
 
     //#then
     expect(result).toContain("Plan Agent")
-    expect(result).toContain("session_id")
+    expect(result).toContain("task_id")
     expect(result).toContain("Multi-step")
   })
 

--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -957,7 +957,8 @@ session_id: ses_untrusted_999
       const updatedState = readBoulderState(TEST_DIR)
       expect(updatedState?.task_sessions?.["todo:1"]).toBeUndefined()
       expect(output.output).not.toContain('task(session_id="ses_untrusted_999"')
-      expect(output.output).toContain('task(session_id="<session_id>"')
+      expect(output.output).not.toContain('task(task_id="ses_untrusted_999"')
+      expect(output.output).toContain('task(task_id="<session_id>"')
 
       cleanupMessageStorage(sessionID)
     })

--- a/src/hooks/atlas/verification-reminders.ts
+++ b/src/hooks/atlas/verification-reminders.ts
@@ -29,7 +29,7 @@ Your completion will NOT be recorded until you complete ALL of the following:
 
 If anything fails while closing this out, resume the same session immediately:
 \`\`\`typescript
-task(session_id="${sessionId}", load_skills=[], prompt="fix: checkbox not recorded correctly")
+task(task_id="${sessionId}", load_skills=[], prompt="fix: checkbox not recorded correctly")
 \`\`\`
 
 **Your completion is NOT tracked until the checkbox is marked in the plan file.**
@@ -47,7 +47,7 @@ ${VERIFICATION_REMINDER}
 
 **If ANY verification fails, use this immediately:**
 \`\`\`
-task(session_id="${sessionId}", load_skills=[], prompt="fix: [describe the specific failure]")
+task(task_id="${sessionId}", load_skills=[], prompt="fix: [describe the specific failure]")
 \`\`\`
 
 ${buildReuseHint(sessionId)}`


### PR DESCRIPTION
Fixes the remaining CI failures after the `task_id` refactor.

PR #3481 partially fixed the atlas test but left the final `toContain` assertion still expecting `task(session_id=...)`. This PR completes the migration:

- `src/hooks/atlas/index.test.ts`: change last assertion from `session_id` to `task_id`
- `src/agents/dynamic-agent-core-sections.ts`: update prompt text to use `task_id`  
- `src/hooks/atlas/verification-reminders.ts`: update both resume template strings to use `task_id`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the migration from `session_id` to `task_id` across prompts and tests to fix remaining CI failures in atlas and planner flows. All emitted `task(...)` calls and assertions now use `task_id`.

- **Bug Fixes**
  - Updated planner prompt in `src/agents/dynamic-agent-core-sections.ts` to instruct using `task_id`.
  - Updated atlas verification reminder templates in `src/hooks/atlas/verification-reminders.ts` to use `task(task_id=...)`.
  - Fixed tests to expect `task_id` instead of `session_id` (`src/hooks/atlas/index.test.ts`, `src/agents/dynamic-agent-prompt-builder.test.ts`).

<sup>Written for commit 2fca3dced8aa495ca069b437ab2451fcc592754a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

