### PR TITLE
fix(background): exit after fatal cleanup

### DIFF
--- a/src/features/background-agent/process-cleanup.test.ts
+++ b/src/features/background-agent/process-cleanup.test.ts
@@ -135,9 +135,7 @@ describe("#given process cleanup registration", () => {
     })
 
     test("#given two managers registered #when uncaughtException fires #then both shutdowns called", async () => {
-      const exitSpy = spyOn(process, "exit").mockImplementation((code?: number): never => {
-        throw new Error(`Unexpected process.exit(${String(code)})`)
-      })
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
       const shutdownOne = mock(() => {})
       const shutdownTwo = mock(() => {})
       const managerOne = { shutdown: shutdownOne }
@@ -154,7 +152,7 @@ describe("#given process cleanup registration", () => {
         expect(shutdownOne).toHaveBeenCalledTimes(1)
         expect(shutdownTwo).toHaveBeenCalledTimes(1)
         expect(process.exitCode).toBe(1)
-        expect(exitSpy).not.toHaveBeenCalled()
+        expect(exitSpy).toHaveBeenCalledWith(1)
       } finally {
         exitSpy.mockRestore()
       }
@@ -219,10 +217,8 @@ describe("#given process cleanup registration", () => {
   })
 
   describe("#given uncaught exception and rejection cleanup", () => {
-    test("#given manager registered AND process emits uncaughtException #when event fires #then manager.shutdown() called AND process.exitCode set to 1", async () => {
-      const exitSpy = spyOn(process, "exit").mockImplementation((code?: number): never => {
-        throw new Error(`Unexpected process.exit(${String(code)})`)
-      })
+    test("#given manager registered AND process emits uncaughtException #when event fires #then manager shuts down before process exits", async () => {
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
       const shutdown = mock(() => {})
       const manager = { shutdown }
       registeredManagers.push(manager)
@@ -235,16 +231,14 @@ describe("#given process cleanup registration", () => {
 
         expect(shutdown).toHaveBeenCalledTimes(1)
         expect(process.exitCode).toBe(1)
-        expect(exitSpy).not.toHaveBeenCalled()
+        expect(exitSpy).toHaveBeenCalledWith(1)
       } finally {
         exitSpy.mockRestore()
       }
     })
 
-    test("#given manager registered AND process emits unhandledRejection #when event fires #then manager.shutdown() called AND process.exitCode set to 1", async () => {
-      const exitSpy = spyOn(process, "exit").mockImplementation((code?: number): never => {
-        throw new Error(`Unexpected process.exit(${String(code)})`)
-      })
+    test("#given manager registered AND process emits unhandledRejection #when event fires #then manager shuts down before process exits", async () => {
+      const exitSpy = spyOn(process, "exit").mockImplementation((() => undefined) as never)
       const shutdown = mock(() => {})
       const manager = { shutdown }
       registeredManagers.push(manager)
@@ -257,7 +251,7 @@ describe("#given process cleanup registration", () => {
 
         expect(shutdown).toHaveBeenCalledTimes(1)
         expect(process.exitCode).toBe(1)
-        expect(exitSpy).not.toHaveBeenCalled()
+        expect(exitSpy).toHaveBeenCalledWith(1)
       } finally {
         exitSpy.mockRestore()
       }

--- a/src/features/background-agent/process-cleanup.ts
+++ b/src/features/background-agent/process-cleanup.ts
@@ -3,11 +3,18 @@ import { log } from "../../shared"
 type ProcessCleanupSignal = NodeJS.Signals | "beforeExit" | "exit"
 type ProcessCleanupErrorEvent = "uncaughtException" | "unhandledRejection"
 
-function scheduleForcedExit(cleanupResult: void | Promise<void>, exitCode: number): void {
+function scheduleForcedExit(
+  cleanupResult: void | Promise<void>,
+  exitCode: number,
+  exitAfterCleanup = false,
+): void {
   process.exitCode = exitCode
   const exitTimeout = setTimeout(() => process.exit(), 6000)
   void Promise.resolve(cleanupResult).finally(() => {
     clearTimeout(exitTimeout)
+    if (exitAfterCleanup) {
+      process.exit(exitCode)
+    }
   })
 }
 
@@ -32,7 +39,7 @@ function registerErrorEvent(
 ): (error: unknown) => void {
   const listener = (error: unknown) => {
     log(`[background-agent] ${signal} received during shutdown cleanup:`, error)
-    scheduleForcedExit(handler(error), 1)
+    scheduleForcedExit(handler(error), 1, true)
   }
   process.on(signal, listener)
   return listener


### PR DESCRIPTION
## Summary
- make fatal cleanup handlers call `process.exit(1)` after registered managers finish shutting down
- keep the existing fallback timer for hung cleanup paths
- update cleanup tests to assert fatal `uncaughtException` / `unhandledRejection` paths exit after cleanup

## Tests
- `bun test src/features/background-agent/process-cleanup.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the background agent exits with code 1 after fatal errors once cleanup finishes, preventing hung processes and ensuring consistent shutdown behavior.

- **Bug Fixes**
  - On `uncaughtException` and `unhandledRejection`, run all registered shutdowns, then call `process.exit(1)`.
  - Keep the 6s fallback timer to force-exit if cleanup hangs.
  - Update tests to assert managers shut down before exit and that `process.exit(1)` is invoked.

<sup>Written for commit dafca989fab6c742d29cac340e5ea109542b31ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

