### PR TITLE
fix(model-capabilities): mark minimax/non-thinking-kimi as supportsThinking:false (fixes #3590)

### DIFF
--- a/src/shared/model-capabilities.test.ts
+++ b/src/shared/model-capabilities.test.ts
@@ -59,6 +59,12 @@ describe("getModelCapabilities", () => {
           output: 128_000,
         },
       },
+      "minimax-m2.7": {
+        id: "minimax-m2.7",
+        family: "minimax",
+        reasoning: true,
+        temperature: true,
+      },
     },
   }
 
@@ -323,6 +329,55 @@ describe("getModelCapabilities", () => {
       family: { source: "heuristic" },
       reasoningEfforts: { source: "heuristic" },
     })
+  })
+
+  test("marks MiniMax M2.7 as not supporting thinking despite snapshot reasoning", () => {
+    // given
+    const modelID = "minimax-m2.7"
+
+    // when
+    const result = getModelCapabilities({
+      providerID: "volcengine",
+      modelID,
+      bundledSnapshot,
+    })
+
+    // then
+    expect(result.supportsThinking).toBe(false)
+    expect(result.diagnostics.supportsThinking.source).toBe("heuristic")
+  })
+
+  test("marks non-thinking Kimi K2.6 as not supporting thinking", () => {
+    // given
+    const modelID = "kimi-k2.6"
+
+    // when
+    const result = getModelCapabilities({
+      providerID: "volcengine",
+      modelID,
+      bundledSnapshot,
+    })
+
+    // then
+    expect(result.supportsThinking).toBe(false)
+    expect(result.diagnostics.supportsThinking.source).toBe("heuristic")
+  })
+
+  test("keeps thinking-flavored Kimi K2.6 models as supporting thinking", () => {
+    // given
+    const modelID = "kimi-k2.6-thinking"
+
+    // when
+    const result = getModelCapabilities({
+      providerID: "volcengine",
+      modelID,
+      bundledSnapshot,
+    })
+
+    // then
+    expect(result.supportsThinking).toBe(true)
+    expect(result.family).toBe("kimi-thinking")
+    expect(result.diagnostics.supportsThinking.source).toBe("heuristic")
   })
 
   test("detects prefixed o-series model IDs through the heuristic fallback", () => {

--- a/src/shared/model-capability-heuristics.ts
+++ b/src/shared/model-capability-heuristics.ts
@@ -45,9 +45,17 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
     variants: ["low", "medium", "high"],
   },
   {
+    family: "kimi-thinking",
+    includes: ["kimi-thinking", "k2-thinking", "k2-think"],
+    pattern: /(?:kimi|k2).*-(?:thinking|think)/,
+    variants: ["low", "medium", "high"],
+    supportsThinking: true,
+  },
+  {
     family: "kimi",
     includes: ["kimi", "k2"],
     variants: ["low", "medium", "high"],
+    supportsThinking: false,
   },
   {
     family: "glm",
@@ -58,6 +66,7 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
     family: "minimax",
     includes: ["minimax"],
     variants: ["low", "medium", "high"],
+    supportsThinking: false,
   },
   {
     family: "deepseek",

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
+import { getModelCapabilities } from "./model-capabilities"
 import { resolveCompatibleModelSettings } from "./model-settings-compatibility"
 
 describe("resolveCompatibleModelSettings", () => {
@@ -465,6 +466,48 @@ describe("resolveCompatibleModelSettings", () => {
         reason: "unsupported-by-model-metadata",
       },
     ])
+  })
+
+  test("drops thinking for MiniMax M2.7 capabilities resolved from heuristics", () => {
+    // given
+    const capabilities = getModelCapabilities({
+      providerID: "volcengine",
+      modelID: "minimax-m2.7",
+    })
+
+    // when
+    const result = resolveCompatibleModelSettings({
+      providerID: "volcengine",
+      modelID: "minimax-m2.7",
+      desired: { thinking: { type: "enabled", budgetTokens: 4096 } },
+      capabilities,
+    })
+
+    // then
+    expect(result.thinking).toBeUndefined()
+    expect(result.changes[0]?.field).toBe("thinking")
+    expect(result.changes[0]?.reason).toBe("unsupported-by-model-metadata")
+  })
+
+  test("drops thinking for non-thinking Kimi K2.6 capabilities resolved from heuristics", () => {
+    // given
+    const capabilities = getModelCapabilities({
+      providerID: "volcengine",
+      modelID: "kimi-k2.6",
+    })
+
+    // when
+    const result = resolveCompatibleModelSettings({
+      providerID: "volcengine",
+      modelID: "kimi-k2.6",
+      desired: { thinking: { type: "enabled", budgetTokens: 4096 } },
+      capabilities,
+    })
+
+    // then
+    expect(result.thinking).toBeUndefined()
+    expect(result.changes[0]?.field).toBe("thinking")
+    expect(result.changes[0]?.reason).toBe("unsupported-by-model-metadata")
   })
 
   test("clamps maxTokens to the model output limit", () => {


### PR DESCRIPTION
## Summary
- Mark MiniMax and non-thinking Kimi heuristic families as not supporting the `thinking` request parameter.
- Preserve thinking-flavored Kimi models as thinking-capable before the broader Kimi heuristic matches.

## Changes
- Adds a `kimi-thinking` heuristic family before `kimi`.
- Sets `supportsThinking: false` for `kimi` and `minimax` families.
- Adds regression coverage for MiniMax M2.7, Kimi K2.6, and request setting compatibility.

## Testing
- `bun --install=fallback /Users/yeongyu/.config/opencode/skills/typescript-programmer/scripts/check-no-excuse-rules.ts src/shared/model-capability-heuristics.ts src/shared/model-capabilities.test.ts src/shared/model-settings-compatibility.test.ts`
- `bun test src/shared/model-capabilities.test.ts src/shared/model-settings-compatibility.test.ts`
- `bun run typecheck`
- `bun run build`

Closes #3590

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the `thinking` request param for `minimax` and non-thinking `kimi` models, and add a `kimi-thinking` heuristic so thinking variants remain supported. Fixes #3590.

- **Bug Fixes**
  - Added `kimi-thinking` family before `kimi` to detect `*-thinking`/`*-think` variants; `supportsThinking: true`.
  - Set `supportsThinking: false` for `kimi` and `minimax` families to prevent accidental enablement.
  - Updated tests for MiniMax M2.7 and Kimi K2.6, plus compatibility checks that drop `thinking` when unsupported.

<sup>Written for commit 71c29c8fe047a8abfbf25cbb909d4aaedd8e5881. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

