### PR TITLE
Fix/gpt 5.5 sisyphus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/harness-kimjang"]
-	path = vendor/harness-kimjang
-	url = https://github.com/islee23520/harness-kimjang.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/harness-kimjang"]
+	path = vendor/harness-kimjang
+	url = https://github.com/islee23520/harness-kimjang.git

--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -21,13 +21,13 @@ Sisyphus is the developer who knows everyone, goes everywhere, and gets things d
 - Understanding nuanced delegation and orchestration patterns
 - Producing well-structured, communicative output
 
-Using Sisyphus with older GPT models would be like taking your best project manager — the one who coordinates everyone, runs standups, and keeps the whole team aligned — and sticking them in a room alone to debug a race condition. Wrong fit. GPT-5.4 now has a dedicated Sisyphus prompt path, but GPT is still not the default recommendation for the orchestrator.
+Using Sisyphus with older GPT models would be like taking your best project manager — the one who coordinates everyone, runs standups, and keeps the whole team aligned — and sticking them in a room alone to debug a race condition. Wrong fit. GPT-5.5 now has a dedicated Sisyphus prompt path, but GPT is still not the default recommendation for the orchestrator.
 
 ### Hephaestus: The Deep Specialist
 
 Hephaestus is the developer who stays in their room coding all day. Doesn't talk much. Might seem socially awkward. But give them a hard technical problem and they'll emerge three hours later with a solution nobody else could have found.
 
-**This is why Hephaestus uses GPT-5.4.** GPT-5.4 is built for exactly this:
+**This is why Hephaestus uses GPT-5.5.** GPT-5.5 is built for exactly this:
 
 - Deep, autonomous exploration without hand-holding
 - Multi-file reasoning across complex codebases
@@ -56,110 +56,186 @@ Agents that support both families (Prometheus, Atlas) auto-detect your model at 
 
 ---
 
+## Step 1 — Check What's Actually Available
+
+Before configuring anything, see what your current system can run.
+
+### List all available models
+
+```bash
+opencode models
+```
+
+This prints every `provider/model` combination you can address right now. Providers are derived from your connected auth + the `models.dev` catalogue.
+
+Opencode sorts the output so `opencode*` providers appear first — that's intentional, not cosmetic.
+
+### List connected providers
+
+```bash
+opencode auth list
+```
+
+Shows which providers you've already logged into.
+
+### If the model you want isn't listed
+
+You need to log in to that provider:
+
+```bash
+opencode auth login
+```
+
+The interactive picker prioritizes providers in this order:
+
+| Priority | Provider | Opencode's own hint |
+|---|---|---|
+| 0 | `opencode` | **(Recommended)** |
+| 1 | `opencode-go` | Low cost subscription for everyone |
+| 2 | `openai` | ChatGPT Plus/Pro or API key |
+| 3 | `github-copilot` | — |
+| 4 | `anthropic` | API key |
+| 5 | `google` | — |
+
+You can also skip the picker: `opencode auth login --provider opencode-go`.
+
+### Verify what oh-my-openagent will actually use
+
+```bash
+bunx oh-my-opencode doctor
+```
+
+This shows the **effective model resolution** for every agent and category based on your current auth state. If an agent says "system-default" instead of a real fallback, that's a signal you're missing providers from its chain.
+
+---
+
+## Step 2 — The Recommended Stack
+
+You don't need every provider. You need the right two.
+
+### The Optimal Combination: OpenCode Go + OpenAI Plus/Pro
+
+**~$30/month total.** Beats direct Anthropic + OpenAI + Google subscriptions (~$60+/month) on both cost and coverage.
+
+| Subscription | Cost | What You Get | Covers |
+|---|---|---|---|
+| **OpenCode Go** | $10/mo | `kimi-k2.5`, `kimi-k2.6`, `glm-5`, `glm-5.1`, `minimax-m2.5`, `minimax-m2.7`, `mimo-v2-pro`, `qwen3.5-plus`, `qwen3.6-plus` | Claude-family alternatives (Kimi, GLM), Gemini-family alternatives (Qwen), utility/retrieval (MiniMax) |
+| **OpenAI Plus/Pro** | $20+/mo | `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.5`, `gpt-5.3-codex` | GPT-native agents (Hephaestus, Oracle, Momus), dual-prompt agents' GPT path |
+
+### Why this specific combination
+
+1. **Hephaestus requires GPT-5.4/5.5.** It has no Claude-family fallback. ChatGPT Plus/Pro is the cheapest real path.
+2. **OpenCode Go covers the orchestration and creative surface.** Kimi K2.5/2.6 behaves like Claude for Sisyphus/Atlas. GLM-5 fills the long tail. Qwen handles visual tasks when Gemini isn't available.
+3. **No single provider can cover everything.** Anthropic-only setups break Hephaestus. OpenAI-only setups degrade Sisyphus. You need at least one from each family.
+
+### What if you already have a Claude subscription?
+
+Add `--claude=max20` (or `yes`) on install. Claude Opus 4.7 becomes the default for Sisyphus/Prometheus/Atlas and you still get the OpenCode Go fallbacks for free. Best-in-class orchestration + budget safety net.
+
+### What if you have zero subscriptions?
+
+OpenCode Go alone gets Sisyphus/Atlas/Oracle/Librarian/Explore working. Hephaestus won't activate without GPT access, so you lose autonomous deep work. Consider adding ChatGPT Plus as soon as you can.
+
+---
+
+## Step 3 — Model Family Alternatives (Priority Order)
+
+When the "native" model isn't available, oh-my-openagent walks each agent's fallback chain until something connects. The chains are hardcoded in [`src/shared/model-requirements.ts`](../../src/shared/model-requirements.ts). Here are the **substitution rules** you should internalize.
+
+### Claude Family (communicative, instruction-following)
+
+Used by: Sisyphus, Atlas, Sisyphus-Junior, Metis (Claude path), Prometheus (Claude path), `unspecified-low`, `unspecified-high`.
+
+| Priority | Model | Provider | Why |
+|---|---|---|---|
+| 1 | `claude-opus-4-7` (max) | `anthropic`, `github-copilot`, `opencode`, `vercel` | Best overall compliance with ~1,100-line Sisyphus prompt. |
+| 2 | `claude-sonnet-4-6` | same | Faster, cheaper, still Claude. |
+| 3 | **`kimi-k2.5` or `kimi-k2.6` — RECOMMENDED ALTERNATIVE** | `opencode-go`, `kimi-for-coding`, `moonshotai`, `opencode`, `vercel` | Instruction-following mirrors Claude closely. Default orchestrator when Anthropic isn't connected. |
+| 4 | **`glm-5` or `glm-5.1` — ACCEPTABLE ALTERNATIVE** | `opencode-go`, `zai-coding-plan`, `opencode`, `vercel` | Claude-like, slightly looser on long nested workflows. Solid fallback. |
+| 5 | `big-pickle` (GLM 4.6) | `opencode` | Free-tier safety net. |
+
+> **Kimi ≻ GLM.** Kimi K2.5/2.6 hold up under Sisyphus's nested todo+delegation prompts better than GLM. Use Kimi whenever both are available.
+
+### GPT Family (principle-driven, autonomous)
+
+Used by: Hephaestus, Oracle, Momus, `deep`, `ultrabrain`, `quick`, Prometheus (GPT path), Atlas (GPT path).
+
+| Priority | Model | Provider | Why |
+|---|---|---|---|
+| 1 | `gpt-5.5` / `gpt-5.4` (pro / xhigh / high / medium) | `openai`, `github-copilot`, `opencode`, `vercel` | Native OpenAI is the gold standard for principle-driven prompts. Hephaestus requires this family. |
+| 2 | `gpt-5.3-codex` | same | Still the deep-coding powerhouse. Kept as an explicit override option. |
+| 3 | **DeepSeek — LIMITED ALTERNATIVE** (`deepseek-v3.2`, `deepseek-chat-v3.1`) | `openrouter/deepseek` | Closest OSS equivalent for autonomous coding behavior. Not wired into default chains — add via `fallback_models`. |
+| 4 | **MiniMax — STRONGLY DISCOURAGED** (`minimax-m2.7`, `minimax-m2.5`) | `opencode-go`, `opencode`, `openrouter/minimax` | Used only in **utility** fallback chains (Explore, Librarian, `quick`). Consistency and long-context management issues make it a poor substitute for Hephaestus/Oracle. Do NOT override deep agents to MiniMax. |
+
+> **DeepSeek ≻≻ MiniMax.** DeepSeek retains GPT's autonomous exploration character. MiniMax loses coherence on multi-step deep work. MiniMax is fine for grep-style utility agents, nothing more.
+
+### Gemini Family (visual, different reasoning style)
+
+Used by: `visual-engineering`, `artistry`, Oracle (visual fallback), Multimodal-Looker.
+
+| Priority | Model | Provider | Why |
+|---|---|---|---|
+| 1 | `gemini-3.1-pro` (high) | `google`, `github-copilot`, `opencode`, `vercel` | Best for UI/UX, CSS, design tokens, layout decisions. `artistry` category **requires** this family. |
+| 2 | `gemini-3-flash` | same | Fast variant, writing/doc tasks. |
+| 3 | **Qwen — ALTERNATIVE** (`qwen3.6-plus`, `qwen3.5-plus`) | `opencode-go`, `openrouter/qwen` | Closest vision-capable substitute when Google isn't connected. Uses different reasoning style but handles visual tasks competently. |
+
+> **No GLM/Kimi here.** They're not Gemini substitutes for visual work. Use Qwen.
+
+---
+
+## Cheat Sheet: Substitution Rules
+
+| If you lose... | Swap to (in order) | Avoid |
+|---|---|---|
+| Claude Opus/Sonnet | Kimi K2.5/K2.6 → GLM 5 → Big Pickle | Older GPT models |
+| GPT-5.4/5.5 | GPT-5.3 Codex → DeepSeek v3.2 | MiniMax (except for utility work) |
+| Gemini 3.1 Pro | Qwen 3.6-plus / 3.5-plus | Claude/Kimi (wrong reasoning style for visual) |
+| Grok Code Fast 1 (Explore) | GPT-5.4 Mini Fast → MiniMax M2.7 Highspeed → Claude Haiku | Opus (massive cost waste) |
+
+---
+
 ## Agent Profiles
+
+Exact runtime chains from [`src/shared/model-requirements.ts`](../../src/shared/model-requirements.ts).
 
 ### Communicators → Claude / Kimi / GLM
 
 These agents have Claude-optimized prompts — long, detailed, mechanics-driven. They need models that reliably follow complex, multi-layered instructions.
 
-| Agent        | Role              | Fallback Chain                         | Notes                                                                                             |
-| ------------ | ----------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Sisyphus** | Main orchestrator | anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → opencode-go\|vercel/kimi-k2.5 → kimi-for-coding/k2p5 → opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix\|vercel/kimi-k2.5 → openai\|github-copilot\|opencode\|vercel/gpt-5.4 (medium) → zai-coding-plan\|opencode\|vercel/glm-5 → opencode/big-pickle | Exact runtime chain from `src/shared/model-requirements.ts`. |
-| **Metis**    | Plan gap analyzer | anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → openai\|github-copilot\|opencode\|vercel/gpt-5.4 (high) → opencode-go\|vercel/glm-5 → kimi-for-coding/k2p5 | Exact runtime chain from `src/shared/model-requirements.ts`. |
+| Agent | Role | Fallback Chain |
+|---|---|---|
+| **Sisyphus** | Main orchestrator | `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `opencode-go\|vercel/kimi-k2.5` → `kimi-for-coding/k2p5` → `opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix\|vercel/kimi-k2.5` → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (medium) → `zai-coding-plan\|opencode\|vercel/glm-5` → `opencode/big-pickle` |
+| **Metis** | Plan gap analyzer | `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (high) → `opencode-go\|vercel/glm-5` → `kimi-for-coding/k2p5` |
 
 ### Dual-Prompt Agents → Claude preferred, GPT supported
 
 These agents ship separate prompts for Claude and GPT families. They auto-detect your model and switch at runtime.
 
-| Agent          | Role              | Fallback Chain                         | Notes                                                                |
-| -------------- | ----------------- | -------------------------------------- | -------------------------------------------------------------------- |
-| **Prometheus** | Strategic planner | anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → openai\|github-copilot\|opencode\|vercel/gpt-5.4 (high) → opencode-go\|vercel/glm-5 → google\|github-copilot\|opencode\|vercel/gemini-3.1-pro | Exact runtime chain from `src/shared/model-requirements.ts`. |
-| **Atlas**      | Todo orchestrator | anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6 → opencode-go\|vercel/kimi-k2.5 → openai\|github-copilot\|opencode\|vercel/gpt-5.4 (medium) → opencode-go\|vercel/minimax-m2.7 | Exact runtime chain from `src/shared/model-requirements.ts`. |
+| Agent | Role | Fallback Chain |
+|---|---|---|
+| **Prometheus** | Strategic planner | `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (high) → `opencode-go\|vercel/glm-5` → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` |
+| **Atlas** | Todo orchestrator | `anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6` → `opencode-go\|vercel/kimi-k2.5` → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (medium) → `opencode-go\|vercel/minimax-m2.7` |
 
 ### Deep Specialists → GPT
 
-These agents are built for GPT's principle-driven style. Their prompts assume autonomous, goal-oriented execution. Don't override to Claude.
+These agents are built for GPT's principle-driven style. Their prompts assume autonomous, goal-oriented execution. **Don't override to Claude.**
 
-| Agent          | Role                    | Fallback Chain                         | Notes                                            |
-| -------------- | ----------------------- | -------------------------------------- | ------------------------------------------------ |
-| **Hephaestus** | Autonomous deep worker  | openai\|github-copilot\|venice\|opencode\|vercel/gpt-5.4 (medium) | Single-entry chain. Requires one of those providers. The craftsman. |
-| **Oracle**     | Architecture consultant | openai\|github-copilot\|opencode\|vercel/gpt-5.4 (high) → google\|github-copilot\|opencode\|vercel/gemini-3.1-pro (high) → anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → opencode-go\|vercel/glm-5 | Exact runtime chain from `src/shared/model-requirements.ts`. |
-| **Momus**      | Ruthless reviewer       | openai\|github-copilot\|opencode\|vercel/gpt-5.4 (xhigh) → anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → google\|github-copilot\|opencode\|vercel/gemini-3.1-pro (high) → opencode-go\|vercel/glm-5 | Exact runtime chain from `src/shared/model-requirements.ts`. |
+| Agent | Role | Fallback Chain |
+|---|---|---|
+| **Hephaestus** | Autonomous deep worker | `openai\|github-copilot\|venice\|opencode\|vercel/gpt-5.5` (medium) — single-entry chain, requires one of those providers. The craftsman. |
+| **Oracle** | Architecture consultant | `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (high) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `opencode-go\|vercel/glm-5` |
+| **Momus** | Ruthless reviewer | `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (xhigh) → `anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7` (max) → `google\|github-copilot\|opencode\|vercel/gemini-3.1-pro` (high) → `opencode-go\|vercel/glm-5` |
 
 ### Utility Runners → Speed over Intelligence
 
 These agents do grep, search, and retrieval. They intentionally use the fastest, cheapest models available. **Don't "upgrade" them to Opus** — that's hiring a senior engineer to file paperwork.
 
-| Agent                 | Role               | Fallback Chain                                 | Notes                                                 |
-| --------------------- | ------------------ | ---------------------------------------------- | ----------------------------------------------------- |
-| **Explore**           | Fast codebase grep | openai/gpt-5.4-mini-fast → opencode-go\|vercel/minimax-m2.7-highspeed → opencode-go\|vercel/minimax-m2.7 → anthropic\|opencode\|vercel/claude-haiku-4-5 → openai\|opencode\|vercel/gpt-5.4-nano | Exact runtime chain from `src/shared/model-requirements.ts`. |
-| **Librarian**         | Docs/code search   | openai/gpt-5.4-mini-fast → opencode-go\|vercel/minimax-m2.7-highspeed → opencode-go\|vercel/minimax-m2.7 → anthropic\|opencode\|vercel/claude-haiku-4-5 → openai\|opencode\|vercel/gpt-5.4-nano | Exact runtime chain from `src/shared/model-requirements.ts`. |
-| **Multimodal Looker** | Vision/screenshots | openai\|opencode\|vercel/gpt-5.4 (medium) → opencode-go\|vercel/kimi-k2.5 → zai-coding-plan\|vercel/glm-4.6v → openai\|github-copilot\|opencode\|vercel/gpt-5-nano | Exact runtime chain from `src/shared/model-requirements.ts`. |
-| **Sisyphus-Junior**   | Category executor  | anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6 → opencode-go\|vercel/kimi-k2.5 → openai\|github-copilot\|opencode\|vercel/gpt-5.4 (medium) → opencode-go\|vercel/minimax-m2.7 → opencode/big-pickle | Exact runtime chain from `src/shared/model-requirements.ts`. |
-
----
-
-## Model Families
-
-### Claude Family
-
-Communicative, instruction-following, structured output. Best for agents that need to follow complex multi-step prompts.
-
-| Model                 | Strengths                                                                    |
-| --------------------- | ---------------------------------------------------------------------------- |
-| **Claude Opus 4.7**   | Best overall. Highest compliance with complex prompts. Default for Sisyphus. |
-| **Claude Sonnet 4.6** | Faster, cheaper. Good balance for everyday tasks.                            |
-| **Claude Haiku 4.5**  | Fast and cheap. Good for quick tasks and utility work.                       |
-| **Kimi K2.5**         | Behaves very similarly to Claude. Great all-rounder at lower cost.           |
-| **GLM 5**             | Claude-like behavior. Solid for orchestration tasks.                         |
-
-### GPT Family
-
-Principle-driven, explicit reasoning, deep technical capability. Best for agents that work autonomously on complex problems.
-
-| Model             | Strengths                                                                                       |
-| ----------------- | ----------------------------------------------------------------------------------------------- |
-| **GPT-5.3 Codex** | Deep coding powerhouse. Autonomous exploration. Still available for deep category and explicit overrides. |
-| **GPT-5.4**       | High intelligence, strategic reasoning. Default for Oracle, Momus, and a key fallback for Prometheus / Atlas. Uses xhigh variant for Momus. |
-| **GPT-5.4 Mini**  | Fast + strong reasoning. Good for lightweight autonomous tasks. Default for quick category. |
-| **GPT-5-Nano**    | Ultra-cheap, fast. Good for simple utility tasks.                                               |
-
-### Other Models
-
-| Model                | Strengths                                                                                                    |
-| -------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Gemini 3.1 Pro**   | Excels at visual/frontend tasks. Different reasoning style. Default for `visual-engineering` and `artistry`. |
-| **Gemini 3 Flash**   | Fast. Good for doc search and light tasks.                                                                   |
-| **GPT-5.4 Mini Fast** | Default for Explore and Librarian agents. Blazing-fast reasoning-capable mini model. |
-| **MiniMax M2.7**     | Fast and smart. Used in OpenCode Go and OpenCode Zen utility fallback chains. |
-| **MiniMax M2.7 Highspeed** | High-speed OpenCode catalog entry used in utility fallback chains that prefer the fastest available MiniMax path. |
-
-### OpenCode Go
-
-A premium subscription tier ($10/month) that provides reliable access to Chinese frontier models through OpenCode's infrastructure.
-
-**Available Models:**
-
-| Model                    | Use Case                                                              |
-| ------------------------ | --------------------------------------------------------------------- |
-| **opencode-go/kimi-k2.5** | Vision-capable, Claude-like reasoning. Used by Sisyphus, Atlas, Sisyphus-Junior, Multimodal Looker. |
-| **opencode-go/glm-5**     | Text-only orchestration model. Used by Oracle, Prometheus, Metis, Momus.                           |
-| **opencode-go/minimax-m2.7** | Ultra-cheap, fast responses. Used by Atlas, Sisyphus-Junior, Explore and Librarian fallbacks for utility work. |
-| **opencode-go/minimax-m2.7-highspeed** | Even faster OpenCode Go MiniMax entry used as a secondary fallback for Explore and Librarian when GPT-5.4 Mini Fast is unavailable. |
-
-**When It Gets Used:**
-
-OpenCode Go models appear throughout the fallback chains as intermediate options. Depending on the agent, they can sit before GPT, after GPT, or act as the last structured-model fallback before cheaper utility paths.
-
-**Go-Only Scenarios:**
-
-Some model identifiers like `k2p5` (paid Kimi K2.5) and `glm-5` may only be available through OpenCode Go subscription in certain regions. When configured with these short identifiers, the system resolves them through the opencode-go provider first.
-
-### About Free-Tier Fallbacks
-
-You may see model names like `kimi-k2.5-free`, `minimax-m2.7`, `minimax-m2.7-highspeed`, or `big-pickle` (GLM 4.6) in the source code or logs. These are provider-specific or speed-optimized entries in fallback chains.
-
-You don't need to configure them. The system includes them so it degrades gracefully when you don't have every paid subscription. If you have the paid version, the paid version is always preferred.
+| Agent | Role | Fallback Chain |
+|---|---|---|
+| **Explore** | Fast codebase grep | `openai/gpt-5.4-mini-fast` → `opencode-go\|vercel/minimax-m2.7-highspeed` → `opencode-go\|vercel/minimax-m2.7` → `anthropic\|opencode\|vercel/claude-haiku-4-5` → `openai\|opencode\|vercel/gpt-5.4-nano` |
+| **Librarian** | Docs/code search | same as Explore |
+| **Multimodal Looker** | Vision/screenshots | `openai\|opencode\|vercel/gpt-5.5` (medium) → `opencode-go\|vercel/kimi-k2.5` → `zai-coding-plan\|vercel/glm-4.6v` → `openai\|github-copilot\|opencode\|vercel/gpt-5-nano` |
+| **Sisyphus-Junior** | Category executor | `anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6` → `opencode-go\|vercel/kimi-k2.5` → `openai\|github-copilot\|opencode\|vercel/gpt-5.5` (medium) → `opencode-go\|vercel/minimax-m2.7` → `opencode/big-pickle` |
 
 ---
 
@@ -167,100 +243,180 @@ You don't need to configure them. The system includes them so it degrades gracef
 
 When agents delegate work, they don't pick a model name — they pick a **category**. The category maps to the right model automatically.
 
-| Category             | When Used                  | Fallback Chain                               |
-| -------------------- | -------------------------- | -------------------------------------------- |
-| `visual-engineering` | Frontend, UI, CSS, design  | google\|github-copilot\|opencode\|vercel/gemini-3.1-pro (high) → zai-coding-plan\|opencode\|vercel/glm-5 → anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → opencode-go\|vercel/glm-5 → kimi-for-coding/k2p5 |
-| `ultrabrain`         | Maximum reasoning needed   | openai\|opencode\|vercel/gpt-5.4 (xhigh) → google\|github-copilot\|opencode\|vercel/gemini-3.1-pro (high) → anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → opencode-go\|vercel/glm-5 |
-| `deep`               | Deep coding, complex logic | openai\|github-copilot\|venice\|opencode\|vercel/gpt-5.4 (medium) → anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → google\|github-copilot\|opencode\|vercel/gemini-3.1-pro (high) |
-| `artistry`           | Creative, novel approaches | google\|github-copilot\|opencode\|vercel/gemini-3.1-pro (high) → anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → openai\|github-copilot\|opencode\|vercel/gpt-5.4 |
-| `quick`              | Simple, fast tasks         | openai\|github-copilot\|opencode\|vercel/gpt-5.4-mini → anthropic\|github-copilot\|opencode\|vercel/claude-haiku-4-5 → google\|github-copilot\|opencode\|vercel/gemini-3-flash → opencode-go\|vercel/minimax-m2.7 → opencode\|vercel/gpt-5-nano |
-| `unspecified-high`   | General complex work       | anthropic\|github-copilot\|opencode\|vercel/claude-opus-4-7 (max) → openai\|github-copilot\|opencode\|vercel/gpt-5.4 (high) → zai-coding-plan\|opencode\|vercel/glm-5 → kimi-for-coding/k2p5 → opencode-go\|vercel/glm-5 → opencode\|vercel/kimi-k2.5 → opencode\|moonshotai\|moonshotai-cn\|firmware\|ollama-cloud\|aihubmix\|vercel/kimi-k2.5 |
-| `unspecified-low`    | General standard work      | anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6 → openai\|opencode\|vercel/gpt-5.3-codex (medium) → opencode-go\|vercel/kimi-k2.5 → google\|github-copilot\|opencode\|vercel/gemini-3-flash → opencode-go\|vercel/minimax-m2.7 |
-| `writing`            | Text, docs, prose          | google\|github-copilot\|opencode\|vercel/gemini-3-flash → opencode-go\|vercel/kimi-k2.5 → anthropic\|github-copilot\|opencode\|vercel/claude-sonnet-4-6 → opencode-go\|vercel/minimax-m2.7 |
+| Category | Used For | Default Model | Fallback Chain |
+|---|---|---|---|
+| `visual-engineering` | Frontend, UI, CSS, design | `google/gemini-3.1-pro` (high) | Gemini → `zai-coding-plan/glm-5` → `claude-opus-4-7` (max) → `opencode-go/glm-5` → `kimi-for-coding/k2p5` |
+| `artistry` | Creative, novel approaches | `google/gemini-3.1-pro` (high) | Gemini → `claude-opus-4-7` (max) → `gpt-5.5` — requires Gemini family to activate |
+| `ultrabrain` | Maximum reasoning needed | `openai/gpt-5.5` (xhigh) | GPT-5.5 xhigh → `gemini-3.1-pro` (high) → `claude-opus-4-7` (max) → `opencode-go/glm-5` |
+| `deep` | Deep coding, complex logic | `openai/gpt-5.5` (medium) | GPT-5.5 → `claude-opus-4-7` (max) → `gemini-3.1-pro` (high) |
+| `quick` | Simple, fast tasks | `openai/gpt-5.4-mini` | GPT-5.4-mini → `claude-haiku-4-5` → `gemini-3-flash` → `opencode-go/minimax-m2.7` → `opencode/gpt-5-nano` |
+| `unspecified-high` | General complex work | `anthropic/claude-opus-4-7` (max) | Opus → `gpt-5.5` (high) → `zai-coding-plan/glm-5` → `kimi-for-coding/k2p5` → `opencode-go/glm-5` → `opencode/kimi-k2.5` → `moonshotai/kimi-k2.5` |
+| `unspecified-low` | General standard work | `anthropic/claude-sonnet-4-6` | Sonnet → `gpt-5.3-codex` (medium) → `opencode-go/kimi-k2.5` → `google/gemini-3-flash` → `opencode-go/minimax-m2.7` |
+| `writing` | Text, docs, prose | `kimi-for-coding/k2p5` | Kimi → `gemini-3-flash` → `opencode-go/kimi-k2.5` → `claude-sonnet-4-6` → `opencode-go/minimax-m2.7` |
 
 See the [Orchestration System Guide](./orchestration.md) for how agents dispatch tasks to categories.
 
 ### Vercel AI Gateway fallback coverage
 
-`src/shared/model-requirements.ts` now includes `vercel` on nearly every gateway-compatible fallback entry across both agent and category chains. Treat it as a universal extra provider path for the listed model IDs, not as a different model family. If a row above shows `|vercel` in the provider set, that is the current source-of-truth runtime fallback, not a docs-only convenience alias.
+`src/shared/model-requirements.ts` includes `vercel` on nearly every gateway-compatible fallback entry across both agent and category chains. Treat it as a universal extra provider path for the listed model IDs, not as a different model family.
 
 ---
 
 ## Customization
 
-### Example Configuration
+### Example A — Recommended Stack (OpenCode Go + OpenAI Plus/Pro)
 
 ```jsonc
 {
   "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   "agents": {
-    // Main orchestrator: Claude Opus or Kimi K2.5 work best
+    // Sisyphus: Kimi K2.6 is the top alternative to Claude for orchestration
     "sisyphus": {
-      "model": "kimi-for-coding/k2p5",
-      "ultrawork": { "model": "anthropic/claude-opus-4-7", "variant": "max" },
+      "model": "opencode-go/kimi-k2.6",
+      "ultrawork": { "model": "opencode-go/kimi-k2.6" },
     },
 
-    // Research agents: cheaper models are fine
-    "librarian": { "model": "google/gemini-3-flash" },
-    "explore": { "model": "github-copilot/grok-code-fast-1" },
+    // Hephaestus: needs GPT. ChatGPT Plus gets you here.
+    "hephaestus": { "model": "openai/gpt-5.5", "variant": "medium" },
 
-    // Architecture consultation: GPT or Claude Opus
-    "oracle": { "model": "openai/gpt-5.4", "variant": "high" },
+    // Oracle: GPT preferred for architecture reasoning
+    "oracle": { "model": "openai/gpt-5.5", "variant": "high" },
 
-    // Prometheus inherits sisyphus model; just add prompt guidance
-    "prometheus": {
-      "prompt_append": "Leverage deep & quick agents heavily, always in parallel.",
-    },
+    // Prometheus inherits Sisyphus behavior
+    "prometheus": { "model": "opencode-go/kimi-k2.6" },
+
+    // Atlas also communicative — Kimi works great
+    "atlas": { "model": "opencode-go/kimi-k2.5" },
+
+    // Utility agents stay cheap
+    "explore": { "model": "opencode-go/minimax-m2.7-highspeed" },
+    "librarian": { "model": "opencode-go/minimax-m2.7-highspeed" },
   },
 
   "categories": {
-    "quick": { "model": "opencode/gpt-5-nano" },
-    "unspecified-low": { "model": "anthropic/claude-sonnet-4-6" },
-    "unspecified-high": { "model": "anthropic/claude-opus-4-7", "variant": "max" },
-    "visual-engineering": {
-      "model": "google/gemini-3.1-pro",
-      "variant": "high",
-    },
-    "writing": { "model": "google/gemini-3-flash" },
+    "visual-engineering": { "model": "opencode-go/qwen3.6-plus" },  // Qwen as Gemini alt
+    "deep": { "model": "openai/gpt-5.5", "variant": "medium" },
+    "ultrabrain": { "model": "openai/gpt-5.5", "variant": "xhigh" },
+    "quick": { "model": "openai/gpt-5.4-mini" },
+    "unspecified-low": { "model": "opencode-go/kimi-k2.5" },
+    "unspecified-high": { "model": "opencode-go/kimi-k2.6" },
+    "writing": { "model": "opencode-go/kimi-k2.5" },
   },
 
-  // Limit expensive providers; let cheap ones run freely
   "background_task": {
     "providerConcurrency": {
-      "anthropic": 3,
       "openai": 3,
-      "opencode": 10,
-      "zai-coding-plan": 10,
-    },
-    "modelConcurrency": {
-      "anthropic/claude-opus-4-7": 2,
-      "opencode/gpt-5-nano": 20,
+      "opencode-go": 10,
     },
   },
 }
 ```
 
-Run `opencode models` to see available models, `opencode auth login` to authenticate providers.
+### Example B — All Native (Anthropic + OpenAI + Google)
+
+Highest quality, highest cost. No surprises.
+
+```jsonc
+{
+  "agents": {
+    "sisyphus": {
+      "model": "anthropic/claude-opus-4-7",
+      "variant": "max",
+    },
+    "hephaestus": { "model": "openai/gpt-5.5", "variant": "medium" },
+    "oracle": { "model": "openai/gpt-5.5", "variant": "high" },
+  },
+  "categories": {
+    "visual-engineering": { "model": "google/gemini-3.1-pro", "variant": "high" },
+    "deep": { "model": "openai/gpt-5.5", "variant": "medium" },
+    "unspecified-high": { "model": "anthropic/claude-opus-4-7", "variant": "max" },
+  },
+}
+```
+
+### Example C — OpenCode Go Only (Budget, No GPT)
+
+Cheapest full-stack path. Hephaestus won't activate — accept that trade-off.
+
+```jsonc
+{
+  "agents": {
+    "sisyphus": { "model": "opencode-go/kimi-k2.6" },
+    "atlas": { "model": "opencode-go/kimi-k2.5" },
+    // Omit hephaestus entirely; it needs GPT.
+    "oracle": { "model": "opencode-go/glm-5" },  // Degraded but functional
+    "explore": { "model": "opencode-go/minimax-m2.7-highspeed" },
+    "librarian": { "model": "opencode-go/minimax-m2.7-highspeed" },
+  },
+  "categories": {
+    "visual-engineering": { "model": "opencode-go/qwen3.6-plus" },
+    "deep": { "model": "opencode-go/kimi-k2.6" },  // Not ideal — Kimi isn't GPT, but best available
+    "unspecified-high": { "model": "opencode-go/kimi-k2.6" },
+    "unspecified-low": { "model": "opencode-go/kimi-k2.5" },
+    "quick": { "model": "opencode-go/minimax-m2.7" },
+    "writing": { "model": "opencode-go/kimi-k2.5" },
+  },
+}
+```
+
+### Example D — Adding DeepSeek as GPT Alternative
+
+If you have OpenRouter and want DeepSeek in the chain when GPT is unavailable:
+
+```jsonc
+{
+  "agents": {
+    "oracle": {
+      "model": "openai/gpt-5.5",
+      "variant": "high",
+      "fallback_models": [
+        "anthropic/claude-opus-4-7",
+        { "model": "openrouter/deepseek/deepseek-v3.2", "temperature": 0.7 },
+        "opencode-go/glm-5",
+      ],
+    },
+  },
+}
+```
+
+`fallback_models` accepts a mix of plain model strings and per-fallback objects with `variant`, `reasoningEffort`, `temperature`, `top_p`, `maxTokens`, `thinking`.
+
+---
 
 ### Safe vs Dangerous Overrides
 
 **Safe** — same personality type:
 
-- Sisyphus: Opus → Sonnet, Kimi K2.5, GLM 5 (all communicative models)
+- Sisyphus: Opus → Sonnet, Kimi K2.5/2.6, GLM 5 (all communicative models)
 - Prometheus: Opus → GPT-5.4 (auto-switches to the GPT prompt)
-- Atlas: Claude Sonnet 4.6 → GPT-5.4 (auto-switches to the GPT prompt)
+- Atlas: Claude Sonnet 4.6 → Kimi K2.5, GPT-5.4 (auto-switches to the GPT prompt)
 
 **Dangerous** — personality mismatch:
 
