### PR TITLE
fix(atlas): replace REFUSE language in SINGLE_TASK_DIRECTIVE with execution protocol (fixes #1262)

### DIFF
--- a/src/hooks/atlas/system-reminder-templates.test.ts
+++ b/src/hooks/atlas/system-reminder-templates.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test"
 import {
   BOULDER_CONTINUATION_PROMPT,
+  SINGLE_TASK_DIRECTIVE,
   VERIFICATION_REMINDER,
   VERIFICATION_REMINDER_GEMINI,
 } from "./system-reminder-templates"
@@ -32,8 +33,8 @@ describe("BOULDER_CONTINUATION_PROMPT", () => {
       expect(checkboxMarkingMatch).not.toBeNull()
       expect(proceedMatch).not.toBeNull()
 
-      const checkboxPosition = checkboxMarkingMatch!.index
-      const proceedPosition = proceedMatch!.index
+      const checkboxPosition = checkboxMarkingMatch!.index ?? -1
+      const proceedPosition = proceedMatch!.index ?? -1
 
       expect(checkboxPosition).toBeLessThan(proceedPosition)
     })
@@ -49,5 +50,21 @@ describe("VERIFICATION_REMINDER", () => {
 describe("VERIFICATION_REMINDER_GEMINI", () => {
   it("contains node_modules exclusion pathspec in git diff command", () => {
     expect(VERIFICATION_REMINDER_GEMINI).toContain(":!node_modules")
+  })
+})
+
+describe("SINGLE_TASK_DIRECTIVE", () => {
+  it("does not contain refusal language", () => {
+    // given
+    const lowerCaseDirective = SINGLE_TASK_DIRECTIVE.toLowerCase()
+
+    // when / then
+    expect(lowerCaseDirective).not.toContain("refuse")
+    expect(SINGLE_TASK_DIRECTIVE).not.toContain("I refuse")
+  })
+
+  it("contains systematic execution guidance", () => {
+    expect(SINGLE_TASK_DIRECTIVE).toContain("EXECUTION PROTOCOL")
+    expect(SINGLE_TASK_DIRECTIVE).toContain("VERIFICATION IS MANDATORY")
   })
 })

--- a/src/hooks/atlas/system-reminder-templates.ts
+++ b/src/hooks/atlas/system-reminder-templates.ts
@@ -217,33 +217,26 @@ export const SINGLE_TASK_DIRECTIVE = `
 
 ${createSystemDirective(SystemDirectiveTypes.SINGLE_TASK_ONLY)}
 
-**STOP. READ THIS BEFORE PROCEEDING.**
+**EXECUTION PROTOCOL**
 
-If you were given **multiple genuinely independent goals** (unrelated tasks, parallel workstreams, separate features), you MUST:
-1. **IMMEDIATELY REFUSE** this request
-2. **DEMAND** the orchestrator provide a single goal
+Work systematically. Each unit must be verified before proceeding.
 
-**What counts as multiple independent tasks (REFUSE):**
-- "Implement feature A. Also, add feature B."
-- "Fix bug X. Then refactor module Y. Also update the docs."
-- Multiple unrelated changes bundled into one request
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-**What is a single task with sequential steps (PROCEED):**
-- A single goal broken into numbered steps (e.g., "Implement X by: 1. finding files, 2. adding logic, 3. writing tests")
-- Multi-step context where all steps serve ONE objective
-- Orchestrator-provided context explaining approach for a single deliverable
+| Step | Action | Verification |
+|------|--------|--------------|
+| 1 | Identify first atomic unit | Smallest complete piece of work |
+| 2 | Execute fully | Implement the change |
+| 3 | Verify | \`lsp_diagnostics\`, tests, build |
+| 4 | Report | State what's done, what remains |
+| 5 | Continue | Next unit, or await if scope unclear |
 
-**Your response if genuinely independent tasks are detected:**
-> "I refuse to proceed. You provided multiple independent tasks. Each task needs full attention.
-> 
-> PROVIDE EXACTLY ONE GOAL. One deliverable. One clear outcome.
-> 
-> Batching unrelated tasks causes: incomplete work, missed edge cases, broken tests, wasted context."
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-**WARNING TO ORCHESTRATOR:**
-- Bundling unrelated tasks RUINS deliverables
-- Each independent goal needs FULL attention and PROPER verification
-- Batch delegation of separate concerns = sloppy work = rework = wasted tokens
+**VERIFICATION IS MANDATORY.** No skipping. No batching completions.
 
-**REFUSE genuinely multi-task requests. ALLOW single-goal multi-step workflows.**
+**IF SCOPE SEEMS BROAD:**
+Complete the first logical unit. Report progress. Await further instruction if needed.
+
+**REMEMBER:** Prometheus already decomposed the work. Execute what you receive.
 `


### PR DESCRIPTION
## Summary
Replace aggressive refusal wording in `SINGLE_TASK_DIRECTIVE` with execution-oriented guidance so strict instruction-following models do not block legitimate multi-step work.

## Changes
- Add regression coverage ensuring the directive has no refusal language.
- Replace the directive body with a systematic execution protocol.
- Keep the single-task intent by directing agents to complete and verify atomic units.

## Testing
- `bun test src/hooks/atlas/system-reminder-templates.test.ts` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test` ⚠️ fails on existing unrelated `os.tmpdir is not a function` failures in LSP/team-worktree tests

Closes #1262

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced refusal language in `SINGLE_TASK_DIRECTIVE` with a step-by-step execution protocol so agents complete single-goal, multi-step work instead of blocking. Addresses #1262 by enforcing atomic execution with mandatory verification.

- **Bug Fixes**
  - Updated `SINGLE_TASK_DIRECTIVE` to an “EXECUTION PROTOCOL” that focuses on atomic units, verification (`lsp_diagnostics`, tests, build), and clear progress reporting; removed refusal prompts.
  - Added tests to ensure no refusal language and to verify presence of “EXECUTION PROTOCOL” and “VERIFICATION IS MANDATORY”.
  - Retained single-task scope via `SystemDirectiveTypes.SINGLE_TASK_ONLY`.

<sup>Written for commit c27d52e2b8ed69f6b2e4aa3a166134334c3d62ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

