### PR TITLE
fix(resolve-file-uri): explain project boundary restriction in rejection warning (fixes #3554)

### DIFF
--- a/src/agents/builtin-agents/resolve-file-uri.test.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.test.ts
@@ -161,4 +161,16 @@ describe("resolvePromptAppend", () => {
     expect(resolved).toContain("[WARNING: Path rejected:")
     expect(resolved).not.toContain("absolute-content")
   })
+
+  test("rejection warning explains the project boundary restriction (issue #3554)", () => {
+    //#given
+    const input = `file://${absoluteFilePath}`
+
+    //#when
+    const resolved = resolvePromptAppend(input, configDir)
+
+    //#then
+    expect(resolved).toContain("[WARNING: Path rejected:")
+    expect(resolved).toMatch(/outside project root/i)
+  })
 })

--- a/src/agents/builtin-agents/resolve-file-uri.ts
+++ b/src/agents/builtin-agents/resolve-file-uri.ts
@@ -27,7 +27,7 @@ export function resolvePromptAppend(promptAppend: string, configDir?: string): s
       filePath,
       projectRoot,
     })
-    return `[WARNING: Path rejected: ${promptAppend}]`
+    return `[WARNING: Path rejected: ${promptAppend} (resolved outside project root ${projectRoot}; file:// prompts must reside within the project boundary)]`
   }
 
   if (!existsSync(filePath)) {


### PR DESCRIPTION
## Summary
Make the `[WARNING: Path rejected: ...]` placeholder explain *why* the path was rejected. The current message just echoes the URI and gives no hint that `file://` prompt loading is intentionally confined to the project boundary, which leaves users (correctly) confused given that the docs advertise broader `file://` path support.

## Root Cause
`resolvePromptAppend()` in `src/agents/builtin-agents/resolve-file-uri.ts` calls `isWithinProject(filePath, projectRoot)` and, on rejection, returns `[WARNING: Path rejected: ${promptAppend}]`. There is no signal that:

- the path was rejected because it resolved outside `configDir ?? process.cwd()`, and
- file URIs for prompts must live inside the project boundary even though the docs (`docs/reference/configuration.md` and `docs/guide/agent-model-matching.md`) describe absolute, relative, and `~`-home `file://` paths.

The boundary check itself was added intentionally for security (commit `98659783c0def8ecf60c4f6108c119a5f6435f73`, "fix(security): confine file resolution to project roots"). This PR keeps that restriction; it only improves the diagnostic so users can self-correct without reading the source.

## Changes
| File | Change |
|------|--------|
| `src/agents/builtin-agents/resolve-file-uri.ts` | Extend the rejection warning to include the resolved `projectRoot` and an explicit note that `file://` prompts must reside within the project boundary. |
| `src/agents/builtin-agents/resolve-file-uri.test.ts` | Add a regression test that asserts the rejection warning matches `/outside project root/i`. |

## Reproduction (before fix)
With the regression test added but the source change reverted, the new test fails:

```
(fail) resolvePromptAppend > rejection warning explains the project boundary restriction (issue #3554)

  expect(received).toMatch(expected)
    Expected substring or pattern: /outside project root/i
    Received: "[WARNING: Path rejected: file:///.../absolute.txt]"
```

## Verification (after fix)
```
$ bun test src/agents/builtin-agents/resolve-file-uri.test.ts -t "issue #3554"
 1 pass
 10 filtered out
 0 fail
 2 expect() calls

$ bun test src/agents/builtin-agents/resolve-file-uri.test.ts
 11 pass
 0 fail
 15 expect() calls
```

```
$ bun run typecheck
$ tsc --noEmit
(no output, exit 0)
```

## Test
- Regression test: `src/agents/builtin-agents/resolve-file-uri.test.ts` (new case `rejection warning explains the project boundary restriction (issue #3554)`).
- Existing rejection tests (`rejects absolute file URI outside configDir`, `rejects traversal file URI that escapes configDir`, `rejects symlink file URI that escapes configDir`, `resolves home directory URI path`) still match on the `[WARNING: Path rejected:` prefix and continue to pass.
- Full `resolve-file-uri.test.ts`: 11 pass / 0 fail.
- `bun run typecheck`: clean.

Fixes #3554

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/code-yeongyu/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the `file://` prompt rejection message to explain the project boundary restriction and show the resolved project root. Fixes #3554.

- **Bug Fixes**
  - Extend `resolvePromptAppend()` warning to include `projectRoot` and a note that `file://` prompts must stay within the project boundary.
  - Add a regression test to assert the new wording; the security restriction is unchanged.

<sup>Written for commit 111b7968203482bbafe4e0287f740cd74e60475a. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3679?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