-- Sisyphus → older GPT models: **Still a bad fit. GPT-5.4 is the only dedicated GPT prompt path.**
-- Hephaestus → Claude: **Built for Codex's autonomous style. Claude can't replicate this.**
-- Explore → Opus: **Massive cost waste. Explore needs speed, not intelligence.**
-- Librarian → Opus: **Same. Doc search doesn't need Opus-level reasoning.**
+- **Sisyphus → older GPT models**: Still a bad fit. GPT-5.5 is the dedicated GPT prompt path.
+- **Hephaestus → Claude**: Built for Codex's autonomous style. Claude can't replicate this.
+- **Hephaestus → MiniMax**: MiniMax loses coherence on multi-step deep work. **Never do this.**
+- **Oracle → MiniMax**: Same reason. Oracle needs sustained reasoning; MiniMax drifts.
+- **Explore → Opus**: Massive cost waste. Explore needs speed, not intelligence.
+- **Librarian → Opus**: Same. Doc search doesn't need Opus-level reasoning.
+- **`visual-engineering` → Kimi/GLM**: Wrong reasoning style. Use Qwen if Gemini is unavailable, not Claude-likes.
 
-### How Model Resolution Works
+---
+
+## How Model Resolution Works
 
 Each agent has a fallback chain. The system tries models in priority order until it finds one available through your connected providers. You don't need to configure providers per model. Just authenticate (`opencode auth login`) and the system figures out which models are available and where.
+
+Resolution pipeline (from [`src/shared/model-resolution-pipeline.ts`](../../src/shared/model-resolution-pipeline.ts)):
+
+```
+1. Override          → User's explicit config or UI-selected model (primary agents only)
+2. Category default  → From category config (when agent has category set)
+3. User fallback_models → Configured strings/objects tried before hardcoded chain
+4. Provider fallback → AGENT_MODEL_REQUIREMENTS / CATEGORY_MODEL_REQUIREMENTS
+5. System default    → Ultimate safety net
+```
 
 Core-agent tab cycling is deterministic via injected runtime order field. The fixed priority order is Sisyphus (order: 1), Hephaestus (order: 2), Prometheus (order: 3), and Atlas (order: 4), then the remaining agents follow.
 
@@ -268,7 +424,7 @@ Your explicit configuration always wins. If you set a specific model for an agen
 
 Variant and `reasoningEffort` overrides are normalized to model-supported values, so cross-provider overrides degrade gracefully instead of failing hard.
 
-Model capabilities are models.dev-backed, with a refreshable cache and capability diagnostics. Use `bunx oh-my-opencode refresh-model-capabilities` to update the cache, or configure `model_capabilities.auto_refresh_on_start` to refresh at startup.
+Model capabilities are `models.dev`-backed, with a refreshable cache and capability diagnostics. Use `bunx oh-my-opencode refresh-model-capabilities` to update the cache, or configure `model_capabilities.auto_refresh_on_start` to refresh at startup.
 
 To see which models your agents will actually use, run `bunx oh-my-opencode doctor`. This shows effective model resolution based on your current authentication and config.
 
@@ -284,17 +440,17 @@ You can load agent system prompts from external files using `file://` URLs in th
 {
   "agents": {
     "sisyphus": {
-      "prompt": "file:///path/to/custom-prompt.md"
+      "prompt": "file:///path/to/custom-prompt.md",
     },
     "oracle": {
-      "prompt_append": "file:///path/to/additional-context.md"
-    }
+      "prompt_append": "file:///path/to/additional-context.md",
+    },
   },
   "categories": {
     "deep": {
-      "prompt_append": "file:///path/to/deep-category-append.md"
-    }
-  }
+      "prompt_append": "file:///path/to/deep-category-append.md",
+    },
+  },
 }
 ```
 

--- a/src/agents/agent-identity.test.ts
+++ b/src/agents/agent-identity.test.ts
@@ -76,10 +76,10 @@ describe("Sisyphus prompt identity", () => {
     })
   })
 
-  describe("#given a Sisyphus agent created with GPT-5.4 model", () => {
+  describe("#given a Sisyphus agent created with GPT-5.5 model", () => {
     describe("#when checking the prompt", () => {
       it("#then contains the agent identity section", () => {
-        const config = createSisyphusAgent("openai/gpt-5.4")
+        const config = createSisyphusAgent("openai/gpt-5.5")
 
         expect(config.prompt).toContain("<agent-identity>")
         expect(config.prompt).toContain("Sisyphus")
@@ -93,7 +93,7 @@ describe("Hephaestus prompt identity", () => {
   describe("#given a Hephaestus agent created with GPT model", () => {
     describe("#when checking the prompt", () => {
       it("#then contains the agent identity section", () => {
-        const config = createHephaestusAgent("openai/gpt-5.4")
+        const config = createHephaestusAgent("openai/gpt-5.5")
 
         expect(config.prompt).toContain("<agent-identity>")
         expect(config.prompt).toContain("Hephaestus")
@@ -101,7 +101,7 @@ describe("Hephaestus prompt identity", () => {
       })
 
       it("#then identity section appears at the start of the prompt", () => {
-        const config = createHephaestusAgent("openai/gpt-5.4")
+        const config = createHephaestusAgent("openai/gpt-5.5")
         const prompt = config.prompt ?? ""
         const identityIndex = prompt.indexOf("<agent-identity>")
 
@@ -130,7 +130,7 @@ describe("Agent identity preservation through overrides", () => {
     describe("#when merging the override", () => {
       it("#then identity section is preserved unchanged", () => {
         const baseConfig = createSisyphusAgent("anthropic/claude-opus-4-7")
-        const merged = mergeAgentConfig(baseConfig, { model: "openai/gpt-5.4" })
+        const merged = mergeAgentConfig(baseConfig, { model: "openai/gpt-5.5" })
 
         expect(merged.prompt).toContain("<agent-identity>")
         expect(merged.prompt).toContain("Sisyphus")

--- a/src/agents/atlas/agent.ts
+++ b/src/agents/atlas/agent.ts
@@ -5,7 +5,7 @@
  * You are the conductor of a symphony of specialized agents.
  *
  * Routing:
- * 1. GPT models (openai/*, github-copilot/gpt-*) → gpt.ts (GPT-5.4 optimized)
+ * 1. GPT models (openai/*, github-copilot/gpt-*) → gpt.ts (GPT-5.5 optimized)
  * 2. Gemini models (google/*, google-vertex/*) → gemini.ts (Gemini-optimized)
  * 3. Default (Claude, etc.) → default.ts (Claude-optimized)
  */

--- a/src/agents/builtin-agents/sisyphus-agent.test.ts
+++ b/src/agents/builtin-agents/sisyphus-agent.test.ts
@@ -9,7 +9,7 @@ describe("maybeCreateSisyphusConfig", () => {
       // given
       const agentOverrides: AgentOverrides = {
         sisyphus: {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
           permission: {
             apply_patch: "allow",
           },
@@ -21,8 +21,8 @@ describe("maybeCreateSisyphusConfig", () => {
       const config = maybeCreateSisyphusConfig({
         disabledAgents: [],
         agentOverrides,
-        availableModels: new Set(["openai/gpt-5.4"]),
-        systemDefaultModel: "openai/gpt-5.4",
+        availableModels: new Set(["openai/gpt-5.5"]),
+        systemDefaultModel: "openai/gpt-5.5",
         isFirstRunNoCache: false,
         availableAgents: [],
         availableSkills: [],
@@ -33,7 +33,7 @@ describe("maybeCreateSisyphusConfig", () => {
 
       // then
       expect(config).toBeDefined();
-      expect(config?.model).toBe("openai/gpt-5.4");
+      expect(config?.model).toBe("openai/gpt-5.5");
       expect(config?.permission).toHaveProperty("apply_patch", "deny");
     });
   });

--- a/src/agents/custom-agent-orchestrator-visibility.test.ts
+++ b/src/agents/custom-agent-orchestrator-visibility.test.ts
@@ -8,7 +8,7 @@ describe("createBuiltinAgents custom agent visibility", () => {
 	test("#given runtime custom agents #when orchestrator prompts are built #then custom agents are not advertised for automatic delegation", async () => {
 		//#given
 		const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-			new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.4"])
+			new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.5"])
 		)
 
 		try {

--- a/src/agents/delegation-trust-prompt.test.ts
+++ b/src/agents/delegation-trust-prompt.test.ts
@@ -68,17 +68,16 @@ describe("delegation trust prompt rules", () => {
     expect(prompt).toContain("DO NOT perform the same search yourself")
   })
 
-  test("Hephaestus GPT-5.4 prompt forbids duplicate delegated exploration", () => {
+  test("Hephaestus GPT-5.5 prompt forbids duplicate delegated exploration", () => {
     // given
-    const agent = createHephaestusAgent("openai/gpt-5.4", [exploreAgent])
+    const agent = createHephaestusAgent("openai/gpt-5.5", [exploreAgent])
 
     // when
     const prompt = agent.prompt
 
     // then
-    expect(prompt).toContain("continue only with non-overlapping work while they search")
-    expect(prompt).toContain("Continue only with non-overlapping work after launching background agents")
-    expect(prompt).toContain("DO NOT perform the same search yourself")
+    expect(prompt).toContain("do not manually perform the same search yourself")
+    expect(prompt).toContain("non-overlapping preparation")
   })
 
   test("Hephaestus GPT-5.3 Codex prompt forbids duplicate delegated exploration", () => {
@@ -103,28 +102,26 @@ describe("delegation trust prompt rules", () => {
     expect(prompt).toContain("DO NOT perform the same search yourself")
   })
 
-  test("Sisyphus GPT-5.4 prompt forbids duplicate delegated exploration", () => {
+  test("Sisyphus GPT-5.5 prompt forbids duplicate delegated exploration", () => {
     // given
-    const agent = createSisyphusAgent("openai/gpt-5.4", [exploreAgent])
+    const agent = createSisyphusAgent("openai/gpt-5.5", [exploreAgent])
 
     // when
     const prompt = agent.prompt
 
     // then
-    expect(prompt).toContain("do only non-overlapping work simultaneously")
-    expect(prompt).toContain("Continue only with non-overlapping work")
-    expect(prompt).toContain("DO NOT perform the same search yourself")
-    expect(prompt).toContain("Do not use `apply_patch`")
-    expect(prompt).toContain("`edit` and `write`")
+    expect(prompt).toContain("After firing exploration agents")
+    expect(prompt).toContain("do not manually perform the same search yourself")
+    expect(prompt).toContain("Always use `apply_patch`")
   })
 
-  test("Sisyphus-Junior GPT-5.4 prompt forbids duplicate delegated exploration", () => {
+  test("Sisyphus-Junior GPT-5.5 prompt forbids duplicate delegated exploration", () => {
     // given
-    const prompt = buildSisyphusJuniorPrompt("openai/gpt-5.4", false)
+    const prompt = buildSisyphusJuniorPrompt("openai/gpt-5.5", false)
 
     // when / then
-    expect(prompt).toContain("continue only with non-overlapping work while they search")
-    expect(prompt).toContain("DO NOT perform the same search yourself")
+    expect(prompt).toContain("do not manually perform the same search yourself")
+    expect(prompt).toContain("Continue only with non-overlapping preparation")
   })
 
   test("Sisyphus-Junior GPT-5.3 Codex prompt forbids duplicate delegated exploration", () => {

--- a/src/agents/dynamic-agent-prompt-builder.test.ts
+++ b/src/agents/dynamic-agent-prompt-builder.test.ts
@@ -197,7 +197,7 @@ describe("buildParallelDelegationSection", () => {
 
   it("#given non-Claude model with unspecified-high category #when building #then returns aggressive delegation section", () => {
     //#given
-    const model = "openai/gpt-5.4"
+    const model = "openai/gpt-5.5"
     const categories = [unspecifiedHighCategory, otherCategory]
 
     //#when
@@ -223,7 +223,7 @@ describe("buildParallelDelegationSection", () => {
 
   it("#given non-Claude model without deep or unspecified-high category #when building #then returns empty", () => {
     //#given
-    const model = "openai/gpt-5.4"
+    const model = "openai/gpt-5.5"
     const categories = [otherCategory]
 
     //#when
@@ -261,7 +261,7 @@ describe("buildNonClaudePlannerSection", () => {
 
   it("#given GPT model #when building #then returns plan agent section", () => {
     //#given
-    const model = "openai/gpt-5.4"
+    const model = "openai/gpt-5.5"
 
     //#when
     const result = buildNonClaudePlannerSection(model)

--- a/src/agents/hephaestus/AGENTS.md
+++ b/src/agents/hephaestus/AGENTS.md
@@ -12,7 +12,7 @@
 |------|---------|
 | `agent.ts` | `createHephaestusAgent()` factory, model-variant routing |
 | `gpt.ts` | Base GPT prompt: discipline rules, delegation, verification |
-| `gpt-5-4.ts` | GPT-5.4-native prompt with XML-tagged blocks, entropy-reduced |
+| `gpt-5-5.ts` | GPT-5.4-native prompt with XML-tagged blocks, entropy-reduced |
 | `gpt-5-3-codex.ts` | GPT-5.3 Codex variant with task discipline sections |
 | `index.ts` | Barrel exports |
 
@@ -30,6 +30,6 @@
 | Model | Prompt Source | Optimizations |
 |-------|-------------|---------------|
 | gpt-5.5 | `gpt-5-5.ts` | GPT-5.5-tuned prompt architecture |
-| gpt-5.4 | `gpt-5-4.ts` | XML-tagged blocks, 8 sections |
+| gpt-5.5 | `gpt-5-5.ts` | XML-tagged blocks, 8 sections |
 | gpt-5.3-codex | `gpt-5-3-codex.ts` | Task discipline, 549 LOC prompt |
 | Other GPT | `gpt.ts` | Base prompt, 507 LOC |

--- a/src/agents/hephaestus/agent.test.ts
+++ b/src/agents/hephaestus/agent.test.ts
@@ -6,11 +6,11 @@ import {
 } from "./index";
 
 describe("getHephaestusPromptSource", () => {
-  test("returns 'gpt-5-4' for gpt-5.4 models", () => {
+  test("routes gpt-5.5 to GPT-5.5 and legacy GPT-5.4 family to GPT-5.4", () => {
     // given
-    const model1 = "openai/gpt-5.4";
+    const model1 = "openai/gpt-5.5";
     const model2 = "openai/gpt-5.4-codex";
-    const model3 = "github-copilot/gpt-5.4";
+    const model3 = "github-copilot/gpt-5.5";
 
     // when
     const source1 = getHephaestusPromptSource(model1);
@@ -18,9 +18,9 @@ describe("getHephaestusPromptSource", () => {
     const source3 = getHephaestusPromptSource(model3);
 
     // then
-    expect(source1).toBe("gpt-5-4");
+    expect(source1).toBe("gpt-5-5");
     expect(source2).toBe("gpt-5-4");
-    expect(source3).toBe("gpt-5-4");
+    expect(source3).toBe("gpt-5-5");
   });
 
   test("returns 'gpt-5-5' for gpt-5.5 models", () => {
@@ -87,17 +87,17 @@ describe("getHephaestusPromptSource", () => {
 });
 
 describe("getHephaestusPrompt", () => {
-  test("GPT 5.4 model returns GPT-5.4 optimized prompt", () => {
+  test("GPT 5.5 model returns GPT-5.5 optimized prompt", () => {
     // given
-    const model = "openai/gpt-5.4";
+    const model = "openai/gpt-5.5";
 
     // when
     const prompt = getHephaestusPrompt(model);
 
     // then
     expect(prompt).toContain("You build context by examining");
-    expect(prompt).toContain("Never chain together bash commands");
-    expect(prompt).toContain("<tool_usage_rules>");
+    expect(prompt).toContain("Forbidden stops");
+    expect(prompt).toContain("Three-attempt failure protocol");
   });
 
   test("GPT 5.4-codex model returns GPT-5.4 optimized prompt", () => {
@@ -164,15 +164,15 @@ describe("getHephaestusPrompt", () => {
     expect(prompt).toContain("Hephaestus");
   });
 
-  test("useTaskSystem=true includes Task Discipline for GPT models", () => {
+  test("useTaskSystem=true includes task-system guidance for GPT models", () => {
     // given
-    const model = "openai/gpt-5.4";
+    const model = "openai/gpt-5.5";
 
     // when
     const prompt = getHephaestusPrompt(model, true);
 
     // then
-    expect(prompt).toContain("Task Discipline");
+    expect(prompt).toContain("Create tasks before any non-trivial work");
     expect(prompt).toContain("task_create");
     expect(prompt).toContain("task_update");
   });
@@ -193,7 +193,7 @@ describe("getHephaestusPrompt", () => {
 describe("createHephaestusAgent", () => {
   test("returns AgentConfig with required fields", () => {
     // given
-    const model = "openai/gpt-5.4";
+    const model = "openai/gpt-5.5";
 
     // when
     const config = createHephaestusAgent(model);
@@ -201,7 +201,7 @@ describe("createHephaestusAgent", () => {
     // then
     expect(config).toHaveProperty("description");
     expect(config).toHaveProperty("mode", "primary");
-    expect(config).toHaveProperty("model", "openai/gpt-5.4");
+    expect(config).toHaveProperty("model", "openai/gpt-5.5");
     expect(config).toHaveProperty("maxTokens", 32000);
     expect(config).toHaveProperty("prompt");
     expect(config).toHaveProperty("color", "#D97706");
@@ -211,19 +211,18 @@ describe("createHephaestusAgent", () => {
     expect(config).toHaveProperty("reasoningEffort", "medium");
   });
 
-  test("GPT 5.4 model includes GPT-5.4 specific prompt content", () => {
+  test("GPT 5.5 model includes GPT-5.5 specific prompt content", () => {
     // given
-    const model = "openai/gpt-5.4";
+    const model = "openai/gpt-5.5";
 
     // when
     const config = createHephaestusAgent(model);
 
     // then
     expect(config.prompt).toContain("You build context by examining");
-    expect(config.prompt).toContain("Never chain together bash commands");
-    expect(config.prompt).toContain("<tool_usage_rules>");
-    expect(config.prompt).toContain("Do not use `apply_patch`");
-    expect(config.prompt).toContain("`edit` and `write`");
+    expect(config.prompt).toContain("Forbidden stops");
+    expect(config.prompt).toContain("Three-attempt failure protocol");
+    expect(config.prompt).toContain("Always use `apply_patch`");
   });
 
   test("GPT 5.3-codex model includes GPT-5.3 specific prompt content", () => {
@@ -243,7 +242,7 @@ describe("createHephaestusAgent", () => {
 
   test("includes Hephaestus identity in prompt", () => {
     // given
-    const model = "openai/gpt-5.4";
+    const model = "openai/gpt-5.5";
 
     // when
     const config = createHephaestusAgent(model);
@@ -267,7 +266,7 @@ describe("createHephaestusAgent", () => {
 
   test("GPT models deny apply_patch while non-GPT models do not", () => {
     // given
-    const gpt54Model = "openai/gpt-5.4";
+    const gpt54Model = "openai/gpt-5.5";
     const gptGenericModel = "openai/gpt-4o";
     const claudeModel = "anthropic/claude-opus-4-7";
 
@@ -284,7 +283,7 @@ describe("createHephaestusAgent", () => {
 
   test("useTaskSystem=true produces Task Discipline prompt", () => {
     // given
-    const model = "openai/gpt-5.4";
+    const model = "openai/gpt-5.5";
 
     // when
     const config = createHephaestusAgent(model, [], [], [], [], true);
@@ -297,7 +296,7 @@ describe("createHephaestusAgent", () => {
 
   test("useTaskSystem=false produces Todo Discipline prompt", () => {
     // given
-    const model = "openai/gpt-5.4";
+    const model = "openai/gpt-5.5";
 
     // when
     const config = createHephaestusAgent(model, [], [], [], [], false);
@@ -318,7 +317,7 @@ describe("maybeCreateHephaestusConfig GPT apply_patch guard", () => {
       // given
       const agentOverrides: AgentOverrides = {
         hephaestus: {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
           permission: {
             apply_patch: "allow",
           },
@@ -330,8 +329,8 @@ describe("maybeCreateHephaestusConfig GPT apply_patch guard", () => {
       const config = maybeCreateHephaestusConfig({
         disabledAgents: [],
         agentOverrides,
-        availableModels: new Set(["openai/gpt-5.4"]),
-        systemDefaultModel: "openai/gpt-5.4",
+        availableModels: new Set(["openai/gpt-5.5"]),
+        systemDefaultModel: "openai/gpt-5.5",
         isFirstRunNoCache: false,
         availableAgents: [],
         availableSkills: [],
@@ -342,7 +341,7 @@ describe("maybeCreateHephaestusConfig GPT apply_patch guard", () => {
 
       // then
       expect(config).toBeDefined();
-      expect(config?.model).toBe("openai/gpt-5.4");
+      expect(config?.model).toBe("openai/gpt-5.5");
       expect(config?.permission).toHaveProperty("apply_patch", "deny");
     });
   });

--- a/src/agents/hephaestus/gpt-5-4.ts
+++ b/src/agents/hephaestus/gpt-5-4.ts
@@ -1,15 +1,15 @@
 /**
- * GPT-5.4 optimized Hephaestus prompt - entropy-reduced rewrite.
+ * GPT-5.5 optimized Hephaestus prompt - entropy-reduced rewrite.
  *
- * Design principles (aligned with OpenAI GPT-5.4 prompting guidance):
+ * Design principles (aligned with OpenAI GPT-5.5 prompting guidance):
  * - Personality/tone at position 1 for strong tonal priming
  * - Prose-based instructions; no FORBIDDEN/MUST/NEVER rhetoric
  * - 3 targeted prompt blocks: tool_persistence, dig_deeper, dependency_checks
- * - GPT-5.4 follows instructions well - trust it, fewer threats needed
+ * - GPT-5.5 follows instructions well - trust it, fewer threats needed
  * - Conflicts eliminated: no "every 30s" + "be concise" contradiction
  * - Each concern appears in exactly one section
  *
- * Architecture (XML-tagged blocks, consistent with Sisyphus GPT-5.4):
+ * Architecture (XML-tagged blocks, consistent with Sisyphus GPT-5.5):
  *   1. <identity>       - Role, personality/tone, autonomy, scope
  *   2. <intent>         - Intent mapping, complexity classification, ambiguity protocol
  *   3. <explore>        - Tool selection, tool_persistence, dig_deeper, dependency_checks, parallelism

--- a/src/agents/momus.ts
+++ b/src/agents/momus.ts
@@ -199,9 +199,9 @@ If REJECT:
 `;
 
 /**
- * GPT-5.4 Optimized Momus System Prompt
+ * GPT-5.5 Optimized Momus System Prompt
  *
- * Tuned for GPT-5.4 system prompt design principles:
+ * Tuned for GPT-5.5 system prompt design principles:
  * - XML-tagged instruction blocks for clear structure
  * - Prose-first output, explicit opener blacklist
  * - Blocker-finder philosophy preserved

--- a/src/agents/oracle.ts
+++ b/src/agents/oracle.ts
@@ -153,9 +153,9 @@ Your response goes directly to the user with no intermediate processing. Make yo
 </delivery>`;
 
 /**
- * GPT-5.4 Optimized Oracle System Prompt
+ * GPT-5.5 Optimized Oracle System Prompt
  *
- * Tuned for GPT-5.4 system prompt design principles:
+ * Tuned for GPT-5.5 system prompt design principles:
  * - Expert advisor framing with approach-first mentality
  * - Prose-first output (favor conciseness, avoid bullet defaults)
  * - Explicit opener blacklist

--- a/src/agents/prometheus/gpt.ts
+++ b/src/agents/prometheus/gpt.ts
@@ -1,7 +1,7 @@
 /**
- * GPT-5.4 Optimized Prometheus System Prompt
+ * GPT-5.5 Optimized Prometheus System Prompt
  *
- * Tuned for GPT-5.4 system prompt design principles:
+ * Tuned for GPT-5.5 system prompt design principles:
  * - XML-tagged instruction blocks for clear structure
  * - Prose-first output, explicit verbosity constraints
  * - Scope discipline (no extra features)

--- a/src/agents/prometheus/system-prompt.ts
+++ b/src/agents/prometheus/system-prompt.ts
@@ -48,7 +48,7 @@ export function getPrometheusPromptSource(model?: string): PrometheusPromptSourc
 
 /**
  * Gets the appropriate Prometheus prompt based on model.
- * GPT models → GPT-5.4 optimized prompt (XML-tagged, principle-driven)
+ * GPT models → GPT-5.5 optimized prompt (XML-tagged, principle-driven)
  * Gemini models → Gemini-optimized prompt (aggressive tool-call enforcement, thinking checkpoints)
  * Default (Claude, etc.) → Claude-optimized prompt (modular sections)
  */

--- a/src/agents/sisyphus-junior/agent.ts
+++ b/src/agents/sisyphus-junior/agent.ts
@@ -5,7 +5,7 @@
  * Category-spawned executor with domain-specific configurations.
  *
  * Routing:
