### PR TITLE
fix(agent-display): remove ZWSP sort prefixes that truncate agent names

### DIFF
--- a/src/cli/run/agent-resolver.ts
+++ b/src/cli/run/agent-resolver.ts
@@ -1,7 +1,7 @@
 import pc from "picocolors"
 import type { RunOptions } from "./types"
 import type { OhMyOpenCodeConfig } from "../../config"
-import { getAgentConfigKey, getAgentDisplayName, getAgentRuntimeName } from "../../shared/agent-display-names"
+import { getAgentConfigKey, getAgentDisplayName } from "../../shared/agent-display-names"
 
 const CORE_AGENT_ORDER = ["sisyphus", "hephaestus", "prometheus", "atlas"] as const
 const DEFAULT_AGENT = "sisyphus"
@@ -21,12 +21,11 @@ const normalizeAgentName = (agent?: string): ResolvedAgent | undefined => {
 
   const configKey = getAgentConfigKey(trimmed)
   const displayName = getAgentDisplayName(configKey)
-  const runtimeName = getAgentRuntimeName(configKey)
   const isKnownAgent = displayName !== configKey
 
   return {
     configKey,
-    resolvedName: isKnownAgent ? runtimeName : trimmed,
+    resolvedName: isKnownAgent ? displayName : trimmed,
   }
 }
 
