### PR TITLE
fix(background-agent): ensure parent receives subagent completion result (fixes #2702)

### DIFF
--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -467,6 +467,53 @@ describe("BackgroundManager.getAllDescendantTasks", () => {
   })
 })
 
+describe("BackgroundManager notification fallback", () => {
+  test("queues a pending notification when promptAsync delivery fails", async () => {
+    //#given
+    const promptAsync = spyOn({
+      promptAsync: async () => {
+        throw new Error("network timeout")
+      },
+    }, "promptAsync")
+
+    const client = {
+      session: {
+        prompt: async () => ({}),
+        promptAsync,
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+        status: async () => ({ data: {} }),
+        todo: async () => ({ data: [] }),
+      },
+    }
+    const manager = new BackgroundManager({ client, directory: tmpdir() } as unknown as PluginInput)
+    const task: BackgroundTask = {
+      id: "task-notification-fallback",
+      parentSessionID: "parent-session",
+      parentMessageID: "parent-message",
+      description: "collect READY result",
+      prompt: "return READY",
+      agent: "explore",
+      status: "running",
+      startedAt: new Date(),
+    }
+    getTaskMap(manager).set(task.id, task)
+
+    //#when
+    const completed = await tryCompleteTaskForTest(manager, task)
+    const pendingNotifications = getPendingNotifications(manager)
+
+    //#then
+    expect(completed).toBe(true)
+    expect(task.status).toBe("completed")
+    expect(promptAsync).toHaveBeenCalledTimes(1)
+    expect(pendingNotifications.get(task.parentSessionID)).toHaveLength(1)
+    expect(pendingNotifications.get(task.parentSessionID)?.[0]).toContain(task.description)
+
+    await manager.shutdown()
+  })
+})
+
 describe("BackgroundManager.notifyParentSession - release ordering", () => {
   test("should unblock queued task even when prompt hangs", async () => {
     // given - concurrency limit 1, task1 running, task2 waiting

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -1849,14 +1849,18 @@ export class BackgroundManager {
           })
         } catch (error) {
           if (isAbortedSessionError(error)) {
-            log("[background-agent] Parent session aborted while sending notification; continuing cleanup:", {
+            log("[background-agent] Parent session aborted while sending notification; queued fallback notification:", {
               taskId: task.id,
               parentSessionID: task.parentSessionID,
             })
-            this.queuePendingNotification(task.parentSessionID, notification)
           } else {
-            log("[background-agent] Failed to send notification:", error)
+            log("[background-agent] Failed to send notification; queued fallback notification:", {
+              taskId: task.id,
+              parentSessionID: task.parentSessionID,
+              error,
+            })
           }
+          this.queuePendingNotification(task.parentSessionID, notification)
         }
       } else {
         log("[background-agent] Parent session notifications disabled, skipping prompt injection:", {


### PR DESCRIPTION
## Summary
- Queue the parent notification into the pending fallback path when `promptAsync()` fails during background task completion.
- Add regression coverage for completion delivery failures in the background manager.

## Problem
`@explore` background tasks can complete successfully while the parent session never receives the completion notification. When `notifyParentSession()` hits a transient `promptAsync()` failure, the manager logged the error and cleaned up anyway, so the parent stayed stuck waiting for a result that was never delivered.

## Fix
The notification delivery path now always queues the generated completion message into the fallback pending-notification buffer when direct delivery fails, not just for aborted-session errors. That preserves the subagent result for the parent session's next message cycle and prevents silent loss of the completion handoff.

## Changes
| File | Change |
|------|--------|
| `src/features/background-agent/manager.ts` | Queue fallback notifications for any `promptAsync()` delivery failure in `notifyParentSession()` |
| `src/features/background-agent/manager.test.ts` | Add regression coverage for queued fallback delivery on completion |

Fixes #2702

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure parent sessions always receive subagent completion results by queuing a fallback notification when direct delivery via `promptAsync()` fails. Fixes #2702.

- **Bug Fixes**
  - Queue pending notifications for any `promptAsync()` failure in `notifyParentSession()`, not only aborted sessions.
  - Add regression test to verify fallback delivery when completion notification fails.

<sup>Written for commit 07d7bf7821916095166a729a8f4c687d5a16a2e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

