### PR TITLE
feat(notification): add cmux as notification provider

### DIFF
--- a/src/hooks/session-notification-sender.test.ts
+++ b/src/hooks/session-notification-sender.test.ts
@@ -66,6 +66,7 @@ function createThrowingShellPromise(shouldThrow: (cmdStr: string) => boolean) {
 describe("session-notification-sender", () => {
 	beforeEach(() => {
 		jest.restoreAllMocks()
+		spyOn(utils, "getCmuxPath").mockResolvedValue(null)
 		spyOn(utils, "getTerminalNotifierPath").mockResolvedValue("/usr/local/bin/terminal-notifier")
 		spyOn(utils, "getOsascriptPath").mockResolvedValue("/usr/bin/osascript")
 		spyOn(utils, "getNotifySendPath").mockResolvedValue("/usr/bin/notify-send")
@@ -76,6 +77,105 @@ describe("session-notification-sender", () => {
 	})
 
 	describe("#given sendSessionNotification", () => {
+		describe("#when cmux is available", () => {
+			test("#then should use cmux notify", async () => {
+				spyOn(utils, "getCmuxPath").mockResolvedValue("/usr/local/bin/cmux")
+
+				const executedCmds: string[] = []
+				const mockCtx = {
+					$: createShellPromise((cmdStr) => executedCmds.push(cmdStr)),
+				} as unknown as PluginInput
+
+				await sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")
+
+				expect(executedCmds.length).toBe(1)
+				expect(executedCmds[0]).toContain("cmux")
+				expect(executedCmds[0]).toContain("notify")
+				expect(executedCmds[0]).not.toContain("terminal-notifier")
+				expect(executedCmds[0]).not.toContain("osascript")
+			})
+		})
+
+		describe("#when cmux fails", () => {
+			test("#then should fall back to terminal-notifier", async () => {
+				spyOn(utils, "getCmuxPath").mockResolvedValue("/usr/local/bin/cmux")
+
+				const allCmds: string[] = []
+				const mockCtx = {
+					$: (cmd: TemplateStringsArray, ...values: unknown[]) => {
+						const cmdStr = cmd.reduce((acc, part, i) => acc + part + (values[i] ?? ""), "")
+						allCmds.push(cmdStr)
+
+						if (cmdStr.includes("/usr/local/bin/cmux")) {
+							const err = Object.assign(new Error("command failed"), { stdout: Buffer.from(""), stderr: Buffer.from(""), exitCode: 1 })
+							const p = Promise.reject(err) as any
+							p.quiet = () => p
+							p.nothrow = () => { const q = Promise.resolve({}) as any; q.quiet = () => q; return q }
+							return p
+						}
+
+						const result = { stdout: Buffer.from(""), stderr: Buffer.from(""), exitCode: 0 }
+						const p = Promise.resolve(result) as any
+						p.quiet = () => p
+						p.nothrow = () => p
+						return p
+					},
+				} as unknown as PluginInput
+
+				await sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")
+
+				expect(allCmds.some((cmd) => cmd.includes("/usr/local/bin/cmux"))).toBe(true)
+				expect(allCmds.some((cmd) => cmd.includes("terminal-notifier"))).toBe(true)
+			})
+
+			test("#then should fall back to osascript when both cmux and terminal-notifier fail", async () => {
+				spyOn(utils, "getCmuxPath").mockResolvedValue("/usr/local/bin/cmux")
+
+				const allCmds: string[] = []
+				const mockCtx = {
+					$: (cmd: TemplateStringsArray, ...values: unknown[]) => {
+						const cmdStr = cmd.reduce((acc, part, i) => acc + part + (values[i] ?? ""), "")
+						allCmds.push(cmdStr)
+
+						if (cmdStr.includes("/usr/local/bin/cmux") || cmdStr.includes("terminal-notifier")) {
+							const err = Object.assign(new Error("command failed"), { stdout: Buffer.from(""), stderr: Buffer.from(""), exitCode: 1 })
+							const p = Promise.reject(err) as any
+							p.quiet = () => p
+							p.nothrow = () => { const q = Promise.resolve({}) as any; q.quiet = () => q; return q }
+							return p
+						}
+
+						const result = { stdout: Buffer.from(""), stderr: Buffer.from(""), exitCode: 0 }
+						const p = Promise.resolve(result) as any
+						p.quiet = () => p
+						p.nothrow = () => p
+						return p
+					},
+				} as unknown as PluginInput
+
+				await sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")
+
+				expect(allCmds.some((cmd) => cmd.includes("/usr/local/bin/cmux"))).toBe(true)
+				expect(allCmds.some((cmd) => cmd.includes("terminal-notifier"))).toBe(true)
+				expect(allCmds.some((cmd) => cmd.includes("osascript"))).toBe(true)
+			})
+		})
+
+		describe("#when cmux is not available", () => {
+			test("#then should skip to terminal-notifier", async () => {
+				const executedCmds: string[] = []
+				const mockCtx = {
+					$: createShellPromise((cmdStr) => executedCmds.push(cmdStr)),
+				} as unknown as PluginInput
+
+				await sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")
+
+				expect(executedCmds.length).toBe(1)
+				expect(executedCmds[0]).toContain("terminal-notifier")
+				expect(executedCmds[0]).not.toContain("/usr/local/bin/cmux")
+			})
+		})
+
 		describe("#when calling ctx.$ for notifications", () => {
 			test("#then should call .quiet() on all shell commands to suppress stdout/stderr", async () => {
 				const quietCalls: string[] = []

--- a/src/hooks/session-notification-sender.ts
+++ b/src/hooks/session-notification-sender.ts
@@ -1,6 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { platform } from "os"
 import {
+  getCmuxPath,
   getOsascriptPath,
   getNotifySendPath,
   getPowershellPath,
@@ -40,7 +41,15 @@ export async function sendSessionNotification(
 ): Promise<void> {
   switch (platform) {
     case "darwin": {
-      // Try terminal-notifier first - deterministic click-to-focus
+      const cmuxPath = await getCmuxPath()
+      if (cmuxPath) {
+        try {
+          await ctx.$`${cmuxPath} notify --title ${title} --body ${message}`.quiet()
+          break
+        } catch {
+        }
+      }
+
       const terminalNotifierPath = await getTerminalNotifierPath()
       if (terminalNotifierPath) {
         const bundleId = process.env.__CFBundleIdentifier
@@ -55,7 +64,7 @@ export async function sendSessionNotification(
         }
       }
 
-      // Fallback: osascript (click may open Finder instead of terminal)
+      // Fallback: osascript
       const osascriptPath = await getOsascriptPath()
       if (!osascriptPath) return
 

--- a/src/hooks/session-notification-utils.ts
+++ b/src/hooks/session-notification-utils.ts
@@ -50,9 +50,13 @@ export const getAfplayPath = createCommandFinder("afplay")
 export const getPaplayPath = createCommandFinder("paplay")
 export const getAplayPath = createCommandFinder("aplay")
 export const getTerminalNotifierPath = createCommandFinder("terminal-notifier")
+export const getCmuxPath = createCommandFinder("cmux")
 
 export function startBackgroundCheck(platform: Platform): void {
   if (platform === "darwin") {
+    getCmuxPath().catch((error) => {
+      logBackgroundCheckError("cmux", error)
+    })
     getOsascriptPath().catch((error) => {
       logBackgroundCheckError("osascript", error)
     })


### PR DESCRIPTION
Fixes #3628

## Summary

- Adds [cmux](https://github.com/manaflow-ai/cmux) as a notification provider, before `terminal-notifier` and `osascript`
- Notifications are sent via `cmux notify --title <title> --body <message>`

## Problem

When `terminal-notifier` is not installed, session notifications fall back to `osascript -e 'display notification ...'`. This attributes notifications to **Script Editor**, which is confusing for users.

## Solution

[cmux](https://github.com/manaflow-ai/cmux) is a terminal app (built on libghostty) that exposes a `cmux notify` CLI command. When available, it delivers notifications properly attributed to the cmux app instead of Script Editor.

Notification priority:
1. **cmux**
2. **terminal-notifier**
3. **osascript** (fallback)

## Changes

- `session-notification-utils.ts` — added `getCmuxPath` command finder + background check
- `session-notification-sender.ts` — added cmux in notification chain
- `session-notification-sender.test.ts` — tests for cmux path and fallback behavior

## CI Note

The 13 test failures in CI are pre-existing and unrelated to this PR — they are model config expectation mismatches (`gpt-5.4` vs `gpt-5.5`) from a recent defaults update. This PR only touches notification files.