### PR TITLE
fix(todo-continuation): ignore activity signals after injection to prevent runaway loop (fixes #3446)

### DIFF
--- a/src/hooks/todo-continuation-enforcer/session-state.ts
+++ b/src/hooks/todo-continuation-enforcer/session-state.ts
@@ -184,9 +184,12 @@ export function createSessionStateStore(): SessionStateStore {
       }
     }
 
+    // After a continuation injection, only actual todo changes count as progress.
+    // Activity signals (e.g. assistant text responses) must NOT reset stagnation
+    // after injection, otherwise blocked tasks cause infinite continuation loops.
     const progressSource = incompleteCount < previousIncompleteCount || hasCompletedMoreTodos || hasTodoSnapshotChanged
       ? "todo"
-      : hasObservedExternalActivity
+      : (hasObservedExternalActivity && !hadSuccessfulInjectionAwaitingProgressCheck)
         ? "activity"
         : "none"
 


### PR DESCRIPTION
## Summary
- Prevent infinite BOULDER CONTINUATION loops when the agent repeatedly identifies a blocked task without making actual todo progress

## Problem
When an agent encounters a blocked task, it produces text explaining why it is blocked but fails to edit the plan file. The todo-continuation enforcer treats each assistant response as an "activity signal", which resets the stagnation counter to 0. Because stagnation never reaches `MAX_STAGNATION_COUNT` (3), the continuation loop runs indefinitely -- the reporter observed a 6-hour loop.

Root cause: `trackContinuationProgress()` in `session-state.ts` allows activity signals (any assistant message) to count as "progress" even after a continuation injection. This prevents the stagnation detector from ever stopping the loop.

## Fix
After a continuation injection (`awaitingPostInjectionProgressCheck = true`), only actual todo changes (completed items, changed snapshots) count as progress. Activity signals from assistant text responses are ignored during the post-injection progress check, so the stagnation counter properly increments and reaches the max threshold to stop the loop.

## Changes
| File | Change |
|------|--------|
| `src/hooks/todo-continuation-enforcer/session-state.ts` | Skip activity-based progress when awaiting post-injection progress check |

Fixes #3446

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents runaway todo-continuation loops by ignoring assistant activity signals after a continuation injection. Only real todo changes count as progress so the stagnation counter can stop the loop. Fixes #3446.

- **Bug Fixes**
  - In `src/hooks/todo-continuation-enforcer/session-state.ts`, set "activity" progress only when not awaiting a post-injection progress check.
  - Ensures activity signals don’t reset stagnation; the loop exits when no todo progress occurs.

<sup>Written for commit 03311acf2a6ad56a681abeb89a39b7f00b488415. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

