### PR TITLE
fix(plugin-handlers): normalize default_agent config key before runtime-name lookup (fixes #3313)

### DIFF
--- a/src/plugin-handlers/agent-config-handler.test.ts
+++ b/src/plugin-handlers/agent-config-handler.test.ts
@@ -191,6 +191,56 @@ describe("applyAgentConfig builtin override protection", () => {
     }
   })
 
+  test("normalizes display-name default_agent to runtime agent name", async () => {
+    // given
+    const config = createBaseConfig()
+    config.default_agent = "Sisyphus - Ultraworker"
+
+    // when
+    await applyAgentConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    expect(config.default_agent).toBe(getAgentRuntimeName("sisyphus"))
+  })
+
+  test("keeps config-key default_agent behavior unchanged", async () => {
+    // given
+    const config = createBaseConfig()
+    config.default_agent = "sisyphus"
+
+    // when
+    await applyAgentConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    expect(config.default_agent).toBe(getAgentRuntimeName("sisyphus"))
+  })
+
+  test("keeps fallback default_agent behavior unchanged", async () => {
+    // given
+    const config = createBaseConfig()
+
+    // when
+    await applyAgentConfig({
+      config,
+      pluginConfig: createPluginConfig(),
+      ctx: { directory: "/tmp" },
+      pluginComponents: createPluginComponents(),
+    })
+
+    // then
+    expect(config.default_agent).toBe(getAgentRuntimeName("sisyphus"))
+  })
+
   test("filters user agents whose key matches the builtin display-name alias", async () => {
     // given
     loadUserAgentsSpy.mockReturnValue({

--- a/src/plugin-handlers/agent-config-handler.ts
+++ b/src/plugin-handlers/agent-config-handler.ts
@@ -2,7 +2,11 @@ import { createBuiltinAgents } from "../agents";
 import { createSisyphusJuniorAgentWithOverrides } from "../agents/sisyphus-junior";
 import type { OhMyOpenCodeConfig } from "../config";
 import { isTaskSystemEnabled, log, migrateAgentConfig } from "../shared";
-import { getAgentRuntimeName } from "../shared/agent-display-names";
+import {
+  getAgentConfigKey,
+  getAgentRuntimeName,
+  normalizeAgentForPromptKey,
+} from "../shared/agent-display-names";
 import { AGENT_NAME_MAP } from "../shared/migration";
 import { registerAgentName } from "../features/claude-code-session-state";
 import {
@@ -189,8 +193,10 @@ export async function applyAgentConfig(params: {
 
   if (isSisyphusEnabled && builtinAgents.sisyphus) {
     if (configuredDefaultAgent) {
+      const configKey = getAgentConfigKey(configuredDefaultAgent);
+      const runtimeConfigKey = normalizeAgentForPromptKey(configuredDefaultAgent) ?? configKey;
       (params.config as { default_agent?: string }).default_agent =
-        getAgentRuntimeName(configuredDefaultAgent);
+        getAgentRuntimeName(runtimeConfigKey);
     } else {
       (params.config as { default_agent?: string }).default_agent =
         getAgentRuntimeName("sisyphus");


### PR DESCRIPTION
## Summary
Normalize configured `default_agent` values before runtime-name lookup so display names like `Sisyphus - Ultraworker` resolve to the same ZWSP-prefixed runtime agent key OpenCode registers.

## Changes
- Added regression coverage for display-name, config-key, and fallback default_agent behavior.
- Normalized configured default agents before calling `getAgentRuntimeName` while preserving custom default agent names.

## Testing
- `bun --install=fallback /Users/yeongyu/.config/opencode/skills/typescript-programmer/scripts/check-no-excuse-rules.ts src/plugin-handlers/agent-config-handler.ts src/plugin-handlers/agent-config-handler.test.ts`
- `bun test src/plugin-handlers/agent-config-handler.test.ts --test-name-pattern "default_agent"`
- `bun test src/plugin-handlers/config-handler.test.ts --test-name-pattern "default_agent"`
- `bun run typecheck`
- `bun run build`

Note: full `bun test` was run and still has unrelated baseline failures in existing LSP/team-worktree tests where `os.tmpdir` is unavailable under current Bun test state, plus the pre-existing config custom-default test before preservation was fixed in this branch.

Closes #3313

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize `default_agent` before runtime-name lookup so display names like "Sisyphus - Ultraworker" resolve to the correct runtime agent key. Preserves custom default names and keeps fallback behavior unchanged. Fixes #3313.

- **Bug Fixes**
  - Normalize configured `default_agent` (display name or config key) to the runtime agent name.
  - Keep behavior the same for config-key input and the fallback default (`sisyphus`).
  - Add regression tests for display-name, config-key, and fallback cases.

<sup>Written for commit 9081475ec045d1c438f59ee7d4908128c3a54509. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

