### PR TITLE
fix(delegate-task): detect error state and thinking parts in sync poller (fixes #3421)

### DIFF
--- a/src/tools/delegate-task/sync-session-poller.test.ts
+++ b/src/tools/delegate-task/sync-session-poller.test.ts
@@ -342,6 +342,96 @@ describe("pollSyncSession", () => {
       expect(result).toBeNull()
       expect(callCount).toBeGreaterThan(1)
     })
+
+    test("returns failure string when sessionStatus reports error (issue #3421)", async () => {
+      // given: session enters error state with assistant error info available
+      const { pollSyncSession } = require("./sync-session-poller")
+
+      const mockClient = {
+        session: {
+          messages: async () => ({
+            data: [
+              { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+              {
+                info: {
+                  id: "msg_002",
+                  role: "assistant",
+                  time: { created: 2000 },
+                  error: { data: { message: "Provider connection lost" } },
+                },
+                parts: [],
+              },
+            ],
+          }),
+          status: async () => ({ data: { ses_test: { type: "error" } } }),
+        },
+      }
+
+      // when: calling pollSyncSession
+      const result = await pollSyncSession(createMockCtx(), mockClient, {
+        sessionID: "ses_test",
+        agentToUse: "test-agent",
+        toastManager: null,
+        taskId: undefined,
+      })
+
+      // then: returns failure string instead of null (so caller does not treat as success)
+      expect(result).toBe("Provider connection lost")
+    })
+
+    test("returns generic error when sessionStatus reports error and messages are empty (issue #3421)", async () => {
+      // given: session enters error state but no terminal assistant error available
+      const { pollSyncSession } = require("./sync-session-poller")
+
+      const mockClient = {
+        session: {
+          messages: async () => ({ data: [] }),
+          status: async () => ({ data: { ses_test_empty: { type: "error" } } }),
+        },
+      }
+
+      // when: calling pollSyncSession
+      const result = await pollSyncSession(createMockCtx(), mockClient, {
+        sessionID: "ses_test_empty",
+        agentToUse: "test-agent",
+        toastManager: null,
+        taskId: undefined,
+      })
+
+      // then: returns generic session-id-bearing error so caller can surface failure
+      expect(result).toBe("Session ses_test_empty entered error state")
+    })
+
+    test("detects assistant thinking parts via .thinking field for fallback completion (issue #3421)", async () => {
+      // given: assistant emitted thinking parts (Anthropic-style: text empty, content in .thinking)
+      const { pollSyncSession } = require("./sync-session-poller")
+
+      const mockClient = {
+        session: {
+          messages: async () => ({
+            data: [
+              { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+              {
+                info: { id: "msg_002", role: "assistant", time: { created: 2000 } },
+                parts: [{ type: "thinking", thinking: "Considering the request" }],
+              },
+            ],
+          }),
+          status: async () => ({ data: { ses_thinking: { type: "idle" } } }),
+        },
+      }
+
+      // when: calling pollSyncSession
+      const result = await pollSyncSession(createMockCtx(), mockClient, {
+        sessionID: "ses_thinking",
+        agentToUse: "test-agent",
+        toastManager: null,
+        taskId: undefined,
+      })
+
+      // then: returns null (success) because thinking content was detected
+      expect(result).toBeNull()
+    })
   })
 
   describe("abort handling", () => {

--- a/src/tools/delegate-task/sync-session-poller.ts
+++ b/src/tools/delegate-task/sync-session-poller.ts
@@ -136,6 +136,18 @@ export async function pollSyncSession(
       })
     }
 
+    if (sessionStatus && sessionStatus.type === "error") {
+      log("[task] Session entered error state, surfacing failure", { sessionID: input.sessionID })
+      let messages: SessionMessage[] = []
+      try {
+        messages = await fetchSessionMessages(client, input.sessionID)
+      } catch (error) {
+        log("[task] Failed to fetch messages on error state", { sessionID: input.sessionID, error: String(error) })
+      }
+      const errorFromMessages = getTerminalSessionError(messages)
+      return errorFromMessages ?? `Session ${input.sessionID} entered error state`
+    }
+
     if (sessionStatus && sessionStatus.type !== "idle") {
       continue
     }
@@ -184,9 +196,14 @@ export async function pollSyncSession(
       if (m.info?.role !== "assistant") return false
       const parts = m.parts ?? []
       return parts.some((p) => {
-        if (p.type !== "text" && p.type !== "reasoning") return false
-        const text = (p.text ?? "").trim()
-        return text.length > 0
+        if (p.type === "text" || p.type === "reasoning") {
+          return (p.text ?? "").trim().length > 0
+        }
+        if (p.type === "thinking") {
+          const thinkingText = (p as { thinking?: string }).thinking ?? p.text ?? ""
+          return thinkingText.trim().length > 0
+        }
+        return false
       })
     })
 


### PR DESCRIPTION
## Summary
- Fix sync task() calls hanging indefinitely when used with agents that have extended thinking enabled on Anthropic models

## Problem
When calling `task()` with `run_in_background=false` for agents configured with `thinking: { type: "enabled" }` (like Metis or Momus) on Anthropic models, the sync polling loop hangs for up to 30 minutes. The session may enter an error state due to thinking configuration issues, but the poller only checks for "idle" status -- any other status (including "error") causes it to continue looping. Additionally, Anthropic thinking blocks (part type "thinking") are not recognized as valid assistant content in the fallback completion detector.

## Fix
Two changes in `sync-session-poller.ts`:
1. Break out of the poll loop when session status is "error" instead of continuing to poll
2. Add "thinking" to the recognized part types alongside "text" and "reasoning" in the fallback assistant content detector

## Changes
| File | Change |
|------|--------|
| `src/tools/delegate-task/sync-session-poller.ts` | Detect error state to stop polling; recognize thinking parts as valid assistant content |

Fixes #3421

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sync `task()` hangs with Anthropic agents using extended thinking by surfacing errors and recognizing `thinking` parts to avoid long polling loops. Fixes #3421.

- **Bug Fixes**
  - Return a failure message and stop polling when session status is `error` (use assistant error if present; otherwise a generic message with the session ID).
  - Treat Anthropic `thinking` parts as valid assistant content in the fallback detector by reading `part.thinking` (and `part.text`).

<sup>Written for commit 05b1c63081327432eee2f1d55c8ed9984f58d19c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

