### PR TITLE
feat(model-requirements): add kimi-k2.6 and glm-5.1 to Sisyphus fallback chains (fixes #3568)

### DIFF
--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -25,8 +25,21 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "claude-opus-4-7",
         variant: "max",
       },
+      { providers: ["opencode-go", "vercel"], model: "kimi-k2.6" },
       { providers: ["opencode-go", "vercel"], model: "kimi-k2.5" },
       { providers: ["kimi-for-coding"], model: "k2p5" },
+      {
+        providers: [
+          "opencode",
+          "moonshotai",
+          "moonshotai-cn",
+          "firmware",
+          "ollama-cloud",
+          "aihubmix",
+          "vercel",
+        ],
+        model: "kimi-k2.6",
+      },
       {
         providers: [
           "opencode",
@@ -40,6 +53,7 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "kimi-k2.5",
       },
       { providers: ["openai", "github-copilot", "opencode", "vercel"], model: "gpt-5.4", variant: "medium" },
+      { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5.1" },
       { providers: ["zai-coding-plan", "opencode", "vercel"], model: "glm-5" },
       { providers: ["opencode"], model: "big-pickle" },
     ],


### PR DESCRIPTION
## Summary
- Add kimi-k2.6 and glm-5.1 as higher-priority fallback options in Sisyphus agent model requirements

## Problem
Sisyphus currently uses kimi-k2.5 and glm-5 as fallback orchestration models. Their successors (kimi-k2.6 and glm-5.1) offer significant improvements in long-horizon agentic execution and autonomous coding, but are not yet in the fallback chains. Users with access to these newer models cannot benefit from automatic model routing.

## Fix
Added kimi-k2.6 and glm-5.1 as higher-priority entries in the Sisyphus fallback chain, placed before their predecessors. Both older versions (kimi-k2.5, glm-5) remain as fallbacks for users who haven't updated their providers. The fallback chain now tries newer models first, falling back to older versions if unavailable.

## Changes
| File | Change |
|------|--------|
| `src/shared/model-requirements.ts` | Add kimi-k2.6 and glm-5.1 entries to Sisyphus fallback chain |

Fixes #3568

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `kimi-k2.6` and `glm-5.1` to the Sisyphus agent fallback chain, prioritized ahead of `kimi-k2.5` and `glm-5` to route to newer models first. Expands provider routing for `kimi-k2.6` (e.g., `opencode-go`, `opencode`, `vercel`, `moonshotai`) while keeping older models as fallbacks.

<sup>Written for commit 1efa956d65bd9368d4fdc56fd66abb10fdc36b65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

