### PR TITLE
Fix #3512: remove invisible agent name prefixes

### DIFF
--- a/src/plugin-handlers/AGENTS.md
+++ b/src/plugin-handlers/AGENTS.md
@@ -8,28 +8,31 @@ The canonical agent order is **sisyphus → hephaestus → prometheus → atlas*
 
 This order is enforced via two mechanisms working together:
 1. `CANONICAL_CORE_AGENT_ORDER` in `agent-priority-order.ts` controls object key insertion order
-2. `agent-key-remapper.ts` injects ZWSP-prefixed runtime names into the `name` field for OpenCode's `localeCompare` sort
+2. `agent-priority-order.ts` injects explicit `order` fields onto core agent configs so OpenCode can sort them without mutating visible names
 
 ### Why Two Mechanisms
 
-OpenCode's `Agent.list()` sorts agents by `name` field via `localeCompare`. Object key order alone is not enough. The `name` field carries ZWSP prefixes (1-4 chars) so core agents sort before alphabetically-named agents.
+Object key order alone is not enough because multiple merge paths can reshuffle assembled configs. The emitted `order` field provides a stable, explicit priority without leaking invisible characters into the UI or terminal renderers.
 
-ZWSP is intentionally used in the `name` field only. It MUST NOT appear in:
+Historical ZWSP-prefixed names may still appear in old sessions or cached state. They MUST NOT be emitted in current runtime names, object keys, or display names. Compatibility stripping lives in `shared/agent-display-names.ts`.
+
+Invisible characters MUST NOT appear in:
 - Object keys (used as HTTP header values, causes RFC 7230 violations)
+- Runtime names returned by `getAgentRuntimeName()`
 - Display names returned by `getAgentDisplayName()`
 - Config keys
 
 ### History
 
 Agent ordering has caused 15+ commits, 8+ PRs, and multiple reverts due to:
-1. Early ZWSP attempts that leaked into HTTP headers via object keys
+1. Early invisible-prefix attempts that leaked into visible UI surfaces
 2. Object.entries() iteration order depending on merge sequence
 3. Multiple code paths assembling agents differently
 
 ### Forbidden Patterns
 
 DO NOT introduce:
-- ZWSP in object keys or display names (only allowed in `name` field via `getAgentRuntimeName()`)
+- ZWSP or other invisible sort prefixes in emitted names
 - Runtime sort shims or comparators
 - Alternative ordering constants
 - Object.entries() order dependencies

