### PR TITLE
Normalize legacy gateway model aliases to canonical vercel models

### DIFF
--- a/src/cli/doctor/checks/model-resolution-details.ts
+++ b/src/cli/doctor/checks/model-resolution-details.ts
@@ -42,6 +42,9 @@ export function buildModelResolutionDetails(options: {
       getEffectiveVariant(agent.name, agent.requirement, options.config)
     )
     details.push(`  ${marker} ${agent.name}: ${display} [capabilities: ${formatCapabilityResolutionLabel(agent.capabilityDiagnostics?.resolutionMode)}]`)
+    if (agent.userOverride?.startsWith("gateway/") && agent.userOverride !== agent.effectiveModel) {
+      details.push(`    ↳ deprecated alias: ${agent.userOverride} -> use ${agent.effectiveModel}`)
+    }
   }
   details.push("")
   details.push("Categories:")
@@ -52,6 +55,9 @@ export function buildModelResolutionDetails(options: {
       getCategoryEffectiveVariant(category.name, category.requirement, options.config)
     )
     details.push(`  ${marker} ${category.name}: ${display} [capabilities: ${formatCapabilityResolutionLabel(category.capabilityDiagnostics?.resolutionMode)}]`)
+    if (category.userOverride?.startsWith("gateway/") && category.userOverride !== category.effectiveModel) {
+      details.push(`    ↳ deprecated alias: ${category.userOverride} -> use ${category.effectiveModel}`)
+    }
   }
   details.push("")
   details.push("● = user override, ○ = provider fallback")

--- a/src/cli/doctor/checks/model-resolution.test.ts
+++ b/src/cli/doctor/checks/model-resolution.test.ts
@@ -90,6 +90,22 @@ describe("model-resolution check", () => {
       expect(sisyphus!.effectiveResolution).toContain("anthropic")
     })
 
+    it("normalizes deprecated gateway aliases to canonical vercel models while preserving the raw override for diagnostics", async () => {
+      const { getModelResolutionInfoWithOverrides } = await import("./model-resolution")
+
+      const info = getModelResolutionInfoWithOverrides({
+        agents: {
+          oracle: { model: "gateway/gpt-5.4" },
+        },
+      })
+
+      const oracle = info.agents.find((a) => a.name === "oracle")
+      expect(oracle).toBeDefined()
+      expect(oracle!.userOverride).toBe("gateway/gpt-5.4")
+      expect(oracle!.effectiveModel).toBe("vercel/openai/gpt-5.4")
+      expect(oracle!.effectiveResolution).toBe("User override: vercel/openai/gpt-5.4")
+    })
+
     it("captures user variant for agent when configured", async () => {
       const { getModelResolutionInfoWithOverrides } = await import("./model-resolution")
 
@@ -234,6 +250,40 @@ describe("model-resolution check", () => {
       expect(issues).toHaveLength(1)
       expect(issues[0]?.title).toContain("compatibility fallback")
       expect(issues[0]?.description).toContain("oracle=custom/unknown-llm")
+    })
+
+    it("collects warnings when deprecated gateway aliases are configured", async () => {
+      const { collectCapabilityResolutionIssues, getModelResolutionInfoWithOverrides } = await import("./model-resolution")
+
+      const info = getModelResolutionInfoWithOverrides({
+        agents: {
+          oracle: { model: "gateway/gpt-5.4" },
+        },
+      })
+
+      const issues = collectCapabilityResolutionIssues(info)
+
+      expect(issues.some((issue) => issue.title.includes("Deprecated gateway model alias"))).toBe(true)
+      expect(issues.some((issue) => issue.description.includes("gateway/gpt-5.4 -> vercel/openai/gpt-5.4"))).toBe(true)
+    })
+
+    it("includes deprecated gateway alias guidance in verbose details", async () => {
+      const { checkModelResolution } = await import("./model-resolution")
+      const configModule = await import("./model-resolution-config")
+
+      const loadOmoConfigSpy = spyOn(configModule, "loadOmoConfig")
+      loadOmoConfigSpy.mockReturnValue({
+        agents: {
+          oracle: { model: "gateway/gpt-5.4" },
+        },
+      })
+
+      try {
+        const result = await checkModelResolution()
+        expect(result.details?.some((line) => line.includes("deprecated alias: gateway/gpt-5.4 -> use vercel/openai/gpt-5.4"))).toBe(true)
+      } finally {
+        loadOmoConfigSpy.mockRestore()
+      }
     })
   })
 

