### PR TITLE
feat(agents): add GPT-5.5 native Sisyphus support

### DIFF
--- a/src/agents/hephaestus/agent.test.ts
+++ b/src/agents/hephaestus/agent.test.ts
@@ -23,6 +23,23 @@ describe("getHephaestusPromptSource", () => {
     expect(source3).toBe("gpt-5-4");
   });
 
+  test("returns 'gpt-5-4' for gpt-5.5 models", () => {
+    // given
+    const model1 = "openai/gpt-5.5";
+    const model2 = "openai/gpt-5-5";
+    const model3 = "github-copilot/gpt-5.5";
+
+    // when
+    const source1 = getHephaestusPromptSource(model1);
+    const source2 = getHephaestusPromptSource(model2);
+    const source3 = getHephaestusPromptSource(model3);
+
+    // then
+    expect(source1).toBe("gpt-5-4");
+    expect(source2).toBe("gpt-5-4");
+    expect(source3).toBe("gpt-5-4");
+  });
+
   test("returns 'gpt-5-3-codex' for GPT 5.3 Codex models", () => {
     // given
     const model1 = "openai/gpt-5.3-codex";
@@ -86,6 +103,19 @@ describe("getHephaestusPrompt", () => {
   test("GPT 5.4-codex model returns GPT-5.4 optimized prompt", () => {
     // given
     const model = "openai/gpt-5.4-codex";
+
+    // when
+    const prompt = getHephaestusPrompt(model);
+
+    // then
+    expect(prompt).toContain("You build context by examining");
+    expect(prompt).toContain("Never chain together bash commands");
+    expect(prompt).toContain("<tool_usage_rules>");
+  });
+
+  test("GPT 5.5 model returns GPT-5.4 optimized prompt", () => {
+    // given
+    const model = "openai/gpt-5.5";
 
     // when
     const prompt = getHephaestusPrompt(model);

--- a/src/agents/hephaestus/agent.ts
+++ b/src/agents/hephaestus/agent.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "../types";
-import { isGpt5_4Model, isGpt5_3CodexModel } from "../types";
+import { isGpt5_3CodexModel, isGptNativeSisyphusModel } from "../types";
 import type {
   AvailableAgent,
   AvailableTool,
@@ -21,7 +21,7 @@ export type HephaestusPromptSource = "gpt-5-4" | "gpt-5-3-codex" | "gpt";
 export function getHephaestusPromptSource(
   model?: string,
 ): HephaestusPromptSource {
-  if (model && isGpt5_4Model(model)) {
+  if (model && isGptNativeSisyphusModel(model)) {
     return "gpt-5-4";
   }
   if (model && isGpt5_3CodexModel(model)) {

--- a/src/agents/sisyphus.ts
+++ b/src/agents/sisyphus.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
-import { isGptModel, isGeminiModel, isGpt5_4Model } from "./types";
+import { isGptModel, isGeminiModel, isGptNativeSisyphusModel } from "./types";
 import {
   buildGeminiToolMandate,
   buildGeminiDelegationOverride,
@@ -480,7 +480,7 @@ export function createSisyphusAgent(
   const categories = availableCategories ?? [];
   const agents = availableAgents ?? [];
 
-  if (isGpt5_4Model(model)) {
+  if (isGptNativeSisyphusModel(model)) {
     const prompt = buildGpt54SisyphusPrompt(
       model,
       agents,

--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -3,68 +3,44 @@ import {
   isGptModel,
   isGeminiModel,
   isGlmModel,
-  isGpt5_4Model,
-  isGpt5_5Model,
   isGptNativeSisyphusModel,
   isMiniMaxModel,
 } from "./types";
 
-describe("isGpt5_4Model", () => {
-  test("detects gpt-5.4 models", () => {
-    expect(isGpt5_4Model("openai/gpt-5.4")).toBe(true);
-    expect(isGpt5_4Model("openai/gpt-5-4")).toBe(true);
-    expect(isGpt5_4Model("openai/gpt-5.4-codex")).toBe(true);
-    expect(isGpt5_4Model("github-copilot/gpt-5.4")).toBe(true);
-    expect(isGpt5_4Model("venice/gpt-5-4")).toBe(true);
-  });
-
-  test("does not match other GPT models", () => {
-    expect(isGpt5_4Model("openai/gpt-5.3-codex")).toBe(false);
-    expect(isGpt5_4Model("openai/gpt-5.1")).toBe(false);
-    expect(isGpt5_4Model("openai/gpt-4o")).toBe(false);
-    expect(isGpt5_4Model("github-copilot/gpt-4o")).toBe(false);
-  });
-
-  test("does not match non-GPT models", () => {
-    expect(isGpt5_4Model("anthropic/claude-opus-4-7")).toBe(false);
-    expect(isGpt5_4Model("google/gemini-3.1-pro")).toBe(false);
-    expect(isGpt5_4Model("openai/o1")).toBe(false);
-  });
-});
-
-describe("isGpt5_5Model", () => {
-  test("detects gpt-5.5 models", () => {
-    expect(isGpt5_5Model("gpt-5.5")).toBe(true);
-    expect(isGpt5_5Model("gpt-5-5")).toBe(true);
-    expect(isGpt5_5Model("openai/gpt-5.5")).toBe(true);
-    expect(isGpt5_5Model("openai/gpt-5-5")).toBe(true);
-    expect(isGpt5_5Model("github-copilot/gpt-5.5")).toBe(true);
-  });
-
-  test("does not match other GPT models", () => {
-    expect(isGpt5_5Model("openai/gpt-5.4")).toBe(false);
-    expect(isGpt5_5Model("openai/gpt-5.3-codex")).toBe(false);
-    expect(isGpt5_5Model("openai/gpt-4o")).toBe(false);
-  });
-
-  test("does not match non-GPT models", () => {
-    expect(isGpt5_5Model("anthropic/claude-opus-4-7")).toBe(false);
-    expect(isGpt5_5Model("google/gemini-3.1-pro")).toBe(false);
-  });
-});
-
 describe("isGptNativeSisyphusModel", () => {
-  test("allows GPT-5.4 and GPT-5.5 variants", () => {
+  test("allows GPT-5.x where x >= 4", () => {
     expect(isGptNativeSisyphusModel("openai/gpt-5.4")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5-4")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.5")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5-5")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.9")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5-9")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.10")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5-10")).toBe(true);
   });
 
-  test("rejects non-native Sisyphus GPT models and non-GPT models", () => {
+  test("allows with various providers and suffixes", () => {
+    expect(isGptNativeSisyphusModel("github-copilot/gpt-5.4")).toBe(true);
+    expect(isGptNativeSisyphusModel("venice/gpt-5-4")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.4-codex")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.5-mini")).toBe(true);
+  });
+
+  test("rejects GPT-5.x where x < 4", () => {
     expect(isGptNativeSisyphusModel("openai/gpt-5.3-codex")).toBe(false);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.1")).toBe(false);
+    expect(isGptNativeSisyphusModel("openai/gpt-5-0")).toBe(false);
+  });
+
+  test("rejects other GPT models", () => {
     expect(isGptNativeSisyphusModel("openai/gpt-4o")).toBe(false);
+    expect(isGptNativeSisyphusModel("github-copilot/gpt-4o")).toBe(false);
+  });
+
+  test("rejects non-GPT models", () => {
     expect(isGptNativeSisyphusModel("anthropic/claude-opus-4-7")).toBe(false);
+    expect(isGptNativeSisyphusModel("google/gemini-3.1-pro")).toBe(false);
+    expect(isGptNativeSisyphusModel("openai/o1")).toBe(false);
   });
 });
 

--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -1,5 +1,13 @@
 import { describe, test, expect } from "bun:test";
-import { isGptModel, isGeminiModel, isGlmModel, isGpt5_4Model, isMiniMaxModel } from "./types";
+import {
+  isGptModel,
+  isGeminiModel,
+  isGlmModel,
+  isGpt5_4Model,
+  isGpt5_5Model,
+  isGptNativeSisyphusModel,
+  isMiniMaxModel,
+} from "./types";
 
 describe("isGpt5_4Model", () => {
   test("detects gpt-5.4 models", () => {
@@ -21,6 +29,42 @@ describe("isGpt5_4Model", () => {
     expect(isGpt5_4Model("anthropic/claude-opus-4-7")).toBe(false);
     expect(isGpt5_4Model("google/gemini-3.1-pro")).toBe(false);
     expect(isGpt5_4Model("openai/o1")).toBe(false);
+  });
+});
+
+describe("isGpt5_5Model", () => {
+  test("detects gpt-5.5 models", () => {
+    expect(isGpt5_5Model("gpt-5.5")).toBe(true);
+    expect(isGpt5_5Model("gpt-5-5")).toBe(true);
+    expect(isGpt5_5Model("openai/gpt-5.5")).toBe(true);
+    expect(isGpt5_5Model("openai/gpt-5-5")).toBe(true);
+    expect(isGpt5_5Model("github-copilot/gpt-5.5")).toBe(true);
+  });
+
+  test("does not match other GPT models", () => {
+    expect(isGpt5_5Model("openai/gpt-5.4")).toBe(false);
+    expect(isGpt5_5Model("openai/gpt-5.3-codex")).toBe(false);
+    expect(isGpt5_5Model("openai/gpt-4o")).toBe(false);
+  });
+
+  test("does not match non-GPT models", () => {
+    expect(isGpt5_5Model("anthropic/claude-opus-4-7")).toBe(false);
+    expect(isGpt5_5Model("google/gemini-3.1-pro")).toBe(false);
+  });
+});
+
+describe("isGptNativeSisyphusModel", () => {
+  test("allows GPT-5.4 and GPT-5.5 variants", () => {
+    expect(isGptNativeSisyphusModel("openai/gpt-5.4")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5-4")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.5")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5-5")).toBe(true);
+  });
+
+  test("rejects non-native Sisyphus GPT models and non-GPT models", () => {
+    expect(isGptNativeSisyphusModel("openai/gpt-5.3-codex")).toBe(false);
+    expect(isGptNativeSisyphusModel("openai/gpt-4o")).toBe(false);
+    expect(isGptNativeSisyphusModel("anthropic/claude-opus-4-7")).toBe(false);
   });
 });
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -79,18 +79,11 @@ export function isGptModel(model: string): boolean {
   return modelName.includes("gpt");
 }
 
-export function isGpt5_4Model(model: string): boolean {
-  const modelName = extractModelName(model).toLowerCase();
-  return modelName.includes("gpt-5.4") || modelName.includes("gpt-5-4");
-}
-
-export function isGpt5_5Model(model: string): boolean {
-  const modelName = extractModelName(model).toLowerCase();
-  return modelName.includes("gpt-5.5") || modelName.includes("gpt-5-5");
-}
+const GPT_NATIVE_SISYPHUS_RE = /gpt-5[.-](?:[4-9]|\d{2,})/i;
 
 export function isGptNativeSisyphusModel(model: string): boolean {
-  return isGpt5_4Model(model) || isGpt5_5Model(model);
+  const modelName = extractModelName(model).toLowerCase();
+  return GPT_NATIVE_SISYPHUS_RE.test(modelName);
 }
 
 export function isGpt5_3CodexModel(model: string): boolean {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -84,6 +84,15 @@ export function isGpt5_4Model(model: string): boolean {
   return modelName.includes("gpt-5.4") || modelName.includes("gpt-5-4");
 }
 
+export function isGpt5_5Model(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase();
+  return modelName.includes("gpt-5.5") || modelName.includes("gpt-5-5");
+}
+
+export function isGptNativeSisyphusModel(model: string): boolean {
+  return isGpt5_4Model(model) || isGpt5_5Model(model);
+}
+
 export function isGpt5_3CodexModel(model: string): boolean {
   const modelName = extractModelName(model).toLowerCase();
   return modelName.includes("gpt-5.3-codex") || modelName.includes("gpt-5-3-codex");

--- a/src/hooks/no-sisyphus-gpt/hook.ts
+++ b/src/hooks/no-sisyphus-gpt/hook.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { isGptModel, isGpt5_4Model } from "../../agents/types"
+import { isGptModel, isGptNativeSisyphusModel } from "../../agents/types"
 import {
   getSessionAgent,
   resolveRegisteredAgentName,
@@ -11,8 +11,8 @@ import { getAgentConfigKey } from "../../shared/agent-display-names"
 const TOAST_TITLE = "NEVER Use Sisyphus with GPT"
 const TOAST_MESSAGE = [
   "Sisyphus works best with Claude Opus, and works fine with Kimi/GLM models.",
-  "Do NOT use Sisyphus with GPT (except GPT-5.4 which has specialized support).",
-  "For GPT models (other than 5.4), always use Hephaestus.",
+  "Do NOT use Sisyphus with GPT (except GPT-5.4 and GPT-5.5 which have specialized support).",
+  "For other GPT models, always use Hephaestus.",
 ].join("\n")
 function showToast(ctx: PluginInput, sessionID: string): void {
   ctx.client.tui.showToast({
@@ -43,7 +43,7 @@ export function createNoSisyphusGptHook(ctx: PluginInput) {
       const agentKey = getAgentConfigKey(rawAgent)
       const modelID = input.model?.modelID
 
-      if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGpt5_4Model(modelID)) {
+      if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGptNativeSisyphusModel(modelID)) {
         showToast(ctx, input.sessionID)
         input.agent = resolveRegisteredAgentName("hephaestus") ?? "hephaestus"
         if (output?.message) {

--- a/src/hooks/no-sisyphus-gpt/index.test.ts
+++ b/src/hooks/no-sisyphus-gpt/index.test.ts
@@ -43,7 +43,7 @@ describe("no-sisyphus-gpt hook", () => {
     expect(showToast.mock.calls[0]?.[0]).toMatchObject({
       body: {
         title: "NEVER Use Sisyphus with GPT",
-        message: expect.stringContaining("For GPT models (other than 5.4), always use Hephaestus."),
+        message: expect.stringContaining("For other GPT models, always use Hephaestus."),
         variant: "error",
       },
     })
@@ -63,6 +63,27 @@ describe("no-sisyphus-gpt hook", () => {
       sessionID: "ses_gpt54",
       agent: SISYPHUS_DISPLAY,
       model: { providerID: "openai", modelID: "gpt-5.4" },
+    }, output)
+
+    // then - no toast, agent NOT switched to Hephaestus
+    expect(showToast).toHaveBeenCalledTimes(0)
+    expect(output.message.agent).toBeUndefined()
+  })
+
+  test("does not show toast for gpt-5.5 model (native Sisyphus support)", async () => {
+    // given - sisyphus with gpt-5.5 model (should be allowed)
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook({
+      client: { tui: { showToast } },
+    } as any)
+
+    const output = createOutput()
+
+    // when - chat.message runs with gpt-5.5
+    await hook["chat.message"]?.({
+      sessionID: "ses_gpt55",
+      agent: SISYPHUS_DISPLAY,
+      model: { providerID: "openai", modelID: "gpt-5.5" },
     }, output)
 
     // then - no toast, agent NOT switched to Hephaestus


### PR DESCRIPTION
## Summary
- Add GPT-5.5 detection and include it in the shared native Sisyphus GPT helper.
- Route GPT-5.5 through the existing GPT-5.4 Sisyphus/Hephaestus prompt family without duplicating family checks.
- Update the no-Sisyphus-GPT hook and tests so GPT-5.5 is allowed while other GPT models still redirect to Hephaestus.

## Context
This follows the intent of #3602 while addressing the review feedback to keep GPT-5.4/GPT-5.5 family logic centralized in `isGptNativeSisyphusModel()` and to add helper-level tests for provider-prefixed forms.

## Tests
- `bun test src/agents/types.test.ts src/agents/hephaestus/agent.test.ts src/hooks/no-sisyphus-gpt/index.test.ts`
- `bun run typecheck`
- `bun test src/shared/model-capability-aliases.test.ts src/shared/model-capability-guardrails.test.ts src/shared/model-capabilities.test.ts src/cli/doctor/checks/model-resolution.test.ts`
- `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Sisyphus support for GPT-5.5 by routing it through the GPT-5.4 prompt family in both Sisyphus and Hephaestus. Generalizes model detection to GPT-5.x (>=5.4) and updates the no‑Sisyphus‑GPT hook.

- **New Features**
  - Detects GPT-5.x (>=5.4), including `5.5`, dash/dot variants, provider-prefixed/suffixed.
  - Routes GPT-5.5 to the GPT-5.4 Sisyphus/Hephaestus prompt family; Hephaestus serves the GPT-5.4-optimized prompt.
  - Updates the no‑Sisyphus‑GPT hook: allows GPT-5.5 and tweaks toast copy; other GPT models redirect to Hephaestus.

- **Refactors**
  - Replaces per-version checks with regex-based `isGptNativeSisyphusModel`; used by Sisyphus, Hephaestus, and the hook.
  - Expands tests for detection (5.4–5.10), prompt source/content, and hook behavior.

<sup>Written for commit 563b6569d302ff169cc756132a02db84ea851275. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

