### PR TITLE
fix(builtin-skills): treat dev-browser as a selectable browser provider (fixes #3411)

### DIFF
--- a/src/features/builtin-skills/skills.test.ts
+++ b/src/features/builtin-skills/skills.test.ts
@@ -25,8 +25,30 @@ describe("createBuiltinSkills", () => {
 		// then
 		const playwrightSkill = skills.find((s) => s.name === "playwright")
 		const agentBrowserSkill = skills.find((s) => s.name === "agent-browser")
+		const devBrowserSkill = skills.find((s) => s.name === "dev-browser")
 		expect(playwrightSkill).toBeDefined()
 		expect(agentBrowserSkill).toBeUndefined()
+		expect(devBrowserSkill).toBeUndefined()
+	})
+
+	test("returns dev-browser skill when browserProvider is 'dev-browser'", () => {
+		// given
+		const options = { browserProvider: "dev-browser" as const }
+
+		// when
+		const skills = createBuiltinSkills(options)
+
+		// then
+		const skillNames = skills.map((skill) => skill.name)
+		const devBrowserSkill = skills.find((skill) => skill.name === "dev-browser")
+		const playwrightSkill = skills.find((skill) => skill.name === "playwright")
+		const agentBrowserSkill = skills.find((skill) => skill.name === "agent-browser")
+		expect(devBrowserSkill).toBeDefined()
+		expect(devBrowserSkill!.description).toContain("Browser automation")
+		expect(playwrightSkill).toBeUndefined()
+		expect(agentBrowserSkill).toBeUndefined()
+		expect(skillNames).not.toContain("playwright-cli")
+		expect(skills.some((skill) => skill.allowedTools?.includes("Bash(playwright-cli:*)"))).toBe(false)
 	})
 
 	test("returns agent-browser skill when browserProvider is 'agent-browser'", () => {
@@ -67,9 +89,10 @@ describe("createBuiltinSkills", () => {
 		// when
 		const defaultSkills = createBuiltinSkills()
 		const agentBrowserSkills = createBuiltinSkills({ browserProvider: "agent-browser" })
+		const devBrowserSkills = createBuiltinSkills({ browserProvider: "dev-browser" })
 
 		// then
-		for (const skills of [defaultSkills, agentBrowserSkills]) {
+		for (const skills of [defaultSkills, agentBrowserSkills, devBrowserSkills]) {
 			expect(skills.find((s) => s.name === "frontend-ui-ux")).toBeDefined()
 			expect(skills.find((s) => s.name === "git-master")).toBeDefined()
 			expect(skills.find((s) => s.name === "review-work")).toBeDefined()
@@ -77,16 +100,18 @@ describe("createBuiltinSkills", () => {
 		}
 	})
 
-	test("returns exactly 6 skills regardless of provider", () => {
+	test("returns exactly 5 skills regardless of provider", () => {
 		// given
 
 		// when
 		const defaultSkills = createBuiltinSkills()
 		const agentBrowserSkills = createBuiltinSkills({ browserProvider: "agent-browser" })
+		const devBrowserSkills = createBuiltinSkills({ browserProvider: "dev-browser" })
 
 		// then
-		expect(defaultSkills).toHaveLength(6)
-		expect(agentBrowserSkills).toHaveLength(6)
+		expect(defaultSkills).toHaveLength(5)
+		expect(agentBrowserSkills).toHaveLength(5)
+		expect(devBrowserSkills).toHaveLength(5)
 	})
 
 	test("should exclude playwright when it is in disabledSkills", () => {
@@ -100,10 +125,10 @@ describe("createBuiltinSkills", () => {
 		expect(skills.map((s) => s.name)).not.toContain("playwright")
 		expect(skills.map((s) => s.name)).toContain("frontend-ui-ux")
 		expect(skills.map((s) => s.name)).toContain("git-master")
-		expect(skills.map((s) => s.name)).toContain("dev-browser")
+		expect(skills.map((s) => s.name)).not.toContain("dev-browser")
 		expect(skills.map((s) => s.name)).toContain("review-work")
 		expect(skills.map((s) => s.name)).toContain("ai-slop-remover")
-		expect(skills.length).toBe(5)
+		expect(skills.length).toBe(4)
 	})
 
 	test("should exclude multiple skills when they are in disabledSkills", () => {
@@ -117,17 +142,15 @@ describe("createBuiltinSkills", () => {
 		expect(skills.map((s) => s.name)).not.toContain("playwright")
 		expect(skills.map((s) => s.name)).not.toContain("git-master")
 		expect(skills.map((s) => s.name)).toContain("frontend-ui-ux")
-		expect(skills.map((s) => s.name)).toContain("dev-browser")
+		expect(skills.map((s) => s.name)).not.toContain("dev-browser")
 		expect(skills.map((s) => s.name)).toContain("review-work")
 		expect(skills.map((s) => s.name)).toContain("ai-slop-remover")
-		expect(skills.length).toBe(4)
+		expect(skills.length).toBe(3)
 	})
 
 	test("should return an empty array when all skills are disabled", () => {
 		// #given
-		const options = {
-			disabledSkills: new Set(["playwright", "frontend-ui-ux", "git-master", "dev-browser", "review-work", "ai-slop-remover"]),
-		}
+		const options = { disabledSkills: new Set(["playwright", "frontend-ui-ux", "git-master", "review-work", "ai-slop-remover"]) }
 
 		// #when
 		const skills = createBuiltinSkills(options)
@@ -144,7 +167,7 @@ describe("createBuiltinSkills", () => {
 		const skills = createBuiltinSkills(options)
 
 		// #then
-		expect(skills.length).toBe(6)
+		expect(skills.length).toBe(5)
 	})
 
 	test("review-work skill has correct structure", () => {

--- a/src/features/builtin-skills/skills.ts
+++ b/src/features/builtin-skills/skills.ts
@@ -21,15 +21,17 @@ export function createBuiltinSkills(options: CreateBuiltinSkillsOptions = {}): B
   const { browserProvider = "playwright", disabledSkills } = options
 
   let browserSkill: BuiltinSkill
-  if (browserProvider === "agent-browser") {
-    browserSkill = agentBrowserSkill
-  } else if (browserProvider === "playwright-cli") {
-    browserSkill = playwrightCliSkill
-  } else {
-    browserSkill = playwrightSkill
-  }
+	if (browserProvider === "agent-browser") {
+		browserSkill = agentBrowserSkill
+	} else if (browserProvider === "dev-browser") {
+		browserSkill = devBrowserSkill
+	} else if (browserProvider === "playwright-cli") {
+		browserSkill = playwrightCliSkill
+	} else {
+		browserSkill = playwrightSkill
+	}
 
-  const skills = [browserSkill, frontendUiUxSkill, gitMasterSkill, devBrowserSkill, reviewWorkSkill, aiSlopRemoverSkill]
+	const skills = [browserSkill, frontendUiUxSkill, gitMasterSkill, reviewWorkSkill, aiSlopRemoverSkill]
 
   if (!disabledSkills) {
     return skills

--- a/src/plugin/skill-context.test.ts
+++ b/src/plugin/skill-context.test.ts
@@ -85,4 +85,68 @@ describe("createSkillContext", () => {
       getSystemMcpServerNamesSpy.mockRestore()
     }
   })
+
+  it("excludes discovered dev-browser skill when browser provider is playwright", async () => {
+    // given
+    const discoveredDevBrowserSkill = {
+      name: "dev-browser",
+      definition: { description: "Discovered dev-browser skill" },
+      scope: "user" as const,
+    }
+
+    const discoverConfigSourceSkillsSpy = spyOn(
+      skillLoader,
+      "discoverConfigSourceSkills",
+    ).mockResolvedValue([])
+    const discoverUserClaudeSkillsSpy = spyOn(
+      skillLoader,
+      "discoverUserClaudeSkills",
+    ).mockResolvedValue([discoveredDevBrowserSkill])
+    const discoverProjectClaudeSkillsSpy = spyOn(
+      skillLoader,
+      "discoverProjectClaudeSkills",
+    ).mockResolvedValue([])
+    const discoverOpencodeGlobalSkillsSpy = spyOn(
+      skillLoader,
+      "discoverOpencodeGlobalSkills",
+    ).mockResolvedValue([])
+    const discoverProjectAgentsSkillsSpy = spyOn(
+      skillLoader,
+      "discoverProjectAgentsSkills",
+    ).mockResolvedValue([])
+    const discoverGlobalAgentsSkillsSpy = spyOn(
+      skillLoader,
+      "discoverGlobalAgentsSkills",
+    ).mockResolvedValue([])
+    const getSystemMcpServerNamesSpy = spyOn(
+      mcpLoader,
+      "getSystemMcpServerNames",
+    ).mockReturnValue(new Set<string>())
+
+    const pluginConfig = OhMyOpenCodeConfigSchema.parse({
+      browser_automation_engine: { provider: "playwright" },
+    })
+
+    try {
+      // when
+      const result = await createSkillContext({
+        directory: testDirectory,
+        pluginConfig,
+      })
+
+      // then
+      expect(result.browserProvider).toBe("playwright")
+      expect(result.mergedSkills.some((skill) => skill.name === "playwright")).toBe(true)
+      expect(result.mergedSkills.some((skill) => skill.name === "dev-browser")).toBe(false)
+      expect(result.availableSkills.some((skill) => skill.name === "dev-browser")).toBe(false)
+    } finally {
+      discoverConfigSourceSkillsSpy.mockRestore()
+      discoverUserClaudeSkillsSpy.mockRestore()
+      discoverProjectClaudeSkillsSpy.mockRestore()
+      discoverOpencodeGlobalSkillsSpy.mockRestore()
+      discoverProjectAgentsSkillsSpy.mockRestore()
+      discoverGlobalAgentsSkillsSpy.mockRestore()
+      getSystemMcpServerNamesSpy.mockRestore()
+    }
+  })
 })

--- a/src/plugin/skill-context.ts
+++ b/src/plugin/skill-context.ts
@@ -26,7 +26,7 @@ export type SkillContext = {
   disabledSkills: Set<string>
 }
 
-const PROVIDER_GATED_SKILL_NAMES = new Set(["agent-browser", "playwright"])
+const PROVIDER_GATED_SKILL_NAMES = new Set(["agent-browser", "dev-browser", "playwright"])
 
 function mapScopeToLocation(scope: SkillScope): AvailableSkill["location"] {
   if (scope === "user" || scope === "opencode") return "user"


### PR DESCRIPTION
## Summary
- Treat `dev-browser` as a selectable browser automation provider instead of an always-on builtin skill.
- Prevent conflicting browser automation `MUST USE` skill claims when another provider is selected.

## Changes
- Select `devBrowserSkill` only when `browser_automation_engine.provider` is `dev-browser`.
- Remove `devBrowserSkill` from the unconditional builtin skills list.
- Add `dev-browser` to provider-gated skill filtering for discovered skills.
- Add regression coverage for builtin provider selection and skill-context filtering.

## Testing
- `bun test src/features/builtin-skills/skills.test.ts src/plugin/skill-context.test.ts` ✅
- `bun --install=fallback /Users/yeongyu/.config/opencode/skills/typescript-programmer/scripts/check-no-excuse-rules.ts src/features/builtin-skills/skills.ts src/plugin/skill-context.ts src/features/builtin-skills/skills.test.ts src/plugin/skill-context.test.ts` ✅
- `bun run typecheck` ✅
- `bun test` ✅
- `bun run build` ✅

## Related Issues
Fixes #3411

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `dev-browser` a selectable browser automation provider gated by `browser_automation_engine.provider`, instead of an always-on builtin skill. This prevents conflicts with other providers’ MUST USE claims and fixes #3411.

- **Bug Fixes**
  - Select `devBrowserSkill` only when provider is `dev-browser`; remove it from the unconditional builtin skills (builtin list now totals 5).
  - Add `dev-browser` to provider-gated filtering so discovered skills are excluded when another provider (e.g., `playwright`, `agent-browser`, `playwright-cli`) is selected.
  - Update tests for provider selection, provider-gated discovery (including a `playwright` case), and adjusted builtin counts.

<sup>Written for commit f1d4eb7846d1d25309cfd88ce21f40e9d9ea7c16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