--- a/src/cli/doctor/checks/model-resolution.ts
+++ b/src/cli/doctor/checks/model-resolution.ts
@@ -1,5 +1,6 @@
 import { AGENT_MODEL_REQUIREMENTS, CATEGORY_MODEL_REQUIREMENTS } from "../../../shared/model-requirements"
 import { getModelCapabilities } from "../../../shared/model-capabilities"
+import { normalizeModel } from "../../../shared/model-normalization"
 import { CHECK_IDS, CHECK_NAMES } from "../constants"
 import type { CheckResult, DoctorIssue } from "../types"
 import { loadAvailableModelsFromCache } from "./model-resolution-cache"
@@ -61,28 +62,30 @@ export function getModelResolutionInfo(): ModelResolutionInfo {
 export function getModelResolutionInfoWithOverrides(config: OmoConfig): ModelResolutionInfo {
   const agents: AgentResolutionInfo[] = Object.entries(AGENT_MODEL_REQUIREMENTS).map(([name, requirement]) => {
     const userOverride = config.agents?.[name]?.model
+    const normalizedUserOverride = normalizeModel(userOverride)
     const userVariant = config.agents?.[name]?.variant
     return attachCapabilityDiagnostics({
       name,
       requirement,
       userOverride,
       userVariant,
-      effectiveModel: getEffectiveModel(requirement, userOverride),
-      effectiveResolution: buildEffectiveResolution(requirement, userOverride),
+      effectiveModel: getEffectiveModel(requirement, normalizedUserOverride),
+      effectiveResolution: buildEffectiveResolution(requirement, normalizedUserOverride),
     })
   })
 
   const categories: CategoryResolutionInfo[] = Object.entries(CATEGORY_MODEL_REQUIREMENTS).map(
     ([name, requirement]) => {
       const userOverride = config.categories?.[name]?.model
+      const normalizedUserOverride = normalizeModel(userOverride)
       const userVariant = config.categories?.[name]?.variant
       return attachCapabilityDiagnostics({
         name,
         requirement,
         userOverride,
         userVariant,
-        effectiveModel: getEffectiveModel(requirement, userOverride),
-        effectiveResolution: buildEffectiveResolution(requirement, userOverride),
+        effectiveModel: getEffectiveModel(requirement, normalizedUserOverride),
+        effectiveResolution: buildEffectiveResolution(requirement, normalizedUserOverride),
       })
     }
   )
@@ -99,19 +102,35 @@ export function collectCapabilityResolutionIssues(info: ModelResolutionInfo): Do
   })
 
   if (fallbackEntries.length === 0) {
-    return issues
+    // continue collecting alias warnings below
+  } else {
+    const summary = fallbackEntries
+      .map((entry) => `${entry.name}=${entry.effectiveModel} (${entry.capabilityDiagnostics?.resolutionMode ?? "unknown"})`)
+      .join(", ")
+
+    issues.push({
+      title: "Configured models rely on compatibility fallback",
+      description: summary,
+      severity: "warning",
+      affects: fallbackEntries.map((entry) => entry.name),
+    })
   }
 
