### PR TITLE
fix(schema): flatten skills JSON schema intersection

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -1990,113 +1990,103 @@
           }
         },
         {
-          "allOf": [
-            {
-              "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
-              "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "sources": {
+              "type": "array",
+              "items": {
                 "anyOf": [
                   {
-                    "type": "boolean"
+                    "type": "string"
                   },
                   {
                     "type": "object",
                     "properties": {
-                      "description": {
+                      "path": {
                         "type": "string"
                       },
-                      "template": {
-                        "type": "string"
-                      },
-                      "from": {
-                        "type": "string"
-                      },
-                      "model": {
-                        "type": "string"
-                      },
-                      "agent": {
-                        "type": "string"
-                      },
-                      "subtask": {
+                      "recursive": {
                         "type": "boolean"
                       },
-                      "argument-hint": {
+                      "glob": {
                         "type": "string"
-                      },
-                      "license": {
-                        "type": "string"
-                      },
-                      "compatibility": {
-                        "type": "string"
-                      },
-                      "metadata": {
-                        "type": "object",
-                        "propertyNames": {
-                          "type": "string"
-                        },
-                        "additionalProperties": {}
-                      },
-                      "allowed-tools": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "disable": {
-                        "type": "boolean"
                       }
-                    }
+                    },
+                    "required": [
+                      "path"
+                    ]
                   }
                 ]
               }
             },
-            {
-              "type": "object",
-              "properties": {
-                "sources": {
-                  "type": "array",
-                  "items": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "path": {
-                            "type": "string"
-                          },
-                          "recursive": {
-                            "type": "boolean"
-                          },
-                          "glob": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "path"
-                        ]
-                      }
-                    ]
-                  }
-                },
-                "enable": {
-                  "type": "array",
-                  "items": {
+            "enable": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "disable": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "description": {
                     "type": "string"
-                  }
-                },
-                "disable": {
-                  "type": "array",
-                  "items": {
+                  },
+                  "template": {
                     "type": "string"
+                  },
+                  "from": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "agent": {
+                    "type": "string"
+                  },
+                  "subtask": {
+                    "type": "boolean"
+                  },
+                  "argument-hint": {
+                    "type": "string"
+                  },
+                  "license": {
+                    "type": "string"
+                  },
+                  "compatibility": {
+                    "type": "string"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  },
+                  "allowed-tools": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "disable": {
+                    "type": "boolean"
                   }
                 }
               }
-            }
-          ]
+            ]
+          }
         }
       ]
     },

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import * as z from "zod"
 import { AgentOverrideConfigSchema, BuiltinCategoryNameSchema, CategoryConfigSchema, OhMyOpenCodeConfigSchema } from "./schema"
 
 describe("disabled_mcps schema", () => {
@@ -506,5 +507,29 @@ describe("Sisyphus-Junior agent override", () => {
       expect(result.data.agents?.metis?.category).toBe("ultrabrain")
       expect(result.data.agents?.momus?.category).toBe("quick")
     }
+  })
+})
+
+describe("generated JSON schema", () => {
+  test("does not serialize skills config as an allOf intersection", () => {
+    // #when
+    const jsonSchema = z.toJSONSchema(OhMyOpenCodeConfigSchema, {
+      io: "input",
+      target: "draft-7",
+    }) as {
+      properties?: {
+        skills?: {
+          anyOf?: Array<Record<string, unknown>>
+        }
+      }
+    }
+
+    const skillsObjectBranch = jsonSchema.properties?.skills?.anyOf?.find(
+      branch => branch.type === "object"
+    )
+
+    // #then
+    expect(skillsObjectBranch).toBeDefined()
+    expect(skillsObjectBranch).not.toHaveProperty("allOf")
   })
 })

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -261,11 +261,11 @@ export const SkillEntrySchema = z.union([
 
 export const SkillsConfigSchema = z.union([
   z.array(z.string()),
-  z.record(z.string(), SkillEntrySchema).and(z.object({
+  z.object({
     sources: z.array(SkillSourceSchema).optional(),
     enable: z.array(z.string()).optional(),
     disable: z.array(z.string()).optional(),
-  }).partial()),
+  }).catchall(SkillEntrySchema),
 ])
 
 export const RalphLoopConfigSchema = z.object({


### PR DESCRIPTION
## Summary
- replace the `skills` schema intersection on `master` with a single object branch using `catchall`, so `skills.sources` no longer serializes into a contradictory `allOf`
- add a regression test that fails if the generated JSON schema emits the old intersection shape again
- regenerate `assets/oh-my-opencode.schema.json` for the raw `master` artifact served to users

## Verification
- `bun test src/config/schema.test.ts`
- `bun run typecheck`
- `bun run build`

## Related
- fixes #3549

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattened the `skills` JSON schema to a single object with `catchall`, removing the `allOf` intersection so `skills.sources` validates correctly. Added a regression test and regenerated `assets/oh-my-opencode.schema.json`. Fixes #3549.

<sup>Written for commit 0f5d63cc447475db2b66b1348ff5765896be7909. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

