### PR TITLE
docs(agents): add YAML frontmatter to AGENTS.md documentation files

### DIFF
--- a/src/agents/AGENTS.md
+++ b/src/agents/AGENTS.md
@@ -1,3 +1,8 @@
+---
+name: agents-directory
+description: Developer reference for all 11 Oh My OpenAgent agent definitions, factory patterns, tool restrictions, and model routing.
+---
+
 # src/agents/ — 11 Agent Definitions
 
 **Generated:** 2026-04-18

--- a/src/agents/hephaestus/AGENTS.md
+++ b/src/agents/hephaestus/AGENTS.md
@@ -1,3 +1,8 @@
+---
+name: hephaestus-agent
+description: Developer reference for the Hephaestus autonomous deep worker agent — model variants, key behaviors, and delegation patterns.
+---
+
 # src/agents/hephaestus/ -- Autonomous Deep Worker
 
 **Generated:** 2026-04-11

--- a/src/agents/prometheus/AGENTS.md
+++ b/src/agents/prometheus/AGENTS.md
@@ -1,3 +1,8 @@
+---
+name: prometheus-agent
+description: Developer reference for the Prometheus strategic planner agent — interview flow, plan output format, and key constraints.
+---
+
 # src/agents/prometheus/ -- Strategic Planner
 
 **Generated:** 2026-04-11

--- a/src/agents/sisyphus/AGENTS.md
+++ b/src/agents/sisyphus/AGENTS.md
@@ -1,3 +1,8 @@
+---
+name: sisyphus-variants
+description: Developer reference for Sisyphus orchestrator model-specific prompt variants — selection logic and key exports.
+---
+
 # src/agents/sisyphus/ -- Orchestrator Variants
 
 **Generated:** 2026-04-11


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What

Adds YAML frontmatter (`name` + `description`) to four auto-generated `AGENTS.md` documentation files:

- `src/agents/AGENTS.md`
- `src/agents/hephaestus/AGENTS.md`
- `src/agents/prometheus/AGENTS.md`
- `src/agents/sisyphus/AGENTS.md`

## Why it matters

These files are recognized by NL tooling (e.g. OpenCode skill/agent indexing) as NL artifacts. Without `name` and `description` in YAML frontmatter, they cannot be registered, discovered, or indexed — they silently fail to appear in any registry lookup. The content of each file is already high-quality; the frontmatter is the only missing piece.

The descriptions were derived directly from each file's existing heading and purpose summary, so no new information is introduced.

## The fix

Each file gets a minimal three-line frontmatter block prepended:

```yaml
---
name: <kebab-case name matching the agent/directory>
description: <one-sentence summary drawn from the file's own overview>
---
```

No existing content is modified. This is a purely additive, zero-risk change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds YAML frontmatter (name and description) to four auto-generated AGENTS.md files under `src/agents` so NL tooling can discover and index them. Prepend-only docs change; no existing content is modified.

<sup>Written for commit 53e3061b4c7f437b831f53391034685af3bc0388. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

