### PR TITLE
feat(tmux): sweep stale omo-agents-<pid> sessions on first spawn

### DIFF
--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -1932,6 +1932,47 @@ describe('TmuxSessionManager', () => {
       expect(mockKillTmuxSessionIfExists).toHaveBeenCalledTimes(0)
     })
 
+    test('#given sweepStaleOmoAgentSessions throws on first onSessionCreated #when second onSessionCreated fires #then sweep is retried instead of skipped forever', async () => {
+      // given
+      mockSweepStaleOmoAgentSessions.mockClear()
+      mockSweepStaleOmoAgentSessions.mockImplementationOnce(async () => {
+        throw new Error('simulated sweep failure')
+      })
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({
+        enabled: true,
+        isolation: 'session',
+      }), mockTmuxDeps)
+
+      // when
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_first', 'ses_parent', 'First'))
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_second', 'ses_parent', 'Second'))
+
+      // then
+      expect(mockSweepStaleOmoAgentSessions).toHaveBeenCalledTimes(2)
+    })
+
+    test('#given sweepStaleOmoAgentSessions succeeds #when additional onSessionCreated events fire in same process #then sweep runs exactly once', async () => {
+      // given
+      mockSweepStaleOmoAgentSessions.mockClear()
+      mockSweepStaleOmoAgentSessions.mockImplementation(async () => 0)
+      mockIsInsideTmux.mockReturnValue(true)
+      const { TmuxSessionManager } = await import('./manager')
+      const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({
+        enabled: true,
+        isolation: 'session',
+      }), mockTmuxDeps)
+
+      // when
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_a', 'ses_parent', 'A'))
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_b', 'ses_parent', 'B'))
+      await manager.onSessionCreated(createSessionCreatedEvent('ses_c', 'ses_parent', 'C'))
+
+      // then
+      expect(mockSweepStaleOmoAgentSessions).toHaveBeenCalledTimes(1)
+    })
+
     test('#given killTmuxSessionIfExists throws #when cleanup runs #then cleanup still completes without throwing', async () => {
       // given
       mockKillTmuxSessionIfExists.mockClear()

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -1932,43 +1932,6 @@ describe('TmuxSessionManager', () => {
       expect(mockKillTmuxSessionIfExists).toHaveBeenCalledTimes(0)
     })
 
-    test('#given a tracked session #when onSessionError is invoked #then the pane is closed like onSessionDeleted', async () => {
-      // given
-      mockIsInsideTmux.mockReturnValue(true)
-      mockExecuteAction.mockClear()
-      const { TmuxSessionManager } = await import('./manager')
-      const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({
-        enabled: true,
-        isolation: 'session',
-      }), mockTmuxDeps)
-      await manager.onSessionCreated(createSessionCreatedEvent('ses_err', 'ses_parent', 'Errored Task'))
-      mockExecuteAction.mockClear()
-
-      // when
-      await manager.onSessionError({ sessionID: 'ses_err' })
-
-      // then
-      expect(mockExecuteAction).toHaveBeenCalled()
-    })
-
-    test('#given an untracked session #when onSessionError is invoked #then it is a no-op and does not throw', async () => {
-      // given
-      mockIsInsideTmux.mockReturnValue(true)
-      mockExecuteAction.mockClear()
-      const { TmuxSessionManager } = await import('./manager')
-      const manager = new TmuxSessionManager(createMockContext(), createTmuxConfig({
-        enabled: true,
-        isolation: 'session',
-      }), mockTmuxDeps)
-
-      // when
-      const errorHandler = manager.onSessionError({ sessionID: 'ses_unknown' })
-
-      // then
-      await expect(errorHandler).resolves.toBeUndefined()
-      expect(mockExecuteAction).not.toHaveBeenCalled()
-    })
-
     test('#given killTmuxSessionIfExists throws #when cleanup runs #then cleanup still completes without throwing', async () => {
       // given
       mockKillTmuxSessionIfExists.mockClear()

--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -58,6 +58,7 @@ const mockSpawnTmuxSession = mock<(
   paneId: '%isolated-session',
 }))
 const mockKillTmuxSessionIfExists = mock<(sessionName: string) => Promise<boolean>>(async () => true)
+const mockSweepStaleOmoAgentSessions = mock<() => Promise<number>>(async () => 0)
 const mockIsInsideTmux = mock<() => boolean>(() => true)
 const mockGetCurrentPaneId = mock<() => string | undefined>(() => '%0')
 
@@ -102,6 +103,7 @@ mock.module('../../shared/tmux', () => {
     spawnTmuxSession: mockSpawnTmuxSession,
     killTmuxSessionIfExists: mockKillTmuxSessionIfExists,
     getIsolatedSessionName: (pid: number = 12345) => `omo-agents-${pid}`,
+    sweepStaleOmoAgentSessions: mockSweepStaleOmoAgentSessions,
   }
 })
 

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -12,6 +12,7 @@ import {
   spawnTmuxSession,
   killTmuxSessionIfExists,
   getIsolatedSessionName,
+  sweepStaleOmoAgentSessions,
 } from "../../shared/tmux"
 import { queryWindowState } from "./pane-state-querier"
 import { decideSpawnActions, decideCloseAction, type SessionMapping } from "./decision-engine"
