### PR TITLE
fix(aliases): stop rewriting canonical claude-opus-4-6-thinking

### DIFF
--- a/src/shared/model-capability-aliases.test.ts
+++ b/src/shared/model-capability-aliases.test.ts
@@ -107,4 +107,14 @@ describe("model-capability-aliases", () => {
       ruleID: "claude-thinking-legacy-alias",
     })
   })
+
+  test("treats claude-opus-4-6-thinking as canonical, not as a legacy alias", () => {
+    const result = resolveModelIDAlias("claude-opus-4-6-thinking")
+
+    expect(result).toEqual({
+      requestedModelID: "claude-opus-4-6-thinking",
+      canonicalModelID: "claude-opus-4-6-thinking",
+      source: "canonical",
+    })
+  })
 })

--- a/src/shared/model-capability-aliases.ts
+++ b/src/shared/model-capability-aliases.ts
@@ -41,8 +41,8 @@ const EXACT_ALIAS_RULES_BY_MODEL: ReadonlyMap<string, ExactAliasRule> = new Map(
 const PATTERN_ALIAS_RULES: ReadonlyArray<PatternAliasRule> = [
   {
     ruleID: "claude-thinking-legacy-alias",
-    description: "Normalizes legacy Claude Opus thinking suffixes (4-6, 4-7) to the canonical snapshot ID.",
-    match: (normalizedModelID) => /^claude-opus-4-(?:6|7)-thinking$/.test(normalizedModelID),
+    description: "Normalizes the legacy claude-opus-4-7-thinking id to the canonical snapshot ID.",
+    match: (normalizedModelID) => /^claude-opus-4-7-thinking$/.test(normalizedModelID),
     canonicalize: () => "claude-opus-4-7",
   },
   {


### PR DESCRIPTION
Fixes the Root Cause B from #3635 — the alias/snapshot collision that has been failing `bun run test:model-capabilities` (and therefore the `refresh-model-capabilities` cron) since 2026-04-20.

## Why

`PATTERN_ALIAS_RULES[0]` (`claude-thinking-legacy-alias`) was authored when both `claude-opus-4-6-thinking` and `claude-opus-4-7-thinking` were treated as legacy non-canonical IDs that needed to be redirected to the latest canonical model. The rule:

```ts
{
  ruleID: "claude-thinking-legacy-alias",
  match: (id) => /^claude-opus-4-(?:6|7)-thinking$/.test(id),
  canonicalize: () => "claude-opus-4-7",
}
```

After 2026-04-20, `models.dev` started shipping **`claude-opus-4-6-thinking` as a real canonical model** (e.g. `302ai/claude-opus-4-6-thinking`). Since `4-6-thinking` is now its own snapshot-backed model, the rule's pattern is too broad: it matches a canonical model and rewrites it to a different canonical (`claude-opus-4-7`), which is exactly the kind of misrouting `pattern-alias-collides-with-snapshot` exists to flag.

`claude-opus-4-7-thinking`, in contrast, is **not** in `models.dev` (verified against current `https://models.dev/api.json`), so the rule still has work to do for that legacy form.

The minimal correct fix is to drop `4-6` from the regex.

## Changes

- `src/shared/model-capability-aliases.ts`: tighten `claude-thinking-legacy-alias` to only match `claude-opus-4-7-thinking`, and update the rule's description accordingly.
- `src/shared/model-capability-aliases.test.ts`: add a new case asserting that `claude-opus-4-6-thinking` resolves with `source: "canonical"` (i.e. is no longer treated as a legacy alias), to lock in the behaviour change.

## Verification

```bash
$ bun run typecheck       # ✓ passes
$ bun run build           # ✓ passes

# Reproduce the original CI failure first
$ git checkout upstream/dev -- src/shared/model-capability-aliases.ts
$ bun run build:model-capabilities    # refresh snapshot from models.dev
$ bun test src/shared/model-capability-guardrails.test.ts \
    -t "keeps the current alias registry"
# (fail) … "Pattern alias claude-thinking-legacy-alias would rewrite
#           canonical snapshot model claude-opus-4-6-thinking to claude-opus-4-7."

# Apply this PR's change and re-run
$ git checkout HEAD -- src/shared/model-capability-aliases.ts
$ bun test src/shared/model-capability-guardrails.test.ts \
    -t "keeps the current alias registry"
# 1 pass / 0 fail

# Full alias test file
$ bun test src/shared/model-capability-aliases.test.ts
# 11 pass / 0 fail (including the new canonical-resolution case)
```

## A note on the broader test suite

`bun run test:model-capabilities` still has one failure on this branch in
`model-capability-guardrails.test.ts > requires built-in requirement models to stay unique and sorted` — it expects `getBuiltInRequirementModelIDs()` to contain `gpt-5.4`, but the list does not. **This failure exists on `upstream/dev` independently of this PR** (reproducible by running the same command against `upstream/dev` HEAD with no local edits, and unchanged whether the snapshot is the bundled 2026-04-17 copy or a fresh fetch). It is out of scope here and would be better addressed in a separate PR or as part of the broader Root Cause A discussion in #3635.

## Scope

This PR only addresses Root Cause B (alias collision). Root Cause A from #3635 (GitHub Actions repo setting that prevents `peter-evans/create-pull-request` from opening the automated refresh PR) is a Settings change and cannot be addressed by code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops rewriting canonical claude-opus-4-6-thinking to claude-opus-4-7 by narrowing the legacy alias rule. This fixes the alias/snapshot collision blocking model capability tests and the refresh cron (Root Cause B in #3635).

- **Bug Fixes**
  - Updated `claude-thinking-legacy-alias` regex to only match claude-opus-4-7-thinking and updated its description.
  - Added a test to ensure claude-opus-4-6-thinking resolves as canonical.

<sup>Written for commit 9c7102b73b098e822090b2f93c76be8b6507366f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

