### PR TITLE
fix: quota errors now always trigger fallback instead of stopping

### DIFF
--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -169,10 +169,8 @@ export function isRetryableError(error: unknown, retryOnErrors: number[]): boole
   }
 
   if (errorType === "quota_exceeded") {
-    // When a provider signals an auto-retry (e.g. "retrying in ~2 weeks"),
-    // we should still trigger fallback to another model rather than STOP.
-    const hasAutoRetrySignal = /retrying\s+in/i.test(message)
-    return hasAutoRetrySignal
+    if (statusCode === 402) return false
+    return true
   }
 
   if (statusCode && retryOnErrors.includes(statusCode)) {

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -169,7 +169,11 @@ export function isRetryableError(error: unknown, retryOnErrors: number[]): boole
   }
 
   if (errorType === "quota_exceeded") {
+    // Block HTTP 402 explicitly - this is a billing/payment issue, not a retryable quota issue
+    // Check explicit statusCode field
     if (statusCode === 402) return false
+    // Also check if message contains just "402" as status code (e.g., "error 402: payment required")
+    if (/^402\b/i.test(message) || /\b402[,:]\s*payment/i.test(message)) return false
     return true
   }
 

--- a/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
+++ b/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
@@ -27,6 +27,17 @@ describe("runtime-fallback quota error regressions", () => {
     expect(retryable).toBe(false)
   })
 
+  test("treats message-only 402 as non-retryable (regression fix)", () => {
+    //#given - no explicit statusCode, but message contains "402 payment"
+    const error = { message: "402: Payment Required. Please upgrade your plan." }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then - should NOT retry billing issues
+    expect(retryable).toBe(false)
+  })
+
   test("keeps HTTP 429 rate limit retryable", () => {
     //#given
     const error = { statusCode: 429, message: "Too Many Requests: rate limit reached" }

--- a/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
+++ b/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
@@ -3,20 +3,17 @@ import { describe, expect, test } from "bun:test"
 import { classifyErrorType, isRetryableError } from "./error-classifier"
 
 describe("runtime-fallback quota error regressions", () => {
-  test("classifies subscription quota errors as quota_exceeded and stops retry", () => {
-    //#given
+  test("classifies subscription quota errors as quota_exceeded and allows retry", () => {
     const error = {
       name: "AI_APICallError",
       message: "Subscription quota exceeded. You can continue using free models.",
     }
 
-    //#when
     const errorType = classifyErrorType(error)
     const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
 
-    //#then
     expect(errorType).toBe("quota_exceeded")
-    expect(retryable).toBe(false)
+    expect(retryable).toBe(true)
   })
 
   test("treats HTTP 402 payment required as non-retryable", () => {
@@ -41,16 +38,13 @@ describe("runtime-fallback quota error regressions", () => {
     expect(retryable).toBe(true)
   })
 
-  test("classifies quota error names as quota_exceeded without retry", () => {
-    //#given
+  test("classifies quota error names as quota_exceeded and allows retry", () => {
     const error = { name: "QuotaExceededError", message: "Request failed." }
 
-    //#when
     const errorType = classifyErrorType(error)
     const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
 
-    //#then
     expect(errorType).toBe("quota_exceeded")
-    expect(retryable).toBe(false)
+    expect(retryable).toBe(true)
   })
 })

--- a/src/hooks/todo-continuation-enforcer/continuation-injection.ts
+++ b/src/hooks/todo-continuation-enforcer/continuation-injection.ts
@@ -78,12 +78,14 @@ export async function injectContinuation(args: {
     return
   }
 
-  const hasRunningBgTasks = backgroundManager
-    ? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running")
+  const hasActiveBgTasks = backgroundManager
+    ? backgroundManager.getTasksByParentSession(sessionID).some(
+        (task: { status: string }) => task.status === "running" || task.status === "pending"
+      )
     : false
 
-  if (hasRunningBgTasks) {
-    log(`[${HOOK_NAME}] Skipped injection: background tasks running`, { sessionID })
+  if (hasActiveBgTasks) {
+    log(`[${HOOK_NAME}] Skipped injection: background tasks active (pending or running)`, { sessionID })
     return
   }
 

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -70,12 +70,14 @@ export async function handleSessionIdle(args: {
     state.abortDetectedAt = undefined
   }
 
-  const hasRunningBgTasks = backgroundManager
-    ? backgroundManager.getTasksByParentSession(sessionID).some((task: { status: string }) => task.status === "running")
+  const hasActiveBgTasks = backgroundManager
+    ? backgroundManager.getTasksByParentSession(sessionID).some(
+        (task: { status: string }) => task.status === "running" || task.status === "pending"
+      )
     : false
 
-  if (hasRunningBgTasks) {
-    log(`[${HOOK_NAME}] Skipped: background tasks running`, { sessionID })
+  if (hasActiveBgTasks) {
+    log(`[${HOOK_NAME}] Skipped: background tasks active (pending or running)`, { sessionID })
     return
   }
 

--- a/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
+++ b/src/hooks/todo-continuation-enforcer/todo-continuation-enforcer.test.ts
@@ -370,6 +370,31 @@ describe("todo-continuation-enforcer", () => {
     expect(promptCalls).toHaveLength(0)
   })
 
+  test("should not inject when background tasks are pending", async () => {
+    // given - session with pending background tasks (regression test for issue #3362)
+    const sessionID = "main-pending-123"
+    setMainSession(sessionID)
+
+    // Mock background manager that returns pending tasks
+    const pendingBgManager = {
+      getTasksByParentSession: () => [{ id: "task-1", status: "pending" }],
+    }
+
+    const hook = createTodoContinuationEnforcer(createMockPluginInput(), {
+      backgroundManager: pendingBgManager as BackgroundManager,
+    })
+
+    // when - session goes idle
+    await hook.handler({
+      event: { type: "session.idle", properties: { sessionID } },
+    })
+
+    await fakeTimers.advanceBy(3000)
+
+    // then - no continuation injected (pending tasks should block just like running)
+    expect(promptCalls).toHaveLength(0)
+  })
+
   test("should inject for any session with incomplete todos", async () => {
     fakeTimers.restore()
     //#given — any session, not necessarily main session


### PR DESCRIPTION
## Summary

Quota errors were causing agents to abort instead of falling back to the next model in the chain.

## Changes

1. **error-classifier.ts**: Changed `isRetryableError` to return `true` for `quota_exceeded` errors, allowing fallback to trigger instead of stopping.

2. **error-classifier.ts**: Added explicit check to block HTTP 402 (Payment Required) from retrying, as it's a billing issue, not a quota issue.

3. **quota-error-classifier.regression.test.ts**: Updated tests to expect `retryable: true` for quota errors.

## Testing

Ran `bun test src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts` - all 4 tests pass.

## Related Issues

- Fixes: #479, #3645, #3648
- User reported: "quota exhausted" errors causing agents to abort instead of falling back

## Notes

- This is a behavior change: quota errors now ALWAYS trigger retry/fallback
- HTTP 402 is explicitly excluded from retry to handle payment-required scenarios

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quota errors now trigger model fallback instead of aborting. Also skips todo continuation when background tasks are pending to prevent idle loops (fixes #3519, #3362).

- **Bug Fixes**
  - `quota_exceeded` is retryable for fallback; HTTP 402 (including message-only 402 patterns) remains non-retryable to avoid billing loops.
  - Skip continuation and idle handling when background tasks are pending or running; adds a regression test.

<sup>Written for commit 968febc11ad842a753cce78f59e8878cacfe1a26. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3680?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

