### PR TITLE
fix(auto-update-checker): read loaded plugin's package.json, not the legacy flat install

### DIFF
--- a/src/hooks/auto-update-checker/checker/cached-version.test.ts
+++ b/src/hooks/auto-update-checker/checker/cached-version.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 // Hold mutable mock state so beforeEach can swap the cache root for each test.
-const mockState: { candidates: string[] } = { candidates: [] }
+const mockState: { candidates: string[]; walkUpResult: string | null } = {
+  candidates: [],
+  walkUpResult: null,
+}
 
 mock.module("../constants", () => ({
   INSTALLED_PACKAGE_JSON_CANDIDATES: new Proxy([], {
@@ -22,7 +25,7 @@ mock.module("../constants", () => ({
 }))
 
 mock.module("./package-json-locator", () => ({
-  findPackageJsonUp: () => null,
+  findPackageJsonUp: () => mockState.walkUpResult,
 }))
 
 import { getCachedVersion } from "./cached-version"
@@ -36,11 +39,13 @@ describe("getCachedVersion (GH-3257)", () => {
       join(cacheRoot, "node_modules", "oh-my-opencode", "package.json"),
       join(cacheRoot, "node_modules", "oh-my-openagent", "package.json"),
     ]
+    mockState.walkUpResult = null
   })
 
   afterEach(() => {
     rmSync(cacheRoot, { recursive: true, force: true })
     mockState.candidates = []
+    mockState.walkUpResult = null
   })
 
   it("returns the version when the package is installed under oh-my-opencode", () => {
@@ -76,5 +81,24 @@ describe("getCachedVersion (GH-3257)", () => {
 
   it("returns null when neither candidate exists and fallbacks find nothing", () => {
     expect(getCachedVersion()).toBeNull()
+  })
+
+  it("prefers the loaded module's package.json over flat-install candidates", () => {
+    // OpenCode loads plugins from a per-plugin sandbox at
+    // <CACHE_DIR>/<plugin-entry>/node_modules/<pkg>/, while a parallel flat
+    // install at <CACHE_DIR>/node_modules/<pkg>/ can drift independently when
+    // bun re-resolves "latest". The flat install must NOT take precedence,
+    // because that's the path the user is actually running.
+    const sandboxDir = join(cacheRoot, "oh-my-openagent@latest", "node_modules", "oh-my-openagent")
+    mkdirSync(sandboxDir, { recursive: true })
+    const sandboxPkgJson = join(sandboxDir, "package.json")
+    writeFileSync(sandboxPkgJson, JSON.stringify({ name: "oh-my-openagent", version: "3.17.5" }))
+    mockState.walkUpResult = sandboxPkgJson
+
+    const flatDir = join(cacheRoot, "node_modules", "oh-my-opencode")
+    mkdirSync(flatDir, { recursive: true })
+    writeFileSync(join(flatDir, "package.json"), JSON.stringify({ name: "oh-my-opencode", version: "3.17.6" }))
+
+    expect(getCachedVersion()).toBe("3.17.5")
   })
 })

--- a/src/hooks/auto-update-checker/checker/cached-version.ts
+++ b/src/hooks/auto-update-checker/checker/cached-version.ts
@@ -13,16 +13,12 @@ function readPackageVersion(packageJsonPath: string): string | null {
 }
 
 export function getCachedVersion(): string | null {
-  for (const candidate of INSTALLED_PACKAGE_JSON_CANDIDATES) {
-    try {
-      if (fs.existsSync(candidate)) {
-        return readPackageVersion(candidate)
-      }
-    } catch {
-      // ignore; try next candidate
-    }
-  }
-
+  // Walk up from the loaded module first. OpenCode loads plugins from a
+  // per-plugin sandbox at <CACHE_DIR>/<plugin-entry>/node_modules/<pkg>/, while
+  // a parallel flat install at <CACHE_DIR>/node_modules/<pkg>/ can drift
+  // independently when bun re-resolves "latest". Reading the flat install
+  // first means the toast can announce a version the runtime isn't running.
+  // The module-relative walk-up always reflects what is actually loaded.
   try {
     const currentDir = path.dirname(fileURLToPath(import.meta.url))
     const pkgPath = findPackageJsonUp(currentDir)
@@ -31,6 +27,16 @@ export function getCachedVersion(): string | null {
     }
   } catch (err) {
     log("[auto-update-checker] Failed to resolve version from current directory:", err)
+  }
+
+  for (const candidate of INSTALLED_PACKAGE_JSON_CANDIDATES) {
+    try {
+      if (fs.existsSync(candidate)) {
+        return readPackageVersion(candidate)
+      }
+    } catch {
+      // ignore; try next candidate
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary

`getCachedVersion()` reads the **legacy flat install** at `<CACHE_DIR>/node_modules/<pkg>/package.json` before checking the actually-loaded module, so the startup toast and `omo --version` can report a version the runtime isn't running.

OpenCode loads plugins from a per-plugin sandbox at `<CACHE_DIR>/<plugin-entry>/node_modules/<pkg>/package.json`. The two install layers drift independently because:

- The flat install is driven by `<CACHE_DIR>/package.json` (`"oh-my-opencode": "latest"`) — bun re-resolves on every install.
- The sandbox is driven by `<CACHE_DIR>/<plugin-entry>/package.json`, which gets a literal version pin baked in at first install.

## Reproduction

With `"oh-my-openagent@latest"` in the user's `opencode.json`:

| Layer | Path | Version |
|---|---|---|
| Flat install (read by current code) | `~/.cache/opencode/packages/node_modules/oh-my-opencode/package.json` | **3.17.6** |
| Sandbox (actually loaded) | `~/.cache/opencode/packages/oh-my-openagent@latest/node_modules/oh-my-openagent/package.json` | **3.17.5** |

Startup toast announced **v3.17.6**. The loaded plugin code was **3.17.5**. The user investigated the version mismatch and noticed the lie.

## Fix

Reorder `getCachedVersion()` so the module-relative walk-up (`findPackageJsonUp(currentDir)` from `import.meta.url`) runs **first**. That always reflects the actually-loaded module. The flat-install candidates and execPath walk-up remain as fallbacks for bundled or otherwise unusual environments.

## Test plan

- [x] Added a new unit test (`prefers the loaded module's package.json over flat-install candidates`) that sets up both layers with different versions and asserts the sandbox version wins.
- [x] All 5 tests in `cached-version.test.ts` pass.
- [x] Pre-existing test failures elsewhere in `src/hooks/auto-update-checker/` (9 failures + 1 error) are unrelated to this change — they reproduce on a clean checkout of `dev` and are caused by tests reading the developer's real `~/.config/opencode/opencode.json`. Happy to file a separate issue/PR for those if useful.

## Notes

- The fallback ordering preserves all existing behavior for the `GH-3257` cases (npm users with both `oh-my-opencode` and `oh-my-openagent` flat installs); those tests continue to pass unchanged.
- No public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes version reporting by reading the loaded plugin’s package.json first, not the legacy flat install. Ensures the startup toast and `omo --version` show the actual running version of `oh-my-opencode`/`oh-my-openagent`.

- **Bug Fixes**
  - Reordered `getCachedVersion()` to prefer the module-relative walk-up from `import.meta.url`, then fall back to flat-install candidates and `execPath`.
  - Added a unit test to confirm the sandboxed (loaded) version wins when versions differ.
  - Preserves existing fallbacks; no public API changes.

<sup>Written for commit 5291ee7d3df0c81f7386f851c44829d9e56852ea. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3718?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

