### PR TITLE
fix(todo-continuation): skip continuation when background tasks are pending (fixes #3362)

### DIFF
--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -79,11 +79,13 @@ export async function injectContinuation(args: {
   }
 
   const hasRunningBgTasks = backgroundManager
-    ? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running")
+    ? backgroundManager
+      .getTasksByParentSession(sessionID)
+      .some((task: { status: string }) => task.status === "pending" || task.status === "running")
     : false
 
   if (hasRunningBgTasks) {
-    log(`[${HOOK_NAME}] Skipped injection: background tasks running`, { sessionID })
+    log(`[${HOOK_NAME}] Skipped injection: background tasks active`, { sessionID })
     return
   }
 

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -71,11 +71,13 @@ export async function handleSessionIdle(args: {
   }
 
   const hasRunningBgTasks = backgroundManager
-    ? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running")
+    ? backgroundManager
+      .getTasksByParentSession(sessionID)
+      .some((task: { status: string }) => task.status === "pending" || task.status === "running")
     : false
 
   if (hasRunningBgTasks) {
-    log(`[${HOOK_NAME}] Skipped: background tasks running`, { sessionID })
+    log(`[${HOOK_NAME}] Skipped: background tasks active`, { sessionID })
     return
   }
 

--- a/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -228,10 +228,10 @@ describe("todo-continuation-enforcer", () => {
     } as any
   }
 
-  function createMockBackgroundManager(runningTasks: boolean = false): BackgroundManager {
+  function createMockBackgroundManager(taskStatus?: "pending" | "running"): BackgroundManager {
     return {
-      getTasksByParentSession: () => runningTasks
-        ? [{ status: "running" }]
+      getTasksByParentSession: () => taskStatus
+        ? [{ status: taskStatus }]
         : [],
     } as any
   }
@@ -262,7 +262,7 @@ describe("todo-continuation-enforcer", () => {
       const sessionID = "main-lazy-prune"
       setMainSession(sessionID)
       const hook = createTodoContinuationEnforcer(createMockPluginInput(), {
-        backgroundManager: createMockBackgroundManager(true),
+        backgroundManager: createMockBackgroundManager("running"),
       })
 
       // when
@@ -283,7 +283,7 @@ describe("todo-continuation-enforcer", () => {
     setMainSession(sessionID)
 
     const hook = createTodoContinuationEnforcer(createMockPluginInput(), {
-      backgroundManager: createMockBackgroundManager(false),
+      backgroundManager: createMockBackgroundManager(),
     })
 
     // when - session goes idle
@@ -350,24 +350,28 @@ describe("todo-continuation-enforcer", () => {
     expect(promptCalls).toHaveLength(0)
   })
 
-  test("should not inject when background tasks are running", async () => {
-    // given - session with running background tasks
+  test("should not inject when background tasks are active", async () => {
+    // given - session with active background tasks
     const sessionID = "main-789"
     setMainSession(sessionID)
 
-    const hook = createTodoContinuationEnforcer(createMockPluginInput(), {
-      backgroundManager: createMockBackgroundManager(true),
-    })
+    for (const taskStatus of ["pending", "running"] as const) {
+      promptCalls.length = 0
 
-    // when - session goes idle
-    await hook.handler({
-      event: { type: "session.idle", properties: { sessionID } },
-    })
+      const hook = createTodoContinuationEnforcer(createMockPluginInput(), {
+        backgroundManager: createMockBackgroundManager(taskStatus),
+      })
 
-    await fakeTimers.advanceBy(3000)
+      // when - session goes idle
+      await hook.handler({
+        event: { type: "session.idle", properties: { sessionID } },
+      })
 
-    // then - no continuation injected
-    expect(promptCalls).toHaveLength(0)
+      await fakeTimers.advanceBy(3000)
+
+      // then - no continuation injected
+      expect(promptCalls).toHaveLength(0)
+    }
   })
 
   test("should inject for any session with incomplete todos", async () => {
@@ -1544,7 +1548,7 @@ describe("todo-continuation-enforcer", () => {
     setMainSession(sessionID)
 
     const hook = createTodoContinuationEnforcer(createMockPluginInput(), {
-      backgroundManager: createMockBackgroundManager(false),
+      backgroundManager: createMockBackgroundManager(),
     })
 
     // when - session goes idle and continuation is injected


### PR DESCRIPTION
## Summary
- Skip todo-continuation injection while background tasks are still pending or running
- Cover the pending-task case in the todo continuation regression test

## Problem
In ULW mode, the todo-continuation enforcer only treated `running` background tasks as active. When the main session was waiting on a queued background task, the idle hook kept injecting continuation prompts even though the agent could not proceed, which created a loop.

## Fix
The todo-continuation idle gate and the final continuation injection gate now both treat `pending` and `running` background tasks as active. This keeps the main session paused until the background work is actually ready and preserves the existing race guard right before prompt injection.

## Changes
| File | Change |
|------|--------|
| `src/hooks/todo-continuation-enforcer/idle-event.ts` | Block continuation while background tasks are pending or running |
| `src/hooks/todo-continuation-enforcer/continuation-injection.ts` | Re-check pending background tasks before injecting continuation |
| `src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts` | Add regression coverage for pending background tasks |

Fixes #3362

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip todo continuation when background tasks are pending or running to prevent the ULW idle loop and keep the main session paused until work is ready. Fixes #3362.

- **Bug Fixes**
  - Treat `pending` and `running` background tasks as active in both the idle gate and the final injection gate.
  - Re-check for active tasks right before injection; update logs to say “background tasks active”.
  - Extend regression tests to cover pending/running tasks and adjust the background manager mock.

<sup>Written for commit a15d4c69dfe8faeb7fc2601c1c9c1b6cc1db31c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

