### PR TITLE
test: fix remaining stale gpt-5.4 expectations after gpt-5.5 promotion

### DIFF
--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -1016,7 +1016,7 @@ describe("createBuiltinAgents with requiresAnyModel gating (sisyphus)", () => {
 
   test("atlas and metis resolve to OpenAI in an OpenAI-only environment without a system default", async () => {
     // #given
-    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set(["openai/gpt-5.4"]))
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set(["openai/gpt-5.5"]))
     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
 
     try {
@@ -1025,10 +1025,10 @@ describe("createBuiltinAgents with requiresAnyModel gating (sisyphus)", () => {
 
       // #then
       expect(agents.atlas).toBeDefined()
-      expect(agents.atlas.model).toBe("openai/gpt-5.4")
+      expect(agents.atlas.model).toBe("openai/gpt-5.5")
       expect(agents.atlas.variant).toBe("medium")
       expect(agents.metis).toBeDefined()
-      expect(agents.metis.model).toBe("openai/gpt-5.4")
+      expect(agents.metis.model).toBe("openai/gpt-5.5")
       expect(agents.metis.variant).toBe("high")
     } finally {
       fetchSpy.mockRestore()
@@ -1185,7 +1185,7 @@ describe("buildAgent with category and skills", () => {
     const agent = buildAgent(source["test-agent"], TEST_MODEL)
 
     // #then - category's built-in model and skills are applied
-    expect(agent.model).toBe("openai/gpt-5.4")
+    expect(agent.model).toBe("openai/gpt-5.5")
     expect(agent.variant).toBe("xhigh")
     expect(agent.prompt).toContain("Role: Designer-Turned-Developer")
     expect(agent.prompt).toContain("Task description")
@@ -1309,9 +1309,9 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - ultrabrain category: model=openai/gpt-5.4, variant=xhigh
+    // #then - ultrabrain category: model=openai/gpt-5.5, variant=xhigh
     expect(agents.oracle).toBeDefined()
-    expect(agents.oracle.model).toBe("openai/gpt-5.4")
+    expect(agents.oracle.model).toBe("openai/gpt-5.5")
     expect(agents.oracle.variant).toBe("xhigh")
   })
 
@@ -1378,9 +1378,9 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - ultrabrain category: model=openai/gpt-5.4, variant=xhigh
+    // #then - ultrabrain category: model=openai/gpt-5.5, variant=xhigh
     expect(agents.sisyphus).toBeDefined()
-    expect(agents.sisyphus.model).toBe("openai/gpt-5.4")
+    expect(agents.sisyphus.model).toBe("openai/gpt-5.5")
     expect(agents.sisyphus.variant).toBe("xhigh")
   })
 
@@ -1393,9 +1393,9 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - ultrabrain category: model=openai/gpt-5.4, variant=xhigh
+    // #then - ultrabrain category: model=openai/gpt-5.5, variant=xhigh
     expect(agents.atlas).toBeDefined()
-    expect(agents.atlas.model).toBe("openai/gpt-5.4")
+    expect(agents.atlas.model).toBe("openai/gpt-5.5")
     expect(agents.atlas.variant).toBe("xhigh")
   })
 

--- a/src/cli/config-manager/generate-omo-config.test.ts
+++ b/src/cli/config-manager/generate-omo-config.test.ts
@@ -96,10 +96,10 @@ describe("generateOmoConfig - model fallback system", () => {
     const result = generateOmoConfig(config)
 
     //#then
-    expect((result.agents as Record<string, { model: string; variant?: string }>).sisyphus.model).toBe("openai/gpt-5.4")
+    expect((result.agents as Record<string, { model: string; variant?: string }>).sisyphus.model).toBe("openai/gpt-5.5")
     expect((result.agents as Record<string, { model: string; variant?: string }>).sisyphus.variant).toBe("medium")
     expect((result.agents as Record<string, { model: string }>).oracle.model).toBe("openai/gpt-5.5")
-    expect((result.agents as Record<string, { model: string }>)['multimodal-looker'].model).toBe("openai/gpt-5.4")
+    expect((result.agents as Record<string, { model: string }>)['multimodal-looker'].model).toBe("openai/gpt-5.5")
   })
 
   test("adds fallback_models when multiple providers are available", () => {
@@ -134,7 +134,7 @@ describe("generateOmoConfig - model fallback system", () => {
     expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4-7")
     expect(agents.sisyphus.fallback_models).toEqual([
       {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         variant: "medium",
       },
     ])

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -750,7 +750,7 @@ describe("Prometheus category config resolution", () => {
 
     // then
     expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.4")
+    expect(config?.model).toBe("openai/gpt-5.5")
     expect(config?.variant).toBe("xhigh")
   })
 
@@ -810,7 +810,7 @@ describe("Prometheus category config resolution", () => {
 
     // then - falls back to DEFAULT_CATEGORIES
     expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.4")
+    expect(config?.model).toBe("openai/gpt-5.5")
     expect(config?.variant).toBe("xhigh")
   })
 

--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -124,10 +124,10 @@ describe("resolveVariantForModel", () => {
     expect(variant).toBe("medium")
   })
 
-  test("returns medium for openai/gpt-5.4 in sisyphus chain", () => {
-    // #given openai/gpt-5.4 is now in sisyphus fallback chain with variant medium
+  test("returns medium for openai/gpt-5.5 in sisyphus chain", () => {
+    // #given openai/gpt-5.5 is now in sisyphus fallback chain with variant medium
     const config = {} as OhMyOpenCodeConfig
-    const model = { providerID: "openai", modelID: "gpt-5.4" }
+    const model = { providerID: "openai", modelID: "gpt-5.5" }
 
     // when
     const variant = resolveVariantForModel(config, "sisyphus", model)
@@ -179,7 +179,7 @@ describe("resolveVariantForModel", () => {
         "custom-agent": { category: "ultrabrain" },
       },
     } as OhMyOpenCodeConfig
-    const model = { providerID: "openai", modelID: "gpt-5.4" }
+    const model = { providerID: "openai", modelID: "gpt-5.5" }
 
     // when
     const variant = resolveVariantForModel(config, "custom-agent", model)

--- a/src/shared/model-capability-guardrails.test.ts
+++ b/src/shared/model-capability-guardrails.test.ts
@@ -20,7 +20,7 @@ describe("model-capability-guardrails", () => {
     expect(modelIDs).toEqual([...modelIDs].sort())
     expect(new Set(modelIDs).size).toBe(modelIDs.length)
     expect(modelIDs).toContain("claude-opus-4-7")
-    expect(modelIDs).toContain("gpt-5.4")
+    expect(modelIDs).toContain("gpt-5.5")
     expect(modelIDs).toContain("kimi-k2.5")
   })
 

--- a/src/tools/look-at/multimodal-fallback-chain.test.ts
+++ b/src/tools/look-at/multimodal-fallback-chain.test.ts
@@ -34,7 +34,7 @@ describe("buildMultimodalLookerFallbackChain", () => {
   it("preserves hardcoded variant metadata for cache-derived entries", async () => {
     // given
     const { buildMultimodalLookerFallbackChain } = await import("./multimodal-fallback-chain")
-    const visionCapableModels = [{ providerID: "openai", modelID: "gpt-5.4" }]
+    const visionCapableModels = [{ providerID: "openai", modelID: "gpt-5.5" }]
 
     // when
     const result = buildMultimodalLookerFallbackChain(visionCapableModels)
@@ -42,7 +42,7 @@ describe("buildMultimodalLookerFallbackChain", () => {
     // then
     expect(result[0]).toEqual({
       providers: ["openai"],
-      model: "gpt-5.4",
+      model: "gpt-5.5",
       variant: "medium",
     })
   })


### PR DESCRIPTION
## Summary

- Fix 13 test failures caused by stale `openai/gpt-5.4` expectations after the GPT-5.5 model promotion in `3bab66b96`–`708891dab`
- Commit `708891dab` ("test: fix stale expectations after gpt-5.5 model promotion") fixed most tests but missed 13 across 6 files

## Root Cause

The GPT-5.5 promotion updated `DEFAULT_CATEGORIES` (ultrabrain/deep → `openai/gpt-5.5`) and `AGENT_MODEL_REQUIREMENTS` (sisyphus, hephaestus, oracle, prometheus, metis, multimodal-looker chains → `gpt-5.5`), but 13 test expectations were not updated to match.

## Files Changed

| File | Tests Fixed |
|------|------------|
| `src/agents/utils.test.ts` | 5: atlas/metis resolution, buildAgent category, override.category expansion |
| `src/plugin-handlers/config-handler.test.ts` | 2: ultrabrain config resolution + fallback |
| `src/shared/agent-variant.test.ts` | 2: sisyphus chain variant + category fallback |
| `src/shared/model-capability-guardrails.test.ts` | 1: built-in requirement model ID check |
| `src/tools/look-at/multimodal-fallback-chain.test.ts` | 1: multimodal-looker variant metadata |
| `src/cli/config-manager/generate-omo-config.test.ts` | 2: sisyphus model + fallback_models |

## Test Plan

- [x] All 13 previously failing tests now pass (146/146 across affected files)
- [x] CI-equivalent run: 4865 pass, 0 regressions from this change
- [x] `bun run typecheck` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix 13 failing tests by updating stale `openai/gpt-5.4` expectations to `openai/gpt-5.5` after the model promotion. Aligns tests with updated `DEFAULT_CATEGORIES`, `AGENT_MODEL_REQUIREMENTS`, and multimodal fallback metadata to restore green CI.

- **Bug Fixes**
  - Covers atlas/metis resolution, ultrabrain/prometheus config fallbacks, sisyphus chain variant, multimodal-looker metadata, config generator fallbacks, and model guardrails across 6 test files.

<sup>Written for commit 0afacfa7564ef742503abc2670ffc52eb77e19ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

