### PR TITLE
fix(agents): cover dotted opus frontier model

### DIFF
--- a/src/agents/builtin-agents/sisyphus-agent.test.ts
+++ b/src/agents/builtin-agents/sisyphus-agent.test.ts
@@ -109,6 +109,40 @@ describe("maybeCreateSisyphusConfig", () => {
     });
   });
 
+  describe("#given dotted Opus 4.7 model with user override allowing grep and glob", () => {
+    test("#when config is created #then grep and glob are still denied", () => {
+      // given
+      const agentOverrides: AgentOverrides = {
+        sisyphus: {
+          model: "anthropic/claude-opus-4.7",
+          permission: {
+            grep: "allow",
+            glob: "allow",
+          } as Record<string, "allow">,
+        },
+      };
+      const mergedCategories: Record<string, CategoryConfig> = {};
+
+      // when
+      const config = maybeCreateSisyphusConfig({
+        disabledAgents: [],
+        agentOverrides,
+        availableModels: new Set(["anthropic/claude-opus-4.7"]),
+        systemDefaultModel: "anthropic/claude-opus-4.7",
+        isFirstRunNoCache: false,
+        availableAgents: [],
+        availableSkills: [],
+        availableCategories: [],
+        mergedCategories,
+        useTaskSystem: false,
+      });
+
+      // then
+      expect(config?.permission).toHaveProperty("grep", "deny");
+      expect(config?.permission).toHaveProperty("glob", "deny");
+    });
+  });
+
   describe("#given GPT 5.5 model with user override allowing grep and glob", () => {
     test("#when config is created #then grep and glob are still denied", () => {
       // given

--- a/src/agents/frontier-tool-schema-guard.ts
+++ b/src/agents/frontier-tool-schema-guard.ts
@@ -7,7 +7,8 @@ type MutablePermission = Record<string, PermissionValue | Record<string, Permiss
 
 function isOpus47Model(model: string): boolean {
   const modelName = model.includes("/") ? (model.split("/").pop() ?? model) : model
-  return modelName.toLowerCase().includes("claude-opus-4-7")
+  const normalizedModelName = modelName.toLowerCase().replaceAll(".", "-")
+  return normalizedModelName.includes("claude-opus-4-7")
 }
 
 export function getFrontierToolSchemaPermission(model: string): Record<string, "deny"> {

--- a/src/agents/hephaestus/agent.test.ts
+++ b/src/agents/hephaestus/agent.test.ts
@@ -451,6 +451,40 @@ describe("maybeCreateHephaestusConfig GPT apply_patch guard", () => {
     });
   });
 
+  describe("#given dotted Opus 4.7 model with user override allowing grep and glob", () => {
+    test("#when config is created #then grep and glob are still denied", () => {
+      // given
+      const agentOverrides: AgentOverrides = {
+        hephaestus: {
+          model: "anthropic/claude-opus-4.7",
+          permission: {
+            grep: "allow",
+            glob: "allow",
+          } as Record<string, "allow">,
+        },
+      };
+      const mergedCategories: Record<string, CategoryConfig> = {};
+
+      // when
+      const config = maybeCreateHephaestusConfig({
+        disabledAgents: [],
+        agentOverrides,
+        availableModels: new Set(["anthropic/claude-opus-4.7"]),
+        systemDefaultModel: "anthropic/claude-opus-4.7",
+        isFirstRunNoCache: false,
+        availableAgents: [],
+        availableSkills: [],
+        availableCategories: [],
+        mergedCategories,
+        useTaskSystem: false,
+      });
+
+      // then
+      expect(config?.permission).toHaveProperty("grep", "deny");
+      expect(config?.permission).toHaveProperty("glob", "deny");
+    });
+  });
+
   describe("#given GPT 5.5 model with user override allowing grep and glob", () => {
     test("#when config is created #then grep and glob are still denied", () => {
       // given

--- a/src/agents/tool-restrictions.test.ts
+++ b/src/agents/tool-restrictions.test.ts
@@ -140,8 +140,10 @@ describe("read-only agent tool restrictions", () => {
       // given
       const frontierAgents = [
         createSisyphusAgent("anthropic/claude-opus-4-7"),
+        createSisyphusAgent("anthropic/claude-opus-4.7"),
         createSisyphusAgent("openai/gpt-5.5"),
         createHephaestusAgent("anthropic/claude-opus-4-7"),
+        createHephaestusAgent("anthropic/claude-opus-4.7"),
         createHephaestusAgent("openai/gpt-5.5"),
       ]
 


### PR DESCRIPTION
## Summary
- Fix frontier tool-schema detection for dotted `claude-opus-4.7` model IDs in addition to dashed `claude-opus-4-7`.
- Add regression coverage for Sisyphus and Hephaestus direct factories and config override paths.

## Testing
- `bun test src/agents/tool-restrictions.test.ts src/agents/builtin-agents/sisyphus-agent.test.ts src/agents/hephaestus/agent.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run build`
- Manual permission QA for dotted Opus 4.7 Sisyphus/Hephaestus

## Related
- Follow-up to #3656

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes frontier tool-schema detection for dotted `anthropic/claude-opus-4.7` IDs (in addition to dashed), ensuring Sisyphus and Hephaestus still apply the restricted schema and deny `grep` and `glob` even if overrides try to allow them. Adds regression tests for both agents and override paths to cover dotted and dashed model IDs.

<sup>Written for commit 80791f10bc1abb47a584f4778d7affea1f0bfc26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

