### PR TITLE
fix(chat-message): remove unreachable guard that blocked session model recovery (fixes #3561)

### DIFF
--- a/src/plugin/chat-message.ts
+++ b/src/plugin/chat-message.ts
@@ -81,9 +81,9 @@ function getStoredMainSessionModel(
     return undefined
   }
 
-  if (output.message["model"] !== undefined) {
-    return undefined
-  }
+  // Removed: `output.message["model"] !== undefined` guard was unreachable.
+  // OpenCode always populates output.message.model before triggering chat.message,
+  // so the guard short-circuited every time, preventing session model recovery.
 
   if (hasExplicitAgentModelOverride(input.agent, pluginConfig)) {
     return undefined


### PR DESCRIPTION
## Summary
- Remove unreachable guard that prevented session model recovery from restoring the user's previous model selection

## Problem
`getStoredMainSessionModel()` in `chat-message.ts` contains a guard `if (output.message["model"] !== undefined) return undefined` that always short-circuits because OpenCode populates `output.message.model` before triggering the `chat.message` hook. This makes the recovery branch (`getSessionModel(sessionID)`) dead code. When the UI drops the model selection on subsequent messages, the user's previously chosen model is silently lost instead of being restored.

## Fix
Removed the unreachable `output.message["model"]` guard. The remaining guards (`isFirstMessage`, `subagentSessions`, `mainSessionID`, `input.model`, `hasExplicitAgentModelOverride`) still prevent inappropriate model overrides. Now `getSessionModel()` can actually restore the stored model when the UI drops the selection.

## Changes
| File | Change |
|------|--------|
| `src/plugin/chat-message.ts` | Remove unreachable `output.message["model"]` guard in `getStoredMainSessionModel` |

Fixes #3561

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unreachable guard in `src/plugin/chat-message.ts` that prevented session model recovery, so the user’s previously selected model is restored when the UI omits a model. Existing guards still prevent unintended overrides. Fixes #3561.

<sup>Written for commit 7fa21efc2a3a36b1d957b4ad97dfd7e729fb20f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

