### PR TITLE
feat: support GPT-5.4/5.5 variant model IDs for Sisyphus

### DIFF
--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -23,6 +23,9 @@ describe("isGptNativeSisyphusModel", () => {
     expect(isGptNativeSisyphusModel("github-copilot/gpt-5.4")).toBe(true);
     expect(isGptNativeSisyphusModel("venice/gpt-5-4")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.4-codex")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.4-fast")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/gpt-5.5-fast")).toBe(true);
+    expect(isGptNativeSisyphusModel("openai/GPT-5.5-Pro")).toBe(true);
     expect(isGptNativeSisyphusModel("openai/gpt-5.5-mini")).toBe(true);
   });
 
@@ -35,6 +38,7 @@ describe("isGptNativeSisyphusModel", () => {
   test("rejects other GPT models", () => {
     expect(isGptNativeSisyphusModel("openai/gpt-4o")).toBe(false);
     expect(isGptNativeSisyphusModel("github-copilot/gpt-4o")).toBe(false);
+    expect(isGptNativeSisyphusModel("openai/my-gpt-5.5-wrapper")).toBe(false);
   });
 
   test("rejects non-GPT models", () => {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -79,7 +79,7 @@ export function isGptModel(model: string): boolean {
   return modelName.includes("gpt");
 }
 
-const GPT_NATIVE_SISYPHUS_RE = /gpt-5[.-](?:[4-9]|\d{2,})/i;
+const GPT_NATIVE_SISYPHUS_RE = /^gpt-5[.-](?:[4-9]|\d{2,})(?:$|[.-])/i;
 
 export function isGptNativeSisyphusModel(model: string): boolean {
   const modelName = extractModelName(model).toLowerCase();

--- a/src/hooks/no-sisyphus-gpt/index.test.ts
+++ b/src/hooks/no-sisyphus-gpt/index.test.ts
@@ -81,6 +81,25 @@ describe("no-sisyphus-gpt hook", () => {
     expect(output.message.agent).toBeUndefined()
   })
 
+  test("does not show toast for gpt-5.4-fast model (Sisyphus has specialized support)", async () => {
+    // given - sisyphus with a GPT-5.4 speed variant
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
+
+    const output = createOutput()
+
+    // when - chat.message runs with gpt-5.4-fast
+    await hook["chat.message"]?.({
+      sessionID: "ses_gpt54_fast",
+      agent: SISYPHUS_DISPLAY,
+      model: { providerID: "openai", modelID: "gpt-5.4-fast" },
+    }, output)
+
+    // then - no toast, agent NOT switched to Hephaestus
+    expect(showToast).toHaveBeenCalledTimes(0)
+    expect(output.message.agent).toBeUndefined()
+  })
+
   test("does not show toast for gpt-5.5 model (native Sisyphus support)", async () => {
     // given - sisyphus with gpt-5.5 model (should be allowed)
     const showToast = spyOn({ fn: async () => ({}) }, "fn")
@@ -138,6 +157,46 @@ describe("no-sisyphus-gpt hook", () => {
     expect(showToast).toHaveBeenCalledTimes(0)
     expect(output.message.agent).toBeUndefined()
     expect(output.message.variant).toBe("high")
+  })
+
+  test("does not show toast for gpt-5.5-fast model when native Sisyphus support is used", async () => {
+    // given - sisyphus with a GPT-5.5 speed variant
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
+
+    const output = createOutput()
+
+    // when - chat.message runs with gpt-5.5-fast
+    await hook["chat.message"]?.({
+      sessionID: "ses_gpt55_fast",
+      agent: SISYPHUS_DISPLAY,
+      model: { providerID: "openai", modelID: "gpt-5.5-fast" },
+    }, output)
+
+    // then - no toast, agent NOT switched to Hephaestus
+    expect(showToast).toHaveBeenCalledTimes(0)
+    expect(output.message.agent).toBeUndefined()
+    expect(output.message.variant).toBeUndefined()
+  })
+
+  test("does not show toast for gpt-5.5-Pro model when native Sisyphus support is used", async () => {
+    // given - sisyphus with a GPT-5.5 tier variant
+    const showToast = spyOn({ fn: async () => ({}) }, "fn")
+    const hook = createNoSisyphusGptHook(createHookContext(showToast))
+
+    const output = createOutput()
+
+    // when - chat.message runs with mixed-case gpt-5.5-Pro
+    await hook["chat.message"]?.({
+      sessionID: "ses_gpt55_pro",
+      agent: SISYPHUS_DISPLAY,
+      model: { providerID: "openai", modelID: "gpt-5.5-Pro" },
+    }, output)
+
+    // then - no toast, agent NOT switched to Hephaestus
+    expect(showToast).toHaveBeenCalledTimes(0)
+    expect(output.message.agent).toBeUndefined()
+    expect(output.message.variant).toBeUndefined()
   })
 
   test("does not show toast for non-gpt model", async () => {


### PR DESCRIPTION
## Summary

- Tighten isGptNativeSisyphusModel so GPT-native Sisyphus matching is anchored to the actual model ID instead of any substring.
- Keep Sisyphus active for OpenCode-supported model IDs such as gpt-5.4-fast, gpt-5.5-fast, and mixed-case GPT-5.5-Pro.
- Add guard-level regression coverage confirming these model IDs do not trigger the no-Sisyphus-GPT toast or force a Hephaestus switch.

## Root cause

The guard decision belongs in the GPT-native model classifier. Suffix model IDs should be accepted as model IDs by the classifier, not handled through fallback-chain variant inheritance. This patch keeps variant handling unchanged and scopes the behavior to model detection plus no-toast/no-switch regression tests.

## Validation

- bun test src/agents/types.test.ts src/hooks/no-sisyphus-gpt/index.test.ts
- git diff --check origin/dev...HEAD

bun run typecheck still fails on pre-existing repository issues unrelated to this patch, including @opencode-ai/plugin PluginModule export errors and missing posthog-node types.