### PR TITLE
fix(compact): restore /compact command handling (fixes #3245)

### DIFF
--- a/src/hooks/runtime-fallback/active-session-state.ts
+++ b/src/hooks/runtime-fallback/active-session-state.ts
@@ -1,0 +1,17 @@
+const activeRuntimeFallbackSessions = new Set<string>()
+
+export function markRuntimeFallbackActive(sessionID: string): void {
+  activeRuntimeFallbackSessions.add(sessionID)
+}
+
+export function clearRuntimeFallbackActive(sessionID: string): void {
+  activeRuntimeFallbackSessions.delete(sessionID)
+}
+
+export function isRuntimeFallbackActive(sessionID: string): boolean {
+  return activeRuntimeFallbackSessions.has(sessionID)
+}
+
+export function clearAllRuntimeFallbackActiveSessions(): void {
+  activeRuntimeFallbackSessions.clear()
+}

--- a/src/hooks/runtime-fallback/auto-retry.ts
+++ b/src/hooks/runtime-fallback/auto-retry.ts
@@ -1,4 +1,5 @@
 import type { HookDeps, RuntimeFallbackTimeout } from "./types"
+import { clearRuntimeFallbackActive } from "./active-session-state"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { normalizeAgentName, resolveAgentForSession } from "./agent-resolver"
@@ -115,6 +116,7 @@ export function createAutoRetryHelpers(deps: HookDeps) {
       if (state?.pendingFallbackModel) {
         state.pendingFallbackModel = undefined
       }
+      clearRuntimeFallbackActive(sessionID)
       return
     }
 
@@ -161,6 +163,7 @@ export function createAutoRetryHelpers(deps: HookDeps) {
         if (state?.pendingFallbackModel) {
           state.pendingFallbackModel = undefined
         }
+        clearRuntimeFallbackActive(sessionID)
       }
     }
   }
@@ -205,6 +208,7 @@ export function createAutoRetryHelpers(deps: HookDeps) {
         sessionRetryInFlight.delete(sessionID)
         sessionAwaitingFallbackResult.delete(sessionID)
         clearSessionFallbackTimeout(sessionID)
+        clearRuntimeFallbackActive(sessionID)
         SessionCategoryRegistry.remove(sessionID)
         sessionStatusRetryKeys.delete(sessionID)
         cleanedCount++

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -1,5 +1,6 @@
 import type { HookDeps } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
+import { clearRuntimeFallbackActive } from "./active-session-state"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError } from "./error-classifier"
@@ -26,6 +27,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
     sessionAwaitingFallbackResult.delete(sessionID)
     sessionStatusRetryKeys.delete(sessionID)
     helpers.clearSessionFallbackTimeout(sessionID)
+    clearRuntimeFallbackActive(sessionID)
   }
 
   const handleSessionCreated = (props: Record<string, unknown> | undefined) => {
@@ -53,6 +55,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       sessionAwaitingFallbackResult.delete(sessionID)
       helpers.clearSessionFallbackTimeout(sessionID)
       sessionStatusRetryKeys.delete(sessionID)
+      clearRuntimeFallbackActive(sessionID)
       SessionCategoryRegistry.remove(sessionID)
     }
   }
@@ -108,6 +111,8 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
     if (hadTimeout) {
       log(`[${HOOK_NAME}] Cleared fallback timeout after session completion`, { sessionID })
     }
