### PR TITLE
fix(doctor): suppress resolved model capability warnings

### DIFF
--- a/src/cli/doctor/checks/model-resolution.test.ts
+++ b/src/cli/doctor/checks/model-resolution.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from "bun:test"
+import { describe, it, expect } from "bun:test"
 
 describe("model-resolution check", () => {
   describe("getModelResolutionInfo", () => {
@@ -234,6 +234,28 @@ describe("model-resolution check", () => {
       expect(issues).toHaveLength(1)
       expect(issues[0]?.title).toContain("compatibility fallback")
       expect(issues[0]?.description).toContain("oracle=custom/unknown-llm")
+    })
+
+    it("does not warn for known provider aliases used by current recommended models", async () => {
+      const { collectCapabilityResolutionIssues, getModelResolutionInfoWithOverrides } = await import("./model-resolution")
+
+      // #given current recommended provider aliases from user configuration
+      const info = getModelResolutionInfoWithOverrides({
+        agents: {
+          sisyphus: { model: "kimi-for-coding/k2pb" },
+          metis: { model: "github-copilot/claude-opus-4.7" },
+        },
+        categories: {
+          "visual-engineering": { model: "github-copilot/claude-opus-4.7" },
+          artistry: { model: "github-copilot/claude-opus-4.7" },
+        },
+      })
+
+      // #when collecting doctor capability issues
+      const issues = collectCapabilityResolutionIssues(info)
+
+      // #then these known aliases do not create compatibility fallback warnings
+      expect(issues).toHaveLength(0)
     })
   })
 

--- a/src/cli/doctor/checks/model-resolution.ts
+++ b/src/cli/doctor/checks/model-resolution.ts
@@ -95,7 +95,7 @@ export function collectCapabilityResolutionIssues(info: ModelResolutionInfo): Do
   const allEntries = [...info.agents, ...info.categories]
   const fallbackEntries = allEntries.filter((entry) => {
     const mode = entry.capabilityDiagnostics?.resolutionMode
-    return mode === "alias-backed" || mode === "heuristic-backed" || mode === "unknown"
+    return mode === "unknown"
   })
 
   if (fallbackEntries.length === 0) {

--- a/src/shared/model-capability-aliases.test.ts
+++ b/src/shared/model-capability-aliases.test.ts
@@ -56,6 +56,28 @@ describe("model-capability-aliases", () => {
     })
   })
 
+  test("normalizes Kimi for Coding k2pb aliases to the snapshot ID", () => {
+    const result = resolveModelIDAlias("kimi-for-coding/k2pb")
+
+    expect(result).toEqual({
+      requestedModelID: "kimi-for-coding/k2pb",
+      canonicalModelID: "k2p5",
+      source: "exact-alias",
+      ruleID: "kimi-k2pb-alias",
+    })
+  })
+
+  test("normalizes GitHub Copilot dotted Claude Opus aliases to the snapshot ID", () => {
+    const result = resolveModelIDAlias("github-copilot/claude-opus-4.7")
+
+    expect(result).toEqual({
+      requestedModelID: "github-copilot/claude-opus-4.7",
+      canonicalModelID: "claude-opus-4-7",
+      source: "exact-alias",
+      ruleID: "claude-opus-dotted-version-alias",
+    })
+  })
+
   test("does not resolve prototype keys as aliases", () => {
     const result = resolveModelIDAlias("constructor")
 

--- a/src/shared/model-capability-aliases.ts
+++ b/src/shared/model-capability-aliases.ts
@@ -32,6 +32,18 @@ const EXACT_ALIAS_RULES: ReadonlyArray<ExactAliasRule> = [
     canonicalModelID: "gemini-3-pro-preview",
     rationale: "Legacy Gemini 3 tier suffixes still need to land on the canonical preview model.",
   },
+  {
+    aliasModelID: "k2pb",
+    ruleID: "kimi-k2pb-alias",
+    canonicalModelID: "k2p5",
+    rationale: "Kimi for Coding exposes k2pb while the bundled capabilities snapshot uses the canonical k2p5 ID.",
+  },
+  {
+    aliasModelID: "claude-opus-4.7",
+    ruleID: "claude-opus-dotted-version-alias",
+    canonicalModelID: "claude-opus-4-7",
+    rationale: "GitHub Copilot exposes Claude Opus 4.7 with dotted version syntax while the snapshot uses dashed syntax.",
+  },
 ]
 
 const EXACT_ALIAS_RULES_BY_MODEL: ReadonlyMap<string, ExactAliasRule> = new Map(


### PR DESCRIPTION
## Summary
Fixes false-positive `doctor` model capability warnings for current recommended provider aliases by canonicalizing known aliases before capability lookup and only warning when capability resolution is genuinely unknown.

## Changes
- Map `kimi-for-coding/k2pb` to the bundled `k2p5` capability snapshot.
- Map `github-copilot/claude-opus-4.7` to the bundled `claude-opus-4-7` capability snapshot.
- Stop treating resolved alias-backed or heuristic-backed capability diagnostics as doctor warnings.

## Testing
- `bun test src/shared/model-capability-aliases.test.ts src/shared/model-capabilities.test.ts src/cli/doctor/checks/model-resolution.test.ts src/cli/doctor/checks/model-resolution-cache.test.ts --bail`
- `bun run typecheck`
- `bun run build`
- `bun src/cli/index.ts doctor --verbose`
- `bun test`

## Related
- Discord report: https://discord.com/channels/1452487457085063218/1452487600647442464/1498200460366975128

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses false-positive `doctor` model capability warnings by canonicalizing known provider aliases and only warning when resolution is unknown. Users on recommended models no longer see fallback warnings for `kimi-for-coding/k2pb` and `github-copilot/claude-opus-4.7`.

- **Bug Fixes**
  - Canonicalize `kimi-for-coding/k2pb` to `k2p5`.
  - Canonicalize `github-copilot/claude-opus-4.7` to `claude-opus-4-7`.
  - `doctor` now only warns when capability resolution is `unknown` (ignores alias-backed and heuristic-backed).

<sup>Written for commit 136a54f4672204b9a2b4968c7c7a19b07a62c8b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

