### PR TITLE
feat(delegate-task): emit subagent_type enum when subagent list is known

### DIFF
--- a/src/plugin/tool-registry.ts
+++ b/src/plugin/tool-registry.ts
@@ -29,6 +29,25 @@ import {
   createTaskUpdateTool,
   createHashlineEditTool,
 } from "../tools"
+import {
+  loadUserAgents,
+  loadProjectAgents,
+  loadOpencodeGlobalAgents,
+  loadOpencodeProjectAgents,
+  readOpencodeConfigAgents,
+  loadAgentDefinitions,
+} from "../features/claude-code-agent-loader"
+// Mirror of runtime-registered built-in subagents. Sync with the agent registry.
+const BUILTIN_SUBAGENT_NAMES = [
+  "explore",
+  "librarian",
+  "oracle",
+  "hephaestus",
+  "multimodal-looker",
+  "metis",
+  "momus",
+  "sisyphus-junior",
+] as const
 import { getMainSessionID } from "../features/claude-code-session-state"
 import { filterDisabledTools } from "../shared/disabled-tools"
 import { isTaskSystemEnabled, log } from "../shared"
@@ -178,10 +197,39 @@ export function createToolRegistry(args: {
   )
   const lookAt = isMultimodalLookerEnabled ? factories.createLookAt(ctx) : null
 
+  const disabledAgents = new Set((pluginConfig.disabled_agents ?? []).map((a) => a.toLowerCase()))
+  const includeClaudeAgents = pluginConfig.claude_code?.agents ?? true
+  const agentDicts = [
+    includeClaudeAgents ? loadUserAgents() : {},
+    includeClaudeAgents ? loadProjectAgents(ctx.directory) : {},
+    loadOpencodeGlobalAgents(),
+    loadOpencodeProjectAgents(ctx.directory),
+    readOpencodeConfigAgents(ctx.directory),
+    pluginConfig.agent_definitions
+      ? loadAgentDefinitions(pluginConfig.agent_definitions, "definition-file")
+      : {},
+  ]
+  const discoveredNames = new Set<string>()
+  for (const dict of agentDicts) {
+    for (const [name, cfg] of Object.entries(dict)) {
+      const mode = (cfg as { mode?: string } | null | undefined)?.mode
+      if (mode === "subagent" || mode === "all" || mode === undefined) {
+        discoveredNames.add(name)
+      }
+    }
+  }
+  const builtinNames = [...BUILTIN_SUBAGENT_NAMES]
+  const availableSubagentNames = Array.from(
+    new Set([...builtinNames, ...discoveredNames]),
+  )
+    .filter((name) => !disabledAgents.has(name.toLowerCase()))
+    .sort((a, b) => a.localeCompare(b))
+
   const delegateTask = factories.createDelegateTask({
     manager: managers.backgroundManager,
     client: ctx.client,
     directory: ctx.directory,
+    availableSubagentNames,
     userCategories: pluginConfig.categories,
     agentOverrides: pluginConfig.agents,
     gitMasterConfig: pluginConfig.git_master,

--- a/src/tools/delegate-task/task-schema.test.ts
+++ b/src/tools/delegate-task/task-schema.test.ts
@@ -46,6 +46,72 @@ function createDelegateTask(...args: Parameters<typeof import("./tools").createD
 		expect(description).not.toContain("hephaestus")
 		expect(description).not.toContain("prometheus")
 	})
+
+	test("#given no availableSubagentNames #when tool is created #then subagent_type is plain string (back-compat)", () => {
+		//#given
+		const toolDefinition = createDelegateTask({ manager: {} as never, client: {} as never, directory: "/tmp/test" })
+
+		//#when
+		const subagentSchema = toolDefinition.args.subagent_type as unknown as {
+			def: { type: string; innerType: { def: { type: string } } }
+		}
+
+		//#then
+		expect(subagentSchema.def.type).toBe("optional")
+		expect(subagentSchema.def.innerType.def.type).toBe("string")
+	})
+
+	test("#given availableSubagentNames option #when tool is created #then subagent_type emits enum with those names", () => {
+		//#given
+		const toolDefinition = createDelegateTask({
+			manager: {} as never,
+			client: {} as never,
+			directory: "/tmp/test",
+			availableSubagentNames: ["oracle", "librarian", "dev"],
+		})
+
+		//#when
+		const subagentSchema = toolDefinition.args.subagent_type as unknown as {
+			def: {
+				type: string
+				innerType: {
+					def: {
+						type: string
+						entries?: Record<string, string>
+						values?: string[]
+					}
+				}
+			}
+		}
+
+		//#then
+		expect(subagentSchema.def.type).toBe("optional")
+		expect(subagentSchema.def.innerType.def.type).toBe("enum")
+		const inner = subagentSchema.def.innerType.def
+		const values = inner.entries ? Object.values(inner.entries) : (inner.values ?? [])
+		expect(values).toContain("oracle")
+		expect(values).toContain("librarian")
+		expect(values).toContain("dev")
+	})
+
+	test("#given empty availableSubagentNames #when tool is created #then subagent_type stays plain string", () => {
+		//#given
+		const toolDefinition = createDelegateTask({
+			manager: {} as never,
+			client: {} as never,
+			directory: "/tmp/test",
+			availableSubagentNames: [],
+		})
+
+		//#when
+		const subagentSchema = toolDefinition.args.subagent_type as unknown as {
+			def: { type: string; innerType: { def: { type: string } } }
+		}
+
+		//#then
+		expect(subagentSchema.def.type).toBe("optional")
+		expect(subagentSchema.def.innerType.def.type).toBe("string")
+	})
 })
 
 export {}

