### PR TITLE
fix(cli): cap Copilot fallback variants below max (fixes #3524)

### DIFF
--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -1411,13 +1411,13 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "momus": {
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "github-copilot/gemini-3.1-pro-preview",
@@ -1425,7 +1425,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
         },
       ],
       "model": "github-copilot/gpt-5.5",
-      "variant": "xhigh",
+      "variant": "high",
     },
     "multimodal-looker": {
       "model": "github-copilot/gpt-5-nano",
@@ -1438,7 +1438,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
       ],
       "model": "github-copilot/gpt-5.5",
@@ -1455,7 +1455,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "sisyphus": {
       "fallback_models": [
@@ -1465,7 +1465,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "sisyphus-junior": {
       "fallback_models": [
@@ -1482,7 +1482,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "github-copilot/gpt-5.5",
@@ -1495,7 +1495,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "github-copilot/gemini-3.1-pro-preview",
@@ -1520,7 +1520,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
       ],
       "model": "github-copilot/gemini-3.1-pro-preview",
@@ -1546,7 +1546,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models when 
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
       ],
       "model": "github-copilot/gemini-3.1-pro-preview",
@@ -1592,13 +1592,13 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "momus": {
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "github-copilot/gemini-3.1-pro-preview",
@@ -1606,7 +1606,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
         },
       ],
       "model": "github-copilot/gpt-5.5",
-      "variant": "xhigh",
+      "variant": "high",
     },
     "multimodal-looker": {
       "model": "github-copilot/gpt-5-nano",
@@ -1619,7 +1619,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
       ],
       "model": "github-copilot/gpt-5.5",