@@ -65,6 +66,7 @@ export class TmuxSessionManager {
   private isolatedContainerPaneId: string | undefined
   private isolatedWindowPaneId: string | undefined
   private isolatedContainerNullStateCount = 0
+  private staleSweepCompleted = false
   constructor(ctx: PluginInput, tmuxConfig: TmuxConfig, deps: TmuxUtilDeps = defaultTmuxDeps) {
     this.client = ctx.client
     this.tmuxConfig = tmuxConfig
@@ -668,6 +670,7 @@ export class TmuxSessionManager {
       return
     }
 
+    await this.sweepStaleIsolatedSessionsOnce()
     await this.retryPendingCloses()
 
     if (
@@ -983,6 +986,28 @@ export class TmuxSessionManager {
           error: String(error),
         })
       }
+    }
+
+    this.staleSweepCompleted = false
+  }
+
+  private async sweepStaleIsolatedSessionsOnce(): Promise<void> {
+    if (this.staleSweepCompleted) return
+    if (this.tmuxConfig.isolation !== "session") {
+      this.staleSweepCompleted = true
+      return
+    }
+
+    this.staleSweepCompleted = true
+    try {
+      const killed = await sweepStaleOmoAgentSessions()
+      if (killed > 0) {
+        log("[tmux-session-manager] stale isolated sessions swept", { killed })
+      }
+    } catch (error) {
+      log("[tmux-session-manager] stale sweep failed", {
+        error: String(error),
+      })
     }
 
     log("[tmux-session-manager] cleanup complete")

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -838,18 +838,6 @@ export class TmuxSessionManager {
     await this.spawnQueue
   }
 
-  async onSessionError(event: { sessionID: string }): Promise<void> {
-    if (!this.isEnabled()) return
-    if (!this.getEffectiveSourcePaneId()) return
-    if (!this.sessions.has(event.sessionID)) return
-
-    log("[tmux-session-manager] onSessionError - routing to cleanup", {
-      sessionId: event.sessionID,
-    })
-
-    await this.onSessionDeleted(event)
-  }
-
   async onSessionDeleted(event: { sessionID: string }): Promise<void> {
     if (!this.isEnabled()) return
     if (!this.getEffectiveSourcePaneId()) return

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -989,6 +989,8 @@ export class TmuxSessionManager {
     }
 
     this.staleSweepCompleted = false
+
+    log("[tmux-session-manager] cleanup complete")
   }
 
   private async sweepStaleIsolatedSessionsOnce(): Promise<void> {
@@ -1009,7 +1011,5 @@ export class TmuxSessionManager {
         error: String(error),
       })
     }
