### PR TITLE
fix: block reused release versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,8 +138,8 @@ jobs:
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/oh-my-opencode/${VERSION}")
           if [ "$STATUS" = "200" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            echo "✓ oh-my-opencode@${VERSION} already published"
+            echo "::error::oh-my-opencode@${VERSION} is already published. Choose a new version so the GitHub tag cannot diverge from the immutable npm artifact."
+            exit 1
           else
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
@@ -186,8 +186,8 @@ jobs:
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/oh-my-openagent/${VERSION}")
           if [ "$STATUS" = "200" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            echo "✓ oh-my-openagent@${VERSION} already published"
+            echo "::error::oh-my-openagent@${VERSION} is already published. Choose a new version so the GitHub tag cannot diverge from the immutable npm artifact."
+            exit 1
           else
             echo "skip=false" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary
- Fail the publish workflow when either root npm package already has the requested version.
- Prevents creating a GitHub release/tag from source that differs from an immutable npm artifact, which is what happened for 3.17.5.

## Changes
- Replace the existing silent publish skips for `oh-my-opencode` and `oh-my-openagent` with explicit workflow errors.

## Testing
- `bun test script/publish-workflow.test.ts`
- `bun run typecheck`
- `bun run build`

## Related Issues
Refs #3615

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the publish workflow if the requested version of `oh-my-opencode` or `oh-my-openagent` already exists on npm. This prevents creating a GitHub tag/release that could diverge from the immutable npm artifact. Refs #3615.

- **Bug Fixes**
  - When npm returns 200 for the requested version, emit an `::error` and exit 1 instead of silently skipping (for both packages).

<sup>Written for commit e540e2236c5bd6eb6c06c5c4b92054813944cd8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