@@ -1636,7 +1636,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "sisyphus": {
       "fallback_models": [
@@ -1646,7 +1646,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "sisyphus-junior": {
       "fallback_models": [
@@ -1663,7 +1663,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "github-copilot/gpt-5.5",
@@ -1676,7 +1676,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "github-copilot/gemini-3.1-pro-preview",
@@ -1701,7 +1701,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
       ],
       "model": "github-copilot/gemini-3.1-pro-preview",
@@ -1715,7 +1715,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "unspecified-low": {
       "fallback_models": [
@@ -1729,7 +1729,7 @@ exports[`generateModelConfig fallback providers uses GitHub Copilot models with 
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
       ],
       "model": "github-copilot/gemini-3.1-pro-preview",
@@ -2203,17 +2203,17 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "momus": {
       "fallback_models": [
         {
           "model": "github-copilot/gpt-5.5",
-          "variant": "xhigh",
+          "variant": "high",
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "github-copilot/gemini-3.1-pro-preview",
@@ -2247,7 +2247,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
       ],
       "model": "openai/gpt-5.5",
@@ -2268,7 +2268,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "sisyphus": {
       "fallback_models": [
@@ -2282,7 +2282,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "sisyphus-junior": {
       "fallback_models": [
@@ -2303,7 +2303,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "openai/gpt-5.5",
@@ -2323,7 +2323,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "github-copilot/gemini-3.1-pro-preview",
@@ -2355,7 +2355,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
       ],
       "model": "openai/gpt-5.5",
@@ -2389,7 +2389,7 @@ exports[`generateModelConfig mixed provider scenarios uses OpenAI + Copilot comb
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
       ],
       "model": "github-copilot/gemini-3.1-pro-preview",
@@ -2687,7 +2687,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "momus": {
       "fallback_models": [
@@ -2697,7 +2697,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -2713,7 +2713,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
       ],
       "model": "github-copilot/gpt-5.5",
-      "variant": "xhigh",
+      "variant": "high",
     },
     "multimodal-looker": {
       "fallback_models": [
@@ -2746,7 +2746,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -2778,7 +2778,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "sisyphus": {
       "fallback_models": [
@@ -2808,7 +2808,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
       ],
       "model": "github-copilot/claude-opus-4.7",
-      "variant": "max",
+      "variant": "high",
     },
     "sisyphus-junior": {
       "fallback_models": [
@@ -2839,7 +2839,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -2863,7 +2863,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -2916,7 +2916,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -2976,7 +2976,7 @@ exports[`generateModelConfig mixed provider scenarios uses all fallback provider
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3083,7 +3083,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3109,7 +3109,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "fallback_models": [
         {
           "model": "github-copilot/gpt-5.5",
-          "variant": "xhigh",
+          "variant": "high",
         },
         {
           "model": "opencode/gpt-5.5",
@@ -3121,7 +3121,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3193,7 +3193,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3207,7 +3207,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3242,7 +3242,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3320,7 +3320,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3355,7 +3355,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3433,7 +3433,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3521,7 +3521,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers togethe
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3634,7 +3634,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3660,7 +3660,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "fallback_models": [
         {
           "model": "github-copilot/gpt-5.5",
-          "variant": "xhigh",
+          "variant": "high",
         },
         {
           "model": "opencode/gpt-5.5",
@@ -3672,7 +3672,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3744,7 +3744,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3758,7 +3758,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3793,7 +3793,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3871,7 +3871,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3906,7 +3906,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3984,7 +3984,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -3998,7 +3998,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
       "fallback_models": [
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",
@@ -4079,7 +4079,7 @@ exports[`generateModelConfig mixed provider scenarios uses all providers with is
         },
         {
           "model": "github-copilot/claude-opus-4.7",
-          "variant": "max",
+          "variant": "high",
         },
         {
           "model": "opencode/claude-opus-4-7",

--- a/src/cli/model-fallback-config-helpers.ts
+++ b/src/cli/model-fallback-config-helpers.ts
@@ -1,0 +1,93 @@
+import type { FallbackModelObject } from "../config/schema/fallback-models"
+import type { FallbackEntry } from "../shared/model-requirements"
+import type { AgentConfig, CategoryConfig, ProviderAvailability } from "./model-fallback-types"
+import { isProviderAvailable } from "./provider-availability"
+import { transformModelForProvider } from "./provider-model-id-transform"
+
+function normalizeVariantForProvider(provider: string, variant?: string): string | undefined {
+	if (!variant || provider !== "github-copilot") {
+		return variant
+	}
+
+	if (variant === "max" || variant === "xhigh") {
+		return "high"
+	}
+
+	return variant
+}
+
+export function normalizeResolvedVariant(model: string, variant?: string): string | undefined {
+	const [provider] = model.split("/", 1)
+	return normalizeVariantForProvider(provider, variant)
+}
+
+function toFallbackModelObject(entry: FallbackEntry, provider: string): FallbackModelObject {
+	const variant = normalizeVariantForProvider(provider, entry.variant)
+
+	return {
+		model: `${provider}/${transformModelForProvider(provider, entry.model)}`,
+		...(variant ? { variant } : {}),
+		...(entry.reasoningEffort ? { reasoningEffort: entry.reasoningEffort as FallbackModelObject["reasoningEffort"] } : {}),
+		...(entry.temperature !== undefined ? { temperature: entry.temperature } : {}),
+		...(entry.top_p !== undefined ? { top_p: entry.top_p } : {}),
+		...(entry.maxTokens !== undefined ? { maxTokens: entry.maxTokens } : {}),
+		...(entry.thinking ? { thinking: entry.thinking } : {}),
+	}
+}
+
+function collectAvailableFallbacks(
+	fallbackChain: FallbackEntry[],
+	availability: ProviderAvailability,
+): FallbackModelObject[] {
+	const expandedFallbacks = fallbackChain.flatMap((entry) =>
+		entry.providers
+			.filter((provider) => isProviderAvailable(provider, availability))
+			.map((provider) => toFallbackModelObject(entry, provider))
+	)
+
+	return expandedFallbacks.filter((entry, index, allEntries) =>
+		allEntries.findIndex((candidate) =>
+			candidate.model === entry.model &&
+			candidate.variant === entry.variant
+		) === index
+	)
+}
+
+export function attachFallbackModels<T extends AgentConfig | CategoryConfig>(
+	config: T,
+	fallbackChain: FallbackEntry[],
+	availability: ProviderAvailability,
+): T {
+	const uniqueFallbacks = collectAvailableFallbacks(fallbackChain, availability)
+	const primaryIndex = uniqueFallbacks.findIndex((entry) => entry.model === config.model)
+	if (primaryIndex === -1) {
+		return config
+	}
+
+	const fallbackModels = uniqueFallbacks.slice(primaryIndex + 1)
+	if (fallbackModels.length === 0) {
+		return config
+	}
+
+	return {
+		...config,
+		fallback_models: fallbackModels,
+	}
+}
+
+export function attachAllFallbackModels<T extends AgentConfig | CategoryConfig>(
+	config: T,
+	fallbackChain: FallbackEntry[],
+	availability: ProviderAvailability,
+): T {
+	const uniqueFallbacks = collectAvailableFallbacks(fallbackChain, availability)
+	const fallbackModels = uniqueFallbacks.filter((entry) => entry.model !== config.model)
+	if (fallbackModels.length === 0) {
+		return config
+	}
+
+	return {
+		...config,
+		fallback_models: fallbackModels,
+	}
+}

--- a/src/cli/model-fallback-copilot-variant.test.ts
+++ b/src/cli/model-fallback-copilot-variant.test.ts
@@ -1,0 +1,81 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+
+import { generateModelConfig } from "./model-fallback"
+import type { InstallConfig } from "./types"
+
+function createConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
+	return {
+		hasClaude: false,
+		isMax20: false,
+		hasOpenAI: false,
+		hasGemini: false,
+		hasCopilot: false,
+		hasOpencodeZen: false,
+		hasZaiCodingPlan: false,
+		hasKimiForCoding: false,
+		hasOpencodeGo: false,
+		hasVercelAiGateway: false,
+		...overrides,
+	}
+}
+
+function collectUnsupportedCopilotVariants(value: unknown): string[] {
+	if (!value || typeof value !== "object") {
+		return []
+	}
+
+	if (Array.isArray(value)) {
+		return value.flatMap((entry) => collectUnsupportedCopilotVariants(entry))
+	}
+
+	const record = value as Record<string, unknown>
+	const model = typeof record.model === "string" ? record.model : undefined
+	const variant = typeof record.variant === "string" ? record.variant : undefined
+	const currentMatch =
+		model?.startsWith("github-copilot/") && (variant === "max" || variant === "xhigh")
+			? [`${model}:${variant}`]
+			: []
+
+	return Object.values(record).reduce<string[]>((matches, entry) => {
+		matches.push(...collectUnsupportedCopilotVariants(entry))
+		return matches
+	}, currentMatch)
+}
+
+describe("generateModelConfig Copilot variants", () => {
+	test("downgrades unsupported Copilot max-class variants when only Copilot is available", () => {
+		const result = generateModelConfig(createConfig({ hasCopilot: true }))
+
+		expect(result.agents?.sisyphus).toEqual({
+			model: "github-copilot/claude-opus-4.7",
+			variant: "high",
+			fallback_models: [{ model: "github-copilot/gpt-5.5", variant: "medium" }],
+		})
+		expect(result.agents?.momus).toEqual({
+			model: "github-copilot/gpt-5.5",
+			variant: "high",
+			fallback_models: [
+				{ model: "github-copilot/claude-opus-4.7", variant: "high" },
+				{ model: "github-copilot/gemini-3.1-pro-preview", variant: "high" },
+			],
+		})
+		expect(result.categories?.["unspecified-high"]).toEqual({
+			model: "github-copilot/claude-sonnet-4.6",
+			fallback_models: [{ model: "github-copilot/gemini-3-flash-preview" }],
+		})
+		expect(collectUnsupportedCopilotVariants(result)).toEqual([])
+	})
+
+	test("keeps Copilot variants capped even when max plan is selected", () => {
+		const result = generateModelConfig(createConfig({ hasCopilot: true, isMax20: true }))
+
+		expect(result.categories?.["unspecified-high"]).toEqual({
+			model: "github-copilot/claude-opus-4.7",
+			variant: "high",
+			fallback_models: [{ model: "github-copilot/gpt-5.5", variant: "high" }],
+		})
+		expect(collectUnsupportedCopilotVariants(result)).toEqual([])
+	})
+})

--- a/src/cli/model-fallback.ts
+++ b/src/cli/model-fallback.ts
@@ -2,13 +2,11 @@ import {
   CLI_AGENT_MODEL_REQUIREMENTS,
   CLI_CATEGORY_MODEL_REQUIREMENTS,
 } from "./model-fallback-requirements"
-import type { FallbackModelObject } from "../config/schema/fallback-models"
-import type { FallbackEntry } from "../shared/model-requirements"
 import type { InstallConfig } from "./types"
 
 import type { AgentConfig, CategoryConfig, GeneratedOmoConfig } from "./model-fallback-types"
 import { applyOpenAiOnlyModelCatalog, isOpenAiOnlyAvailability } from "./openai-only-model-catalog"
-import { isProviderAvailable, toProviderAvailability } from "./provider-availability"
+import { toProviderAvailability } from "./provider-availability"
 import {
 	getSisyphusFallbackChain,
 	isAnyFallbackEntryAvailable,
@@ -16,7 +14,11 @@ import {
 	isRequiredProviderAvailable,
 	resolveModelFromChain,
 } from "./fallback-chain-resolution"
-import { transformModelForProvider } from "./provider-model-id-transform"
+import {
+	attachAllFallbackModels,
+	attachFallbackModels,
+	normalizeResolvedVariant,
+} from "./model-fallback-config-helpers"
 
 export type { GeneratedOmoConfig } from "./model-fallback-types"
 
@@ -24,76 +26,6 @@ const ZAI_MODEL = "zai-coding-plan/glm-4.7"
 
 const ULTIMATE_FALLBACK = "opencode/gpt-5-nano"
 const SCHEMA_URL = "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json"
-
-function toFallbackModelObject(entry: FallbackEntry, provider: string): FallbackModelObject {
-  return {
-    model: `${provider}/${transformModelForProvider(provider, entry.model)}`,
-    ...(entry.variant ? { variant: entry.variant } : {}),
-    ...(entry.reasoningEffort ? { reasoningEffort: entry.reasoningEffort as FallbackModelObject["reasoningEffort"] } : {}),
-    ...(entry.temperature !== undefined ? { temperature: entry.temperature } : {}),
-    ...(entry.top_p !== undefined ? { top_p: entry.top_p } : {}),
-    ...(entry.maxTokens !== undefined ? { maxTokens: entry.maxTokens } : {}),
-    ...(entry.thinking ? { thinking: entry.thinking } : {}),
-  }
-}
-
-function collectAvailableFallbacks(
-  fallbackChain: FallbackEntry[],
-  availability: ReturnType<typeof toProviderAvailability>,
-): FallbackModelObject[] {
-  const expandedFallbacks = fallbackChain.flatMap((entry) =>
-    entry.providers
-      .filter((provider) => isProviderAvailable(provider, availability))
-      .map((provider) => toFallbackModelObject(entry, provider))
-  )
-  return expandedFallbacks.filter((entry, index, allEntries) =>
-    allEntries.findIndex((candidate) =>
-      candidate.model === entry.model &&
-      candidate.variant === entry.variant
-    ) === index
-  )
-}
-
-function attachFallbackModels<T extends AgentConfig | CategoryConfig>(
-  config: T,
-  fallbackChain: FallbackEntry[],
-  availability: ReturnType<typeof toProviderAvailability>,
-): T {
-  const uniqueFallbacks = collectAvailableFallbacks(fallbackChain, availability)
-  const primaryIndex = uniqueFallbacks.findIndex((entry) => entry.model === config.model)
-  if (primaryIndex === -1) {
-    return config
-  }
-
-  const fallbackModels = uniqueFallbacks.slice(primaryIndex + 1)
-  if (fallbackModels.length === 0) {
-    return config
-  }
-
-  return {
-    ...config,
-    fallback_models: fallbackModels,
-  }
-}
-
-function attachAllFallbackModels<T extends AgentConfig | CategoryConfig>(
-  config: T,
-  fallbackChain: FallbackEntry[],
-  availability: ReturnType<typeof toProviderAvailability>,
-): T {
-  const uniqueFallbacks = collectAvailableFallbacks(fallbackChain, availability)
-  const fallbackModels = uniqueFallbacks.filter((entry) => entry.model !== config.model)
-  if (fallbackModels.length === 0) {
-    return config
-  }
-
-  return {
-    ...config,
-    fallback_models: fallbackModels,
-  }
-}
-
-
 
 export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
   const avail = toProviderAvailability(config)
@@ -170,7 +102,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
       }
       const resolved = resolveModelFromChain(fallbackChain, avail)
       if (resolved) {
-        const variant = resolved.variant ?? req.variant
+        const variant = normalizeResolvedVariant(resolved.model, resolved.variant ?? req.variant)
         const agentConfig = variant ? { model: resolved.model, variant } : { model: resolved.model }
         agents[role] = attachFallbackModels(agentConfig, fallbackChain, avail)
       }
@@ -186,7 +118,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
 
     const resolved = resolveModelFromChain(req.fallbackChain, avail)
     if (resolved) {
-      const variant = resolved.variant ?? req.variant
+      const variant = normalizeResolvedVariant(resolved.model, resolved.variant ?? req.variant)
       const agentConfig = variant ? { model: resolved.model, variant } : { model: resolved.model }
       agents[role] = attachFallbackModels(agentConfig, req.fallbackChain, avail)
     } else {
@@ -210,7 +142,7 @@ export function generateModelConfig(config: InstallConfig): GeneratedOmoConfig {
 
     const resolved = resolveModelFromChain(fallbackChain, avail)
     if (resolved) {
-      const variant = resolved.variant ?? req.variant
+      const variant = normalizeResolvedVariant(resolved.model, resolved.variant ?? req.variant)
       const categoryConfig = variant ? { model: resolved.model, variant } : { model: resolved.model }
       categories[cat] = attachFallbackModels(categoryConfig, fallbackChain, avail)
     } else {


### PR DESCRIPTION
## Summary
- cap GitHub Copilot model variants at `high` during CLI config generation
- normalize Copilot fallback variants and cover the regression with dedicated tests

## Problem
The installer reused shared fallback-chain variants verbatim, so Copilot-only setups could emit `max` or `xhigh` variants that Copilot Pro+ does not support. That left generated configs pointing agents and fallback chains at unsupported reasoning effort levels.

## Fix
I extracted the CLI fallback config assembly helpers and normalized Copilot `max` and `xhigh` variants down to `high` before writing primary or fallback model entries. I also added a focused regression test and refreshed the existing CLI snapshots so Copilot-only and mixed-provider configs stop assigning unsupported variants.

## Changes
| File | Change |
|------|--------|
| `src/cli/model-fallback.ts` | Normalize resolved variants and delegate fallback config assembly |
| `src/cli/model-fallback-config-helpers.ts` | Add provider-aware fallback config helpers and Copilot variant capping |
| `src/cli/model-fallback-copilot-variant.test.ts` | Add regression coverage for Copilot-only variant selection |
| `src/cli/__snapshots__/model-fallback.test.ts.snap` | Update expected generated configs for Copilot variant normalization |

Fixes #3524

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps GitHub Copilot variants to "high" in CLI-generated primary and fallback configs (including resolved chains) to avoid unsupported "max"/"xhigh" values. Adds targeted tests and moves provider-aware fallback assembly and normalization into shared helpers.

- **Bug Fixes**
  - Normalize Copilot "max"/"xhigh" variants to "high" for agents and categories, including fallbacks and Max plan cases.
  - Stop emitting unsupported variants in Copilot-only and mixed-provider configs; refreshed snapshots.

- **Refactors**
  - Introduced provider-aware helpers to collect/dedupe fallbacks and normalize variants; removed duplicated logic from `model-fallback.ts`.

<sup>Written for commit 4a2241553c464314e2df97968c157297a5b41235. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

