### PR TITLE
Fix: Prevent transcript cache growth in Claude Code post-tool-use hook

### DIFF
--- a/src/hooks/claude-code-hooks/transcript.test.ts
+++ b/src/hooks/claude-code-hooks/transcript.test.ts
@@ -100,7 +100,7 @@ describe("transcript caching", () => {
     expect(client.session.messages).toHaveBeenCalledTimes(2)
   })
 
-  it("keeps intermediate tool calls across sequential transcript rebuilds", async () => {
+  it("should not grow cached base entries across sequential transcript rebuilds", async () => {
     // given
     const client = createMockClient([])
 
@@ -112,6 +112,12 @@ describe("transcript caching", () => {
       "bash",
       { command: "echo first" }
     )
+    if (firstPath) {
+      const firstLines = readFileSync(firstPath, "utf-8").trim().split("\n")
+      expect(firstLines).toHaveLength(1)
+      expect(firstLines[0]).toContain("Bash")
+    }
+
     const secondPath = await buildTranscriptFromSession(
       client,
       "ses_sequential",
@@ -119,6 +125,8 @@ describe("transcript caching", () => {
       "read",
       { filePath: "/tmp/second.txt" }
     )
+    const secondLines = secondPath ? readFileSync(secondPath, "utf-8").trim().split("\n") : []
+
     const thirdPath = await buildTranscriptFromSession(
       client,
       "ses_sequential",
@@ -132,12 +140,18 @@ describe("transcript caching", () => {
     expect(secondPath).not.toBeNull()
     expect(thirdPath).not.toBeNull()
 
-    if (thirdPath) {
-      const content = readFileSync(thirdPath, "utf-8")
+    if (secondPath && thirdPath) {
+      expect(secondLines).toHaveLength(1)
+      expect(secondLines[0]).toContain("Read")
 
-      expect(content).toContain("Bash")
-      expect(content).toContain("Read")
-      expect(content).toContain("Write")
+      const thirdLines = readFileSync(thirdPath, "utf-8").trim().split("\n")
+      expect(thirdLines).toHaveLength(1)
+      expect(thirdLines[0]).toContain("Write")
+    }
+
+    // Cached previous temp files should be replaced on rebuild
+    if (firstPath) {
+      expect(existsSync(firstPath)).toBe(false)
     }
 
     deleteTempTranscript(firstPath)

--- a/src/hooks/claude-code-hooks/transcript.ts
+++ b/src/hooks/claude-code-hooks/transcript.ts
@@ -216,7 +216,6 @@ export async function buildTranscriptFromSession(
 
     const cacheEntry = transcriptCache.get(sessionId)
     if (cacheEntry) {
-      cacheEntry.baseEntries = allEntries
       cacheEntry.tempPath = tempPath
       cacheEntry.createdAt = Date.now()
     }


### PR DESCRIPTION
## Summary
- Fix transcript cache growth in `buildTranscriptFromSession` by keeping cache base entries stable instead of appending each current tool call into the cached baseline.
- Remove assigning `allEntries` into `cacheEntry.baseEntries` in `src/hooks/claude-code-hooks/transcript.ts`.
- Update transcript tests to verify sequential rebuilds keep a single current entry and do not re-use a growing cached baseline (issue #3647).

## Related issue
Closes #3647

## Validation
- `bun test src/hooks/claude-code-hooks/transcript.test.ts`
- `bun run typecheck`
- `bun run build`

## Notes
- This change prevents unbounded in-memory transcript growth during long sessions while preserving existing temp transcript replacement behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unbounded transcript cache growth during sequential rebuilds by keeping cached base entries stable and only writing the current tool call to the temp transcript. This stabilizes memory usage in long sessions and keeps temp files correctly replaced.

- **Bug Fixes**
  - Stop updating `cacheEntry.baseEntries` in `buildTranscriptFromSession`, preventing baseline growth across tool calls.
  - Update `src/hooks/claude-code-hooks/transcript.test.ts` to assert one current entry per rebuild and that prior temp files are replaced.

<sup>Written for commit 6529c44b2d02c767a66769c925a92254a1ae185c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

