### PR TITLE
fix(ralph-loop): skip continuation when background tasks are pending (fixes #3526)

### DIFF
--- a/src/create-hooks.ts
+++ b/src/create-hooks.ts
@@ -59,6 +59,7 @@ export function createHooks(args: {
     ctx,
     pluginConfig,
     modelCacheState,
+    backgroundManager,
     modelFallbackControllerAccessor,
     isHookEnabled,
     safeHookEnabled,

--- a/src/hooks/ralph-loop/index.test.ts
+++ b/src/hooks/ralph-loop/index.test.ts
@@ -17,7 +17,7 @@ describe("ralph-loop", () => {
   let mockSessionMessages: Array<{ info?: { role?: string }; parts?: Array<{ type: string; text?: string }> }>
   let mockMessagesApiResponseShape: "data" | "array"
 
-  function createMockPluginInput() {
+  function createMockPluginInput(): Parameters<typeof createRalphLoopHook>[0] {
     return {
       client: {
         session: {
@@ -63,7 +63,7 @@ describe("ralph-loop", () => {
         },
       },
       directory: TEST_DIR,
-    } as unknown as Parameters<typeof createRalphLoopHook>[0]
+    } as Parameters<typeof createRalphLoopHook>[0]
   }
 
   beforeEach(() => {
@@ -302,6 +302,33 @@ describe("ralph-loop", () => {
       // then - iteration should be incremented
       const state = hook.getState()
       expect(state?.iteration).toBe(2)
+    })
+
+    test("should skip continuation when background task is running", async () => {
+      // given - active loop state with a running background task
+      const hook = createRalphLoopHook(createMockPluginInput(), {
+        backgroundManager: {
+          getTasksByParentSession: (sessionID: string) => sessionID === "session-123"
+            ? [{ status: "running" }]
+            : [],
+        },
+      })
+      hook.startLoop("session-123", "Build a feature", { maxIterations: 10 })
+
+      // when - session goes idle
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-123" },
+        },
+      })
+
+      // then - no continuation should be injected
+      expect(promptCalls.length).toBe(0)
+
+      // then - iteration should not be incremented
+      const state = hook.getState()
+      expect(state?.iteration).toBe(1)
     })
 
     test("should stop loop when max iterations reached", async () => {
@@ -1144,20 +1171,14 @@ Original task: Build something`
     test("should not hang when session.messages() throws", async () => {
       // given - API that throws (simulates timeout error)
       let apiCallCount = 0
-      const errorMock = {
-        ...createMockPluginInput(),
-        client: {
-          ...createMockPluginInput().client,
-          session: {
-            ...createMockPluginInput().client.session,
-            messages: async () => {
-              apiCallCount++
-              throw new Error("API timeout")
-            },
-          },
+      const errorMock = createMockPluginInput()
+      Object.defineProperty(errorMock.client.session, "messages", {
+        value: async () => {
+          apiCallCount++
+          throw new Error("API timeout")
         },
-      }
-      const hook = createRalphLoopHook(errorMock as any, {
+      })
+      const hook = createRalphLoopHook(errorMock, {
         getTranscriptPath: () => join(TEST_DIR, "nonexistent.jsonl"),
         apiTimeout: 100,
       })

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -25,7 +25,7 @@ type LoopStateController = {
 	setVerificationSessionID: (sessionID: string, verificationSessionID: string) => RalphLoopState | null
 	restartAfterFailedVerification: (sessionID: string, messageCountAtStart?: number) => RalphLoopState | null
 }
-type RalphLoopEventHandlerOptions = { directory: string; apiTimeoutMs: number; getTranscriptPath: (sessionID: string) => string | undefined; checkSessionExists?: RalphLoopOptions["checkSessionExists"]; sessionRecovery: SessionRecovery; loopState: LoopStateController }
+type RalphLoopEventHandlerOptions = { directory: string; apiTimeoutMs: number; getTranscriptPath: (sessionID: string) => string | undefined; checkSessionExists?: RalphLoopOptions["checkSessionExists"]; backgroundManager?: RalphLoopOptions["backgroundManager"]; sessionRecovery: SessionRecovery; loopState: LoopStateController }
 
 export function createRalphLoopEventHandler(
 	ctx: PluginInput,
@@ -56,6 +56,15 @@ export function createRalphLoopEventHandler(
 
 				const state = options.loopState.getState()
 				if (!state || !state.active) {
+					return
+				}
+
+				const hasRunningBackgroundTasks = options.backgroundManager
+					? options.backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running")
+					: false
+
+				if (hasRunningBackgroundTasks) {
+					log(`[${HOOK_NAME}] Skipped: background tasks running`, { sessionID })
 					return
 				}
 

--- a/src/hooks/ralph-loop/ralph-loop-hook.ts
+++ b/src/hooks/ralph-loop/ralph-loop-hook.ts
@@ -46,6 +46,7 @@ export function createRalphLoopHook(
   const getTranscriptPath = options?.getTranscriptPath ?? getDefaultTranscriptPath
   const apiTimeout = options?.apiTimeout ?? DEFAULT_API_TIMEOUT
   const checkSessionExists = options?.checkSessionExists
+  const backgroundManager = options?.backgroundManager
 
 	const loopState = createLoopStateController({
 		directory: ctx.directory,
@@ -59,6 +60,7 @@ export function createRalphLoopHook(
 		apiTimeoutMs: apiTimeout,
 		getTranscriptPath,
 		checkSessionExists,
+		backgroundManager,
 		sessionRecovery,
 		loopState,
 	})

--- a/src/hooks/ralph-loop/types.ts
+++ b/src/hooks/ralph-loop/types.ts
@@ -22,4 +22,5 @@ export interface RalphLoopOptions {
   getTranscriptPath?: (sessionId: string) => string
   apiTimeout?: number
   checkSessionExists?: (sessionId: string) => Promise<boolean>
+  backgroundManager?: { getTasksByParentSession: (sessionId: string) => Array<{ status: string }> }
 }

--- a/src/plugin/hooks/create-core-hooks.ts
+++ b/src/plugin/hooks/create-core-hooks.ts
@@ -1,4 +1,5 @@
 import type { HookName, OhMyOpenCodeConfig } from "../../config"
+import type { BackgroundManager } from "../../features/background-agent"
 import type { ModelFallbackControllerAccessor } from "../../hooks/model-fallback"
 import type { PluginContext } from "../types"
 import type { ModelCacheState } from "../../plugin-state"
@@ -11,16 +12,18 @@ export function createCoreHooks(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
   modelCacheState: ModelCacheState
+  backgroundManager: BackgroundManager
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   isHookEnabled: (hookName: HookName) => boolean
   safeHookEnabled: boolean
 }) {
-  const { ctx, pluginConfig, modelCacheState, modelFallbackControllerAccessor, isHookEnabled, safeHookEnabled } = args
+  const { ctx, pluginConfig, modelCacheState, backgroundManager, modelFallbackControllerAccessor, isHookEnabled, safeHookEnabled } = args
 
   const session = createSessionHooks({
     ctx,
     pluginConfig,
     modelCacheState,
+    backgroundManager,
     modelFallbackControllerAccessor,
     isHookEnabled,
     safeHookEnabled,

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -1,4 +1,5 @@
 import type { OhMyOpenCodeConfig, HookName } from "../../config"
+import type { BackgroundManager } from "../../features/background-agent"
 import type { ModelFallbackControllerAccessor } from "../../hooks/model-fallback"
 import type { ModelCacheState } from "../../plugin-state"
 import type { PluginContext } from "../types"
@@ -70,11 +71,12 @@ export function createSessionHooks(args: {
   ctx: PluginContext
   pluginConfig: OhMyOpenCodeConfig
   modelCacheState: ModelCacheState
+  backgroundManager: BackgroundManager
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   isHookEnabled: (hookName: HookName) => boolean
   safeHookEnabled: boolean
 }): SessionHooks {
-  const { ctx, pluginConfig, modelCacheState, modelFallbackControllerAccessor, isHookEnabled, safeHookEnabled } = args
+  const { ctx, pluginConfig, modelCacheState, backgroundManager, modelFallbackControllerAccessor, isHookEnabled, safeHookEnabled } = args
   const safeHook = <T>(hookName: HookName, factory: () => T): T | null =>
     safeCreateHook(hookName, factory, { enabled: safeHookEnabled })
 
@@ -211,6 +213,7 @@ export function createSessionHooks(args: {
         createRalphLoopHook(ctx, {
           config: pluginConfig.ralph_loop,
           checkSessionExists: async (sessionId) => await sessionExists(sessionId),
+          backgroundManager,
         }))
     : null
 


### PR DESCRIPTION
## Summary
- Prevent ralph-loop `/ulw-loop` idle continuation from firing while background subagents are still running.
- Add a regression test covering the running-background-task case.

## Changes
- Thread `backgroundManager` from hook creation into ralph-loop options.
- Check `getTasksByParentSession(sessionID)` for running tasks before incrementing and injecting continuation.
- Keep ralph-loop state unchanged when continuation is skipped.

## Testing
- `bun test src/hooks/ralph-loop/index.test.ts` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun run script/run-ci-tests.ts` ✅
- `bun test` attempted; direct unsplit run hit existing mock leakage around `node:os.tmpdir`, while CI split test runner passed.

Closes #3526

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent ralph-loop from auto-continuing when a session goes idle if background subagents are still running. Fixes #3526.

- **Bug Fixes**
  - Skip idle continuation when `backgroundManager.getTasksByParentSession(sessionID)` reports any running tasks.
  - Thread `backgroundManager` through ralph-loop options and hook creation (`create-hooks`, `create-core-hooks`, `create-session-hooks`).
  - Keep loop state unchanged when continuation is skipped.
  - Add a regression test covering the running background task scenario.

<sup>Written for commit d0dee70f9d7a8b9b7fc7eccd001fb4412b2a47f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

