### PR TITLE
fix(tmux): wait for session readiness before attach

### DIFF
--- a/src/features/tmux-subagent/manager.test.ts
+++ b/src/features/tmux-subagent/manager.test.ts
@@ -108,6 +108,7 @@ mock.module('../../shared/tmux', () => {
 })
 
 const trackedSessions = new Set<string>()
+const readySessions = new Set<string>()
 
 function createMockContext(overrides?: {
   sessionStatusResult?: { data?: Record<string, { type: string }> }
@@ -122,7 +123,7 @@ function createMockContext(overrides?: {
             return overrides.sessionStatusResult
           }
           const data: Record<string, { type: string }> = {}
-          for (const sessionId of trackedSessions) {
+          for (const sessionId of readySessions) {
             data[sessionId] = { type: 'running' }
           }
           return { data }
@@ -143,6 +144,7 @@ function createSessionCreatedEvent(
   parentID: string | undefined,
   title: string
 ) {
+  readySessions.add(id)
   return {
     type: 'session.created',
     properties: {
@@ -188,6 +190,7 @@ describe('TmuxSessionManager', () => {
     mockIsInsideTmux.mockClear()
     mockGetCurrentPaneId.mockClear()
     trackedSessions.clear()
+    readySessions.clear()
 
     mockQueryWindowState.mockImplementation(async () => createWindowState())
     mockExecuteActions.mockImplementation(async (actions: PaneAction[]) => { for (const action of actions) {
@@ -1137,7 +1140,7 @@ describe('TmuxSessionManager', () => {
       })
     })
 
-    test('#given session.status never reports session ready #when onSessionCreated runs #then pane is tracked immediately without blocking', async () => {
+    test('#given session.status never reports session ready #when onSessionCreated runs #then pane attach is deferred', async () => {
       // given
       mockIsInsideTmux.mockReturnValue(true)
       mockQueryWindowState.mockImplementation(async () => createWindowState())
@@ -1146,16 +1149,15 @@ describe('TmuxSessionManager', () => {
       const ctx = createMockContext({ sessionStatusResult: { data: {} } })
       const config = createTmuxConfig({ enabled: true })
       const manager = new TmuxSessionManager(ctx, config, mockTmuxDeps)
-      const event = createSessionCreatedEvent('ses_fast_track', 'ses_parent', 'Fast Track')
+      const event = createSessionCreatedEvent('ses_wait_for_ready', 'ses_parent', 'Wait For Ready')
 
       // when
-      const start = Date.now()
       await manager.onSessionCreated(event)
-      const elapsed = Date.now() - start
 
       // then
-      expect(elapsed < 500).toBe(true)
-      expect(getTrackedSessions(manager).has('ses_fast_track')).toBe(true)
+      expect(mockExecuteActions).toHaveBeenCalledTimes(0)
+      expect(getTrackedSessions(manager).has('ses_wait_for_ready')).toBe(false)
+      expect((manager as any).deferredQueue).toEqual(['ses_wait_for_ready'])
     })
   })
 
@@ -1202,7 +1204,9 @@ describe('TmuxSessionManager', () => {
       await manager.onSessionDeleted({ sessionID: 'ses_timeout' })
 
       // then
-      expect(mockExecuteAction).toHaveBeenCalledTimes(1)
+      expect(mockExecuteAction).toHaveBeenCalledTimes(0)
+      expect(getTrackedSessions(manager).has('ses_timeout')).toBe(false)
+      expect((manager as any).deferredQueue).toEqual([])
     })
 
     test('closes pane when tracked session is deleted', async () => {

--- a/src/features/tmux-subagent/manager.ts
+++ b/src/features/tmux-subagent/manager.ts
@@ -518,6 +518,9 @@ export class TmuxSessionManager {
       return
     }
 
+    const ready = await this.waitForSessionReady(sessionId)
+    if (!ready) return
+
     if (deferred.retryIsolatedContainer) {
       const isolatedPaneId = await this.spawnInIsolatedContainer(sessionId, deferred.title)
       if (isolatedPaneId) {
@@ -650,6 +653,17 @@ export class TmuxSessionManager {
     return false
   }
 
+  private async waitForSessionBeforeAttach(sessionId: string, title: string, retryIsolatedContainer = false): Promise<boolean> {
+    const ready = await this.waitForSessionReady(sessionId)
+    if (ready) return true
+
+    log("[tmux-session-manager] deferring attach until session is ready", {
+      sessionId,
+    })
+    this.enqueueDeferredSession(sessionId, title, retryIsolatedContainer)
+    return false
+  }
+
   async onSessionCreated(event: SessionCreatedEvent): Promise<void> {
     const enabled = this.isEnabled()
     log("[tmux-session-manager] onSessionCreated called", {
@@ -691,6 +705,9 @@ export class TmuxSessionManager {
 
     await this.enqueueSpawn(async () => {
       try {
+        const ready = await this.waitForSessionBeforeAttach(sessionId, title, this.isIsolated())
+        if (!ready) return
+
         const isolatedPaneId = await this.spawnInIsolatedContainer(sessionId, title)
         if (isolatedPaneId) {
           this.sessions.set(


### PR DESCRIPTION
## Summary
- wait until the new opencode session is visible in `session.status` before spawning the tmux attach pane
- keep sessions that are not ready yet in the deferred attach queue instead of tracking a pane that may immediately exit
- update the tmux session manager tests to cover the readiness-timeout path

Fixes #3505.

## Tests
- `bun test src/features/tmux-subagent/manager.test.ts`
- `bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wait for tmux sessions to be ready before attaching, deferring pane spawn until the session appears in `session.status`. This prevents transient panes and stabilizes the attach flow. Fixes #3505.

- **Bug Fixes**
  - Gate attach behind `waitForSessionReady` in both creation and deferred paths.
  - Defer not-ready sessions to the `deferredQueue` instead of spawning/tracking panes that may exit.
  - Avoid closing panes for sessions that never attached (timeout/deletion cases).
  - Updated tests to cover readiness timeouts and deferred attach behavior.

<sup>Written for commit 42657f94f77dd8cc4ae38fc3fe1b364fb9758d35. Summary will update on new commits. <a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/3733?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

