### PR TITLE
fix(messages-transform): isolate hook failures so tool-pair-validator always runs

### DIFF
--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "bun:test"
+
+import { createMessagesTransformHandler } from "./messages-transform"
+import { createToolPairValidatorHook } from "../hooks/tool-pair-validator/hook"
+import type { CreatedHooks } from "../create-hooks"
+
+type TestPart = {
+  type: string
+  id?: string
+  callID?: string
+  tool_use_id?: string
+  content?: string
+  text?: string
+}
+
+type TestMessage = {
+  info: { role: "assistant" | "user" }
+  parts: TestPart[]
+}
+
+type TransformHook = (
+  input: Record<string, never>,
+  output: { messages: TestMessage[] },
+) => Promise<void>
+
+function makeHook(handler: TransformHook): NonNullable<CreatedHooks["toolPairValidator"]> {
+  return {
+    "experimental.chat.messages.transform": handler as never,
+  } as never
+}
+
+function makeHooks(overrides: {
+  contextInjector?: TransformHook
+  thinkingBlock?: TransformHook
+  toolPair?: TransformHook
+}): CreatedHooks {
+  return {
+    contextInjectorMessagesTransform: overrides.contextInjector ? makeHook(overrides.contextInjector) : undefined,
+    thinkingBlockValidator: overrides.thinkingBlock ? makeHook(overrides.thinkingBlock) : undefined,
+    toolPairValidator: overrides.toolPair ? makeHook(overrides.toolPair) : undefined,
+  } as unknown as CreatedHooks
+}
+
+async function runHandler(
+  hooks: CreatedHooks,
+  messages: TestMessage[],
+): Promise<void> {
+  const handler = createMessagesTransformHandler({ hooks })
+  await handler({} as never, { messages: messages as never })
+}
+
+describe("createMessagesTransformHandler", () => {
+  it("runs all hooks in order when none throw", async () => {
+    //#given
+    const callOrder: string[] = []
+    const hooks = makeHooks({
+      contextInjector: async () => {
+        callOrder.push("context-injector")
+      },
+      thinkingBlock: async () => {
+        callOrder.push("thinking-block-validator")
+      },
+      toolPair: async () => {
+        callOrder.push("tool-pair-validator")
+      },
+    })
+
+    //#when
+    await runHandler(hooks, [])
+
+    //#then
+    expect(callOrder).toEqual([
+      "context-injector",
+      "thinking-block-validator",
+      "tool-pair-validator",
+    ])
+  })
+
+  it("runs tool-pair-validator even when context-injector throws", async () => {
+    //#given
+    let toolPairRan = false
+    const hooks = makeHooks({
+      contextInjector: async () => {
+        throw new Error("context-injector boom")
+      },
+      toolPair: async () => {
+        toolPairRan = true
+      },
+    })
+
+    //#when
+    await runHandler(hooks, [])
+
+    //#then
+    expect(toolPairRan).toBe(true)
+  })
+
+  it("runs tool-pair-validator even when thinking-block-validator throws", async () => {
+    //#given
+    let toolPairRan = false
+    const hooks = makeHooks({
+      thinkingBlock: async () => {
+        throw new Error("thinking-block boom")
+      },
+      toolPair: async () => {
+        toolPairRan = true
+      },
+    })
+
+    //#when
+    await runHandler(hooks, [])
+
+    //#then
+    expect(toolPairRan).toBe(true)
+  })
+
+  it("repairs orphaned tool_use after upstream hook throws (regression for ses_22bd806)", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      { info: { role: "user" }, parts: [{ type: "text", text: "summary stand-in" }] },
+      { info: { role: "assistant" }, parts: [{ type: "tool_use", id: "toolu_01SRMQs3DUtVKWoSxC8bxxVA" }] },
+      { info: { role: "assistant" }, parts: [{ type: "tool_use", id: "toolu_01Lu5cHvRtEvzoifP1UVBVRb" }] },
+      { info: { role: "user" }, parts: [{ type: "text", text: "next" }] },
+    ]
+    const hooks = makeHooks({
+      contextInjector: async () => {
+        throw new Error("simulating upstream hook failure")
+      },
+      toolPair: createRealToolPairValidator(),
+    })
+
+    //#when
+    await runHandler(hooks, messages)
+
+    //#then
+    expect(messages).toHaveLength(5)
+    expect(messages[2]).toEqual({
+      info: { role: "user" },
+      parts: [{ type: "tool_result", tool_use_id: "toolu_01SRMQs3DUtVKWoSxC8bxxVA", content: "Tool output unavailable (context compacted)" }],
+    })
+    expect(messages[4]?.parts[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "toolu_01Lu5cHvRtEvzoifP1UVBVRb",
+      content: "Tool output unavailable (context compacted)",
+    })
+    expect(messages[4]?.parts[1]).toEqual({ type: "text", text: "next" })
+  })
+
+  it("does not throw when tool-pair-validator itself fails", async () => {
+    //#given
+    const hooks = makeHooks({
+      toolPair: async () => {
+        throw new Error("validator boom")
+      },
+    })
+
+    //#when / #then
+    await runHandler(hooks, [])
+  })
+})
+
+function createRealToolPairValidator(): TransformHook {
+  const validator = createToolPairValidatorHook()
+  const handler = validator["experimental.chat.messages.transform"]
+  if (!handler) throw new Error("validator missing transform")
+  return handler as never
+}

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -1,5 +1,6 @@
 import type { Message, Part } from "@opencode-ai/sdk"
 