-  const summary = fallbackEntries
-    .map((entry) => `${entry.name}=${entry.effectiveModel} (${entry.capabilityDiagnostics?.resolutionMode ?? "unknown"})`)
-    .join(", ")
+  const deprecatedGatewayEntries = allEntries.filter(
+    (entry) => entry.userOverride?.startsWith("gateway/") && entry.userOverride !== entry.effectiveModel
+  )
+  if (deprecatedGatewayEntries.length > 0) {
+    const summary = deprecatedGatewayEntries
+      .map((entry) => `${entry.name}=${entry.userOverride} -> ${entry.effectiveModel}`)
+      .join(", ")
 
-  issues.push({
-    title: "Configured models rely on compatibility fallback",
-    description: summary,
-    severity: "warning",
-    affects: fallbackEntries.map((entry) => entry.name),
-  })
+    issues.push({
+      title: "Deprecated gateway model alias configured",
+      description: `${summary}. Replace gateway/... with vercel/...`,
+      severity: "warning",
+      affects: deprecatedGatewayEntries.map((entry) => entry.name),
+    })
+  }
 
   return issues
 }

--- a/src/cli/run/model-resolver.test.ts
+++ b/src/cli/run/model-resolver.test.ts
@@ -48,6 +48,28 @@ describe("resolveRunModel", () => {
     expect(result).toEqual({ providerID: "openai", modelID: "gpt-5.3/preview" })
   })
 
