### PR TITLE
fix(chat-params): guard against zero maxOutputTokens from custom providers (fixes #3410)

### DIFF
--- a/src/plugin/chat-params.ts
+++ b/src/plugin/chat-params.ts
@@ -96,7 +96,7 @@ export function createChatParamsHandler(args: {
       if (storedPromptParams.topP !== undefined) {
         output.topP = storedPromptParams.topP
       }
-      if (storedPromptParams.maxOutputTokens !== undefined) {
+      if (storedPromptParams.maxOutputTokens !== undefined && storedPromptParams.maxOutputTokens > 0) {
         (output as Record<string, unknown>).maxOutputTokens = storedPromptParams.maxOutputTokens
       }
       if (storedPromptParams.options) {
@@ -162,9 +162,12 @@ export function createChatParamsHandler(args: {
     }
 
     if ("maxTokens" in compatibility) {
-      if (compatibility.maxTokens !== undefined) {
+      if (compatibility.maxTokens !== undefined && compatibility.maxTokens > 0) {
         output.maxOutputTokens = compatibility.maxTokens
       } else {
+        // Remove invalid maxOutputTokens (0 or undefined) so the provider
+        // uses its own default. Custom OpenAI-compatible providers may report
+        // limit.output as 0 for models with unknown output caps.
         delete output.maxOutputTokens
       }
     }


### PR DESCRIPTION
## Summary
- Prevent the plugin from setting maxOutputTokens to 0 when custom OpenAI-compatible providers report no output limit

## Problem
Custom OpenAI-compatible providers (e.g., local Qwen models) may report `limit.output` as 0 in their model metadata because the model's maximum output tokens is unknown. The plugin's `chat.params` handler passes this zero value through to OpenCode, which then sends `maxOutputTokens: 0` to the API. The API rejects with "Invalid argument for parameter maxOutputTokens: maxOutputTokens must be >= 1". Without the plugin installed, OpenCode handles this correctly by not setting the parameter.

## Fix
Added a `> 0` guard in two places within `chat-params.ts`:
1. When applying stored prompt params (from session state)
2. When applying model settings compatibility results

When `maxOutputTokens` is 0 or undefined, the parameter is deleted from the output so the provider uses its own default limit.

## Changes
| File | Change |
|------|--------|
| `src/plugin/chat-params.ts` | Guard against zero maxOutputTokens in both stored params and compatibility resolution paths |

Fixes #3410

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard against zero `maxOutputTokens` from custom OpenAI-compatible providers to avoid API errors and let providers use their default limits. Fixes #3410.

- **Bug Fixes**
  - Set `maxOutputTokens` only if stored param > 0.
  - Apply `compatibility.maxTokens` only if > 0; otherwise delete `maxOutputTokens` from output.

<sup>Written for commit 2b4725a7b370f5558fe20a9e56ca78887339c3e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

