### PR TITLE
fix(file-reference-resolver): expand $VAR env vars in @path file references (fixes #3476)

### DIFF
--- a/src/shared/file-reference-resolver.test.ts
+++ b/src/shared/file-reference-resolver.test.ts
@@ -1,8 +1,62 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test"
 import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { resolveFileReferencesInText } from "./file-reference-resolver"
+import { join, resolve } from "node:path"
+import { resolveFilePath, resolveFileReferencesInText } from "./file-reference-resolver"
+
+describe("resolveFilePath", () => {
+  const cwd = "/skills/gsd"
+
+  test("expands bare environment variables before resolving absolute paths", () => {
+    //#given
+    const homeDir = process.env.HOME
+    if (!homeDir) {
+      throw new Error("HOME must be set for file reference resolver tests")
+    }
+
+    //#when
+    const resolved = resolveFilePath("$HOME/foo.md", cwd)
+
+    //#then
+    expect(resolved).toBe(resolve(homeDir, "foo.md"))
+  })
+
+  test("expands braced environment variables before resolving absolute paths", () => {
+    //#given
+    const homeDir = process.env.HOME
+    if (!homeDir) {
+      throw new Error("HOME must be set for file reference resolver tests")
+    }
+
+    //#when
+    const resolved = resolveFilePath("${HOME}/foo.md", cwd)
+
+    //#then
+    expect(resolved).toBe(resolve(homeDir, "foo.md"))
+  })
+
+  test("keeps absolute paths absolute", () => {
+    //#given
+    const absolutePath = "/abs/path.md"
+
+    //#when
+    const resolved = resolveFilePath(absolutePath, cwd)
+
+    //#then
+    expect(resolved).toBe(resolve(absolutePath))
+  })
+
+  test("resolves relative paths from cwd", () => {
+    //#given
+    const relativePath = "relative/path.md"
+
+    //#when
+    const resolved = resolveFilePath(relativePath, cwd)
+
+    //#then
+    expect(resolved).toBe(resolve(cwd, relativePath))
+  })
+})
 
 describe("resolveFileReferencesInText", () => {
   const fixtureRoot = join(tmpdir(), `file-reference-resolver-${Date.now()}`)

--- a/src/shared/file-reference-resolver.ts
+++ b/src/shared/file-reference-resolver.ts
@@ -30,12 +30,20 @@ function findFileReferences(text: string): FileMatch[] {
   return matches
 }
 
-function resolveFilePath(filePath: string, cwd: string): string {
-  if (isAbsolute(filePath)) {
-    return resolve(filePath)
+export function resolveFilePath(filePath: string, cwd: string): string {
+  const expanded = filePath.replace(/\$\{(\w+)\}|\$(\w+)/g, (match, braced: string | undefined, bare: string | undefined) => {
+    const variableName = braced ?? bare
+    if (!variableName) {
+      return match
+    }
+    return process.env[variableName] ?? match
+  })
+
+  if (isAbsolute(expanded)) {
+    return resolve(expanded)
   }
 
-  return resolve(cwd, filePath)
+  return resolve(cwd, expanded)
 }
 
 function readFileContent(resolvedPath: string): string {


### PR DESCRIPTION
## Summary
- Expands `$VAR` and `${VAR}` environment variables before resolving `@path` file references.
- Prevents skill-loaded slash commands like `/gsd-do` from treating `$HOME/...` as cwd-relative paths.

## Changes
- Exported and covered `resolveFilePath` with env-var, absolute, and relative path tests.
- Applies env expansion before `isAbsolute()` and preserves unresolved env references unchanged.

## Testing
- `bun test src/shared/file-reference-resolver.test.ts` ✅
- RED confirmed before fix: bare and braced env-var tests failed
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun run script/run-ci-tests.ts` ✅
- `bun test` attempted; raw full-suite fails on pre-existing module-mock leakage around `os.tmpdir`, while CI split runner passes

Closes #3476

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand environment variables in `@path` file references before resolving paths. Prevents `$HOME/...` and similar from being treated as cwd-relative in skill commands like `/gsd-do`.

- **Bug Fixes**
  - Expand `$VAR` and `${VAR}`; leave unknown vars unchanged.
  - Check absolute after expansion; resolve absolute paths directly, otherwise from `cwd`.
  - Export `resolveFilePath` and add tests for env-var, absolute, and relative paths.

<sup>Written for commit a46b7b82402474b52cd5532890c56c7bc08819d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