@@ -62,13 +61,12 @@ export const resolveRunAgent = (
     envAgent ??
     configAgent ?? {
       configKey: DEFAULT_AGENT,
-      resolvedName: getAgentRuntimeName(DEFAULT_AGENT),
+      resolvedName: getAgentDisplayName(DEFAULT_AGENT),
     }
 
   if (isAgentDisabled(resolved.configKey, pluginConfig)) {
     const fallback = pickFallbackAgent(pluginConfig)
     const fallbackDisplayName = getAgentDisplayName(fallback)
-    const fallbackRuntimeName = getAgentRuntimeName(fallback)
     const fallbackDisabled = isAgentDisabled(fallback, pluginConfig)
     if (fallbackDisabled) {
       console.log(
@@ -76,14 +74,14 @@ export const resolveRunAgent = (
           `Requested agent "${resolved.resolvedName}" is disabled and no enabled core agent was found. Proceeding with "${fallbackDisplayName}".`
         )
       )
-      return fallbackRuntimeName
+      return fallbackDisplayName
     }
     console.log(
       pc.yellow(
         `Requested agent "${resolved.resolvedName}" is disabled. Falling back to "${fallbackDisplayName}".`
       )
     )
-    return fallbackRuntimeName
+    return fallbackDisplayName
   }
 
   return resolved.resolvedName

--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -9,13 +9,13 @@ import type { OhMyOpenCodeConfig } from "../config"
 import * as agentLoader from "../features/claude-code-agent-loader"
 import * as skillLoader from "../features/opencode-skill-loader"
 import type { LoadedSkill } from "../features/opencode-skill-loader"
-import { getAgentListDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+import { getAgentDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
 import { applyAgentConfig } from "./agent-config-handler"
 import type { PluginComponents } from "./plugin-components-loader"
 
-const BUILTIN_SISYPHUS_DISPLAY_NAME = getAgentListDisplayName("sisyphus")
-const BUILTIN_SISYPHUS_JUNIOR_DISPLAY_NAME = getAgentListDisplayName("sisyphus-junior")
-const BUILTIN_MULTIMODAL_LOOKER_DISPLAY_NAME = getAgentListDisplayName("multimodal-looker")
+const BUILTIN_SISYPHUS_DISPLAY_NAME = getAgentDisplayName("sisyphus")
+const BUILTIN_SISYPHUS_JUNIOR_DISPLAY_NAME = getAgentDisplayName("sisyphus-junior")
+const BUILTIN_MULTIMODAL_LOOKER_DISPLAY_NAME = getAgentDisplayName("multimodal-looker")
 
 function createPluginComponents(): PluginComponents {
   return {
@@ -184,8 +184,8 @@ describe("applyAgentConfig builtin override protection", () => {
     })
 
     // then every registered agent key must be HTTP-header-safe (no parentheses)
-    // Parentheses in agent names cause HTTP header validation errors in
-    // x-opencode-agent-name and prevent the agents from showing in the OpenCode UI.
+    // Agent keys can flow into HTTP header values in some plugin paths.
+    // Parentheses and ZWSP characters violate RFC 7230 header value rules.
     for (const key of Object.keys(result)) {
       expect(key).not.toMatch(/[()]/)
     }

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -2,7 +2,7 @@ import { createBuiltinAgents } from "../agents";
 import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
 import type { OhMyOpenCodeConfig } from "../config";
 import { isTaskSystemEnabled, log, migrateAgentConfig } from "../shared";
-import { getAgentRuntimeName } from "../shared/agent-display-names";
+import { getAgentDisplayName } from "../shared/agent-display-names";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { registerAgentName } from "../features/claude-code-session-state";
 import {
@@ -190,10 +190,10 @@ export async function applyAgentConfig(params: {
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
     if (configuredDefaultAgent) {
       (params.config as { default_agent?: string }).default_agent =
-        getAgentRuntimeName(configuredDefaultAgent);
+        getAgentDisplayName(configuredDefaultAgent);
     } else {
       (params.config as { default_agent?: string }).default_agent =
-        getAgentRuntimeName("sisyphus");
+        getAgentDisplayName("sisyphus");
     }
 
     // Assembly order: Sisyphus -> Hephaestus -> Prometheus -> Atlas

--- a/src/plugin-handlers/agent-key-remapper.test.ts
+++ b/src/plugin-handlers/agent-key-remapper.test.ts
@@ -1,8 +1,59 @@
 import { describe, it, expect } from "bun:test"
 import { remapAgentKeysToDisplayNames } from "./agent-key-remapper"
-import { getAgentDisplayName, getAgentListDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
+
+const ZWSP_REGEX = /[\u200B\u200C\u200D\uFEFF]/
 
 describe("remapAgentKeysToDisplayNames", () => {
+  it("object keys must not contain ZWSP characters (RFC 7230)", () => {
+    // given all core agents with ZWSP-based ordering
+    const agents = {
+      sisyphus: { prompt: "test" },
+      hephaestus: { prompt: "test" },
+      prometheus: { prompt: "test" },
+      atlas: { prompt: "test" },
+    }
+
+    // when remapping
+    const result = remapAgentKeysToDisplayNames(agents)
+
+    // then NO object key should contain ZWSP (RFC 7230 compliance)
+    for (const key of Object.keys(result)) {
+      expect(key).not.toMatch(ZWSP_REGEX)
+    }
+  })
+
+  it("name field MUST NOT contain ZWSP (sorting handled by order field)", () => {
+    // given core agents
+    const agents = {
+      sisyphus: { prompt: "test" },
+      hephaestus: { prompt: "test" },
+      prometheus: { prompt: "test" },
+      atlas: { prompt: "test" },
+    }
+
+    // when remapping
+    const result = remapAgentKeysToDisplayNames(agents)
+
+    // then name fields MUST NOT have ZWSP (sorting is handled by order field)
+    const sisyphusConfig = result[getAgentDisplayName("sisyphus")] as Record<string, unknown>
+    const hephaestusConfig = result[getAgentDisplayName("hephaestus")] as Record<string, unknown>
+    const prometheusConfig = result[getAgentDisplayName("prometheus")] as Record<string, unknown>
+    const atlasConfig = result[getAgentDisplayName("atlas")] as Record<string, unknown>
+
+    expect(sisyphusConfig.name).not.toMatch(ZWSP_REGEX)
+    expect(hephaestusConfig.name).not.toMatch(ZWSP_REGEX)
+    expect(prometheusConfig.name).not.toMatch(ZWSP_REGEX)
+    expect(atlasConfig.name).not.toMatch(ZWSP_REGEX)
+
+    // And they should be the display names (without ZWSP)
+    expect(sisyphusConfig.name).toBe(getAgentDisplayName("sisyphus"))
+    expect(hephaestusConfig.name).toBe(getAgentDisplayName("hephaestus"))
+    expect(prometheusConfig.name).toBe(getAgentDisplayName("prometheus"))
+    expect(atlasConfig.name).toBe(getAgentDisplayName("atlas"))
+  })
+
+
   it("remaps known agent keys to display names", () => {
     // given agents with lowercase keys
     const agents = {
@@ -14,7 +65,7 @@ describe("remapAgentKeysToDisplayNames", () => {
     const result = remapAgentKeysToDisplayNames(agents)
 
     // then known agents get display name keys only
-    expect(result[getAgentListDisplayName("sisyphus")]).toBeDefined()
+    expect(result[getAgentDisplayName("sisyphus")]).toBeDefined()
     expect(result["oracle"]).toBeDefined()
     expect(result["sisyphus"]).toBeUndefined()
   })
@@ -49,13 +100,13 @@ describe("remapAgentKeysToDisplayNames", () => {
     const result = remapAgentKeysToDisplayNames(agents)
 
     // then all get display name keys
-    expect(result[getAgentListDisplayName("sisyphus")]).toBeDefined()
+    expect(result[getAgentDisplayName("sisyphus")]).toBeDefined()
     expect(result["sisyphus"]).toBeUndefined()
-    expect(result[getAgentListDisplayName("hephaestus")]).toBeDefined()
+    expect(result[getAgentDisplayName("hephaestus")]).toBeDefined()
     expect(result["hephaestus"]).toBeUndefined()
-    expect(result[getAgentListDisplayName("prometheus")]).toBeDefined()
+    expect(result[getAgentDisplayName("prometheus")]).toBeDefined()
     expect(result["prometheus"]).toBeUndefined()
-    expect(result[getAgentListDisplayName("atlas")]).toBeDefined()
+    expect(result[getAgentDisplayName("atlas")]).toBeDefined()
     expect(result["atlas"]).toBeUndefined()
     expect(result[getAgentDisplayName("athena")]).toBeDefined()
     expect(result["athena"]).toBeUndefined()
@@ -77,8 +128,8 @@ describe("remapAgentKeysToDisplayNames", () => {
     const result = remapAgentKeysToDisplayNames(agents)
 
     // then only display key is emitted
-    expect(Object.keys(result)).toEqual([getAgentListDisplayName("sisyphus")])
-    expect(result[getAgentListDisplayName("sisyphus")]).toBeDefined()
+    expect(Object.keys(result)).toEqual([getAgentDisplayName("sisyphus")])
+    expect(result[getAgentDisplayName("sisyphus")]).toBeDefined()
     expect(result["sisyphus"]).toBeUndefined()
   })
 
@@ -96,10 +147,10 @@ describe("remapAgentKeysToDisplayNames", () => {
 
     // then
     expect(remappedNames).toEqual([
-      getAgentListDisplayName("atlas"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("sisyphus"),
+      getAgentDisplayName("atlas"),
+      getAgentDisplayName("prometheus"),
+      getAgentDisplayName("hephaestus"),
+      getAgentDisplayName("sisyphus"),
     ])
   })
 
@@ -118,28 +169,28 @@ describe("remapAgentKeysToDisplayNames", () => {
 
     // then keys and names both use the same runtime-facing list names
     expect(Object.keys(result).slice(0, 4)).toEqual([
-      getAgentListDisplayName("sisyphus"),
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("atlas"),
+      getAgentDisplayName("sisyphus"),
+      getAgentDisplayName("hephaestus"),
+      getAgentDisplayName("prometheus"),
+      getAgentDisplayName("atlas"),
     ])
-    expect(result[getAgentListDisplayName("sisyphus")]).toEqual({
-      name: getAgentRuntimeName("sisyphus"),
+    expect(result[getAgentDisplayName("sisyphus")]).toEqual({
+      name: getAgentDisplayName("sisyphus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("hephaestus")]).toEqual({
-      name: getAgentRuntimeName("hephaestus"),
+    expect(result[getAgentDisplayName("hephaestus")]).toEqual({
+      name: getAgentDisplayName("hephaestus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("prometheus")]).toEqual({
-      name: getAgentRuntimeName("prometheus"),
+    expect(result[getAgentDisplayName("prometheus")]).toEqual({
+      name: getAgentDisplayName("prometheus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("atlas")]).toEqual({
-      name: getAgentRuntimeName("atlas"),
+    expect(result[getAgentDisplayName("atlas")]).toEqual({
+      name: getAgentDisplayName("atlas"),
       prompt: "test",
       mode: "primary",
     })
@@ -159,23 +210,23 @@ describe("remapAgentKeysToDisplayNames", () => {
     const result = remapAgentKeysToDisplayNames(agents)
 
     // then runtime-facing names stay aligned even when builtin configs omit name
-    expect(result[getAgentListDisplayName("sisyphus")]).toEqual({
-      name: getAgentRuntimeName("sisyphus"),
+    expect(result[getAgentDisplayName("sisyphus")]).toEqual({
+      name: getAgentDisplayName("sisyphus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("hephaestus")]).toEqual({
-      name: getAgentRuntimeName("hephaestus"),
+    expect(result[getAgentDisplayName("hephaestus")]).toEqual({
+      name: getAgentDisplayName("hephaestus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("prometheus")]).toEqual({
-      name: getAgentRuntimeName("prometheus"),
+    expect(result[getAgentDisplayName("prometheus")]).toEqual({
+      name: getAgentDisplayName("prometheus"),
       prompt: "test",
       mode: "primary",
     })
-    expect(result[getAgentListDisplayName("atlas")]).toEqual({
-      name: getAgentRuntimeName("atlas"),
+    expect(result[getAgentDisplayName("atlas")]).toEqual({
+      name: getAgentDisplayName("atlas"),
       prompt: "test",
       mode: "primary",
     })

--- a/src/plugin-handlers/agent-key-remapper.ts
+++ b/src/plugin-handlers/agent-key-remapper.ts
@@ -1,4 +1,4 @@
-import { getAgentListDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
 
 function rewriteAgentNameForListDisplay(
   key: string,
@@ -11,7 +11,7 @@ function rewriteAgentNameForListDisplay(
   const agent = value as Record<string, unknown>
   return {
     ...agent,
-    name: getAgentRuntimeName(key),
+    name: getAgentDisplayName(key),
   }
 }
 
@@ -21,7 +21,7 @@ export function remapAgentKeysToDisplayNames(
   const result: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(agents)) {
-    const displayName = getAgentListDisplayName(key)
+    const displayName = getAgentDisplayName(key)
     if (displayName && displayName !== key) {
       result[displayName] = rewriteAgentNameForListDisplay(key, value)
       // Regression guard: do not also assign result[key].

--- a/src/plugin-handlers/agent-priority-order.test.ts
+++ b/src/plugin-handlers/agent-priority-order.test.ts
@@ -6,7 +6,7 @@ import {
   reorderAgentsByPriority,
   CANONICAL_CORE_AGENT_ORDER,
 } from "./agent-priority-order"
-import { getAgentDisplayName, getAgentListDisplayName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
 
 describe("agent-priority-order", () => {
   describe("CANONICAL_CORE_AGENT_ORDER", () => {
@@ -35,11 +35,11 @@ describe("agent-priority-order", () => {
   })
 
   describe("reorderAgentsByPriority", () => {
-    // given: display names for all core agents
-    const sisyphus = getAgentListDisplayName("sisyphus")
-    const hephaestus = getAgentListDisplayName("hephaestus")
-    const prometheus = getAgentListDisplayName("prometheus")
-    const atlas = getAgentListDisplayName("atlas")
+    // given: display names for all core agents (no ZWSP in keys)
+    const sisyphus = getAgentDisplayName("sisyphus")
+    const hephaestus = getAgentDisplayName("hephaestus")
+    const prometheus = getAgentDisplayName("prometheus")
+    const atlas = getAgentDisplayName("atlas")
     const oracle = getAgentDisplayName("oracle")
     const librarian = getAgentDisplayName("librarian")
     const explore = getAgentDisplayName("explore")

--- a/src/plugin-handlers/agent-priority-order.ts
+++ b/src/plugin-handlers/agent-priority-order.ts
@@ -1,4 +1,4 @@
-import { getAgentListDisplayName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
 
 /**
  * CRITICAL: This is the ONLY source of truth for core agent ordering.
@@ -25,7 +25,7 @@ const CORE_AGENT_ORDER: ReadonlyArray<{
   order: number
 }> = CANONICAL_CORE_AGENT_ORDER.map((configKey, index) => ({
   configKey,
-  displayName: getAgentListDisplayName(configKey),
+  displayName: getAgentDisplayName(configKey),
   order: index + 1,
 }))
 

--- a/src/plugin-handlers/command-config-handler.test.ts
+++ b/src/plugin-handlers/command-config-handler.test.ts
@@ -7,10 +7,7 @@ import * as skillLoader from "../features/opencode-skill-loader";
 import type { OhMyOpenCodeConfig } from "../config";
 import type { PluginComponents } from "./plugin-components-loader";
 import { applyCommandConfig } from "./command-config-handler";
-import {
-  getAgentDisplayName,
-  getAgentListDisplayName,
-} from "../shared/agent-display-names";
+import { getAgentDisplayName } from "../shared/agent-display-names";
 
 function createPluginComponents(): PluginComponents {
   return {
@@ -108,7 +105,7 @@ describe("applyCommandConfig", () => {
     expect(commandConfig["agents-global-skill"]?.description).toContain("Agents global skill");
   });
 
-  test("normalizes Atlas command agents to the runtime list name used by opencode command routing", async () => {
+  test("normalizes Atlas command agents to the display name for HTTP-safe routing", async () => {
     // given
     loadBuiltinCommandsSpy.mockReturnValue({
       "start-work": {
@@ -130,10 +127,10 @@ describe("applyCommandConfig", () => {
 
     // then
     const commandConfig = config.command as Record<string, { agent?: string }>;
-    expect(commandConfig["start-work"]?.agent).toBe(getAgentListDisplayName("atlas"));
+    expect(commandConfig["start-work"]?.agent).toBe(getAgentDisplayName("atlas"));
   });
 
-  test("normalizes legacy display-name command agents to the runtime list name", async () => {
+  test("normalizes legacy display-name command agents to the display name", async () => {
     // given
     loadBuiltinCommandsSpy.mockReturnValue({
       "start-work": {
@@ -155,6 +152,6 @@ describe("applyCommandConfig", () => {
 
     // then
     const commandConfig = config.command as Record<string, { agent?: string }>;
-    expect(commandConfig["start-work"]?.agent).toBe(getAgentListDisplayName("atlas"));
+    expect(commandConfig["start-work"]?.agent).toBe(getAgentDisplayName("atlas"));
   });
 });

--- a/src/plugin-handlers/command-config-handler.ts
+++ b/src/plugin-handlers/command-config-handler.ts
@@ -1,7 +1,7 @@
 import type { OhMyOpenCodeConfig } from "../config";
 import {
   getAgentConfigKey,
-  getAgentListDisplayName,
+  getAgentDisplayName,
 } from "../shared/agent-display-names";
 import {
   loadUserCommands,
@@ -99,7 +99,7 @@ export async function applyCommandConfig(params: {
 function remapCommandAgentFields(commands: Record<string, Record<string, unknown>>): void {
   for (const cmd of Object.values(commands)) {
     if (cmd?.agent && typeof cmd.agent === "string") {
-      cmd.agent = getAgentListDisplayName(getAgentConfigKey(cmd.agent));
+      cmd.agent = getAgentDisplayName(getAgentConfigKey(cmd.agent));
     }
   }
 }

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -3,7 +3,7 @@
 import { describe, test, expect, spyOn, beforeEach, afterEach, mock } from "bun:test"
 import type { CategoryConfig } from "../config/schema"
 import type { OhMyOpenCodeConfig } from "../config"
-import { getAgentDisplayName, getAgentDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+import { getAgentDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
 import { resolveCategoryConfig } from "./category-config-resolver"
 
 import * as agents from "../agents"

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -3,7 +3,7 @@
 import { describe, test, expect, spyOn, beforeEach, afterEach, mock } from "bun:test"
 import type { CategoryConfig } from "../config/schema"
 import type { OhMyOpenCodeConfig } from "../config"
-import { getAgentDisplayName, getAgentListDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
+import { getAgentDisplayName, getAgentDisplayName, getAgentRuntimeName } from "../shared/agent-display-names"
 import { resolveCategoryConfig } from "./category-config-resolver"
 
 import * as agents from "../agents"
@@ -264,10 +264,10 @@ describe("Plan agent demote behavior", () => {
     // #then
     const keys = Object.keys(config.agent as Record<string, unknown>)
     const coreAgents = [
-      getAgentListDisplayName("sisyphus"),
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("atlas"),
+      getAgentDisplayName("sisyphus"),
+      getAgentDisplayName("hephaestus"),
+      getAgentDisplayName("prometheus"),
+      getAgentDisplayName("atlas"),
     ]
     const ordered = keys.filter((key) => coreAgents.includes(key))
     expect(ordered).toEqual(coreAgents)
@@ -312,10 +312,10 @@ describe("Plan agent demote behavior", () => {
       reorderSpy.mock.calls.at(0)?.[0] as Record<string, unknown>
     )
     expect(assembledAgentKeys.slice(0, 4)).toEqual([
-      getAgentListDisplayName("sisyphus"),
-      getAgentListDisplayName("hephaestus"),
-      getAgentListDisplayName("prometheus"),
-      getAgentListDisplayName("atlas"),
+      getAgentDisplayName("sisyphus"),
+      getAgentDisplayName("hephaestus"),
+      getAgentDisplayName("prometheus"),
+      getAgentDisplayName("atlas"),
     ])
   })
 
@@ -358,19 +358,19 @@ describe("Plan agent demote behavior", () => {
 
     expect(emittedCoreEntries).toEqual([
       [
-        getAgentListDisplayName("sisyphus"),
+        getAgentDisplayName("sisyphus"),
         expect.objectContaining({ name: getAgentRuntimeName("sisyphus") }),
       ],
       [
-        getAgentListDisplayName("hephaestus"),
+        getAgentDisplayName("hephaestus"),
         expect.objectContaining({ name: getAgentRuntimeName("hephaestus") }),
       ],
       [
-        getAgentListDisplayName("prometheus"),
+        getAgentDisplayName("prometheus"),
         expect.objectContaining({ name: getAgentRuntimeName("prometheus") }),
       ],
       [
-        getAgentListDisplayName("atlas"),
+        getAgentDisplayName("atlas"),
         expect.objectContaining({ name: getAgentRuntimeName("atlas") }),
       ],
     ])
@@ -411,7 +411,7 @@ describe("Plan agent demote behavior", () => {
     expect(agents.plan).toBeDefined()
     expect(agents.plan.mode).toBe("subagent")
     expect(agents.plan.prompt).toBeUndefined()
-    expect(agents[getAgentListDisplayName("prometheus")]?.prompt).toBeDefined()
+    expect(agents[getAgentDisplayName("prometheus")]?.prompt).toBeDefined()
   })
 
   test("plan agent remains unchanged when planner is disabled", async () => {
@@ -445,7 +445,7 @@ describe("Plan agent demote behavior", () => {
 
     // #then - plan is not touched, prometheus is not created
     const agents = config.agent as Record<string, { mode?: string; name?: string; prompt?: string }>
-    expect(agents[getAgentListDisplayName("prometheus")]).toBeUndefined()
+    expect(agents[getAgentDisplayName("prometheus")]).toBeUndefined()
     expect(agents.plan).toBeDefined()
     expect(agents.plan.mode).toBe("primary")
     expect(agents.plan.prompt).toBe("original plan prompt")
@@ -476,7 +476,7 @@ describe("Plan agent demote behavior", () => {
 
     // then
     const agents = config.agent as Record<string, { mode?: string }>
-    const prometheusKey = getAgentListDisplayName("prometheus")
+    const prometheusKey = getAgentDisplayName("prometheus")
     expect(agents[prometheusKey]).toBeDefined()
     expect(agents[prometheusKey].mode).toBe("primary")
   })
@@ -512,7 +512,7 @@ describe("Agent permission defaults", () => {
 
     // #then
     const agentConfig = config.agent as Record<string, { permission?: Record<string, string> }>
-    const hephaestusKey = getAgentListDisplayName("hephaestus")
+    const hephaestusKey = getAgentDisplayName("hephaestus")
     expect(agentConfig[hephaestusKey]).toBeDefined()
     expect(agentConfig[hephaestusKey].permission?.task).toBe("allow")
   })
@@ -540,7 +540,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("canonicalizes configured default_agent when key uses mixed case", async () => {
@@ -564,7 +564,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("canonicalizes configured default_agent key to display name", async () => {
@@ -588,13 +588,13 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // #then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("preserves existing display-name default_agent", async () => {
     // #given
     const pluginConfig = createPluginConfig({})
-    const displayName = getAgentListDisplayName("hephaestus")
+    const displayName = getAgentDisplayName("hephaestus")
     const config: Record<string, unknown> = {
       model: "anthropic/claude-opus-4-7",
       default_agent: displayName,
@@ -613,7 +613,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // #then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("sets default_agent to sisyphus when missing", async () => {
@@ -636,7 +636,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // #then
-    expect(config.default_agent).toBe(getAgentRuntimeName("sisyphus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("sisyphus"))
   })
 
   test("uses canonical default_agent display name so OpenCode lookups match emitted agent keys", async () => {
@@ -660,7 +660,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // then
-    expect(config.default_agent).toBe(getAgentRuntimeName("hephaestus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("hephaestus"))
   })
 
   test("sets default_agent to sisyphus when configured default_agent is empty after trim", async () => {
@@ -684,7 +684,7 @@ describe("default_agent behavior with Sisyphus orchestration", () => {
     await handler(config)
 
     // then
-    expect(config.default_agent).toBe(getAgentRuntimeName("sisyphus"))
+    expect(config.default_agent).toBe(getAgentDisplayName("sisyphus"))
   })
 
   test("preserves custom default_agent names while trimming whitespace", async () => {
@@ -878,7 +878,7 @@ describe("Prometheus direct override priority over category", () => {
 
     // then - direct override's reasoningEffort wins
     const agents = config.agent as Record<string, { reasoningEffort?: string }>
-    const pKey = getAgentListDisplayName("prometheus")
+    const pKey = getAgentDisplayName("prometheus")
     expect(agents[pKey]).toBeDefined()
     expect(agents[pKey].reasoningEffort).toBe("low")
   })
@@ -919,7 +919,7 @@ describe("Prometheus direct override priority over category", () => {
 
     // then - category's reasoningEffort is applied
     const agents = config.agent as Record<string, { reasoningEffort?: string }>
-    const pKey = getAgentListDisplayName("prometheus")
+    const pKey = getAgentDisplayName("prometheus")
     expect(agents[pKey]).toBeDefined()
     expect(agents[pKey].reasoningEffort).toBe("high")
   })
@@ -961,7 +961,7 @@ describe("Prometheus direct override priority over category", () => {
 
     // then - direct temperature wins over category
     const agents = config.agent as Record<string, { temperature?: number }>
-    const pKey = getAgentListDisplayName("prometheus")
+    const pKey = getAgentDisplayName("prometheus")
     expect(agents[pKey]).toBeDefined()
     expect(agents[pKey].temperature).toBe(0.1)
   })
@@ -997,7 +997,7 @@ describe("Prometheus direct override priority over category", () => {
 
     // #then - prompt_append is appended to base prompt, not overwriting it
     const agents = config.agent as Record<string, { prompt?: string }>
-    const pKey = getAgentListDisplayName("prometheus")
+    const pKey = getAgentDisplayName("prometheus")
     expect(agents[pKey]).toBeDefined()
     expect(agents[pKey].prompt).toContain("Prometheus")
     expect(agents[pKey].prompt).toContain(customInstructions)
@@ -1222,7 +1222,7 @@ describe("Deadlock prevention - fetchAvailableModels must not receive client", (
 
     // then - regression guard: handler completes and still assembles planner config
     const agentConfig = config.agent as Record<string, unknown>
-    expect(agentConfig[getAgentListDisplayName("prometheus")]).toBeDefined()
+    expect(agentConfig[getAgentDisplayName("prometheus")]).toBeDefined()
   })
 })
 
@@ -1388,17 +1388,17 @@ describe("command agent routing coherence", () => {
     //#then
     const agentConfig = config.agent as Record<string, unknown>
     const commandConfig = config.command as Record<string, { agent?: string }>
-    expect(Object.keys(agentConfig)).toContain(getAgentListDisplayName("atlas"))
-    expect(commandConfig["start-work"]?.agent).toBe(getAgentListDisplayName("atlas"))
+    expect(Object.keys(agentConfig)).toContain(getAgentDisplayName("atlas"))
+    expect(commandConfig["start-work"]?.agent).toBe(getAgentDisplayName("atlas"))
   })
 })
 
 describe("per-agent todowrite/todoread deny when task_system enabled", () => {
   const AGENTS_WITH_TODO_DENY = new Set([
-    getAgentListDisplayName("sisyphus"),
-    getAgentListDisplayName("hephaestus"),
-    getAgentListDisplayName("prometheus"),
-    getAgentListDisplayName("atlas"),
+    getAgentDisplayName("sisyphus"),
+    getAgentDisplayName("hephaestus"),
+    getAgentDisplayName("prometheus"),
+    getAgentDisplayName("atlas"),
     getAgentDisplayName("sisyphus-junior"),
   ])
 
@@ -1479,10 +1479,10 @@ describe("per-agent todowrite/todoread deny when task_system enabled", () => {
     expect(lastCall?.[11]).toBe(false)
 
     const agentResult = config.agent as Record<string, { permission?: Record<string, unknown> }>
-    expect(agentResult[getAgentListDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
-    expect(agentResult[getAgentListDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
-    expect(agentResult[getAgentListDisplayName("hephaestus")]?.permission?.todowrite).toBeUndefined()
-    expect(agentResult[getAgentListDisplayName("hephaestus")]?.permission?.todoread).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("hephaestus")]?.permission?.todowrite).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("hephaestus")]?.permission?.todoread).toBeUndefined()
   })
 
   test("does not deny todowrite/todoread when task_system is undefined", async () => {
@@ -1518,8 +1518,8 @@ describe("per-agent todowrite/todoread deny when task_system enabled", () => {
     expect(lastCall?.[11]).toBe(false)
 
     const agentResult = config.agent as Record<string, { permission?: Record<string, unknown> }>
-    expect(agentResult[getAgentListDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
-    expect(agentResult[getAgentListDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todowrite).toBeUndefined()
+    expect(agentResult[getAgentDisplayName("sisyphus")]?.permission?.todoread).toBeUndefined()
   })
 })
 

--- a/src/plugin-handlers/tool-config-handler.ts
+++ b/src/plugin-handlers/tool-config-handler.ts
@@ -1,5 +1,5 @@
 import type { OhMyOpenCodeConfig } from "../config";
-import { getAgentDisplayName, getAgentListDisplayName } from "../shared/agent-display-names";
+import { getAgentDisplayName } from "../shared/agent-display-names";
 import { isTaskSystemEnabled } from "../shared";
 
 type AgentWithPermission = { permission?: Record<string, unknown> };
@@ -16,7 +16,7 @@ function getConfigQuestionPermission(): string | null {
 }
 
 function agentByKey(agentResult: Record<string, unknown>, key: string): AgentWithPermission | undefined {
-  return (agentResult[getAgentListDisplayName(key)] ?? agentResult[getAgentDisplayName(key)] ?? agentResult[key]) as
+  return (agentResult[getAgentDisplayName(key)] ?? agentResult[key]) as
     | AgentWithPermission
     | undefined;
 }

--- a/src/plugin-interface.test.ts
+++ b/src/plugin-interface.test.ts
@@ -6,7 +6,7 @@ import { randomUUID } from "node:crypto"
 import { createPluginInterface } from "./plugin-interface"
 import { createAutoSlashCommandHook } from "./hooks/auto-slash-command"
 import { createStartWorkHook } from "./hooks/start-work"
-import { getAgentListDisplayName } from "./shared/agent-display-names"
+import { getAgentDisplayName } from "./shared/agent-display-names"
 import { readBoulderState } from "./features/boulder-state"
 import {
   _resetForTesting,

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -10,7 +10,7 @@ import { createKeywordDetectorHook } from "../hooks/keyword-detector"
 import { createStartWorkHook } from "../hooks/start-work"
 import { readBoulderState } from "../features/boulder-state"
 import { _resetForTesting, setMainSession, subagentSessions, registerAgentName, updateSessionAgent, getSessionAgent } from "../features/claude-code-session-state"
-import { getAgentListDisplayName } from "../shared/agent-display-names"
+import { getAgentDisplayName } from "../shared/agent-display-names"
 import { getOmoOpenCodeCacheDir, getOpenCodeCacheDir } from "../shared/data-path"
 import { clearSessionModel, getSessionModel, setSessionModel } from "../shared/session-model-state"
 
@@ -738,7 +738,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
       },
     })
     const handler = createChatMessageHandler(args)
-    const input = createMockInput(getAgentListDisplayName("prometheus"))
+    const input = createMockInput(getAgentDisplayName("prometheus"))
     const output = createMockOutput()
 
     //#when

--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -194,11 +194,11 @@ describe("getAgentConfigKey", () => {
 })
 
 describe("getAgentListDisplayName", () => {
-  it("applies invisible stable-sort prefixes to the core agent list", () => {
-    expect(getAgentListDisplayName("sisyphus")).toBe("\u200BSisyphus - Ultraworker")
-    expect(getAgentListDisplayName("hephaestus")).toBe("\u200B\u200BHephaestus - Deep Agent")
-    expect(getAgentListDisplayName("prometheus")).toBe("\u200B\u200B\u200BPrometheus - Plan Builder")
-    expect(getAgentListDisplayName("atlas")).toBe("\u200B\u200B\u200B\u200BAtlas - Plan Executor")
+  it("returns display names without ZWSP prefixes (sorting handled by order field)", () => {
+    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentListDisplayName("hephaestus")).toBe("Hephaestus - Deep Agent")
+    expect(getAgentListDisplayName("prometheus")).toBe("Prometheus - Plan Builder")
+    expect(getAgentListDisplayName("atlas")).toBe("Atlas - Plan Executor")
   })
 
   it("keeps non-core agents unprefixed for list display", () => {

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -4,10 +4,16 @@
  * Display names include suffixes for UI/logs (e.g., "Sisyphus - Ultraworker").
  *
  * IMPORTANT: Display names MUST NOT contain parentheses or other characters
- * that are invalid in HTTP header values per RFC 7230. OpenCode passes the
- * agent name in the `x-opencode-agent-name` header, and parentheses cause
- * header validation failures that prevent agents from appearing in the UI
- * type selector dropdown. Use ` - ` (space-dash-space) instead of `(...)`.
+ * that are invalid in HTTP header values per RFC 7230. Config object keys
+ * can flow into HTTP header values in some plugin paths. Use ` - `
+ * (space-dash-space) instead of `(...)` to avoid header validation failures.
+ *
+ * NOTE: ZWSP sort prefixes were removed. Agent ordering is now handled by
+ * the `order` field injected by reorderAgentsByPriority() in
+ * agent-priority-order.ts. The AGENT_LIST_SORT_PREFIXES map is kept as empty
+ * strings for backward compatibility with existing session data that may
+ * contain ZWSP-prefixed agent names. stripInvisibleAgentCharacters() still
+ * strips any residual ZWSP from legacy sessions.
  */
 export const AGENT_DISPLAY_NAMES: Record<string, string> = {
   sisyphus: "Sisyphus - Ultraworker",
@@ -27,10 +33,10 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
 }
 
 const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {
-  sisyphus: "\u200B",
-  hephaestus: "\u200B\u200B",
-  prometheus: "\u200B\u200B\u200B",
-  atlas: "\u200B\u200B\u200B\u200B",
+  sisyphus: "",
+  hephaestus: "",
+  prometheus: "",
+  atlas: "",
 }
 
 const INVISIBLE_AGENT_CHARACTERS_REGEX = /[\u200B\u200C\u200D\uFEFF]/g

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -1,7 +1,7 @@
 declare const require: NodeJS.Require
 const { describe, test, expect, beforeEach, afterEach, spyOn, mock } = require("bun:test")
 import { DEFAULT_CATEGORIES, CATEGORY_PROMPT_APPENDS, CATEGORY_DESCRIPTIONS, isPlanAgent, PLAN_AGENT_NAMES, isPlanFamily, PLAN_FAMILY_NAMES } from "./constants"
-import { getAgentDisplayName, getAgentListDisplayName } from "../../shared/agent-display-names"
+import { getAgentDisplayName, getAgentDisplayName } from "../../shared/agent-display-names"
 import type { CategoryConfig } from "../../config/schema"
 import type { DelegateTaskArgs } from "./types"
 import { __resetModelCache } from "../../shared/model-availability"
@@ -277,7 +277,7 @@ describe("sisyphus-task", () => {
 
     test("returns true for prometheus list display name with zwsp prefix", () => {
       //#given / #when
-      const result = isPlanFamily(getAgentListDisplayName("prometheus"))
+      const result = isPlanFamily(getAgentDisplayName("prometheus"))
       //#then
       expect(result).toBe(true)
     })

--- a/src/tools/delegate-task/tools.test.ts
+++ b/src/tools/delegate-task/tools.test.ts
@@ -1,7 +1,7 @@
 declare const require: NodeJS.Require
 const { describe, test, expect, beforeEach, afterEach, spyOn, mock } = require("bun:test")
 import { DEFAULT_CATEGORIES, CATEGORY_PROMPT_APPENDS, CATEGORY_DESCRIPTIONS, isPlanAgent, PLAN_AGENT_NAMES, isPlanFamily, PLAN_FAMILY_NAMES } from "./constants"
-import { getAgentDisplayName, getAgentDisplayName } from "../../shared/agent-display-names"
+import { getAgentDisplayName } from "../../shared/agent-display-names"
 import type { CategoryConfig } from "../../config/schema"
 import type { DelegateTaskArgs } from "./types"
 import { __resetModelCache } from "../../shared/model-availability"


### PR DESCRIPTION
## Summary

Removes Zero-Width Space (ZWSP) characters from agent display names that caused name truncation in VS Code, WezTerm, Warp, Ghostty, and other terminals that mishandle zero-width characters. Agent names like "Sisyphus - Ultraworker" would appear as "Sisyphus - ltraworker" because terminals "ate" visible characters proportional to the ZWSP count.

## Root Cause

`AGENT_LIST_SORT_PREFIXES` prepended `\u200B` ZWSP characters to agent names for UI sort ordering. Terminals that don't correctly handle zero-width characters would render these invisible characters by consuming adjacent visible characters, producing garbled output.

## Changes

### Production code
- **`agent-display-names.ts`**: Set `AGENT_LIST_SORT_PREFIXES` values to `""` (sorting now handled by `order` field from `CANONICAL_CORE_AGENT_ORDER`); updated doc comment explaining ZWSP removal rationale; preserved `stripInvisibleAgentCharacters`/`stripAgentListSortPrefix` for backward compatibility with legacy session data
- **`agent-key-remapper.ts`**: Changed `name` field from `getAgentRuntimeName(key)` to `getAgentDisplayName(key)` (no ZWSP); removed unused `getAgentRuntimeName` import
- **`agent-config-handler.ts`**: Removed unused `getAgentRuntimeName` import
- **`agent-resolver.ts`**: All `getAgentRuntimeName` to `getAgentDisplayName`
- **`agent-priority-order.ts`**: Use `getAgentDisplayName` for lookups (from cherry-pick of 35fdd22d)
- **`command-config-handler.ts`**: Use `getAgentDisplayName` (from cherry-pick of 35fdd22d)
- **`tool-config-handler.ts`**: Use `getAgentDisplayName` (from cherry-pick of 35fdd22d)

### Tests
- Updated 8 test files to expect ZWSP-free display names and use `getAgentDisplayName`

## Why this supersedes PR #3419

PR #3419 only removed ZWSP from `AGENT_LIST_SORT_PREFIXES` values but left `getAgentRuntimeName`/`getAgentListDisplayName` calls injecting ZWSP into:
- Object keys (causing RFC 7230 violations in HTTP headers)
- The `name` field (causing `session.create` Agent not found errors because OpenCode does exact-string matching on agent names)

This PR removes ZWSP from **all** agent name surfaces while preserving backward compatibility for legacy session data that may still contain ZWSP names.

## Fixes

Fixes #3418, supersedes #3419, fixes #3337, fixes #3512, fixes #3453

## Testing

- 319 tests passing
- Typecheck clean
- Build successful
- Manual verification in OpenCode with local plugin build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove zero‑width space (ZWSP) prefixes from agent names and standardize all name surfaces to ZWSP‑free `getAgentDisplayName()` values. Fixes truncated names in terminals and prevents RFC 7230 header issues; sorting now uses the `order` field.

- **Bug Fixes**
  - Set `AGENT_LIST_SORT_PREFIXES` to empty; sorting comes from `CANONICAL_CORE_AGENT_ORDER` via the `order` field.
  - Replaced `getAgentRuntimeName`/`getAgentListDisplayName` with `getAgentDisplayName` across the CLI resolver, priority order, command/tool handlers, and key remapper; keys and `name` fields are now HTTP‑safe.
  - Kept `stripInvisibleAgentCharacters` and `stripAgentListSortPrefix` for legacy session data.
  - Tests now enforce ZWSP‑free names and RFC 7230 compliance; removed duplicate imports in `config-handler.test.ts` and `tools.test.ts`.
  - Supersedes #3419; fixes #3418, #3337, #3512, #3453.

<sup>Written for commit eb41ec4bb910a88762d3355e6a1ca841bb0da2c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

