### PR TITLE
fix(doctor): catch unexpected failures and provide actionable diagnostics (fixes #3345)

### DIFF
--- a/src/cli/doctor/index.ts
+++ b/src/cli/doctor/index.ts
@@ -1,9 +1,18 @@
 import type { DoctorOptions } from "./types"
 import { runDoctor } from "./runner"
+import { EXIT_CODES } from "./constants"
 
 export async function doctor(options: DoctorOptions = { mode: "default" }): Promise<number> {
-  const result = await runDoctor(options)
-  return result.exitCode
+  try {
+    const result = await runDoctor(options)
+    return result.exitCode
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error("\nDoctor failed unexpectedly:", message)
+    console.error("This may indicate memory pressure (OOM/SIGKILL) or a corrupted installation.")
+    console.error("Try: OMO_DISABLE_POSTHOG=1 bunx oh-my-opencode doctor --verbose\n")
+    return EXIT_CODES.FAILURE
+  }
 }
 
 export * from "./types"


### PR DESCRIPTION
## Summary
- Wrap doctor execution with error handling so unexpected failures produce actionable diagnostics instead of silent exit 137

## Problem
`bunx oh-my-opencode doctor` can exit with code 137 (OOM/SIGKILL) and produce no output. Users get no indication of what went wrong or how to recover. The doctor entry point had no try/catch, so any unexpected error during check execution would propagate as an unhandled rejection.

## Fix
Wrapped the `runDoctor()` call in a try/catch that outputs: the error message, a hint about memory pressure/corrupted installation, and a suggestion to retry with `OMO_DISABLE_POSTHOG=1` and `--verbose`. Returns EXIT_CODES.FAILURE instead of crashing silently.

## Changes
| File | Change |
|------|--------|
| `src/cli/doctor/index.ts` | Add try/catch with actionable error message around runDoctor() |

Fixes #3345

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Catch unexpected failures in the `doctor` command and print clear diagnostics instead of a silent exit 137. Wrap `runDoctor()` in try/catch, log the error with OOM/corrupted-install hints, suggest retrying with `OMO_DISABLE_POSTHOG=1 bunx oh-my-opencode doctor --verbose`, and return `EXIT_CODES.FAILURE` (fixes #3345).

<sup>Written for commit 29713229521ddda4a0add4a29ab8764902ec60bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

