### PR TITLE
fix(todo-continuation): skip continuation when runtime-fallback is active (fixes #2063)

### DIFF
--- a/src/hooks/runtime-fallback/active-session-state.ts
+++ b/src/hooks/runtime-fallback/active-session-state.ts
@@ -1,0 +1,17 @@
+const activeRuntimeFallbackSessions = new Set<string>()
+
+export function markRuntimeFallbackActive(sessionID: string): void {
+  activeRuntimeFallbackSessions.add(sessionID)
+}
+
+export function clearRuntimeFallbackActive(sessionID: string): void {
+  activeRuntimeFallbackSessions.delete(sessionID)
+}
+
+export function isRuntimeFallbackActive(sessionID: string): boolean {
+  return activeRuntimeFallbackSessions.has(sessionID)
+}
+
+export function clearAllRuntimeFallbackActiveSessions(): void {
+  activeRuntimeFallbackSessions.clear()
+}

--- a/src/hooks/runtime-fallback/auto-retry.ts
+++ b/src/hooks/runtime-fallback/auto-retry.ts
@@ -1,4 +1,5 @@
 import type { HookDeps, RuntimeFallbackTimeout } from "./types"
+import { clearRuntimeFallbackActive } from "./active-session-state"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { normalizeAgentName, resolveAgentForSession } from "./agent-resolver"
@@ -115,6 +116,7 @@ export function createAutoRetryHelpers(deps: HookDeps) {
       if (state?.pendingFallbackModel) {
         state.pendingFallbackModel = undefined
       }
+      clearRuntimeFallbackActive(sessionID)
       return
     }
 
@@ -161,6 +163,7 @@ export function createAutoRetryHelpers(deps: HookDeps) {
         if (state?.pendingFallbackModel) {
           state.pendingFallbackModel = undefined
         }
+        clearRuntimeFallbackActive(sessionID)
       }
     }
   }
@@ -205,6 +208,7 @@ export function createAutoRetryHelpers(deps: HookDeps) {
         sessionRetryInFlight.delete(sessionID)
         sessionAwaitingFallbackResult.delete(sessionID)
         clearSessionFallbackTimeout(sessionID)
+        clearRuntimeFallbackActive(sessionID)
         SessionCategoryRegistry.remove(sessionID)
         sessionStatusRetryKeys.delete(sessionID)
         cleanedCount++

--- a/src/hooks/runtime-fallback/event-handler.ts
+++ b/src/hooks/runtime-fallback/event-handler.ts
@@ -1,5 +1,6 @@
 import type { HookDeps } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
+import { clearRuntimeFallbackActive } from "./active-session-state"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError } from "./error-classifier"
@@ -26,6 +27,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
     sessionAwaitingFallbackResult.delete(sessionID)
     sessionStatusRetryKeys.delete(sessionID)
     helpers.clearSessionFallbackTimeout(sessionID)
+    clearRuntimeFallbackActive(sessionID)
   }
 
   const handleSessionCreated = (props: Record<string, unknown> | undefined) => {
@@ -53,6 +55,7 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
       sessionAwaitingFallbackResult.delete(sessionID)
       helpers.clearSessionFallbackTimeout(sessionID)
       sessionStatusRetryKeys.delete(sessionID)
+      clearRuntimeFallbackActive(sessionID)
       SessionCategoryRegistry.remove(sessionID)
     }
   }
