### PR TITLE
fix: pass process.env to Bun.spawn() in spawnWithWindowsHide

### DIFF
--- a/src/shared/spawn-with-windows-hide.ts
+++ b/src/shared/spawn-with-windows-hide.ts
@@ -68,13 +68,13 @@ function wrapNodeProcess(proc: ChildProcess): SpawnedProcess {
 
 export function spawnWithWindowsHide(command: string[], options: SpawnOptions): SpawnedProcess {
   if (process.platform !== "win32") {
-    return bunSpawn(command, options)
+    return bunSpawn(command, { ...options, env: options.env ?? process.env })
   }
 
   const [cmd, ...args] = command
   const proc = nodeSpawn(cmd, args, {
     cwd: options.cwd,
-    env: options.env,
+    env: options.env ?? process.env,
     stdio: [options.stdin ?? "pipe", options.stdout ?? "pipe", options.stderr ?? "pipe"],
     windowsHide: true,
     shell: true,


### PR DESCRIPTION
When Bun.spawn() is called without an env property, it creates a clean environment instead of inheriting from process.env. This causes proxy environment variables (HTTP_PROXY, HTTPS_PROXY, etc.) to be lost when spawning 'bun install' for plugin installation.

Fixes: fetch() proxy.url must be a non-empty string error when plugin auto-install runs behind a proxy.

## Summary

<!-- Brief description of what this PR does. 1-3 bullet points. -->

- 

## Changes

<!-- What was changed and how. List specific modifications. -->

- 

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Testing

<!-- How to verify this PR works correctly. Delete if not applicable. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure spawned processes inherit the environment by default to avoid losing proxy variables. Pass `process.env` to `Bun.spawn()` (and Windows `spawn`) when `env` isn’t provided, fixing plugin auto-install behind proxies.

- **Bug Fixes**
  - Preserve `HTTP_PROXY`/`HTTPS_PROXY` so `bun install` works during plugin auto-install; resolves “fetch() proxy.url must be a non-empty string”.

<sup>Written for commit 3da9b5dea275881e94100b40183f2c7c60da5cfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

