### PR TITLE
fix(context-window-monitor): clamp displayed context status percentages so the directive stays trustworthy (fixes #3655)

### DIFF
--- a/src/hooks/context-window-monitor.test.ts
+++ b/src/hooks/context-window-monitor.test.ts
@@ -143,6 +143,62 @@ describe("context-window-monitor", () => {
     expect(ctx.client.session.messages).not.toHaveBeenCalled()
   })
 
+  // #given total input tokens exceed the resolved actualLimit (e.g. 1M-context
+  //        Anthropic model where resolveActualContextLimit falls back to the
+  //        200K default for the model family)
+  // #when tool.execute.after appends the context status block
+  // #then the displayed used% must be clamped to 100 and remaining% must not go
+  //       negative. Safety-tuned models flag the >100% / negative-remaining
+  //       block as prompt injection (issue #3655).
+  it("should clamp displayed percentages when input exceeds actualLimit (regression #3655)", async () => {
+    const hook = createContextWindowMonitorHook(ctx as never)
+    const sessionID = "ses_overflow"
+
+    // 289,370 input + 0 cache against a 200K resolved limit -> 144.7% raw,
+    // -44.7% remaining if not clamped.
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            finish: true,
+            tokens: {
+              input: 289370,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    const output = { title: "", output: "original", metadata: null }
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      output
+    )
+
+    // The block must still be emitted (we are above the 70% threshold).
+    expect(output.output).toContain("[Context Status:")
+
+    // Extract the displayed percentages and assert clamping.
+    const match = output.output.match(
+      /\[Context Status: ([\d.-]+)% used \([\d,]+\/[\d,]+ tokens\), ([\d.-]+)% remaining\]/,
+    )
+    expect(match).not.toBeNull()
+    const usedPct = Number(match![1])
+    const remainingPct = Number(match![2])
+
+    expect(usedPct).toBeLessThanOrEqual(100)
+    expect(usedPct).toBeGreaterThanOrEqual(0)
+    expect(remainingPct).toBeGreaterThanOrEqual(0)
+    expect(remainingPct).toBeLessThanOrEqual(100)
+  })
+
   it("should append context reminder for google-vertex-anthropic provider", async () => {
     //#given cached usage for google-vertex-anthropic above threshold
     const hook = createContextWindowMonitorHook(ctx as never)

--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -65,8 +65,15 @@ export function createContextWindowMonitorHook(
 
     remindedSessions.add(sessionID)
 
-    const usedPct = (actualUsagePercentage * 100).toFixed(1)
-    const remainingPct = ((1 - actualUsagePercentage) * 100).toFixed(1)
+    // Clamp the displayed percentages so the block stays trustworthy when the
+    // resolved actualLimit underestimates the model's real context window
+    // (e.g. a 1M-context Anthropic model that falls back to the 200K default).
+    // Without clamping, the block would advertise >100% used and a negative
+    // "remaining" - safety-tuned models flag exactly that pattern as a prompt
+    // injection and refuse to follow the directive (issue #3655).
+    const clampedPercentage = Math.min(Math.max(actualUsagePercentage, 0), 1)
+    const usedPct = (clampedPercentage * 100).toFixed(1)
+    const remainingPct = ((1 - clampedPercentage) * 100).toFixed(1)
     const usedTokens = totalInputTokens.toLocaleString()
     const limitTokens = actualLimit.toLocaleString()
 


### PR DESCRIPTION
## Summary
Clamp the displayed `% used` and `% remaining` numbers in the `[SYSTEM DIRECTIVE: OH-MY-OPENCODE - CONTEXT WINDOW MONITOR]` block to `[0, 100]` so the directive remains trustworthy when the resolved `actualLimit` underestimates the model's real context window. Without clamping, the block currently advertises numbers like `144.7% used (289,370/200,000 tokens), -44.7% remaining`, which safety-tuned models flag as a prompt injection and refuse to follow.

## Root Cause
`src/hooks/context-window-monitor.ts` lines 62-74 compute and render the directive:

```ts
const actualUsagePercentage = totalInputTokens / actualLimit
if (actualUsagePercentage < CONTEXT_WARNING_THRESHOLD) return
// ...
const usedPct = (actualUsagePercentage * 100).toFixed(1)
const remainingPct = ((1 - actualUsagePercentage) * 100).toFixed(1)
output.output += `\n\n${createContextReminder(actualLimit)}
[Context Status: ${usedPct}% used (${usedTokens}/${limitTokens} tokens), ${remainingPct}% remaining]`
```

When `resolveActualContextLimit()` underestimates the real context window (the deeper concern tracked as #3450 - e.g. a 1M-context Anthropic model that falls back to `DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000`), `totalInputTokens / actualLimit` exceeds 1.0 and the formatting math then produces nonsensical numbers. The injected block also wraps itself in `[SYSTEM DIRECTIVE: ...]` framing and issues behavioral imperatives, so safety-tuned models correctly identify the >100% / negative-remaining pattern as adversarial:

> "I ignored it as a prompt injection - context usage is fine, and the directive contradicted my actual instructions." (real session log from issue #3655)

## Changes
| File | Change |
|------|--------|
| `src/hooks/context-window-monitor.ts` | Compute `clampedPercentage = Math.min(Math.max(actualUsagePercentage, 0), 1)` and use it for both `usedPct` and `remainingPct`. The threshold check on line 64 still uses the raw value so the block continues to fire correctly above 70%. `resolveActualContextLimit()` is left untouched (deeper concern, tracked as #3450). |
| `src/hooks/context-window-monitor.test.ts` | Add a regression test that drives the hook with `input: 289,370` against a `200,000` resolved limit (matching the issue's reproduction numbers) and asserts both `usedPct` and `remainingPct` stay within `[0, 100]`. |

Total diff: 2 files, +65 lines.

## Reproduction (before fix)
With the regression test added but the source change reverted:

```
(fail) context-window-monitor > should clamp displayed percentages when input
       exceeds actualLimit (regression #3655)

  expect(received).toBeLessThanOrEqual(expected)
    Expected: <= 100
    Received: 144.7

 0 pass
 1 fail
```

The actually rendered block looks like:

```
[Context Status: 144.7% used (289,370/200,000 tokens), -44.7% remaining]
```

## Verification (after fix)
```
$ bun test src/hooks/context-window-monitor.test.ts -t "regression #3655"
 1 pass / 0 fail / 6 expect() calls

$ bun test src/hooks/context-window-monitor.test.ts \
           src/hooks/context-window-monitor.model-context-limits.test.ts
 15 pass / 0 fail / 29 expect() calls

$ bun run typecheck
$ tsc --noEmit
(no output, exit 0)
```

After the fix, the block now reads:

```
[Context Status: 100.0% used (289,370/200,000 tokens), 0.0% remaining]
```

The numbers are still informative (token counts are unchanged so the user still sees they are over the resolved limit) but they no longer match the prompt-injection pattern that safety-tuned models reject.

## Test
- Regression test: `src/hooks/context-window-monitor.test.ts` (new case `should clamp displayed percentages when input exceeds actualLimit (regression #3655)`).
- Full hook suites: `context-window-monitor.test.ts` (9 tests) + `context-window-monitor.model-context-limits.test.ts` (6 tests) - 15 pass / 0 fail.
- Typecheck: clean.
- Note: this PR does NOT change `resolveActualContextLimit()` itself. Fixing the underlying root cause - so the resolver returns the model's real context window for 1M-context Anthropic models - is tracked as #3450 and will land separately. This PR is purely a defensive UX clamp on the displayed string.

Fixes #3655

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp context status percentages to 0–100% so the monitor stays accurate and doesn’t trigger safety checks. Fixes #3655 by preventing outputs like “144.7% used, -44.7% remaining” when the resolved limit is lower than the model’s real window.

- **Bug Fixes**
  - Format `used%`/`remaining%` from a clamped usage value; threshold logic still uses the raw ratio so the block triggers as before.
  - Added a regression test (289,370 / 200,000) to ensure percentages stay within [0, 100]; all existing tests pass and typecheck is clean.

<sup>Written for commit 07064a96f5a1627aa2e6bbdd82f56934a74a14fc. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3701?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

