### PR TITLE
fix(anthropic-effort): clamp pre-set effort max to high for constrained providers (fixes #3563)

### DIFF
--- a/src/hooks/anthropic-effort/hook.ts
+++ b/src/hooks/anthropic-effort/hook.ts
@@ -79,10 +79,24 @@ export function createAnthropicEffortHook() {
       if (message.variant !== "max") return
       if (!isClaudeProvider(model.providerID, model.modelID)) return
       if (shouldSkipForInternalAgent(agent?.name)) return
-      if (output.options.effort !== undefined) return
-
       const opus = isOpusModel(model.modelID)
       const constrained = isConstrainedProvider(model.providerID)
+
+      // If effort was pre-set (e.g., via session prompt params), still clamp
+      // for constrained providers that reject "max".
+      if (output.options.effort !== undefined) {
+        if (constrained && output.options.effort === "max") {
+          output.options.effort = MAX_VARIANT_BY_TIER.default
+          ;(message as { variant?: string }).variant = MAX_VARIANT_BY_TIER.default
+          log("anthropic-effort: clamped pre-set effort max→high", {
+            sessionID: input.sessionID,
+            provider: model.providerID,
+            model: model.modelID,
+          })
+        }
+        return
+      }
+
       const clamped = clampVariant(message.variant, opus, constrained)
       output.options.effort = clamped
 


### PR DESCRIPTION
## Summary
- Clamp pre-set `effort: "max"` to `"high"` for constrained providers like GitHub Copilot

## Problem
When `output.options.effort` is pre-set to `"max"` via session prompt params (e.g., from the ultrawork keyword-detector or session-level configuration), the anthropic-effort hook skips clamping entirely because of an early return at `if (output.options.effort !== undefined) return`. This causes GitHub Copilot's claude-opus-4.6 to receive `effort: "max"` which it rejects with `output_config.effort "max" is not supported; supported values: [low medium high]`.

## Fix
Before the early return on pre-set effort, check if the provider is constrained and the effort is `"max"`. If so, clamp it to `"high"` and override the message variant accordingly. Non-constrained providers with pre-set effort still skip as before.

## Changes
| File | Change |
|------|--------|
| `src/hooks/anthropic-effort/hook.ts` | Clamp pre-set `effort: "max"` for constrained providers before early return |

Fixes #3563

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp pre-set effort "max" to "high" for constrained providers (e.g., GitHub Copilot) to prevent unsupported-effort errors and avoid failed requests. Adds a debug log to trace clamping. Fixes #3563.

- **Bug Fixes**
  - If `output.options.effort` is "max" and the provider is constrained, clamp to "high", update `message.variant`, and log the change before returning.
  - Non-constrained providers with pre-set effort remain unchanged; existing clamping still applies when effort isn’t pre-set.

<sup>Written for commit 3de1c612adf2e14e5bfd4d7619173aad936037ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

