### PR TITLE
fix(agents): reference prometheus instead of conditional plan alias in prompts (fixes #3596)

### DIFF
--- a/src/agents/dynamic-agent-core-sections.ts
+++ b/src/agents/dynamic-agent-core-sections.ts
@@ -181,7 +181,7 @@ export function buildNonClaudePlannerSection(model: string): string {
 Multi-step task? **ALWAYS consult Plan Agent first.** Do NOT start implementation without a plan.
 
 - Single-file fix or trivial change → proceed directly
-- Anything else (2+ steps, unclear scope, architecture) → \`task(subagent_type="plan", ...)\` FIRST
+- Anything else (2+ steps, unclear scope, architecture) → \`task(subagent_type="prometheus", ...)\` FIRST
 - Use \`task_id\` to resume the same Plan Agent - ask follow-up questions aggressively
 - If ANY part of the task is ambiguous, ask Plan Agent before guessing
 

--- a/src/agents/sisyphus/gpt-5-4.ts
+++ b/src/agents/sisyphus/gpt-5-4.ts
@@ -287,7 +287,7 @@ Every implementation task follows this cycle. No exceptions.
    Follow \`<explore>\` protocol for tool usage and agent prompts.
 
 2. PLAN - List files to modify, specific changes, dependencies, complexity estimate.
-   Multi-step (2+) → consult Plan Agent via \`task(subagent_type="plan", ...)\`.
+   Multi-step (2+) → consult Plan Agent via \`task(subagent_type="prometheus", ...)\`.
    Single-step → mental plan is sufficient.
 
    <dependency_checks>


### PR DESCRIPTION
## Summary
- Use canonical `prometheus` subagent name instead of conditional `plan` alias in Sisyphus prompts

## Problem
Sisyphus prompts instruct the agent to call `task(subagent_type="plan", ...)`, but `plan` is only injected as a hidden alias when `planner_enabled && replace_plan` is true. When either setting is false, the `plan` subagent does not exist, causing runtime delegation failures.

## Fix
Changed `subagent_type="plan"` to `subagent_type="prometheus"` in both `gpt-5-4.ts` and `dynamic-agent-core-sections.ts`. `prometheus` is the canonical planner agent name that exists whenever the planner is enabled, regardless of the `replace_plan` flag.

## Changes
| File | Change |
|------|--------|
| `src/agents/sisyphus/gpt-5-4.ts` | Replace `"plan"` with `"prometheus"` in PLAN step |
| `src/agents/dynamic-agent-core-sections.ts` | Replace `"plan"` with `"prometheus"` in Plan Agent Dependency section |

Fixes #3596

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Sisyphus prompts to call the canonical `prometheus` planner instead of the conditional `plan` alias, preventing runtime delegation failures when the alias is missing (fixes #3596). Agents now use `task(subagent_type="prometheus", ...)` in `src/agents/sisyphus/gpt-5-4.ts` and `src/agents/dynamic-agent-core-sections.ts`.

<sup>Written for commit 32e56c0e60b9917dce3b095f56d985eb3a7e0e2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

