### PR TITLE
fix(explore): allow LSP and ast-grep tools

### DIFF
--- a/src/agents/explore.ts
+++ b/src/agents/explore.ts
@@ -25,13 +25,10 @@ export const EXPLORE_PROMPT_METADATA: AgentPromptMetadata = {
 }
 
 export function createExploreAgent(model: string): AgentConfig {
-  const restrictions = createAgentToolRestrictions([
-    "write",
-    "edit",
-    "apply_patch",
-    "task",
-    "call_omo_agent",
-  ])
+  const restrictions = createAgentToolRestrictions(
+    ["write", "edit", "apply_patch", "task", "call_omo_agent"],
+    ["lsp_symbols", "lsp_goto_definition", "lsp_find_references", "lsp_diagnostics", "ast_grep_search"],
+  )
 
   return {
     description:

--- a/src/shared/permission-compat.ts
+++ b/src/shared/permission-compat.ts
@@ -13,12 +13,14 @@ export interface PermissionFormat {
  * Creates tool restrictions that deny specified tools.
  */
 export function createAgentToolRestrictions(
-  denyTools: string[]
+  denyTools: string[],
+  allowTools: string[] = [],
 ): PermissionFormat {
   return {
-    permission: Object.fromEntries(
-      denyTools.map((tool) => [tool, "deny" as const])
-    ),
+    permission: Object.fromEntries([
+      ...denyTools.map((tool) => [tool, "deny" as const]),
+      ...allowTools.map((tool) => [tool, "allow" as const]),
+    ]),
   }
 }
 


### PR DESCRIPTION
`explore.ts` tells explore to use LSP tools in the Tool Strategy section, but `createAgentToolRestrictions` in `permission-compat.ts` only emitted deny rules.

opencode core gives explore `"*": "deny"`, so `lsp_symbols`, `lsp_goto_definition`, `lsp_find_references`, `lsp_diagnostics`, and `ast_grep_search` were blocked even though the explore prompt tells the agent to use them.

OmO appends its permission rules after core's rules, so adding more deny rules for write/edit/task does not change core's earlier `*` deny for LSP.

This changes `createAgentToolRestrictions` to accept an optional `allowTools` argument and emit allow rules, then updates `explore.ts` to allow:
- `lsp_symbols`
- `lsp_goto_definition`
- `lsp_find_references`
- `lsp_diagnostics`
- `ast_grep_search`

Because permission matching uses the last matching rule, these allow entries override the inherited core deny for those tools.

Related upstream:
- anomalyco/opencode#12566
- anomalyco/opencode#6892

### Testing
- Ran `opencode debug agent explore` and confirmed `lsp_symbols: true` and `ast_grep_search: true`
- Spawned an explore agent and verified successful calls to `lsp_symbols`, `lsp_goto_definition`, and `ast_grep_search`
- Confirmed existing denied tools such as write/edit/task remain denied
- Verified librarian and oracle permissions are unchanged when `allowTools` is omitted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the explore agent to use LSP and ast-grep tools by adding explicit allow rules that override core’s deny-all, fixing the mismatch between the prompt and actual permissions.

- **Bug Fixes**
  - Added an optional allowTools parameter to createAgentToolRestrictions to emit allow rules that take precedence over inherited denies.
  - Enabled tools for explore: lsp_symbols, lsp_goto_definition, lsp_find_references, lsp_diagnostics, ast_grep_search; write/edit/apply_patch/task/call_omo_agent remain denied.

<sup>Written for commit 73f09fdb37deed2056a9309a851846daef2401f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