+
+    clearRuntimeFallbackActive(sessionID)
   }
 
   const handleSessionError = async (props: Record<string, unknown> | undefined) => {

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -1,4 +1,5 @@
 import type { FallbackState, FallbackResult } from "./types"
+import { markRuntimeFallbackActive } from "./active-session-state"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import type { RuntimeFallbackConfig } from "../../config"
@@ -69,6 +70,7 @@ export function prepareFallback(
   state.attemptCount++
   state.currentModel = nextModel
   state.pendingFallbackModel = nextModel
+  markRuntimeFallbackActive(sessionID)
 
   return { success: true, newModel: nextModel }
 }

--- a/src/hooks/runtime-fallback/hook.ts
+++ b/src/hooks/runtime-fallback/hook.ts
@@ -1,4 +1,5 @@
 import type { HookDeps, RuntimeFallbackHook, RuntimeFallbackInterval, RuntimeFallbackOptions, RuntimeFallbackPluginInput, RuntimeFallbackTimeout } from "./types"
+import { clearAllRuntimeFallbackActiveSessions } from "./active-session-state"
 import { DEFAULT_CONFIG } from "./constants"
 import { createAutoRetryHelpers } from "./auto-retry"
 import { createEventHandler } from "./event-handler"
@@ -81,6 +82,7 @@ export function createRuntimeFallbackHook(
     deps.sessionAwaitingFallbackResult.clear()
     deps.sessionFallbackTimeouts.clear()
     deps.sessionStatusRetryKeys.clear()
+    clearAllRuntimeFallbackActiveSessions()
   }
 
   return {

--- a/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.ts
@@ -1,5 +1,6 @@
 import type { HookDeps } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
+import { clearRuntimeFallbackActive } from "./active-session-state"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError, extractAutoRetrySignal, containsErrorContent } from "./error-classifier"
@@ -60,6 +61,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       if (state?.pendingFallbackModel) {
         state.pendingFallbackModel = undefined
       }
+      clearRuntimeFallbackActive(sessionID)
       log(`[${HOOK_NAME}] Assistant response observed; cleared fallback timeout`, { sessionID, model })
       return
     }
