### PR TITLE
fix(posthog): guard os.cpus() against Bun /sys/firmware permissions error (fixes #3496)

### DIFF
--- a/src/shared/posthog.test.ts
+++ b/src/shared/posthog.test.ts
@@ -54,4 +54,49 @@ describe("posthog client creation", () => {
     expect(() => pluginPostHog.trackActive("plugin", "plugin_loaded")).not.toThrow()
     await expect(pluginPostHog.shutdown()).resolves.toBeUndefined()
   })
+
+  it("creates a plugin client when os.cpus throws", async () => {
+    // given
+    process.env.OMO_DISABLE_POSTHOG = "0"
+    process.env.OMO_SEND_ANONYMOUS_TELEMETRY = "1"
+    process.env.POSTHOG_API_KEY = "test-api-key"
+
+    mock.module("os", () => ({
+      default: {
+        arch: () => "x64",
+        cpus: () => {
+          throw new Error("Failed to get CPU information")
+        },
+        hostname: () => "test-host",
+        platform: () => "linux",
+        release: () => "6.8.0-arch1-1",
+        totalmem: () => 8 * 1024 * 1024 * 1024,
+        type: () => "Linux",
+      },
+    }))
+
+    mock.module("posthog-node", () => ({
+      PostHog: class {
+        capture() {}
+        captureException() {}
+        async shutdown() {}
+      },
+    }))
+
+    const { createPluginPostHog } = await importPostHogModule()
+
+    // when
+    const pluginPostHog = createPluginPostHog()
+
+    // then
+    expect(() =>
+      pluginPostHog.capture({
+        distinctId: "plugin",
+        event: "plugin_loaded",
+      }),
+    ).not.toThrow()
+    expect(() => pluginPostHog.captureException(new Error("plugin failure"), "plugin")).not.toThrow()
+    expect(() => pluginPostHog.trackActive("plugin", "plugin_loaded")).not.toThrow()
+    await expect(pluginPostHog.shutdown()).resolves.toBeUndefined()
+  })
 })

--- a/src/shared/posthog.ts
+++ b/src/shared/posthog.ts
@@ -55,7 +55,18 @@ function getPostHogHost(): string {
   return process.env.POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST
 }
 
+function safeCpus(): { length: number; model: string | undefined } {
+  try {
+    const cpus = os.cpus()
+    return { length: cpus.length, model: cpus[0]?.model }
+  } catch {
+    return { length: 0, model: undefined }
+  }
+}
+
 function getSharedProperties(source: PostHogSource): NonNullable<PostHogCaptureEvent["properties"]> {
+  const cpus = safeCpus()
+
   return {
     platform: "oh-my-opencode",
     package_name: PUBLISHED_PACKAGE_NAME,
@@ -68,8 +79,8 @@ function getSharedProperties(source: PostHogSource): NonNullable<PostHogCaptureE
     $os_version: os.release(),
     os_arch: os.arch(),
     os_type: os.type(),
-    cpu_count: os.cpus().length,
-    cpu_model: os.cpus()[0]?.model,
+    cpu_count: cpus.length,
+    cpu_model: cpus.model,
     total_memory_gb: Math.round(os.totalmem() / 1024 / 1024 / 1024),
     locale: Intl.DateTimeFormat().resolvedOptions().locale,
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,


### PR DESCRIPTION
## Summary
- Prevent PostHog telemetry initialization from crashing when Bun's `os.cpus()` throws on hardened Linux DMI sysfs permissions.
- Degrade CPU metadata to safe fallbacks so plugin registration can continue.

## Changes
- Added `safeCpus()` around `os.cpus()` in shared PostHog properties.
- Reused the safe CPU metadata for `cpu_count` and `cpu_model`.
- Added a regression test that mocks `os.cpus()` throwing and verifies plugin PostHog client creation remains usable.

## Testing
- `bun run typecheck`
- `bun test src/shared/posthog.test.ts`
- `bun run build`

Closes #3496

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents PostHog telemetry from crashing when Bun’s `os.cpus()` fails on hardened Linux. Falls back to safe CPU metadata so the plugin client initializes reliably. Fixes #3496.

- **Bug Fixes**
  - Added `safeCpus()` wrapper and used it for `cpu_count` and `cpu_model`.
  - Added a regression test that mocks `os.cpus()` throwing and verifies the plugin PostHog client still works.

<sup>Written for commit d1bc25a6ce2c7a3f74a88a3baa6a5f8d45c4dd51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

