### PR TITLE
fix(doctor): parse provider/model with indexOf for multi-slash IDs (fixes #3380)

### DIFF
--- a/src/cli/doctor/checks/model-resolution.test.ts
+++ b/src/cli/doctor/checks/model-resolution.test.ts
@@ -1,6 +1,47 @@
 import { describe, it, expect } from "bun:test"
 
 describe("model-resolution check", () => {
+  describe("parseProviderModel", () => {
+    it("splits chutes model IDs at the provider separator", async () => {
+      const { parseProviderModel } = await import("./model-resolution")
+
+      // #given a provider-prefixed model whose model ID contains a slash
+      const value = "chutes/deepseek-ai/DeepSeek-V3.2-TEE"
+
+      // #when parsing the provider and model IDs
+      const result = parseProviderModel(value)
+
+      // #then only the first slash separates the provider
+      expect(result).toEqual({ providerID: "chutes", modelID: "deepseek-ai/DeepSeek-V3.2-TEE" })
+    })
+
+    it("splits simple provider model IDs", async () => {
+      const { parseProviderModel } = await import("./model-resolution")
+
+      // #given a provider-prefixed model without extra slashes
+      const value = "openai/gpt-5"
+
+      // #when parsing the provider and model IDs
+      const result = parseProviderModel(value)
+
+      // #then provider and model are split normally
+      expect(result).toEqual({ providerID: "openai", modelID: "gpt-5" })
+    })
+
+    it("splits synthetic provider model IDs at the provider separator", async () => {
+      const { parseProviderModel } = await import("./model-resolution")
+
+      // #given a synthetic provider model whose model ID contains a slash
+      const value = "synthetic/hf:zai-org/GLM-5.1"
+
+      // #when parsing the provider and model IDs
+      const result = parseProviderModel(value)
+
+      // #then only the first slash separates the provider
+      expect(result).toEqual({ providerID: "synthetic", modelID: "hf:zai-org/GLM-5.1" })
+    })
+  })
+
   describe("getModelResolutionInfo", () => {
     // given: Model requirements are defined in model-requirements.ts
     // when: Getting model resolution info

--- a/src/cli/doctor/checks/model-resolution.ts
+++ b/src/cli/doctor/checks/model-resolution.ts
@@ -8,8 +8,8 @@ import { buildModelResolutionDetails } from "./model-resolution-details"
 import { buildEffectiveResolution, getEffectiveModel } from "./model-resolution-effective-model"
 import type { AgentResolutionInfo, CategoryResolutionInfo, ModelResolutionInfo, OmoConfig } from "./model-resolution-types"
 
-function parseProviderModel(value: string): { providerID: string; modelID: string } | null {
-  const slashIndex = value.lastIndexOf("/")
+export function parseProviderModel(value: string): { providerID: string; modelID: string } | null {
+  const slashIndex = value.indexOf("/")
   if (slashIndex <= 0 || slashIndex === value.length - 1) {
     return null
   }


### PR DESCRIPTION
## Summary
Fixes the doctor model-resolution parser so provider/model strings split on the first `/`, matching the rest of the codebase and preserving multi-slash model IDs.

## Changes
- Exported `parseProviderModel` for direct regression coverage.
- Changed doctor parsing from `lastIndexOf("/")` to `indexOf("/")`.
- Added regression tests for `chutes/...`, `openai/...`, and `synthetic/hf:...` model strings.

## Testing
- `bun test src/cli/doctor/checks/model-resolution.test.ts` ✅
- `bun run script/run-ci-tests.ts` ✅
- `bun run typecheck` ✅
- `bun run build` ✅

## Related Issues
Closes #3380

Partially fixes #3380: this PR addresses Problem A only. Problem B, adding alias rules for `-TEE` variants or heuristics for mimo/xiaomimimo, is separate concern.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the doctor model-resolution parser to split provider/model at the first '/', preserving multi-slash model IDs and aligning with the rest of the codebase. Addresses #3380 (Problem A).

- **Bug Fixes**
  - Switched `parseProviderModel` to use `indexOf("/")` instead of `lastIndexOf("/")`.
  - Exported `parseProviderModel` for direct regression tests.
  - Added tests for `chutes/deepseek-ai/DeepSeek-V3.2-TEE`, `openai/gpt-5`, and `synthetic/hf:zai-org/GLM-5.1`.

<sup>Written for commit e95a37fd3c62a67ef9f5ad6663d15681045b0a89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

