### PR TITLE
docs(readme): fix Kimi Code subscription link and price

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -141,7 +141,7 @@ Read this and tell me why it's not just another boilerplate: https://raw.githubu
 
 以下のサブスクリプションだけでも、ultraworkは十分に機能します（このプロジェクトとは無関係であり、個人的な推奨にすぎません）：
 - [ChatGPT サブスクリプション ($20)](https://chatgpt.com/)
-- [Kimi Code サブスクリプション ($0.99) (*今月限定)](https://www.kimi.com/membership/pricing?track_id=5cdeca93-66f0-4d35-aabb-b6df8fcea328)
+- [Kimi Code サブスクリプション ($19)](https://www.kimi.com/code)
 - [GLM Coding プラン ($10)](https://z.ai/subscribe)
 - 従量課金（pay-per-token）の対象であれば、kimiやgeminiモデルを使っても費用はほとんどかかりません。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -135,7 +135,7 @@ Read this and tell me why it's not just another boilerplate: https://raw.githubu
 
 다음 구독만 있어도 ultrawork는 충분히 잘 돌아갑니다 (본 프로젝트와 무관하며, 개인적인 추천일 뿐입니다):
 - [ChatGPT 구독 ($20)](https://chatgpt.com/)
-- [Kimi Code 구독 ($0.99) (*이번 달 한정)](https://www.kimi.com/membership/pricing?track_id=5cdeca93-66f0-4d35-aabb-b6df8fcea328)
+- [Kimi Code 구독 ($19)](https://www.kimi.com/code)
 - [GLM Coding 요금제 ($10)](https://z.ai/subscribe)
 - 종량제(pay-per-token) 대상자라면 kimi와 gemini 모델을 써도 비용이 별로 안 나옵니다.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Everything below, every feature, every optimization, you don't need to know it. 
 
 Even only with following subscriptions, ultrawork will work well (this project is not affiliated, this is just personal recommendation):
 - [ChatGPT Subscription ($20)](https://chatgpt.com/)
-- [Kimi Code Subscription ($0.99) (*only this month)](https://www.kimi.com/kimiplus/sale)
+- [Kimi Code Subscription ($19)](https://www.kimi.com/code)
 - [GLM Coding Plan ($10)](https://z.ai/subscribe)
 - If you are eligible for pay-per-token, using kimi and gemini models won't cost you that much.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -128,7 +128,7 @@ Read this and tell me why it's not just another boilerplate: https://raw.githubu
 Даже при наличии только следующих подписок ultrawork будет работать отлично (проект не аффилирован с ними, это личная рекомендация):
 
 - [Подписка ChatGPT ($20)](https://chatgpt.com/)
-- [Подписка Kimi Code ($0.99) (*только в этом месяце)](https://www.kimi.com/membership/pricing?track_id=5cdeca93-66f0-4d35-aabb-b6df8fcea328)
+- [Подписка Kimi Code ($19)](https://www.kimi.com/code)
 - [Тариф GLM Coding ($10)](https://z.ai/subscribe)
 - При доступе к оплате за токены использование моделей Kimi и Gemini обойдётся недорого.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -142,7 +142,7 @@ Read this and tell me why it's not just another boilerplate: https://raw.githubu
 
 只需以下订阅之一，ultrawork 就能顺畅工作（本项目与它们没有任何关联，纯属个人推荐）：
 - [ChatGPT 订阅 ($20)](https://chatgpt.com/)
-- [Kimi Code 订阅 ($0.99) (*仅限本月*)](https://www.kimi.com/membership/pricing?track_id=5cdeca93-66f0-4d35-aabb-b6df8fcea328)
+- [Kimi Code 订阅 ($19)](https://www.kimi.com/code)
 - [GLM Coding 套餐 ($10)](https://z.ai/subscribe)
 - 如果你能使用按 token 计费的方式，用 kimi 和 gemini 模型花不了多少钱。
 


### PR DESCRIPTION
## Summary

The Kimi Code subscription link had drifted across the 5 README translations:

- **English** (`README.md`) pointed to outdated `https://www.kimi.com/kimiplus/sale` at $0.99
- **Japanese, Korean, Russian, Simplified Chinese** all pointed to `https://www.kimi.com/membership/pricing?track_id=...` (referral tracking URL) at $0.99 with an "only this month" qualifier

Normalized all 5 to the canonical `https://www.kimi.com/code` at $19, preserving each language's localized "Kimi Code Subscription" wording.

## Changes

- `README.md`, `README.ja.md`, `README.ko.md`, `README.ru.md`, `README.zh-cn.md` — single-line link update in each

## Test plan

- [x] Verified all 5 READMEs now point to `https://www.kimi.com/code`
- [x] Verified localized wording preserved in each translation
- [x] Verified no other Kimi-related copy was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Kimi Code subscription link and price across all five README translations to the canonical https://www.kimi.com/code at $19, removing outdated $0.99 promo and referral URLs. Kept each language’s localized “Kimi Code Subscription” wording.

<sup>Written for commit 3577f302438effec88dc25568e655447f67faf46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