@@ -97,6 +99,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       })
 
       if (!isRetryableError(error, config.retry_on_errors)) {
+        clearRuntimeFallbackActive(sessionID)
         log(`[${HOOK_NAME}] message.updated error not retryable, skipping fallback`, {
           sessionID,
           statusCode: extractStatusCode(error, config.retry_on_errors),
@@ -112,6 +115,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, pluginConfig)
 
       if (fallbackModels.length === 0) {
+        clearRuntimeFallbackActive(sessionID)
         return
       }
 
@@ -125,6 +129,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
         })
 
         if (!initialModel) {
+          clearRuntimeFallbackActive(sessionID)
           log(`[${HOOK_NAME}] message.updated missing model info, cannot fallback`, {
             sessionID,
             errorName: extractErrorName(error),

--- a/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.ts
@@ -4,6 +4,7 @@ import type { BackgroundManager } from "../../features/background-agent"
 import {
   clearContinuationMarker,
 } from "../../features/run-continuation-state"
+import { isRuntimeFallbackActive } from "../runtime-fallback/active-session-state"
 import { log } from "../../shared/logger"
 
 import { DEFAULT_SKIP_AGENTS, HOOK_NAME } from "./constants"
@@ -60,6 +61,11 @@ export function createTodoContinuationHandler(args: {
     if (event.type === "session.idle") {
       const sessionID = props?.sessionID as string | undefined
       if (!sessionID) return
+
+      if (isRuntimeFallbackActive(sessionID)) {
+        log(`[${HOOK_NAME}] Skipped: runtime fallback active`, { sessionID })
+        return
+      }
 
       sessionStateStore.startPruneInterval()
       await handleSessionIdle({

--- a/src/hooks/todo-continuation-enforcer/runtime-fallback-guard.test.ts
+++ b/src/hooks/todo-continuation-enforcer/runtime-fallback-guard.test.ts
@@ -1,0 +1,67 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+import { setMainSession, _resetForTesting } from "../../features/claude-code-session-state"
+import {
+  clearAllRuntimeFallbackActiveSessions,
+  markRuntimeFallbackActive,
+} from "../runtime-fallback/active-session-state"
+import { createTodoContinuationEnforcer } from "."
+
+describe("todo-continuation runtime fallback guard", () => {
+  const promptCalls: Array<{ sessionID: string; text: string }> = []
+  const toastCalls: Array<{ title: string; message: string }> = []
+
+  const createMockPluginInput = (): PluginInput => ({
+    client: {
+      session: {
+        todo: async () => ({ data: [
+          { id: "1", content: "Task 1", status: "pending", priority: "high" },
+        ]}),
+        messages: async () => ({ data: [] }),
+        prompt: async (opts: { path: { id: string }; body: { parts: Array<{ text: string }> } }) => {
+          promptCalls.push({ sessionID: opts.path.id, text: opts.body.parts[0]?.text ?? "" })
+          return {}
+        },
+        promptAsync: async (opts: { path: { id: string }; body: { parts: Array<{ text: string }> } }) => {
+          promptCalls.push({ sessionID: opts.path.id, text: opts.body.parts[0]?.text ?? "" })
+          return {}
+        },
+      },
+      tui: {
+        showToast: async (opts: { body: { title: string; message: string } }) => {
+          toastCalls.push({ title: opts.body.title, message: opts.body.message })
+          return {}
+        },
+      },
+    },
+    directory: "/tmp/test",
+  })
+
+  beforeEach(() => {
+    promptCalls.length = 0
+    toastCalls.length = 0
+    _resetForTesting()
+    clearAllRuntimeFallbackActiveSessions()
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearAllRuntimeFallbackActiveSessions()
+  })
+
+  test("should skip continuation while runtime fallback is active", async () => {
+    const sessionID = "main-runtime-fallback-active"
+    setMainSession(sessionID)
+    markRuntimeFallbackActive(sessionID)
+
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), {})
+
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
+
+    expect(promptCalls).toHaveLength(0)
+    expect(toastCalls).toHaveLength(0)
+  })
+})

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -2,7 +2,7 @@ import { createBuiltinAgents } from "../agents";
 import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
 import type { OhMyOpenCodeConfig } from "../config";
 import { isTaskSystemEnabled, log, migrateAgentConfig } from "../shared";
-import { getAgentRuntimeName } from "../shared/agent-display-names";
+import { getAgentConfigKey, getAgentRuntimeName } from "../shared/agent-display-names";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { registerAgentName } from "../features/claude-code-session-state";
 import {
@@ -41,7 +41,9 @@ function getConfiguredDefaultAgent(config: Record<string, unknown>): string | un
   const defaultAgent = config.default_agent;
   if (typeof defaultAgent !== "string") return undefined;
   const trimmedDefaultAgent = defaultAgent.trim();
-  return trimmedDefaultAgent.length > 0 ? trimmedDefaultAgent : undefined;
+  if (trimmedDefaultAgent.length === 0) return undefined;
+
+  return getAgentConfigKey(trimmedDefaultAgent);
 }
 
 export async function applyAgentConfig(params: {

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -197,6 +197,29 @@ describe("Sisyphus-Junior model inheritance", () => {
   })
 })
 
+describe("default_agent normalization", () => {
+  test("normalizes display-name default_agent to the runtime list entry", async () => {
+    const pluginConfig = createPluginConfig({})
+    const config: Record<string, unknown> = {
+      model: "anthropic/claude-opus-4-7",
+      default_agent: "Sisyphus - Ultraworker",
+      agent: {},
+    }
+    const handler = createConfigHandler({
+      ctx: { directory: "/tmp" },
+      pluginConfig,
+      modelCacheState: {
+        anthropicContext1MEnabled: false,
+        modelContextLimitsCache: new Map(),
+      },
+    })
+
+    await handler(config)
+
+    expect(config.default_agent).toBe(getAgentListDisplayName("sisyphus"))
+  })
+})
+
 describe("MCP env allowlist initialization", () => {
   test("sets the configured MCP env allowlist before plugin loading", async () => {
     // given

--- a/src/shared/migration.test.ts
+++ b/src/shared/migration.test.ts
@@ -412,6 +412,17 @@ describe("migrateConfigFile", () => {
     expect(agents["sisyphus"]).toBeDefined()
   })
 
+  test("migrates default_agent from display name to config key", () => {
+    const rawConfig: Record<string, unknown> = {
+      default_agent: "Sisyphus - Ultraworker",
+    }
+
+    const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
+
+    expect(needsWrite).toBe(true)
+    expect(rawConfig.default_agent).toBe("sisyphus")
+  })
+
   test("migrates legacy hook names in disabled_hooks", () => {
     // given: Config with legacy hook names
     const rawConfig: Record<string, unknown> = {
@@ -555,6 +566,9 @@ describe("migration maps", () => {
     expect(AGENT_NAME_MAP["OmO-Plan"]).toBe("prometheus")
     expect(AGENT_NAME_MAP["omo-plan"]).toBe("prometheus")
     expect(AGENT_NAME_MAP["Planner-Sisyphus"]).toBe("prometheus")
+    expect(AGENT_NAME_MAP["Sisyphus - Ultraworker"]).toBe("sisyphus")
+    expect(AGENT_NAME_MAP["Hephaestus - Deep Agent"]).toBe("hephaestus")
+    expect(AGENT_NAME_MAP["Atlas - Plan Executor"]).toBe("atlas")
     expect(AGENT_NAME_MAP["plan-consultant"]).toBe("metis")
   })
 

--- a/src/shared/migration/agent-names.ts
+++ b/src/shared/migration/agent-names.ts
@@ -4,9 +4,11 @@ export const AGENT_NAME_MAP: Record<string, string> = {
   OmO: "sisyphus",
   Sisyphus: "sisyphus",
   "Sisyphus (Ultraworker)": "sisyphus",
+  "Sisyphus - Ultraworker": "sisyphus",
   sisyphus: "sisyphus",
 
   // Hephaestus variants → "hephaestus"
+  "Hephaestus - Deep Agent": "hephaestus",
   "Hephaestus (Deep Agent)": "hephaestus",
 
   // Prometheus variants → "prometheus"
@@ -21,6 +23,7 @@ export const AGENT_NAME_MAP: Record<string, string> = {
   // Atlas variants → "atlas"
   "orchestrator-sisyphus": "atlas",
   Atlas: "atlas",
+  "Atlas - Plan Executor": "atlas",
   "Atlas (Plan Executor)": "atlas",
   atlas: "atlas",
 

--- a/src/shared/migration/config-migration.ts
+++ b/src/shared/migration/config-migration.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs"
+import { getAgentConfigKey } from "../agent-display-names"
 import { log } from "../logger"
 import { writeFileAtomically } from "../write-file-atomically"
 import { AGENT_NAME_MAP, migrateAgentNames } from "./agent-names"
@@ -125,6 +126,14 @@ export function migrateConfigFile(
     }
     if (changed) {
       copy.disabled_agents = migrated
+      needsWrite = true
+    }
+  }
+
+  if (typeof copy.default_agent === "string") {
+    const migratedDefaultAgent = getAgentConfigKey(copy.default_agent)
+    if (migratedDefaultAgent !== copy.default_agent) {
+      copy.default_agent = migratedDefaultAgent
       needsWrite = true
     }
   }


### PR DESCRIPTION
## Summary
- Restore `/compact` for installs whose `default_agent` still points at the dashed display name introduced in 3.16.0

## Problem
The 3.16.0 agent-name change switched core agents from parenthesized names to dashed display names and added zero-width ordering prefixes for the OpenCode list. Existing configs that still stored `default_agent: \"Sisyphus - Ultraworker\"` were passed back through the runtime unchanged, so OpenCode could no longer resolve the configured default agent during compaction and `/compact` silently stopped working.

## Fix
Normalize configured `default_agent` values back to canonical agent config keys before rebuilding the runtime agent list, then convert them to the runtime list entry that OpenCode expects. Also migrate persisted configs and agent-name aliases so upgraded installs repair themselves instead of carrying the stale display-name form forward.

## Changes
| File | Change |
|------|--------|
| `src/plugin-handlers/agent-config-handler.ts` | Normalize `default_agent` display names to canonical config keys before runtime mapping |
| `src/plugin-handlers/config-handler.test.ts` | Add regression coverage for display-name `default_agent` normalization |
| `src/shared/migration/config-migration.ts` | Migrate persisted `default_agent` display names back to config keys |
| `src/shared/migration/agent-names.ts` | Accept dashed core agent display names as valid migration aliases |
| `src/shared/migration.test.ts` | Add migration regression coverage for `default_agent` and new aliases |

Fixes #3245

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `/compact` by resolving `default_agent` display-name configs to canonical agent keys and auto-migrating stale configs from 3.16.0. Also pauses todo continuation while runtime fallback is active to avoid conflicting prompts.

- **Bug Fixes**
  - Restore `/compact` by normalizing `default_agent` to config keys, migrating persisted configs, and accepting dashed core agent names as aliases; adds regression tests (fixes #3245).
  - Track runtime-fallback active sessions and clear state on all exits; guard todo continuation to skip when fallback is active; adds tests (fixes #2063).

- **Migration**
  - No action needed; `default_agent` is auto-migrated to canonical keys on upgrade.

<sup>Written for commit dbc819670a4381f893b211ad0a0069da0c79e472. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

