### PR TITLE
fix(telemetry): cut PostHog cost via HAU removal + plugin_loaded daily dedupe

### DIFF
--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -16,7 +16,7 @@ We collect limited non-personal information needed to operate and improve the Se
 
 When anonymous telemetry is enabled, the Application may collect:
 
-- Anonymous usage events, including `run_started`, `run_completed`, `run_failed`, `install_completed`, `install_failed`, `plugin_loaded`, `omo_daily_active`, and `omo_hourly_active`
+- Anonymous usage events, including `run_started`, `run_completed`, `run_failed`, `install_completed`, `install_failed`, `plugin_loaded`, and `omo_daily_active`
 - Application metadata such as package version, plugin name, runtime, and command or entry-point context
 - Error diagnostics captured during failed CLI runs
 - A pseudonymous installation identifier derived from a one-way hash of the local hostname
@@ -25,7 +25,7 @@ We do not intentionally collect prompt contents, source files, repository conten
 
 ### Configuration and local state
 
-The Application stores local configuration and telemetry deduplication state on your machine to support installation, configuration, and anonymous daily or hourly active tracking.
+The Application stores local configuration and telemetry deduplication state on your machine to support installation, configuration, and anonymous daily active tracking.
 
 ## 2. How Telemetry Works
 

--- a/src/index.telemetry.test.ts
+++ b/src/index.telemetry.test.ts
@@ -104,6 +104,12 @@ function installModuleMocks(): void {
     createPluginPostHog: mockCreatePluginPostHog,
     getPostHogDistinctId: mockGetPostHogDistinctId,
   }))
