### PR TITLE
refactor: simplify retry-model-payload and CI test workflow

### DIFF
--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -14,7 +14,7 @@ describe("test workflows", () => {
       // #given
       const workflow = readFileSync(workflowPath, "utf8")
 
-      // #then - should use run-ci-tests.ts for mock isolation
+      // #then
       expect(workflow).toContain("- name: Run tests")
       expect(workflow).toContain("run-ci-tests.ts")
     }

--- a/src/hooks/runtime-fallback/auto-retry.ts
+++ b/src/hooks/runtime-fallback/auto-retry.ts
@@ -105,10 +105,7 @@ export function createAutoRetryHelpers(deps: HookDeps) {
     const agentSettings = resolvedAgent
       ? pluginConfig?.agents?.[resolvedAgent as keyof typeof pluginConfig.agents]
       : undefined
-    const retryModelPayload = buildRetryModelPayload(newModel, agentSettings ? {
-      variant: agentSettings.variant,
-      reasoningEffort: agentSettings.reasoningEffort,
-    } : undefined)
+    const retryModelPayload = buildRetryModelPayload(newModel, agentSettings)
     if (!retryModelPayload) {
       log(`[${HOOK_NAME}] Invalid model format (missing provider prefix): ${newModel}`)
       const state = sessionStates.get(sessionID)

--- a/src/hooks/runtime-fallback/retry-model-payload.ts
+++ b/src/hooks/runtime-fallback/retry-model-payload.ts
@@ -12,19 +12,12 @@ export function buildRetryModelPayload(
   const variant = parsedModel.variant ?? agentSettings?.variant
   const reasoningEffort = agentSettings?.reasoningEffort
 
-  const payload: { model: { providerID: string; modelID: string }; variant?: string; reasoningEffort?: string } = {
+  return {
     model: {
       providerID: parsedModel.providerID,
       modelID: parsedModel.modelID,
     },
+    ...(variant ? { variant } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
   }
-
-  if (variant) {
-    payload.variant = variant
-  }
-  if (reasoningEffort) {
-    payload.reasoningEffort = reasoningEffort
-  }
-
-  return payload
 }


### PR DESCRIPTION
## Summary

- Pass `agentSettings` directly to `buildRetryModelPayload` instead of manually picking `variant`/`reasoningEffort` into a new intermediate object
- Replace mutable typed `payload` builder with a single conditional-spread return, removing the duplicate inline type annotation
- Remove change-narrating comment from `publish-workflow.test.ts`

## Files changed

- `src/hooks/runtime-fallback/auto-retry.ts`
- `src/hooks/runtime-fallback/retry-model-payload.ts`
- `script/publish-workflow.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies retry model payload construction by passing `agentSettings` directly and using a conditional-spread return. Removes a noisy test comment; no behavior changes.

- **Refactors**
  - Pass `agentSettings` directly to `buildRetryModelPayload` in `auto-retry.ts`.
  - Replace mutable payload builder with a single conditional-spread return in `retry-model-payload.ts` (removes duplicate inline type).
  - Remove narrating comment in `publish-workflow.test.ts` to keep the test focused.

<sup>Written for commit 992ac2fa82f91fe174e64c165a843068639b8234. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