-
-    log("[tmux-session-manager] cleanup complete")
   }
 }

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -67,6 +67,7 @@ export class TmuxSessionManager {
   private isolatedWindowPaneId: string | undefined
   private isolatedContainerNullStateCount = 0
   private staleSweepCompleted = false
+  private staleSweepInProgress = false
   constructor(ctx: PluginInput, tmuxConfig: TmuxConfig, deps: TmuxUtilDeps = defaultTmuxDeps) {
     this.client = ctx.client
     this.tmuxConfig = tmuxConfig
@@ -977,27 +978,32 @@ export class TmuxSessionManager {
     }
 
     this.staleSweepCompleted = false
+    this.staleSweepInProgress = false
 
     log("[tmux-session-manager] cleanup complete")
   }
 
   private async sweepStaleIsolatedSessionsOnce(): Promise<void> {
     if (this.staleSweepCompleted) return
+    if (this.staleSweepInProgress) return
     if (this.tmuxConfig.isolation !== "session") {
       this.staleSweepCompleted = true
       return
     }
 
-    this.staleSweepCompleted = true
+    this.staleSweepInProgress = true
     try {
       const killed = await sweepStaleOmoAgentSessions()
       if (killed > 0) {
         log("[tmux-session-manager] stale isolated sessions swept", { killed })
       }
+      this.staleSweepCompleted = true
     } catch (error) {
       log("[tmux-session-manager] stale sweep failed", {
         error: String(error),
       })
+    } finally {
+      this.staleSweepInProgress = false
     }
   }
 }

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -615,10 +615,6 @@ export function createEventHandler(args: {
         const sessionID = props?.sessionID as string | undefined;
         const error = props?.error;
 
-        if (tmuxIntegrationEnabled && sessionID) {
-          await managers.tmuxSessionManager.onSessionError({ sessionID });
-        }
-
         const errorName = extractErrorName(error);
         const errorMessage = extractErrorMessage(error);
         const errorInfo = { name: errorName, message: errorMessage };

--- a/src/shared/tmux/tmux-utils.ts
+++ b/src/shared/tmux/tmux-utils.ts
@@ -12,5 +12,6 @@ export { replaceTmuxPane } from "./tmux-utils/pane-replace"
 export { spawnTmuxWindow } from "./tmux-utils/window-spawn"
 export { spawnTmuxSession, getIsolatedSessionName } from "./tmux-utils/session-spawn"
 export { killTmuxSessionIfExists } from "./tmux-utils/session-kill"
+export { sweepStaleOmoAgentSessions } from "./tmux-utils/stale-session-sweep"
 
 export { applyLayout, enforceMainPaneWidth } from "./tmux-utils/layout"

--- a/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
+++ b/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
@@ -1,188 +1,154 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+import { sweepStaleOmoAgentSessionsWith, type SweepDeps } from "./stale-session-sweep"
 
-type SweepStaleOmoAgentSessions = typeof import("./stale-session-sweep").sweepStaleOmoAgentSessions
-
-type SpawnCall = { command: string[] }
-
-type FakeSubprocess = {
-	exited: Promise<number>
-	stdout: ReadableStream<Uint8Array>
-	stderr: ReadableStream<Uint8Array>
+type SweepFixture = {
+	deps: SweepDeps
+	candidates: string[]
+	killed: string[]
+	killSessionMock: ReturnType<typeof mock>
+	setCandidates: (sessions: string[]) => void
+	setAlive: (predicate: (pid: number) => boolean) => void
 }
 
-const spawnCalls: SpawnCall[] = []
-const queuedProcesses: FakeSubprocess[] = []
+function createFixture(): SweepFixture {
+	const candidates: string[] = []
+	const killed: string[] = []
+	let aliveCheck: (pid: number) => boolean = () => false
 
-function createClosedStream(): ReadableStream<Uint8Array> {
-	return new ReadableStream({ start(controller) { controller.close() } })
-}
-
-function createTextStream(text: string): ReadableStream<Uint8Array> {
-	return new ReadableStream({
-		start(controller) {
-			controller.enqueue(new TextEncoder().encode(text))
-			controller.close()
-		},
+	const killSessionMock = mock(async (sessionName: string): Promise<boolean> => {
+		killed.push(sessionName)
+		return true
 	})
-}
 
-function makeProcess(exitCode: number, stdoutText: string): FakeSubprocess {
+	const deps: SweepDeps = {
+		isInsideTmux: () => true,
+		getTmuxPath: async () => "tmux",
+		listCandidateSessions: async () => [...candidates],
+		killSession: killSessionMock,
+		processAlive: (pid) => aliveCheck(pid),
+		currentPid: 12345,
+		log: () => undefined,
+	}
+
 	return {
-		exited: Promise.resolve(exitCode),
-		stdout: createTextStream(stdoutText),
-		stderr: createClosedStream(),
+		deps,
+		candidates,
+		killed,
+		killSessionMock,
+		setCandidates: (sessions) => {
+			candidates.length = 0
+			candidates.push(...sessions)
+		},
+		setAlive: (predicate) => {
+			aliveCheck = predicate
+		},
 	}
 }
 
-const spawnMock = mock((command: string[]): FakeSubprocess => {
-	spawnCalls.push({ command })
-	const process = queuedProcesses.shift()
-	if (!process) {
-		throw new Error(`No fake subprocess configured for ${command.join(" ")}`)
-	}
-	return process
-})
+describe("sweepStaleOmoAgentSessionsWith", () => {
+	let fixture: SweepFixture
 
-const isInsideTmuxMock = mock((): boolean => true)
-const getTmuxPathMock = mock(async (): Promise<string | undefined> => "tmux")
-const logMock = mock(() => undefined)
-const killTmuxSessionMock = mock(async (_name: string): Promise<boolean> => true)
-const isProcessAliveMock = mock((_pid: number): boolean => false)
-
-const sweepSpecifier = import.meta.resolve("./stale-session-sweep")
-const spawnProcessSpecifier = import.meta.resolve("./spawn-process")
-const environmentSpecifier = import.meta.resolve("./environment")
-const loggerSpecifier = import.meta.resolve("../../logger")
-const tmuxPathResolverSpecifier = import.meta.resolve("../../../tools/interactive-bash/tmux-path-resolver")
-const sessionKillSpecifier = import.meta.resolve("./session-kill")
-
-function registerModuleMocks(): void {
-	mock.module(spawnProcessSpecifier, () => ({ spawn: spawnMock }))
-	mock.module(environmentSpecifier, () => ({ isInsideTmux: isInsideTmuxMock }))
-	mock.module(loggerSpecifier, () => ({ log: logMock }))
-	mock.module(tmuxPathResolverSpecifier, () => ({ getTmuxPath: getTmuxPathMock }))
-	mock.module(sessionKillSpecifier, () => ({ killTmuxSessionIfExists: killTmuxSessionMock }))
-}
-
-const originalProcessKill = process.kill
-
-async function loadSweeper(overrideProcessAlive?: (pid: number) => boolean): Promise<SweepStaleOmoAgentSessions> {
-	const processAlive = overrideProcessAlive ?? isProcessAliveMock
-	process.kill = ((pid: number, signal?: number | string): true => {
-		if (signal === 0) {
-			if (processAlive(pid)) {
-				return true
-			}
-			const err = new Error("ESRCH") as NodeJS.ErrnoException
-			err.code = "ESRCH"
-			throw err
-		}
-		return originalProcessKill.call(process, pid, signal)
-	}) as typeof process.kill
-	const module = await import(`${sweepSpecifier}?test=${crypto.randomUUID()}`)
-	return module.sweepStaleOmoAgentSessions
-}
-
-describe("sweepStaleOmoAgentSessions", () => {
 	beforeEach(() => {
-		registerModuleMocks()
-		spawnCalls.length = 0
-		queuedProcesses.length = 0
-		spawnMock.mockClear()
-		isInsideTmuxMock.mockClear()
-		getTmuxPathMock.mockClear()
-		logMock.mockClear()
-		killTmuxSessionMock.mockClear()
-		isProcessAliveMock.mockClear()
-
-		isInsideTmuxMock.mockImplementation((): boolean => true)
-		getTmuxPathMock.mockImplementation(async (): Promise<string | undefined> => "tmux")
-		killTmuxSessionMock.mockImplementation(async (_name: string): Promise<boolean> => true)
-		isProcessAliveMock.mockImplementation((_pid: number): boolean => false)
+		fixture = createFixture()
 	})
 
-	afterEach(() => {
-		process.kill = originalProcessKill
-	})
-
-	it("#given not inside tmux #when sweepStaleOmoAgentSessions called #then returns 0 without spawn", async () => {
+	it("#given not inside tmux #when sweep called #then returns 0 without listing", async () => {
 		// given
-		isInsideTmuxMock.mockImplementation((): boolean => false)
-		const sweep = await loadSweeper()
+		const deps: SweepDeps = { ...fixture.deps, isInsideTmux: () => false }
 
 		// when
-		const result = await sweep()
+		const result = await sweepStaleOmoAgentSessionsWith(deps)
 
 		// then
 		expect(result).toBe(0)
-		expect(spawnCalls).toHaveLength(0)
 	})
 
-	it("#given no omo-agents sessions exist #when sweepStaleOmoAgentSessions called #then returns 0", async () => {
+	it("#given tmux not found #when sweep called #then returns 0 without listing", async () => {
 		// given
-		queuedProcesses.push(makeProcess(0, "other-session\nmain\n"))
-		const sweep = await loadSweeper()
+		const deps: SweepDeps = { ...fixture.deps, getTmuxPath: async () => undefined }
 
 		// when
-		const result = await sweep()
+		const result = await sweepStaleOmoAgentSessionsWith(deps)
 
 		// then
 		expect(result).toBe(0)
-		expect(killTmuxSessionMock).toHaveBeenCalledTimes(0)
 	})
 
-	it("#given omo-agents sessions with dead PIDs #when sweepStaleOmoAgentSessions called #then each dead session is killed", async () => {
+	it("#given candidate list is empty #when sweep called #then returns 0 and does not kill anything", async () => {
 		// given
-		queuedProcesses.push(makeProcess(0, "omo-agents-99991\nomo-agents-99992\nunrelated\n"))
-		const sweep = await loadSweeper(() => false)
+		fixture.setCandidates([])
 
 		// when
-		const result = await sweep()
+		const result = await sweepStaleOmoAgentSessionsWith(fixture.deps)
+
+		// then
+		expect(result).toBe(0)
+		expect(fixture.killed).toEqual([])
+	})
+
+	it("#given sessions with dead PIDs #when sweep called #then each dead session is killed once", async () => {
+		// given
+		fixture.setCandidates(["omo-agents-99991", "omo-agents-99992"])
+		fixture.setAlive(() => false)
+
+		// when
+		const result = await sweepStaleOmoAgentSessionsWith(fixture.deps)
 
 		// then
 		expect(result).toBe(2)
-		expect(killTmuxSessionMock).toHaveBeenCalledTimes(2)
-		expect(killTmuxSessionMock.mock.calls[0]?.[0]).toBe("omo-agents-99991")
-		expect(killTmuxSessionMock.mock.calls[1]?.[0]).toBe("omo-agents-99992")
+		expect(fixture.killed).toEqual(["omo-agents-99991", "omo-agents-99992"])
 	})
 
-	it("#given session matches current PID #when sweepStaleOmoAgentSessions called #then it is not killed", async () => {
+	it("#given session matches current PID #when sweep called #then it is NOT killed", async () => {
 		// given
-		queuedProcesses.push(makeProcess(0, `omo-agents-${process.pid}\nomo-agents-99999\n`))
-		const sweep = await loadSweeper(() => false)
+		fixture.setCandidates([`omo-agents-${fixture.deps.currentPid}`, "omo-agents-99999"])
+		fixture.setAlive(() => false)
 
 		// when
-		const result = await sweep()
+		const result = await sweepStaleOmoAgentSessionsWith(fixture.deps)
 
 		// then
 		expect(result).toBe(1)
-		expect(killTmuxSessionMock).toHaveBeenCalledTimes(1)
-		expect(killTmuxSessionMock.mock.calls[0]?.[0]).toBe("omo-agents-99999")
+		expect(fixture.killed).toEqual(["omo-agents-99999"])
 	})
 
-	it("#given session PID is still alive #when sweepStaleOmoAgentSessions called #then it is not killed", async () => {
+	it("#given session PID is still alive #when sweep called #then it is NOT killed", async () => {
 		// given
-		queuedProcesses.push(makeProcess(0, "omo-agents-88888\n"))
-		const sweep = await loadSweeper((pid) => pid === 88888)
+		fixture.setCandidates(["omo-agents-88888"])
+		fixture.setAlive((pid) => pid === 88888)
 
 		// when
-		const result = await sweep()
+		const result = await sweepStaleOmoAgentSessionsWith(fixture.deps)
 
 		// then
 		expect(result).toBe(0)
-		expect(killTmuxSessionMock).toHaveBeenCalledTimes(0)
+		expect(fixture.killed).toEqual([])
 	})
 
-	it("#given list-sessions fails #when sweepStaleOmoAgentSessions called #then returns 0 without killing", async () => {
+	it("#given killSession returns false #when sweep called #then session is not counted toward killedCount", async () => {
 		// given
-		queuedProcesses.push(makeProcess(1, ""))
-		const sweep = await loadSweeper(() => false)
+		fixture.setCandidates(["omo-agents-55555"])
+		fixture.setAlive(() => false)
+		fixture.killSessionMock.mockImplementation(async () => false)
 
 		// when
-		const result = await sweep()
+		const result = await sweepStaleOmoAgentSessionsWith(fixture.deps)
 
 		// then
 		expect(result).toBe(0)
-		expect(killTmuxSessionMock).toHaveBeenCalledTimes(0)
+		expect(fixture.killSessionMock).toHaveBeenCalledTimes(1)
+	})
+
+	it("#given non-matching sessions mixed in #when sweep called #then only omo-agents-<pid> sessions are considered", async () => {
+		// given
+		fixture.setCandidates(["main", "omo-agents-99999", "other-session", "omo-agents-abc"])
+		fixture.setAlive(() => false)
+
+		// when
+		const result = await sweepStaleOmoAgentSessionsWith(fixture.deps)
+
+		// then
+		expect(result).toBe(1)
+		expect(fixture.killed).toEqual(["omo-agents-99999"])
 	})
 })

--- a/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
+++ b/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+
+type SweepStaleOmoAgentSessions = typeof import("./stale-session-sweep").sweepStaleOmoAgentSessions
+
+type SpawnCall = { command: string[] }
+
+type FakeSubprocess = {
+	exited: Promise<number>
+	stdout: ReadableStream<Uint8Array>
+	stderr: ReadableStream<Uint8Array>
+}
+
+const spawnCalls: SpawnCall[] = []
+const queuedProcesses: FakeSubprocess[] = []
+
+function createClosedStream(): ReadableStream<Uint8Array> {
+	return new ReadableStream({ start(controller) { controller.close() } })
+}
+
+function createTextStream(text: string): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(text))
+			controller.close()
+		},
+	})
+}
+
+function makeProcess(exitCode: number, stdoutText: string): FakeSubprocess {
+	return {
+		exited: Promise.resolve(exitCode),
+		stdout: createTextStream(stdoutText),
+		stderr: createClosedStream(),
+	}
+}
+
+const spawnMock = mock((command: string[]): FakeSubprocess => {
+	spawnCalls.push({ command })
+	const process = queuedProcesses.shift()
+	if (!process) {
+		throw new Error(`No fake subprocess configured for ${command.join(" ")}`)
+	}
+	return process
+})
+
+const isInsideTmuxMock = mock((): boolean => true)
+const getTmuxPathMock = mock(async (): Promise<string | undefined> => "tmux")
+const logMock = mock(() => undefined)
+const killTmuxSessionMock = mock(async (_name: string): Promise<boolean> => true)
+const isProcessAliveMock = mock((_pid: number): boolean => false)
+
+const sweepSpecifier = import.meta.resolve("./stale-session-sweep")
+const spawnProcessSpecifier = import.meta.resolve("./spawn-process")
+const environmentSpecifier = import.meta.resolve("./environment")
+const loggerSpecifier = import.meta.resolve("../../logger")
+const tmuxPathResolverSpecifier = import.meta.resolve("../../../tools/interactive-bash/tmux-path-resolver")
+const sessionKillSpecifier = import.meta.resolve("./session-kill")
+
+function registerModuleMocks(): void {
+	mock.module(spawnProcessSpecifier, () => ({ spawn: spawnMock }))
+	mock.module(environmentSpecifier, () => ({ isInsideTmux: isInsideTmuxMock }))
+	mock.module(loggerSpecifier, () => ({ log: logMock }))
+	mock.module(tmuxPathResolverSpecifier, () => ({ getTmuxPath: getTmuxPathMock }))
+	mock.module(sessionKillSpecifier, () => ({ killTmuxSessionIfExists: killTmuxSessionMock }))
+}
+
+async function loadSweeper(overrideProcessAlive?: (pid: number) => boolean): Promise<SweepStaleOmoAgentSessions> {
+	const originalKill = process.kill
+	const processAlive = overrideProcessAlive ?? isProcessAliveMock
+	process.kill = ((pid: number, signal?: number | string): true => {
+		if (signal === 0) {
+			if (processAlive(pid)) {
+				return true
+			}
+			const err = new Error("ESRCH") as NodeJS.ErrnoException
+			err.code = "ESRCH"
+			throw err
+		}
+		return originalKill.call(process, pid, signal)
+	}) as typeof process.kill
+	const module = await import(`${sweepSpecifier}?test=${crypto.randomUUID()}`)
+	return module.sweepStaleOmoAgentSessions
+}
+
+describe("sweepStaleOmoAgentSessions", () => {
+	beforeEach(() => {
+		registerModuleMocks()
+		spawnCalls.length = 0
+		queuedProcesses.length = 0
+		spawnMock.mockClear()
+		isInsideTmuxMock.mockClear()
+		getTmuxPathMock.mockClear()
+		logMock.mockClear()
+		killTmuxSessionMock.mockClear()
+		isProcessAliveMock.mockClear()
+
+		isInsideTmuxMock.mockImplementation((): boolean => true)
+		getTmuxPathMock.mockImplementation(async (): Promise<string | undefined> => "tmux")
+		killTmuxSessionMock.mockImplementation(async (_name: string): Promise<boolean> => true)
+		isProcessAliveMock.mockImplementation((_pid: number): boolean => false)
+	})
+
+	it("#given not inside tmux #when sweepStaleOmoAgentSessions called #then returns 0 without spawn", async () => {
+		// given
+		isInsideTmuxMock.mockImplementation((): boolean => false)
+		const sweep = await loadSweeper()
+
+		// when
+		const result = await sweep()
+
+		// then
+		expect(result).toBe(0)
+		expect(spawnCalls).toHaveLength(0)
+	})
+
+	it("#given no omo-agents sessions exist #when sweepStaleOmoAgentSessions called #then returns 0", async () => {
+		// given
+		queuedProcesses.push(makeProcess(0, "other-session\nmain\n"))
+		const sweep = await loadSweeper()
+
+		// when
+		const result = await sweep()
+
+		// then
+		expect(result).toBe(0)
+		expect(killTmuxSessionMock).toHaveBeenCalledTimes(0)
+	})
+
+	it("#given omo-agents sessions with dead PIDs #when sweepStaleOmoAgentSessions called #then each dead session is killed", async () => {
+		// given
+		queuedProcesses.push(makeProcess(0, "omo-agents-99991\nomo-agents-99992\nunrelated\n"))
+		const sweep = await loadSweeper(() => false)
+
+		// when
+		const result = await sweep()
+
+		// then
+		expect(result).toBe(2)
+		expect(killTmuxSessionMock).toHaveBeenCalledTimes(2)
+		expect(killTmuxSessionMock.mock.calls[0]?.[0]).toBe("omo-agents-99991")
+		expect(killTmuxSessionMock.mock.calls[1]?.[0]).toBe("omo-agents-99992")
+	})
+
+	it("#given session matches current PID #when sweepStaleOmoAgentSessions called #then it is not killed", async () => {
+		// given
+		queuedProcesses.push(makeProcess(0, `omo-agents-${process.pid}\nomo-agents-99999\n`))
+		const sweep = await loadSweeper(() => false)
+
+		// when
+		const result = await sweep()
+
+		// then
+		expect(result).toBe(1)
+		expect(killTmuxSessionMock).toHaveBeenCalledTimes(1)
+		expect(killTmuxSessionMock.mock.calls[0]?.[0]).toBe("omo-agents-99999")
+	})
+
+	it("#given session PID is still alive #when sweepStaleOmoAgentSessions called #then it is not killed", async () => {
+		// given
+		queuedProcesses.push(makeProcess(0, "omo-agents-88888\n"))
+		const sweep = await loadSweeper((pid) => pid === 88888)
+
+		// when
+		const result = await sweep()
+
+		// then
+		expect(result).toBe(0)
+		expect(killTmuxSessionMock).toHaveBeenCalledTimes(0)
+	})
+
+	it("#given list-sessions fails #when sweepStaleOmoAgentSessions called #then returns 0 without killing", async () => {
+		// given
+		queuedProcesses.push(makeProcess(1, ""))
+		const sweep = await loadSweeper(() => false)
+
+		// when
+		const result = await sweep()
+
+		// then
+		expect(result).toBe(0)
+		expect(killTmuxSessionMock).toHaveBeenCalledTimes(0)
+	})
+})

--- a/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
+++ b/src/shared/tmux/tmux-utils/stale-session-sweep.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 
 type SweepStaleOmoAgentSessions = typeof import("./stale-session-sweep").sweepStaleOmoAgentSessions
 
@@ -64,8 +64,9 @@ function registerModuleMocks(): void {
 	mock.module(sessionKillSpecifier, () => ({ killTmuxSessionIfExists: killTmuxSessionMock }))
 }
 
+const originalProcessKill = process.kill
+
 async function loadSweeper(overrideProcessAlive?: (pid: number) => boolean): Promise<SweepStaleOmoAgentSessions> {
-	const originalKill = process.kill
 	const processAlive = overrideProcessAlive ?? isProcessAliveMock
 	process.kill = ((pid: number, signal?: number | string): true => {
 		if (signal === 0) {
@@ -76,7 +77,7 @@ async function loadSweeper(overrideProcessAlive?: (pid: number) => boolean): Pro
 			err.code = "ESRCH"
 			throw err
 		}
-		return originalKill.call(process, pid, signal)
+		return originalProcessKill.call(process, pid, signal)
 	}) as typeof process.kill
 	const module = await import(`${sweepSpecifier}?test=${crypto.randomUUID()}`)
 	return module.sweepStaleOmoAgentSessions
@@ -98,6 +99,10 @@ describe("sweepStaleOmoAgentSessions", () => {
 		getTmuxPathMock.mockImplementation(async (): Promise<string | undefined> => "tmux")
 		killTmuxSessionMock.mockImplementation(async (_name: string): Promise<boolean> => true)
 		isProcessAliveMock.mockImplementation((_pid: number): boolean => false)
+	})
+
+	afterEach(() => {
+		process.kill = originalProcessKill
 	})
 
 	it("#given not inside tmux #when sweepStaleOmoAgentSessions called #then returns 0 without spawn", async () => {

--- a/src/shared/tmux/tmux-utils/stale-session-sweep.ts
+++ b/src/shared/tmux/tmux-utils/stale-session-sweep.ts
@@ -1,0 +1,72 @@
+const STALE_SESSION_PATTERN = /^omo-agents-(\d+)$/
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch (error) {
+		const err = error as NodeJS.ErrnoException
+		return err?.code === "EPERM"
+	}
+}
+
+async function listOmoAgentSessions(tmux: string): Promise<string[]> {
+	const { spawn } = await import("./spawn-process")
+	const proc = spawn([tmux, "list-sessions", "-F", "#{session_name}"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	})
+	const [stdout, , exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	])
+
+	if (exitCode !== 0) {
+		return []
+	}
+
+	return stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((name) => STALE_SESSION_PATTERN.test(name))
+}
+
+export async function sweepStaleOmoAgentSessions(): Promise<number> {
+	const [{ log }, { isInsideTmux }, { getTmuxPath }, { killTmuxSessionIfExists }] = await Promise.all([
+		import("../../logger"),
+		import("./environment"),
+		import("../../../tools/interactive-bash/tmux-path-resolver"),
+		import("./session-kill"),
+	])
+
+	if (!isInsideTmux()) {
+		return 0
+	}
+
+	const tmux = await getTmuxPath()
+	if (!tmux) {
+		return 0
+	}
+
+	const candidateSessions = await listOmoAgentSessions(tmux)
+	let killedCount = 0
+
+	for (const sessionName of candidateSessions) {
+		const pidMatch = sessionName.match(STALE_SESSION_PATTERN)
+		if (!pidMatch) continue
+
+		const pid = Number.parseInt(pidMatch[1], 10)
+		if (!Number.isFinite(pid)) continue
+		if (pid === process.pid) continue
+		if (isProcessAlive(pid)) continue
+
+		log("[sweepStaleOmoAgentSessions] killing stale session", { sessionName, deadPid: pid })
+		const killed = await killTmuxSessionIfExists(sessionName)
+		if (killed) {
+			killedCount += 1
+		}
+	}
+
+	return killedCount
+}

--- a/src/shared/tmux/tmux-utils/stale-session-sweep.ts
+++ b/src/shared/tmux/tmux-utils/stale-session-sweep.ts
@@ -10,7 +10,7 @@ function isProcessAlive(pid: number): boolean {
 	}
 }
 
-async function listOmoAgentSessions(tmux: string): Promise<string[]> {
+async function listOmoAgentSessionsViaTmux(tmux: string): Promise<string[]> {
 	const { spawn } = await import("./spawn-process")
 	const proc = spawn([tmux, "list-sessions", "-F", "#{session_name}"], {
 		stdout: "pipe",
@@ -32,7 +32,17 @@ async function listOmoAgentSessions(tmux: string): Promise<string[]> {
 		.filter((name) => STALE_SESSION_PATTERN.test(name))
 }
 
-export async function sweepStaleOmoAgentSessions(): Promise<number> {
+export type SweepDeps = {
+	isInsideTmux: () => boolean
+	getTmuxPath: () => Promise<string | null | undefined>
+	listCandidateSessions: (tmux: string) => Promise<string[]>
+	killSession: (sessionName: string) => Promise<boolean>
+	processAlive: (pid: number) => boolean
+	currentPid: number
+	log: (message: string, payload?: unknown) => void
+}
+
+async function buildRuntimeDeps(): Promise<SweepDeps> {
 	const [{ log }, { isInsideTmux }, { getTmuxPath }, { killTmuxSessionIfExists }] = await Promise.all([
 		import("../../logger"),
 		import("./environment"),
@@ -40,16 +50,28 @@ export async function sweepStaleOmoAgentSessions(): Promise<number> {
 		import("./session-kill"),
 	])
 
-	if (!isInsideTmux()) {
+	return {
+		isInsideTmux,
+		getTmuxPath,
+		listCandidateSessions: listOmoAgentSessionsViaTmux,
+		killSession: killTmuxSessionIfExists,
+		processAlive: isProcessAlive,
+		currentPid: process.pid,
+		log,
+	}
+}
+
+export async function sweepStaleOmoAgentSessionsWith(deps: SweepDeps): Promise<number> {
+	if (!deps.isInsideTmux()) {
 		return 0
 	}
 
-	const tmux = await getTmuxPath()
+	const tmux = await deps.getTmuxPath()
 	if (!tmux) {
 		return 0
 	}
 
-	const candidateSessions = await listOmoAgentSessions(tmux)
+	const candidateSessions = await deps.listCandidateSessions(tmux)
 	let killedCount = 0
 
 	for (const sessionName of candidateSessions) {
@@ -58,15 +80,20 @@ export async function sweepStaleOmoAgentSessions(): Promise<number> {
 
 		const pid = Number.parseInt(pidMatch[1], 10)
 		if (!Number.isFinite(pid)) continue
-		if (pid === process.pid) continue
-		if (isProcessAlive(pid)) continue
+		if (pid === deps.currentPid) continue
+		if (deps.processAlive(pid)) continue
 
-		log("[sweepStaleOmoAgentSessions] killing stale session", { sessionName, deadPid: pid })
-		const killed = await killTmuxSessionIfExists(sessionName)
+		deps.log("[sweepStaleOmoAgentSessions] killing stale session", { sessionName, deadPid: pid })
+		const killed = await deps.killSession(sessionName)
 		if (killed) {
 			killedCount += 1
 		}
 	}
 
 	return killedCount
+}
+
+export async function sweepStaleOmoAgentSessions(): Promise<number> {
+	const deps = await buildRuntimeDeps()
+	return sweepStaleOmoAgentSessionsWith(deps)
 }


### PR DESCRIPTION
## Summary

Follow-up to #3507 addressing the Oracle-noted operational limitation: per-PID isolated session names mean a SIGKILL'd opencode process leaves `omo-agents-<old-pid>` running forever.

Adds `sweepStaleOmoAgentSessions()`:
- Lists tmux sessions matching `^omo-agents-(\d+)$`
- `process.kill(pid, 0)` to detect dead PIDs (EPERM = alive owned by other user, ESRCH = dead)
- Skips current PID
- Kills sessions whose owner process is gone

Wired into `TmuxSessionManager.onSessionCreated()` as a one-shot (staleSweepCompleted flag) so it runs lazily on first subagent spawn when `isolation="session"`. Reset in cleanup() for process reuse.

## Manual E2E QA

Verified on live tmux (user's real environment):

```
=== E2E Test: tmux.isolation=session flow ===
Current PID: 5469

Step 1: Creating stale session omo-agents-99999
  stale session exists: true

Step 2: Running sweepStaleOmoAgentSessions
  killed count: 1
  stale session still exists?: false (should be false) ✅

Step 3: Spawning our isolated session omo-agents-5469
  spawned paneId: %547

Step 4: closeTmuxPane(%547) (Ctrl+C exits sleep, tmux auto-destroys pane)
  close result: true (should be true) ✅

Step 5: killTmuxSessionIfExists(omo-agents-5469)
  kill result: false (session already auto-destroyed with its only pane)

Step 6: Verify zero orphans
  remaining omo-agents-* sessions: NONE (PASS) ✅
```

## Tests

- `stale-session-sweep.test.ts`: 6 new tests (outside tmux, no matches, multiple dead PIDs, current PID skip, live PID skip, list-sessions failure)
- `manager.test.ts`: extended `../../shared/tmux` mock with `sweepStaleOmoAgentSessions` to keep 46 existing tests green
- typecheck: clean

## Scope

This PR only addresses the stale-sweep gap. All other fixes from #3507 are already merged on dev.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sweeps stale `omo-agents-<pid>` tmux sessions on first subagent spawn and fixes a regression that killed panes on recoverable errors. Also refactors the sweep for cleaner tests without cross-file mock leaks.

- **Bug Fixes**
  - Added `sweepStaleOmoAgentSessions()` to list `omo-agents-<pid>` sessions, skip the current PID, detect dead PIDs via `process.kill(pid, 0)`, and kill stale ones. Runs once when `isolation="session"`, retries on first-failure, blocks parallel runs, and resets flags in `cleanup()`. No-ops outside tmux or when tmux is missing; logs failures without breaking flow.
  - Reverted `session.error` → pane cleanup routing; only `session.deleted` triggers cleanup to avoid tearing down panes on recoverable errors.

- **Refactors**
  - Exposed `sweepStaleOmoAgentSessionsWith(deps)` for DI; rewrote sweep tests to avoid monkey-patching and cross-file module mocks, and added cases for retry-on-failure and single-run semantics.

<sup>Written for commit e35ac38bbfca4fbae8c390f04e9a6554f7ab0de9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

