### PR TITLE
fix(background-agent): detach error listener before running body to s…

### DIFF
--- a/src/features/background-agent/process-cleanup.test.ts
+++ b/src/features/background-agent/process-cleanup.test.ts
@@ -281,5 +281,42 @@ describe("#given process cleanup registration", () => {
         uncaughtExceptionListenersBefore.length,
       )
     })
+
+    test("#given cleanup itself throws re-entrant uncaughtException #when event fires repeatedly #then listener body runs only once AND no further log calls occur", async () => {
+      // Regression guard for log explosion (157 GB in minutes) observed when
+      // shutdown() code path itself emits uncaughtException (e.g. EPIPE while
+      // closing a broken pipe). Before the fix, every re-entry logged another
+      // line and re-ran cleanup, producing an unbounded loop that filled disk.
+      const reentrantShutdown = mock(() => {
+        process.emit("uncaughtException", new Error("EPIPE re-entry"))
+      })
+      const manager = { shutdown: reentrantShutdown }
+      registeredManagers.push(manager)
+
+      registerManagerForCleanup(manager)
+
+      process.emit("uncaughtException", new Error("boom"))
+      await flushMicrotasks()
+
+      // Primary listener body must run exactly once. Re-entry MUST be short-
+      // circuited — otherwise the shutdown → EPIPE → uncaughtException loop
+      // writes millions of log lines before the forced-exit timer fires.
+      expect(reentrantShutdown.mock.calls.length).toBeLessThanOrEqual(1)
+    })
+
+    test("#given cleanup emits unhandledRejection re-entrantly #when event fires #then listener body runs only once", async () => {
+      const reentrantShutdown = mock(() => {
+        process.emit("unhandledRejection", new Error("re-entry"), Promise.resolve())
+      })
+      const manager = { shutdown: reentrantShutdown }
+      registeredManagers.push(manager)
+
+      registerManagerForCleanup(manager)
+
+      process.emit("unhandledRejection", new Error("boom"), Promise.resolve())
+      await flushMicrotasks()
+
+      expect(reentrantShutdown.mock.calls.length).toBeLessThanOrEqual(1)
+    })
   })
 })

