### PR TITLE
fix(cli): inject server auth for attach clients

### DIFF
--- a/src/cli/run/server-connection.test.ts
+++ b/src/cli/run/server-connection.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, mock, beforeEach, afterEach, afterAll } from "bun
 import * as originalSdk from "@opencode-ai/sdk"
 import * as originalPortUtils from "../../shared/port-utils"
 import * as originalBinaryResolver from "./opencode-binary-resolver"
+import * as originalServerAuth from "../../shared/opencode-server-auth"
 
 const originalConsole = globalThis.console
 
@@ -13,11 +14,15 @@ const mockCreateOpencode = mock(() =>
     server: { url: "http://127.0.0.1:4096", close: mockServerClose },
   })
 )
-const mockCreateOpencodeClient = mock(() => ({ session: {} }))
+const mockCreateOpencodeClient = mock((options?: { baseUrl?: string }) => ({
+  session: {},
+  baseUrl: options?.baseUrl,
+}))
 const mockIsPortAvailable = mock(() => Promise.resolve(true))
 const mockGetAvailableServerPort = mock(() => Promise.resolve({ port: 4096, wasAutoSelected: false }))
 const mockConsoleLog = mock(() => {})
 const mockWithWorkingOpencodePath = mock((startServer: () => Promise<unknown>) => startServer())