+import { log } from "../shared/logger"
 import type { CreatedHooks } from "../create-hooks"
 
 type MessageWithParts = {
@@ -9,20 +10,56 @@ type MessageWithParts = {
 
 type MessagesTransformOutput = { messages: MessageWithParts[] }
 
+async function runMessagesTransformHookSafely<I, O>(
+  hookName: string,
+  handler: ((input: I, output: O) => unknown | Promise<unknown>) | null | undefined,
+  input: I,
+  output: O,
+): Promise<void> {
+  if (!handler) return
+  try {
+    await Promise.resolve(handler(input, output))
+  } catch (error) {
+    // Isolate per-handler failures so later handlers (notably toolPairValidator)
+    // always run. A throw here used to leave orphaned tool_use blocks in the
+    // post-compaction payload, producing API 400s like
+    // "tool_use ids were found without tool_result blocks immediately after".
+    log("[messages-transform] hook execution failed", {
+      hook: hookName,
+      error,
+    })
+  }
+}
+
 export function createMessagesTransformHandler(args: {
   hooks: CreatedHooks
 }): (input: Record<string, never>, output: MessagesTransformOutput) => Promise<void> {
   return async (input, output): Promise<void> => {
-    await args.hooks.contextInjectorMessagesTransform?.[
-      "experimental.chat.messages.transform"
-    ]?.(input, output)
+    await runMessagesTransformHookSafely(
+      "contextInjectorMessagesTransform",
+      args.hooks.contextInjectorMessagesTransform?.[
+        "experimental.chat.messages.transform"
+      ],
+      input,
+      output,
+    )
 
-    await args.hooks.thinkingBlockValidator?.[
-      "experimental.chat.messages.transform"
-    ]?.(input, output)
+    await runMessagesTransformHookSafely(
+      "thinkingBlockValidator",
+      args.hooks.thinkingBlockValidator?.[
+        "experimental.chat.messages.transform"
+      ],
+      input,
+      output,
+    )
 
-    await args.hooks.toolPairValidator?.[
-      "experimental.chat.messages.transform"
-    ]?.(input, output)
+    await runMessagesTransformHookSafely(
+      "toolPairValidator",
+      args.hooks.toolPairValidator?.[
+        "experimental.chat.messages.transform"
+      ],
+      input,
+      output,
+    )
   }
 }


### PR DESCRIPTION
## Summary

`createMessagesTransformHandler` awaits three transform hooks sequentially with no per-hook error handling. If `contextInjectorMessagesTransform` or `thinkingBlockValidator` throws at runtime, `toolPairValidator` is silently skipped and orphaned `tool_use` blocks reach the Anthropic API, producing:

```
messages.N: tool_use ids were found without tool_result blocks immediately after: toolu_xxx.
Each tool_use block must have a corresponding tool_result block in the next message.
```

This is most visible after compaction when the OpenCode core's selected `tail_start_id` lands inside a sequence of consecutive assistant messages — exactly the case `toolPairValidator` was built to repair.

## Why this is a real regression of #3014

* **PR #3017** (Apr 2) added `tool-pair-validator` specifically to fix **#3014** (`Plan mode fails with tool_use/tool_result mismatch — messages.N: tool_use ids found without tool_result blocks`). The thread explicitly identifies the `experimental.chat.messages.transform` chain as the failure surface.
* **#2775** documents that `thinking-block-validator` can throw at runtime ("Invalid signature in thinking block") — that hook sits **upstream** of `tool-pair-validator` in the chain.
* **#2070** is the same error class triggered by Prometheus → Momus interleaved tool calls, linked to upstream `anomalyco/opencode#14456`.
* The unguarded `await` chain means any throw from an upstream hook silently bypasses `tool-pair-validator`, regressing #3014.

Note: `safeCreateHook` (in `src/shared/safe-create-hook.ts`) only catches errors during hook **construction**, not during runtime invocation, so it does not protect this code path.

## Following the existing house pattern

This isn't a new abstraction — the codebase already has the exact same pattern.

[`event.ts:222-239`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/plugin/event.ts#L222-L239) defines `runEventHookSafely`, which wraps ~25 sequential event-hook calls with a try/catch + log. We modeled `runMessagesTransformHookSafely` after it as closely as the differing hook surface allows:

| | `runEventHookSafely` | `runMessagesTransformHookSafely` |
|---|---|---|
| First param | `hookName: string` | `hookName: string` |
| Handler param name | `handler` | `handler` |
| Handler type | `((input) => unknown \| Promise<unknown>) \| null \| undefined` | `((input, output) => unknown \| Promise<unknown>) \| null \| undefined` |
| Body | `await Promise.resolve(handler(input))` | `await Promise.resolve(handler(input, output))` |
| Log message | `"[event] hook execution failed"` | `"[messages-transform] hook execution failed"` |
| Log fields | `{ hook: hookName, ..., error }` | `{ hook: hookName, error }` |
| Callsite name format | `"autoUpdateChecker"`, `"sessionNotification"`, ... (camelCase) | `"contextInjectorMessagesTransform"`, ... (camelCase) |

`runEventHookSafely` is the proven precedent — it's been live since the event-hook fanout was added and has hardened the event chain in the same way this PR hardens the transform chain. Cite it as the validating reference for this approach.

## Change

* `runMessagesTransformHookSafely(hookName, handler, input, output)` wraps each hook in try/catch; failures are logged via the existing `log()` channel and the chain continues.
* `tool-pair-validator` now runs unconditionally even if upstream hooks throw.
* New regression test file `src/plugin/messages-transform.test.ts` covering:
  * happy path: all three hooks run in order
  * `context-injector` throws → `tool-pair-validator` still runs
  * `thinking-block-validator` throws → `tool-pair-validator` still runs
  * orphaned `tool_use` after upstream failure is repaired (regression for `ses_22bd806`, structurally matches the consecutive-assistants tail from #3014)
  * `tool-pair-validator` itself throwing does not propagate

## Verification

* `bun run typecheck` — clean
* `bun test src/plugin/messages-transform.test.ts src/hooks/tool-pair-validator/` — 10/10 pass (5 new)
* `bun run build` — clean

## Related

* Closes regression of #3014
* Builds on PR #3017
* Mitigates downstream impact of #2775 and #2070
* Follows existing pattern from `runEventHookSafely` in `src/plugin/event.ts:222`
* Upstream root cause: anomalyco/opencode#14367 (Open), anomalyco/opencode#14456