### PR TITLE
fix: remove PostHog HAU telemetry + repair baseline test regressions

### DIFF
--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -16,7 +16,7 @@ We collect limited non-personal information needed to operate and improve the Se
 
 When anonymous telemetry is enabled, the Application may collect:
 
-- Anonymous usage events, including `run_started`, `run_completed`, `run_failed`, `install_completed`, `install_failed`, `plugin_loaded`, `omo_daily_active`, and `omo_hourly_active`
+- Anonymous usage events, including `run_started`, `run_completed`, `run_failed`, `install_completed`, `install_failed`, `plugin_loaded`, and `omo_daily_active`
 - Application metadata such as package version, plugin name, runtime, and command or entry-point context
 - Error diagnostics captured during failed CLI runs
 - A pseudonymous installation identifier derived from a one-way hash of the local hostname
@@ -25,7 +25,7 @@ We do not intentionally collect prompt contents, source files, repository conten
 
 ### Configuration and local state
 
-The Application stores local configuration and telemetry deduplication state on your machine to support installation, configuration, and anonymous daily or hourly active tracking.
+The Application stores local configuration and telemetry deduplication state on your machine to support installation, configuration, and anonymous daily active tracking.
 
 ## 2. How Telemetry Works
 

--- a/src/shared/posthog-activity-state.test.ts
+++ b/src/shared/posthog-activity-state.test.ts
@@ -37,9 +37,7 @@ describe("getPostHogActivityCaptureState", () => {
     // then
     expect(result).toEqual({
       dayUTC: "2026-04-11",
-      hourUTC: "2026-04-11T10",
       captureDaily: true,
-      captureHourly: true,
     })
 
     rmSync(dataHomePath, { recursive: true, force: true })
@@ -60,9 +58,7 @@ describe("getPostHogActivityCaptureState", () => {
     // then
     expect(result).toEqual({
       dayUTC: "2026-04-11",
-      hourUTC: "2026-04-11T10",
       captureDaily: true,
-      captureHourly: true,
     })
 
     rmSync(dataHomePath, { recursive: true, force: true })
@@ -83,9 +79,7 @@ describe("getPostHogActivityCaptureState", () => {
     // then
     expect(result).toEqual({
       dayUTC: "2026-04-11",
-      hourUTC: "2026-04-11T10",
       captureDaily: true,
-      captureHourly: true,
     })
 
     rmSync(dataHomePath, { recursive: true, force: true })
@@ -112,9 +106,33 @@ describe("getPostHogActivityCaptureState", () => {
     // then
     expect(result).toEqual({
       dayUTC: "2026-04-11",
-      hourUTC: "2026-04-11T10",
       captureDaily: false,
-      captureHourly: false,
+    })
+
+    rmSync(dataHomePath, { recursive: true, force: true })
+  })
+
+  it("reads legacy hourly state without crashing", async () => {
+    // given
+    const dataHomePath = createDataHomePath()
+    const cachePath = join(dataHomePath, "oh-my-opencode")
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(
+      join(cachePath, "posthog-activity.json"),
+      `${JSON.stringify({
+        lastActiveHourUTC: "2026-04-11T10",
+      })}\n`,
+    )
+    process.env.XDG_DATA_HOME = dataHomePath
+    const { getPostHogActivityCaptureState } = await importPostHogActivityStateModule()
+
+    // when
+    const result = getPostHogActivityCaptureState(new Date("2026-04-11T10:15:00.000Z"))
+
+    // then
+    expect(result).toEqual({
+      dayUTC: "2026-04-11",
+      captureDaily: true,
     })
 
     rmSync(dataHomePath, { recursive: true, force: true })

--- a/src/shared/posthog-activity-state.ts
+++ b/src/shared/posthog-activity-state.ts
@@ -8,14 +8,11 @@ import { writeFileAtomically } from "./write-file-atomically"
 
 type PostHogActivityState = {
   lastActiveDayUTC?: string
-  lastActiveHourUTC?: string
 }
 
 type PostHogActivityCaptureState = {
   dayUTC: string
-  hourUTC: string
   captureDaily: boolean
-  captureHourly: boolean
 }
 
 const POSTHOG_ACTIVITY_STATE_FILE = "posthog-activity.json"
@@ -26,10 +23,6 @@ function getPostHogActivityStateFilePath(): string {
 
 function getUtcDayString(date: Date): string {
   return date.toISOString().slice(0, 10)
-}
-
-function getUtcHourString(date: Date): string {
-  return date.toISOString().slice(0, 13)
 }
 
 function isPostHogActivityState(value: unknown): value is PostHogActivityState {
@@ -75,22 +68,17 @@ function writePostHogActivityState(nextState: PostHogActivityState): void {
 export function getPostHogActivityCaptureState(now: Date = new Date()): PostHogActivityCaptureState {
   const state = readPostHogActivityState()
   const dayUTC = getUtcDayString(now)
-  const hourUTC = getUtcHourString(now)
 
   const captureDaily = state.lastActiveDayUTC !== dayUTC
-  const captureHourly = state.lastActiveHourUTC !== hourUTC
 
-  if (captureDaily || captureHourly) {
+  if (captureDaily) {
     writePostHogActivityState({
       lastActiveDayUTC: captureDaily ? dayUTC : state.lastActiveDayUTC,
-      lastActiveHourUTC: captureHourly ? hourUTC : state.lastActiveHourUTC,
     })
   }
 
   return {
     dayUTC,
-    hourUTC,
     captureDaily,
-    captureHourly,
   }
 }

--- a/src/shared/posthog.test.ts
+++ b/src/shared/posthog.test.ts
@@ -1,23 +1,54 @@
-import { afterEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+
+type CapturedPostHogMessage = {
+  distinctId: string
+  event: string
+  properties?: Record<string, unknown>
+}
 
 async function importPostHogModule(): Promise<typeof import("./posthog")> {
   return import(`./posthog?test=${Date.now()}-${Math.random()}`)
 }
 
+function enableTelemetryEnv(): void {
+  process.env.OMO_DISABLE_POSTHOG = "0"
+  process.env.OMO_SEND_ANONYMOUS_TELEMETRY = "1"
+  process.env.POSTHOG_API_KEY = "test-api-key"
+}
+
+function clearTelemetryEnv(): void {
+  delete process.env.OMO_DISABLE_POSTHOG
+  delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
+  delete process.env.POSTHOG_API_KEY
+  delete process.env.POSTHOG_HOST
+}
+
+function mockPostHogNode(capturedMessages: CapturedPostHogMessage[]): void {
+  mock.module("posthog-node", () => ({
+    PostHog: class {
+      capture(message: CapturedPostHogMessage): void {
+        capturedMessages.push(message)
+      }
+      captureException(): void {}
+      async shutdown(): Promise<void> {}
+    },
+  }))
+}
+
 describe("posthog client creation", () => {
+  beforeEach(() => {
+    mock.restore()
+    clearTelemetryEnv()
+  })
+
   afterEach(() => {
     mock.restore()
-    delete process.env.OMO_DISABLE_POSTHOG
-    delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
-    delete process.env.POSTHOG_API_KEY
-    delete process.env.POSTHOG_HOST
+    clearTelemetryEnv()
   })
 
   it("returns a no-op client when PostHog construction throws", async () => {
     // given
-    process.env.OMO_DISABLE_POSTHOG = "0"
-    process.env.OMO_SEND_ANONYMOUS_TELEMETRY = "1"
-    process.env.POSTHOG_API_KEY = "test-api-key"
+    enableTelemetryEnv()
 
     mock.module("posthog-node", () => ({
       PostHog: class {
@@ -53,5 +84,75 @@ describe("posthog client creation", () => {
     expect(() => pluginPostHog.captureException(new Error("plugin failure"), "plugin")).not.toThrow()
     expect(() => pluginPostHog.trackActive("plugin", "plugin_loaded")).not.toThrow()
     await expect(pluginPostHog.shutdown()).resolves.toBeUndefined()
+  })
+})
+
+describe("posthog trackActive emission contract", () => {
+  let resetActivityStateProvider: (() => void) | null = null
+
+  beforeEach(() => {
+    mock.restore()
+    clearTelemetryEnv()
+  })
+
+  afterEach(() => {
+    resetActivityStateProvider?.()
+    resetActivityStateProvider = null
+    mock.restore()
+    clearTelemetryEnv()
+  })
+
+  it("emits exactly one omo_daily_active and never omo_hourly_active when captureDaily is true", async () => {
+    // given
+    enableTelemetryEnv()
+    const captured: CapturedPostHogMessage[] = []
+    mockPostHogNode(captured)
+    const posthogModule = await importPostHogModule()
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: true,
+    }))
+    resetActivityStateProvider = posthogModule.__resetActivityStateProviderForTesting
+    const client = posthogModule.createCliPostHog()
+
+    // when
+    client.trackActive("distinct-cli", "run_started")
+
+    // then
+    expect(captured).toHaveLength(1)
+    const emittedEvents = captured.map((message) => message.event)
+    expect(emittedEvents).not.toContain("omo_hourly_active")
+    const [dailyEvent] = captured
+    expect(dailyEvent?.event).toBe("omo_daily_active")
+    expect(dailyEvent?.distinctId).toBe("distinct-cli")
+    expect(dailyEvent?.properties).toMatchObject({
+      day_utc: "2026-04-18",
+      reason: "run_started",
+      source: "cli",
+    })
+    expect(dailyEvent?.properties).not.toHaveProperty("hour_utc")
+  })
+
+  it("emits nothing and never omo_hourly_active when captureDaily is false", async () => {
+    // given
+    enableTelemetryEnv()
+    const captured: CapturedPostHogMessage[] = []
+    mockPostHogNode(captured)
+    const posthogModule = await importPostHogModule()
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: false,
+    }))
+    resetActivityStateProvider = posthogModule.__resetActivityStateProviderForTesting
+    const client = posthogModule.createPluginPostHog()
+
+    // when
+    client.trackActive("distinct-plugin", "plugin_loaded")
+
+    // then
+    expect(captured).toHaveLength(0)
+    const emittedEvents = captured.map((message) => message.event)
+    expect(emittedEvents).not.toContain("omo_daily_active")
+    expect(emittedEvents).not.toContain("omo_hourly_active")
   })
 })

--- a/src/shared/posthog.ts
+++ b/src/shared/posthog.ts
@@ -5,6 +5,25 @@ import packageJson from "../../package.json" with { type: "json" }
 import { PLUGIN_NAME, PUBLISHED_PACKAGE_NAME } from "./plugin-identity"
 import { getPostHogActivityCaptureState } from "./posthog-activity-state"
 
+/** @internal test-only seam: keep null in production to use the real implementation. */
+let activityStateProviderOverride: typeof getPostHogActivityCaptureState | null = null
+
+function resolveActivityState(): ReturnType<typeof getPostHogActivityCaptureState> {
+  return (activityStateProviderOverride ?? getPostHogActivityCaptureState)()
+}
+
+/** @internal test-only */
+export function __setActivityStateProviderForTesting(
+  provider: typeof getPostHogActivityCaptureState,
+): void {
+  activityStateProviderOverride = provider
+}
+
+/** @internal test-only */
+export function __resetActivityStateProviderForTesting(): void {
+  activityStateProviderOverride = null
+}
+
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"
 const DEFAULT_POSTHOG_API_KEY = "phc_CFJhj5HyvA62QPhvyaUCtaq23aUfznnijg5VaaGkNk74"
 
@@ -117,7 +136,7 @@ function createPostHogClient(
       })
     },
     trackActive: (distinctId, reason) => {
-      const activityState = getPostHogActivityCaptureState()
+      const activityState = resolveActivityState()
 
       if (activityState.captureDaily) {
         configuredClient.capture({
@@ -126,18 +145,6 @@ function createPostHogClient(
           properties: {
             ...sharedProperties,
             day_utc: activityState.dayUTC,
-            reason,
-          },
-        })
-      }
-
-      if (activityState.captureHourly) {
-        configuredClient.capture({
-          distinctId,
-          event: "omo_hourly_active",
-          properties: {
-            ...sharedProperties,
-            hour_utc: activityState.hourUTC,
             reason,
           },
         })


### PR DESCRIPTION
## What

Removes hourly active user (HAU) telemetry from PostHog while preserving DAU emission. Also repairs baseline test regressions that were already failing on `origin/dev` before this change.

## Why

HAU emission was producing excessive telemetry volume without adding value beyond DAU. This PR removes the hourly capture path end-to-end while keeping DAU intact and reading legacy state files without crashing.

## Changes

**HAU removal (core)**
- `src/shared/posthog.ts` — drop `captureHourly` emission block
- `src/shared/posthog-activity-state.ts` — drop `lastActiveHourUTC`, `hourUTC`, `captureHourly`, `getUtcHourString`; legacy state files with old fields are still read safely
- `docs/legal/privacy-policy.md` — remove `omo_hourly_active` from collected events list

**Test updates for HAU**
- `src/shared/posthog-activity-state.test.ts` — drop hourly assertions, add legacy-state-read case
- `src/shared/posthog.test.ts` — verify DAU-only emission, HAU never emitted

**Baseline test regression repairs (unrelated to HAU, but pre-existing failures on dev)**
- `src/agents/explore-tool-strategy.test.ts` — update stale literal assertions (`read the hint`, `$$$`) after prompt refactor in acd867ec, preserving test intent
- `src/agents/librarian-ast-grep-discipline.test.ts` — same, after refactor 1ecf5ab8
- `src/hooks/auto-slash-command/executor.ts`, `hook.ts`, `src/tools/slashcommand/command-discovery.ts` — switch from `../../shared` barrel imports to direct module paths (fixes test discovery bug that surfaced in bare suite runs)
- `src/hooks/auto-slash-command/index.test.ts`, `executor-resolution.test.ts` — aligned with new import shape

## Verification

- `bun test`: **5766 pass / 0 fail**
- `bun run typecheck`: green
- `bun run build`: green
- Oracle reviewed twice (blocker judgment + final patch review): both **GREEN**

## Notes

- Backward-compat: state files with `lastActiveHourUTC` still read without crashing; unknown field is simply ignored
- No breaking changes to DAU path

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes PostHog hourly active telemetry and keeps daily-only activity to reduce event volume. Updates tests with a simple seam and adjusts the privacy policy.

- **Bug Fixes**
  - Stop emitting `omo_hourly_active`; keep `omo_daily_active` only.
  - Update privacy policy to remove the hourly event and wording.
  - Make activity-state daily-only; read legacy `lastActiveHourUTC` without crashing.
  - Add a test-only activity-state override (`__setActivityStateProviderForTesting`/`__resetActivityStateProviderForTesting`) and verify DAU-only emission.

<sup>Written for commit e0230a435db9fca29a09dec01bf8f0ca73b4485d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