+const mockInjectServerAuthIntoClient = mock(() => {})
 
 mock.module("@opencode-ai/sdk", () => ({
   createOpencode: mockCreateOpencode,
@@ -34,10 +39,15 @@ mock.module("./opencode-binary-resolver", () => ({
   withWorkingOpencodePath: mockWithWorkingOpencodePath,
 }))
 
+mock.module("../../shared/opencode-server-auth", () => ({
+  injectServerAuthIntoClient: mockInjectServerAuthIntoClient,
+}))
+
 afterAll(() => {
   mock.module("@opencode-ai/sdk", () => originalSdk)
   mock.module("../../shared/port-utils", () => originalPortUtils)
   mock.module("./opencode-binary-resolver", () => originalBinaryResolver)
+  mock.module("../../shared/opencode-server-auth", () => originalServerAuth)
   mock.restore()
 })
 
@@ -52,11 +62,55 @@ describe("createServerConnection", () => {
     mockServerClose.mockClear()
     mockConsoleLog.mockClear()
     mockWithWorkingOpencodePath.mockClear()
+    mockInjectServerAuthIntoClient.mockClear()
     globalThis.console = { ...console, log: mockConsoleLog } as typeof console
   })
 
   afterEach(() => {
     globalThis.console = originalConsole
+  })
+
+  it("attach mode injects auth only for loopback URLs", async () => {
+    // given
+    const signal = new AbortController().signal
+
+    // when
+    const localhostResult = await createServerConnection({ attach: "http://localhost:8080", signal })
+    const loopbackResult = await createServerConnection({ attach: "http://127.0.0.1:8080", signal })
+    const anyBindResult = await createServerConnection({ attach: "http://0.0.0.0:8080", signal })
+    const remoteResult = await createServerConnection({ attach: "https://example.com", signal })
+
+    // then
+    expect(mockCreateOpencodeClient).toHaveBeenCalledWith({ baseUrl: "http://localhost:8080" })
+    expect(mockCreateOpencodeClient).toHaveBeenCalledWith({ baseUrl: "http://127.0.0.1:8080" })
+    expect(mockCreateOpencodeClient).toHaveBeenCalledWith({ baseUrl: "http://0.0.0.0:8080" })
+    expect(mockCreateOpencodeClient).toHaveBeenCalledWith({ baseUrl: "https://example.com" })
+    expect(mockInjectServerAuthIntoClient).toHaveBeenCalledTimes(3)
+    expect(mockInjectServerAuthIntoClient).toHaveBeenNthCalledWith(1, localhostResult.client)
+    expect(mockInjectServerAuthIntoClient).toHaveBeenNthCalledWith(2, loopbackResult.client)
+    expect(mockInjectServerAuthIntoClient).toHaveBeenNthCalledWith(3, anyBindResult.client)
+    expect(mockInjectServerAuthIntoClient).not.toHaveBeenCalledWith(remoteResult.client)
+    expect(mockWithWorkingOpencodePath).not.toHaveBeenCalled()
+    localhostResult.cleanup()
+    loopbackResult.cleanup()
+    anyBindResult.cleanup()
+    remoteResult.cleanup()
+    expect(mockServerClose).not.toHaveBeenCalled()
+  })
+
+  it("attach mode skips auth injection for invalid attach URLs", async () => {
+    // given
+    const signal = new AbortController().signal
+    const attachUrl = "not-a-url"
+
+    // when
+    const result = await createServerConnection({ attach: attachUrl, signal })
+
+    // then
+    expect(mockCreateOpencodeClient).toHaveBeenCalledWith({ baseUrl: attachUrl })
+    expect(mockInjectServerAuthIntoClient).not.toHaveBeenCalled()
+    result.cleanup()
+    expect(mockServerClose).not.toHaveBeenCalled()
   })
 
   it("attach mode returns client with no-op cleanup", async () => {
@@ -68,8 +122,6 @@ describe("createServerConnection", () => {
     const result = await createServerConnection({ attach: attachUrl, signal })
 
     // then
-    expect(mockCreateOpencodeClient).toHaveBeenCalledWith({ baseUrl: attachUrl })
-    expect(mockWithWorkingOpencodePath).not.toHaveBeenCalled()
     expect(result.client).toBeDefined()
     expect(result.cleanup).toBeDefined()
     result.cleanup()

--- a/src/cli/run/server-connection.ts
+++ b/src/cli/run/server-connection.ts
@@ -1,6 +1,7 @@
 import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk"
 import pc from "picocolors"
 import type { ServerConnection } from "./types"
+import { injectServerAuthIntoClient } from "../../shared/opencode-server-auth"
 import { getAvailableServerPort, isPortAvailable, DEFAULT_SERVER_PORT } from "../../shared/port-utils"
 import { withWorkingOpencodePath } from "./opencode-binary-resolver"
 
@@ -40,6 +41,7 @@ export async function createServerConnection(options: {
   if (attach !== undefined) {
     console.log(pc.dim("Attaching to existing server at"), pc.cyan(attach))
     const client = createOpencodeClient({ baseUrl: attach })
+    injectServerAuthIntoClient(client)
     return { client, cleanup: () => {} }
   }
 
@@ -66,12 +68,14 @@ export async function createServerConnection(options: {
 
         console.log(pc.dim("Port"), pc.cyan(port.toString()), pc.dim("became occupied, attaching to existing server"))
         const client = createOpencodeClient({ baseUrl: `http://127.0.0.1:${port}` })
+        injectServerAuthIntoClient(client)
         return { client, cleanup: () => {} }
       }
     }
 
     console.log(pc.dim("Port"), pc.cyan(port.toString()), pc.dim("is occupied, attaching to existing server"))
     const client = createOpencodeClient({ baseUrl: `http://127.0.0.1:${port}` })
+    injectServerAuthIntoClient(client)
     return { client, cleanup: () => {} }
   }
 
@@ -93,6 +97,7 @@ export async function createServerConnection(options: {
 
     console.log(pc.dim("Port range exhausted, attaching to existing server on"), pc.cyan(DEFAULT_SERVER_PORT.toString()))
     const client = createOpencodeClient({ baseUrl: `http://127.0.0.1:${DEFAULT_SERVER_PORT}` })
+    injectServerAuthIntoClient(client)
     return { client, cleanup: () => {} }
   }
 

--- a/src/cli/run/server-connection.ts
+++ b/src/cli/run/server-connection.ts
@@ -5,6 +5,17 @@ import { injectServerAuthIntoClient } from "../../shared/opencode-server-auth"
 import { getAvailableServerPort, isPortAvailable, DEFAULT_SERVER_PORT } from "../../shared/port-utils"
 import { withWorkingOpencodePath } from "./opencode-binary-resolver"
 
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]", "0.0.0.0"])
+
+function isLoopbackAttachUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return LOOPBACK_HOSTS.has(parsed.hostname)
+  } catch {
+    return false
+  }
+}
+
 function isPortStartFailure(error: unknown, port: number): boolean {
   if (!(error instanceof Error)) {
     return false
@@ -41,7 +52,9 @@ export async function createServerConnection(options: {
   if (attach !== undefined) {
     console.log(pc.dim("Attaching to existing server at"), pc.cyan(attach))
     const client = createOpencodeClient({ baseUrl: attach })
-    injectServerAuthIntoClient(client)
+    if (isLoopbackAttachUrl(attach)) {
+      injectServerAuthIntoClient(client)
+    }
     return { client, cleanup: () => {} }
   }
 

--- a/src/shared/opencode-server-auth.ts
+++ b/src/shared/opencode-server-auth.ts
@@ -78,7 +78,7 @@ function tryInjectViaInterceptors(internal: UnknownRecord, auth: string): boolea
     return false
   }
 
-  use((request: Request): Request => {
+  use.call(requestInterceptors, (request: Request): Request => {
     if (!request.headers.get("Authorization")) {
       request.headers.set("Authorization", auth)
     }


### PR DESCRIPTION
Fixes #3513

## Summary

Fixes `oh-my-opencode run --attach` failing with `Unauthorized` against authenticated existing OpenCode servers.

The CLI run path created attach clients without applying server auth injection. After wiring that path, auth injection could still fail because interceptor registration in `src/shared/opencode-server-auth.ts` used an unbound method call.

## Changes

- inject server auth into every CLI-created attach client in:
  - explicit `--attach`
  - occupied-port attach fallback
  - port-became-occupied attach fallback
  - default-port attach fallback
- bind interceptor registration correctly in `src/shared/opencode-server-auth.ts`

## Testing

- reproduced the failure described in #3513 on a fresh authenticated server
- confirmed plain `opencode attach` worked while `oh-my-opencode run --attach` failed before the fix
- verified the attach-auth flow succeeded after applying both changes
- confirmed a real session was created successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Unauthorized errors when attaching to authenticated servers with `oh-my-opencode run --attach` by injecting server auth into attach clients (restricted to loopback URLs) and fixing interceptor binding. Fixes #3513.

- **Bug Fixes**
  - Inject server auth for CLI attach clients across all paths (explicit `--attach`, occupied-port, port-became-occupied, default-port), but only for loopback URLs (`localhost`, `127.0.0.1`, `::1`, `0.0.0.0`).
  - Bind interceptor registration correctly in `src/shared/opencode-server-auth.ts` so the Authorization header is added.

<sup>Written for commit 69315fcad7516818f4a8a7d09e3fd91a7937e636. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

