### PR TITLE
fix(notification): session-idle notifications never fire due to stale platform

### DIFF
--- a/src/hooks/session-notification-scheduler.ts
+++ b/src/hooks/session-notification-scheduler.ts
@@ -1,5 +1,4 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import type { Platform } from "./session-notification-sender"
 
 type SessionNotificationConfig = {
   playSound: boolean
@@ -13,11 +12,10 @@ type SessionNotificationConfig = {
 
 export function createIdleNotificationScheduler(options: {
   ctx: PluginInput
-  platform: Platform
   config: SessionNotificationConfig
   hasIncompleteTodos: (ctx: PluginInput, sessionID: string) => Promise<boolean>
-  send: (ctx: PluginInput, platform: Platform, sessionID: string) => Promise<void>
-  playSound: (ctx: PluginInput, platform: Platform, soundPath: string) => Promise<void>
+  send: (ctx: PluginInput, sessionID: string) => Promise<void>
+  playSound: (ctx: PluginInput, soundPath: string) => Promise<void>
 }) {
   const notifiedSessions = new Set<string>()
   const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>()
@@ -136,10 +134,10 @@ export function createIdleNotificationScheduler(options: {
 
       notifiedSessions.add(sessionID)
 
-      await options.send(options.ctx, options.platform, sessionID)
+      await options.send(options.ctx, sessionID)
 
       if (options.config.playSound && options.config.soundPath) {
-        await options.playSound(options.ctx, options.platform, options.config.soundPath)
+        await options.playSound(options.ctx, options.config.soundPath)
       }
     } finally {
       executingNotifications.delete(sessionID)

--- a/src/hooks/session-notification.ts
+++ b/src/hooks/session-notification.ts
@@ -47,10 +47,10 @@ export function createSessionNotification(ctx: PluginInput, config: SessionNotif
 
   const scheduler = createIdleNotificationScheduler({
     ctx,
-    platform: "unsupported",
     config: mergedConfig,
     hasIncompleteTodos,
-    send: async (hookCtx, platform, sessionID) => {
+    send: async (hookCtx, sessionID) => {
+      const platform = ensureNotificationPlatform()
       if (typeof hookCtx.client.session.get !== "function" && typeof hookCtx.client.session.messages !== "function") {
         await sessionNotificationSender.sendSessionNotification(hookCtx, platform, mergedConfig.title, mergedConfig.message)
         return
@@ -64,7 +64,10 @@ export function createSessionNotification(ctx: PluginInput, config: SessionNotif
 
       await sessionNotificationSender.sendSessionNotification(hookCtx, platform, content.title, content.message)
     },
-    playSound: sessionNotificationSender.playSessionNotificationSound,
+    playSound: async (hookCtx, soundPath) => {
+      const platform = ensureNotificationPlatform()
+      await sessionNotificationSender.playSessionNotificationSound(hookCtx, platform, soundPath)
+    },
   })
 
   const QUESTION_TOOLS = new Set(["question", "ask_user_question", "askuserquestion"])


### PR DESCRIPTION
Fixes #3712

## Problem

Session-idle (completion) notifications never fire. The idle notification scheduler is initialized with `platform: "unsupported"` before platform detection runs. This stale value is passed to `send`/`playSound` callbacks, and `sendSessionNotification` has no switch case for `"unsupported"` — so it silently does nothing.

Direct notifications (question tool, permission events) work fine because they call `ensureNotificationPlatform()` and pass the result directly to the sender.

## Root Cause

```typescript
const scheduler = createIdleNotificationScheduler({
  platform: "unsupported", // ← set at construction, never updated
  send: async (hookCtx, platform, sessionID) => {
    // platform is always "unsupported" here
    await sendSessionNotification(hookCtx, platform, ...)
  },
})
```

## Fix

Remove `platform` from the scheduler interface entirely. The scheduler has no need for platform state — it only orchestrates timers and version guards. Callbacks now resolve platform via `ensureNotificationPlatform()`, which is sync, cached after first call (`os.platform()`), and already invoked by each event handler before scheduling.

## Changes

- `session-notification-scheduler.ts` — removed `platform` from options type, callback signatures, and call sites
- `session-notification.ts` — removed `platform: "unsupported"` from construction; `send` and `playSound` callbacks resolve platform via closure

## Discovery

Found while testing #3708 (cmux notification provider). The cmux notifications were being sent correctly but never reached the OS because the scheduler was passing `"unsupported"` to the sender.

## Testing

All 29 existing notification tests pass. The fix is structural — removing the dead field prevents future regressions.