@@ -108,6 +111,8 @@ export function createEventHandler(deps: HookDeps, helpers: AutoRetryHelpers) {
     if (hadTimeout) {
       log(`[${HOOK_NAME}] Cleared fallback timeout after session completion`, { sessionID })
     }
+
+    clearRuntimeFallbackActive(sessionID)
   }
 
   const handleSessionError = async (props: Record<string, unknown> | undefined) => {

--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -1,4 +1,5 @@
 import type { FallbackState, FallbackResult } from "./types"
+import { markRuntimeFallbackActive } from "./active-session-state"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import type { RuntimeFallbackConfig } from "../../config"
@@ -69,6 +70,7 @@ export function prepareFallback(
   state.attemptCount++
   state.currentModel = nextModel
   state.pendingFallbackModel = nextModel
+  markRuntimeFallbackActive(sessionID)
 
   return { success: true, newModel: nextModel }
 }

--- a/src/hooks/runtime-fallback/hook.ts
+++ b/src/hooks/runtime-fallback/hook.ts
@@ -1,4 +1,5 @@
 import type { HookDeps, RuntimeFallbackHook, RuntimeFallbackInterval, RuntimeFallbackOptions, RuntimeFallbackPluginInput, RuntimeFallbackTimeout } from "./types"
+import { clearAllRuntimeFallbackActiveSessions } from "./active-session-state"
 import { DEFAULT_CONFIG } from "./constants"
 import { createAutoRetryHelpers } from "./auto-retry"
 import { createEventHandler } from "./event-handler"
@@ -81,6 +82,7 @@ export function createRuntimeFallbackHook(
     deps.sessionAwaitingFallbackResult.clear()
     deps.sessionFallbackTimeouts.clear()
     deps.sessionStatusRetryKeys.clear()
+    clearAllRuntimeFallbackActiveSessions()
   }
 
   return {

--- a/src/hooks/runtime-fallback/message-update-handler.ts
+++ b/src/hooks/runtime-fallback/message-update-handler.ts
@@ -1,5 +1,6 @@
 import type { HookDeps } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
+import { clearRuntimeFallbackActive } from "./active-session-state"
 import { HOOK_NAME } from "./constants"
 import { log } from "../../shared/logger"
 import { extractStatusCode, extractErrorName, classifyErrorType, isRetryableError, extractAutoRetrySignal, containsErrorContent } from "./error-classifier"
@@ -60,6 +61,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       if (state?.pendingFallbackModel) {
         state.pendingFallbackModel = undefined
       }
+      clearRuntimeFallbackActive(sessionID)
       log(`[${HOOK_NAME}] Assistant response observed; cleared fallback timeout`, { sessionID, model })
       return
     }
@@ -97,6 +99,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       })
 
       if (!isRetryableError(error, config.retry_on_errors)) {
+        clearRuntimeFallbackActive(sessionID)
         log(`[${HOOK_NAME}] message.updated error not retryable, skipping fallback`, {
           sessionID,
           statusCode: extractStatusCode(error, config.retry_on_errors),
@@ -112,6 +115,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
       const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, pluginConfig)
 
       if (fallbackModels.length === 0) {
+        clearRuntimeFallbackActive(sessionID)
         return
       }
 
@@ -125,6 +129,7 @@ export function createMessageUpdateHandler(deps: HookDeps, helpers: AutoRetryHel
         })
 
         if (!initialModel) {
+          clearRuntimeFallbackActive(sessionID)
           log(`[${HOOK_NAME}] message.updated missing model info, cannot fallback`, {
             sessionID,
             errorName: extractErrorName(error),

--- a/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.ts
@@ -4,6 +4,7 @@ import type { BackgroundManager } from "../../features/background-agent"
 import {
   clearContinuationMarker,
 } from "../../features/run-continuation-state"
+import { isRuntimeFallbackActive } from "../runtime-fallback/active-session-state"
 import { log } from "../../shared/logger"
 
 import { DEFAULT_SKIP_AGENTS, HOOK_NAME } from "./constants"
@@ -60,6 +61,11 @@ export function createTodoContinuationHandler(args: {
     if (event.type === "session.idle") {
       const sessionID = props?.sessionID as string | undefined
       if (!sessionID) return
+
+      if (isRuntimeFallbackActive(sessionID)) {
+        log(`[${HOOK_NAME}] Skipped: runtime fallback active`, { sessionID })
+        return
+      }
 
       sessionStateStore.startPruneInterval()
       await handleSessionIdle({

--- a/src/hooks/todo-continuation-enforcer/runtime-fallback-guard.test.ts
+++ b/src/hooks/todo-continuation-enforcer/runtime-fallback-guard.test.ts
@@ -1,0 +1,67 @@
+import type { PluginInput } from "@opencode-ai/plugin"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+import { setMainSession, _resetForTesting } from "../../features/claude-code-session-state"
+import {
+  clearAllRuntimeFallbackActiveSessions,
+  markRuntimeFallbackActive,
+} from "../runtime-fallback/active-session-state"
+import { createTodoContinuationEnforcer } from "."
+
+describe("todo-continuation runtime fallback guard", () => {
+  const promptCalls: Array<{ sessionID: string; text: string }> = []
+  const toastCalls: Array<{ title: string; message: string }> = []
+
+  const createMockPluginInput = (): PluginInput => ({
+    client: {
+      session: {
+        todo: async () => ({ data: [
+          { id: "1", content: "Task 1", status: "pending", priority: "high" },
+        ]}),
+        messages: async () => ({ data: [] }),
+        prompt: async (opts: { path: { id: string }; body: { parts: Array<{ text: string }> } }) => {
+          promptCalls.push({ sessionID: opts.path.id, text: opts.body.parts[0]?.text ?? "" })
+          return {}
+        },
+        promptAsync: async (opts: { path: { id: string }; body: { parts: Array<{ text: string }> } }) => {
+          promptCalls.push({ sessionID: opts.path.id, text: opts.body.parts[0]?.text ?? "" })
+          return {}
+        },
+      },
+      tui: {
+        showToast: async (opts: { body: { title: string; message: string } }) => {
+          toastCalls.push({ title: opts.body.title, message: opts.body.message })
+          return {}
+        },
+      },
+    },
+    directory: "/tmp/test",
+  })
+
+  beforeEach(() => {
+    promptCalls.length = 0
+    toastCalls.length = 0
+    _resetForTesting()
+    clearAllRuntimeFallbackActiveSessions()
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    clearAllRuntimeFallbackActiveSessions()
+  })
+
+  test("should skip continuation while runtime fallback is active", async () => {
+    const sessionID = "main-runtime-fallback-active"
+    setMainSession(sessionID)
+    markRuntimeFallbackActive(sessionID)
+
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), {})
+
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
+
+    expect(promptCalls).toHaveLength(0)
+    expect(toastCalls).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Skip todo-continuation injection when runtime-fallback is processing a model switch

## Problem
The todo-continuation-enforcer fires on session.idle during runtime-fallback model switching. Since the fallback is still resolving, the continuation message goes to the old rate-limited model, which fails again, triggering another idle event and creating an infinite retry loop.

## Fix
Added a guard in the todo-continuation handler that checks whether the session is currently awaiting a runtime-fallback result before injecting a continuation prompt. If fallback is active, the handler returns early.

## Changes
| File | Change |
|------|--------|
| `src/hooks/todo-continuation-enforcer/handler.ts` | Add runtime-fallback active check before continuation injection |

Fixes #2063

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip todo-continuation injection while runtime-fallback is switching models to prevent infinite idle-loop retries. Adds a per-session fallback-active flag and clears it reliably. Fixes #2063.

- **Bug Fixes**
  - Add `src/hooks/runtime-fallback/active-session-state.ts` with `markRuntimeFallbackActive`, `clearRuntimeFallbackActive`, `isRuntimeFallbackActive`, `clearAllRuntimeFallbackActiveSessions`.
  - Mark active on fallback prepare; clear on success, error, timeout, session completion, and hook reset.
  - Guard `todo-continuation-enforcer` to no-op when `isRuntimeFallbackActive(sessionID)` is true.
  - Add test `runtime-fallback-guard.test.ts` to ensure continuation is skipped during fallback.

<sup>Written for commit d9a7feb0d585fd254c30eaae7458bd96003c39f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

