### PR TITLE
fix(tmux): isolate agent sessions by server URL

### DIFF
--- a/src/shared/tmux/tmux-utils/session-spawn.test.ts
+++ b/src/shared/tmux/tmux-utils/session-spawn.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test"
+import { getIsolatedSessionName } from "./session-spawn"
+
+describe("getIsolatedSessionName", () => {
+	it("returns the same tmux session name for the same server URL", () => {
+		const first = getIsolatedSessionName("http://127.0.0.1:4096")
+		const second = getIsolatedSessionName("http://127.0.0.1:4096")
+
+		expect(first).toBe(second)
+		expect(first).toMatch(/^omo-agents-[a-f0-9]{10}$/)
+	})
+
+	it("uses different tmux session names for different plugin server URLs", () => {
+		const first = getIsolatedSessionName("http://127.0.0.1:4096")
+		const second = getIsolatedSessionName("http://127.0.0.1:4097")
+
+		expect(first).not.toBe(second)
+	})
+})

--- a/src/shared/tmux/tmux-utils/session-spawn.ts
+++ b/src/shared/tmux/tmux-utils/session-spawn.ts
@@ -1,4 +1,5 @@
 import { spawn } from "bun"
+import { createHash } from "node:crypto"
 import type { TmuxConfig } from "../../../config/schema"
 import { getTmuxPath } from "../../../tools/interactive-bash/tmux-path-resolver"
 import type { SpawnPaneResult } from "../types"
@@ -6,7 +7,12 @@ import { isInsideTmux } from "./environment"
 import { isServerRunning } from "./server-health"
 import { shellEscapeForDoubleQuotedCommand } from "../../shell-env"
 
-const ISOLATED_SESSION_NAME = "omo-agents"
+const ISOLATED_SESSION_NAME_PREFIX = "omo-agents"
+
+export function getIsolatedSessionName(serverUrl: string): string {
+	const digest = createHash("sha256").update(serverUrl).digest("hex").slice(0, 10)
+	return `${ISOLATED_SESSION_NAME_PREFIX}-${digest}`
+}
 
 async function getWindowDimensions(
 	tmux: string,
@@ -87,12 +93,13 @@ export async function spawnTmuxSession(
 		}
 	}
 
-	const sessionAlreadyExists = await sessionExists(tmux, ISOLATED_SESSION_NAME)
+	const isolatedSessionName = getIsolatedSessionName(serverUrl)
+	const sessionAlreadyExists = await sessionExists(tmux, isolatedSessionName)
 
 	const args = sessionAlreadyExists
 		? [
 			"new-window",
-			"-t", ISOLATED_SESSION_NAME,
+			"-t", isolatedSessionName,
 			"-P",
 			"-F", "#{pane_id}",
 			opencodeCmd,
@@ -100,7 +107,7 @@ export async function spawnTmuxSession(
 		: [
 			"new-session",
 			"-d",
-			"-s", ISOLATED_SESSION_NAME,
+			"-s", isolatedSessionName,
 			...sizeArgs,
 			"-P",
 			"-F", "#{pane_id}",
@@ -109,7 +116,7 @@ export async function spawnTmuxSession(
 
 	log("[spawnTmuxSession] spawning", {
 		mode: sessionAlreadyExists ? "new-window" : "new-session",
-		sessionName: ISOLATED_SESSION_NAME,
+		sessionName: isolatedSessionName,
 	})
 
 	const proc = spawn([tmux, ...args], { stdout: "pipe", stderr: "pipe" })
@@ -140,6 +147,6 @@ export async function spawnTmuxSession(
 		})
 	}
 
-	log("[spawnTmuxSession] SUCCESS", { paneId, sessionName: ISOLATED_SESSION_NAME })
+	log("[spawnTmuxSession] SUCCESS", { paneId, sessionName: isolatedSessionName })
 	return { success: true, paneId }
 }


### PR DESCRIPTION
## Summary
- derive the isolated tmux session name from the plugin server URL instead of using one global `omo-agents` session
- keep sessions stable for the same server URL while separating different plugin/server instances
- add regression coverage for stable same-instance names and different-instance isolation

## Tests
- `bun test src/shared/tmux/tmux-utils/session-spawn.test.ts src/shared/tmux/tmux-utils/pane-spawn.test.ts`
- `git diff --check`

Note: `bunx tsc --noEmit --pretty false --incremental false` could not run in this checkout because dependencies are not installed (`bun-types` is missing from node_modules).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolate tmux agent sessions by plugin server URL to prevent cross-instance collisions. Session names now use a stable 10-char SHA-256 hash of the URL.

- **Bug Fixes**
  - Replaced global `omo-agents` session with per-URL session `omo-agents-<hash>` via `getIsolatedSessionName(serverUrl)`.
  - Added tests to verify stable naming for the same URL and isolation across different URLs.

<sup>Written for commit 35e81e168954ef5f632e0ec255006ab5e54e2193. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