--- a/src/tools/delegate-task/tools.ts
+++ b/src/tools/delegate-task/tools.ts
@@ -20,19 +20,33 @@ export { resolveCategoryConfig } from "./categories"
 export type { SyncSessionCreatedEvent, DelegateTaskToolOptions, BuildSystemContentInput } from "./types"
 export { buildSystemContent, buildTaskPrompt } from "./prompt-builder"
 
-const delegateTaskArgsSchema = {
-  load_skills: tool.schema.array(tool.schema.string()).describe("Skill names to inject. REQUIRED - pass [] if no skills needed."),
-  description: tool.schema.string().optional().describe("Short task description (3-5 words). Auto-generated from prompt if omitted."),
-  prompt: tool.schema.string().describe("Full detailed prompt for the agent"),
-  run_in_background: tool.schema.boolean().describe("REQUIRED. true=async (returns task_id), false=sync (waits). Use false for task delegation, true ONLY for parallel exploration."),
-  category: tool.schema.string().optional().describe("REQUIRED if subagent_type not provided. Do NOT provide both category and subagent_type."),
-  subagent_type: tool.schema.string().optional().describe("REQUIRED if category not provided. Do NOT provide both category and subagent_type."),
-  task_id: tool.schema.string().optional().describe("Existing task to continue. Canonical resume identifier."),
-  command: tool.schema.string().optional().describe("The command that triggered this task"),
+function buildSubagentTypeSchema(availableSubagentNames?: readonly string[]) {
+  const describe = "REQUIRED if category not provided. Do NOT provide both category and subagent_type."
+  if (availableSubagentNames && availableSubagentNames.length > 0) {
+    return tool.schema
+      .enum(availableSubagentNames as unknown as [string, ...string[]])
+      .optional()
+      .describe(describe)
+  }
+  return tool.schema.string().optional().describe(describe)
+}
+
+function buildDelegateTaskArgsSchema(availableSubagentNames?: readonly string[]) {
+  return {
+    load_skills: tool.schema.array(tool.schema.string()).describe("Skill names to inject. REQUIRED - pass [] if no skills needed."),
+    description: tool.schema.string().optional().describe("Short task description (3-5 words). Auto-generated from prompt if omitted."),
+    prompt: tool.schema.string().describe("Full detailed prompt for the agent"),
+    run_in_background: tool.schema.boolean().describe("REQUIRED. true=async (returns task_id), false=sync (waits). Use false for task delegation, true ONLY for parallel exploration."),
+    category: tool.schema.string().optional().describe("REQUIRED if subagent_type not provided. Do NOT provide both category and subagent_type."),
+    subagent_type: buildSubagentTypeSchema(availableSubagentNames),
+    task_id: tool.schema.string().optional().describe("Existing task to continue. Canonical resume identifier."),
+    command: tool.schema.string().optional().describe("The command that triggered this task"),
+  }
 }
 
 export function createDelegateTask(options: DelegateTaskToolOptions): ToolDefinition {
   const { availableCategories, availableSkills, categoryExamples, description } = createDelegateTaskPresentation(options)
+  const delegateTaskArgsSchema = buildDelegateTaskArgsSchema(options.availableSubagentNames)
 
   return tool({
     description,

--- a/src/tools/delegate-task/types.ts
+++ b/src/tools/delegate-task/types.ts
@@ -69,6 +69,7 @@ export interface DelegateTaskToolOptions {
   modelFallbackControllerAccessor?: ModelFallbackControllerAccessor
   onSyncSessionCreated?: (event: SyncSessionCreatedEvent) => Promise<void>
   syncPollTimeoutMs?: number
+  availableSubagentNames?: readonly string[]
 }
 
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"


### PR DESCRIPTION
## Summary

- Builds the `task` tool argument `subagent_type` as a `zod.enum(...)` when the runtime can enumerate available subagents, instead of a free-form string.
- Falls back to plain string when no list is available, preserving current behavior.

## Changes

- New optional field on `DelegateTaskToolOptions`: `availableSubagentNames?: readonly string[]`.
- `createDelegateTask` builds its args schema dynamically:
  - non-empty list → `tool.schema.enum(names).optional().describe(...)`
  - otherwise → existing `tool.schema.string().optional().describe(...)`
- `tool-registry.ts` plumbs the discovery: union of `BUILTIN_SUBAGENT_TYPES` + agents from `loadUserAgents`, `loadProjectAgents`, `loadOpencodeGlobalAgents`, `loadOpencodeProjectAgents`, `readOpencodeConfigAgents`. Filters by `mode === "subagent" | "all" | undefined`. Removes entries listed in `pluginConfig.disabled_agents`. Deduplicated.

The description text, runtime branches, category resolution, and execution paths are unchanged.

## Motivation

Today `subagent_type` is `tool.schema.string().optional()`. The resulting JSON Schema only carries `{"type":"string"}` — there is no machine-readable list of valid agent names anywhere in the tool definition. Downstream consumers that do not parse the description text (LLM proxies, validators, harness adapters, observability tools) cannot discover the user's configured subagents.

JSON Schema's `enum` is the canonical place to declare a closed set of string values, and it is what every standard tooling pipeline already understands.

## Backward compatibility

- Public option is fully optional; no caller is required to change.
- When `availableSubagentNames` is omitted or empty, the schema is byte-identical to before.
- The `category`, `subagent_type`, and `task_id` runtime branches in the tool body are untouched.
- No change to category configs, fallback chains, or sync/background execution.

## Testing

```bash
bun run typecheck
bun test src/tools/delegate-task/task-schema.test.ts
```

3 new tests:

- No `availableSubagentNames` → `subagent_type` stays plain string.
- `availableSubagentNames: ["oracle", "librarian", "dev"]` → `subagent_type` is enum and contains those names.
- Empty array → falls back to plain string.

## Token impact

Each agent name adds ~3-5 input tokens to the tool definition. The tool definition lives in the cached prompt prefix, so the cost is paid once and amortizes to near-zero across a session.

## Why this matters

Without an enum on `subagent_type`, any harness sitting between OpenCode and the model has to parse natural-language description text to discover the agent list — fragile and version-dependent. With it, the canonical JSON Schema field carries the list, which is what every standard tooling pipeline already knows how to consume.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `task.subagent_type` a constrained enum when the runtime knows available subagents, improving validation and tooling. Falls back to a plain string when unknown; the registry now discovers, filters, and passes subagent names.

- **New Features**
  - Emit `zod.enum(...)` for `subagent_type` when `availableSubagentNames` is non-empty; otherwise use a string.
  - Discover names from built-ins plus `loadUserAgents`, `loadProjectAgents`, `loadOpencodeGlobalAgents`, `loadOpencodeProjectAgents`, `readOpencodeConfigAgents`, and `loadAgentDefinitions`. Respect `pluginConfig.claude_code?.agents`, filter by `mode`, exclude `pluginConfig.disabled_agents`, dedupe/sort, and pass via `availableSubagentNames` to `createDelegateTask`.
  - Add `availableSubagentNames?: readonly string[]` to `DelegateTaskToolOptions`; add tests for enum, empty, and missing cases.

<sup>Written for commit f142b13091e69239c69836465e6164dcac7d8343. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3719?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