- * 1. GPT models (openai/*, github-copilot/gpt-*) -> gpt.ts (GPT-5.4 optimized)
+ * 1. GPT models (openai/*, github-copilot/gpt-*) -> gpt.ts (GPT-5.5 optimized)
  * 2. Gemini models (google/*, google-vertex/*) -> gemini.ts (Gemini-optimized)
  * 3. Default (Claude, etc.) -> default.ts (Claude-optimized)
  */
@@ -42,8 +42,8 @@ export const SISYPHUS_JUNIOR_DEFAULTS = {
 export type SisyphusJuniorPromptSource =
   | "default"
   | "gpt"
-  | "gpt-5-5"
   | "gpt-5-4"
+  | "gpt-5-5"
   | "gpt-5-3-codex"
   | "gemini"
 
@@ -51,6 +51,7 @@ export function getSisyphusJuniorPromptSource(model?: string): SisyphusJuniorPro
   if (model && isGptModel(model)) {
     if (isGpt5_5Model(model)) return "gpt-5-5"
     const lower = model.toLowerCase()
+    if (lower.includes("gpt-5.5") || lower.includes("gpt-5-5")) return "gpt-5-5"
     if (lower.includes("gpt-5.4") || lower.includes("gpt-5-4")) return "gpt-5-4"
     if (lower.includes("gpt-5.3-codex") || lower.includes("gpt-5-3-codex")) return "gpt-5-3-codex"
     return "gpt"

--- a/src/agents/sisyphus-junior/gpt-5-4.ts
+++ b/src/agents/sisyphus-junior/gpt-5-4.ts
@@ -1,7 +1,7 @@
 /**
- * GPT-5.4 Optimized Sisyphus-Junior System Prompt
+ * GPT-5.5 Optimized Sisyphus-Junior System Prompt
  *
- * Tuned for GPT-5.4 system prompt design principles:
+ * Tuned for GPT-5.5 system prompt design principles:
  * - Expert coding agent framing with approach-first mentality
  * - Deterministic tool usage (always/never, not try/maybe)
  * - Prose-first output style

--- a/src/agents/sisyphus-junior/index.test.ts
+++ b/src/agents/sisyphus-junior/index.test.ts
@@ -10,13 +10,13 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
   describe("honored fields", () => {
     test("applies model override", () => {
       // given
-      const override = { model: "openai/gpt-5.4" }
+      const override = { model: "openai/gpt-5.5" }
 
       // when
       const result = createSisyphusJuniorAgentWithOverrides(override)
 
       // then
-      expect(result.model).toBe("openai/gpt-5.4")
+      expect(result.model).toBe("openai/gpt-5.5")
     })
 
     test("applies temperature override", () => {
@@ -105,7 +105,7 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
       // given
       const override = {
         disable: true,
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         temperature: 0.9,
       }
 
@@ -146,7 +146,7 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
   describe("reasoning configuration", () => {
     test("#given GPT model #when agent is created #then uses reasoningEffort", () => {
       // given
-      const override = { model: "openai/gpt-5.4" }
+      const override = { model: "openai/gpt-5.5" }
 
       // when
       const result = createSisyphusJuniorAgentWithOverrides(override)
@@ -254,13 +254,13 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
 
     test("useTaskSystem=true produces Task Discipline prompt for GPT", () => {
       //#given
-      const override = { model: "openai/gpt-5.4" }
+      const override = { model: "openai/gpt-5.5" }
 
       //#when
       const result = createSisyphusJuniorAgentWithOverrides(override, undefined, true)
 
       //#then
-      expect(result.prompt).toContain("Task Discipline")
+      expect(result.prompt).toContain("Create tasks before any non-trivial work")
       expect(result.prompt).toContain("task_create")
       expect(result.prompt).not.toContain("Todo Discipline")
     })
@@ -291,7 +291,7 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
 
     test("useTaskSystem=true includes task_create/task_update in GPT prompt", () => {
       //#given
-      const override = { model: "openai/gpt-5.4" }
+      const override = { model: "openai/gpt-5.5" }
 
       //#when
       const result = createSisyphusJuniorAgentWithOverrides(override, undefined, true)
@@ -341,32 +341,28 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
 
     test("GPT model uses GPT-optimized prompt with Hephaestus-style sections", () => {
       // given
-      const override = { model: "openai/gpt-5.4" }
+      const override = { model: "openai/gpt-5.5" }
 
       // when
       const result = createSisyphusJuniorAgentWithOverrides(override)
 
-      // then
-      expect(result.prompt).toContain("Scope Discipline")
-      expect(result.prompt).toContain("<tool_usage_rules>")
-      expect(result.prompt).toContain("Progress Updates")
-      expect(result.prompt).toContain("Do not use `apply_patch`")
-      expect(result.prompt).toContain("`edit` and `write`")
+    // then
+      expect(result.prompt).toContain("focused task executor")
+      expect(result.prompt).toContain("## Identity and role")
+      expect(result.prompt).toContain("Always use `apply_patch`")
     })
 
-    test("GPT 5.4 model uses GPT-5.4 specific prompt", () => {
+    test("GPT 5.4 model uses GPT-5.5 specific prompt", () => {
       // given
-      const override = { model: "openai/gpt-5.4" }
+      const override = { model: "openai/gpt-5.5" }
 
       // when
       const result = createSisyphusJuniorAgentWithOverrides(override)
 
       // then
-      expect(result.prompt).toContain("expert coding agent")
-      expect(result.prompt).toContain("<tool_usage_rules>")
-      expect(result.prompt).toContain("Do not use `apply_patch`")
-      expect(result.prompt).toContain("`edit` and `write`")
-      expect(result.prompt).not.toContain("Always use apply_patch")
+      expect(result.prompt).toContain("focused task executor")
+      expect(result.prompt).toContain("## Identity and role")
+      expect(result.prompt).toContain("Always use `apply_patch`")
     })
 
     test("GPT 5.3 Codex model uses GPT-5.3-codex specific prompt", () => {
@@ -385,7 +381,7 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
 
     test("GPT variants deny apply_patch while Claude variants do not", () => {
       // given
-      const gpt54Override = { model: "openai/gpt-5.4" }
+      const gpt54Override = { model: "openai/gpt-5.5" }
       const gpt53Override = { model: "openai/gpt-5.3-codex" }
       const gptGenericOverride = { model: "openai/gpt-4o" }
       const claudeOverride = { model: "anthropic/claude-sonnet-4-6" }
@@ -420,26 +416,26 @@ describe("createSisyphusJuniorAgentWithOverrides", () => {
 })
 
 describe("getSisyphusJuniorPromptSource", () => {
-  test("returns 'gpt-5-4' for GPT 5.4 models", () => {
+  test("returns 'gpt-5-5' for GPT 5.4 models", () => {
     // given
-    const model = "openai/gpt-5.4"
+    const model = "openai/gpt-5.5"
 
     // when
     const source = getSisyphusJuniorPromptSource(model)
 
     // then
-    expect(source).toBe("gpt-5-4")
+    expect(source).toBe("gpt-5-5")
   })
 
-  test("returns 'gpt-5-4' for GitHub Copilot GPT 5.4", () => {
+  test("returns 'gpt-5-5' for GitHub Copilot GPT 5.4", () => {
     // given
-    const model = "github-copilot/gpt-5.4"
+    const model = "github-copilot/gpt-5.5"
 
     // when
     const source = getSisyphusJuniorPromptSource(model)
 
     // then
-    expect(source).toBe("gpt-5-4")
+    expect(source).toBe("gpt-5-5")
   })
 
   test("returns 'gpt-5-3-codex' for GPT 5.3 Codex models", () => {
@@ -510,18 +506,17 @@ describe("getSisyphusJuniorPromptSource", () => {
 })
 
 describe("buildSisyphusJuniorPrompt", () => {
-  test("GPT 5.4 model uses GPT-5.4 optimized prompt", () => {
+  test("GPT 5.5 model uses GPT-5.5 optimized prompt", () => {
     // given
-    const model = "openai/gpt-5.4"
+    const model = "openai/gpt-5.5"
 
     // when
     const prompt = buildSisyphusJuniorPrompt(model, false)
 
     // then
-    expect(prompt).toContain("expert coding agent")
-    expect(prompt).toContain("Scope Discipline")
-    expect(prompt).toContain("<tool_usage_rules>")
-    expect(prompt).toContain("Do not use `apply_patch`")
+    expect(prompt).toContain("focused task executor")
+    expect(prompt).toContain("## Identity and role")
+    expect(prompt).toContain("Always use `apply_patch`")
   })
 
   test("GPT 5.3 Codex model uses GPT-5.3-codex prompt", () => {
@@ -540,7 +535,7 @@ describe("buildSisyphusJuniorPrompt", () => {
 
   test("generic GPT model uses generic GPT prompt", () => {
     // given
-    const model = "openai/gpt-5.4"
+    const model = "openai/gpt-4o"
 
     // when
     const prompt = buildSisyphusJuniorPrompt(model, false)
@@ -566,15 +561,15 @@ describe("buildSisyphusJuniorPrompt", () => {
     expect(prompt).toContain("todowrite")
   })
 
-  test("useTaskSystem=true includes Task Discipline for GPT 5.4", () => {
+  test("useTaskSystem=true includes task-system guidance for GPT 5.5", () => {
     // given
-    const model = "openai/gpt-5.4"
+    const model = "openai/gpt-5.5"
 
     // when
     const prompt = buildSisyphusJuniorPrompt(model, true)
 
     // then
-    expect(prompt).toContain("Task Discipline")
+    expect(prompt).toContain("Create tasks before any non-trivial work")
     expect(prompt).toContain("task_create")
   })
 

--- a/src/agents/sisyphus/AGENTS.md
+++ b/src/agents/sisyphus/AGENTS.md
@@ -12,14 +12,14 @@
 |------|---------|
 | `default.ts` | Base/Claude variant: task management, delegation guides, 542 LOC |
 | `gemini.ts` | Gemini-optimized: stricter tool-usage rules, 5 NEVER rules |
-| `gpt-5-4.ts` | GPT-5.4-native: 8-block architecture, entropy-reduced, 449 LOC |
+| `gpt-5-5.ts` | GPT-5.4-native: 8-block architecture, entropy-reduced, 449 LOC |
 | `index.ts` | Barrel exports |
 
 ## VARIANT SELECTION
 
 Parent `sisyphus.ts` selects variant by model name:
 - Contains "gemini" -> `gemini.ts`
-- Contains "gpt-5.4" -> `gpt-5-4.ts`
+- Contains "gpt-5.5" -> `gpt-5-5.ts`
 - Default -> `default.ts` (Claude, Kimi, GLM, etc.)
 
 ## KEY EXPORTS

--- a/src/agents/sisyphus/index.ts
+++ b/src/agents/sisyphus/index.ts
@@ -4,7 +4,7 @@
  * This directory contains model-specific prompt variants:
  * - default.ts: Base implementation for Claude and general models
  * - gemini.ts: Corrective overlays for Gemini's aggressive tendencies
- * - gpt-5-4.ts: Native GPT-5.4 prompt with block-structured guidance
+ * - gpt-5-5.ts: Native GPT-5.5 prompt with block-structured guidance
  */
 
 export { buildDefaultSisyphusPrompt, buildTaskManagementSection } from "./default";

--- a/src/agents/tool-restrictions.test.ts
+++ b/src/agents/tool-restrictions.test.ts
@@ -116,7 +116,7 @@ describe("read-only agent tool restrictions", () => {
   describe("Sisyphus GPT variants", () => {
     test("deny apply_patch for GPT models but not Claude models", () => {
       // given
-      const gpt54Agent = createSisyphusAgent("openai/gpt-5.4")
+      const gpt54Agent = createSisyphusAgent("openai/gpt-5.5")
       const gptGenericAgent = createSisyphusAgent("openai/gpt-5.2")
       const claudeAgent = createSisyphusAgent(TEST_MODEL)
 

--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -9,8 +9,8 @@ import {
 
 describe("isGptNativeSisyphusModel", () => {
   test("allows GPT-5.x where x >= 4", () => {
-    expect(isGptNativeSisyphusModel("openai/gpt-5.4")).toBe(true);
-    expect(isGptNativeSisyphusModel("openai/gpt-5-4")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.5")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5-5")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.5")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5-5")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.9")).toBe(true);
@@ -20,8 +20,8 @@ describe("isGptNativeSisyphusModel", () => {
   });
 
   test("allows with various providers and suffixes", () => {
-    expect(isGptNativeSisyphusModel("github-copilot/gpt-5.4")).toBe(true);
-    expect(isGptNativeSisyphusModel("venice/gpt-5-4")).toBe(true);
+    expect(isGptNativeSisyphusModel("github-copilot/gpt-5.5")).toBe(true);
+    expect(isGptNativeSisyphusModel("venice/gpt-5-5")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.4-codex")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.5-mini")).toBe(true);
   });
@@ -46,7 +46,7 @@ describe("isGptNativeSisyphusModel", () => {
 
 describe("isGptModel", () => {
   test("standard openai provider gpt models", () => {
-    expect(isGptModel("openai/gpt-5.4")).toBe(true);
+    expect(isGptModel("openai/gpt-5.5")).toBe(true);
     expect(isGptModel("openai/gpt-4o")).toBe(true);
   });
 
@@ -59,22 +59,22 @@ describe("isGptModel", () => {
   });
 
   test("github copilot gpt models", () => {
-    expect(isGptModel("github-copilot/gpt-5.4")).toBe(true);
+    expect(isGptModel("github-copilot/gpt-5.5")).toBe(true);
     expect(isGptModel("github-copilot/gpt-4o")).toBe(true);
   });
 
   test("litellm proxied gpt models", () => {
-    expect(isGptModel("litellm/gpt-5.4")).toBe(true);
+    expect(isGptModel("litellm/gpt-5.5")).toBe(true);
     expect(isGptModel("litellm/gpt-4o")).toBe(true);
   });
 
   test("other proxied gpt models", () => {
     expect(isGptModel("ollama/gpt-4o")).toBe(true);
-    expect(isGptModel("custom-provider/gpt-5.4")).toBe(true);
+    expect(isGptModel("custom-provider/gpt-5.5")).toBe(true);
   });
 
   test("venice provider gpt models", () => {
-    expect(isGptModel("venice/gpt-5.4")).toBe(true);
+    expect(isGptModel("venice/gpt-5.5")).toBe(true);
     expect(isGptModel("venice/gpt-4o")).toBe(true);
   });
 
@@ -114,7 +114,7 @@ describe("isMiniMaxModel", () => {
   });
 
   test("does not match non-minimax models", () => {
-    expect(isMiniMaxModel("openai/gpt-5.4")).toBe(false);
+    expect(isMiniMaxModel("openai/gpt-5.5")).toBe(false);
     expect(isMiniMaxModel("anthropic/claude-opus-4-7")).toBe(false);
     expect(isMiniMaxModel("google/gemini-3.1-pro")).toBe(false);
     expect(isMiniMaxModel("opencode-go/kimi-k2.5")).toBe(false);
@@ -135,7 +135,7 @@ describe("isGlmModel", () => {
   });
 
   test("#given non-GLM models #then returns false", () => {
-    expect(isGlmModel("openai/gpt-5.4")).toBe(false);
+    expect(isGlmModel("openai/gpt-5.5")).toBe(false);
     expect(isGlmModel("anthropic/claude-opus-4-7")).toBe(false);
     expect(isGlmModel("google/gemini-3.1-pro")).toBe(false);
   });
@@ -170,7 +170,7 @@ describe("isGeminiModel", () => {
   });
 
   test("#given gpt models #then returns false", () => {
-    expect(isGeminiModel("openai/gpt-5.4")).toBe(false);
+    expect(isGeminiModel("openai/gpt-5.5")).toBe(false);
     expect(isGeminiModel("openai/o3-mini")).toBe(false);
     expect(isGeminiModel("litellm/gpt-4o")).toBe(false);
   });

--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -10,8 +10,8 @@ import {
 
 describe("isGptNativeSisyphusModel", () => {
   test("allows GPT-5.x where x >= 4", () => {
-    expect(isGptNativeSisyphusModel("openai/gpt-5.5")).toBe(true);
-    expect(isGptNativeSisyphusModel("openai/gpt-5-5")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.4")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5-4")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.5")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5-5")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.9")).toBe(true);

--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import {
   isGptModel,
+  isGpt5_5Model,
   isGeminiModel,
   isGlmModel,
   isGptNativeSisyphusModel,
@@ -41,6 +42,21 @@ describe("isGptNativeSisyphusModel", () => {
     expect(isGptNativeSisyphusModel("anthropic/claude-opus-4-7")).toBe(false);
     expect(isGptNativeSisyphusModel("google/gemini-3.1-pro")).toBe(false);
     expect(isGptNativeSisyphusModel("openai/o1")).toBe(false);
+  });
+});
+
+describe("isGpt5_5Model", () => {
+  test("detects dotted and dashed GPT-5.5 model IDs", () => {
+    expect(isGpt5_5Model("openai/gpt-5.5")).toBe(true);
+    expect(isGpt5_5Model("openai/gpt-5-5")).toBe(true);
+    expect(isGpt5_5Model("github-copilot/gpt-5.5-high")).toBe(true);
+    expect(isGpt5_5Model("venice/gpt-5-5-medium")).toBe(true);
+  });
+
+  test("rejects adjacent GPT model versions", () => {
+    expect(isGpt5_5Model("openai/gpt-5.4")).toBe(false);
+    expect(isGpt5_5Model("openai/gpt-5.6")).toBe(false);
+    expect(isGpt5_5Model("openai/gpt-4o")).toBe(false);
   });
 });
 

--- a/src/agents/utils.test.ts
+++ b/src/agents/utils.test.ts
@@ -58,14 +58,14 @@ describe("createBuiltinAgents with model overrides", () => {
     const providerModelsSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue(null)
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set())
     const overrides = {
-      sisyphus: { model: "github-copilot/gpt-5.4" },
+      sisyphus: { model: "github-copilot/gpt-5.5" },
     }
 
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL, undefined, undefined, [], undefined, undefined)
 
     // #then
-    expect(agents.sisyphus.model).toBe("github-copilot/gpt-5.4")
+    expect(agents.sisyphus.model).toBe("github-copilot/gpt-5.5")
     expect(agents.sisyphus.reasoningEffort).toBe("medium")
     expect(agents.sisyphus.thinking).toBeUndefined()
     providerModelsSpy.mockRestore()
@@ -75,9 +75,9 @@ describe("createBuiltinAgents with model overrides", () => {
   test("Atlas uses uiSelectedModel", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"])
+      new Set(["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"])
     )
-    const uiSelectedModel = "openai/gpt-5.4"
+    const uiSelectedModel = "openai/gpt-5.5"
 
     try {
       // #when
@@ -96,7 +96,7 @@ describe("createBuiltinAgents with model overrides", () => {
 
       // #then
       expect(agents.atlas).toBeDefined()
-      expect(agents.atlas.model).toBe("openai/gpt-5.4")
+      expect(agents.atlas.model).toBe("openai/gpt-5.5")
     } finally {
       fetchSpy.mockRestore()
     }
@@ -105,9 +105,9 @@ describe("createBuiltinAgents with model overrides", () => {
   test("user config model takes priority over uiSelectedModel for sisyphus", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"])
+      new Set(["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"])
     )
-    const uiSelectedModel = "openai/gpt-5.4"
+    const uiSelectedModel = "openai/gpt-5.5"
     const overrides = {
       sisyphus: { model: "google/antigravity-claude-opus-4-5-thinking" },
     }
@@ -138,9 +138,9 @@ describe("createBuiltinAgents with model overrides", () => {
   test("user config model takes priority over uiSelectedModel for atlas", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"])
+      new Set(["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"])
     )
-    const uiSelectedModel = "openai/gpt-5.4"
+    const uiSelectedModel = "openai/gpt-5.5"
     const overrides = {
       atlas: { model: "google/antigravity-claude-opus-4-5-thinking" },
     }
@@ -263,14 +263,14 @@ describe("createBuiltinAgents with model overrides", () => {
      const providerModelsSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue(null)
      const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set())
      const overrides = {
-       sisyphus: { model: "github-copilot/gpt-5.4", temperature: 0.5 },
+       sisyphus: { model: "github-copilot/gpt-5.5", temperature: 0.5 },
      }
 
      // #when
      const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL, undefined, undefined, [], undefined, undefined)
 
      // #then
-     expect(agents.sisyphus.model).toBe("github-copilot/gpt-5.4")
+     expect(agents.sisyphus.model).toBe("github-copilot/gpt-5.5")
      expect(agents.sisyphus.temperature).toBe(0.5)
      providerModelsSpy.mockRestore()
      fetchSpy.mockRestore()
@@ -304,7 +304,7 @@ describe("createBuiltinAgents with model overrides", () => {
         "opencode/kimi-k2.5-free",
         "zai-coding-plan/glm-5",
         "opencode/big-pickle",
-        "openai/gpt-5.4",
+        "openai/gpt-5.5",
       ])
     )
 
@@ -341,7 +341,7 @@ describe("createBuiltinAgents with model overrides", () => {
   test("excludes hidden custom agents from orchestrator prompts", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.4"])
+      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.5"])
     )
 
     const customAgentSummaries = [
@@ -377,7 +377,7 @@ describe("createBuiltinAgents with model overrides", () => {
   test("excludes disabled custom agents from orchestrator prompts", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.4"])
+      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.5"])
     )
 
     const customAgentSummaries = [
@@ -413,7 +413,7 @@ describe("createBuiltinAgents with model overrides", () => {
   test("excludes custom agents when disabledAgents contains their name (case-insensitive)", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.4"])
+      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.5"])
     )
 
     const disabledAgents = ["ReSeArChEr"]
@@ -449,7 +449,7 @@ describe("createBuiltinAgents with model overrides", () => {
   test("does not advertise duplicate custom agents case-insensitively", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.4"])
+      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.5"])
     )
 
     const customAgentSummaries = [
@@ -481,7 +481,7 @@ describe("createBuiltinAgents with model overrides", () => {
   test("does not surface custom agent strings in orchestrator prompts", async () => {
     // #given
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.4"])
+      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.5"])
     )
 
     const customAgentSummaries = [
@@ -840,7 +840,7 @@ describe("Atlas is unaffected by environment context toggle", () => {
 
   beforeEach(() => {
     fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.4"])
+      new Set(["anthropic/claude-opus-4-7", "openai/gpt-5.5"])
     )
   })
 
@@ -966,7 +966,7 @@ describe("createBuiltinAgents with requiresAnyModel gating (sisyphus)", () => {
     // #given - user configures a model from a plugin provider (like antigravity)
     // that is NOT in the availableModels cache and NOT in the fallback chain
     const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(
-      new Set(["openai/gpt-5.4"])
+      new Set(["openai/gpt-5.5"])
     )
     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(
       ["openai"]
@@ -1016,7 +1016,7 @@ describe("createBuiltinAgents with requiresAnyModel gating (sisyphus)", () => {
 
   test("atlas and metis resolve to OpenAI in an OpenAI-only environment without a system default", async () => {
     // #given
-    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set(["openai/gpt-5.4"]))
+    const fetchSpy = spyOn(shared, "fetchAvailableModels").mockResolvedValue(new Set(["openai/gpt-5.5"]))
     const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
 
     try {
@@ -1025,10 +1025,10 @@ describe("createBuiltinAgents with requiresAnyModel gating (sisyphus)", () => {
 
       // #then
       expect(agents.atlas).toBeDefined()
-      expect(agents.atlas.model).toBe("openai/gpt-5.4")
+      expect(agents.atlas.model).toBe("openai/gpt-5.5")
       expect(agents.atlas.variant).toBe("medium")
       expect(agents.metis).toBeDefined()
-      expect(agents.metis.model).toBe("openai/gpt-5.4")
+      expect(agents.metis.model).toBe("openai/gpt-5.5")
       expect(agents.metis.variant).toBe("high")
     } finally {
       fetchSpy.mockRestore()
@@ -1096,7 +1096,7 @@ describe("buildAgent with category and skills", () => {
 
     const categories = {
       "custom-category": {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         variant: "xhigh",
       },
     }
@@ -1105,7 +1105,7 @@ describe("buildAgent with category and skills", () => {
     const agent = buildAgent(source["test-agent"], TEST_MODEL, categories)
 
     // #then
-    expect(agent.model).toBe("openai/gpt-5.4")
+    expect(agent.model).toBe("openai/gpt-5.5")
     expect(agent.variant).toBe("xhigh")
   })
 
@@ -1185,7 +1185,7 @@ describe("buildAgent with category and skills", () => {
     const agent = buildAgent(source["test-agent"], TEST_MODEL)
 
     // #then - category's built-in model and skills are applied
-    expect(agent.model).toBe("openai/gpt-5.4")
+    expect(agent.model).toBe("openai/gpt-5.5")
     expect(agent.variant).toBe("xhigh")
     expect(agent.prompt).toContain("Role: Designer-Turned-Developer")
     expect(agent.prompt).toContain("Task description")
@@ -1309,9 +1309,9 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - ultrabrain category: model=openai/gpt-5.4, variant=xhigh
+    // #then - ultrabrain category: model=openai/gpt-5.5, variant=xhigh
     expect(agents.oracle).toBeDefined()
-    expect(agents.oracle.model).toBe("openai/gpt-5.4")
+    expect(agents.oracle.model).toBe("openai/gpt-5.5")
     expect(agents.oracle.variant).toBe("xhigh")
   })
 
@@ -1333,7 +1333,7 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #given - custom category has reasoningEffort=xhigh, direct override says "low"
     const categories = {
       "test-cat": {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         reasoningEffort: "xhigh" as const,
       },
     }
@@ -1353,7 +1353,7 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #given - custom category has reasoningEffort, no direct reasoningEffort in override
     const categories = {
       "reasoning-cat": {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         reasoningEffort: "high" as const,
       },
     }
@@ -1378,9 +1378,9 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - ultrabrain category: model=openai/gpt-5.4, variant=xhigh
+    // #then - ultrabrain category: model=openai/gpt-5.5, variant=xhigh
     expect(agents.sisyphus).toBeDefined()
-    expect(agents.sisyphus.model).toBe("openai/gpt-5.4")
+    expect(agents.sisyphus.model).toBe("openai/gpt-5.5")
     expect(agents.sisyphus.variant).toBe("xhigh")
   })
 
@@ -1393,9 +1393,9 @@ describe("override.category expansion in createBuiltinAgents", () => {
     // #when
     const agents = await createBuiltinAgents([], overrides, undefined, TEST_DEFAULT_MODEL)
 
-    // #then - ultrabrain category: model=openai/gpt-5.4, variant=xhigh
+    // #then - ultrabrain category: model=openai/gpt-5.5, variant=xhigh
     expect(agents.atlas).toBeDefined()
-    expect(agents.atlas.model).toBe("openai/gpt-5.4")
+    expect(agents.atlas.model).toBe("openai/gpt-5.5")
     expect(agents.atlas.variant).toBe("xhigh")
   })
 

--- a/src/cli/cli-program.ts
+++ b/src/cli/cli-program.ts
@@ -43,7 +43,7 @@ Examples:
 
 Model Providers (Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi > Vercel):
   Claude        Native anthropic/ models (Opus, Sonnet, Haiku)
-  OpenAI        Native openai/ models (GPT-5.4 for Oracle)
+  OpenAI        Native openai/ models (GPT-5.5 for Oracle)
   Gemini        Native google/ models (Gemini 3.1 Pro, Flash)
   Copilot       github-copilot/ models (fallback)
   OpenCode Zen  opencode/ models (opencode/claude-opus-4-7, etc.)

--- a/src/cli/config-manager/generate-omo-config.test.ts
+++ b/src/cli/config-manager/generate-omo-config.test.ts
@@ -96,10 +96,10 @@ describe("generateOmoConfig - model fallback system", () => {
     const result = generateOmoConfig(config)
 
     //#then
-    expect((result.agents as Record<string, { model: string; variant?: string }>).sisyphus.model).toBe("openai/gpt-5.4")
+    expect((result.agents as Record<string, { model: string; variant?: string }>).sisyphus.model).toBe("openai/gpt-5.5")
     expect((result.agents as Record<string, { model: string; variant?: string }>).sisyphus.variant).toBe("medium")
     expect((result.agents as Record<string, { model: string }>).oracle.model).toBe("openai/gpt-5.5")
-    expect((result.agents as Record<string, { model: string }>)['multimodal-looker'].model).toBe("openai/gpt-5.4")
+    expect((result.agents as Record<string, { model: string }>)['multimodal-looker'].model).toBe("openai/gpt-5.5")
   })
 
   test("adds fallback_models when multiple providers are available", () => {
@@ -134,7 +134,7 @@ describe("generateOmoConfig - model fallback system", () => {
     expect(agents.sisyphus.model).toBe("anthropic/claude-opus-4-7")
     expect(agents.sisyphus.fallback_models).toEqual([
       {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         variant: "medium",
       },
     ])

--- a/src/cli/doctor/checks/model-resolution-cache.test.ts
+++ b/src/cli/doctor/checks/model-resolution-cache.test.ts
@@ -33,7 +33,7 @@ describe("loadAvailableModelsFromCache", () => {
     writeFileSync(
       join(tempDir, "cache", "opencode", "models.json"),
       JSON.stringify({
-        openai: { models: { "gpt-5.4": {} } },
+        openai: { models: { "gpt-5.5": {} } },
         anthropic: { models: { "claude-opus-4-7": {}, "claude-sonnet-4-6": {} } },
       })
     )
@@ -49,7 +49,7 @@ describe("loadAvailableModelsFromCache", () => {
     writeFileSync(
       join(tempDir, "cache", "opencode", "models.json"),
       JSON.stringify({
-        openai: { models: { "gpt-5.4": {} } },
+        openai: { models: { "gpt-5.5": {} } },
       })
     )
     writeFileSync(
@@ -58,7 +58,7 @@ describe("loadAvailableModelsFromCache", () => {
         provider: {
           "openai-custom": {
             npm: "@ai-sdk/openai-compatible",
-            models: { "gpt-5.4": {} },
+            models: { "gpt-5.5": {} },
           },
           "my-local-llm": {
             npm: "@ai-sdk/openai-compatible",
@@ -79,7 +79,7 @@ describe("loadAvailableModelsFromCache", () => {
     writeFileSync(
       join(tempDir, "cache", "opencode", "models.json"),
       JSON.stringify({
-        openai: { models: { "gpt-5.4": {} } },
+        openai: { models: { "gpt-5.5": {} } },
       })
     )
     writeFileSync(
@@ -104,7 +104,7 @@ describe("loadAvailableModelsFromCache", () => {
         provider: {
           "openai-custom": {
             npm: "@ai-sdk/openai-compatible",
-            models: { "gpt-5.4": {} },
+            models: { "gpt-5.5": {} },
           },
         },
       })
@@ -135,7 +135,7 @@ describe("loadAvailableModelsFromCache", () => {
   test("ignores malformed opencode.json gracefully", () => {
     writeFileSync(
       join(tempDir, "cache", "opencode", "models.json"),
-      JSON.stringify({ openai: { models: { "gpt-5.4": {} } } })
+      JSON.stringify({ openai: { models: { "gpt-5.5": {} } } })
     )
     writeFileSync(
       join(tempDir, "config", "opencode", "opencode.json"),

--- a/src/cli/doctor/checks/model-resolution.test.ts
+++ b/src/cli/doctor/checks/model-resolution.test.ts
@@ -61,7 +61,7 @@ describe("model-resolution check", () => {
       // given: User has override for visual-engineering category
       const mockConfig = {
         categories: {
-          "visual-engineering": { model: "openai/gpt-5.4" },
+          "visual-engineering": { model: "openai/gpt-5.5" },
         },
       }
 
@@ -70,8 +70,8 @@ describe("model-resolution check", () => {
       // then: visual-engineering should show the override
       const visual = info.categories.find((c) => c.name === "visual-engineering")
       expect(visual).toBeDefined()
-      expect(visual!.userOverride).toBe("openai/gpt-5.4")
-      expect(visual!.effectiveResolution).toBe("User override: openai/gpt-5.4")
+      expect(visual!.userOverride).toBe("openai/gpt-5.5")
+      expect(visual!.effectiveResolution).toBe("User override: openai/gpt-5.5")
     })
 
     it("shows provider fallback when no override exists", async () => {
@@ -96,7 +96,7 @@ describe("model-resolution check", () => {
       //#given User has model with variant override for oracle agent
       const mockConfig = {
         agents: {
-          oracle: { model: "openai/gpt-5.4", variant: "xhigh" },
+          oracle: { model: "openai/gpt-5.5", variant: "xhigh" },
         },
       }
 
@@ -106,7 +106,7 @@ describe("model-resolution check", () => {
       //#then Oracle should have userVariant set
       const oracle = info.agents.find((a) => a.name === "oracle")
       expect(oracle).toBeDefined()
-      expect(oracle!.userOverride).toBe("openai/gpt-5.4")
+      expect(oracle!.userOverride).toBe("openai/gpt-5.5")
       expect(oracle!.userVariant).toBe("xhigh")
     })
 

--- a/src/cli/doctor/formatter.test.ts
+++ b/src/cli/doctor/formatter.test.ts
@@ -61,7 +61,7 @@ function createDoctorResultWithDetails(): DoctorResult {
       name: "Models",
       status: "pass",
       message: "2 agents, 1 category, 0 overrides",
-      details: ["Available models: openai/gpt-5.4", "Agent sisyphus -> openai/gpt-5.4"],
+      details: ["Available models: openai/gpt-5.5", "Agent sisyphus -> openai/gpt-5.5"],
       issues: [],
     },
   ]
@@ -167,8 +167,8 @@ describe("formatDoctorOutput", () => {
 
       //#then
       expect(output).toContain("Models")
-      expect(output).toContain("Available models: openai/gpt-5.4")
-      expect(output).toContain("Agent sisyphus -> openai/gpt-5.4")
+      expect(output).toContain("Available models: openai/gpt-5.5")
+      expect(output).toContain("Agent sisyphus -> openai/gpt-5.5")
     })
   })
 

--- a/src/cli/install-validators.ts
+++ b/src/cli/install-validators.ts
@@ -34,7 +34,7 @@ export function formatConfigSummary(config: InstallConfig): string {
 
   const claudeDetail = config.hasClaude ? (config.isMax20 ? "max20" : "standard") : undefined
   lines.push(formatProvider("Claude", config.hasClaude, claudeDetail))
-  lines.push(formatProvider("OpenAI/ChatGPT", config.hasOpenAI, "GPT-5.4 for Oracle"))
+  lines.push(formatProvider("OpenAI/ChatGPT", config.hasOpenAI, "GPT-5.5 for Oracle"))
   lines.push(formatProvider("Gemini", config.hasGemini))
   lines.push(formatProvider("GitHub Copilot", config.hasCopilot, "fallback"))
   lines.push(formatProvider("OpenCode Zen", config.hasOpencodeZen, "opencode/ models"))

--- a/src/cli/provider-model-id-transform.test.ts
+++ b/src/cli/provider-model-id-transform.test.ts
@@ -231,12 +231,12 @@ describe("transformModelForProvider", () => {
     })
 
     test("prepends openai/ for gpt models", () => {
-      // #given vercel provider and gpt-5.4 model
+      // #given vercel provider and gpt-5.5 model
       // #when transformModelForProvider is called
-      const result = transformModelForProvider("vercel", "gpt-5.4")
+      const result = transformModelForProvider("vercel", "gpt-5.5")
 
-      // #then should produce openai/gpt-5.4
-      expect(result).toBe("openai/gpt-5.4")
+      // #then should produce openai/gpt-5.5
+      expect(result).toBe("openai/gpt-5.5")
     })
 
     test("prepends google/ and applies google transform for gemini models", () => {

--- a/src/cli/refresh-model-capabilities.test.ts
+++ b/src/cli/refresh-model-capabilities.test.ts
@@ -13,7 +13,7 @@ describe("refreshModelCapabilities", () => {
       generatedAt: "2026-03-25T00:00:00.000Z",
       sourceUrl: "https://mirror.example/api.json",
       models: {
-        "gpt-5.4": { id: "gpt-5.4" },
+        "gpt-5.5": { id: "gpt-5.5" },
       },
     }))
     let stdout = ""
@@ -48,7 +48,7 @@ describe("refreshModelCapabilities", () => {
       generatedAt: "2026-03-25T00:00:00.000Z",
       sourceUrl: "https://override.example/api.json",
       models: {
-        "gpt-5.4": { id: "gpt-5.4" },
+        "gpt-5.5": { id: "gpt-5.5" },
         "claude-opus-4-7": { id: "claude-opus-4-7" },
       },
     }))

--- a/src/cli/run/completion-continuation.test.ts
+++ b/src/cli/run/completion-continuation.test.ts
@@ -128,7 +128,7 @@ describe("checkCompletionConditions continuation coverage", () => {
     })) as unknown as RunContext["client"]["session"]["get"]
     ctx.client.session.messages = mock(async ({ path }: { path: { id: string } }) => ({
       data: path.id === "child-session"
-        ? [{ info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.4" } }]
+        ? [{ info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.5" } }]
         : [],
     })) as unknown as RunContext["client"]["session"]["messages"]
 
@@ -191,7 +191,7 @@ describe("checkCompletionConditions continuation coverage", () => {
     })) as unknown as RunContext["client"]["session"]["get"]
     ctx.client.session.messages = mock(async ({ path }: { path: { id: string } }) => ({
       data: path.id === "mismatch-subagent-session"
-        ? [{ info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.4" } }]
+        ? [{ info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.5" } }]
         : [],
     })) as unknown as RunContext["client"]["session"]["messages"]
 
@@ -226,7 +226,7 @@ describe("checkCompletionConditions continuation coverage", () => {
     })) as unknown as RunContext["client"]["session"]["get"]
     ctx.client.session.messages = mock(async ({ path }: { path: { id: string } }) => ({
       data: path.id === "appended-mismatch-session"
-        ? [{ info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.4" } }]
+        ? [{ info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.5" } }]
         : [],
     })) as unknown as RunContext["client"]["session"]["messages"]
 
@@ -258,7 +258,7 @@ describe("checkCompletionConditions continuation coverage", () => {
     }) as unknown as RunContext["client"]["session"]["get"]
     ctx.client.session.messages = mock(async ({ path }: { path: { id: string } }) => ({
       data: path.id === "ses_appended_descendant"
-        ? [{ info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.4" } }]
+        ? [{ info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.5" } }]
         : [],
     })) as unknown as RunContext["client"]["session"]["messages"]
 
@@ -374,7 +374,7 @@ describe("checkCompletionConditions continuation coverage", () => {
     })) as unknown as RunContext["client"]["session"]["get"]
     ctx.client.session.messages = mock(async ({ path }: { path: { id: string } }) => ({
       data: path.id === "ses_direct_child"
-        ? [{ info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.4" } }]
+        ? [{ info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.5" } }]
         : [],
     })) as unknown as RunContext["client"]["session"]["messages"]
 
@@ -411,8 +411,8 @@ describe("checkCompletionConditions continuation coverage", () => {
     ctx.client.session.messages = mock(async ({ path }: { path: { id: string } }) => ({
       data: path.id === "ses_child_after_compaction"
         ? [
-            { info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.4" } },
-            { info: { agent: "compaction", providerID: "openai", modelID: "gpt-5.4" } },
+            { info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.5" } },
+            { info: { agent: "compaction", providerID: "openai", modelID: "gpt-5.5" } },
           ]
         : [],
     })) as unknown as RunContext["client"]["session"]["messages"]
@@ -446,9 +446,9 @@ describe("checkCompletionConditions continuation coverage", () => {
     ctx.client.session.messages = mock(async ({ path }: { path: { id: string } }) => ({
       data: path.id === "ses_sqlite_descendant"
         ? [
-            { id: "msg_0001", info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.4", time: { created: 100 } } },
-            { id: "msg_0003", info: { agent: "compaction", providerID: "openai", modelID: "gpt-5.4", time: { created: 200 } } },
-            { id: "msg_0002", info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.4", time: { created: 100 } } },
+            { id: "msg_0001", info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.5", time: { created: 100 } } },
+            { id: "msg_0003", info: { agent: "compaction", providerID: "openai", modelID: "gpt-5.5", time: { created: 200 } } },
+            { id: "msg_0002", info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.5", time: { created: 100 } } },
           ]
         : [],
     })) as unknown as RunContext["client"]["session"]["messages"]

--- a/src/cli/run/continuation-state.json-backend.test.ts
+++ b/src/cli/run/continuation-state.json-backend.test.ts
@@ -57,7 +57,7 @@ function writeJsonMessage(sessionID: string, fileName: string, agent: string): v
     join(messageDir, fileName),
       JSON.stringify({
         agent,
-        model: { providerID: "openai", modelID: "gpt-5.4" },
+        model: { providerID: "openai", modelID: "gpt-5.5" },
         time: { created: fileName.includes("002") ? 200 : 100 },
       }),
       "utf-8",
@@ -115,7 +115,7 @@ describe("getContinuationState JSON backend descendant coverage", () => {
       join(TEST_MESSAGE_STORAGE, sessionID, "msg_00000000_000999.json"),
       JSON.stringify({
         agent: "earliest-agent",
-        model: { providerID: "openai", modelID: "gpt-5.4" },
+        model: { providerID: "openai", modelID: "gpt-5.5" },
         time: { created: 10 },
       }),
       "utf-8",
@@ -151,17 +151,17 @@ describe("getContinuationState JSON backend descendant coverage", () => {
     mkdirSync(messageDir, { recursive: true })
     writeFileSync(join(messageDir, "msg_a91f00ab_000001.json"), JSON.stringify({
       agent: "atlas",
-      model: { providerID: "openai", modelID: "gpt-5.4" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
       time: { created: 100 },
     }), "utf-8")
     writeFileSync(join(messageDir, "msg_f0e1d2c3_000002.json"), JSON.stringify({
       agent: "compaction",
-      model: { providerID: "openai", modelID: "gpt-5.4" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
       time: { created: 200 },
     }), "utf-8")
     writeFileSync(join(messageDir, "msg_d4c3b2a1_000003.json"), JSON.stringify({
       agent: "sisyphus-junior",
-      model: { providerID: "openai", modelID: "gpt-5.4" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
       time: { created: 100 },
     }), "utf-8")
     sessionLastAgentBySessionID.set(sessionID, "sisyphus-junior")

--- a/src/cli/tui-install-prompts.ts
+++ b/src/cli/tui-install-prompts.ts
@@ -44,7 +44,7 @@ export async function promptInstallConfig(detected: DetectedConfig): Promise<Ins
     message: "Do you have an OpenAI/ChatGPT Plus subscription?",
     options: [
       { value: "no", label: "No", hint: "Oracle will use fallback models" },
-      { value: "yes", label: "Yes", hint: "GPT-5.4 for Oracle (high-IQ debugging)" },
+      { value: "yes", label: "Yes", hint: "GPT-5.5 for Oracle (high-IQ debugging)" },
     ],
     initialValue: initial.openai,
   })

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -299,7 +299,7 @@ describe("AgentOverrideConfigSchema", () => {
   describe("backward compatibility", () => {
     test("still accepts model field (deprecated)", () => {
       // given
-      const config = { model: "openai/gpt-5.4" }
+      const config = { model: "openai/gpt-5.5" }
 
       // when
       const result = AgentOverrideConfigSchema.safeParse(config)
@@ -307,14 +307,14 @@ describe("AgentOverrideConfigSchema", () => {
       // then
       expect(result.success).toBe(true)
       if (result.success) {
-        expect(result.data.model).toBe("openai/gpt-5.4")
+        expect(result.data.model).toBe("openai/gpt-5.5")
       }
     })
 
     test("accepts both model and category (deprecated usage)", () => {
       // given - category should take precedence at runtime, but both should validate
       const config = { 
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         category: "ultrabrain"
       }
 
@@ -324,7 +324,7 @@ describe("AgentOverrideConfigSchema", () => {
       // then
       expect(result.success).toBe(true)
       if (result.success) {
-        expect(result.data.model).toBe("openai/gpt-5.4")
+        expect(result.data.model).toBe("openai/gpt-5.5")
         expect(result.data.category).toBe("ultrabrain")
       }
     })
@@ -376,7 +376,7 @@ describe("AgentOverrideConfigSchema", () => {
 describe("CategoryConfigSchema", () => {
   test("accepts variant as optional string", () => {
     // given
-    const config = { model: "openai/gpt-5.4", variant: "xhigh" }
+    const config = { model: "openai/gpt-5.5", variant: "xhigh" }
 
     // when
     const result = CategoryConfigSchema.safeParse(config)
@@ -424,7 +424,7 @@ describe("CategoryConfigSchema", () => {
 
   test("rejects non-string variant", () => {
     // given
-    const config = { model: "openai/gpt-5.4", variant: 123 }
+    const config = { model: "openai/gpt-5.5", variant: 123 }
 
     // when
     const result = CategoryConfigSchema.safeParse(config)
@@ -477,7 +477,7 @@ describe("Sisyphus-Junior agent override", () => {
     const config = {
       agents: {
         "sisyphus-junior": {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
           temperature: 0.2,
         },
       },
@@ -490,7 +490,7 @@ describe("Sisyphus-Junior agent override", () => {
     expect(result.success).toBe(true)
     if (result.success) {
       expect(result.data.agents?.["sisyphus-junior"]).toBeDefined()
-      expect(result.data.agents?.["sisyphus-junior"]?.model).toBe("openai/gpt-5.4")
+      expect(result.data.agents?.["sisyphus-junior"]?.model).toBe("openai/gpt-5.5")
       expect(result.data.agents?.["sisyphus-junior"]?.temperature).toBe(0.2)
     }
   })

--- a/src/config/schema/fallback-models.test.ts
+++ b/src/config/schema/fallback-models.test.ts
@@ -9,7 +9,7 @@ import { FallbackModelsSchema } from "./fallback-models"
 describe("FallbackModelsSchema", () => {
   test("accepts string array fallback_models", () => {
     // given
-    const fallbackModels = ["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"]
+    const fallbackModels = ["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"]
 
     // when
     const result = FallbackModelsSchema.safeParse(fallbackModels)
@@ -25,7 +25,7 @@ describe("FallbackModelsSchema", () => {
     // given
     const fallbackModels: FallbackModelObject[] = [
       {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         variant: "high",
         reasoningEffort: "high",
         temperature: 0.3,
@@ -48,7 +48,7 @@ describe("OhMyOpenCodeConfigSchema fallback_models", () => {
     // given
     const fallbackModels: FallbackModelObject[] = [
       {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         variant: "low",
         reasoningEffort: "medium",
       },
@@ -75,7 +75,7 @@ describe("OhMyOpenCodeConfigSchema fallback_models", () => {
     // given
     const fallbackModels: FallbackModelObject[] = [
       {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         maxTokens: 4096,
         thinking: { type: "disabled" },
       },

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -3254,7 +3254,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         description: "Task 2",
         prompt: "Do something else",
         agent: "test-agent",
-        model: { providerID: "openai", modelID: "gpt-5.5" },
+        model: { providerID: "openai", modelID: "gpt-5.4" },
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
       }
@@ -5432,7 +5432,7 @@ describe("BackgroundManager - tool permission spread order", () => {
       agent: "sisyphus-junior",
       parentSessionID: "parent-session",
       parentMessageID: "parent-message",
-      model: { providerID: "openai", modelID: "gpt-5.5", variant: "medium" },
+      model: { providerID: "openai", modelID: "gpt-5.4", variant: "medium" },
     }
     const input: import("./types").LaunchInput = {
       description: task.description,
@@ -5450,7 +5450,7 @@ describe("BackgroundManager - tool permission spread order", () => {
     //#then
     expect(promptCalls).toHaveLength(1)
     expect(promptCalls[0].body.agent).toBe("sisyphus-junior")
-    expect(promptCalls[0].body.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+    expect(promptCalls[0].body.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
     expect(promptCalls[0].body.variant).toBe("medium")
 
     manager.shutdown()

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -3254,7 +3254,7 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
         description: "Task 2",
         prompt: "Do something else",
         agent: "test-agent",
-        model: { providerID: "openai", modelID: "gpt-5.4" },
+        model: { providerID: "openai", modelID: "gpt-5.5" },
         parentSessionID: "parent-session",
         parentMessageID: "parent-message",
       }
@@ -5432,7 +5432,7 @@ describe("BackgroundManager - tool permission spread order", () => {
       agent: "sisyphus-junior",
       parentSessionID: "parent-session",
       parentMessageID: "parent-message",
-      model: { providerID: "openai", modelID: "gpt-5.4", variant: "medium" },
+      model: { providerID: "openai", modelID: "gpt-5.5", variant: "medium" },
     }
     const input: import("./types").LaunchInput = {
       description: task.description,
@@ -5450,7 +5450,7 @@ describe("BackgroundManager - tool permission spread order", () => {
     //#then
     expect(promptCalls).toHaveLength(1)
     expect(promptCalls[0].body.agent).toBe("sisyphus-junior")
-    expect(promptCalls[0].body.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+    expect(promptCalls[0].body.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
     expect(promptCalls[0].body.variant).toBe("medium")
 
     manager.shutdown()

--- a/src/features/background-agent/spawner.test.ts
+++ b/src/features/background-agent/spawner.test.ts
@@ -357,7 +357,7 @@ describe("background-agent spawner fallback model promotion", () => {
       parentMessageID: "message-1",
       model: {
         providerID: "openai",
-        modelID: "gpt-5.4",
+        modelID: "gpt-5.5",
         variant: "low",
         reasoningEffort: "high",
         temperature: 0.4,
@@ -393,7 +393,7 @@ describe("background-agent spawner fallback model promotion", () => {
     //#then
     expect(promptArgs.body.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
     })
     expect(promptArgs.body.variant).toBe("low")
     expect(promptArgs.body.options).toBeUndefined()
@@ -429,7 +429,7 @@ describe("background-agent spawner fallback model promotion", () => {
       agent: "sisyphus-junior",
       parentSessionID: "ses_parent",
       parentMessageID: "msg_parent",
-      model: { providerID: "openai", modelID: "gpt-5.4", variant: "medium" },
+      model: { providerID: "openai", modelID: "gpt-5.5", variant: "medium" },
     })
 
     const item = {
@@ -462,7 +462,7 @@ describe("background-agent spawner fallback model promotion", () => {
     expect(promptCalls[0]?.body?.agent).toBe("sisyphus-junior")
     expect(promptCalls[0]?.body?.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
     })
     expect(promptCalls[0]?.body?.variant).toBe("medium")
   })

--- a/src/features/background-agent/spawner.test.ts
+++ b/src/features/background-agent/spawner.test.ts
@@ -357,7 +357,7 @@ describe("background-agent spawner fallback model promotion", () => {
       parentMessageID: "message-1",
       model: {
         providerID: "openai",
-        modelID: "gpt-5.5",
+        modelID: "gpt-5.4",
         variant: "low",
         reasoningEffort: "high",
         temperature: 0.4,
@@ -393,7 +393,7 @@ describe("background-agent spawner fallback model promotion", () => {
     //#then
     expect(promptArgs.body.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.5",
+      modelID: "gpt-5.4",
     })
     expect(promptArgs.body.variant).toBe("low")
     expect(promptArgs.body.options).toBeUndefined()
@@ -429,7 +429,7 @@ describe("background-agent spawner fallback model promotion", () => {
       agent: "sisyphus-junior",
       parentSessionID: "ses_parent",
       parentMessageID: "msg_parent",
-      model: { providerID: "openai", modelID: "gpt-5.5", variant: "medium" },
+      model: { providerID: "openai", modelID: "gpt-5.4", variant: "medium" },
     })
 
     const item = {
@@ -462,7 +462,7 @@ describe("background-agent spawner fallback model promotion", () => {
     expect(promptCalls[0]?.body?.agent).toBe("sisyphus-junior")
     expect(promptCalls[0]?.body?.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.5",
+      modelID: "gpt-5.4",
     })
     expect(promptCalls[0]?.body?.variant).toBe("medium")
   })

--- a/src/features/task-toast-manager/manager.test.ts
+++ b/src/features/task-toast-manager/manager.test.ts
@@ -288,15 +288,15 @@ describe("TaskToastManager", () => {
         agent: "sisyphus-junior",
         isBackground: true,
         category: "deep",
-        modelInfo: { model: "openai/gpt-5.5", type: "category-default" as const },
+        modelInfo: { model: "openai/gpt-5.4", type: "category-default" as const },
       }
 
       // when - addTask is called
       toastManager.addTask(task)
 
-      // then - toast should show model name before category like "gpt-5.5: deep"
+      // then - toast should show model name before category like "gpt-5.4: deep"
       const call = mockClient.tui.showToast.mock.calls[0][0]
-      expect(call.body.message).toContain("gpt-5.5: deep")
+      expect(call.body.message).toContain("gpt-5.4: deep")
       expect(call.body.message).not.toContain("sisyphus-junior/deep")
     })
 

--- a/src/features/task-toast-manager/manager.test.ts
+++ b/src/features/task-toast-manager/manager.test.ts
@@ -288,15 +288,15 @@ describe("TaskToastManager", () => {
         agent: "sisyphus-junior",
         isBackground: true,
         category: "deep",
-        modelInfo: { model: "openai/gpt-5.4", type: "category-default" as const },
+        modelInfo: { model: "openai/gpt-5.5", type: "category-default" as const },
       }
 
       // when - addTask is called
       toastManager.addTask(task)
 
-      // then - toast should show model name before category like "gpt-5.4: deep"
+      // then - toast should show model name before category like "gpt-5.5: deep"
       const call = mockClient.tui.showToast.mock.calls[0][0]
-      expect(call.body.message).toContain("gpt-5.4: deep")
+      expect(call.body.message).toContain("gpt-5.5: deep")
       expect(call.body.message).not.toContain("sisyphus-junior/deep")
     })
 

--- a/src/hooks/anthropic-effort/index.test.ts
+++ b/src/hooks/anthropic-effort/index.test.ts
@@ -146,7 +146,7 @@ describe("createAnthropicEffortHook", () => {
 
     it("does nothing for non-claude providers/models", async () => {
       const hook = createAnthropicEffortHook()
-      const { input, output } = createMockParams({ providerID: "openai", modelID: "gpt-5.4" })
+      const { input, output } = createMockParams({ providerID: "openai", modelID: "gpt-5.5" })
 
       await hook["chat.params"](input, output)
 

--- a/src/hooks/atlas/background-task-retry.test.ts
+++ b/src/hooks/atlas/background-task-retry.test.ts
@@ -379,7 +379,7 @@ describe("atlas background task retry", () => {
           promptAsync: promptAsyncMock,
           messages: async ({ path }: { path: { id: string } }) => ({
             data: path.id === descendantSessionID
-              ? [{ info: { agent: descendantAgent, providerID: "openai", modelID: "gpt-5.4" } }]
+              ? [{ info: { agent: descendantAgent, providerID: "openai", modelID: "gpt-5.5" } }]
               : [],
           }),
         },

--- a/src/hooks/atlas/idle-event-persisted-lineage.test.ts
+++ b/src/hooks/atlas/idle-event-persisted-lineage.test.ts
@@ -109,7 +109,7 @@ describe("atlas hook idle-event persisted lineage", () => {
       },
       {
         [descendantSessionID]: [
-          { info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.4" } },
+          { info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.5" } },
         ],
       },
     )
@@ -144,7 +144,7 @@ describe("atlas hook idle-event persisted lineage", () => {
       },
       {
         [descendantSessionID]: [
-          { info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.4" } },
+          { info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.5" } },
         ],
       },
     )
@@ -181,7 +181,7 @@ describe("atlas hook idle-event persisted lineage", () => {
             throw new Error("session lookup failed")
           },
           messages: async () => ({
-            data: [{ info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.4" } }],
+            data: [{ info: { agent: "atlas", providerID: "openai", modelID: "gpt-5.5" } }],
           }),
           prompt: async (input: unknown) => {
             promptCalls.push(input)
@@ -225,7 +225,7 @@ describe("atlas hook idle-event persisted lineage", () => {
       },
       {
         [descendantSessionID]: [
-          { info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.4" } },
+          { info: { agent: "sisyphus-junior", providerID: "openai", modelID: "gpt-5.5" } },
         ],
       },
     )

--- a/src/hooks/atlas/index.test.ts
+++ b/src/hooks/atlas/index.test.ts
@@ -312,7 +312,7 @@ session_id: ses_standalone_def
         metadata: {
           sessionId: "ses_standalone_def",
           agent: "sisyphus-junior",
-          model: { providerID: "openai", modelID: "gpt-5.4" },
+          model: { providerID: "openai", modelID: "gpt-5.5" },
           truncated: false,
         } as Record<string, unknown>,
       }
@@ -327,7 +327,7 @@ session_id: ses_standalone_def
       expect(output.output).toContain("LYING")
       expect(output.metadata.sessionId).toBe("ses_standalone_def")
       expect(output.metadata.agent).toBe("sisyphus-junior")
-      expect(output.metadata.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+      expect(output.metadata.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
       expect(output.metadata.truncated).toBe(false)
 
       cleanupMessageStorage(sessionID)

--- a/src/hooks/atlas/recent-model-resolver-fallback.test.ts
+++ b/src/hooks/atlas/recent-model-resolver-fallback.test.ts
@@ -45,7 +45,7 @@ describe("resolveRecentPromptContextForSession fallback ordering", () => {
     }), "utf-8")
     writeFileSync(join(messageDir, "msg_00000000_000999.json"), JSON.stringify({
       agent: "atlas",
-      model: { providerID: "openai", modelID: "gpt-5.4" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
       tools: { edit: true },
       time: { created: 100 },
     }), "utf-8")
@@ -66,7 +66,7 @@ describe("resolveRecentPromptContextForSession fallback ordering", () => {
     const result = await resolveRecentPromptContextForSession(ctx as never, sessionID)
 
     // then
-    expect(result.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+    expect(result.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
     expect(result.tools).toEqual({ edit: true })
   })
 })

--- a/src/hooks/atlas/recent-model-resolver.test.ts
+++ b/src/hooks/atlas/recent-model-resolver.test.ts
@@ -23,7 +23,7 @@ describe("resolveRecentPromptContextForSession", () => {
                 id: "msg_older_in_array",
                 info: {
                   providerID: "openai",
-                  modelID: "gpt-5.4",
+                  modelID: "gpt-5.5",
                   tools: { edit: true },
                   time: { created: 100 },
                 },
@@ -38,7 +38,7 @@ describe("resolveRecentPromptContextForSession", () => {
     const result = await resolveRecentPromptContextForSession(ctx, "ses_123")
 
     // then
-    expect(result.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+    expect(result.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
     expect(result.tools).toEqual({ edit: true })
   })
 })

--- a/src/hooks/no-sisyphus-gpt/hook.ts
+++ b/src/hooks/no-sisyphus-gpt/hook.ts
@@ -11,7 +11,7 @@ import { getAgentConfigKey } from "../../shared/agent-display-names"
 const TOAST_TITLE = "NEVER Use Sisyphus with GPT"
 const TOAST_MESSAGE = [
   "Sisyphus works best with Claude Opus, and works fine with Kimi/GLM models.",
-  "Do NOT use Sisyphus with GPT (except GPT-5.4 and GPT-5.5 which have specialized support).",
+  "Do NOT use Sisyphus with GPT (except GPT-5.5 and GPT-5.5 which have specialized support).",
   "For other GPT models, always use Hephaestus.",
 ].join("\n")
 function showToast(ctx: PluginInput, sessionID: string): void {

--- a/src/hooks/no-sisyphus-gpt/hook.ts
+++ b/src/hooks/no-sisyphus-gpt/hook.ts
@@ -5,13 +5,13 @@ import {
   resolveRegisteredAgentName,
   updateSessionAgent,
 } from "../../features/claude-code-session-state"
-import { log } from "../../shared"
+import { AGENT_MODEL_REQUIREMENTS, log } from "../../shared"
 import { getAgentConfigKey } from "../../shared/agent-display-names"
 
 const TOAST_TITLE = "NEVER Use Sisyphus with GPT"
 const TOAST_MESSAGE = [
   "Sisyphus works best with Claude Opus, and works fine with Kimi/GLM models.",
-  "Do NOT use Sisyphus with GPT (except GPT-5.5 and GPT-5.5 which have specialized support).",
+  "Do NOT use Sisyphus with GPT (except GPT-5.4 and GPT-5.5 which have specialized support).",
   "For other GPT models, always use Hephaestus.",
 ].join("\n")
 function showToast(ctx: PluginInput, sessionID: string): void {
@@ -30,6 +30,18 @@ function showToast(ctx: PluginInput, sessionID: string): void {
   })
 }
 
+function getNativeSisyphusGptVariant(model: { providerID: string; modelID: string }): string | undefined {
+  const chain = AGENT_MODEL_REQUIREMENTS["sisyphus"]?.fallbackChain ?? []
+  const exactMatch = chain.find((entry) =>
+    entry.providers.includes(model.providerID) && entry.model === model.modelID
+  )
+  if (exactMatch?.variant !== undefined) {
+    return exactMatch.variant
+  }
+
+  return chain.find((entry) => entry.model === model.modelID)?.variant
+}
+
 export function createNoSisyphusGptHook(ctx: PluginInput) {
   return {
     "chat.message": async (input: {
@@ -42,6 +54,20 @@ export function createNoSisyphusGptHook(ctx: PluginInput) {
       const rawAgent = input.agent ?? getSessionAgent(input.sessionID) ?? ""
       const agentKey = getAgentConfigKey(rawAgent)
       const modelID = input.model?.modelID
+
+      if (
+        agentKey === "sisyphus"
+        && input.model
+        && modelID
+        && isGptNativeSisyphusModel(modelID)
+        && output?.message
+        && output.message.variant === undefined
+      ) {
+        const variant = getNativeSisyphusGptVariant(input.model)
+        if (variant !== undefined) {
+          output.message.variant = variant
+        }
+      }
 
       if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGptNativeSisyphusModel(modelID)) {
         showToast(ctx, input.sessionID)

--- a/src/hooks/no-sisyphus-gpt/index.test.ts
+++ b/src/hooks/no-sisyphus-gpt/index.test.ts
@@ -1,4 +1,7 @@
+/// <reference types="bun-types" />
+
 import { describe, expect, spyOn, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
 import { _resetForTesting, updateSessionAgent } from "../../features/claude-code-session-state"
 import { getAgentDisplayName } from "../../shared/agent-display-names"
 import { createNoSisyphusGptHook } from "./index"
@@ -6,20 +9,29 @@ import { createNoSisyphusGptHook } from "./index"
 const SISYPHUS_DISPLAY = getAgentDisplayName("sisyphus")
 const HEPHAESTUS_DISPLAY = getAgentDisplayName("hephaestus")
 
-function createOutput() {
+type HookOutput = {
+  message: { agent?: string; variant?: string; [key: string]: unknown }
+  parts: unknown[]
+}
+
+function createOutput(): HookOutput {
   return {
     message: {},
     parts: [],
   }
 }
 
+function createHookContext(showToast: (input: unknown) => Promise<unknown>): PluginInput {
+  return {
+    client: { tui: { showToast } },
+  } as unknown as PluginInput
+}
+
 describe("no-sisyphus-gpt hook", () => {
   test("shows toast on every chat.message when sisyphus uses gpt model", async () => {
     // given - sisyphus (display name) with gpt model
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
-    const hook = createNoSisyphusGptHook({
-      client: { tui: { showToast } },
-    } as any)
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
 
     const output1 = createOutput()
     const output2 = createOutput()
@@ -40,7 +52,8 @@ describe("no-sisyphus-gpt hook", () => {
     expect(showToast).toHaveBeenCalledTimes(2)
     expect(output1.message.agent).toBe("hephaestus")
     expect(output2.message.agent).toBe("hephaestus")
-    expect(showToast.mock.calls[0]?.[0]).toMatchObject({
+    const firstToastCall = (showToast.mock.calls as Array<Array<unknown>>)[0]?.[0]
+    expect(firstToastCall).toMatchObject({
       body: {
         title: "NEVER Use Sisyphus with GPT",
         message: expect.stringContaining("For other GPT models, always use Hephaestus."),
@@ -52,9 +65,7 @@ describe("no-sisyphus-gpt hook", () => {
   test("does not show toast for gpt-5.5 model (Sisyphus has specialized support)", async () => {
     // given - sisyphus with gpt-5.5 model (should be allowed)
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
-    const hook = createNoSisyphusGptHook({
-      client: { tui: { showToast } },
-    } as any)
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
 
     const output = createOutput()
 
@@ -73,9 +84,7 @@ describe("no-sisyphus-gpt hook", () => {
   test("does not show toast for gpt-5.5 model (native Sisyphus support)", async () => {
     // given - sisyphus with gpt-5.5 model (should be allowed)
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
-    const hook = createNoSisyphusGptHook({
-      client: { tui: { showToast } },
-    } as any)
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
 
     const output = createOutput()
 
@@ -91,12 +100,50 @@ describe("no-sisyphus-gpt hook", () => {
     expect(output.message.agent).toBeUndefined()
   })
 
+  test("sets medium variant for gpt-5.5 model when native Sisyphus support is used", async () => {
+    // given - sisyphus with gpt-5.5 model and no selected variant
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
+
+    const output = createOutput()
+
+    // when - chat.message runs with gpt-5.5
+    await hook["chat.message"]?.({
+      sessionID: "ses_gpt55_medium",
+      agent: SISYPHUS_DISPLAY,
+      model: { providerID: "openai", modelID: "gpt-5.5" },
+    }, output)
+
+    // then - Sisyphus stays active and receives its configured GPT-5.5 variant
+    expect(showToast).toHaveBeenCalledTimes(0)
+    expect(output.message.agent).toBeUndefined()
+    expect(output.message.variant).toBe("medium")
+  })
+
+  test("preserves selected variant for gpt-5.5 model when native Sisyphus support is used", async () => {
+    // given - sisyphus with gpt-5.5 model and a selected variant
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
+
+    const output: HookOutput = { message: { variant: "high" }, parts: [] }
+
+    // when - chat.message runs with gpt-5.5
+    await hook["chat.message"]?.({
+      sessionID: "ses_gpt55_high",
+      agent: SISYPHUS_DISPLAY,
+      model: { providerID: "openai", modelID: "gpt-5.5" },
+    }, output)
+
+    // then - user-selected variant is not overwritten
+    expect(showToast).toHaveBeenCalledTimes(0)
+    expect(output.message.agent).toBeUndefined()
+    expect(output.message.variant).toBe("high")
+  })
+
   test("does not show toast for non-gpt model", async () => {
     // given - sisyphus with claude model
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
-    const hook = createNoSisyphusGptHook({
-      client: { tui: { showToast } },
-    } as any)
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
 
     const output = createOutput()
 
@@ -115,9 +162,7 @@ describe("no-sisyphus-gpt hook", () => {
   test("does not show toast for non-sisyphus agent", async () => {
     // given - hephaestus with gpt model
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
-    const hook = createNoSisyphusGptHook({
-      client: { tui: { showToast } },
-    } as any)
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
 
     const output = createOutput()
 
@@ -138,9 +183,7 @@ describe("no-sisyphus-gpt hook", () => {
     _resetForTesting()
     updateSessionAgent("ses_4", SISYPHUS_DISPLAY)
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
-    const hook = createNoSisyphusGptHook({
-      client: { tui: { showToast } },
-    } as any)
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
 
     const output = createOutput()
 

--- a/src/hooks/no-sisyphus-gpt/index.test.ts
+++ b/src/hooks/no-sisyphus-gpt/index.test.ts
@@ -49,8 +49,8 @@ describe("no-sisyphus-gpt hook", () => {
     })
   })
 
-  test("does not show toast for gpt-5.4 model (Sisyphus has specialized support)", async () => {
-    // given - sisyphus with gpt-5.4 model (should be allowed)
+  test("does not show toast for gpt-5.5 model (Sisyphus has specialized support)", async () => {
+    // given - sisyphus with gpt-5.5 model (should be allowed)
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
     const hook = createNoSisyphusGptHook({
       client: { tui: { showToast } },
@@ -58,11 +58,11 @@ describe("no-sisyphus-gpt hook", () => {
 
     const output = createOutput()
 
-    // when - chat.message runs with gpt-5.4
+    // when - chat.message runs with gpt-5.5
     await hook["chat.message"]?.({
       sessionID: "ses_gpt54",
       agent: SISYPHUS_DISPLAY,
-      model: { providerID: "openai", modelID: "gpt-5.4" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
     }, output)
 
     // then - no toast, agent NOT switched to Hephaestus
@@ -125,7 +125,7 @@ describe("no-sisyphus-gpt hook", () => {
     await hook["chat.message"]?.({
       sessionID: "ses_3",
       agent: HEPHAESTUS_DISPLAY,
-      model: { providerID: "openai", modelID: "gpt-5.4" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
     }, output)
 
     // then - no toast

--- a/src/hooks/no-sisyphus-gpt/index.test.ts
+++ b/src/hooks/no-sisyphus-gpt/index.test.ts
@@ -62,25 +62,6 @@ describe("no-sisyphus-gpt hook", () => {
     })
   })
 
-  test("does not show toast for gpt-5.5 model (Sisyphus has specialized support)", async () => {
-    // given - sisyphus with gpt-5.5 model (should be allowed)
-    const showToast = spyOn({ fn: async () => ({}) }, "fn")
-    const hook = createNoSisyphusGptHook(createHookContext(showToast))
-
-    const output = createOutput()
-
-    // when - chat.message runs with gpt-5.5
-    await hook["chat.message"]?.({
-      sessionID: "ses_gpt54",
-      agent: SISYPHUS_DISPLAY,
-      model: { providerID: "openai", modelID: "gpt-5.5" },
-    }, output)
-
-    // then - no toast, agent NOT switched to Hephaestus
-    expect(showToast).toHaveBeenCalledTimes(0)
-    expect(output.message.agent).toBeUndefined()
-  })
-
   test("does not show toast for gpt-5.5 model (native Sisyphus support)", async () => {
     // given - sisyphus with gpt-5.5 model (should be allowed)
     const showToast = spyOn({ fn: async () => ({}) }, "fn")

--- a/src/hooks/runtime-fallback/dispose.test.ts
+++ b/src/hooks/runtime-fallback/dispose.test.ts
@@ -127,7 +127,7 @@ describe("createRuntimeFallbackHook dispose", () => {
 
     capturedDeps?.sessionStates.set("session-1", {
       originalModel: "anthropic/claude-opus-4-7",
-      currentModel: "openai/gpt-5.4",
+      currentModel: "openai/gpt-5.5",
       fallbackIndex: 1,
       failedModels: new Map([["anthropic/claude-opus-4-7", 1]]),
       attemptCount: 1,

--- a/src/hooks/runtime-fallback/event-handler.test.ts
+++ b/src/hooks/runtime-fallback/event-handler.test.ts
@@ -66,7 +66,7 @@ describe("createEventHandler", () => {
     const abortCalls: string[] = []
     const clearCalls: string[] = []
     const state = createFallbackState("google/gemini-2.5-pro")
-    state.pendingFallbackModel = "openai/gpt-5.4"
+    state.pendingFallbackModel = "openai/gpt-5.5"
     deps.sessionStates.set(sessionID, state)
     deps.sessionRetryInFlight.add(sessionID)
     deps.sessionStatusRetryKeys.set(sessionID, "retry:1")
@@ -88,7 +88,7 @@ describe("createEventHandler", () => {
     const abortCalls: string[] = []
     const clearCalls: string[] = []
     const state = createFallbackState("google/gemini-2.5-pro")
-    state.pendingFallbackModel = "openai/gpt-5.4"
+    state.pendingFallbackModel = "openai/gpt-5.5"
     deps.sessionStates.set(sessionID, state)
     deps.sessionRetryInFlight.add(sessionID)
     deps.sessionFallbackTimeouts.set(sessionID, 1)
@@ -111,10 +111,10 @@ describe("createEventHandler", () => {
     const abortCalls: string[] = []
     const clearCalls: string[] = []
     const state = createFallbackState("google/gemini-2.5-pro")
-    state.currentModel = "openai/gpt-5.4"
+    state.currentModel = "openai/gpt-5.5"
     state.fallbackIndex = 1
     state.attemptCount = 2
-    state.pendingFallbackModel = "openai/gpt-5.4"
+    state.pendingFallbackModel = "openai/gpt-5.5"
     state.failedModels.set("google/gemini-2.5-pro", Date.now())
     deps.sessionStates.set(sessionID, state)
     deps.sessionRetryInFlight.add(sessionID)
@@ -144,10 +144,10 @@ describe("createEventHandler", () => {
     const abortCalls: string[] = []
     const clearCalls: string[] = []
     const state = createFallbackState("google/gemini-2.5-pro")
-    state.currentModel = "openai/gpt-5.4"
+    state.currentModel = "openai/gpt-5.5"
     state.fallbackIndex = 1
     state.attemptCount = 2
-    state.pendingFallbackModel = "openai/gpt-5.4"
+    state.pendingFallbackModel = "openai/gpt-5.5"
     deps.sessionStates.set(sessionID, state)
     const handler = createEventHandler(deps, createHelpers(deps, abortCalls, clearCalls))
 

--- a/src/hooks/runtime-fallback/index.test.ts
+++ b/src/hooks/runtime-fallback/index.test.ts
@@ -141,7 +141,7 @@ describe("runtime-fallback", () => {
       await hook.event({
         event: {
           type: "session.created",
-          properties: { info: { id: sessionID, model: "openai/gpt-5.4" } },
+          properties: { info: { id: sessionID, model: "openai/gpt-5.5" } },
         },
       })
 
@@ -240,7 +240,7 @@ describe("runtime-fallback", () => {
     test("should trigger fallback for missing API key errors when fallback models are configured", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
-        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.4"]),
+        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.5"]),
       })
       const sessionID = "test-session-missing-api-key-fallback"
       SessionCategoryRegistry.register(sessionID, "test")
@@ -268,7 +268,7 @@ describe("runtime-fallback", () => {
 
       const fallbackLog = logCalls.find((c) => c.msg.includes("Preparing fallback"))
       expect(fallbackLog).toBeDefined()
-      expect(fallbackLog?.data).toMatchObject({ from: "google/gemini-2.5-pro", to: "openai/gpt-5.4" })
+      expect(fallbackLog?.data).toMatchObject({ from: "google/gemini-2.5-pro", to: "openai/gpt-5.5" })
     })
 
     test("should detect retryable error from message pattern 'rate limit'", async () => {
@@ -330,7 +330,7 @@ describe("runtime-fallback", () => {
         config: createMockConfig({ notify_on_fallback: false }),
         pluginConfig: createMockPluginConfigWithCategoryFallback([
           "anthropic/claude-opus-4.7",
-          "openai/gpt-5.4",
+          "openai/gpt-5.5",
         ]),
       })
       const sessionID = "test-session-model-not-found"
@@ -372,7 +372,7 @@ describe("runtime-fallback", () => {
 
       const fallbackLogs = logCalls.filter((c) => c.msg.includes("Preparing fallback"))
       expect(fallbackLogs.length).toBeGreaterThanOrEqual(2)
-      expect(fallbackLogs[1]?.data).toMatchObject({ from: "anthropic/claude-opus-4.7", to: "openai/gpt-5.4" })
+      expect(fallbackLogs[1]?.data).toMatchObject({ from: "anthropic/claude-opus-4.7", to: "openai/gpt-5.5" })
 
       const nonRetryLog = logCalls.find(
         (c) => c.msg.includes("Error not retryable") && (c.data as { sessionID?: string } | undefined)?.sessionID === sessionID
@@ -385,7 +385,7 @@ describe("runtime-fallback", () => {
         config: createMockConfig({ notify_on_fallback: false }),
         pluginConfig: createMockPluginConfigWithCategoryFallback([
           "anthropic/claude-opus-4.7",
-          "openai/gpt-5.4",
+          "openai/gpt-5.5",
         ]),
       })
       const sessionID = "test-session-provider-model-not-found"
@@ -431,7 +431,7 @@ describe("runtime-fallback", () => {
 
       const fallbackLogs = logCalls.filter((c) => c.msg.includes("Preparing fallback"))
       expect(fallbackLogs.length).toBeGreaterThanOrEqual(2)
-      expect(fallbackLogs[1]?.data).toMatchObject({ from: "anthropic/claude-opus-4.7", to: "openai/gpt-5.4" })
+      expect(fallbackLogs[1]?.data).toMatchObject({ from: "anthropic/claude-opus-4.7", to: "openai/gpt-5.5" })
     })
 
     test("should bootstrap session.error fallback from session category model and preserve variant", async () => {
@@ -453,7 +453,7 @@ describe("runtime-fallback", () => {
           pluginConfig: createMockPluginConfigWithCategoryModel(
             "quick",
             "anthropic/claude-haiku-4-5",
-            ["openai/gpt-5.4(high)"],
+            ["openai/gpt-5.5(high)"],
           ),
         },
       )
@@ -475,7 +475,7 @@ describe("runtime-fallback", () => {
         model?: { providerID?: string; modelID?: string }
         variant?: string
       } | undefined
-      expect(promptBody?.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+      expect(promptBody?.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
       expect(promptBody?.variant).toBe("high")
 
       const bootstrapLog = logCalls.find((call) =>
@@ -491,7 +491,7 @@ describe("runtime-fallback", () => {
     test("should trigger fallback on Copilot auto-retry signal in message.updated", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
-        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.4"]),
+        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.5"]),
       })
 
       const sessionID = "test-session-copilot-auto-retry"
@@ -524,7 +524,7 @@ describe("runtime-fallback", () => {
 
       const fallbackLog = logCalls.find((c) => c.msg.includes("Preparing fallback"))
       expect(fallbackLog).toBeDefined()
-      expect(fallbackLog?.data).toMatchObject({ from: "github-copilot/claude-opus-4.7", to: "openai/gpt-5.4" })
+      expect(fallbackLog?.data).toMatchObject({ from: "github-copilot/claude-opus-4.7", to: "openai/gpt-5.5" })
     })
 
     test("should trigger fallback on OpenAI auto-retry signal in message.updated", async () => {
@@ -1055,7 +1055,7 @@ describe("runtime-fallback", () => {
     test("should trigger fallback when message.updated has missing API key error without model", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
-        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.4"]),
+        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.5"]),
       })
       const sessionID = "test-message-updated-missing-model"
       SessionCategoryRegistry.register(sessionID, "test")
@@ -1086,7 +1086,7 @@ describe("runtime-fallback", () => {
 
       const fallbackLog = logCalls.find((c) => c.msg.includes("Preparing fallback"))
       expect(fallbackLog).toBeDefined()
-      expect(fallbackLog?.data).toMatchObject({ from: "google/gemini-2.5-pro", to: "openai/gpt-5.4" })
+      expect(fallbackLog?.data).toMatchObject({ from: "google/gemini-2.5-pro", to: "openai/gpt-5.5" })
     })
 
     test("should bootstrap message.updated fallback from session category model and preserve variant", async () => {
@@ -1108,7 +1108,7 @@ describe("runtime-fallback", () => {
           pluginConfig: createMockPluginConfigWithCategoryModel(
             "quick",
             "anthropic/claude-haiku-4-5",
-            ["openai/gpt-5.4(high)"],
+            ["openai/gpt-5.5(high)"],
           ),
         },
       )
@@ -1133,7 +1133,7 @@ describe("runtime-fallback", () => {
         model?: { providerID?: string; modelID?: string }
         variant?: string
       } | undefined
-      expect(promptBody?.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+      expect(promptBody?.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
       expect(promptBody?.variant).toBe("high")
 
       const bootstrapLog = logCalls.find((call) =>
@@ -1163,7 +1163,7 @@ describe("runtime-fallback", () => {
           pluginConfig: createMockPluginConfigWithCategoryFallback([
             "github-copilot/claude-opus-4.7",
             "anthropic/claude-opus-4-7",
-            "openai/gpt-5.4",
+            "openai/gpt-5.5",
           ]),
         }
       )
@@ -1253,7 +1253,7 @@ describe("runtime-fallback", () => {
           pluginConfig: createMockPluginConfigWithCategoryFallback([
             "github-copilot/claude-opus-4.7",
             "anthropic/claude-opus-4-7",
-            "openai/gpt-5.4",
+            "openai/gpt-5.5",
           ]),
         }
       )
@@ -1337,7 +1337,7 @@ describe("runtime-fallback", () => {
           pluginConfig: createMockPluginConfigWithCategoryFallback([
             "github-copilot/claude-opus-4.7",
             "anthropic/claude-opus-4-7",
-            "openai/gpt-5.4",
+            "openai/gpt-5.5",
           ]),
           session_timeout_ms: 20,
         }
@@ -1403,7 +1403,7 @@ describe("runtime-fallback", () => {
           pluginConfig: createMockPluginConfigWithCategoryFallback([
             "github-copilot/claude-opus-4.7",
             "anthropic/claude-opus-4-7",
-            "openai/gpt-5.4",
+            "openai/gpt-5.5",
           ]),
           session_timeout_ms: 20,
         }
@@ -1488,7 +1488,7 @@ describe("runtime-fallback", () => {
           pluginConfig: createMockPluginConfigWithCategoryFallback([
             "github-copilot/claude-opus-4.7",
             "anthropic/claude-opus-4-7",
-            "openai/gpt-5.4",
+            "openai/gpt-5.5",
           ]),
           session_timeout_ms: 20,
         }
@@ -1553,7 +1553,7 @@ describe("runtime-fallback", () => {
           pluginConfig: createMockPluginConfigWithCategoryFallback([
             "github-copilot/claude-opus-4.7",
             "anthropic/claude-opus-4-7",
-            "openai/gpt-5.4",
+            "openai/gpt-5.5",
           ]),
           session_timeout_ms: 20,
         }
@@ -2091,7 +2091,7 @@ describe("runtime-fallback", () => {
         }),
         {
           config: createMockConfig({ notify_on_fallback: false }),
-          pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.4"]),
+          pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.5"]),
         }
       )
 
@@ -2202,7 +2202,7 @@ describe("runtime-fallback", () => {
         }),
         {
           config: createMockConfig({ notify_on_fallback: false }),
-          pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.4"]),
+          pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.5"]),
         }
       )
 
@@ -2298,7 +2298,7 @@ describe("runtime-fallback", () => {
     test("should apply fallback model on next chat.message after error", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
-        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.4", "google/gemini-3.1-pro"]),
+        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.5", "google/gemini-3.1-pro"]),
       })
       const sessionID = "test-session-switch"
       SessionCategoryRegistry.register(sessionID, "test")
@@ -2328,13 +2328,13 @@ describe("runtime-fallback", () => {
         output
       )
 
-      expect(output.message.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+      expect(output.message.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
     })
 
     test("should notify when fallback occurs", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: true }),
-        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.4"]),
+        pluginConfig: createMockPluginConfigWithCategoryFallback(["openai/gpt-5.5"]),
       })
       const sessionID = "test-session-notify"
       SessionCategoryRegistry.register(sessionID, "test")
@@ -2354,7 +2354,7 @@ describe("runtime-fallback", () => {
       })
 
       expect(toastCalls.length).toBe(1)
-      expect(toastCalls[0]?.message.includes("gpt-5.4")).toBe(true)
+      expect(toastCalls[0]?.message.includes("gpt-5.5")).toBe(true)
     })
   })
 
@@ -2378,7 +2378,7 @@ describe("runtime-fallback", () => {
       const input = createMockPluginInput()
       const hook = createRuntimeFallbackHook(input, {
         config: createMockConfig({ notify_on_fallback: false }),
-        pluginConfig: createMockPluginConfigWithAgentFallback("oracle", ["openai/gpt-5.4", "google/gemini-3.1-pro"]),
+        pluginConfig: createMockPluginConfigWithAgentFallback("oracle", ["openai/gpt-5.5", "google/gemini-3.1-pro"]),
       })
       const sessionID = "test-agent-fallback"
 
@@ -2398,16 +2398,16 @@ describe("runtime-fallback", () => {
         },
       })
 
-      //#then - should prepare fallback to openai/gpt-5.4
+      //#then - should prepare fallback to openai/gpt-5.5
       const fallbackLog = logCalls.find((c) => c.msg.includes("Preparing fallback"))
       expect(fallbackLog).toBeDefined()
-      expect(fallbackLog?.data).toMatchObject({ from: "anthropic/claude-opus-4-5", to: "openai/gpt-5.4" })
+      expect(fallbackLog?.data).toMatchObject({ from: "anthropic/claude-opus-4-5", to: "openai/gpt-5.5" })
     })
 
     test("should detect agent from sessionID pattern", async () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ notify_on_fallback: false }),
-        pluginConfig: createMockPluginConfigWithAgentFallback("sisyphus", ["openai/gpt-5.4"]),
+        pluginConfig: createMockPluginConfigWithAgentFallback("sisyphus", ["openai/gpt-5.5"]),
       })
       const sessionID = "sisyphus-session-123"
 
@@ -2428,7 +2428,7 @@ describe("runtime-fallback", () => {
       //#then - should detect sisyphus from sessionID and use its fallback
       const fallbackLog = logCalls.find((c) => c.msg.includes("Preparing fallback"))
       expect(fallbackLog).toBeDefined()
-      expect(fallbackLog?.data).toMatchObject({ to: "openai/gpt-5.4" })
+      expect(fallbackLog?.data).toMatchObject({ to: "openai/gpt-5.5" })
     })
 
     test("should preserve resolved agent during auto-retry", async () => {
@@ -2481,7 +2481,7 @@ describe("runtime-fallback", () => {
       const hook = createRuntimeFallbackHook(createMockPluginInput(), {
         config: createMockConfig({ cooldown_seconds: 60, notify_on_fallback: false }),
         pluginConfig: createMockPluginConfigWithCategoryFallback([
-          "openai/gpt-5.4",
+          "openai/gpt-5.5",
           "anthropic/claude-opus-4-5",
         ]),
       })

--- a/src/hooks/runtime-fallback/retry-model-payload.test.ts
+++ b/src/hooks/runtime-fallback/retry-model-payload.test.ts
@@ -83,7 +83,7 @@ describe("buildRetryModelPayload", () => {
 
   test("should include reasoningEffort from agent settings", () => {
     // given
-    const model = "openai/gpt-5.4"
+    const model = "openai/gpt-5.5"
     const agentSettings = { variant: "high", reasoningEffort: "xhigh" }
 
     // when
@@ -91,7 +91,7 @@ describe("buildRetryModelPayload", () => {
 
     // then
     expect(result).toEqual({
-      model: { providerID: "openai", modelID: "gpt-5.4" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
       variant: "high",
       reasoningEffort: "xhigh",
     })

--- a/src/hooks/runtime-fallback/session-status-handler.test.ts
+++ b/src/hooks/runtime-fallback/session-status-handler.test.ts
@@ -36,7 +36,7 @@ function createDeps(): HookDeps {
     pluginConfig: {
       categories: {
         test: {
-          fallback_models: ["openai/gpt-5.4", "google/gemini-2.5-pro"],
+          fallback_models: ["openai/gpt-5.5", "google/gemini-2.5-pro"],
         },
       },
     },
@@ -75,10 +75,10 @@ describe("createSessionStatusHandler", () => {
     const abortCalls: string[] = []
     const retryCalls: Array<{ sessionID: string; model: string; source: string }> = []
     const state = createFallbackState("anthropic/claude-opus-4-7")
-    state.currentModel = "openai/gpt-5.4"
+    state.currentModel = "openai/gpt-5.5"
     state.fallbackIndex = 0
     state.attemptCount = 1
-    state.pendingFallbackModel = "openai/gpt-5.4"
+    state.pendingFallbackModel = "openai/gpt-5.5"
     state.failedModels.set("anthropic/claude-opus-4-7", Date.now())
     deps.sessionStates.set(sessionID, state)
 
@@ -87,11 +87,11 @@ describe("createSessionStatusHandler", () => {
     // when
     await handler({
       sessionID,
-      model: "openai/gpt-5.4",
+      model: "openai/gpt-5.5",
       status: {
         type: "retry",
         attempt: 2,
-        message: "All credentials for model gpt-5.4 are cooling down [retrying in 7m 56s attempt #2]",
+        message: "All credentials for model gpt-5.5 are cooling down [retrying in 7m 56s attempt #2]",
       },
     })
 

--- a/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
+++ b/src/hooks/runtime-fallback/success-retry-key-cleanup.test.ts
@@ -73,7 +73,7 @@ describe("createMessageUpdateHandler retry-key cleanup", () => {
       ],
     })
     const state = createFallbackState("google/gemini-2.5-pro")
-    state.pendingFallbackModel = "openai/gpt-5.4"
+    state.pendingFallbackModel = "openai/gpt-5.5"
     deps.sessionStates.set(sessionID, state)
     deps.sessionAwaitingFallbackResult.add(sessionID)
     deps.sessionStatusRetryKeys.set(sessionID, "retry:1")
@@ -84,7 +84,7 @@ describe("createMessageUpdateHandler retry-key cleanup", () => {
       info: {
         sessionID,
         role: "assistant",
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
       },
     })
 

--- a/src/hooks/think-mode/index.test.ts
+++ b/src/hooks/think-mode/index.test.ts
@@ -67,7 +67,7 @@ describe("createThinkModeHook", () => {
     const input = createHookInput({
       sessionID,
       providerID: "github-copilot",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
     })
     const output = createHookOutput("ultrathink about this")
 

--- a/src/hooks/think-mode/switcher.test.ts
+++ b/src/hooks/think-mode/switcher.test.ts
@@ -46,8 +46,8 @@ describe("think-mode switcher", () => {
       })
 
       it("should handle dots in GPT version numbers", () => {
-        // given a GPT model ID with dot format (gpt-5.4)
-        const variant = getHighVariant("gpt-5.4")
+        // given a GPT model ID with dot format (gpt-5.5)
+        const variant = getHighVariant("gpt-5.5")
 
         // then should return high variant
         expect(variant).toBe("gpt-5-4-high")
@@ -103,7 +103,7 @@ describe("think-mode switcher", () => {
       // given base model IDs without -high suffix
       expect(isAlreadyHighVariant("claude-opus-4-7")).toBe(false)
       expect(isAlreadyHighVariant("claude-opus-4.7")).toBe(false)
-      expect(isAlreadyHighVariant("gpt-5.4")).toBe(false)
+      expect(isAlreadyHighVariant("gpt-5.5")).toBe(false)
       expect(isAlreadyHighVariant("gemini-3.1-pro")).toBe(false)
     })
 
@@ -125,7 +125,7 @@ describe("think-mode switcher", () => {
 
       it("should preserve openai/ prefix when getting high variant", () => {
         // given a model ID with openai/ prefix
-        const variant = getHighVariant("openai/gpt-5-4")
+        const variant = getHighVariant("openai/gpt-5-5")
 
         // then should return high variant with prefix preserved
         expect(variant).toBe("openai/gpt-5-4-high")
@@ -183,12 +183,12 @@ describe("think-mode switcher", () => {
       it("should return false for prefixed base models", () => {
         // given prefixed base model IDs without -high suffix
         expect(isAlreadyHighVariant("vertex_ai/claude-opus-4-7")).toBe(false)
-        expect(isAlreadyHighVariant("openai/gpt-5-4")).toBe(false)
+        expect(isAlreadyHighVariant("openai/gpt-5-5")).toBe(false)
       })
 
       it("should handle prefixed models with dots", () => {
         // given prefixed model IDs with dots
-        expect(isAlreadyHighVariant("vertex_ai/gpt-5.4")).toBe(false)
+        expect(isAlreadyHighVariant("vertex_ai/gpt-5.5")).toBe(false)
         expect(isAlreadyHighVariant("vertex_ai/gpt-5.4-high")).toBe(true)
       })
     })

--- a/src/hooks/think-mode/switcher.test.ts
+++ b/src/hooks/think-mode/switcher.test.ts
@@ -50,7 +50,7 @@ describe("think-mode switcher", () => {
         const variant = getHighVariant("gpt-5.5")
 
         // then should return high variant
-        expect(variant).toBe("gpt-5-4-high")
+        expect(variant).toBe("gpt-5-5-high")
       })
 
       it("should handle dots in GPT-5.1 codex variants", () => {
@@ -74,7 +74,7 @@ describe("think-mode switcher", () => {
       it("should return null for already-high variants", () => {
         // given model IDs that are already high variants
         expect(getHighVariant("claude-opus-4-7-high")).toBeNull()
-        expect(getHighVariant("gpt-5-4-high")).toBeNull()
+        expect(getHighVariant("gpt-5-5-high")).toBeNull()
         expect(getHighVariant("gemini-3-1-pro-high")).toBeNull()
       })
 
@@ -90,13 +90,13 @@ describe("think-mode switcher", () => {
     it("should detect -high suffix", () => {
       // given model IDs with -high suffix
       expect(isAlreadyHighVariant("claude-opus-4-7-high")).toBe(true)
-      expect(isAlreadyHighVariant("gpt-5-4-high")).toBe(true)
+      expect(isAlreadyHighVariant("gpt-5-5-high")).toBe(true)
       expect(isAlreadyHighVariant("gemini-3.1-pro-high")).toBe(true)
     })
 
     it("should detect -high suffix after normalization", () => {
       // given model IDs with dots that end in -high
-      expect(isAlreadyHighVariant("gpt-5.4-high")).toBe(true)
+      expect(isAlreadyHighVariant("gpt-5.5-high")).toBe(true)
     })
 
     it("should return false for base models", () => {
@@ -128,7 +128,7 @@ describe("think-mode switcher", () => {
         const variant = getHighVariant("openai/gpt-5-5")
 
         // then should return high variant with prefix preserved
-        expect(variant).toBe("openai/gpt-5-4-high")
+        expect(variant).toBe("openai/gpt-5-5-high")
       })
 
       it("should handle prefixes with dots in version numbers", () => {
@@ -176,7 +176,7 @@ describe("think-mode switcher", () => {
       it("should detect -high suffix in prefixed models", () => {
         // given prefixed model IDs with -high suffix
         expect(isAlreadyHighVariant("vertex_ai/claude-opus-4-7-high")).toBe(true)
-        expect(isAlreadyHighVariant("openai/gpt-5-4-high")).toBe(true)
+        expect(isAlreadyHighVariant("openai/gpt-5-5-high")).toBe(true)
         expect(isAlreadyHighVariant("custom/gemini-3.1-pro-high")).toBe(true)
       })
 
@@ -189,7 +189,7 @@ describe("think-mode switcher", () => {
       it("should handle prefixed models with dots", () => {
         // given prefixed model IDs with dots
         expect(isAlreadyHighVariant("vertex_ai/gpt-5.5")).toBe(false)
-        expect(isAlreadyHighVariant("vertex_ai/gpt-5.4-high")).toBe(true)
+        expect(isAlreadyHighVariant("vertex_ai/gpt-5.5-high")).toBe(true)
       })
     })
 })

--- a/src/hooks/think-mode/switcher.test.ts
+++ b/src/hooks/think-mode/switcher.test.ts
@@ -168,7 +168,7 @@ describe("think-mode switcher", () => {
       it("should return null for already-high prefixed models", () => {
         // given prefixed model IDs that are already high
         expect(getHighVariant("vertex_ai/claude-opus-4-7-high")).toBeNull()
-        expect(getHighVariant("openai/gpt-5-4-high")).toBeNull()
+        expect(getHighVariant("openai/gpt-5-5-high")).toBeNull()
       })
     })
 

--- a/src/hooks/think-mode/switcher.ts
+++ b/src/hooks/think-mode/switcher.ts
@@ -25,7 +25,7 @@ import { normalizeModelID } from "../../shared"
  * @example
  * extractModelPrefix("vertex_ai/claude-sonnet-4-6") // { prefix: "vertex_ai/", base: "claude-sonnet-4-6" }
  * extractModelPrefix("claude-sonnet-4-6") // { prefix: "", base: "claude-sonnet-4-6" }
- * extractModelPrefix("openai/gpt-5.4") // { prefix: "openai/", base: "gpt-5.4" }
+ * extractModelPrefix("openai/gpt-5.5") // { prefix: "openai/", base: "gpt-5.5" }
  * extractModelPrefix("aws/anthropic/claude-sonnet-4") // { prefix: "aws/anthropic/", base: "claude-sonnet-4" }
  */
 function extractModelPrefix(modelID: string): { prefix: string; base: string } {
@@ -62,8 +62,8 @@ const HIGH_VARIANT_MAP: Record<string, string> = {
   "gpt-5-1-codex": "gpt-5-1-codex-high",
   "gpt-5-1-codex-mini": "gpt-5-1-codex-mini-high",
   "gpt-5-1-codex-max": "gpt-5-1-codex-max-high",
-  // GPT-5.4
-  "gpt-5-4": "gpt-5-4-high",
+  // GPT-5.5
+  "gpt-5-5": "gpt-5-4-high",
   "gpt-5-4-chat-latest": "gpt-5-4-chat-latest-high",
   "gpt-5-4-pro": "gpt-5-4-pro-high",
   // Antigravity (Google)

--- a/src/hooks/think-mode/switcher.ts
+++ b/src/hooks/think-mode/switcher.ts
@@ -63,9 +63,9 @@ const HIGH_VARIANT_MAP: Record<string, string> = {
   "gpt-5-1-codex-mini": "gpt-5-1-codex-mini-high",
   "gpt-5-1-codex-max": "gpt-5-1-codex-max-high",
   // GPT-5.5
-  "gpt-5-5": "gpt-5-4-high",
-  "gpt-5-4-chat-latest": "gpt-5-4-chat-latest-high",
-  "gpt-5-4-pro": "gpt-5-4-pro-high",
+  "gpt-5-5": "gpt-5-5-high",
+  "gpt-5-5-chat-latest": "gpt-5-5-chat-latest-high",
+  "gpt-5-5-pro": "gpt-5-5-pro-high",
   // Antigravity (Google)
   "antigravity-gemini-3-1-pro": "antigravity-gemini-3-1-pro-high",
   "antigravity-gemini-3-flash": "antigravity-gemini-3-flash-high",

--- a/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -1567,8 +1567,8 @@ describe("todo-continuation-enforcer", () => {
 
     // OpenCode returns assistant messages with flat modelID/providerID, not nested model object
     const mockMessagesWithAssistant = [
-      { info: { id: "msg-1", role: "user", agent: "sisyphus", model: { providerID: "openai", modelID: "gpt-5.4" } } },
-      { info: { id: "msg-2", role: "assistant", agent: "sisyphus", modelID: "gpt-5.4", providerID: "openai" } },
+      { info: { id: "msg-1", role: "user", agent: "sisyphus", model: { providerID: "openai", modelID: "gpt-5.5" } } },
+      { info: { id: "msg-2", role: "assistant", agent: "sisyphus", modelID: "gpt-5.5", providerID: "openai" } },
     ]
 
     const mockInput = {
@@ -1612,7 +1612,7 @@ describe("todo-continuation-enforcer", () => {
 
      // then - model should be extracted from assistant message's flat modelID/providerID
      expect(promptCalls.length).toBe(1)
-     expect(promptCalls[0].model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+     expect(promptCalls[0].model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
   })
 
   // ============================================================
@@ -1736,7 +1736,7 @@ describe("todo-continuation-enforcer", () => {
     const mockMessagesWithCompactionMarker = [
       { info: { id: "msg-1", role: "assistant", agent: "sisyphus", modelID: "claude-sonnet-4-6", providerID: "anthropic" } },
       {
-        info: { id: "msg-2", role: "user", agent: "atlas", model: { providerID: "openai", modelID: "gpt-5.4" } },
+        info: { id: "msg-2", role: "user", agent: "atlas", model: { providerID: "openai", modelID: "gpt-5.5" } },
         parts: [{ type: "compaction" }],
       },
     ]

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -34,7 +34,7 @@ describe("mergeConfigs", () => {
       const base = createConfig({
         categories: {
           general: {
-            model: "openai/gpt-5.4",
+            model: "openai/gpt-5.5",
             temperature: 0.5,
           },
           quick: {
@@ -57,7 +57,7 @@ describe("mergeConfigs", () => {
       const result = mergeConfigs(base, override);
 
       // then general.model should be preserved from base
-      expect(result.categories?.general?.model).toBe("openai/gpt-5.4");
+      expect(result.categories?.general?.model).toBe("openai/gpt-5.5");
       // then general.temperature should be overridden
       expect(result.categories?.general?.temperature).toBe(0.3);
       // then quick should be preserved from base
@@ -70,7 +70,7 @@ describe("mergeConfigs", () => {
       const base = createConfig({
         categories: {
           general: {
-            model: "openai/gpt-5.4",
+            model: "openai/gpt-5.5",
           },
         },
       });
@@ -79,7 +79,7 @@ describe("mergeConfigs", () => {
 
       const result = mergeConfigs(base, override);
 
-      expect(result.categories?.general?.model).toBe("openai/gpt-5.4");
+      expect(result.categories?.general?.model).toBe("openai/gpt-5.5");
     });
 
     it("should use override categories when base has no categories", () => {
@@ -88,14 +88,14 @@ describe("mergeConfigs", () => {
       const override = createConfig({
         categories: {
           general: {
-            model: "openai/gpt-5.4",
+            model: "openai/gpt-5.5",
           },
         },
       });
 
       const result = mergeConfigs(base, override);
 
-      expect(result.categories?.general?.model).toBe("openai/gpt-5.4");
+      expect(result.categories?.general?.model).toBe("openai/gpt-5.5");
     });
   });
 
@@ -184,7 +184,7 @@ describe("parseConfigPartially", () => {
       const rawConfig = {
         agents: {
           oracle: { model: "openai/gpt-5.5" },
-          momus: { model: "openai/gpt-5.4" },
+          momus: { model: "openai/gpt-5.5" },
         },
         disabled_hooks: ["comment-checker"],
       };
@@ -193,7 +193,7 @@ describe("parseConfigPartially", () => {
 
       expect(result).not.toBeNull();
       expect(result!.agents?.oracle).toMatchObject({ model: "openai/gpt-5.5" });
-      expect(result!.agents?.momus).toMatchObject({ model: "openai/gpt-5.4" });
+      expect(result!.agents?.momus).toMatchObject({ model: "openai/gpt-5.5" });
       expect(result!.disabled_hooks).toEqual(["comment-checker"]);
     });
   });
@@ -207,7 +207,7 @@ describe("parseConfigPartially", () => {
       const rawConfig = {
         agents: {
           oracle: { model: "openai/gpt-5.5" },
-          momus: { model: "openai/gpt-5.4" },
+          momus: { model: "openai/gpt-5.5" },
           prometheus: {
             permission: {
               edit: { "*": "ask", ".sisyphus/**": "allow" },

--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -89,7 +89,7 @@ describe("applyAgentConfig builtin override protection", () => {
     name: "atlas",
     prompt: "atlas prompt",
     mode: "all",
-    model: "openai/gpt-5.4",
+    model: "openai/gpt-5.5",
   }
 
   const sisyphusJuniorConfig: AgentConfig = {
@@ -332,7 +332,7 @@ describe("applyAgentConfig builtin override protection", () => {
     })
 
     // then
-    expect(createSisyphusJuniorAgentSpy).toHaveBeenCalledWith(undefined, "openai/gpt-5.4", false)
+    expect(createSisyphusJuniorAgentSpy).toHaveBeenCalledWith(undefined, "openai/gpt-5.5", false)
   })
 
   test("defaults mode to subagent for configAgent entries missing mode", async () => {

--- a/src/plugin-handlers/config-handler.test.ts
+++ b/src/plugin-handlers/config-handler.test.ts
@@ -750,7 +750,7 @@ describe("Prometheus category config resolution", () => {
 
     // then
     expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.4")
+    expect(config?.model).toBe("openai/gpt-5.5")
     expect(config?.variant).toBe("xhigh")
   })
 
@@ -810,7 +810,7 @@ describe("Prometheus category config resolution", () => {
 
     // then - falls back to DEFAULT_CATEGORIES
     expect(config).toBeDefined()
-    expect(config?.model).toBe("openai/gpt-5.4")
+    expect(config?.model).toBe("openai/gpt-5.5")
     expect(config?.variant).toBe("xhigh")
   })
 
@@ -849,7 +849,7 @@ describe("Prometheus direct override priority over category", () => {
       },
       categories: {
         "test-planning": {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
           reasoningEffort: "xhigh",
         },
       },
@@ -891,7 +891,7 @@ describe("Prometheus direct override priority over category", () => {
       },
       categories: {
         "reasoning-cat": {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
           reasoningEffort: "high",
         },
       },
@@ -932,7 +932,7 @@ describe("Prometheus direct override priority over category", () => {
       },
       categories: {
         "temp-cat": {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
           temperature: 0.8,
         },
       },
@@ -1055,7 +1055,7 @@ describe("Plan agent model inheritance from prometheus", () => {
   test("plan agent inherits temperature, reasoningEffort, and other model settings from prometheus", async () => {
     //#given - prometheus configured with category that has temperature and reasoningEffort
     spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
-      model: "openai/gpt-5.4",
+      model: "openai/gpt-5.5",
       provenance: "override",
       variant: "high",
     })
@@ -1066,7 +1066,7 @@ describe("Plan agent model inheritance from prometheus", () => {
       },
       agents: {
         prometheus: {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
           variant: "high",
           temperature: 0.3,
           top_p: 0.9,
@@ -1097,7 +1097,7 @@ describe("Plan agent model inheritance from prometheus", () => {
     const agents = config.agent as Record<string, Record<string, unknown>>
     expect(agents.plan).toBeDefined()
     expect(agents.plan.mode).toBe("subagent")
-    expect(agents.plan.model).toBe("openai/gpt-5.4")
+    expect(agents.plan.model).toBe("openai/gpt-5.5")
     expect(agents.plan.variant).toBe("high")
     expect(agents.plan.temperature).toBe(0.3)
     expect(agents.plan.top_p).toBe(0.9)
@@ -1108,7 +1108,7 @@ describe("Plan agent model inheritance from prometheus", () => {
   })
 
   test("plan agent user override takes priority over prometheus inherited settings", async () => {
-    //#given - prometheus resolves to opus, but user has plan override for gpt-5.4
+    //#given - prometheus resolves to opus, but user has plan override for gpt-5.5
     spyOn(shared, "resolveModelPipeline" as any).mockReturnValue({
       model: "anthropic/claude-opus-4-7",
       provenance: "provider-fallback",
@@ -1121,7 +1121,7 @@ describe("Plan agent model inheritance from prometheus", () => {
       },
       agents: {
         plan: {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
           variant: "high",
           temperature: 0.5,
         },
@@ -1145,7 +1145,7 @@ describe("Plan agent model inheritance from prometheus", () => {
 
     //#then - plan uses its own override, not prometheus settings
     const agents = config.agent as Record<string, Record<string, unknown>>
-    expect(agents.plan.model).toBe("openai/gpt-5.4")
+    expect(agents.plan.model).toBe("openai/gpt-5.5")
     expect(agents.plan.variant).toBe("high")
     expect(agents.plan.temperature).toBe(0.5)
   })

--- a/src/plugin-handlers/plan-model-inheritance.test.ts
+++ b/src/plugin-handlers/plan-model-inheritance.test.ts
@@ -64,7 +64,7 @@ describe("buildPlanDemoteConfig", () => {
       reasoningEffort: "high",
     }
     const planOverride = {
-      model: "openai/gpt-5.4",
+      model: "openai/gpt-5.5",
       variant: "high",
       temperature: 0.5,
       reasoningEffort: "low",
@@ -74,7 +74,7 @@ describe("buildPlanDemoteConfig", () => {
     const result = buildPlanDemoteConfig(prometheusConfig, planOverride)
 
     //#then
-    expect(result.model).toBe("openai/gpt-5.4")
+    expect(result.model).toBe("openai/gpt-5.5")
     expect(result.variant).toBe("high")
     expect(result.temperature).toBe(0.5)
     expect(result.reasoningEffort).toBe("low")
@@ -89,14 +89,14 @@ describe("buildPlanDemoteConfig", () => {
       reasoningEffort: "high",
     }
     const planOverride = {
-      model: "openai/gpt-5.4",
+      model: "openai/gpt-5.5",
     }
 
     //#when
     const result = buildPlanDemoteConfig(prometheusConfig, planOverride)
 
     //#then - plan model wins, rest inherits from prometheus
-    expect(result.model).toBe("openai/gpt-5.4")
+    expect(result.model).toBe("openai/gpt-5.5")
     expect(result.variant).toBe("max")
     expect(result.temperature).toBe(0.1)
     expect(result.reasoningEffort).toBe("high")

--- a/src/plugin-handlers/prometheus-agent-config-builder.test.ts
+++ b/src/plugin-handlers/prometheus-agent-config-builder.test.ts
@@ -42,7 +42,7 @@ describe("buildPrometheusAgentConfig", () => {
     describe("#when currentModel is NOT in Prometheus fallback chain", () => {
       test("falls through to fallback chain instead of using currentModel as override", async () => {
         // given - currentModel is a model NOT in Prometheus fallback chain
-        // Prometheus chain: claude-opus-4-7, gpt-5.4, glm-5, gemini-3.1-pro
+        // Prometheus chain: claude-opus-4-7, gpt-5.5, glm-5, gemini-3.1-pro
         const currentModel = "some-provider/gpt-5.3-codex";
 
         // when
@@ -93,12 +93,12 @@ describe("buildPrometheusAgentConfig", () => {
         );
       });
 
-      test("accepts gpt-5.4 from fallback chain", async () => {
+      test("accepts gpt-5.5 from fallback chain", async () => {
         const result = await buildPrometheusAgentConfig({
           configAgentPlan: undefined,
           pluginPrometheusOverride: undefined,
           userCategories: undefined,
-          currentModel: "openai/gpt-5.4",
+          currentModel: "openai/gpt-5.5",
         });
         expect(result).toBeDefined();
       });

--- a/src/plugin/chat-message.test.ts
+++ b/src/plugin/chat-message.test.ts
@@ -111,7 +111,7 @@ describe("createChatMessageHandler - cache warning behavior", () => {
     mkdirSync(getOmoOpenCodeCacheDir(), { recursive: true })
     writeFileSync(providerModelsCachePath, JSON.stringify({
       models: {
-        openai: [{ id: "gpt-5.4" }],
+        openai: [{ id: "gpt-5.5" }],
       },
       connected: ["openai"],
       updatedAt: new Date().toISOString(),
@@ -145,7 +145,7 @@ describe("createChatMessageHandler - cache warning behavior", () => {
       openai: {
         id: "openai",
         models: {
-          "gpt-5.4": { id: "gpt-5.4" },
+          "gpt-5.5": { id: "gpt-5.5" },
         },
       },
     }))
@@ -650,7 +650,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
   test("reuses the stored model for subsequent messages in the main session when the UI sends none", async () => {
     //#given
     setMainSession("test-session")
-    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" })
+    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.5" })
     const args = createMockHandlerArgs({ shouldOverride: false })
     const handler = createChatMessageHandler(args)
     const input = createMockInput("sisyphus")
@@ -660,14 +660,14 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
     await handler(input, output)
 
     //#then
-    expect(output.message["model"]).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
-    expect(getSessionModel("test-session")).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+    expect(output.message["model"]).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+    expect(getSessionModel("test-session")).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
   })
 
   test("does not reuse a stored model for the first message of a session", async () => {
     //#given
     setMainSession("test-session")
-    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" })
+    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.5" })
     const args = createMockHandlerArgs({ shouldOverride: true })
     const handler = createChatMessageHandler(args)
     const input = createMockInput("sisyphus")
@@ -683,7 +683,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
   test("does not reuse the main-session model for subagent sessions", async () => {
     //#given
     setMainSession("main-session")
-    setSessionModel("main-session", { providerID: "openai", modelID: "gpt-5.4" })
+    setSessionModel("main-session", { providerID: "openai", modelID: "gpt-5.5" })
     subagentSessions.add("subagent-session")
     const args = createMockHandlerArgs({ shouldOverride: false })
     const handler = createChatMessageHandler(args)
@@ -704,7 +704,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
   test("does not override explicit agent model overrides with stored session model", async () => {
     //#given
     setMainSession("test-session")
-    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" })
+    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.5" })
     const args = createMockHandlerArgs({
       shouldOverride: false,
       pluginConfig: {
@@ -722,13 +722,13 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
 
     //#then
     expect(output.message["model"]).toBeUndefined()
-    expect(getSessionModel("test-session")).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+    expect(getSessionModel("test-session")).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
   })
 
   test("treats prefixed list-display agent names as explicit model overrides", async () => {
     //#given
     setMainSession("test-session")
-    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.4" })
+    setSessionModel("test-session", { providerID: "openai", modelID: "gpt-5.5" })
     const args = createMockHandlerArgs({
       shouldOverride: false,
       pluginConfig: {
@@ -746,7 +746,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
 
     //#then
     expect(output.message["model"]).toBeUndefined()
-    expect(getSessionModel("test-session")).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+    expect(getSessionModel("test-session")).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
     expect(getSessionAgent("test-session")).toBe("Prometheus - Plan Builder")
   })
 
@@ -756,7 +756,7 @@ describe("createChatMessageHandler - TUI variant passthrough", () => {
     setSessionModel("test-session", { providerID: "anthropic", modelID: "claude-opus-4-7" })
     const args = createMockHandlerArgs({ shouldOverride: false })
     const handler = createChatMessageHandler(args)
-    const nextModel = { providerID: "openai", modelID: "gpt-5.4" }
+    const nextModel = { providerID: "openai", modelID: "gpt-5.5" }
     const input = createMockInput("sisyphus", nextModel)
     const output = createMockOutput()
 

--- a/src/plugin/chat-params.test.ts
+++ b/src/plugin/chat-params.test.ts
@@ -106,8 +106,8 @@ describe("createChatParamsHandler", () => {
       models: {
         openai: [
           {
-            id: "gpt-5.4",
-            name: "GPT-5.4",
+            id: "gpt-5.5",
+            name: "GPT-5.5",
             temperature: true,
             reasoning: true,
             variants: {
@@ -137,7 +137,7 @@ describe("createChatParamsHandler", () => {
     const input = {
       sessionID: "ses_chat_params_temperature",
       agent: { name: "oracle" },
-      model: { providerID: "openai", modelID: "gpt-5.4" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
       provider: { id: "openai" },
       message: {},
     }
@@ -175,7 +175,7 @@ describe("createChatParamsHandler", () => {
     })
   })
 
-  test("drops gpt-5.4 temperature and clamps maxOutputTokens from bundled model capabilities", async () => {
+  test("drops gpt-5.5 temperature and clamps maxOutputTokens from bundled model capabilities", async () => {
     //#given
     setSessionPromptParams("ses_chat_params_temperature", {
       temperature: 0.7,
@@ -189,7 +189,7 @@ describe("createChatParamsHandler", () => {
     const input = {
       sessionID: "ses_chat_params_temperature",
       agent: { name: "oracle" },
-      model: { providerID: "openai", modelID: "gpt-5.4" },
+      model: { providerID: "openai", modelID: "gpt-5.5" },
       provider: { id: "openai" },
       message: {},
     }

--- a/src/plugin/fallback.cliproxyapi-matrix.test.ts
+++ b/src/plugin/fallback.cliproxyapi-matrix.test.ts
@@ -70,7 +70,7 @@ const FIRST_FALLBACK_MODEL = {
 
 const CLIPROXYAPI_FALLBACKS = [
   `${PROVIDER_ID}/claude-sonnet-4-6`,
-  `${PROVIDER_ID}/gpt-5.4`,
+  `${PROVIDER_ID}/gpt-5.5`,
   `${PROVIDER_ID}/kimi-k2.5`,
 ]
 

--- a/src/shared/agent-config-integration.test.ts
+++ b/src/shared/agent-config-integration.test.ts
@@ -45,7 +45,7 @@ describe("Agent Config Integration", () => {
       // given - config with lowercase keys
       const config = {
         sisyphus: { model: "anthropic/claude-opus-4-7" },
-        oracle: { model: "openai/gpt-5.4" },
+        oracle: { model: "openai/gpt-5.5" },
         librarian: { model: "opencode/big-pickle" },
       }
 
@@ -63,7 +63,7 @@ describe("Agent Config Integration", () => {
       // given - config with mixed old and new format
       const mixedConfig = {
         Sisyphus: { model: "anthropic/claude-opus-4-7" },
-        oracle: { model: "openai/gpt-5.4" },
+        oracle: { model: "openai/gpt-5.5" },
         "Prometheus - Plan Builder": { model: "anthropic/claude-opus-4-7" },
         librarian: { model: "opencode/big-pickle" },
       }

--- a/src/shared/agent-variant.test.ts
+++ b/src/shared/agent-variant.test.ts
@@ -36,7 +36,7 @@ describe("resolveAgentVariant", () => {
         sisyphus: { category: "ultrabrain" },
       },
       categories: {
-        ultrabrain: { model: "openai/gpt-5.4", variant: "xhigh" },
+        ultrabrain: { model: "openai/gpt-5.5", variant: "xhigh" },
       },
     } as OhMyOpenCodeConfig
 
@@ -124,10 +124,10 @@ describe("resolveVariantForModel", () => {
     expect(variant).toBe("medium")
   })
 
-  test("returns medium for openai/gpt-5.4 in sisyphus chain", () => {
-    // #given openai/gpt-5.4 is now in sisyphus fallback chain with variant medium
+  test("returns medium for openai/gpt-5.5 in sisyphus chain", () => {
+    // #given openai/gpt-5.5 is now in sisyphus fallback chain with variant medium
     const config = {} as OhMyOpenCodeConfig
-    const model = { providerID: "openai", modelID: "gpt-5.4" }
+    const model = { providerID: "openai", modelID: "gpt-5.5" }
 
     // when
     const variant = resolveVariantForModel(config, "sisyphus", model)
@@ -179,7 +179,7 @@ describe("resolveVariantForModel", () => {
         "custom-agent": { category: "ultrabrain" },
       },
     } as OhMyOpenCodeConfig
-    const model = { providerID: "openai", modelID: "gpt-5.4" }
+    const model = { providerID: "openai", modelID: "gpt-5.5" }
 
     // when
     const variant = resolveVariantForModel(config, "custom-agent", model)

--- a/src/shared/connected-providers-cache.test.ts
+++ b/src/shared/connected-providers-cache.test.ts
@@ -53,7 +53,7 @@ describe("updateConnectedProvidersCache", () => {
 									env: [],
 									models: {
 										"gpt-5.3-codex": { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
-										"gpt-5.4": { id: "gpt-5.4", name: "GPT-5.4" },
+										"gpt-5.5": { id: "gpt-5.5", name: "GPT-5.5" },
 									},
 								},
 								{
@@ -81,7 +81,7 @@ describe("updateConnectedProvidersCache", () => {
 			expect(cache!.models).toEqual({
 				openai: [
 					{ id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
-					{ id: "gpt-5.4", name: "GPT-5.4" },
+					{ id: "gpt-5.5", name: "GPT-5.5" },
 				],
 				anthropic: [
 					{ id: "claude-opus-4-7", name: "Claude Opus 4.7" },
@@ -195,7 +195,7 @@ describe("updateConnectedProvidersCache", () => {
 							{
 								id: "openai",
 								models: {
-									"gpt-5.4": { id: "gpt-5.4" },
+									"gpt-5.5": { id: "gpt-5.5" },
 								},
 							},
 						],
@@ -238,9 +238,9 @@ describe("updateConnectedProvidersCache", () => {
 								{
 									id: "openai",
 									models: {
-										"gpt-5.4": {
-											id: "gpt-5.4",
-											name: "GPT-5.4",
+										"gpt-5.5": {
+											id: "gpt-5.5",
+											name: "GPT-5.5",
 											temperature: false,
 											variants: {
 												low: {},
@@ -260,12 +260,12 @@ describe("updateConnectedProvidersCache", () => {
 			const cache = testCacheStore.readProviderModelsCache()
 
 			//#when
-			const result = findProviderModelMetadata("openai", "gpt-5.4", cache)
+			const result = findProviderModelMetadata("openai", "gpt-5.5", cache)
 
 			//#then
 			expect(result).toEqual({
-				id: "gpt-5.4",
-				name: "GPT-5.4",
+				id: "gpt-5.5",
+				name: "GPT-5.5",
 				temperature: false,
 				variants: {
 					low: {},

--- a/src/shared/fallback-chain-from-models.test.ts
+++ b/src/shared/fallback-chain-from-models.test.ts
@@ -89,19 +89,19 @@ describe("parseFallbackModelEntry (extended)", () => {
   })
 
   it("parses model with space variant", () => {
-    const result = parseFallbackModelEntry("openai/gpt-5.4 xhigh", undefined)
+    const result = parseFallbackModelEntry("openai/gpt-5.5 xhigh", undefined)
     expect(result).toEqual({
       providers: ["openai"],
-      model: "gpt-5.4",
+      model: "gpt-5.5",
       variant: "xhigh",
     })
   })
 
   it("parses model with minimal space variant", () => {
-    const result = parseFallbackModelEntry("openai/gpt-5.4 minimal", undefined)
+    const result = parseFallbackModelEntry("openai/gpt-5.5 minimal", undefined)
     expect(result).toEqual({
       providers: ["openai"],
-      model: "gpt-5.4",
+      model: "gpt-5.5",
       variant: "minimal",
     })
   })
@@ -159,7 +159,7 @@ describe("parseFallbackModelObjectEntry", () => {
   it("carries reasoningEffort and temperature", () => {
     const result = parseFallbackModelObjectEntry(
       {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         variant: "high",
         reasoningEffort: "high",
         temperature: 0.5,
@@ -168,7 +168,7 @@ describe("parseFallbackModelObjectEntry", () => {
     )
     expect(result).toEqual({
       providers: ["openai"],
-      model: "gpt-5.4",
+      model: "gpt-5.5",
       variant: "high",
       reasoningEffort: "high",
       temperature: 0.5,
@@ -193,7 +193,7 @@ describe("parseFallbackModelObjectEntry", () => {
   it("carries all optional fields", () => {
     const result = parseFallbackModelObjectEntry(
       {
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
         variant: "xhigh",
         reasoningEffort: "xhigh",
         temperature: 0.3,
@@ -205,7 +205,7 @@ describe("parseFallbackModelObjectEntry", () => {
     )
     expect(result).toEqual({
       providers: ["openai"],
-      model: "gpt-5.4",
+      model: "gpt-5.5",
       variant: "xhigh",
       reasoningEffort: "xhigh",
       temperature: 0.3,
@@ -226,12 +226,12 @@ describe("buildFallbackChainFromModels (mixed)", () => {
 
   it("handles string array", () => {
     const result = buildFallbackChainFromModels(
-      ["anthropic/claude-sonnet-4-6", "openai/gpt-5.4"],
+      ["anthropic/claude-sonnet-4-6", "openai/gpt-5.5"],
       undefined,
     )
     expect(result).toEqual([
       { providers: ["anthropic"], model: "claude-sonnet-4-6" },
-      { providers: ["openai"], model: "gpt-5.4" },
+      { providers: ["openai"], model: "gpt-5.5" },
     ])
   })
 
@@ -239,7 +239,7 @@ describe("buildFallbackChainFromModels (mixed)", () => {
     const result = buildFallbackChainFromModels(
       [
         { model: "anthropic/claude-sonnet-4-6", variant: "high", reasoningEffort: "high" },
-        { model: "openai/gpt-5.4", reasoningEffort: "xhigh" },
+        { model: "openai/gpt-5.5", reasoningEffort: "xhigh" },
         "chutes/kimi-k2.5",
         { model: "chutes/glm-5", temperature: 0.7 },
         "google/gemini-3-flash",
@@ -248,7 +248,7 @@ describe("buildFallbackChainFromModels (mixed)", () => {
     )
     expect(result).toEqual([
       { providers: ["anthropic"], model: "claude-sonnet-4-6", variant: "high", reasoningEffort: "high" },
-      { providers: ["openai"], model: "gpt-5.4", reasoningEffort: "xhigh" },
+      { providers: ["openai"], model: "gpt-5.5", reasoningEffort: "xhigh" },
       { providers: ["chutes"], model: "kimi-k2.5" },
       { providers: ["chutes"], model: "glm-5", temperature: 0.7 },
       { providers: ["google"], model: "gemini-3-flash" },
@@ -302,36 +302,36 @@ describe("flattenToFallbackModelStrings", () => {
 
   it("explicit variant overrides space-suffix variant", () => {
     expect(flattenToFallbackModelStrings([
-      { model: "openai/gpt-5.4 high", variant: "low" },
-    ])).toEqual(["openai/gpt-5.4(low)"])
+      { model: "openai/gpt-5.5 high", variant: "low" },
+    ])).toEqual(["openai/gpt-5.5(low)"])
   })
 
   it("explicit variant overrides minimal space-suffix variant", () => {
     expect(flattenToFallbackModelStrings([
-      { model: "openai/gpt-5.4 minimal", variant: "low" },
-    ])).toEqual(["openai/gpt-5.4(low)"])
+      { model: "openai/gpt-5.5 minimal", variant: "low" },
+    ])).toEqual(["openai/gpt-5.5(low)"])
   })
 
   it("preserves trailing non-variant suffixes when adding explicit variant", () => {
     expect(flattenToFallbackModelStrings([
-      { model: "openai/gpt-5.4 preview", variant: "low" },
-    ])).toEqual(["openai/gpt-5.4 preview(low)"])
+      { model: "openai/gpt-5.5 preview", variant: "low" },
+    ])).toEqual(["openai/gpt-5.5 preview(low)"])
   })
 
   it("flattens object without variant", () => {
     expect(flattenToFallbackModelStrings([
-      { model: "openai/gpt-5.4" },
-    ])).toEqual(["openai/gpt-5.4"])
+      { model: "openai/gpt-5.5" },
+    ])).toEqual(["openai/gpt-5.5"])
   })
 
   it("handles mixed array", () => {
     expect(flattenToFallbackModelStrings([
       "anthropic/claude-sonnet-4-6",
-      { model: "openai/gpt-5.4", variant: "high" },
+      { model: "openai/gpt-5.5", variant: "high" },
       { model: "google/gemini-3-flash(low)" },
     ])).toEqual([
       "anthropic/claude-sonnet-4-6",
-      "openai/gpt-5.4(high)",
+      "openai/gpt-5.5(high)",
       "google/gemini-3-flash(low)",
     ])
   })
@@ -359,7 +359,7 @@ describe("findMostSpecificFallbackEntry", () => {
     const chain = [
       { providers: ["anthropic"], model: "claude-sonnet-4-6" },
     ]
-    expect(findMostSpecificFallbackEntry("openai", "gpt-5.4", chain)).toBeUndefined()
+    expect(findMostSpecificFallbackEntry("openai", "gpt-5.5", chain)).toBeUndefined()
   })
 
   it("sorts by matched prefix length, not insertion order", () => {
@@ -383,7 +383,7 @@ describe("findMostSpecificFallbackEntry", () => {
 
   it("preserves variant and settings from matched entry", () => {
     const chain = [
-      { providers: ["openai"], model: "gpt-5.4", variant: "high", temperature: 0.7 },
+      { providers: ["openai"], model: "gpt-5.5", variant: "high", temperature: 0.7 },
       { providers: ["openai"], model: "gpt-5.4-preview", variant: "low", reasoningEffort: "medium" },
     ]
     const result = findMostSpecificFallbackEntry("openai", "gpt-5.4-preview", chain)

--- a/src/shared/fallback-chain-from-models.ts
+++ b/src/shared/fallback-chain-from-models.ts
@@ -75,7 +75,7 @@ export function parseFallbackModelObjectEntry(
  * Find the most specific FallbackEntry whose `provider/model` is a prefix of
  * the resolved `provider/modelID`.  Longest match wins so that e.g.
  * `openai/gpt-5.4-preview` picks the entry for `openai/gpt-5.4-preview` over
- * the shorter `openai/gpt-5.4`.
+ * the shorter `openai/gpt-5.5`.
  */
 export function findMostSpecificFallbackEntry(
   providerID: string,

--- a/src/shared/jsonc-parser.test.ts
+++ b/src/shared/jsonc-parser.test.ts
@@ -105,7 +105,7 @@ describe("parseJsonc", () => {
     const jsonc = `{
       // This is an example config
       "agents": {
-        "oracle": { "model": "openai/gpt-5.4" }, // GPT for strategic reasoning
+        "oracle": { "model": "openai/gpt-5.5" }, // GPT for strategic reasoning
       },
       /* Agent overrides */
       "disabled_agents": [],
@@ -118,7 +118,7 @@ describe("parseJsonc", () => {
     }>(jsonc)
 
     // then
-    expect(result.agents.oracle.model).toBe("openai/gpt-5.4")
+    expect(result.agents.oracle.model).toBe("openai/gpt-5.5")
     expect(result.disabled_agents).toEqual([])
   })
 

--- a/src/shared/merge-categories.test.ts
+++ b/src/shared/merge-categories.test.ts
@@ -44,7 +44,7 @@ describe("mergeCategories", () => {
   it("allows user to add custom categories", () => {
     //#given
     const userCategories = {
-      "my-custom": { model: "openai/gpt-5.4", description: "Custom category" },
+      "my-custom": { model: "openai/gpt-5.5", description: "Custom category" },
     }
 
     //#when
@@ -52,13 +52,13 @@ describe("mergeCategories", () => {
 
     //#then
     expect(result["my-custom"]).toBeDefined()
-    expect(result["my-custom"].model).toBe("openai/gpt-5.4")
+    expect(result["my-custom"].model).toBe("openai/gpt-5.5")
   })
 
   it("allows user to disable custom categories", () => {
     //#given
     const userCategories = {
-      "my-custom": { model: "openai/gpt-5.4", disable: true },
+      "my-custom": { model: "openai/gpt-5.5", disable: true },
     }
 
     //#when

--- a/src/shared/migration.test.ts
+++ b/src/shared/migration.test.ts
@@ -59,7 +59,7 @@ describe("migrateAgentNames", () => {
     const agents = {
       SISYPHUS: { model: "test" },
       "planner-sisyphus": { prompt: "test" },
-      "Orchestrator-Sisyphus": { model: "openai/gpt-5.4" },
+      "Orchestrator-Sisyphus": { model: "openai/gpt-5.5" },
     }
 
     // when: Migrate agent names
@@ -68,7 +68,7 @@ describe("migrateAgentNames", () => {
     // then: Case-insensitive lookup should migrate correctly
     expect(migrated["sisyphus"]).toEqual({ model: "test" })
     expect(migrated["prometheus"]).toEqual({ prompt: "test" })
-    expect(migrated["atlas"]).toEqual({ model: "openai/gpt-5.4" })
+    expect(migrated["atlas"]).toEqual({ model: "openai/gpt-5.5" })
   })
 
   test("passes through unknown agent names unchanged", () => {
@@ -578,10 +578,10 @@ describe("MODEL_VERSION_MAP", () => {
     expect(MODEL_VERSION_MAP["anthropic/claude-opus-4-5"]).toBe("anthropic/claude-opus-4-7")
   })
 
-  test("maps openai/gpt-5.3-codex to openai/gpt-5.4 for deep category migration", () => {
+  test("maps openai/gpt-5.3-codex to openai/gpt-5.5 for deep category migration", () => {
     // given/when: Check MODEL_VERSION_MAP
-    // then: gpt-5.3-codex should migrate to gpt-5.4
-    expect(MODEL_VERSION_MAP["openai/gpt-5.3-codex"]).toBe("openai/gpt-5.4")
+    // then: gpt-5.3-codex should migrate to gpt-5.5
+    expect(MODEL_VERSION_MAP["openai/gpt-5.3-codex"]).toBe("openai/gpt-5.5")
   })
 })
 
@@ -888,7 +888,7 @@ describe("migrateAgentConfigToCategory", () => {
     const configs = [
       { model: "google/gemini-3.1-pro" },
       { model: "google/gemini-3-flash" },
-      { model: "openai/gpt-5.4" },
+      { model: "openai/gpt-5.5" },
       { model: "anthropic/claude-haiku-4-5" },
       { model: "anthropic/claude-opus-4-7" },
       { model: "anthropic/claude-sonnet-4-6" },
@@ -910,7 +910,7 @@ describe("migrateAgentConfigToCategory", () => {
   test("preserves non-model fields during migration", () => {
     // given: Config with multiple fields
     const config = {
-      model: "openai/gpt-5.4",
+      model: "openai/gpt-5.5",
       temperature: 0.1,
       top_p: 0.95,
       maxTokens: 4096,
@@ -1345,14 +1345,14 @@ describe("migrateConfigFile with migration tracking via sidecar (#3263)", () => 
 
   test("skips re-applying a migration that is recorded in the sidecar even if the user edited _migrations away", () => {
     // This is the core #3263 regression: a user auto-migrated from
-    // gpt-5.3-codex to gpt-5.4, reverted to gpt-5.3-codex by hand, and
+    // gpt-5.3-codex to gpt-5.5, reverted to gpt-5.3-codex by hand, and
     // deleted _migrations in the process. Without the sidecar their
     // revert was clobbered on every startup.
     const testConfigPath = tempConfigPath("sidecar-revert")
     fs.writeFileSync(
       sidecarPath(testConfigPath),
       JSON.stringify({
-        appliedMigrations: ["model-version:openai/gpt-5.3-codex->openai/gpt-5.4"],
+        appliedMigrations: ["model-version:openai/gpt-5.3-codex->openai/gpt-5.5"],
       }),
     )
     const rawConfig: Record<string, unknown> = {
@@ -1380,7 +1380,7 @@ describe("migrateConfigFile with migration tracking via sidecar (#3263)", () => 
       agents: {
         oracle: { model: "openai/gpt-5.3-codex" },
       },
-      _migrations: ["model-version:openai/gpt-5.3-codex->openai/gpt-5.4"],
+      _migrations: ["model-version:openai/gpt-5.3-codex->openai/gpt-5.5"],
     }
     fs.writeFileSync(testConfigPath, JSON.stringify(rawConfig, null, 2))
 
@@ -1393,7 +1393,7 @@ describe("migrateConfigFile with migration tracking via sidecar (#3263)", () => 
 
     const sidecar = JSON.parse(fs.readFileSync(sidecarPath(testConfigPath), "utf-8"))
     expect(sidecar.appliedMigrations).toEqual([
-      "model-version:openai/gpt-5.3-codex->openai/gpt-5.4",
+      "model-version:openai/gpt-5.3-codex->openai/gpt-5.5",
     ])
   })
 
@@ -1407,7 +1407,7 @@ describe("migrateConfigFile with migration tracking via sidecar (#3263)", () => 
       sidecarPath(testConfigPath),
       JSON.stringify({
         appliedMigrations: [
-          "model-version:openai/gpt-5.3-codex->openai/gpt-5.4",
+          "model-version:openai/gpt-5.3-codex->openai/gpt-5.5",
           "model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-7",
         ],
       }),
@@ -1431,7 +1431,7 @@ describe("migrateConfigFile with migration tracking via sidecar (#3263)", () => 
     const sidecar = JSON.parse(fs.readFileSync(sidecarPath(testConfigPath), "utf-8"))
     expect(sidecar.appliedMigrations).toEqual([
       "model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-7",
-      "model-version:openai/gpt-5.3-codex->openai/gpt-5.4",
+      "model-version:openai/gpt-5.3-codex->openai/gpt-5.5",
     ])
   })
 
@@ -1443,7 +1443,7 @@ describe("migrateConfigFile with migration tracking via sidecar (#3263)", () => 
     fs.writeFileSync(
       sidecarPath(testConfigPath),
       JSON.stringify({
-        appliedMigrations: ["model-version:openai/gpt-5.3-codex->openai/gpt-5.4"],
+        appliedMigrations: ["model-version:openai/gpt-5.3-codex->openai/gpt-5.5"],
       }),
     )
     const rawConfig: Record<string, unknown> = {
@@ -1465,7 +1465,7 @@ describe("migrateConfigFile with migration tracking via sidecar (#3263)", () => 
 
     const sidecar = JSON.parse(fs.readFileSync(sidecarPath(testConfigPath), "utf-8"))
     expect(new Set(sidecar.appliedMigrations)).toEqual(new Set([
-      "model-version:openai/gpt-5.3-codex->openai/gpt-5.4",
+      "model-version:openai/gpt-5.3-codex->openai/gpt-5.5",
       "model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-7",
     ]))
   })
@@ -1477,7 +1477,7 @@ describe("migrateConfigFile with migration tracking via sidecar (#3263)", () => 
       agents: {
         oracle: { model: "anthropic/claude-opus-4-5" },
       },
-      _migrations: ["model-version:openai/gpt-5.3-codex->openai/gpt-5.4"],
+      _migrations: ["model-version:openai/gpt-5.3-codex->openai/gpt-5.5"],
     }
     fs.writeFileSync(testConfigPath, JSON.stringify(rawConfig, null, 2))
 
@@ -1492,7 +1492,7 @@ describe("migrateConfigFile with migration tracking via sidecar (#3263)", () => 
     expect(needsWrite).toBe(true)
     const migrations = rawConfig._migrations as string[]
     expect(Array.isArray(migrations)).toBe(true)
-    expect(migrations).toContain("model-version:openai/gpt-5.3-codex->openai/gpt-5.4")
+    expect(migrations).toContain("model-version:openai/gpt-5.3-codex->openai/gpt-5.5")
     expect(migrations.length).toBeGreaterThanOrEqual(1)
     expect((rawConfig.agents as Record<string, Record<string, unknown>>).oracle.model).toBe("anthropic/claude-opus-4-7")
 

--- a/src/shared/migration/agent-category.ts
+++ b/src/shared/migration/agent-category.ts
@@ -14,7 +14,7 @@
 export const MODEL_TO_CATEGORY_MAP: Record<string, string> = {
   "google/gemini-3.1-pro": "visual-engineering",
   "google/gemini-3-flash": "writing",
-  "openai/gpt-5.4": "ultrabrain",
+  "openai/gpt-5.5": "ultrabrain",
   "anthropic/claude-haiku-4-5": "quick",
   "anthropic/claude-opus-4-6": "unspecified-high",
   "anthropic/claude-opus-4-7": "unspecified-high",

--- a/src/shared/migration/agent-names.test.ts
+++ b/src/shared/migration/agent-names.test.ts
@@ -76,7 +76,7 @@ describe("migrateAgentNames with parenthesized aliases", () => {
     // given
     const legacyAgents = {
       "Sisyphus (Ultraworker)": { model: "claude-opus-4" },
-      "Hephaestus (Deep Agent)": { model: "gpt-5.4" },
+      "Hephaestus (Deep Agent)": { model: "gpt-5.5" },
       "Prometheus (Plan Builder)": { model: "claude-opus-4" },
       "Atlas (Plan Executor)": { model: "kimi-k2.5" },
       "Metis (Plan Consultant)": { model: "claude-opus-4" },
@@ -89,7 +89,7 @@ describe("migrateAgentNames with parenthesized aliases", () => {
     // then
     expect(changed).toBe(true)
     expect(migrated.sisyphus).toEqual({ model: "claude-opus-4" })
-    expect(migrated.hephaestus).toEqual({ model: "gpt-5.4" })
+    expect(migrated.hephaestus).toEqual({ model: "gpt-5.5" })
     expect(migrated.prometheus).toEqual({ model: "claude-opus-4" })
     expect(migrated.atlas).toEqual({ model: "kimi-k2.5" })
     expect(migrated.metis).toEqual({ model: "claude-opus-4" })

--- a/src/shared/migration/migrations-sidecar.test.ts
+++ b/src/shared/migration/migrations-sidecar.test.ts
@@ -41,7 +41,7 @@ describe("migrations sidecar", () => {
         getSidecarPath(configPath),
         JSON.stringify({
           appliedMigrations: [
-            "model-version:openai/gpt-5.3-codex->openai/gpt-5.4",
+            "model-version:openai/gpt-5.3-codex->openai/gpt-5.5",
             "model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-7",
           ],
         }),
@@ -50,7 +50,7 @@ describe("migrations sidecar", () => {
       const applied = readAppliedMigrations(configPath)
 
       expect(applied.size).toBe(2)
-      expect(applied.has("model-version:openai/gpt-5.3-codex->openai/gpt-5.4")).toBe(true)
+      expect(applied.has("model-version:openai/gpt-5.3-codex->openai/gpt-5.5")).toBe(true)
       expect(applied.has("model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-7")).toBe(true)
     })
 
@@ -89,7 +89,7 @@ describe("migrations sidecar", () => {
     test("creates the sidecar with the given migration keys", () => {
       const configPath = join(workdir, "oh-my-openagent.json")
       const migrations = new Set([
-        "model-version:openai/gpt-5.3-codex->openai/gpt-5.4",
+        "model-version:openai/gpt-5.3-codex->openai/gpt-5.5",
       ])
 
       const ok = writeAppliedMigrations(configPath, migrations)
@@ -98,7 +98,7 @@ describe("migrations sidecar", () => {
       expect(existsSync(getSidecarPath(configPath))).toBe(true)
 
       const body = JSON.parse(readFileSync(getSidecarPath(configPath), "utf-8"))
-      expect(body.appliedMigrations).toEqual(["model-version:openai/gpt-5.3-codex->openai/gpt-5.4"])
+      expect(body.appliedMigrations).toEqual(["model-version:openai/gpt-5.3-codex->openai/gpt-5.5"])
     })
 
     test("writes entries in sorted order for stable diffs", () => {
@@ -133,7 +133,7 @@ describe("migrations sidecar", () => {
     test("round-trips via readAppliedMigrations", () => {
       const configPath = join(workdir, "oh-my-openagent.jsonc")
       const original = new Set([
-        "model-version:openai/gpt-5.3-codex->openai/gpt-5.4",
+        "model-version:openai/gpt-5.3-codex->openai/gpt-5.5",
         "model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-7",
       ])
 

--- a/src/shared/migration/migrations-sidecar.ts
+++ b/src/shared/migration/migrations-sidecar.ts
@@ -8,7 +8,7 @@ import { writeFileAtomically } from "../write-file-atomically"
  * config file.
  *
  * Why this exists (#3263): users who revert an auto-migrated value (e.g.
- * `gpt-5.4` → `gpt-5.3-codex`) and then delete the `_migrations` field from
+ * `gpt-5.5` → `gpt-5.3-codex`) and then delete the `_migrations` field from
  * their config would fall into an infinite migration loop — every startup
  * re-applied the migration because there was no memory of the previous
  * application. The sidecar remembers applied migrations even when the user
@@ -21,7 +21,7 @@ import { writeFileAtomically } from "../write-file-atomically"
  *
  *     {
  *       "appliedMigrations": [
- *         "model-version:openai/gpt-5.3-codex->openai/gpt-5.4",
+ *         "model-version:openai/gpt-5.3-codex->openai/gpt-5.5",
  *         "model-version:anthropic/claude-opus-4-5->anthropic/claude-opus-4-7"
  *       ]
  *     }

--- a/src/shared/migration/model-versions.ts
+++ b/src/shared/migration/model-versions.ts
@@ -10,7 +10,7 @@ export const MODEL_VERSION_MAP: Record<string, string> = {
   "anthropic/claude-opus-4-6": "anthropic/claude-opus-4-7",
   "anthropic/claude-sonnet-4-5": "anthropic/claude-sonnet-4-6",
   "openai/gpt-5.3-codex": "openai/gpt-5.5",
-  "openai/gpt-5.5": "openai/gpt-5.5",
+  "openai/gpt-5.4": "openai/gpt-5.5",
 }
 
 function migrationKey(oldModel: string, newModel: string): string {

--- a/src/shared/migration/model-versions.ts
+++ b/src/shared/migration/model-versions.ts
@@ -9,8 +9,8 @@ export const MODEL_VERSION_MAP: Record<string, string> = {
   "anthropic/claude-opus-4-5": "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-6": "anthropic/claude-opus-4-7",
   "anthropic/claude-sonnet-4-5": "anthropic/claude-sonnet-4-6",
-  "openai/gpt-5.3-codex": "openai/gpt-5.4",
-  "openai/gpt-5.4": "openai/gpt-5.5",
+  "openai/gpt-5.3-codex": "openai/gpt-5.5",
+  "openai/gpt-5.5": "openai/gpt-5.5",
 }
 
 function migrationKey(oldModel: string, newModel: string): string {

--- a/src/shared/model-availability.test.ts
+++ b/src/shared/model-availability.test.ts
@@ -64,7 +64,7 @@ describe("fetchAvailableModels", () => {
 
   it("#given cache file with models #when fetchAvailableModels called with connectedProviders #then returns Set of model IDs", async () => {
     writeModelsCache({
-      openai: { id: "openai", models: { "gpt-5.4": { id: "gpt-5.4" } } },
+      openai: { id: "openai", models: { "gpt-5.5": { id: "gpt-5.5" } } },
       anthropic: { id: "anthropic", models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
       google: { id: "google", models: { "gemini-3.1-pro": { id: "gemini-3.1-pro" } } },
     })
@@ -75,14 +75,14 @@ describe("fetchAvailableModels", () => {
 
     expect(result).toBeInstanceOf(Set)
     expect(result.size).toBe(3)
-    expect(result.has("openai/gpt-5.4")).toBe(true)
+    expect(result.has("openai/gpt-5.5")).toBe(true)
     expect(result.has("anthropic/claude-opus-4-7")).toBe(true)
     expect(result.has("google/gemini-3.1-pro")).toBe(true)
   })
 
   it("#given connectedProviders unknown #when fetchAvailableModels called without options #then returns empty Set", async () => {
     writeModelsCache({
-      openai: { id: "openai", models: { "gpt-5.4": { id: "gpt-5.4" } } },
+      openai: { id: "openai", models: { "gpt-5.5": { id: "gpt-5.5" } } },
     })
 
     const result = await fetchAvailableModels()
@@ -144,7 +144,7 @@ describe("fetchAvailableModels", () => {
 
   it("#given cache read twice #when second call made with same providers #then reads fresh each time", async () => {
     writeModelsCache({
-      openai: { id: "openai", models: { "gpt-5.4": { id: "gpt-5.4" } } },
+      openai: { id: "openai", models: { "gpt-5.5": { id: "gpt-5.5" } } },
       anthropic: { id: "anthropic", models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
     })
 
@@ -152,7 +152,7 @@ describe("fetchAvailableModels", () => {
     const result2 = await fetchAvailableModels(undefined, { connectedProviders: ["openai"] })
 
     expect(result1.size).toBe(result2.size)
-    expect(result1.has("openai/gpt-5.4")).toBe(true)
+    expect(result1.has("openai/gpt-5.5")).toBe(true)
   })
 
   it("#given empty providers in cache #when fetchAvailableModels called with connectedProviders #then returns empty Set", async () => {
@@ -190,12 +190,12 @@ describe("fuzzyMatchModel", () => {
 	// then return the matching model
 	it("should match substring in model name", () => {
 		const available = new Set([
-			"openai/gpt-5.4",
+			"openai/gpt-5.5",
 			"openai/gpt-5.3-codex",
 			"anthropic/claude-opus-4-7",
 		])
-		const result = fuzzyMatchModel("gpt-5.4", available)
-		expect(result).toBe("openai/gpt-5.4")
+		const result = fuzzyMatchModel("gpt-5.5", available)
+		expect(result).toBe("openai/gpt-5.5")
 	})
 
 	// given available model with preview suffix
@@ -216,12 +216,12 @@ describe("fuzzyMatchModel", () => {
 	// then return exact match if it exists
 	it("should prefer exact match over substring match", () => {
 		const available = new Set([
-			"openai/gpt-5.4",
+			"openai/gpt-5.5",
 			"openai/gpt-5.3-codex",
 			"openai/gpt-5.4-ultra",
 		])
-		const result = fuzzyMatchModel("gpt-5.4", available)
-		expect(result).toBe("openai/gpt-5.4")
+		const result = fuzzyMatchModel("gpt-5.5", available)
+		expect(result).toBe("openai/gpt-5.5")
 	})
 
 	// given available models with multiple substring matches
@@ -274,12 +274,12 @@ describe("fuzzyMatchModel", () => {
 	// then only search models from specified providers
 	it("should filter by provider when providers array is given", () => {
 		const available = new Set([
-			"openai/gpt-5.4",
+			"openai/gpt-5.5",
 			"anthropic/claude-opus-4-7",
 			"google/gemini-3",
 		])
 		const result = fuzzyMatchModel("gpt", available, ["openai"])
-		expect(result).toBe("openai/gpt-5.4")
+		expect(result).toBe("openai/gpt-5.5")
 	})
 
 	// given available models from multiple providers
@@ -287,7 +287,7 @@ describe("fuzzyMatchModel", () => {
 	// then return null
 	it("should return null when provider filter excludes all matches", () => {
 		const available = new Set([
-			"openai/gpt-5.4",
+			"openai/gpt-5.5",
 			"anthropic/claude-opus-4-7",
 		])
 		const result = fuzzyMatchModel("claude", available, ["openai"])
@@ -299,7 +299,7 @@ describe("fuzzyMatchModel", () => {
 	// then return null
 	it("should return null when no match found", () => {
 		const available = new Set([
-			"openai/gpt-5.4",
+			"openai/gpt-5.5",
 			"anthropic/claude-opus-4-7",
 		])
 		const result = fuzzyMatchModel("gemini", available)
@@ -311,11 +311,11 @@ describe("fuzzyMatchModel", () => {
 	// then match case-insensitively
 	it("should match case-insensitively", () => {
 		const available = new Set([
-			"openai/gpt-5.4",
+			"openai/gpt-5.5",
 			"anthropic/claude-opus-4-7",
 		])
-		const result = fuzzyMatchModel("GPT-5.4", available)
-		expect(result).toBe("openai/gpt-5.4")
+		const result = fuzzyMatchModel("GPT-5.5", available)
+		expect(result).toBe("openai/gpt-5.5")
 	})
 
 	// given available models with exact match and longer variants
@@ -359,11 +359,11 @@ describe("fuzzyMatchModel", () => {
 	// then return shortest full string (preserves tie-break behavior)
 	it("should use shortest tie-break when multiple providers have same model ID", () => {
 		const available = new Set([
-			"opencode/gpt-5.4",
-			"openai/gpt-5.4",
+			"opencode/gpt-5.5",
+			"openai/gpt-5.5",
 		])
-		const result = fuzzyMatchModel("gpt-5.4", available)
-		expect(result).toBe("openai/gpt-5.4")
+		const result = fuzzyMatchModel("gpt-5.5", available)
+		expect(result).toBe("openai/gpt-5.5")
 	})
 
 	// given available models with multiple providers
@@ -371,12 +371,12 @@ describe("fuzzyMatchModel", () => {
 	// then search all specified providers
 	it("should search all specified providers", () => {
 		const available = new Set([
-			"openai/gpt-5.4",
+			"openai/gpt-5.5",
 			"anthropic/claude-opus-4-7",
 			"google/gemini-3",
 		])
 		const result = fuzzyMatchModel("gpt", available, ["openai", "google"])
-		expect(result).toBe("openai/gpt-5.4")
+		expect(result).toBe("openai/gpt-5.5")
 	})
 
 	// given available models with provider prefix
@@ -384,11 +384,11 @@ describe("fuzzyMatchModel", () => {
 	// then only match models with correct provider prefix
 	it("should only match models with correct provider prefix", () => {
 		const available = new Set([
-			"openai/gpt-5.4",
+			"openai/gpt-5.5",
 			"anthropic/gpt-something",
 		])
 		const result = fuzzyMatchModel("gpt", available, ["openai"])
-		expect(result).toBe("openai/gpt-5.4")
+		expect(result).toBe("openai/gpt-5.5")
 	})
 
 	// given empty available set
@@ -519,7 +519,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 	// then only returns models from that provider
 	it("should filter models by connected providers", async () => {
 		writeModelsCache({
-			openai: { models: { "gpt-5.4": { id: "gpt-5.4" } } },
+			openai: { models: { "gpt-5.5": { id: "gpt-5.5" } } },
 			anthropic: { models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
 			google: { models: { "gemini-3.1-pro": { id: "gemini-3.1-pro" } } },
 		})
@@ -530,7 +530,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 
 		expect(result.size).toBe(1)
 		expect(result.has("anthropic/claude-opus-4-7")).toBe(true)
-		expect(result.has("openai/gpt-5.4")).toBe(false)
+		expect(result.has("openai/gpt-5.5")).toBe(false)
 		expect(result.has("google/gemini-3.1-pro")).toBe(false)
 	})
 
@@ -539,7 +539,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 	// then returns models from all specified providers
 	it("should filter models by multiple connected providers", async () => {
 		writeModelsCache({
-			openai: { models: { "gpt-5.4": { id: "gpt-5.4" } } },
+			openai: { models: { "gpt-5.5": { id: "gpt-5.5" } } },
 			anthropic: { models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
 			google: { models: { "gemini-3.1-pro": { id: "gemini-3.1-pro" } } },
 		})
@@ -551,7 +551,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 		expect(result.size).toBe(2)
 		expect(result.has("anthropic/claude-opus-4-7")).toBe(true)
 		expect(result.has("google/gemini-3.1-pro")).toBe(true)
-		expect(result.has("openai/gpt-5.4")).toBe(false)
+		expect(result.has("openai/gpt-5.5")).toBe(false)
 	})
 
 	// given cache with models
@@ -559,7 +559,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 	// then returns empty set
 	it("should return empty set when connectedProviders is empty", async () => {
 		writeModelsCache({
-			openai: { models: { "gpt-5.4": { id: "gpt-5.4" } } },
+			openai: { models: { "gpt-5.5": { id: "gpt-5.5" } } },
 			anthropic: { models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
 		})
 
@@ -575,7 +575,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 	// then returns empty set (triggers fallback in resolver)
 	it("should return empty set when connectedProviders not specified", async () => {
 		writeModelsCache({
-			openai: { models: { "gpt-5.4": { id: "gpt-5.4" } } },
+			openai: { models: { "gpt-5.5": { id: "gpt-5.5" } } },
 			anthropic: { models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
 		})
 
@@ -589,7 +589,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 	// then returns empty set for that provider
 	it("should handle provider not in cache gracefully", async () => {
 		writeModelsCache({
-			openai: { models: { "gpt-5.4": { id: "gpt-5.4" } } },
+			openai: { models: { "gpt-5.5": { id: "gpt-5.5" } } },
 		})
 
 		const result = await fetchAvailableModels(undefined, {
@@ -604,7 +604,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 	// then returns models only from matching providers
 	it("should return models from providers that exist in both cache and connected list", async () => {
 		writeModelsCache({
-			openai: { models: { "gpt-5.4": { id: "gpt-5.4" } } },
+			openai: { models: { "gpt-5.5": { id: "gpt-5.5" } } },
 			anthropic: { models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
 		})
 
@@ -621,7 +621,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 	// then does NOT use cache (dynamic per-session)
 	it("should not cache filtered results", async () => {
 		writeModelsCache({
-			openai: { models: { "gpt-5.4": { id: "gpt-5.4" } } },
+			openai: { models: { "gpt-5.5": { id: "gpt-5.5" } } },
 			anthropic: { models: { "claude-opus-4-7": { id: "claude-opus-4-7" } } },
 		})
 
@@ -636,7 +636,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 			connectedProviders: ["openai"]
 		})
 		expect(result2.size).toBe(1)
-		expect(result2.has("openai/gpt-5.4")).toBe(true)
+		expect(result2.has("openai/gpt-5.5")).toBe(true)
 	})
 
 	// given connectedProviders unknown
@@ -644,7 +644,7 @@ describe("fetchAvailableModels with connected providers filtering", () => {
 	// then always returns empty set (triggers fallback)
 	it("should return empty set when connectedProviders unknown", async () => {
 		writeModelsCache({
-			openai: { models: { "gpt-5.4": { id: "gpt-5.4" } } },
+			openai: { models: { "gpt-5.5": { id: "gpt-5.5" } } },
 		})
 
 		const result1 = await fetchAvailableModels()
@@ -711,7 +711,7 @@ describe("fetchAvailableModels with provider-models cache (whitelist-filtered)",
 			connected: ["opencode", "anthropic"]
 		})
 		writeModelsCache({
-			opencode: { models: { "big-pickle": {}, "gpt-5-nano": {}, "gpt-5.4": {} } },
+			opencode: { models: { "big-pickle": {}, "gpt-5-nano": {}, "gpt-5.5": {} } },
 			anthropic: { models: { "claude-opus-4-7": {}, "claude-sonnet-4-6": {} } }
 		})
 
@@ -723,7 +723,7 @@ describe("fetchAvailableModels with provider-models cache (whitelist-filtered)",
 		expect(result.has("opencode/big-pickle")).toBe(true)
 		expect(result.has("opencode/gpt-5-nano")).toBe(true)
 		expect(result.has("anthropic/claude-opus-4-7")).toBe(true)
-		expect(result.has("opencode/gpt-5.4")).toBe(false)
+		expect(result.has("opencode/gpt-5.5")).toBe(false)
 		expect(result.has("anthropic/claude-sonnet-4-6")).toBe(false)
 	})
 
@@ -753,7 +753,7 @@ describe("fetchAvailableModels with provider-models cache (whitelist-filtered)",
 	// then falls back to models.json (no whitelist filtering)
 	it("should fallback to models.json when provider-models cache not found", async () => {
 		writeModelsCache({
-			opencode: { models: { "big-pickle": {}, "gpt-5-nano": {}, "gpt-5.4": {} } },
+			opencode: { models: { "big-pickle": {}, "gpt-5-nano": {}, "gpt-5.5": {} } },
 		})
 
 		const result = await fetchAvailableModels(undefined, {
@@ -763,7 +763,7 @@ describe("fetchAvailableModels with provider-models cache (whitelist-filtered)",
 		expect(result.size).toBe(3)
 		expect(result.has("opencode/big-pickle")).toBe(true)
 		expect(result.has("opencode/gpt-5-nano")).toBe(true)
-		expect(result.has("opencode/gpt-5.4")).toBe(true)
+		expect(result.has("opencode/gpt-5.5")).toBe(true)
 	})
 
 	// given provider-models cache with whitelist
@@ -924,7 +924,7 @@ describe("fallback model availability", () => {
 
 	it("returns null for completely unknown model", () => {
 		// given
-		const available = new Set(["openai/gpt-5.4", "anthropic/claude-opus-4-7"])
+		const available = new Set(["openai/gpt-5.5", "anthropic/claude-opus-4-7"])
 
 		// when
 		const result = fuzzyMatchModel("non-existent-model-family", available)
@@ -935,7 +935,7 @@ describe("fallback model availability", () => {
 
 	it("returns true when models do not match but provider is connected", () => {
 		// given
-		const fallbackChain = [{ providers: ["openai"], model: "gpt-5.4" }]
+		const fallbackChain = [{ providers: ["openai"], model: "gpt-5.5" }]
 		const availableModels = new Set(["anthropic/claude-opus-4-7"])
 		writeConnectedProvidersCache(["openai"])
 
@@ -967,7 +967,7 @@ describe("fallback model availability", () => {
 	it("returns null when no fallback model resolves", () => {
 		// given
 		const fallbackChain = [
-			{ providers: ["openai"], model: "gpt-5.4" },
+			{ providers: ["openai"], model: "gpt-5.5" },
 			{ providers: ["anthropic"], model: "claude-opus-4-7" },
 		]
 		const availableModels = new Set(["google/gemini-3.1-pro"])

--- a/src/shared/model-availability.ts
+++ b/src/shared/model-availability.ts
@@ -8,7 +8,7 @@ import { normalizeSDKResponse } from "./normalize-sdk-response"
 /**
  * Fuzzy match a target model name against available models
  * 
- * @param target - The model name or substring to search for (e.g., "gpt-5.4", "claude-opus")
+ * @param target - The model name or substring to search for (e.g., "gpt-5.5", "claude-opus")
  * @param available - Set of available model names in format "provider/model-name"
  * @param providers - Optional array of provider names to filter by (e.g., ["openai", "anthropic"])
  * @returns The matched model name or null if no match found
@@ -21,8 +21,8 @@ import { normalizeSDKResponse } from "./normalize-sdk-response"
  * If providers array is given, only models starting with "provider/" are considered.
  * 
  * @example
- * const available = new Set(["openai/gpt-5.4", "openai/gpt-5.3-codex", "anthropic/claude-opus-4-7"])
- * fuzzyMatchModel("gpt-5.4", available) // → "openai/gpt-5.4"
+ * const available = new Set(["openai/gpt-5.5", "openai/gpt-5.3-codex", "anthropic/claude-opus-4-7"])
+ * fuzzyMatchModel("gpt-5.5", available) // → "openai/gpt-5.5"
  * fuzzyMatchModel("claude", available, ["openai"]) // → null (provider filter excludes anthropic)
  */
 function normalizeModelName(name: string): string {
@@ -82,7 +82,7 @@ export function fuzzyMatchModel(
 
 	// Priority 2: Exact model ID match (part after provider/)
 	// This ensures "big-pickle" matches "zai-coding-plan/big-pickle" over "zai-coding-plan/glm-5"
-	// Use filter + shortest to handle multi-provider cases (e.g., openai/gpt-5.4 + opencode/gpt-5.4)
+	// Use filter + shortest to handle multi-provider cases (e.g., openai/gpt-5.5 + opencode/gpt-5.5)
 	const exactModelIdMatches = matches.filter((model) => {
 		const modelId = model.split("/").slice(1).join("/")
 		return normalizeModelName(modelId) === targetNormalized

--- a/src/shared/model-capabilities-cache.test.ts
+++ b/src/shared/model-capabilities-cache.test.ts
@@ -33,8 +33,8 @@ describe("model-capabilities-cache", () => {
     const raw = {
       openai: {
         models: {
-          "gpt-5.4": {
-            id: "gpt-5.4",
+          "gpt-5.5": {
+            id: "gpt-5.5",
             family: "gpt",
             reasoning: true,
             temperature: false,
@@ -70,8 +70,8 @@ describe("model-capabilities-cache", () => {
 
     //#then
     expect(snapshot.sourceUrl).toBe(MODELS_DEV_SOURCE_URL)
-    expect(snapshot.models["gpt-5.4"]).toEqual({
-      id: "gpt-5.4",
+    expect(snapshot.models["gpt-5.5"]).toEqual({
+      id: "gpt-5.5",
       family: "gpt",
       reasoning: true,
       temperature: false,
@@ -101,8 +101,8 @@ describe("model-capabilities-cache", () => {
     const raw = {
       openai: {
         models: {
-          "gpt-5.4": {
-            id: "gpt-5.4",
+          "gpt-5.5": {
+            id: "gpt-5.5",
             family: "gpt",
           },
         },
@@ -110,7 +110,7 @@ describe("model-capabilities-cache", () => {
       alias: {
         models: {
           "gpt-5.4-preview": {
-            id: "gpt-5.4",
+            id: "gpt-5.5",
             reasoning: true,
           },
         },
@@ -119,13 +119,13 @@ describe("model-capabilities-cache", () => {
 
     const snapshot = buildModelCapabilitiesSnapshotFromModelsDev(raw)
 
-    expect(snapshot.models["gpt-5.4"]).toEqual({
-      id: "gpt-5.4",
+    expect(snapshot.models["gpt-5.5"]).toEqual({
+      id: "gpt-5.5",
       family: "gpt",
       reasoning: true,
     })
-    expect(snapshot.models["gpt-5.4"]).not.toHaveProperty("modalities")
-    expect(snapshot.models["gpt-5.4"]).not.toHaveProperty("limit")
+    expect(snapshot.models["gpt-5.5"]).not.toHaveProperty("modalities")
+    expect(snapshot.models["gpt-5.5"]).not.toHaveProperty("limit")
   })
 
   test("refresh writes cache and preserves unrelated files in the cache directory", async () => {
@@ -139,8 +139,8 @@ describe("model-capabilities-cache", () => {
       new Response(JSON.stringify({
         openai: {
           models: {
-            "gpt-5.4": {
-              id: "gpt-5.4",
+            "gpt-5.5": {
+              id: "gpt-5.5",
               family: "gpt",
               reasoning: true,
               limit: { output: 128_000 },
@@ -157,7 +157,7 @@ describe("model-capabilities-cache", () => {
     const reloadedStore = createModelCapabilitiesCacheStore(() => testCacheDir)
 
     //#then
-    expect(snapshot.models["gpt-5.4"]?.limit?.output).toBe(128_000)
+    expect(snapshot.models["gpt-5.5"]?.limit?.output).toBe(128_000)
     expect(existsSync(sentinelPath)).toBe(true)
     expect(readFileSync(sentinelPath, "utf-8")).toBe(JSON.stringify({ keep: true }))
     expect(reloadedStore.readModelCapabilitiesCache()).toEqual(snapshot)

--- a/src/shared/model-capabilities.test.ts
+++ b/src/shared/model-capabilities.test.ts
@@ -45,8 +45,8 @@ describe("getModelCapabilities", () => {
           output: 65_000,
         },
       },
-      "gpt-5.4": {
-        id: "gpt-5.4",
+      "gpt-5.5": {
+        id: "gpt-5.5",
         family: "gpt",
         reasoning: true,
         temperature: false,
@@ -98,7 +98,7 @@ describe("getModelCapabilities", () => {
     findProviderModelMetadataSpy = spyOn(connectedProvidersCache, "findProviderModelMetadata").mockReturnValue(undefined)
     const result = getModelCapabilities({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       runtimeModel: {
         capabilities: {
           reasoning: true,
@@ -117,7 +117,7 @@ describe("getModelCapabilities", () => {
     })
 
     expect(result).toMatchObject({
-      canonicalModelID: "gpt-5.4",
+      canonicalModelID: "gpt-5.5",
       reasoning: true,
       supportsThinking: true,
       supportsTemperature: false,
@@ -139,7 +139,7 @@ describe("getModelCapabilities", () => {
     findProviderModelMetadataSpy = spyOn(connectedProvidersCache, "findProviderModelMetadata").mockReturnValue(undefined)
     const result = getModelCapabilities({
       providerID: "custom-proxy",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       runtimeModel: {
         supportsThinking: true,
       },
@@ -147,7 +147,7 @@ describe("getModelCapabilities", () => {
     })
 
     expect(result).toMatchObject({
-      canonicalModelID: "gpt-5.4",
+      canonicalModelID: "gpt-5.5",
       supportsThinking: true,
     })
     expect(result.diagnostics).toMatchObject({
@@ -159,7 +159,7 @@ describe("getModelCapabilities", () => {
     findProviderModelMetadataSpy = spyOn(connectedProvidersCache, "findProviderModelMetadata").mockReturnValue(undefined)
     const result = getModelCapabilities({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       runtimeModel: {
         variants: ["low", "medium", "high", "xhigh"],
       },
@@ -275,8 +275,8 @@ describe("getModelCapabilities", () => {
       ...bundledSnapshot,
       models: {
         ...bundledSnapshot.models,
-        "gpt-5.4": {
-          ...bundledSnapshot.models["gpt-5.4"],
+        "gpt-5.5": {
+          ...bundledSnapshot.models["gpt-5.5"],
           limit: {
             context: 1_050_000,
             output: 64_000,
@@ -287,13 +287,13 @@ describe("getModelCapabilities", () => {
 
     const result = getModelCapabilities({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       bundledSnapshot,
       runtimeSnapshot,
     })
 
     expect(result).toMatchObject({
-      canonicalModelID: "gpt-5.4",
+      canonicalModelID: "gpt-5.5",
       maxOutputTokens: 64_000,
       supportsTemperature: false,
     })

--- a/src/shared/model-capability-aliases.test.ts
+++ b/src/shared/model-capability-aliases.test.ts
@@ -56,6 +56,28 @@ describe("model-capability-aliases", () => {
     })
   })
 
+  test("normalizes Kimi for Coding k2pb aliases to the snapshot ID", () => {
+    const result = resolveModelIDAlias("kimi-for-coding/k2pb")
+
+    expect(result).toEqual({
+      requestedModelID: "kimi-for-coding/k2pb",
+      canonicalModelID: "k2p5",
+      source: "exact-alias",
+      ruleID: "kimi-k2pb-alias",
+    })
+  })
+
+  test("normalizes GitHub Copilot dotted Claude Opus aliases to the snapshot ID", () => {
+    const result = resolveModelIDAlias("github-copilot/claude-opus-4.7")
+
+    expect(result).toEqual({
+      requestedModelID: "github-copilot/claude-opus-4.7",
+      canonicalModelID: "claude-opus-4-7",
+      source: "exact-alias",
+      ruleID: "claude-opus-dotted-version-alias",
+    })
+  })
+
   test("does not resolve prototype keys as aliases", () => {
     const result = resolveModelIDAlias("constructor")
 

--- a/src/shared/model-capability-aliases.test.ts
+++ b/src/shared/model-capability-aliases.test.ts
@@ -4,11 +4,11 @@ import { resolveModelIDAlias } from "./model-capability-aliases"
 
 describe("model-capability-aliases", () => {
   test("keeps canonical model IDs unchanged", () => {
-    const result = resolveModelIDAlias("gpt-5.4")
+    const result = resolveModelIDAlias("gpt-5.5")
 
     expect(result).toEqual({
-      requestedModelID: "gpt-5.4",
-      canonicalModelID: "gpt-5.4",
+      requestedModelID: "gpt-5.5",
+      canonicalModelID: "gpt-5.5",
       source: "canonical",
     })
   })

--- a/src/shared/model-capability-aliases.ts
+++ b/src/shared/model-capability-aliases.ts
@@ -32,6 +32,18 @@ const EXACT_ALIAS_RULES: ReadonlyArray<ExactAliasRule> = [
     canonicalModelID: "gemini-3-pro-preview",
     rationale: "Legacy Gemini 3 tier suffixes still need to land on the canonical preview model.",
   },
+  {
+    aliasModelID: "k2pb",
+    ruleID: "kimi-k2pb-alias",
+    canonicalModelID: "k2p5",
+    rationale: "Kimi for Coding exposes k2pb while the bundled capabilities snapshot uses the canonical k2p5 ID.",
+  },
+  {
+    aliasModelID: "claude-opus-4.7",
+    ruleID: "claude-opus-dotted-version-alias",
+    canonicalModelID: "claude-opus-4-7",
+    rationale: "GitHub Copilot exposes Claude Opus 4.7 with dotted version syntax while the snapshot uses dashed syntax.",
+  },
 ]
 
 const EXACT_ALIAS_RULES_BY_MODEL: ReadonlyMap<string, ExactAliasRule> = new Map(

--- a/src/shared/model-capability-guardrails.test.ts
+++ b/src/shared/model-capability-guardrails.test.ts
@@ -20,7 +20,7 @@ describe("model-capability-guardrails", () => {
     expect(modelIDs).toEqual([...modelIDs].sort())
     expect(new Set(modelIDs).size).toBe(modelIDs.length)
     expect(modelIDs).toContain("claude-opus-4-7")
-    expect(modelIDs).toContain("gpt-5.4")
+    expect(modelIDs).toContain("gpt-5.5")
     expect(modelIDs).toContain("kimi-k2.5")
   })
 

--- a/src/shared/model-resolver.test.ts
+++ b/src/shared/model-resolver.test.ts
@@ -13,7 +13,7 @@ describe("resolveModel", () => {
       // given
       const input: ModelResolutionInput = {
         userModel: "anthropic/claude-opus-4-7",
-        inheritedModel: "openai/gpt-5.4",
+        inheritedModel: "openai/gpt-5.5",
         systemDefault: "google/gemini-3.1-pro",
       }
 
@@ -28,7 +28,7 @@ describe("resolveModel", () => {
       // given
       const input: ModelResolutionInput = {
         userModel: undefined,
-        inheritedModel: "openai/gpt-5.4",
+        inheritedModel: "openai/gpt-5.5",
         systemDefault: "google/gemini-3.1-pro",
       }
 
@@ -36,7 +36,7 @@ describe("resolveModel", () => {
       const result = resolveModel(input)
 
       // then
-      expect(result).toBe("openai/gpt-5.4")
+      expect(result).toBe("openai/gpt-5.5")
     })
 
     test("returns systemDefault when both userModel and inheritedModel are undefined", () => {
@@ -60,7 +60,7 @@ describe("resolveModel", () => {
       // given
       const input: ModelResolutionInput = {
         userModel: "",
-        inheritedModel: "openai/gpt-5.4",
+        inheritedModel: "openai/gpt-5.5",
         systemDefault: "google/gemini-3.1-pro",
       }
 
@@ -68,7 +68,7 @@ describe("resolveModel", () => {
       const result = resolveModel(input)
 
       // then
-      expect(result).toBe("openai/gpt-5.4")
+      expect(result).toBe("openai/gpt-5.5")
     })
 
     test("treats whitespace-only string as unset, uses fallback", () => {
@@ -92,7 +92,7 @@ describe("resolveModel", () => {
       // given
       const input: ModelResolutionInput = {
         userModel: "anthropic/claude-opus-4-7",
-        inheritedModel: "openai/gpt-5.4",
+        inheritedModel: "openai/gpt-5.5",
         systemDefault: "google/gemini-3.1-pro",
       }
 
@@ -296,9 +296,9 @@ describe("resolveModelWithFallback", () => {
       // given
       const input: ExtendedModelResolutionInput = {
         fallbackChain: [
-          { providers: ["openai", "anthropic", "google"], model: "gpt-5.4" },
+          { providers: ["openai", "anthropic", "google"], model: "gpt-5.5" },
         ],
-        availableModels: new Set(["openai/gpt-5.4", "anthropic/claude-opus-4-7", "google/gemini-3.1-pro"]),
+        availableModels: new Set(["openai/gpt-5.5", "anthropic/claude-opus-4-7", "google/gemini-3.1-pro"]),
         systemDefaultModel: "google/gemini-3.1-pro",
       }
 
@@ -306,7 +306,7 @@ describe("resolveModelWithFallback", () => {
       const result = resolveModelWithFallback(input)
 
       // then
-      expect(result!.model).toBe("openai/gpt-5.4")
+      expect(result!.model).toBe("openai/gpt-5.5")
       expect(result!.source).toBe("provider-fallback")
     })
 
@@ -480,7 +480,7 @@ describe("resolveModelWithFallback", () => {
         fallbackChain: [
           { providers: ["anthropic"], model: "nonexistent-model" },
         ],
-        availableModels: new Set(["openai/gpt-5.4", "anthropic/claude-opus-4-7"]),
+        availableModels: new Set(["openai/gpt-5.5", "anthropic/claude-opus-4-7"]),
         systemDefaultModel: "google/gemini-3.1-pro",
       }
 
@@ -596,7 +596,7 @@ describe("resolveModelWithFallback", () => {
     test("returns system default when fallbackChain is not provided", () => {
       // given
       const input: ExtendedModelResolutionInput = {
-        availableModels: new Set(["openai/gpt-5.4"]),
+        availableModels: new Set(["openai/gpt-5.5"]),
         systemDefaultModel: "google/gemini-3.1-pro",
       }
 
@@ -617,7 +617,7 @@ describe("resolveModelWithFallback", () => {
       // when
       const result = resolveModelWithFallback({
         fallbackChain: [
-          { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.4", variant: "high" },
+          { providers: ["openai", "github-copilot", "opencode"], model: "gpt-5.5", variant: "high" },
           { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-4-7", variant: "max" },
         ],
         availableModels,
@@ -636,7 +636,7 @@ describe("resolveModelWithFallback", () => {
       // when
       const result = resolveModelWithFallback({
         fallbackChain: [
-          { providers: ["openai", "anthropic"], model: "gpt-5.4" },
+          { providers: ["openai", "anthropic"], model: "gpt-5.5" },
           { providers: ["google"], model: "gemini-3.1-pro" },
         ],
         availableModels,
@@ -651,14 +651,14 @@ describe("resolveModelWithFallback", () => {
     test("returns first matching entry even if later entries have better matches", () => {
       // given
       const availableModels = new Set([
-        "openai/gpt-5.4",
+        "openai/gpt-5.5",
         "anthropic/claude-opus-4-7",
       ])
 
       // when
       const result = resolveModelWithFallback({
         fallbackChain: [
-          { providers: ["openai"], model: "gpt-5.4" },
+          { providers: ["openai"], model: "gpt-5.5" },
           { providers: ["anthropic"], model: "claude-opus-4-7" },
         ],
         availableModels,
@@ -666,7 +666,7 @@ describe("resolveModelWithFallback", () => {
       })
 
       // then
-      expect(result!.model).toBe("openai/gpt-5.4")
+      expect(result!.model).toBe("openai/gpt-5.5")
       expect(result!.source).toBe("provider-fallback")
     })
 
@@ -677,7 +677,7 @@ describe("resolveModelWithFallback", () => {
       // when
       const result = resolveModelWithFallback({
         fallbackChain: [
-          { providers: ["openai"], model: "gpt-5.4" },
+          { providers: ["openai"], model: "gpt-5.5" },
           { providers: ["anthropic"], model: "claude-opus-4-7" },
           { providers: ["google"], model: "gemini-3.1-pro" },
         ],
@@ -888,7 +888,7 @@ describe("resolveModelWithFallback", () => {
         fallbackChain: [
           { providers: ["anthropic"], model: "nonexistent-model" },
         ],
-        availableModels: new Set(["openai/gpt-5.4"]),
+        availableModels: new Set(["openai/gpt-5.5"]),
         systemDefaultModel: undefined,
       }
 
@@ -902,7 +902,7 @@ describe("resolveModelWithFallback", () => {
     test("returns undefined when no fallbackChain and systemDefaultModel is undefined", () => {
       // given
       const input: ExtendedModelResolutionInput = {
-        availableModels: new Set(["openai/gpt-5.4"]),
+        availableModels: new Set(["openai/gpt-5.5"]),
         systemDefaultModel: undefined,
       }
 

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -79,7 +79,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("keeps supported GPT reasoningEffort unchanged", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { reasoningEffort: "high" },
     })
 
@@ -107,7 +107,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("does not record case-only normalization as a compatibility downgrade", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { variant: "HIGH", reasoningEffort: "HIGH" },
     })
 
@@ -308,7 +308,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("GPT-5 keeps xhigh variant and reasoningEffort", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { variant: "xhigh", reasoningEffort: "xhigh" },
     })
 
@@ -322,7 +322,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("GPT-5 downgrades unsupported max variant to xhigh", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { variant: "max" },
     })
 
@@ -343,7 +343,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("GPT-5 keeps none reasoningEffort", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { reasoningEffort: "none" },
     })
 
@@ -357,7 +357,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("GPT-5 keeps minimal reasoningEffort", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { reasoningEffort: "minimal" },
     })
 
@@ -403,7 +403,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("GPT-5 keeps xhigh but would downgrade a hypothetical beyond-max level", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { reasoningEffort: "xhigh" },
     })
 
@@ -432,7 +432,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("drops unsupported temperature when capability metadata disables it", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { temperature: 0.7 },
       capabilities: { supportsTemperature: false },
     })
@@ -451,7 +451,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("drops thinking when model capabilities say it is unsupported", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { thinking: { type: "enabled", budgetTokens: 4096 } },
       capabilities: { supportsThinking: false },
     })
@@ -470,7 +470,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("clamps maxTokens to the model output limit", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { maxTokens: 200_000 },
       capabilities: { maxOutputTokens: 128_000 },
     })
@@ -489,7 +489,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("#given capabilities.maxOutputTokens is 0 #then maxTokens preserved unchanged", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { maxTokens: 200_000 },
       capabilities: { maxOutputTokens: 0 },
     })
@@ -501,7 +501,7 @@ describe("resolveCompatibleModelSettings", () => {
   test("#given capabilities.maxOutputTokens is -1 #then maxTokens preserved unchanged", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       desired: { maxTokens: 200_000 },
       capabilities: { maxOutputTokens: -1 },
     })

--- a/src/shared/model-suggestion-retry.test.ts
+++ b/src/shared/model-suggestion-retry.test.ts
@@ -70,7 +70,7 @@ describe("parseModelSuggestion", () => {
           data: {
             providerID: "openai",
             modelID: "gpt-5",
-            suggestions: ["gpt-5.4"],
+            suggestions: ["gpt-5.5"],
           },
         },
       }
@@ -82,7 +82,7 @@ describe("parseModelSuggestion", () => {
       expect(result).toEqual({
         providerID: "openai",
         modelID: "gpt-5",
-        suggestion: "gpt-5.4",
+        suggestion: "gpt-5.5",
       })
     })
 

--- a/src/tools/call-omo-agent/sync-executor-leak.test.ts
+++ b/src/tools/call-omo-agent/sync-executor-leak.test.ts
@@ -172,7 +172,7 @@ describe("executeSync session cleanup", () => {
         createOrGetSession: mock(async () => ({ sessionID, isNew: false })),
         clearSessionFallbackChain,
       })
-      const fallbackChain = [{ providers: ["openai"], model: "gpt-5.4" }]
+      const fallbackChain = [{ providers: ["openai"], model: "gpt-5.5" }]
 
       // when
       await executeSync(args, toolContext, createContext(promptAsync) as never, deps, fallbackChain)

--- a/src/tools/call-omo-agent/sync-executor.test.ts
+++ b/src/tools/call-omo-agent/sync-executor.test.ts
@@ -181,7 +181,7 @@ describe("executeSync", () => {
     }
     const model = {
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       variant: "high",
       temperature: 0.12,
       top_p: 0.34,
@@ -205,7 +205,7 @@ describe("executeSync", () => {
     const promptInput = recorder.getCapturedInput()
     expect(promptInput?.body.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
     })
     expect(promptInput?.body.variant).toBe("high")
     expect(promptInput?.body.temperature).toBe(0.12)

--- a/src/tools/call-omo-agent/tools.test.ts
+++ b/src/tools/call-omo-agent/tools.test.ts
@@ -354,7 +354,7 @@ describe("createCallOmoAgent", () => {
       [],
       {
         explore: {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
           variant: "high",
         },
       },
@@ -381,7 +381,7 @@ describe("createCallOmoAgent", () => {
     const [launchArgs] = firstLaunchCall
     expect(launchArgs.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       variant: "high",
     })
   })
@@ -405,7 +405,7 @@ describe("createCallOmoAgent", () => {
       [],
       {
         explore: {
-          model: "openai/gpt-5.4 high",
+          model: "openai/gpt-5.5 high",
         },
       },
     )
@@ -431,7 +431,7 @@ describe("createCallOmoAgent", () => {
     const [launchArgs] = firstLaunchCall
     expect(launchArgs.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       variant: "high",
     })
   })
@@ -460,7 +460,7 @@ describe("createCallOmoAgent", () => {
       },
       {
         research: {
-          model: "openai/gpt-5.4",
+          model: "openai/gpt-5.5",
         },
       },
     )
@@ -486,7 +486,7 @@ describe("createCallOmoAgent", () => {
     const [launchArgs] = firstLaunchCall
     expect(launchArgs.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
     })
   })
 

--- a/src/tools/delegate-task/background-task.test.ts
+++ b/src/tools/delegate-task/background-task.test.ts
@@ -342,7 +342,7 @@ describeFn("executeBackgroundTask output/session metadata compatibility", () => 
       "explore",
       undefined,
       undefined,
-      [{ providers: ["openai"], model: "gpt-5.4" }],
+      [{ providers: ["openai"], model: "gpt-5.5" }],
     )
 
     await new Promise(resolve => setTimeout(resolve, 5))

--- a/src/tools/delegate-task/category-resolver.test.ts
+++ b/src/tools/delegate-task/category-resolver.test.ts
@@ -118,7 +118,7 @@ describe("resolveCategoryExecution", () => {
 	test("promotes object-style fallback model settings to categoryModel when fallback becomes initial model", async () => {
 		//#given
 		const cacheSpy = spyOn(connectedProvidersCache, "readProviderModelsCache").mockReturnValue({
-			models: { openai: ["gpt-5.4"] },
+			models: { openai: ["gpt-5.5"] },
 			connected: ["openai"],
 			updatedAt: "2026-03-03T00:00:00.000Z",
 		})
@@ -137,7 +137,7 @@ describe("resolveCategoryExecution", () => {
 			quick: {
 				fallback_models: [
 					{
-						model: "openai/gpt-5.4 high",
+						model: "openai/gpt-5.5 high",
 						variant: "low",
 						reasoningEffort: "high",
 						temperature: 0.4,
@@ -154,10 +154,10 @@ describe("resolveCategoryExecution", () => {
 
 		//#then
 		expect(result.error).toBeUndefined()
-		expect(result.actualModel).toBe("openai/gpt-5.4")
+		expect(result.actualModel).toBe("openai/gpt-5.5")
 		expect(result.categoryModel).toEqual({
 			providerID: "openai",
-			modelID: "gpt-5.4",
+			modelID: "gpt-5.5",
 			variant: "low",
 			reasoningEffort: "high",
 			temperature: 0.4,
@@ -183,7 +183,7 @@ describe("resolveCategoryExecution", () => {
 		const executorCtx = createMockExecutorContext()
 		executorCtx.userCategories = {
 			quick: {
-				model: "openai/gpt-5.4 high",
+				model: "openai/gpt-5.5 high",
 			},
 		}
 
@@ -197,10 +197,10 @@ describe("resolveCategoryExecution", () => {
 		if (!result.actualModel || !result.categoryModel) {
 			throw new Error("Expected resolved model and category model")
 		}
-		expect(result.actualModel).toBe("openai/gpt-5.4")
+		expect(result.actualModel).toBe("openai/gpt-5.5")
 		expect(result.categoryModel).toEqual({
 			providerID: "openai",
-			modelID: "gpt-5.4",
+			modelID: "gpt-5.5",
 			variant: "high",
 		})
 	})

--- a/src/tools/delegate-task/model-selection.test.ts
+++ b/src/tools/delegate-task/model-selection.test.ts
@@ -41,7 +41,7 @@ describe("resolveModelForDelegateTask", () => {
 		describe("#when user explicitly set a model override", () => {
 			test("#then returns the user model regardless of cache state", () => {
 				const result = resolveModelForDelegateTask({
-					userModel: "openai/gpt-5.4",
+					userModel: "openai/gpt-5.5",
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
 					fallbackChain: [
 						{ providers: ["anthropic"], model: "claude-sonnet-4-6" },
@@ -50,14 +50,14 @@ describe("resolveModelForDelegateTask", () => {
 					systemDefaultModel: "anthropic/claude-sonnet-4.6",
 				})
 
-				expect(result).toEqual({ model: "openai/gpt-5.4" })
+				expect(result).toEqual({ model: "openai/gpt-5.5" })
 			})
 		})
 
 		describe("#when user set fallback_models but no cache exists", () => {
 			test("#then returns skipped sentinel (skip fallback resolution without cache)", () => {
 				const result = resolveModelForDelegateTask({
-					userFallbackModels: ["openai/gpt-5.4", "google/gemini-3.1-pro"],
+					userFallbackModels: ["openai/gpt-5.5", "google/gemini-3.1-pro"],
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
 					fallbackChain: [
 						{ providers: ["anthropic"], model: "claude-sonnet-4-6" },
@@ -99,16 +99,16 @@ describe("resolveModelForDelegateTask", () => {
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
 					fallbackChain: [
-						{ providers: ["openai"], model: "gpt-5.4", variant: "high" },
+						{ providers: ["openai"], model: "gpt-5.5", variant: "high" },
 					],
 					availableModels: new Set(),
 					systemDefaultModel: "anthropic/claude-sonnet-4.6",
 				})
 
 				expect(result).toEqual({
-					model: "openai/gpt-5.4",
+					model: "openai/gpt-5.5",
 					variant: "high",
-					fallbackEntry: { providers: ["openai"], model: "gpt-5.4", variant: "high" },
+					fallbackEntry: { providers: ["openai"], model: "gpt-5.5", variant: "high" },
 					matchedFallback: true,
 				})
 				readConnectedProvidersSpy.mockRestore()
@@ -118,11 +118,11 @@ describe("resolveModelForDelegateTask", () => {
 				const readConnectedProvidersSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
 
 				const result = resolveModelForDelegateTask({
-					userFallbackModels: ["anthropic/claude-sonnet-4.6", "openai/gpt-5.4"],
+					userFallbackModels: ["anthropic/claude-sonnet-4.6", "openai/gpt-5.5"],
 					availableModels: new Set(),
 				})
 
-				expect(result).toEqual({ model: "openai/gpt-5.4", matchedFallback: true })
+				expect(result).toEqual({ model: "openai/gpt-5.5", matchedFallback: true })
 				readConnectedProvidersSpy.mockRestore()
 			})
 		})
@@ -144,7 +144,7 @@ describe("resolveModelForDelegateTask", () => {
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "new-api-openai/gpt-5.4-high",
 					isUserConfiguredCategoryModel: true,
-					availableModels: new Set(["openai/gpt-5.4"]),
+					availableModels: new Set(["openai/gpt-5.5"]),
 				})
 
 				expect(result).toEqual({ model: "new-api-openai/gpt-5.4-high" })
@@ -210,14 +210,14 @@ describe("resolveModelForDelegateTask", () => {
 				const result = resolveModelForDelegateTask({
 					fallbackChain: [
 						{ providers: ["opencode-go"], model: "minimax-m2.7" },
-						{ providers: ["openai", "github-copilot"], model: "gpt-5.4", variant: "high" },
+						{ providers: ["openai", "github-copilot"], model: "gpt-5.5", variant: "high" },
 					],
 					availableModels: new Set(),
 				})
 
 				expect(result).toBeDefined()
 				const resolved = result as { model: string; variant?: string }
-				expect(resolved.model).toBe("openai/gpt-5.4")
+				expect(resolved.model).toBe("openai/gpt-5.5")
 				expect(resolved.variant).toBe("high")
 			})
 
@@ -259,38 +259,38 @@ describe("resolveModelForDelegateTask", () => {
 		describe("#when userModel contains space-separated variant", () => {
 			test("#then extracts the variant and returns the base model separately", () => {
 				const result = resolveModelForDelegateTask({
-					userModel: "openai/gpt-5.4 high",
+					userModel: "openai/gpt-5.5 high",
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
 					fallbackChain: [
 						{ providers: ["anthropic"], model: "claude-sonnet-4-6" },
 					],
-					availableModels: new Set(["openai/gpt-5.4"]),
+					availableModels: new Set(["openai/gpt-5.5"]),
 				})
 
-				expect(result).toEqual({ model: "openai/gpt-5.4", variant: "high" })
+				expect(result).toEqual({ model: "openai/gpt-5.5", variant: "high" })
 			})
 		})
 
 		describe("#when userModel contains parenthesized variant", () => {
 			test("#then extracts the variant and returns the base model separately", () => {
 				const result = resolveModelForDelegateTask({
-					userModel: "openai/gpt-5.4(max)",
+					userModel: "openai/gpt-5.5(max)",
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
 					availableModels: new Set(),
 				})
 
-				expect(result).toEqual({ model: "openai/gpt-5.4", variant: "max" })
+				expect(result).toEqual({ model: "openai/gpt-5.5", variant: "max" })
 			})
 		})
 
 		describe("#when userModel has no variant syntax", () => {
 			test("#then returns the model without a variant (backward compat)", () => {
 				const result = resolveModelForDelegateTask({
-					userModel: "openai/gpt-5.4",
+					userModel: "openai/gpt-5.5",
 					availableModels: new Set(),
 				})
 
-				expect(result).toEqual({ model: "openai/gpt-5.4" })
+				expect(result).toEqual({ model: "openai/gpt-5.5" })
 			})
 		})
 
@@ -315,24 +315,24 @@ describe("resolveModelForDelegateTask", () => {
 		describe("#when categoryDefaultModel with isUserConfiguredCategoryModel contains a space-separated variant", () => {
 			test("#then extracts the variant and returns the base model separately", () => {
 				const result = resolveModelForDelegateTask({
-					categoryDefaultModel: "openai/gpt-5.4 medium",
+					categoryDefaultModel: "openai/gpt-5.5 medium",
 					isUserConfiguredCategoryModel: true,
-					availableModels: new Set(["openai/gpt-5.4"]),
+					availableModels: new Set(["openai/gpt-5.5"]),
 				})
 
-				expect(result).toEqual({ model: "openai/gpt-5.4", variant: "medium" })
+				expect(result).toEqual({ model: "openai/gpt-5.5", variant: "medium" })
 			})
 		})
 
 		describe("#when categoryDefaultModel with isUserConfiguredCategoryModel contains a parenthesized variant", () => {
 			test("#then extracts the variant and returns the base model separately", () => {
 				const result = resolveModelForDelegateTask({
-					categoryDefaultModel: "openai/gpt-5.4(xhigh)",
+					categoryDefaultModel: "openai/gpt-5.5(xhigh)",
 					isUserConfiguredCategoryModel: true,
 					availableModels: new Set(),
 				})
 
-				expect(result).toEqual({ model: "openai/gpt-5.4", variant: "xhigh" })
+				expect(result).toEqual({ model: "openai/gpt-5.5", variant: "xhigh" })
 			})
 		})
 
@@ -341,7 +341,7 @@ describe("resolveModelForDelegateTask", () => {
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "new-api-openai/gpt-5.4-high",
 					isUserConfiguredCategoryModel: true,
-					availableModels: new Set(["openai/gpt-5.4"]),
+					availableModels: new Set(["openai/gpt-5.5"]),
 				})
 
 				expect(result).toEqual({ model: "new-api-openai/gpt-5.4-high" })
@@ -362,14 +362,14 @@ describe("resolveModelForDelegateTask", () => {
 				const result = resolveModelForDelegateTask({
 					categoryDefaultModel: "anthropic/claude-sonnet-4.6",
 					fallbackChain: [
-						{ providers: ["openai"], model: "gpt-5.4" },
+						{ providers: ["openai"], model: "gpt-5.5" },
 					],
 					availableModels: new Set(),
 				})
 
 				expect(result).toEqual({
-					model: "openai/gpt-5.4",
-					fallbackEntry: { providers: ["openai"], model: "gpt-5.4" },
+					model: "openai/gpt-5.5",
+					fallbackEntry: { providers: ["openai"], model: "gpt-5.5" },
 					matchedFallback: true,
 				})
 				readConnectedProvidersSpy.mockRestore()

--- a/src/tools/delegate-task/oracle-gap-closure.test.ts
+++ b/src/tools/delegate-task/oracle-gap-closure.test.ts
@@ -7,7 +7,7 @@ import type { ParentContext } from "./executor-types"
 import * as executor from "./executor"
 
 const runtimeRequire = require as NodeJS.Require & { cache?: Record<string, unknown> }
-const MODEL = { providerID: "openai", modelID: "gpt-5.4" }
+const MODEL = { providerID: "openai", modelID: "gpt-5.5" }
 
 function clearRequireCache(modulePath: string): void {
   const resolvedPath = runtimeRequire.resolve(modulePath)

--- a/src/tools/delegate-task/resolve-metadata-model.test.ts
+++ b/src/tools/delegate-task/resolve-metadata-model.test.ts
@@ -2,7 +2,7 @@ const { describe, test, expect } = require("bun:test")
 
 import { resolveMetadataModel } from "./resolve-metadata-model"
 
-const PRIMARY = { providerID: "openai", modelID: "gpt-5.4" }
+const PRIMARY = { providerID: "openai", modelID: "gpt-5.5" }
 const FALLBACK = { providerID: "anthropic", modelID: "claude-sonnet-4-6" }
 
 describe("resolveMetadataModel", () => {
@@ -40,11 +40,11 @@ describe("resolveMetadataModel", () => {
 
   describe("#given primary has extra fields", () => {
     test("#when resolving #then preserves variant and strips unrelated fields", () => {
-      const extended = { providerID: "openai", modelID: "gpt-5.4", variant: "high", temperature: 0.7 } as const
+      const extended = { providerID: "openai", modelID: "gpt-5.5", variant: "high", temperature: 0.7 } as const
 
       const result = resolveMetadataModel(extended, undefined)
 
-      expect(result).toEqual({ providerID: "openai", modelID: "gpt-5.4", variant: "high" })
+      expect(result).toEqual({ providerID: "openai", modelID: "gpt-5.5", variant: "high" })
     })
   })
 
@@ -82,11 +82,11 @@ describe("resolveMetadataModel", () => {
 
   describe("#given both lack variant", () => {
     test("#when resolving metadata model #then variant is not on result", () => {
-      const primary = { providerID: "openai", modelID: "gpt-5.4" }
+      const primary = { providerID: "openai", modelID: "gpt-5.5" }
 
       const result = resolveMetadataModel(primary, undefined)
 
-      expect(result).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
+      expect(result).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
       expect(result?.variant).toBeUndefined()
     })
   })

--- a/src/tools/delegate-task/sync-continuation.test.ts
+++ b/src/tools/delegate-task/sync-continuation.test.ts
@@ -365,7 +365,7 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
           data: [
             { info: { id: "msg_001", role: "user", time: { created: 1000 }, agent: "oracle" } },
             {
-              info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "end_turn", agent: "oracle", providerID: "openai", modelID: "gpt-5.4" },
+              info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "end_turn", agent: "oracle", providerID: "openai", modelID: "gpt-5.5" },
               parts: [{ type: "text", text: "Response" }],
             },
           ],

--- a/src/tools/delegate-task/sync-prompt-sender.test.ts
+++ b/src/tools/delegate-task/sync-prompt-sender.test.ts
@@ -204,7 +204,7 @@ bunDescribe("sendSyncPrompt", () => {
       systemContent: undefined,
       categoryModel: {
         providerID: "openai",
-        modelID: "gpt-5.4",
+        modelID: "gpt-5.5",
         variant: "medium",
       },
       toastManager: null,
@@ -219,7 +219,7 @@ bunDescribe("sendSyncPrompt", () => {
     bunExpect(promptArgs.body.agent).toBe("sisyphus-junior")
     bunExpect(promptArgs.body.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
     })
     bunExpect(promptArgs.body.variant).toBe("medium")
   })
@@ -245,7 +245,7 @@ bunDescribe("sendSyncPrompt", () => {
       systemContent: undefined,
       categoryModel: {
         providerID: "openai",
-        modelID: "gpt-5.4",
+        modelID: "gpt-5.5",
         variant: "low",
         reasoningEffort: "high",
         temperature: 0.4,
@@ -271,7 +271,7 @@ bunDescribe("sendSyncPrompt", () => {
     bunExpect(promptWithModelSuggestionRetry).toHaveBeenCalledTimes(1)
     bunExpect(promptArgs.body.model).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
     })
     bunExpect(promptArgs.body.variant).toBe("low")
     bunExpect(promptArgs.body.options).toEqual({
@@ -312,7 +312,7 @@ bunDescribe("sendSyncPrompt", () => {
       systemContent: undefined,
       categoryModel: {
         providerID: "openai",
-        modelID: "gpt-5.4",
+        modelID: "gpt-5.5",
         temperature: 0.25,
       },
       toastManager: null,

--- a/src/tools/delegate-task/sync-task.test.ts
+++ b/src/tools/delegate-task/sync-task.test.ts
@@ -345,7 +345,7 @@ describe("executeSyncTask - cleanup on error paths", () => {
     const fallbackChain = [
       { providers: ["anthropic"], model: "claude-opus-4-7", variant: "max" },
       { providers: ["opencode-go"], model: "kimi-k2.5" },
-      { providers: ["openai"], model: "gpt-5.4", variant: "medium" },
+      { providers: ["openai"], model: "gpt-5.5", variant: "medium" },
     ]
 
     //#when
@@ -358,7 +358,7 @@ describe("executeSyncTask - cleanup on error paths", () => {
     expect(attemptedModels).toEqual([
       { providerID: "anthropic", modelID: "claude-opus-4-7", variant: "max" },
       { providerID: "opencode-go", modelID: "kimi-k2.5", variant: undefined },
-      { providerID: "openai", modelID: "gpt-5.4", variant: "medium" },
+      { providerID: "openai", modelID: "gpt-5.5", variant: "medium" },
     ])
   })
 

--- a/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
+++ b/src/tools/delegate-task/zauc-mocks-subagent-resolver/subagent-resolver.test.ts
@@ -291,7 +291,7 @@ describe("resolveSubagentExecution", () => {
   test("promotes object-style fallback model settings to categoryModel when subagent fallback becomes initial model", async () => {
     //#given
     readProviderModelsCacheMock.mockReturnValue({
-      models: { openai: ["gpt-5.4"] },
+      models: { openai: ["gpt-5.5"] },
       connected: ["openai"],
       updatedAt: "2026-03-03T00:00:00.000Z",
     })
@@ -306,7 +306,7 @@ describe("resolveSubagentExecution", () => {
           explore: {
             fallback_models: [
               {
-                model: "openai/gpt-5.4 high",
+                model: "openai/gpt-5.5 high",
                 variant: "low",
                 reasoningEffort: "high",
                 temperature: 0.2,
@@ -327,7 +327,7 @@ describe("resolveSubagentExecution", () => {
     expect(result.error).toBeUndefined()
     expect(result.categoryModel).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       variant: "low",
       reasoningEffort: "high",
       temperature: 0.2,
@@ -607,7 +607,7 @@ describe("resolveSubagentExecution", () => {
   test("preserves category temperature when fallback entry leaves temperature undefined", async () => {
     //#given
     readProviderModelsCacheMock.mockReturnValue({
-      models: { openai: ["gpt-5.4"] },
+      models: { openai: ["gpt-5.5"] },
       connected: ["openai"],
       updatedAt: "2026-03-03T00:00:00.000Z",
     })
@@ -627,7 +627,7 @@ describe("resolveSubagentExecution", () => {
           research: {
             fallback_models: [
               {
-                model: "openai/gpt-5.4",
+                model: "openai/gpt-5.5",
                 variant: "max",
               },
             ],
@@ -645,7 +645,7 @@ describe("resolveSubagentExecution", () => {
     expect(result.error).toBeUndefined()
     expect(result.categoryModel).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       variant: "max",
       temperature: 0.55,
       top_p: 0.45,
@@ -663,7 +663,7 @@ describe("resolveSubagentExecution", () => {
     const args = createBaseArgs({ subagent_type: "explore" })
     const executorCtx = createExecutorContext(
       async () => ([
-        { name: "explore", mode: "subagent", model: "openai/gpt-5.4" },
+        { name: "explore", mode: "subagent", model: "openai/gpt-5.5" },
       ]),
       {
         agentOverrides: {
@@ -673,7 +673,7 @@ describe("resolveSubagentExecution", () => {
         } as ExecutorContext["agentOverrides"],
         userCategories: {
           research: {
-            model: "openai/gpt-5.4",
+            model: "openai/gpt-5.5",
             variant: "high",
             temperature: 0.61,
             top_p: 0.62,
@@ -692,7 +692,7 @@ describe("resolveSubagentExecution", () => {
     expect(result.error).toBeUndefined()
     expect(result.categoryModel).toEqual({
       providerID: "openai",
-      modelID: "gpt-5.4",
+      modelID: "gpt-5.5",
       variant: "high",
       temperature: 0.61,
       top_p: 0.62,
@@ -705,7 +705,7 @@ describe("resolveSubagentExecution", () => {
   test("resolves user agent from loadUserAgents when calling task(subagent_type=...)", async () => {
     //#given
     readProviderModelsCacheMock.mockReturnValue({
-      models: { openai: ["gpt-5.4"] },
+      models: { openai: ["gpt-5.5"] },
       connected: ["openai"],
       updatedAt: "2026-03-03T00:00:00.000Z",
     })
@@ -715,7 +715,7 @@ describe("resolveSubagentExecution", () => {
         description: "A user agent",
         mode: "subagent",
         prompt: "Do something",
-        model: "openai/gpt-5.4",
+        model: "openai/gpt-5.5",
       },
     }))
     const args = createBaseArgs({ subagent_type: "my-user-agent" })
@@ -727,7 +727,7 @@ describe("resolveSubagentExecution", () => {
     //#then
     expect(result.error).toBeUndefined()
     expect(result.agentToUse).toBe("my-user-agent")
-    expect(result.categoryModel?.modelID).toBe("gpt-5.4")
+    expect(result.categoryModel?.modelID).toBe("gpt-5.5")
   })
 
   test("resolves project agent from loadProjectAgents when calling task(subagent_type=...)", async () => {
@@ -761,7 +761,7 @@ describe("resolveSubagentExecution", () => {
   test("server agent takes precedence over user agent with same name", async () => {
     //#given
     readProviderModelsCacheMock.mockReturnValue({
-      models: { openai: ["gpt-5.4", "gpt-3.5"] },
+      models: { openai: ["gpt-5.5", "gpt-3.5"] },
       connected: ["openai"],
       updatedAt: "2026-03-03T00:00:00.000Z",
     })
@@ -776,7 +776,7 @@ describe("resolveSubagentExecution", () => {
     }))
     const args = createBaseArgs({ subagent_type: "explore" })
     const executorCtx = createExecutorContext(async () => ([
-      { name: "explore", mode: "subagent", model: "openai/gpt-5.4" },
+      { name: "explore", mode: "subagent", model: "openai/gpt-5.5" },
     ]))
 
     //#when
@@ -785,7 +785,7 @@ describe("resolveSubagentExecution", () => {
     //#then
     expect(result.error).toBeUndefined()
     expect(result.agentToUse).toBe("explore")
-    expect(result.categoryModel?.modelID).toBe("gpt-5.4")
+    expect(result.categoryModel?.modelID).toBe("gpt-5.5")
   })
 
   test("project agent takes precedence over user agent with same name", async () => {

--- a/src/tools/look-at/multimodal-agent-metadata.test.ts
+++ b/src/tools/look-at/multimodal-agent-metadata.test.ts
@@ -69,18 +69,18 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
     // given - registered model is in the vision-capable cache
     setVisionCapableModelsCache(new Map([
       [
-        "openai/gpt-5.4",
-        { providerID: "openai", modelID: "gpt-5.4" },
+        "openai/gpt-5.5",
+        { providerID: "openai", modelID: "gpt-5.5" },
       ],
     ]))
     spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(
-      new Set(["openai/gpt-5.4"]),
+      new Set(["openai/gpt-5.5"]),
     )
     spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
     const ctx = createPluginInput([
       {
         name: "multimodal-looker",
-        model: { providerID: "openai", modelID: "gpt-5.4" },
+        model: { providerID: "openai", modelID: "gpt-5.5" },
       },
     ])
 
@@ -89,13 +89,13 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
 
     // then - returns registered metadata directly, variant is undefined since none was set
     expect(result).toEqual({
-      agentModel: { providerID: "openai", modelID: "gpt-5.4" },
+      agentModel: { providerID: "openai", modelID: "gpt-5.5" },
       agentVariant: undefined,
     })
   })
 
   test("prefers registered model over dynamically resolved vision-capable model", async () => {
-    // given - registered model is openai/gpt-5.4, dynamic would resolve to rundao model
+    // given - registered model is openai/gpt-5.5, dynamic would resolve to rundao model
     setVisionCapableModelsCache(new Map([
       [
         "rundao/public/qwen3.5-397b",
@@ -103,13 +103,13 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
       ],
     ]))
     spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(
-      new Set(["openai/gpt-5.4", "rundao/public/qwen3.5-397b"]),
+      new Set(["openai/gpt-5.5", "rundao/public/qwen3.5-397b"]),
     )
     spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai", "rundao"])
     const ctx = createPluginInput([
       {
         name: "multimodal-looker",
-        model: { providerID: "openai", modelID: "gpt-5.4" },
+        model: { providerID: "openai", modelID: "gpt-5.5" },
         variant: "medium",
       },
     ])
@@ -119,7 +119,7 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
 
     // then - registered model takes priority even when not in vision cache
     expect(result).toEqual({
-      agentModel: { providerID: "openai", modelID: "gpt-5.4" },
+      agentModel: { providerID: "openai", modelID: "gpt-5.5" },
       agentVariant: "medium",
     })
   })
@@ -151,13 +151,13 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
   test("returns registered model even when not in vision-capable cache", async () => {
     // given - registered model exists but is NOT in the vision-capable cache
     spyOn(modelAvailability, "fetchAvailableModels").mockResolvedValue(
-      new Set(["openai/gpt-5.4"]),
+      new Set(["openai/gpt-5.5"]),
     )
     spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(["openai"])
     const ctx = createPluginInput([
       {
         name: "multimodal-looker",
-        model: { providerID: "openai", modelID: "gpt-5.4" },
+        model: { providerID: "openai", modelID: "gpt-5.5" },
       },
     ])
 
@@ -166,7 +166,7 @@ describe("resolveMultimodalLookerAgentMetadata", () => {
 
     // then - trusts user's configured model regardless of vision cache
     expect(result).toEqual({
-      agentModel: { providerID: "openai", modelID: "gpt-5.4" },
+      agentModel: { providerID: "openai", modelID: "gpt-5.5" },
       agentVariant: undefined,
     })
   })

--- a/src/tools/look-at/multimodal-fallback-chain.test.ts
+++ b/src/tools/look-at/multimodal-fallback-chain.test.ts
@@ -5,36 +5,36 @@ describe("buildMultimodalLookerFallbackChain", () => {
     // given
     const { buildMultimodalLookerFallbackChain } = await import("./multimodal-fallback-chain")
     const visionCapableModels = [
-      { providerID: "openai", modelID: "gpt-5.4" },
-      { providerID: "opencode", modelID: "gpt-5.4" },
+      { providerID: "openai", modelID: "gpt-5.5" },
+      { providerID: "opencode", modelID: "gpt-5.5" },
     ]
 
     // when
     const result = buildMultimodalLookerFallbackChain(visionCapableModels)
 
     // then
-    const gpt54Entries = result.filter((entry) => entry.model === "gpt-5.4")
+    const gpt54Entries = result.filter((entry) => entry.model === "gpt-5.5")
     expect(gpt54Entries.length).toBeGreaterThan(0)
   })
 
   it("avoids duplicates when adding hardcoded entries", async () => {
     // given
     const { buildMultimodalLookerFallbackChain } = await import("./multimodal-fallback-chain")
-    const visionCapableModels = [{ providerID: "openai", modelID: "gpt-5.4" }]
+    const visionCapableModels = [{ providerID: "openai", modelID: "gpt-5.5" }]
 
     // when
     const result = buildMultimodalLookerFallbackChain(visionCapableModels)
 
     // then
     expect(result.length).toBeGreaterThan(0)
-    expect(result[0].model).toBe("gpt-5.4")
+    expect(result[0].model).toBe("gpt-5.5")
     expect(result[0].providers).toContain("openai")
   })
 
   it("preserves hardcoded variant metadata for cache-derived entries", async () => {
     // given
     const { buildMultimodalLookerFallbackChain } = await import("./multimodal-fallback-chain")
-    const visionCapableModels = [{ providerID: "openai", modelID: "gpt-5.4" }]
+    const visionCapableModels = [{ providerID: "openai", modelID: "gpt-5.5" }]
 
     // when
     const result = buildMultimodalLookerFallbackChain(visionCapableModels)
@@ -42,7 +42,7 @@ describe("buildMultimodalLookerFallbackChain", () => {
     // then
     expect(result[0]).toEqual({
       providers: ["openai"],
-      model: "gpt-5.4",
+      model: "gpt-5.5",
       variant: "medium",
     })
   })


### PR DESCRIPTION
## Summary

- Promotes GPT-native Sisyphus handling from GPT-5.4 to GPT-5.5 so `openai/gpt-5.5` is treated as a native Sisyphus-capable GPT model instead of being rerouted to Hephaestus.
- Updates model metadata, aliases, migrations, think-mode routing, tests, and docs so GPT-5.5 is consistently represented across the harness.

## Changes

- Updates `no-sisyphus-gpt` behavior to recognize GPT-5.5 as the native Sisyphus GPT variant through `AGENT_MODEL_REQUIREMENTS`.
- Fixes GPT-5.5 high variant routing in think-mode (`gpt-5-5` -> `gpt-5-5-high`).
- Adds migration coverage for `openai/gpt-5.4` -> `openai/gpt-5.5` and removes the no-op GPT-5.5 migration entry.
- Hardens model aliases for `kimi-for-coding/k2pb` and `github-copilot/claude-opus-4.7`.
- Refreshes `docs/guide/agent-model-matching.md` to document GPT-5.5 native Sisyphus support and the updated routing expectations.

## Screenshots

Not applicable. This PR changes model routing, metadata, tests, and documentation.

## Testing

```bash
bun test src/hooks/no-sisyphus-gpt/index.test.ts src/hooks/think-mode/index.test.ts src/hooks/think-mode/switcher.test.ts src/shared/model-capability-aliases.test.ts src/shared/migration.test.ts --bail
bun test src/shared/model-capability-aliases.test.ts src/shared/model-capabilities-regression.test.ts src/shared/model-capability-cache.test.ts --bail
bun run typecheck
bun run build
git diff --check
```

## Related Issues

- Addresses #3601 by allowing GPT-5.5 through the Sisyphus GPT guard instead of treating it like a non-native GPT model.
- Addresses #3616 by covering the reported GPT-5.5 + Sisyphus rejection path after `3.17.5`.
- Helps resolve #3615 on the code side by ensuring the branch contains the GPT-5.5 native Sisyphus routing that the stale npm artifact missed. A fresh publish is still required for users to receive the fixed artifact.
- Incorporates the relevant behavior from #3605 and overlaps with the intent of #3602.
- Aligns with #3654 by removing stale GPT-5.4 expectations after the GPT-5.5 promotion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes Sisyphus and all GPT‑native agents to GPT‑5.5 and refreshes routing, docs, and tests across the codebase. Keeps native GPT‑5.4 prompt support and adds migrations/aliases so configs and fallbacks upgrade without user changes.

- **Refactors**
  - Routes GPT models to GPT‑5.5 prompts for Sisyphus, Hephaestus, Sisyphus‑Junior, Atlas, Prometheus; legacy GPT‑5.4 family still maps to its native prompts.
  - Fixes think‑mode high‑variant mapping for GPT‑5.5 (dot/dash forms) and updates resolver/capability caches, CLI/doctor/TUI copy, provider caches, and multimodal looker/fallback chains to prefer GPT‑5.5.
  - Hardens `no-sisyphus-gpt` with chain‑aware native GPT variant detection via `AGENT_MODEL_REQUIREMENTS`; adds `isGpt5_5Model` and expands tests (including GPT‑5.4 native coverage).

- **Migration**
  - Auto‑upgrades `openai/gpt-5.3-codex` and `openai/gpt-5.4` to `openai/gpt-5.5`.
  - Aligns aliases and docs (e.g., `claude-opus-4.7` → `claude-opus-4-7`); no action needed unless you hard‑pin models.

<sup>Written for commit e7a52903aafc8f15bfb9e5417e516bc87831d110. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

