### PR TITLE
fix: block Write tool on notepad files to prevent data loss

### DIFF
--- a/src/hooks/write-existing-file-guard/tool-execute-before-handler.ts
+++ b/src/hooks/write-existing-file-guard/tool-execute-before-handler.ts
@@ -138,6 +138,18 @@ export async function handleWriteExistingFileGuardToolExecuteBefore(params: {
   }
 
   const isSisyphusPath = canonicalPath.includes("/.sisyphus/")
+  const isNotepadPath = canonicalPath.includes("/.sisyphus/notepads/")
+  if (isNotepadPath) {
+    log("[write-existing-file-guard] Blocking notepad overwrite", {
+      sessionID: input.sessionID,
+      filePath,
+    })
+    throw new Error(
+      "Notepad files (.sisyphus/notepads/*) are APPEND-ONLY. " +
+        "Use the Edit tool to append new content at the end. " +
+        "Never use Write tool on notepad files."
+    )
+  }
   if (isSisyphusPath) {
     log("[write-existing-file-guard] Allowing .sisyphus/** overwrite", {
       sessionID: input.sessionID,


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block the Write tool from overwriting notepad files under `/.sisyphus/notepads/` to prevent data loss. Shows a clear error telling users to append with the Edit tool instead.

- **Bug Fixes**
  - Added a guard in `handleWriteExistingFileGuardToolExecuteBefore` to throw on writes to `/.sisyphus/notepads/*`.
  - Logs a block event with `sessionID` and `filePath`, and returns an error explaining notepads are append-only.

<sup>Written for commit 3fa3043604eac4478301eeeea49463cb396014bc. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3687?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

