### PR TITLE
fix(anthropic-effort): clamp pre-existing effort=max for constrained providers

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -76,13 +76,31 @@ export function createAnthropicEffortHook() {
       const { agent, model, message } = input
       if (!model?.modelID || !model?.providerID) return
       if (isEffortUnsupportedModel(model.modelID)) return
-      if (message.variant !== "max") return
       if (!isClaudeProvider(model.providerID, model.modelID)) return
       if (shouldSkipForInternalAgent(agent?.name)) return
-      if (output.options.effort !== undefined) return
+
+      const constrained = isConstrainedProvider(model.providerID)
+
+      // Clamp pre-existing effort for constrained providers (e.g. github-copilot)
+      // OpenCode may pre-populate effort="max" before hooks run; constrained APIs
+      // only accept low | medium | high.
+      if (output.options.effort !== undefined) {
+        if (constrained && output.options.effort === "max") {
+          output.options.effort = MAX_VARIANT_BY_TIER.default
+          ;(message as { variant?: string }).variant = MAX_VARIANT_BY_TIER.default
+          log("anthropic-effort: clamped pre-existing effort max→high", {
+            sessionID: input.sessionID,
+            provider: model.providerID,
+            model: model.modelID,
+            reason: "constrained-provider",
+          })
+        }
+        return
+      }
+
+      if (message.variant !== "max") return
 
       const opus = isOpusModel(model.modelID)
-      const constrained = isConstrainedProvider(model.providerID)
       const clamped = clampVariant(message.variant, opus, constrained)
       output.options.effort = clamped
 


### PR DESCRIPTION
## Summary

- **Problem**: OpenCode may pre-populate `effort="max"` on `chat.params` before hooks run. Constrained providers (e.g. `github-copilot`) only accept `low | medium | high`, causing API rejections when `max` is passed through.
- **Fix**: When a pre-existing `effort=max` is detected on a constrained provider, clamp it to `high` and update `message.variant` accordingly. Non-constrained providers and other pre-set effort values are unaffected.
- **Scope**: Single file change in `src/hooks/anthropic-effort/hook.ts`. No new dependencies.

## Changes

1. Removed the early `message.variant !== "max"` guard that ran before the constrained-provider check
2. Added a new block that detects pre-existing `effort=max` on constrained providers and clamps to `high`
3. Preserved the early-return for other pre-set effort values (non-max)
4. Reordered the logic so constrained-provider detection happens before variant filtering

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamps pre-set `effort="max"` to `high` for constrained providers (e.g., `github-copilot`) to prevent API rejections, and syncs `message.variant`. Non-constrained providers and other effort values are unchanged.

- **Bug Fixes**
  - Clamp pre-existing `effort=max` when the provider is constrained; update `message.variant` and log the change.
  - Reorder checks to evaluate constrained providers before variant filtering; keep early return for non-`max` preset efforts.

<sup>Written for commit 028dad2fb653b437dd973a9319e06f04d3d54bd6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