+  mock.module("./shared/posthog-activity-state", () => ({
+    getPluginLoadedCaptureState: () => ({
+      dayUTC: "2026-04-18",
+      capturePluginLoaded: true,
+    }),
+  }))
 }
 
 describe("oh-my-openagent telemetry isolation", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { installAgentSortShim } from "./shared/agent-sort-shim"
 import { detectExternalSkillPlugin, getSkillPluginConflictWarning } from "./shared/external-plugin-detector"
 import { startBackgroundCheck as startTmuxCheck } from "./tools/interactive-bash"
 import { createPluginPostHog, getPostHogDistinctId } from "./shared/posthog"
+import { getPluginLoadedCaptureState } from "./shared/posthog-activity-state"
 
 const serverPlugin: Plugin = async (input, _options): Promise<Hooks> => {
   installAgentSortShim()
@@ -43,18 +44,26 @@ const serverPlugin: Plugin = async (input, _options): Promise<Hooks> => {
   } catch {
     // telemetry failure is non-fatal, silently ignore
   }
+  let pluginLoadedCaptureState: ReturnType<typeof getPluginLoadedCaptureState> | null = null
   try {
-    posthog.capture({
-      distinctId,
-      event: "plugin_loaded",
-      properties: {
-        entry_point: "plugin",
-        has_openclaw: !!pluginConfig.openclaw,
-        tmux_enabled: isTmuxIntegrationEnabled(pluginConfig),
-      },
-    })
+    pluginLoadedCaptureState = getPluginLoadedCaptureState()
   } catch {
     // telemetry failure is non-fatal, silently ignore
+  }
+  if (pluginLoadedCaptureState?.capturePluginLoaded) {
+    try {
+      posthog.capture({
+        distinctId,
+        event: "plugin_loaded",
+        properties: {
+          entry_point: "plugin",
+          has_openclaw: !!pluginConfig.openclaw,
+          tmux_enabled: isTmuxIntegrationEnabled(pluginConfig),
+        },
+      })
+    } catch {
+      // telemetry failure is non-fatal, silently ignore
+    }
   }
   if (pluginConfig.openclaw) {
     await initializeOpenClaw(pluginConfig.openclaw)

--- a/src/shared/posthog-activity-state.test.ts
+++ b/src/shared/posthog-activity-state.test.ts
@@ -37,9 +37,7 @@ describe("getPostHogActivityCaptureState", () => {
     // then
     expect(result).toEqual({
       dayUTC: "2026-04-11",
-      hourUTC: "2026-04-11T10",
       captureDaily: true,
-      captureHourly: true,
     })
 
     rmSync(dataHomePath, { recursive: true, force: true })
@@ -60,9 +58,7 @@ describe("getPostHogActivityCaptureState", () => {
     // then
     expect(result).toEqual({
       dayUTC: "2026-04-11",
-      hourUTC: "2026-04-11T10",
       captureDaily: true,
-      captureHourly: true,
     })
 
     rmSync(dataHomePath, { recursive: true, force: true })
@@ -83,9 +79,7 @@ describe("getPostHogActivityCaptureState", () => {
     // then
     expect(result).toEqual({
       dayUTC: "2026-04-11",
-      hourUTC: "2026-04-11T10",
       captureDaily: true,
-      captureHourly: true,
     })
 
     rmSync(dataHomePath, { recursive: true, force: true })
@@ -112,9 +106,33 @@ describe("getPostHogActivityCaptureState", () => {
     // then
     expect(result).toEqual({
       dayUTC: "2026-04-11",
-      hourUTC: "2026-04-11T10",
       captureDaily: false,
-      captureHourly: false,
+    })
+
+    rmSync(dataHomePath, { recursive: true, force: true })
+  })
+
+  it("reads legacy hourly state without crashing", async () => {
+    // given
+    const dataHomePath = createDataHomePath()
+    const cachePath = join(dataHomePath, "oh-my-opencode")
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(
+      join(cachePath, "posthog-activity.json"),
+      `${JSON.stringify({
+        lastActiveHourUTC: "2026-04-11T10",
+      })}\n`,
+    )
+    process.env.XDG_DATA_HOME = dataHomePath
+    const { getPostHogActivityCaptureState } = await importPostHogActivityStateModule()
+
+    // when
+    const result = getPostHogActivityCaptureState(new Date("2026-04-11T10:15:00.000Z"))
+
+    // then
+    expect(result).toEqual({
+      dayUTC: "2026-04-11",
+      captureDaily: true,
     })
 
     rmSync(dataHomePath, { recursive: true, force: true })

--- a/src/shared/posthog-activity-state.test.ts
+++ b/src/shared/posthog-activity-state.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
@@ -134,6 +134,161 @@ describe("getPostHogActivityCaptureState", () => {
       dayUTC: "2026-04-11",
       captureDaily: true,
     })
+
+    rmSync(dataHomePath, { recursive: true, force: true })
+  })
+
+  it("preserves lastPluginLoadedDayUTC when writing lastActiveDayUTC", async () => {
+    // given
+    const dataHomePath = createDataHomePath()
+    const cachePath = join(dataHomePath, "oh-my-opencode")
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(
+      join(cachePath, "posthog-activity.json"),
+      `${JSON.stringify({
+        lastActiveDayUTC: "2026-04-10",
+        lastPluginLoadedDayUTC: "2026-04-11",
+      })}\n`,
+    )
+    process.env.XDG_DATA_HOME = dataHomePath
+    const { getPostHogActivityCaptureState } = await importPostHogActivityStateModule()
+
+    // when
+    getPostHogActivityCaptureState(new Date("2026-04-11T10:15:00.000Z"))
+
+    // then
+    const persistedState = JSON.parse(
+      readFileSync(join(cachePath, "posthog-activity.json"), "utf-8"),
+    )
+    expect(persistedState).toEqual({
+      lastActiveDayUTC: "2026-04-11",
+      lastPluginLoadedDayUTC: "2026-04-11",
+    })
+
+    rmSync(dataHomePath, { recursive: true, force: true })
+  })
+})
+
+describe("getPluginLoadedCaptureState", () => {
+  it("returns capturePluginLoaded=true when activity file does not exist", async () => {
+    // given
+    const dataHomePath = createDataHomePath()
+    process.env.XDG_DATA_HOME = dataHomePath
+    const { getPluginLoadedCaptureState } = await importPostHogActivityStateModule()
+
+    // when
+    const result = getPluginLoadedCaptureState(new Date("2026-04-11T10:15:00.000Z"))
+
+    // then
+    expect(result).toEqual({
+      dayUTC: "2026-04-11",
+      capturePluginLoaded: true,
+    })
+
+    rmSync(dataHomePath, { recursive: true, force: true })
+  })
+
+  it("returns capturePluginLoaded=false when lastPluginLoadedDayUTC matches today", async () => {
+    // given
+    const dataHomePath = createDataHomePath()
+    const cachePath = join(dataHomePath, "oh-my-opencode")
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(
+      join(cachePath, "posthog-activity.json"),
+      `${JSON.stringify({
+        lastPluginLoadedDayUTC: "2026-04-11",
+      })}\n`,
+    )
+    process.env.XDG_DATA_HOME = dataHomePath
+    const { getPluginLoadedCaptureState } = await importPostHogActivityStateModule()
+
+    // when
+    const result = getPluginLoadedCaptureState(new Date("2026-04-11T10:15:00.000Z"))
+
+    // then
+    expect(result).toEqual({
+      dayUTC: "2026-04-11",
+      capturePluginLoaded: false,
+    })
+
+    rmSync(dataHomePath, { recursive: true, force: true })
+  })
+
+  it("returns capturePluginLoaded=true when lastPluginLoadedDayUTC is from a previous day", async () => {
+    // given
+    const dataHomePath = createDataHomePath()
+    const cachePath = join(dataHomePath, "oh-my-opencode")
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(
+      join(cachePath, "posthog-activity.json"),
+      `${JSON.stringify({
+        lastPluginLoadedDayUTC: "2026-04-10",
+      })}\n`,
+    )
+    process.env.XDG_DATA_HOME = dataHomePath
+    const { getPluginLoadedCaptureState } = await importPostHogActivityStateModule()
+
+    // when
+    const result = getPluginLoadedCaptureState(new Date("2026-04-11T10:15:00.000Z"))
+
+    // then
+    expect(result).toEqual({
+      dayUTC: "2026-04-11",
+      capturePluginLoaded: true,
+    })
+
+    rmSync(dataHomePath, { recursive: true, force: true })
+  })
+
+  it("preserves lastActiveDayUTC when writing lastPluginLoadedDayUTC", async () => {
+    // given
+    const dataHomePath = createDataHomePath()
+    const cachePath = join(dataHomePath, "oh-my-opencode")
+    mkdirSync(cachePath, { recursive: true })
+    writeFileSync(
+      join(cachePath, "posthog-activity.json"),
+      `${JSON.stringify({
+        lastActiveDayUTC: "2026-04-11",
+        lastPluginLoadedDayUTC: "2026-04-10",
+      })}\n`,
+    )
+    process.env.XDG_DATA_HOME = dataHomePath
+    const { getPluginLoadedCaptureState } = await importPostHogActivityStateModule()
+
+    // when
+    getPluginLoadedCaptureState(new Date("2026-04-11T10:15:00.000Z"))
+
+    // then
+    const persistedState = JSON.parse(
+      readFileSync(join(cachePath, "posthog-activity.json"), "utf-8"),
+    )
+    expect(persistedState).toEqual({
+      lastActiveDayUTC: "2026-04-11",
+      lastPluginLoadedDayUTC: "2026-04-11",
+    })
+
+    rmSync(dataHomePath, { recursive: true, force: true })
+  })
+
+  it("does not rewrite state when lastPluginLoadedDayUTC matches today", async () => {
+    // given
+    const dataHomePath = createDataHomePath()
+    const cachePath = join(dataHomePath, "oh-my-opencode")
+    mkdirSync(cachePath, { recursive: true })
+    const initialPayload = `${JSON.stringify({
+      lastActiveDayUTC: "2026-04-10",
+      lastPluginLoadedDayUTC: "2026-04-11",
+    })}\n`
+    writeFileSync(join(cachePath, "posthog-activity.json"), initialPayload)
+    process.env.XDG_DATA_HOME = dataHomePath
+    const { getPluginLoadedCaptureState } = await importPostHogActivityStateModule()
+
+    // when
+    getPluginLoadedCaptureState(new Date("2026-04-11T10:15:00.000Z"))
+
+    // then
+    const persistedPayload = readFileSync(join(cachePath, "posthog-activity.json"), "utf-8")
+    expect(persistedPayload).toBe(initialPayload)
 
     rmSync(dataHomePath, { recursive: true, force: true })
   })

--- a/src/shared/posthog-activity-state.ts
+++ b/src/shared/posthog-activity-state.ts
@@ -8,14 +8,11 @@ import { writeFileAtomically } from "./write-file-atomically"
 
 type PostHogActivityState = {
   lastActiveDayUTC?: string
-  lastActiveHourUTC?: string
 }
 
 type PostHogActivityCaptureState = {
   dayUTC: string
-  hourUTC: string
   captureDaily: boolean
-  captureHourly: boolean
 }
 
 const POSTHOG_ACTIVITY_STATE_FILE = "posthog-activity.json"
@@ -26,10 +23,6 @@ function getPostHogActivityStateFilePath(): string {
 
 function getUtcDayString(date: Date): string {
   return date.toISOString().slice(0, 10)
-}
-
-function getUtcHourString(date: Date): string {
-  return date.toISOString().slice(0, 13)
 }
 
 function isPostHogActivityState(value: unknown): value is PostHogActivityState {
@@ -75,22 +68,17 @@ function writePostHogActivityState(nextState: PostHogActivityState): void {
 export function getPostHogActivityCaptureState(now: Date = new Date()): PostHogActivityCaptureState {
   const state = readPostHogActivityState()
   const dayUTC = getUtcDayString(now)
-  const hourUTC = getUtcHourString(now)
 
   const captureDaily = state.lastActiveDayUTC !== dayUTC
-  const captureHourly = state.lastActiveHourUTC !== hourUTC
 
-  if (captureDaily || captureHourly) {
+  if (captureDaily) {
     writePostHogActivityState({
       lastActiveDayUTC: captureDaily ? dayUTC : state.lastActiveDayUTC,
-      lastActiveHourUTC: captureHourly ? hourUTC : state.lastActiveHourUTC,
     })
   }
 
   return {
     dayUTC,
-    hourUTC,
     captureDaily,
-    captureHourly,
   }
 }

--- a/src/shared/posthog-activity-state.ts
+++ b/src/shared/posthog-activity-state.ts
@@ -8,11 +8,17 @@ import { writeFileAtomically } from "./write-file-atomically"
 
 type PostHogActivityState = {
   lastActiveDayUTC?: string
+  lastPluginLoadedDayUTC?: string
 }
 
 type PostHogActivityCaptureState = {
   dayUTC: string
   captureDaily: boolean
+}
+
+type PluginLoadedCaptureState = {
+  dayUTC: string
+  capturePluginLoaded: boolean
 }
 
 const POSTHOG_ACTIVITY_STATE_FILE = "posthog-activity.json"
@@ -73,12 +79,32 @@ export function getPostHogActivityCaptureState(now: Date = new Date()): PostHogA
 
   if (captureDaily) {
     writePostHogActivityState({
-      lastActiveDayUTC: captureDaily ? dayUTC : state.lastActiveDayUTC,
+      ...state,
+      lastActiveDayUTC: dayUTC,
     })
   }
 
   return {
     dayUTC,
     captureDaily,
+  }
+}
+
+export function getPluginLoadedCaptureState(now: Date = new Date()): PluginLoadedCaptureState {
+  const state = readPostHogActivityState()
+  const dayUTC = getUtcDayString(now)
+
+  const capturePluginLoaded = state.lastPluginLoadedDayUTC !== dayUTC
+
+  if (capturePluginLoaded) {
+    writePostHogActivityState({
+      ...state,
+      lastPluginLoadedDayUTC: dayUTC,
+    })
+  }
+
+  return {
+    dayUTC,
+    capturePluginLoaded,
   }
 }

--- a/src/shared/posthog.test.ts
+++ b/src/shared/posthog.test.ts
@@ -1,23 +1,54 @@
-import { afterEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+
+type CapturedPostHogMessage = {
+  distinctId: string
+  event: string
+  properties?: Record<string, unknown>
+}
 
 async function importPostHogModule(): Promise<typeof import("./posthog")> {
   return import(`./posthog?test=${Date.now()}-${Math.random()}`)
 }
 
+function enableTelemetryEnv(): void {
+  process.env.OMO_DISABLE_POSTHOG = "0"
+  process.env.OMO_SEND_ANONYMOUS_TELEMETRY = "1"
+  process.env.POSTHOG_API_KEY = "test-api-key"
+}
+
+function clearTelemetryEnv(): void {
+  delete process.env.OMO_DISABLE_POSTHOG
+  delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
+  delete process.env.POSTHOG_API_KEY
+  delete process.env.POSTHOG_HOST
+}
+
+function mockPostHogNode(capturedMessages: CapturedPostHogMessage[]): void {
+  mock.module("posthog-node", () => ({
+    PostHog: class {
+      capture(message: CapturedPostHogMessage): void {
+        capturedMessages.push(message)
+      }
+      captureException(): void {}
+      async shutdown(): Promise<void> {}
+    },
+  }))
+}
+
 describe("posthog client creation", () => {
+  beforeEach(() => {
+    mock.restore()
+    clearTelemetryEnv()
+  })
+
   afterEach(() => {
     mock.restore()
-    delete process.env.OMO_DISABLE_POSTHOG
-    delete process.env.OMO_SEND_ANONYMOUS_TELEMETRY
-    delete process.env.POSTHOG_API_KEY
-    delete process.env.POSTHOG_HOST
+    clearTelemetryEnv()
   })
 
   it("returns a no-op client when PostHog construction throws", async () => {
     // given
-    process.env.OMO_DISABLE_POSTHOG = "0"
-    process.env.OMO_SEND_ANONYMOUS_TELEMETRY = "1"
-    process.env.POSTHOG_API_KEY = "test-api-key"
+    enableTelemetryEnv()
 
     mock.module("posthog-node", () => ({
       PostHog: class {
@@ -98,5 +129,75 @@ describe("posthog client creation", () => {
     expect(() => pluginPostHog.captureException(new Error("plugin failure"), "plugin")).not.toThrow()
     expect(() => pluginPostHog.trackActive("plugin", "plugin_loaded")).not.toThrow()
     await expect(pluginPostHog.shutdown()).resolves.toBeUndefined()
+  })
+})
+
+describe("posthog trackActive emission contract", () => {
+  let resetActivityStateProvider: (() => void) | null = null
+
+  beforeEach(() => {
+    mock.restore()
+    clearTelemetryEnv()
+  })
+
+  afterEach(() => {
+    resetActivityStateProvider?.()
+    resetActivityStateProvider = null
+    mock.restore()
+    clearTelemetryEnv()
+  })
+
+  it("emits exactly one omo_daily_active and never omo_hourly_active when captureDaily is true", async () => {
+    // given
+    enableTelemetryEnv()
+    const captured: CapturedPostHogMessage[] = []
+    mockPostHogNode(captured)
+    const posthogModule = await importPostHogModule()
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: true,
+    }))
+    resetActivityStateProvider = posthogModule.__resetActivityStateProviderForTesting
+    const client = posthogModule.createCliPostHog()
+
+    // when
+    client.trackActive("distinct-cli", "run_started")
+
+    // then
+    expect(captured).toHaveLength(1)
+    const emittedEvents = captured.map((message) => message.event)
+    expect(emittedEvents).not.toContain("omo_hourly_active")
+    const [dailyEvent] = captured
+    expect(dailyEvent?.event).toBe("omo_daily_active")
+    expect(dailyEvent?.distinctId).toBe("distinct-cli")
+    expect(dailyEvent?.properties).toMatchObject({
+      day_utc: "2026-04-18",
+      reason: "run_started",
+      source: "cli",
+    })
+    expect(dailyEvent?.properties).not.toHaveProperty("hour_utc")
+  })
+
+  it("emits nothing and never omo_hourly_active when captureDaily is false", async () => {
+    // given
+    enableTelemetryEnv()
+    const captured: CapturedPostHogMessage[] = []
+    mockPostHogNode(captured)
+    const posthogModule = await importPostHogModule()
+    posthogModule.__setActivityStateProviderForTesting(() => ({
+      dayUTC: "2026-04-18",
+      captureDaily: false,
+    }))
+    resetActivityStateProvider = posthogModule.__resetActivityStateProviderForTesting
+    const client = posthogModule.createPluginPostHog()
+
+    // when
+    client.trackActive("distinct-plugin", "plugin_loaded")
+
+    // then
+    expect(captured).toHaveLength(0)
+    const emittedEvents = captured.map((message) => message.event)
+    expect(emittedEvents).not.toContain("omo_daily_active")
+    expect(emittedEvents).not.toContain("omo_hourly_active")
   })
 })

--- a/src/shared/posthog.ts
+++ b/src/shared/posthog.ts
@@ -5,6 +5,25 @@ import packageJson from "../../package.json" with { type: "json" }
 import { PLUGIN_NAME, PUBLISHED_PACKAGE_NAME } from "./plugin-identity"
 import { getPostHogActivityCaptureState } from "./posthog-activity-state"
 
+/** @internal test-only seam: keep null in production to use the real implementation. */
+let activityStateProviderOverride: typeof getPostHogActivityCaptureState | null = null
+
+function resolveActivityState(): ReturnType<typeof getPostHogActivityCaptureState> {
+  return (activityStateProviderOverride ?? getPostHogActivityCaptureState)()
+}
+
+/** @internal test-only */
+export function __setActivityStateProviderForTesting(
+  provider: typeof getPostHogActivityCaptureState,
+): void {
+  activityStateProviderOverride = provider
+}
+
+/** @internal test-only */
+export function __resetActivityStateProviderForTesting(): void {
+  activityStateProviderOverride = null
+}
+
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"
 const DEFAULT_POSTHOG_API_KEY = "phc_CFJhj5HyvA62QPhvyaUCtaq23aUfznnijg5VaaGkNk74"
 
@@ -128,7 +147,7 @@ function createPostHogClient(
       })
     },
     trackActive: (distinctId, reason) => {
-      const activityState = getPostHogActivityCaptureState()
+      const activityState = resolveActivityState()
 
       if (activityState.captureDaily) {
         configuredClient.capture({
@@ -137,18 +156,6 @@ function createPostHogClient(
           properties: {
             ...sharedProperties,
             day_utc: activityState.dayUTC,
-            reason,
-          },
-        })
-      }
-
-      if (activityState.captureHourly) {
-        configuredClient.capture({
-          distinctId,
-          event: "omo_hourly_active",
-          properties: {
-            ...sharedProperties,
-            hour_utc: activityState.hourUTC,
             reason,
           },
         })


### PR DESCRIPTION
## What

Cuts PostHog event volume in two ways to keep us inside the free tier as the user base grows past 60K MAU:

1. **Remove HAU (`omo_hourly_active`) emission entirely** while keeping DAU (`omo_daily_active`) intact. Picks up the work from #3589, rebased on the latest `dev`.
2. **Dedupe the `plugin_loaded` capture to once per UTC day** per machine. Previously `plugin_loaded` fired on every plugin reload, which is proportional to opencode restarts per user per day - the dominant source of event spend now that MAU has more than doubled in 12 days.

## Why

- HAU adds limited analytic value over DAU and roughly 24x'd the event count for active users.
- `plugin_loaded` was the highest-volume single event after HAU because power users restart `opencode` frequently throughout the day. A single UTC-daily emission per machine preserves all the install / runtime signal we need without paying for repeat restarts.

Both changes are infrastructure-only - no user-visible behavior change, no provider integration change.

## Changes

**HAU removal (cherry-picked from #3589, conflicts cleanly with current `dev`)**
- `src/shared/posthog.ts` - drop `omo_hourly_active` capture block in `trackActive`; add a test-only seam (`__setActivityStateProviderForTesting` / `__resetActivityStateProviderForTesting`) so the daily emission contract can be exercised with a stable provider.
- `src/shared/posthog-activity-state.ts` - drop `lastActiveHourUTC`, `hourUTC`, `captureHourly`, and `getUtcHourString`. Old activity state files containing `lastActiveHourUTC` continue to load without crashing (unknown field is ignored).
- `src/shared/posthog.test.ts` - replace HAU expectations with a DAU-only emission contract using the new test seam.
- `src/shared/posthog-activity-state.test.ts` - drop hourly assertions, add legacy hourly-state read regression case.
- `docs/legal/privacy-policy.md` - remove `omo_hourly_active` from the collected-events list and update wording.

**`plugin_loaded` daily dedupe (new commit)**
- `src/shared/posthog-activity-state.ts`
  - Extend `PostHogActivityState` with `lastPluginLoadedDayUTC?: string`.
  - Add new `getPluginLoadedCaptureState(now?)` returning `{ dayUTC, capturePluginLoaded }`.
  - Fix `getPostHogActivityCaptureState` to spread the existing state when writing so `lastPluginLoadedDayUTC` is preserved (and vice versa).
- `src/index.ts` - call `getPluginLoadedCaptureState()` and only emit the `plugin_loaded` capture when `capturePluginLoaded === true`. Activity-state read errors are caught and silenced (we just skip the capture, never block plugin load).
- `src/shared/posthog-activity-state.test.ts` - add coverage for `getPluginLoadedCaptureState` (no-state, today's state, previous-day state) plus cross-field preservation tests against `lastActiveDayUTC` (both directions) and a "no rewrite when state matches today" assertion.
- `src/index.telemetry.test.ts` - mock the new module so the existing telemetry-isolation test keeps working with the dedupe gate in place.

## Verification

- `bun run typecheck` - green
- `bun script/run-ci-tests.ts` (full suite) - **4945 pass / 0 fail / 24 snapshots / 10549 expect calls** (108s)
- `bun test src/shared/posthog.test.ts src/shared/posthog-activity-state.test.ts src/index.telemetry.test.ts` - **16 pass / 0 fail**
- LSP diagnostics clean on all modified source files.

## Notes

- Backward-compat: existing `posthog-activity.json` files with `lastActiveHourUTC` (HAU) are accepted and the unknown field is ignored on the next write.
- The two daily gates (`lastActiveDayUTC`, `lastPluginLoadedDayUTC`) are independent dimensions stored in the same JSON file. After this change, writing one preserves the other via object spread.
- Supersedes #3589.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce PostHog event volume and cost by removing hourly active (`omo_hourly_active`) and gating `plugin_loaded` to once per UTC day per machine. DAU (`omo_daily_active`) stays; no user-visible changes.

- **Refactors**
  - Removed HAU capture and tests; `trackActive` now emits only `omo_daily_active`. Added a small test seam to stub activity state.
  - Added daily dedupe for `plugin_loaded` using a new `lastPluginLoadedDayUTC` field; preserves `lastActiveDayUTC` independently and handles read errors safely.
  - Updated privacy policy to remove hourly tracking.

<sup>Written for commit 669e0667be78e90d68eb434634b77b18e04b3d4c. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3698?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

