### PR TITLE
feat(notification): add cmux as notification provider

### DIFF
--- a/src/hooks/session-notification-sender.test.ts
+++ b/src/hooks/session-notification-sender.test.ts
@@ -66,6 +66,7 @@ function createThrowingShellPromise(shouldThrow: (cmdStr: string) => boolean) {
 describe("session-notification-sender", () => {
 	beforeEach(() => {
 		jest.restoreAllMocks()
+		spyOn(utils, "getCmuxPath").mockResolvedValue(null)
 		spyOn(utils, "getTerminalNotifierPath").mockResolvedValue("/usr/local/bin/terminal-notifier")
 		spyOn(utils, "getOsascriptPath").mockResolvedValue("/usr/bin/osascript")
 		spyOn(utils, "getNotifySendPath").mockResolvedValue("/usr/bin/notify-send")
@@ -135,6 +136,79 @@ describe("session-notification-sender", () => {
 
 				expect(quietCalls.length).toBeGreaterThanOrEqual(1)
 				expect(quietCalls[0]).toContain("osascript")
+			})
+
+			test("#then should use cmux when available", async () => {
+				spyOn(utils, "getCmuxPath").mockResolvedValue("/usr/local/bin/cmux")
+
+				const calls: string[] = []
+				const mockCtx = {
+					$: createShellPromise((cmdStr) => { calls.push(cmdStr) }),
+				} as unknown as PluginInput
+
+				await sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")
+
+				expect(calls.length).toBe(1)
+				expect(calls[0]).toContain("cmux")
+				expect(calls[0]).not.toContain("terminal-notifier")
+				expect(calls[0]).not.toContain("osascript")
+			})
+
+			test("#then should fall back to terminal-notifier when cmux fails", async () => {
+				spyOn(utils, "getCmuxPath").mockResolvedValue("/usr/local/bin/cmux")
+
+				const mockCtx = {
+					$: createThrowingShellPromise((cmdStr) => cmdStr.includes("cmux notify")),
+				} as unknown as PluginInput
+
+				const originalFactory = mockCtx.$
+				const trackingCalls: string[] = []
+				mockCtx.$ = ((cmd: TemplateStringsArray, ...values: unknown[]) => {
+					const cmdStr = cmd.reduce((acc: string, part: string, i: number) => acc + part + (values[i] ?? ""), "")
+					trackingCalls.push(cmdStr)
+					return originalFactory(cmd, ...values)
+				}) as typeof mockCtx.$
+
+				await sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")
+
+				expect(trackingCalls.some((c) => c.includes("cmux notify"))).toBe(true)
+				expect(trackingCalls.some((c) => c.includes("terminal-notifier"))).toBe(true)
+				expect(trackingCalls.some((c) => c.includes("osascript"))).toBe(false)
+			})
+
+			test("#then should fall back to osascript when cmux and terminal-notifier both fail", async () => {
+				spyOn(utils, "getCmuxPath").mockResolvedValue("/usr/local/bin/cmux")
+
+				const trackingCalls: string[] = []
+				const mockCtx = {
+					$: createThrowingShellPromise((cmdStr) => cmdStr.includes("cmux notify") || cmdStr.includes("terminal-notifier")),
+				} as unknown as PluginInput
+
+				const originalFactory = mockCtx.$
+				mockCtx.$ = ((cmd: TemplateStringsArray, ...values: unknown[]) => {
+					const cmdStr = cmd.reduce((acc: string, part: string, i: number) => acc + part + (values[i] ?? ""), "")
+					trackingCalls.push(cmdStr)
+					return originalFactory(cmd, ...values)
+				}) as typeof mockCtx.$
+
+				await sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")
+
+				expect(trackingCalls.some((c) => c.includes("cmux notify"))).toBe(true)
+				expect(trackingCalls.some((c) => c.includes("terminal-notifier"))).toBe(true)
+				expect(trackingCalls.some((c) => c.includes("osascript"))).toBe(true)
+			})
+
+			test("#then should skip cmux when not available and use terminal-notifier", async () => {
+				const calls: string[] = []
+				const mockCtx = {
+					$: createShellPromise((cmdStr) => { calls.push(cmdStr) }),
+				} as unknown as PluginInput
+
+				await sender.sendSessionNotification(mockCtx, "darwin", "Test", "Message")
+
+				expect(calls.length).toBe(1)
+				expect(calls[0]).toContain("terminal-notifier")
+				expect(calls[0]).not.toContain("cmux notify")
 			})
 
 			test("#then should call .quiet() on linux notify-send", async () => {

--- a/src/hooks/session-notification-sender.ts
+++ b/src/hooks/session-notification-sender.ts
@@ -1,6 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { platform } from "os"
 import {
+  getCmuxPath,
   getOsascriptPath,
   getNotifySendPath,
   getPowershellPath,
@@ -40,7 +41,17 @@ export async function sendSessionNotification(
 ): Promise<void> {
   switch (platform) {
     case "darwin": {
-      // Try terminal-notifier first - deterministic click-to-focus
+      // Try cmux first - native UNUserNotificationCenter, properly attributed
+      const cmuxPath = await getCmuxPath()
+      if (cmuxPath) {
+        try {
+          await ctx.$`${cmuxPath} notify --title ${title} --body ${message}`.quiet()
+          break
+        } catch {
+        }
+      }
+
+      // Try terminal-notifier - deterministic click-to-focus
       const terminalNotifierPath = await getTerminalNotifierPath()
       if (terminalNotifierPath) {
         const bundleId = process.env.__CFBundleIdentifier

--- a/src/hooks/session-notification-utils.ts
+++ b/src/hooks/session-notification-utils.ts
@@ -50,9 +50,13 @@ export const getAfplayPath = createCommandFinder("afplay")
 export const getPaplayPath = createCommandFinder("paplay")
 export const getAplayPath = createCommandFinder("aplay")
 export const getTerminalNotifierPath = createCommandFinder("terminal-notifier")
+export const getCmuxPath = createCommandFinder("cmux")
 
 export function startBackgroundCheck(platform: Platform): void {
   if (platform === "darwin") {
+    getCmuxPath().catch((error) => {
+      logBackgroundCheckError("cmux", error)
+    })
     getOsascriptPath().catch((error) => {
       logBackgroundCheckError("osascript", error)
     })


### PR DESCRIPTION
Fixes #3628

## Summary

- Adds [cmux](https://github.com/manaflow-ai/cmux) as a notification provider, before `terminal-notifier` and `osascript`
- Notifications are sent via `cmux notify --title <title> --body <message>`

## Problem

When `terminal-notifier` is not installed, session notifications fall back to `osascript -e 'display notification ...'`. This attributes notifications to **Script Editor**, which is confusing for users.

## Solution

[cmux](https://github.com/manaflow-ai/cmux) is a terminal app (built on libghostty) that exposes a `cmux notify` CLI command. When available, it delivers notifications properly attributed to the cmux app instead of Script Editor.

Notification priority:
1. **cmux**
2. **terminal-notifier**
3. **osascript** (fallback)

## Changes

- `session-notification-utils.ts` — added `getCmuxPath` command finder + background check
- `session-notification-sender.ts` — added cmux as first provider in darwin notification chain
- `session-notification-sender.test.ts` — tests covering the full fallback chain:
  - cmux available → uses cmux, skips terminal-notifier and osascript
  - cmux fails → falls back to terminal-notifier
  - cmux + terminal-notifier both fail → falls back to osascript
  - cmux not available → skips straight to terminal-notifier

## Previous PR

This is a reissue of #3627, which was closed when the source fork was deleted and re-created. The implementation addresses the Cubic review feedback from the original PR — tests now assert which provider is called on each fallback path.

## Preview

<img width="225" height="161" alt="CMUX Notification Preview" src="https://github.com/user-attachments/assets/d7477134-e9bb-460e-b008-e2f996613a28" />


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cmux` as the top macOS notification provider to send native, correctly attributed notifications. Falls back to `terminal-notifier`, then `osascript`, fixing the misleading Script Editor attribution when `terminal-notifier` isn’t installed.

- **New Features**
  - macOS priority: `cmux` > `terminal-notifier` > `osascript`; uses `cmux notify --title <title> --body <message>` when available.
  - Adds background command check for `cmux` and tests for all fallback paths.

<sup>Written for commit 763ff7e8245cf3090585d480c757daf2e7f61dfe. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3708?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

