### PR TITLE
fix(error-classifier): classify credit balance too low as quota_exceeded for fallback (fixes #3571)

### DIFF
--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -132,7 +132,8 @@ export function classifyErrorType(error: unknown): string | undefined {
     /exhausted\s+your\s+capacity/i.test(message) ||
     /out\s+of\s+credits?/i.test(message) ||
     /payment.?required/i.test(message) ||
-    /usage\s+limit/i.test(message)
+    /usage\s+limit/i.test(message) ||
+    /credit\s+balance.*too\s+low/i.test(message)
   ) {
     return "quota_exceeded"
   }


### PR DESCRIPTION
## Summary
- Recognize Anthropic "credit balance is too low" error as quota_exceeded to trigger model fallback

## Problem
When Anthropic rejects with "Your credit balance is too low to access the Anthropic API", the runtime-fallback hook does not classify it as a quota error. OMO blocks instead of falling back to other authenticated providers, making multi-provider routing unreliable at the exact moment users expect it.

## Fix
Added `/credit\s+balance.*too\s+low/i` pattern to the quota_exceeded classification in `classifyErrorType()`. This triggers the fallback chain to try the next configured model/provider.

## Changes
| File | Change |
|------|--------|
| `src/hooks/runtime-fallback/error-classifier.ts` | Add credit balance too low pattern to quota_exceeded classification |

Fixes #3571

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies Anthropic “credit balance is too low” errors as `quota_exceeded` so the runtime fallback tries the next provider. Fixes #3571.

- **Bug Fixes**
  - Add `/credit\s+balance.*too\s+low/i` to `quota_exceeded` checks in `classifyErrorType()` (`src/hooks/runtime-fallback/error-classifier.ts`) to trigger fallback.

<sup>Written for commit a22416d2705b8619ef873f2f289e965c2887c84b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