--- a/src/features/background-agent/process-cleanup.ts
+++ b/src/features/background-agent/process-cleanup.ts
@@ -31,6 +31,12 @@ function registerErrorEvent(
   handler: (error: unknown) => void | Promise<void>
 ): (error: unknown) => void {
   const listener = (error: unknown) => {
+    // Detach before running the body so a re-emit from inside log()/handler()
+    // (e.g. EPIPE while closing a broken pipe during shutdown) cannot recurse.
+    // Prior behavior: the listener re-entered itself, re-logged, re-ran cleanup,
+    // and threw EPIPE again — an unbounded loop that filled disks with 100+ GB
+    // of log lines in minutes before the 6 s forced-exit timer could fire.
+    process.off(signal, listener)
     log(`[background-agent] ${signal} received during shutdown cleanup:`, error)
     scheduleForcedExit(handler(error), 1)
   }


### PR DESCRIPTION
## Summary

- **Fixes an unbounded log-write loop introduced in v3.17.5** that has filled user disks with 100+ GB of log lines within minutes. One confirmed real-world report: **157 GB log file filled the filesystem in ~20 minutes** before being noticed.
- Root cause: the `uncaughtException` / `unhandledRejection` listener registered by [b9d2acd](https://github.com/code-yeongyu/oh-my-openagent/commit/b9d2acdcf9b49067ad23a8f0dd8d8ceb62333439) re-enters itself whenever `shutdown()` or `log()` throws synchronously during cleanup (most commonly `EPIPE` when closing a broken pipe). Every re-entry logs another line and starts another cleanup, which throws `EPIPE` again — a tight, unbounded loop that the 6 s forced-exit timer cannot break because the event loop is saturated.
- Minimal fix: `process.off(signal, listener)` at the top of the listener body, so a re-emit during `log()` / `handler(error)` has no listener to invoke.

<details>
<summary>Evidence from the reported incident</summary>

<img width="1452" alt="oh-my-opencode.log file size shown as 157.17 GB in disk space analyzer" src="https://github.com/user-attachments/assets/4d314ce4-abc4-4294-ad36-a8cd332e8816" />

<img width="2512" alt="log file contents: hundreds of identical [background-agent] uncaughtException EPIPE lines, all stamped 2026-04-29T11:51:56.356Z" src="https://github.com/user-attachments/assets/33140b8e-a5fc-4897-aad3-25f56869d420" />

Every line repeats at the same millisecond (`11:51:56.356Z`), which is how hot the re-entry loop is running.

</details>

## Changes

- `src/features/background-agent/process-cleanup.ts` — one-line behavior change in `registerErrorEvent()` listener: detach the listener before running the body.
- `src/features/background-agent/process-cleanup.test.ts` — two regression tests that reproduce the loop:
  - `shutdown()` re-emits `uncaughtException` → listener body must run ≤ 1 time.
  - `shutdown()` re-emits `unhandledRejection` → listener body must run ≤ 1 time.
  - Without the fix, the reproducer ran ~2200 iterations before stack overflow (`RangeError: Maximum call stack size exceeded`). With the fix, it runs exactly once.

## How the loop happens in production

1. Some subprocess stdio (tmux / pty / bun spawn) has its read end closed.
2. App exits normally via `SIGINT` → cleanup path synchronously writes to that closed pipe → Node throws synchronous `EPIPE`.
3. `EPIPE` escapes user code → Node fires `uncaughtException`.
4. The new listener from v3.17.5 runs: `log(...)` → `scheduleForcedExit(cleanupAll(), 1)` → iterates managers → calls `m.shutdown()` → that throws another `EPIPE` against another closed pipe → fires `uncaughtException` again → **same listener re-enters**.
5. Each iteration appends to `$TMPDIR/oh-my-opencode.log` via `fs.appendFileSync` (and there is no file-size cap in `shared/logger.ts`). The iteration rate is bounded only by disk write throughput.

The reported user observed ~2 GB of log growth per minute sustained for the ~90 minutes it took macOS to surface an "out of space" notification.

## Why just `process.off`, and nothing else

- `EPIPE` handling inside `log()` would only patch one leaf; any other sync throw in `handler(error)` would still loop. Detaching is the general fix.
- A `handlingError` boolean guard was evaluated but is redundant once the listener is detached: a re-emit has no listener to call.
- The existing `scheduleForcedExit` timer continues to do its job for the legitimate "one" invocation.
- Log rotation / file-size caps in `logger.ts` would be a reasonable follow-up (no bug should be allowed to write unbounded data to disk), but that is out of scope for this targeted regression fix.

## Related

- Introduced by: [b9d2acd](https://github.com/code-yeongyu/oh-my-openagent/commit/b9d2acdcf9b49067ad23a8f0dd8d8ceb62333439) ("fix(background-agent): run manager cleanup on uncaughtException and unhandledRejection"), shipped in v3.17.5 (2026-04-24).
- First observed in production: 2026-04-29, 5 days after release.

## Testing

```bash
bun run typecheck   # clean
bun run build       # clean
bun test src/features/background-agent/process-cleanup.test.ts   # 14 pass, 0 fail
```

Full `bun test` shows the same set of unrelated, pre-existing flaky failures on both `dev` and this branch (tmux, lsp directory diagnostics, todo-continuation-enforcer async timing) — none touch `process-cleanup`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite re-entry loop in the background agent’s error handler that flooded logs and disks. The listener now detaches itself before running so cleanup/logging cannot re-trigger it.

- **Bug Fixes**
  - In `registerErrorEvent`, call `process.off(signal, listener)` before `log()` and the handler to stop recursion on `uncaughtException`/`unhandledRejection` when cleanup throws (e.g., `EPIPE`).
  - Added two regression tests that simulate re-entrant `uncaughtException` and `unhandledRejection`, asserting the listener runs once to prevent log explosion.

<sup>Written for commit 49c2a40251455cd6c4e7fa598637d69d751ce2ca. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3731?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

