### PR TITLE
fix(ralph-loop): strip ZWSP from agent name before promptAsync (fixes #3253)

### DIFF
--- a/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
@@ -2,6 +2,65 @@ import { describe, expect, test } from "bun:test"
 import { injectContinuationPrompt } from "./continuation-prompt-injector"
 
 describe("ralph-loop continuation prompt injector", () => {
+  test("#given inherited message agent has ZWSP prefix #when injecting continuation prompt #then promptAsync receives normalized agent", async () => {
+    // given
+    let promptBody: { agent?: string } | undefined
+    const ctx = {
+      client: {
+        session: {
+          messages: async () => ({
+            data: [{ info: { agent: "\u200bSisyphus - Ultraworker" } }],
+          }),
+          promptAsync: async (input: { body: { agent?: string } }) => {
+            promptBody = input.body
+            return {}
+          },
+        },
+      },
+    }
+
+    // when
+    await injectContinuationPrompt(ctx as never, {
+      sessionID: "ses_ralph_zwsp_agent",
+      prompt: "continue",
+      directory: "/tmp/test",
+      apiTimeoutMs: 50,
+    })
+
+    // then
+    expect(promptBody?.agent).toBe("sisyphus")
+    expect(promptBody?.agent).not.toContain("\u200b")
+  })
+
+  test("#given inherited message agent has no ZWSP prefix #when injecting continuation prompt #then promptAsync receives normalized agent", async () => {
+    // given
+    let promptBody: { agent?: string } | undefined
+    const ctx = {
+      client: {
+        session: {
+          messages: async () => ({
+            data: [{ info: { agent: "Sisyphus - Ultraworker" } }],
+          }),
+          promptAsync: async (input: { body: { agent?: string } }) => {
+            promptBody = input.body
+            return {}
+          },
+        },
+      },
+    }
+
+    // when
+    await injectContinuationPrompt(ctx as never, {
+      sessionID: "ses_ralph_clean_agent",
+      prompt: "continue",
+      directory: "/tmp/test",
+      apiTimeoutMs: 50,
+    })
+
+    // then
+    expect(promptBody?.agent).toBe("sisyphus")
+  })
+
   test("#given inherited message model includes variant #when injecting continuation prompt #then promptAsync receives variant as a top-level field", async () => {
     // given
     let promptBody:

--- a/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -8,6 +8,7 @@ import {
 	normalizeSDKResponse,
 	resolveInheritedPromptTools,
 } from "../../shared"
+import { normalizeAgentForPromptKey } from "../../shared/agent-display-names"
 
 type MessageInfo = {
 	agent?: string
@@ -69,6 +70,7 @@ export async function injectContinuationPrompt(
 	}
 
 	const inheritedTools = resolveInheritedPromptTools(sourceSessionID, tools)
+	const cleanAgent = normalizeAgentForPromptKey(agent)
 
 	const launchModel = model
 		? { providerID: model.providerID, modelID: model.modelID }
@@ -78,7 +80,7 @@ export async function injectContinuationPrompt(
 	await ctx.client.session.promptAsync({
 		path: { id: options.sessionID },
 		body: {
-			...(agent !== undefined ? { agent } : {}),
+			...(cleanAgent !== undefined ? { agent: cleanAgent } : {}),
 			...(launchModel ? { model: launchModel } : {}),
 			...(launchVariant ? { variant: launchVariant } : {}),
 			...(inheritedTools ? { tools: inheritedTools } : {}),


### PR DESCRIPTION
## Summary
- Strip UI sorting prefixes from ralph-loop continuation agent names before calling promptAsync.
- Prevent OpenCode from rejecting ultrawork continuation requests that inherit a ZWSP-prefixed agent from message history.

## Changes
- Normalize the inherited ralph-loop agent name with normalizeAgentForPromptKey before building the promptAsync payload.
- Add regression coverage for ZWSP-prefixed and regular Sisyphus Ultraworker agent names.

## Testing
- bun test src/hooks/ralph-loop/continuation-prompt-injector.test.ts
- bun run typecheck
- bun test src/hooks/ralph-loop/
- bun run build

Closes #3253

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize inherited ralph-loop continuation agent names by stripping ZWSP/UI prefixes before calling promptAsync, so ultrawork continuation requests are accepted. Closes #3253.

- **Bug Fixes**
  - Use `normalizeAgentForPromptKey` to clean the inherited agent before building the prompt payload.
  - Add regression tests for ZWSP-prefixed and regular "Sisyphus - Ultraworker" agent names.

<sup>Written for commit c92f8416884c14c921911290162e0e4c3146473f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