+  it("given legacy gateway alias without sub-provider, when resolved, then returns canonical vercel/openai model", () => {
+    // given
+    const modelString = "gateway/gpt-5.4"
+
+    // when
+    const result = resolveRunModel(modelString)
+
+    // then
+    expect(result).toEqual({ providerID: "vercel", modelID: "openai/gpt-5.4" })
+  })
+
+  it("given legacy gateway alias with explicit sub-provider, when resolved, then returns canonical vercel transport model", () => {
+    // given
+    const modelString = "gateway/anthropic/claude-opus-4-7"
+
+    // when
+    const result = resolveRunModel(modelString)
+
+    // then
+    expect(result).toEqual({ providerID: "vercel", modelID: "anthropic/claude-opus-4.7" })
+  })
+
   it("given no slash 'claude-sonnet-4', when resolved, then throws Error", () => {
     // given
     const modelString = "claude-sonnet-4"

--- a/src/cli/run/model-resolver.ts
+++ b/src/cli/run/model-resolver.ts
@@ -1,3 +1,5 @@
+import { normalizeModel } from "../../shared/model-normalization"
+
 export function resolveRunModel(
   modelString?: string
 ): { providerID: string; modelID: string } | undefined {
@@ -5,12 +7,12 @@ export function resolveRunModel(
     return undefined
   }
 
-  const trimmed = modelString.trim()
-  if (trimmed.length === 0) {
+  const normalized = normalizeModel(modelString)
+  if (normalized === undefined) {
     throw new Error("Model string cannot be empty")
   }
 
-  const parts = trimmed.split("/")
+  const parts = normalized.split("/")
   if (parts.length < 2) {
     throw new Error("Model string must be in 'provider/model' format")
   }

--- a/src/shared/migration.test.ts
+++ b/src/shared/migration.test.ts
@@ -617,10 +617,10 @@ describe("migrateModelVersions", () => {
     expect(prometheus.model).toBe("anthropic/claude-opus-4-7")
   })
 
-  test("leaves unknown model strings untouched", () => {
-    // given: Agent config with unknown model
+  test("leaves truly unmapped model strings untouched", () => {
+    // given: Agent config with model string that is not in the migration map
     const agents = {
-      oracle: { model: "openai/gpt-5.4", temperature: 0.5 },
+      oracle: { model: "openai/gpt-5.4-mini-fast", temperature: 0.5 },
     }
 
     // when: Migrate model versions
@@ -629,7 +629,7 @@ describe("migrateModelVersions", () => {
     // then: Config should remain unchanged
     expect(changed).toBe(false)
     const oracle = migrated["oracle"] as Record<string, unknown>
-    expect(oracle.model).toBe("openai/gpt-5.4")
+    expect(oracle.model).toBe("openai/gpt-5.4-mini-fast")
   })
 
   test("handles agent config with no model field", () => {
@@ -665,7 +665,7 @@ describe("migrateModelVersions", () => {
     const agents = {
       sisyphus: { model: "openai/gpt-5.4-codex" },
       prometheus: { model: "anthropic/claude-opus-4-5" },
-      oracle: { model: "openai/gpt-5.4" },
+      oracle: { model: "openai/gpt-5.4-mini-fast" },
     }
 
     // when: Migrate model versions
@@ -675,7 +675,7 @@ describe("migrateModelVersions", () => {
     expect(changed).toBe(true)
     expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
     expect((migrated["prometheus"] as Record<string, unknown>).model).toBe("anthropic/claude-opus-4-7")
-    expect((migrated["oracle"] as Record<string, unknown>).model).toBe("openai/gpt-5.4")
+    expect((migrated["oracle"] as Record<string, unknown>).model).toBe("openai/gpt-5.4-mini-fast")
   })
 
   test("handles empty object", () => {
@@ -754,6 +754,68 @@ describe("migrateModelVersions", () => {
     expect(changed).toBe(false)
     expect(newMigrations).toHaveLength(0)
     expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe("openai/gpt-5.4-codex")
+  })
+
+  test("migrates legacy gateway alias without sub-provider to vercel canonical model", () => {
+    // given: Agent config with legacy gateway alias
+    const agents = {
+      hephaestus: { model: "gateway/gpt-5.4" },
+    }
+
+    // when: Migrate model versions
+    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
+
+    // then: Model should be rewritten to the canonical vercel provider path
+    expect(changed).toBe(true)
+    expect(newMigrations).toEqual([
+      "model-version:gateway/gpt-5.4->vercel/openai/gpt-5.4",
+    ])
+    expect((migrated["hephaestus"] as Record<string, unknown>).model).toBe("vercel/openai/gpt-5.4")
+  })
+
+  test("migrates legacy gateway alias with explicit sub-provider to vercel canonical model", () => {
+    // given: Agent config with explicit sub-provider under the old gateway alias
+    const agents = {
+      sisyphus: { model: "gateway/anthropic/claude-opus-4-7" },
+    }
+
+    // when: Migrate model versions
+    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
+
+    // then: Model should keep the sub-provider while switching to vercel canonical transport
+    expect(changed).toBe(true)
+    expect(newMigrations).toEqual([
+      "model-version:gateway/anthropic/claude-opus-4-7->vercel/anthropic/claude-opus-4.7",
+    ])
+    expect((migrated["sisyphus"] as Record<string, unknown>).model).toBe("vercel/anthropic/claude-opus-4.7")
+  })
+
+  test("migrates legacy gateway aliases inside fallback_models", () => {
+    // given: Config with legacy gateway aliases in fallback_models
+    const agents = {
+      hephaestus: {
+        model: "openai/gpt-5.4",
+        fallback_models: [
+          "gateway/gpt-5.4",
+          { model: "gateway/anthropic/claude-opus-4-7", variant: "high" },
+        ],
+      },
+    }
+
+    // when: Migrate model versions
+    const { migrated, changed, newMigrations } = migrateModelVersions(agents)
+
+    // then: All legacy fallback entries should be rewritten to canonical vercel transport ids
+    expect(changed).toBe(true)
+    expect(newMigrations).toContain("model-version:gateway/gpt-5.4->vercel/openai/gpt-5.4")
+    expect(newMigrations).toContain(
+      "model-version:gateway/anthropic/claude-opus-4-7->vercel/anthropic/claude-opus-4.7",
+    )
+
+    expect((migrated["hephaestus"] as Record<string, unknown>).fallback_models).toEqual([
+      "vercel/openai/gpt-5.4",
+      { model: "vercel/anthropic/claude-opus-4.7", variant: "high" },
+    ])
   })
 })
 
@@ -1083,7 +1145,7 @@ describe("migrateConfigFile with backup", () => {
     const rawConfig: Record<string, unknown> = {
       agents: {
         "multimodal-looker": { model: "anthropic/claude-haiku-4-5" },
-        oracle: { model: "openai/gpt-5.4" },
+        oracle: { model: "openai/gpt-5.4-mini-fast" },
         "my-custom-agent": { model: "google/gemini-3.1-pro" },
       },
     }
@@ -1094,12 +1156,12 @@ describe("migrateConfigFile with backup", () => {
     // when: Migrate config file
     const needsWrite = migrateConfigFile(testConfigPath, rawConfig)
 
-    // then: No migration needed - model settings should be preserved as-is
+    // then: No category migration should happen - explicit model settings should be preserved as-is
     expect(needsWrite).toBe(false)
 
     const agents = rawConfig.agents as Record<string, Record<string, unknown>>
     expect(agents["multimodal-looker"].model).toBe("anthropic/claude-haiku-4-5")
-    expect(agents.oracle.model).toBe("openai/gpt-5.4")
+    expect(agents.oracle.model).toBe("openai/gpt-5.4-mini-fast")
     expect(agents["my-custom-agent"].model).toBe("google/gemini-3.1-pro")
   })
 

--- a/src/shared/migration/config-migration.test.ts
+++ b/src/shared/migration/config-migration.test.ts
@@ -168,3 +168,55 @@ describe("migrateConfigFile backup skipping", () => {
     expect(backupFiles.length).toBe(1)
   })
 })
+
+describe("migrateConfigFile legacy gateway alias", () => {
+  test("rewrites gateway model aliases in persisted config and in-memory config", () => {
+    // given
+    const workdir = createWorkdir()
+    const configPath = join(workdir, "oh-my-opencode.json")
+    const rawConfig: Record<string, unknown> = {
+      agents: {
+        hephaestus: {
+          model: "gateway/gpt-5.4",
+          fallback_models: [
+            "gateway/gpt-5.4",
+            { model: "gateway/anthropic/claude-opus-4-7", variant: "high" },
+          ],
+        },
+      },
+      categories: {
+        deep: { model: "gateway/anthropic/claude-opus-4-7" },
+      },
+    }
+
+    writeFileSync(configPath, JSON.stringify(rawConfig, null, 2) + "\n")
+
+    // when
+    const needsWrite = migrateConfigFile(configPath, rawConfig)
+
+    // then
+    expect(needsWrite).toBe(true)
+    expect((rawConfig.agents as Record<string, Record<string, unknown>>).hephaestus.model).toBe(
+      "vercel/openai/gpt-5.4",
+    )
+    expect((rawConfig.agents as Record<string, Record<string, unknown>>).hephaestus.fallback_models).toEqual([
+      "vercel/openai/gpt-5.4",
+      { model: "vercel/anthropic/claude-opus-4.7", variant: "high" },
+    ])
+    expect((rawConfig.categories as Record<string, Record<string, unknown>>).deep.model).toBe(
+      "vercel/anthropic/claude-opus-4.7",
+    )
+
+    const persistedConfig = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>
+    expect((persistedConfig.agents as Record<string, Record<string, unknown>>).hephaestus.model).toBe(
+      "vercel/openai/gpt-5.4",
+    )
+    expect((persistedConfig.agents as Record<string, Record<string, unknown>>).hephaestus.fallback_models).toEqual([
+      "vercel/openai/gpt-5.4",
+      { model: "vercel/anthropic/claude-opus-4.7", variant: "high" },
+    ])
+    expect((persistedConfig.categories as Record<string, Record<string, unknown>>).deep.model).toBe(
+      "vercel/anthropic/claude-opus-4.7",
+    )
+  })
+})

--- a/src/shared/migration/model-versions.ts
+++ b/src/shared/migration/model-versions.ts
@@ -1,9 +1,12 @@
+import { transformModelForProvider } from "../provider-model-id-transform"
+
 /**
  * Model version migration map: old full model strings → new full model strings.
  * Used to auto-upgrade hardcoded model versions in user configs when the plugin
  * bumps to newer model versions.
  *
- * Keys are full "provider/model" strings. Only openai and anthropic entries needed.
+ * Keys are full "provider/model" strings. Legacy provider aliases that need
+ * provider-specific rewrites are handled below instead of being hardcoded here.
  */
 export const MODEL_VERSION_MAP: Record<string, string> = {
   "anthropic/claude-opus-4-5": "anthropic/claude-opus-4-7",
@@ -13,8 +16,40 @@ export const MODEL_VERSION_MAP: Record<string, string> = {
   "openai/gpt-5.4": "openai/gpt-5.5",
 }
 
+const LEGACY_GATEWAY_PREFIX = "gateway/"
+
 function migrationKey(oldModel: string, newModel: string): string {
   return `model-version:${oldModel}->${newModel}`
+}
+
+function migrateLegacyGatewayAlias(oldModel: string): string | undefined {
+  if (!oldModel.startsWith(LEGACY_GATEWAY_PREFIX)) {
+    return undefined
+  }
+
+  const legacyModel = oldModel.slice(LEGACY_GATEWAY_PREFIX.length)
+  return `vercel/${transformModelForProvider("vercel", legacyModel)}`
+}
+
+function getMigratedModel(oldModel: string): string | undefined {
+  return migrateLegacyGatewayAlias(oldModel) ?? MODEL_VERSION_MAP[oldModel]
+}
+
+function applyModelMigration(
+  oldModel: string,
+  appliedMigrations?: Set<string>
+): { changed: false; model: string } | { changed: true; model: string; migrationKey: string } {
+  const newModel = getMigratedModel(oldModel)
+  if (!newModel) {
+    return { changed: false, model: oldModel }
+  }
+
+  const mKey = migrationKey(oldModel, newModel)
+  if (appliedMigrations?.has(mKey)) {
+    return { changed: false, model: oldModel }
+  }
+
+  return { changed: true, model: newModel, migrationKey: mKey }
 }
 
 export function migrateModelVersions(
@@ -28,20 +63,58 @@ export function migrateModelVersions(
   for (const [key, value] of Object.entries(configs)) {
     if (value && typeof value === "object" && !Array.isArray(value)) {
       const config = value as Record<string, unknown>
-      if (typeof config.model === "string" && MODEL_VERSION_MAP[config.model]) {
-        const oldModel = config.model
-        const newModel = MODEL_VERSION_MAP[oldModel]
-        const mKey = migrationKey(oldModel, newModel)
+      const migratedConfig = { ...config }
+      let configChanged = false
 
-        // Skip if this migration was already applied (user may have reverted)
-        if (appliedMigrations?.has(mKey)) {
-          migrated[key] = value
-          continue
+      if (typeof config.model === "string") {
+        const modelMigration = applyModelMigration(config.model, appliedMigrations)
+        if (modelMigration.changed) {
+          migratedConfig.model = modelMigration.model
+          configChanged = true
+          if (!newMigrations.includes(modelMigration.migrationKey)) {
+            newMigrations.push(modelMigration.migrationKey)
+          }
         }
+      }
 
-        migrated[key] = { ...config, model: newModel }
+      if (Array.isArray(config.fallback_models)) {
+        const migratedFallbackModels = config.fallback_models.map((entry) => {
+          if (typeof entry === "string") {
+            const fallbackMigration = applyModelMigration(entry, appliedMigrations)
+            if (fallbackMigration.changed) {
+              configChanged = true
+              if (!newMigrations.includes(fallbackMigration.migrationKey)) {
+                newMigrations.push(fallbackMigration.migrationKey)
+              }
+            }
+            return fallbackMigration.model
+          }
+
+          if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+            const fallbackConfig = entry as Record<string, unknown>
+            if (typeof fallbackConfig.model === "string") {
+              const fallbackMigration = applyModelMigration(fallbackConfig.model, appliedMigrations)
+              if (fallbackMigration.changed) {
+                configChanged = true
+                if (!newMigrations.includes(fallbackMigration.migrationKey)) {
+                  newMigrations.push(fallbackMigration.migrationKey)
+                }
+                return { ...fallbackConfig, model: fallbackMigration.model }
+              }
+            }
+          }
+
+          return entry
+        })
+
+        if (configChanged) {
+          migratedConfig.fallback_models = migratedFallbackModels
+        }
+      }
+
+      if (configChanged) {
+        migrated[key] = migratedConfig
         changed = true
-        newMigrations.push(mKey)
         continue
       }
     }

--- a/src/shared/model-normalization.test.ts
+++ b/src/shared/model-normalization.test.ts
@@ -54,6 +54,32 @@ describe("normalizeModel", () => {
 		})
 	})
 
+	describe("#given legacy gateway alias without sub-provider", () => {
+		test("#when normalizeModel is called with gateway/gpt-5.4 #then returns vercel/openai/gpt-5.4", () => {
+			// given
+			const input = "gateway/gpt-5.4"
+
+			// when
+			const result = normalizeModel(input)
+
+			// then
+			expect(result).toBe("vercel/openai/gpt-5.4")
+		})
+	})
+
+	describe("#given legacy gateway alias with explicit sub-provider", () => {
+		test("#when normalizeModel is called with gateway/anthropic/claude-opus-4-7 #then returns vercel/anthropic/claude-opus-4.7", () => {
+			// given
+			const input = "gateway/anthropic/claude-opus-4-7"
+
+			// when
+			const result = normalizeModel(input)
+
+			// then
+			expect(result).toBe("vercel/anthropic/claude-opus-4.7")
+		})
+	})
+
 	describe("#given string with leading and trailing spaces", () => {
 		test("#when normalizeModel is called with spaces #then returns trimmed string", () => {
 			// given

--- a/src/shared/model-normalization.ts
+++ b/src/shared/model-normalization.ts
@@ -1,6 +1,23 @@
+import { transformModelForProvider } from "./provider-model-id-transform"
+
+const LEGACY_GATEWAY_PREFIX = "gateway/"
+
+function normalizeLegacyGatewayAlias(model: string): string {
+	if (!model.startsWith(LEGACY_GATEWAY_PREFIX)) {
+		return model
+	}
+
+	const legacyModel = model.slice(LEGACY_GATEWAY_PREFIX.length)
+	return `vercel/${transformModelForProvider("vercel", legacyModel)}`
+}
+
 export function normalizeModel(model?: string): string | undefined {
 	const trimmed = model?.trim()
-	return trimmed || undefined
+	if (!trimmed) {
+		return undefined
+	}
+
+	return normalizeLegacyGatewayAlias(trimmed)
 }
 
 export function normalizeModelID(modelID: string): string {

--- a/src/shared/model-resolution-pipeline.test.ts
+++ b/src/shared/model-resolution-pipeline.test.ts
@@ -29,4 +29,44 @@ describe("resolveModelPipeline", () => {
     expect(result).toEqual({ model: "openai/gpt-5.3-codex", provenance: "override" })
     expect(hasExplicitUserConfigField).toBe(false)
   })
+
+  test("normalizes legacy gateway aliases in category defaults before connected-provider resolution", () => {
+    // given
+    const result = resolveModelPipeline({
+      intent: {
+        categoryDefaultModel: "gateway/gpt-5.4",
+      },
+      constraints: {
+        availableModels: new Set<string>(),
+        connectedProviders: ["vercel"],
+      },
+    })
+
+    // then
+    expect(result).toEqual({
+      model: "vercel/openai/gpt-5.4",
+      provenance: "category-default",
+      attempted: ["vercel/openai/gpt-5.4"],
+    })
+  })
+
+  test("normalizes legacy gateway aliases in user fallback models before provider fallback resolution", () => {
+    // given
+    const result = resolveModelPipeline({
+      intent: {
+        userFallbackModels: ["gateway/gpt-5.4"],
+      },
+      constraints: {
+        availableModels: new Set<string>(),
+        connectedProviders: ["vercel"],
+      },
+    })
+
+    // then
+    expect(result).toEqual({
+      model: "vercel/openai/gpt-5.4",
+      provenance: "provider-fallback",
+      attempted: ["vercel/openai/gpt-5.4"],
+    })
+  })
 })

--- a/src/shared/model-resolution-pipeline.ts
+++ b/src/shared/model-resolution-pipeline.ts
@@ -101,6 +101,8 @@ export function resolveModelPipeline(
 
   //#when - user configured fallback_models, try them before hardcoded fallback chain
   const userFallbackModels = intent?.userFallbackModels
+    ?.map((model) => normalizeModel(model))
+    .filter((model): model is string => model !== undefined)
   if (userFallbackModels && userFallbackModels.length > 0) {
     if (availableModels.size === 0) {
       const connectedProviders = constraints.connectedProviders ?? connectedProvidersCache.readConnectedProvidersCache()


### PR DESCRIPTION
## Summary

This fixes the split between historical `gateway/...` model strings and the current canonical `vercel/...` Vercel AI Gateway transport.

## What changed

- normalize legacy `gateway/...` model strings at runtime
- migrate persisted config `model` and `fallback_models` entries from `gateway/...` to `vercel/...`
- make `oh-my-opencode run --model gateway/...` resolve to canonical `vercel/...`
- add doctor warnings and verbose details that explicitly tell users `gateway/...` is deprecated and recommend `vercel/...`
- add regression coverage for normalization, migration, CLI run model parsing, and doctor output

## Why

The current codebase already treats `vercel/...` as the canonical Vercel AI Gateway provider surface, but older installs can still carry `gateway/...` in config or cached overrides. That leaves users in a split-brain state where config/debug/runtime do not agree. This change collapses those historical aliases onto the canonical transport and makes the deprecation visible.

## Verification

- `npx bun test src/shared/migration.test.ts src/shared/migration/config-migration.test.ts src/shared/model-normalization.test.ts src/shared/model-resolution-pipeline.test.ts --bail`
- `npx bun test src/cli/doctor/checks/model-resolution.test.ts src/cli/run/model-resolver.test.ts --bail`
- `npx tsc --noEmit`

## Notes

This keeps `gateway/...` as compatibility-only behavior. New configs and user-facing guidance now converge on `vercel/...`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes legacy `gateway/...` model aliases to canonical `vercel/...` IDs across runtime, CLI, and config so older installs keep working while guidance points to `vercel/...`.

- **Refactors**
  - Normalize user overrides with `normalizeModel`, mapping `gateway/...` → `vercel/...`.
  - `oh-my-opencode run --model gateway/...` now resolves to canonical `vercel/...`.
  - Doctor adds warnings and verbose tips showing exact replacements (e.g., `gateway/gpt-5.4 -> vercel/openai/gpt-5.4`).
  - Config migration rewrites `model` and `fallback_models` from `gateway/...` to `vercel/...`.
  - Added tests for normalization, migration, CLI run parsing, doctor details, and resolution pipeline.

- **Migration**
  - No action required. Existing `gateway/...` continues to work but is deprecated.
  - Prefer `vercel/...` in configs going forward; doctor will flag and show replacements.

<sup>Written for commit a99d49695b2992f7417ead1756cc81213df7a14b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

