### PR TITLE
fix(agents): remove ZWSP sort prefixes that garble agent names in terminals (fixes #3485)

### DIFF
--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -194,11 +194,14 @@ describe("getAgentConfigKey", () => {
 })
 
 describe("getAgentListDisplayName", () => {
-  it("applies invisible stable-sort prefixes to the core agent list", () => {
-    expect(getAgentListDisplayName("sisyphus")).toBe("\u200BSisyphus - Ultraworker")
-    expect(getAgentListDisplayName("hephaestus")).toBe("\u200B\u200BHephaestus - Deep Agent")
-    expect(getAgentListDisplayName("prometheus")).toBe("\u200B\u200B\u200BPrometheus - Plan Builder")
-    expect(getAgentListDisplayName("atlas")).toBe("\u200B\u200B\u200B\u200BAtlas - Plan Executor")
+  it("returns clean display names without ZWSP sort prefixes", () => {
+    // ZWSP prefixes were removed because they render as garbled characters
+    // in many terminals (Windows Terminal, WezTerm, xterm-256color).
+    // Sort order is now handled by the `order` field in agent-priority-order.ts.
+    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentListDisplayName("hephaestus")).toBe("Hephaestus - Deep Agent")
+    expect(getAgentListDisplayName("prometheus")).toBe("Prometheus - Plan Builder")
+    expect(getAgentListDisplayName("atlas")).toBe("Atlas - Plan Executor")
   })
 
   it("keeps non-core agents unprefixed for list display", () => {

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -26,11 +26,15 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
   "council-member": "council-member",
 }
 
+// Previously used ZWSP (\u200B) prefixes to force sort order in OpenCode's
+// localeCompare-based agent list. Removed because ZWSP renders as visible
+// garbled characters in many terminals (Windows Terminal, WezTerm, xterm-256color).
+// Sort order is now handled by the `order` field injected in agent-priority-order.ts.
 const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {
-  sisyphus: "\u200B",
-  hephaestus: "\u200B\u200B",
-  prometheus: "\u200B\u200B\u200B",
-  atlas: "\u200B\u200B\u200B\u200B",
+  sisyphus: "",
+  hephaestus: "",
+  prometheus: "",
+  atlas: "",
 }
 
 const INVISIBLE_AGENT_CHARACTERS_REGEX = /[\u200B\u200C\u200D\uFEFF]/g


### PR DESCRIPTION
## Summary
- Remove zero-width space (ZWSP) sort prefixes from agent names to fix garbled TUI rendering

## Problem
Agent names in the OpenCode TUI appear garbled on many terminals (Windows Terminal, WezTerm, xterm-256color). The root cause is ZWSP characters (`\u200B`) prepended to agent names for sort ordering. These invisible Unicode characters render as visible garbled blocks or cause character clipping in terminals that don't handle them gracefully.

## Fix
Set all `AGENT_LIST_SORT_PREFIXES` values to empty strings, removing ZWSP from agent `name` fields entirely. Agent sort order is already handled by the `order` field injected via `agent-priority-order.ts`. Updated tests to expect clean display names.

## Changes
| File | Change |
|------|--------|
| `src/shared/agent-display-names.ts` | Set ZWSP sort prefixes to empty strings |
| `src/shared/agent-display-names.test.ts` | Update assertions to expect clean names without ZWSP |

Fixes #3485

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed zero-width space sort prefixes from agent names to fix garbled TUI rendering in terminals (Windows Terminal, WezTerm, xterm-256color). Sorting now uses the injected `order` field; tests updated to expect clean names.

<sup>Written for commit 5d97d82f23542383fb4737e0d68c1bcc021108ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