--- a/src/shared/agent-display-names.test.ts
+++ b/src/shared/agent-display-names.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "bun:test"
-import { AGENT_DISPLAY_NAMES, getAgentConfigKey, getAgentDisplayName, getAgentListDisplayName, normalizeAgentForPrompt, normalizeAgentForPromptKey } from "./agent-display-names"
+import {
+  AGENT_DISPLAY_NAMES,
+  getAgentConfigKey,
+  getAgentDisplayName,
+  getAgentListDisplayName,
+  getAgentRuntimeName,
+  normalizeAgentForPrompt,
+  normalizeAgentForPromptKey,
+} from "./agent-display-names"
 
 describe("getAgentDisplayName", () => {
   it("returns display name for lowercase config key (new format)", () => {
@@ -194,15 +202,24 @@ describe("getAgentConfigKey", () => {
 })
 
 describe("getAgentListDisplayName", () => {
-  it("applies invisible stable-sort prefixes to the core agent list", () => {
-    expect(getAgentListDisplayName("sisyphus")).toBe("\u200BSisyphus - Ultraworker")
-    expect(getAgentListDisplayName("hephaestus")).toBe("\u200B\u200BHephaestus - Deep Agent")
-    expect(getAgentListDisplayName("prometheus")).toBe("\u200B\u200B\u200BPrometheus - Plan Builder")
-    expect(getAgentListDisplayName("atlas")).toBe("\u200B\u200B\u200B\u200BAtlas - Plan Executor")
+  it("keeps core agent list names free of invisible sort prefixes", () => {
+    expect(getAgentListDisplayName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentListDisplayName("hephaestus")).toBe("Hephaestus - Deep Agent")
+    expect(getAgentListDisplayName("prometheus")).toBe("Prometheus - Plan Builder")
+    expect(getAgentListDisplayName("atlas")).toBe("Atlas - Plan Executor")
   })
 
   it("keeps non-core agents unprefixed for list display", () => {
     expect(getAgentListDisplayName("oracle")).toBe("oracle")
+  })
+})
+
+describe("getAgentRuntimeName", () => {
+  it("matches display names without zero-width ordering characters", () => {
+    expect(getAgentRuntimeName("sisyphus")).toBe("Sisyphus - Ultraworker")
+    expect(getAgentRuntimeName("hephaestus")).toBe("Hephaestus - Deep Agent")
+    expect(getAgentRuntimeName("prometheus")).toBe("Prometheus - Plan Builder")
+    expect(getAgentRuntimeName("atlas")).toBe("Atlas - Plan Executor")
   })
 })
 

--- a/src/shared/agent-display-names.ts
+++ b/src/shared/agent-display-names.ts
@@ -26,13 +26,6 @@ export const AGENT_DISPLAY_NAMES: Record<string, string> = {
   "council-member": "council-member",
 }
 
-const AGENT_LIST_SORT_PREFIXES: Record<string, string> = {
-  sisyphus: "\u200B",
-  hephaestus: "\u200B\u200B",
-  prometheus: "\u200B\u200B\u200B",
-  atlas: "\u200B\u200B\u200B\u200B",
-}
-
 const INVISIBLE_AGENT_CHARACTERS_REGEX = /[\u200B\u200C\u200D\uFEFF]/g
 
 export function stripInvisibleAgentCharacters(agentName: string): string {
@@ -44,10 +37,7 @@ export function stripAgentListSortPrefix(agentName: string): string {
 }
 
 export function getAgentRuntimeName(configKey: string): string {
-  const displayName = getAgentDisplayName(configKey)
-  const prefix = AGENT_LIST_SORT_PREFIXES[configKey.toLowerCase()]
-
-  return prefix ? `${prefix}${displayName}` : displayName
+  return getAgentDisplayName(configKey)
 }
 
 /**
@@ -71,10 +61,13 @@ export function getAgentDisplayName(configKey: string): string {
 }
 
 /**
- * Runtime-facing agent name used for OpenCode list ordering.
+ * Runtime-facing agent name used by OpenCode.
+ * Older versions injected zero-width prefixes for list ordering; we now keep
+ * runtime names clean and rely on explicit `order` fields while still stripping
+ * historical prefixes during lookups for backward compatibility.
  */
 export function getAgentListDisplayName(configKey: string): string {
-  return getAgentRuntimeName(configKey)
+  return getAgentDisplayName(configKey)
 }
 
 const REVERSE_DISPLAY_NAMES: Record<string, string> = Object.fromEntries(


### PR DESCRIPTION
## Summary

- fix garbled agent name rendering by removing invisible zero-width prefixes from emitted runtime/list names
- keep backward compatibility by preserving invisible-character stripping during agent-name lookups
- update the agent ordering docs to describe the order-field based approach

## Changes

- remove `AGENT_LIST_SORT_PREFIXES` from `src/shared/agent-display-names.ts`
- make `getAgentRuntimeName()` and `getAgentListDisplayName()` return clean display names
- update agent name tests to assert prefix-free runtime names while keeping legacy normalization coverage
- refresh `src/plugin-handlers/AGENTS.md` so it no longer documents ZWSP-based ordering

## Testing

Installed Bun locally on Windows (`1.3.13`) and verified the change with:

```bash
bun run typecheck
bun run build
```

Both commands completed successfully.

## Related Issues

Closes #3512
