### PR TITLE
feat(config): add global_prompt_append for all agents and categories

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -8,6 +8,9 @@
     "$schema": {
       "type": "string"
     },
+    "global_prompt_append": {
+      "type": "string"
+    },
     "new_task_system_enabled": {
       "type": "boolean"
     },

--- a/src/agents/builtin-agents.ts
+++ b/src/agents/builtin-agents.ts
@@ -71,7 +71,8 @@ export async function createBuiltinAgents(
   uiSelectedModel?: string,
   disabledSkills?: Set<string>,
   useTaskSystem = false,
-  disableOmoEnv = false
+  disableOmoEnv = false,
+  globalPromptAppend?: string
 ): Promise<Record<string, AgentConfig>> {
 
   const connectedProviders = readConnectedProvidersCache()
@@ -117,6 +118,7 @@ export async function createBuiltinAgents(
     isFirstRunNoCache,
     disabledSkills,
     disableOmoEnv,
+    globalPromptAppend,
   })
 
   const sisyphusConfig = maybeCreateSisyphusConfig({
@@ -134,6 +136,7 @@ export async function createBuiltinAgents(
     userCategories: categories,
     useTaskSystem,
     disableOmoEnv,
+    globalPromptAppend,
   })
   if (sisyphusConfig) {
     result["sisyphus"] = sisyphusConfig
@@ -152,6 +155,7 @@ export async function createBuiltinAgents(
     directory,
     useTaskSystem,
     disableOmoEnv,
+    globalPromptAppend,
   })
   if (hephaestusConfig) {
     result["hephaestus"] = hephaestusConfig
@@ -173,6 +177,7 @@ export async function createBuiltinAgents(
     mergedCategories,
     directory,
     userCategories: categories,
+    globalPromptAppend,
   })
   if (atlasConfig) {
     result["atlas"] = atlasConfig

--- a/src/agents/builtin-agents/agent-overrides.ts
+++ b/src/agents/builtin-agents/agent-overrides.ts
@@ -48,6 +48,7 @@ export function mergeAgentConfig(
     merged.prompt = resolvePromptAppend(merged.prompt, directory)
   }
 
+  // Agent-specific prompt_append is appended last (highest priority)
   if (prompt_append && merged.prompt) {
     merged.prompt = merged.prompt + "\n" + resolvePromptAppend(prompt_append, directory)
   }
@@ -59,9 +60,20 @@ export function applyOverrides(
   config: AgentConfig,
   override: AgentOverrideConfig | undefined,
   mergedCategories: Record<string, CategoryConfig>,
-  directory?: string
+  directory?: string,
+  globalPromptAppend?: string
 ): AgentConfig {
   let result = config
+
+  // Apply global_prompt_append FIRST so it appears before category and agent-specific appends
+  if (globalPromptAppend && typeof result.prompt === "string") {
+    const resolvedGlobal = resolvePromptAppend(globalPromptAppend, directory, true /* allowOutsideProject */)
+    result = {
+      ...result,
+      prompt: result.prompt + "\n" + resolvedGlobal,
+    }
+  }
+
   const overrideCategory = (override as Record<string, unknown> | undefined)?.category as string | undefined
   if (overrideCategory) {
     result = applyCategoryOverride(result, overrideCategory, mergedCategories)

--- a/src/agents/builtin-agents/atlas-agent.ts
+++ b/src/agents/builtin-agents/atlas-agent.ts
@@ -19,6 +19,7 @@ export function maybeCreateAtlasConfig(input: {
   directory?: string
   userCategories?: CategoriesConfig
   useTaskSystem?: boolean
+  globalPromptAppend?: string
 }): AgentConfig | undefined {
   const {
     disabledAgents,
@@ -31,6 +32,7 @@ export function maybeCreateAtlasConfig(input: {
     mergedCategories,
     directory,
     userCategories,
+    globalPromptAppend,
   } = input
 
   if (disabledAgents.includes("atlas")) return undefined
@@ -60,7 +62,7 @@ export function maybeCreateAtlasConfig(input: {
     orchestratorConfig = { ...orchestratorConfig, variant: atlasResolvedVariant }
   }
 
-  orchestratorConfig = applyOverrides(orchestratorConfig, orchestratorOverride, mergedCategories, directory)
+  orchestratorConfig = applyOverrides(orchestratorConfig, orchestratorOverride, mergedCategories, directory, globalPromptAppend)
 
   return orchestratorConfig
 }

--- a/src/agents/builtin-agents/general-agents.ts
+++ b/src/agents/builtin-agents/general-agents.ts
@@ -26,6 +26,7 @@ export function collectPendingBuiltinAgents(input: {
   disabledSkills?: Set<string>
   useTaskSystem?: boolean
   disableOmoEnv?: boolean
+  globalPromptAppend?: string
 }): { pendingAgentConfigs: Map<string, AgentConfig>; availableAgents: AvailableAgent[] } {
   const {
     agentSources,
@@ -42,6 +43,7 @@ export function collectPendingBuiltinAgents(input: {
     isFirstRunNoCache,
     disabledSkills,
     disableOmoEnv = false,
+    globalPromptAppend,
   } = input
 
   const availableAgents: AvailableAgent[] = []
@@ -103,7 +105,7 @@ export function collectPendingBuiltinAgents(input: {
       config = applyEnvironmentContext(config, directory, { disableOmoEnv })
     }
 
-    config = applyOverrides(config, override, mergedCategories, directory)
+    config = applyOverrides(config, override, mergedCategories, directory, globalPromptAppend)
 
     // Store for later - will be added after sisyphus and hephaestus
     pendingAgentConfigs.set(name, config)

--- a/src/agents/builtin-agents/hephaestus-agent.ts
+++ b/src/agents/builtin-agents/hephaestus-agent.ts
@@ -80,20 +80,20 @@ export function maybeCreateHephaestusConfig(input: {
 
   hephaestusConfig = { ...hephaestusConfig, variant: hephaestusResolvedVariant ?? "medium" }
 
+  // Apply global_prompt_append BEFORE category override + merge
+  if (globalPromptAppend && typeof hephaestusConfig.prompt === "string") {
+    hephaestusConfig = {
+      ...hephaestusConfig,
+      prompt: hephaestusConfig.prompt + "\n" + resolvePromptAppend(globalPromptAppend, directory, true /* allowOutsideProject */),
+    }
+  }
+
   const hepOverrideCategory = (hephaestusOverride as Record<string, unknown> | undefined)?.category as string | undefined
   if (hepOverrideCategory) {
     hephaestusConfig = applyCategoryOverride(hephaestusConfig, hepOverrideCategory, mergedCategories)
   }
 
   hephaestusConfig = applyEnvironmentContext(hephaestusConfig, directory, { disableOmoEnv })
-
-  // Apply global_prompt_append FIRST so it appears before agent-specific prompt_append
-  if (globalPromptAppend && typeof hephaestusConfig.prompt === "string") {
-    hephaestusConfig = {
-      ...hephaestusConfig,
-      prompt: hephaestusConfig.prompt + "\n" + resolvePromptAppend(globalPromptAppend, directory),
-    }
-  }
 
   if (hephaestusOverride) {
     hephaestusConfig = mergeAgentConfig(hephaestusConfig, hephaestusOverride, directory)

--- a/src/agents/builtin-agents/hephaestus-agent.ts
+++ b/src/agents/builtin-agents/hephaestus-agent.ts
@@ -6,6 +6,7 @@ import { AGENT_MODEL_REQUIREMENTS, isAnyProviderConnected } from "../../shared"
 import { createHephaestusAgent } from "../hephaestus"
 import { applyEnvironmentContext } from "./environment-context"
 import { applyCategoryOverride, mergeAgentConfig } from "./agent-overrides"
+import { resolvePromptAppend } from "./resolve-file-uri"
 import { applyModelResolution, getFirstFallbackModel } from "./model-resolution"
 import { getGptApplyPatchPermission } from "../gpt-apply-patch-guard"
 
@@ -22,6 +23,7 @@ export function maybeCreateHephaestusConfig(input: {
   directory?: string
   useTaskSystem: boolean
   disableOmoEnv?: boolean
+  globalPromptAppend?: string
 }): AgentConfig | undefined {
   const {
     disabledAgents,
@@ -36,6 +38,7 @@ export function maybeCreateHephaestusConfig(input: {
     directory,
     useTaskSystem,
     disableOmoEnv = false,
+    globalPromptAppend,
   } = input
 
   if (disabledAgents.includes("hephaestus")) return undefined
@@ -83,6 +86,14 @@ export function maybeCreateHephaestusConfig(input: {
   }
 
   hephaestusConfig = applyEnvironmentContext(hephaestusConfig, directory, { disableOmoEnv })
+
+  // Apply global_prompt_append FIRST so it appears before agent-specific prompt_append
+  if (globalPromptAppend && typeof hephaestusConfig.prompt === "string") {
+    hephaestusConfig = {
+      ...hephaestusConfig,
+      prompt: hephaestusConfig.prompt + "\n" + resolvePromptAppend(globalPromptAppend, directory),
+    }
+  }
 
   if (hephaestusOverride) {
     hephaestusConfig = mergeAgentConfig(hephaestusConfig, hephaestusOverride, directory)

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -16,7 +16,23 @@ function isAllowedGlobalPath(filePath: string): boolean {
     const canonicalPath = realpathSync.native(filePath)
     return ALLOWED_GLOBAL_PREFIXES.some((prefix) => canonicalPath.startsWith(prefix))
   } catch {
-    return ALLOWED_GLOBAL_PREFIXES.some((prefix) => filePath.startsWith(prefix))
+    // File doesn't exist yet — canonicalize the deepest existing parent
+    let current = filePath
+    while (current.length > 1) {
+      current = current.substring(0, current.lastIndexOf('/'))
+      try {
+        const canonicalParent = realpathSync.native(current)
+        // Reconstruct canonical child path from canonical parent, then normalize
+        // to collapse any directory traversal segments (e.g., ../) left in remaining
+        const remaining = filePath.substring(current.length)
+        const reconstructed = resolve(canonicalParent + remaining)
+        return ALLOWED_GLOBAL_PREFIXES.some((prefix) => reconstructed.startsWith(prefix))
+      } catch {
+        // Parent also doesn't exist, keep going up
+      }
+    }
+    // No existing ancestor found — reject (secure by default)
+    return false
   }
 }
 

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, readFileSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
 import { isAbsolute, resolve } from "node:path"
 import { isWithinProject } from "../../shared/contains-path"
@@ -12,7 +12,12 @@ const ALLOWED_GLOBAL_PREFIXES = [
 ]
 
 function isAllowedGlobalPath(filePath: string): boolean {
-  return ALLOWED_GLOBAL_PREFIXES.some((prefix) => filePath.startsWith(prefix))
+  try {
+    const canonicalPath = realpathSync.native(filePath)
+    return ALLOWED_GLOBAL_PREFIXES.some((prefix) => canonicalPath.startsWith(prefix))
+  } catch {
+    return ALLOWED_GLOBAL_PREFIXES.some((prefix) => filePath.startsWith(prefix))
+  }
 }
 
 export function resolvePromptAppend(

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -4,7 +4,12 @@ import { isAbsolute, resolve } from "node:path"
 import { isWithinProject } from "../../shared/contains-path"
 import { log } from "../../shared/logger"
 
-export function resolvePromptAppend(promptAppend: string, configDir?: string): string {
+export function resolvePromptAppend(
+  promptAppend: string,
+  configDir?: string,
+  /** When true, skip isWithinProject check (for user-level global configs like ~/.hermes/) */
+  allowOutsideProject?: boolean
+): string {
   if (!promptAppend.startsWith("file://")) return promptAppend
 
   const encoded = promptAppend.slice(7)
@@ -20,14 +25,16 @@ export function resolvePromptAppend(promptAppend: string, configDir?: string): s
     return `[WARNING: Malformed file URI (invalid percent-encoding): ${promptAppend}]`
   }
 
-  const projectRoot = configDir ?? process.cwd()
-  if (!isWithinProject(filePath, projectRoot)) {
-    log("[resolve-file-uri] Rejected file URI outside project root", {
-      promptAppend,
-      filePath,
-      projectRoot,
-    })
-    return `[WARNING: Path rejected: ${promptAppend}]`
+  if (!allowOutsideProject) {
+    const projectRoot = configDir ?? process.cwd()
+    if (!isWithinProject(filePath, projectRoot)) {
+      log("[resolve-file-uri] Rejected file URI outside project root", {
+        promptAppend,
+        filePath,
+        projectRoot,
+      })
+      return `[WARNING: Path rejected: ${promptAppend}]`
+    }
   }
 
   if (!existsSync(filePath)) {

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -1,14 +1,17 @@
 import { existsSync, readFileSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
-import { dirname, isAbsolute, resolve } from "node:path"
+import { dirname, isAbsolute, join, resolve, sep } from "node:path"
 import { isWithinProject } from "../../shared/contains-path"
 import { log } from "../../shared/logger"
 
-/** User directories allowed for global file:// URIs (security whitelist) */
+const homeDir = homedir()
+
+/** User directories allowed for global file:// URIs (security whitelist).
+ *  Built with path.join + trailing sep so startsWith works on all platforms. */
 const ALLOWED_GLOBAL_PREFIXES = [
-  `${homedir()}/.config/`,
-  `${homedir()}/.hermes/`,
-  `${homedir()}/.local/share/`,
+  join(homeDir, ".config") + sep,
+  join(homeDir, ".hermes") + sep,
+  join(homeDir, ".local", "share") + sep,
 ]
 
 function isAllowedGlobalPath(filePath: string): boolean {
@@ -18,14 +21,17 @@ function isAllowedGlobalPath(filePath: string): boolean {
   } catch {
     // File doesn't exist yet — canonicalize the deepest existing parent
     let current = filePath
-    while (current.length > 1) {
-      current = dirname(current)
+    // walk up until we hit the filesystem root (dirname stops changing)
+    for (;;) {
+      const parent = dirname(current)
+      if (parent === current) break // reached root (e.g. C:\ or /), no existing ancestor
+      current = parent
       try {
         const canonicalParent = realpathSync.native(current)
-        // Reconstruct canonical child path from canonical parent, then normalize
-        // to collapse any directory traversal segments (e.g., ../) left in remaining
-        const remaining = filePath.substring(current.length)
-        const reconstructed = resolve(canonicalParent + remaining)
+        // Reconstruct canonical child path, then resolve to collapse any
+        // directory-traversal segments (e.g. ../) that may be in the remaining suffix
+        const remaining = filePath.slice(current.length)
+        const reconstructed = resolve(canonicalParent, `.${remaining}`)
         return ALLOWED_GLOBAL_PREFIXES.some((prefix) => reconstructed.startsWith(prefix))
       } catch {
         // Parent also doesn't exist, keep going up

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
-import { isAbsolute, resolve } from "node:path"
+import { dirname, isAbsolute, resolve } from "node:path"
 import { isWithinProject } from "../../shared/contains-path"
 import { log } from "../../shared/logger"
 
@@ -19,7 +19,7 @@ function isAllowedGlobalPath(filePath: string): boolean {
     // File doesn't exist yet — canonicalize the deepest existing parent
     let current = filePath
     while (current.length > 1) {
-      current = current.substring(0, current.lastIndexOf('/'))
+      current = dirname(current)
       try {
         const canonicalParent = realpathSync.native(current)
         // Reconstruct canonical child path from canonical parent, then normalize

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -4,10 +4,21 @@ import { isAbsolute, resolve } from "node:path"
 import { isWithinProject } from "../../shared/contains-path"
 import { log } from "../../shared/logger"
 
+/** User directories allowed for global file:// URIs (security whitelist) */
+const ALLOWED_GLOBAL_PREFIXES = [
+  `${homedir()}/.config/`,
+  `${homedir()}/.hermes/`,
+  `${homedir()}/.local/share/`,
+]
+
+function isAllowedGlobalPath(filePath: string): boolean {
+  return ALLOWED_GLOBAL_PREFIXES.some((prefix) => filePath.startsWith(prefix))
+}
+
 export function resolvePromptAppend(
   promptAppend: string,
   configDir?: string,
-  /** When true, skip isWithinProject check (for user-level global configs like ~/.hermes/) */
+  /** When true, allow user-level paths outside project root (security whitelist enforced) */
   allowOutsideProject?: boolean
 ): string {
   if (!promptAppend.startsWith("file://")) return promptAppend
@@ -25,7 +36,16 @@ export function resolvePromptAppend(
     return `[WARNING: Malformed file URI (invalid percent-encoding): ${promptAppend}]`
   }
 
-  if (!allowOutsideProject) {
+  if (allowOutsideProject) {
+    if (!isAllowedGlobalPath(filePath)) {
+      log("[resolve-file-uri] Rejected file URI outside allowed global paths", {
+        promptAppend,
+        filePath,
+        allowed: ALLOWED_GLOBAL_PREFIXES,
+      })
+      return `[WARNING: Path rejected (outside allowed global paths): ${promptAppend}]`
+    }
+  } else {
     const projectRoot = configDir ?? process.cwd()
     if (!isWithinProject(filePath, projectRoot)) {
       log("[resolve-file-uri] Rejected file URI outside project root", {

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -21,8 +21,11 @@ function isAllowedGlobalPath(filePath: string): boolean {
   } catch {
     // File doesn't exist yet — canonicalize the deepest existing parent
     let current = filePath
-    // walk up until we hit the filesystem root (dirname stops changing)
-    for (;;) {
+    // walk up until we hit the filesystem root (dirname stops changing).
+    // Guarded by a max-depth counter as defense-in-depth against non-terminating
+    // edge cases (e.g. Windows drive-root where dirname may not converge).
+    const MAX_DEPTH = 64
+    for (let depth = 0; depth < MAX_DEPTH; depth++) {
       const parent = dirname(current)
       if (parent === current) break // reached root (e.g. C:\ or /), no existing ancestor
       current = parent

--- a/src/agents/builtin-agents/sisyphus-agent.ts
+++ b/src/agents/builtin-agents/sisyphus-agent.ts
@@ -24,6 +24,7 @@ export function maybeCreateSisyphusConfig(input: {
   userCategories?: CategoriesConfig
   useTaskSystem: boolean
   disableOmoEnv?: boolean
+  globalPromptAppend?: string
 }): AgentConfig | undefined {
   const {
     disabledAgents,
@@ -39,6 +40,7 @@ export function maybeCreateSisyphusConfig(input: {
     directory,
     useTaskSystem,
     disableOmoEnv = false,
+    globalPromptAppend,
   } = input
 
   const sisyphusOverride = agentOverrides["sisyphus"]
@@ -80,7 +82,7 @@ export function maybeCreateSisyphusConfig(input: {
     sisyphusConfig = { ...sisyphusConfig, variant: sisyphusResolvedVariant }
   }
 
-  sisyphusConfig = applyOverrides(sisyphusConfig, sisyphusOverride, mergedCategories, directory)
+  sisyphusConfig = applyOverrides(sisyphusConfig, sisyphusOverride, mergedCategories, directory, globalPromptAppend)
 
   const resolvedModel = sisyphusConfig.model ?? ""
   const gptDeny = getGptApplyPatchPermission(resolvedModel)

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -26,6 +26,8 @@ import { WebsearchConfigSchema } from "./websearch"
 
 export const OhMyOpenCodeConfigSchema = z.object({
   $schema: z.string().optional(),
+  /** Text appended to ALL agent and category prompts. Supports file:// URIs. Applies globally before agent-specific prompt_append. Use instead of repeating prompt_append across every agent. */
+  global_prompt_append: z.string().optional(),
   /** Enable new task system (default: false) */
   new_task_system_enabled: z.boolean().optional(),
   /** Default agent name for `oh-my-opencode run` (env: OPENCODE_DEFAULT_AGENT) */

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -168,6 +168,7 @@ export async function applyAgentConfig(params: {
     disabledSkills,
     useTaskSystem,
     disableOmoEnv,
+    params.pluginConfig.global_prompt_append,
   );
 
   const disabledAgentNames = new Set(

--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -193,6 +193,7 @@ export function createToolRegistry(args: {
     sisyphusAgentConfig: pluginConfig.sisyphus_agent,
     syncPollTimeoutMs: pluginConfig.background_task?.syncPollTimeoutMs,
     modelFallbackControllerAccessor: managers.modelFallbackControllerAccessor,
+    globalPromptAppend: pluginConfig.global_prompt_append,
     onSyncSessionCreated: async (event) => {
       log("[index] onSyncSessionCreated callback", {
         sessionID: event.sessionID,

--- a/src/tools/delegate-task/categories.ts
+++ b/src/tools/delegate-task/categories.ts
@@ -4,6 +4,7 @@ import { resolveModel } from "../../shared/model-resolver"
 import { isModelAvailable } from "../../shared/model-availability"
 import { normalizeModel } from "../../shared/model-normalization"
 import { CATEGORY_MODEL_REQUIREMENTS } from "../../shared/model-requirements"
+import { resolvePromptAppend } from "../../agents/builtin-agents/resolve-file-uri"
 import { log } from "../../shared/logger"
 
 export interface ResolveCategoryConfigOptions {
@@ -11,6 +12,8 @@ export interface ResolveCategoryConfigOptions {
   inheritedModel?: string
   systemDefaultModel?: string
   availableModels?: Set<string>
+  /** Global prompt append applied before category-specific prompt_append. Supports file:// URIs. */
+  globalPromptAppend?: string
 }
 
 export interface ResolveCategoryConfigResult {
@@ -28,7 +31,7 @@ export function resolveCategoryConfig(
   categoryName: string,
   options: ResolveCategoryConfigOptions
 ): ResolveCategoryConfigResult | null {
-  const { userCategories, inheritedModel: _inheritedModel, systemDefaultModel, availableModels } = options
+  const { userCategories, inheritedModel: _inheritedModel, systemDefaultModel, availableModels, globalPromptAppend } = options
 
   const defaultConfig = DEFAULT_CATEGORIES[categoryName]
   const userConfig = userCategories?.[categoryName]
@@ -66,11 +69,21 @@ export function resolveCategoryConfig(
     variant: userConfig?.variant ?? defaultConfig?.variant,
   }
 
-  let promptAppend = defaultPromptAppend
+  // Build promptAppend chain: global → category-default → user-specific
+  const resolvedGlobal = globalPromptAppend
+    ? resolvePromptAppend(globalPromptAppend, undefined, true /* allowOutsideProject */)
+    : ""
+  let promptAppend = resolvedGlobal
+
+  const appendLayer = (existing: string, next: string): string => {
+    return existing && next ? existing + "\n\n" + next : existing || next
+  }
+
+  if (defaultPromptAppend) {
+    promptAppend = appendLayer(promptAppend, defaultPromptAppend)
+  }
   if (userConfig?.prompt_append) {
-    promptAppend = defaultPromptAppend
-      ? defaultPromptAppend + "\n\n" + userConfig.prompt_append
-      : userConfig.prompt_append
+    promptAppend = appendLayer(promptAppend, userConfig.prompt_append)
   }
 
   return { config, promptAppend, model, isUserConfiguredModel }

--- a/src/tools/delegate-task/category-resolver.ts
+++ b/src/tools/delegate-task/category-resolver.ts
@@ -71,6 +71,7 @@ export async function resolveCategoryExecution(
     inheritedModel,
     systemDefaultModel,
     availableModels,
+    globalPromptAppend: executorCtx.globalPromptAppend,
   })
 
   if (!resolved) {

--- a/src/tools/delegate-task/executor-types.ts
+++ b/src/tools/delegate-task/executor-types.ts
@@ -16,6 +16,8 @@ export interface ExecutorContext {
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   onSyncSessionCreated?: (event: { sessionID: string; parentID: string; title: string }) => Promise<void>
   syncPollTimeoutMs?: number
+  /** Global prompt append applied to all agents and categories. Supports file:// URIs. */
+  globalPromptAppend?: string
 }
 
 export interface ParentContext {

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -69,6 +69,8 @@ export interface DelegateTaskToolOptions {
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>
   syncPollTimeoutMs?: number
+  /** Global prompt append applied to all agents and categories. Supports file:// URIs. */
+  globalPromptAppend?: string
 }
 
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"


### PR DESCRIPTION
## Summary

Add a top-level `global_prompt_append` configuration field that automatically applies to all builtin agents and task categories via a prompt append chain: `global → category-default → agent-specific`.

This eliminates the need to repeat `prompt_append` across every agent and category (currently 19+ identical entries for users with output compression needs).

## Changes

| File | Change |
|------|--------|
| `src/config/schema/oh-my-opencode-config.ts` | Add `global_prompt_append` to root schema |
| `src/agents/builtin-agents/agent-overrides.ts` | Apply global before category + agent-specific appends |
| `src/agents/builtin-agents.ts` | Thread `globalPromptAppend` through `createBuiltinAgents()` → all builders |
| `src/agents/builtin-agents/resolve-file-uri.ts` | Add `allowOutsideProject` flag for user-level file:// URIs |
| `src/tools/delegate-task/categories.ts` | Global prompt append in category resolution chain |
| `src/tools/delegate-task/executor-types.ts` | Add `globalPromptAppend` to `ExecutorContext` |
| `src/tools/delegate-task/types.ts` | Add `globalPromptAppend` to `DelegateTaskToolOptions` |
| `src/plugin/tool-registry.ts` | Thread `globalPromptAppend` from config to delegate task tool |
| `src/plugin-handlers/agent-config-handler.ts` | Pass `global_prompt_append` to `createBuiltinAgents` |

## Prompt Append Chain

```
1. System prompt (agent factory default)
2. global_prompt_append (optional, configured once)
3. category prompt_append (if category reference or category-level config)
4. agent-specific prompt_append (highest priority)
```

## Backward Compatibility

- **Fully backward compatible**: When `global_prompt_append` is omitted, behavior is identical to before.
- **Additive only**: No existing config fields are modified or removed.
- Existing per-agent `prompt_append` continues to work and takes precedence over global.

## Test Results

- 5749 pass, 22 fail (all pre-existing, 0 new failures from this change)
- Follows project conventions: kebab-case filenames, Zod v4 schema, relative imports, factory pattern

## Usage Example

```jsonc
{
  "global_prompt_append": "file:///Users/me/.hermes/caveman-ultra.txt",
  "agents": {
    "sisyphus": { "model": "openrouter/qwen/qwen3.6-plus" },
    // No per-agent prompt_append needed
  }
}
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a top-level `global_prompt_append` that applies to all agents and categories, removing duplicate `prompt_append`. Secures `file://` appends with a canonicalized allowlist and cross‑platform path handling; enforces append order: global → category-default → agent-specific.

- **New Features**
  - Added `global_prompt_append` to root config (supports `file://`).
  - Prompt chain enforced for agents and categories; overrides and `hephaestus` updated.
  - Threaded through builders, category resolver, `ExecutorContext`, tool registry, and config handler.

- **Bug Fixes**
  - Canonicalized allowlist for global `file://`: `~/.config/`, `~/.hermes/`, `~/.local/share/`.
  - Normalizes/realpaths parents to block traversal and symlink bypass, including when files don’t exist.
  - Platform-safe prefixes via `path.join` + `path.sep`; safe reconstruction with `path.resolve()`.
  - Adds a max‑depth guard to parent walking to prevent Windows drive‑root loop edge cases.

<sup>Written for commit a25ccb9cfad4ac858f9b3578853c4fb41f24972f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

