### PR TITLE
fix(tool-registry): pass plugins config to skill tool for proper command filtering (fixes #3582)

### DIFF
--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -244,6 +244,8 @@ export function createToolRegistry(args: {
     gitMasterConfig: pluginConfig.git_master,
     browserProvider: skillContext.browserProvider,
     nativeSkills: "skills" in ctx ? (ctx as { skills: SkillLoadOptions["nativeSkills"] }).skills : undefined,
+    pluginsEnabled: pluginConfig.claude_code?.plugins ?? true,
+    enabledPluginsOverride: pluginConfig.claude_code?.plugins_override,
   })
 
   const taskSystemEnabled = isTaskSystemEnabled(pluginConfig)


### PR DESCRIPTION
## Summary
- Skill tool now respects `claude_code.plugins` and `plugins_override` config when discovering commands

## Problem
The `plugin-components-loader.ts` correctly disables Claude plugins when `claude_code.plugins=false` or `plugins_override` entries are false. However, the skill tool re-discovers plugin commands/skills independently because `tool-registry.ts` did not pass `pluginsEnabled` or `enabledPluginsOverride` to `createSkillTool()`. This caused disabled plugin commands to still appear in the skill tool output.

## Fix
Pass `pluginsEnabled` and `enabledPluginsOverride` from `pluginConfig.claude_code` into `createSkillTool()` in `tool-registry.ts`. The skill tool already supports these options in its `SkillLoadOptions` type and uses them in `getCommands()`.

## Changes
| File | Change |
|------|--------|
| `src/plugin/tool-registry.ts` | Pass `pluginsEnabled` and `enabledPluginsOverride` to `createSkillTool()` |

Fixes #3582

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skill tool now respects `claude_code.plugins` and `plugins_override` when discovering commands, so disabled plugin commands no longer appear. Fixes #3582.

We now pass `pluginsEnabled` and `enabledPluginsOverride` from `pluginConfig.claude_code` into `createSkillTool()`.

<sup>Written for commit 7806df10028511fb8591cdc9ea5d8c669922f1ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

