### PR TITLE
Allow "max" option for "reasoningEffort" field in config schema

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -128,7 +128,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -194,7 +195,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -397,7 +399,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -478,7 +481,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -544,7 +548,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -747,7 +752,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -828,7 +834,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -894,7 +901,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -1097,7 +1105,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -1178,7 +1187,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -1244,7 +1254,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -1447,7 +1458,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -1531,7 +1543,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -1597,7 +1610,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -1800,7 +1814,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -1881,7 +1896,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -1947,7 +1963,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -2150,7 +2167,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -2231,7 +2249,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -2297,7 +2316,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -2500,7 +2520,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -2581,7 +2602,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -2647,7 +2669,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -2850,7 +2873,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -2931,7 +2955,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -2997,7 +3022,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -3200,7 +3226,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -3281,7 +3308,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -3347,7 +3375,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -3550,7 +3579,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -3631,7 +3661,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -3697,7 +3728,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -3900,7 +3932,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -3981,7 +4014,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -4047,7 +4081,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -4250,7 +4285,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -4331,7 +4367,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -4397,7 +4434,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -4600,7 +4638,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -4681,7 +4720,8 @@
                           "low",
                           "medium",
                           "high",
-                          "xhigh"
+                          "xhigh",
+                          "max"
                         ]
                       },
                       "temperature": {
@@ -4747,7 +4787,8 @@
                               "low",
                               "medium",
                               "high",
-                              "xhigh"
+                              "xhigh",
+                              "max"
                             ]
                           },
                           "temperature": {
@@ -4950,7 +4991,8 @@
                 "low",
                 "medium",
                 "high",
-                "xhigh"
+                "xhigh",
+                "max"
               ]
             },
             "textVerbosity": {
@@ -5042,7 +5084,8 @@
                         "low",
                         "medium",
                         "high",
-                        "xhigh"
+                        "xhigh",
+                        "max"
                       ]
                     },
                     "temperature": {
@@ -5108,7 +5151,8 @@
                             "low",
                             "medium",
                             "high",
-                            "xhigh"
+                            "xhigh",
+                            "max"
                           ]
                         },
                         "temperature": {
@@ -5197,7 +5241,8 @@
               "low",
               "medium",
               "high",
-              "xhigh"
+              "xhigh",
+              "max"
             ]
           },
           "textVerbosity": {

--- a/src/config/schema/agent-overrides.ts
+++ b/src/config/schema/agent-overrides.ts
@@ -35,7 +35,7 @@ export const AgentOverrideConfigSchema = z.object({
     })
     .optional(),
   /** Reasoning effort level (OpenAI). Overrides category and default settings. */
-  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]).optional(),
+  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]).optional(),
   /** Text verbosity level. */
   textVerbosity: z.enum(["low", "medium", "high"]).optional(),
   /** Provider-specific options. Passed directly to OpenCode SDK. */

--- a/src/config/schema/categories.ts
+++ b/src/config/schema/categories.ts
@@ -16,7 +16,7 @@ export const CategoryConfigSchema = z.object({
       budgetTokens: z.number().optional(),
     })
     .optional(),
-  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]).optional(),
+  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]).optional(),
   textVerbosity: z.enum(["low", "medium", "high"]).optional(),
   tools: z.record(z.string(), z.boolean()).optional(),
   prompt_append: z.string().optional(),

--- a/src/config/schema/fallback-models.ts
+++ b/src/config/schema/fallback-models.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 export const FallbackModelObjectSchema = z.object({
   model: z.string(),
   variant: z.string().optional(),
-  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh"]).optional(),
+  reasoningEffort: z.enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"]).optional(),
   temperature: z.number().min(0).max(2).optional(),
   top_p: z.number().min(0).max(1).optional(),
   maxTokens: z.number().optional(),

--- a/src/shared/model-capability-heuristics.ts
+++ b/src/shared/model-capability-heuristics.ts
@@ -32,7 +32,7 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
     family: "gpt-5",
     includes: ["gpt-5"],
     variants: ["low", "medium", "high", "xhigh"],
-    reasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh"],
+    reasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
   },
   {
     family: "gpt-legacy",

--- a/src/shared/model-settings-compatibility.ts
+++ b/src/shared/model-settings-compatibility.ts
@@ -32,10 +32,10 @@ export type ModelSettingsCompatibilityChange = {
   from: string
   to?: string
   reason:
-    | "unsupported-by-model-family"
-    | "unknown-model-family"
-    | "unsupported-by-model-metadata"
-    | "max-output-limit"
+  | "unsupported-by-model-family"
+  | "unknown-model-family"
+  | "unsupported-by-model-metadata"
+  | "max-output-limit"
 }
 
 export type ModelSettingsCompatibilityResult = {
@@ -49,7 +49,7 @@ export type ModelSettingsCompatibilityResult = {
 }
 
 const VARIANT_LADDER = ["low", "medium", "high", "xhigh", "max"]
-const REASONING_LADDER = ["none", "minimal", "low", "medium", "high", "xhigh"]
+const REASONING_LADDER = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 function downgradeWithinLadder(value: string, allowed: string[], ladder: string[]): string | undefined {
   const requestedIndex = ladder.indexOf(value)


### PR DESCRIPTION
Listing "max" as a valid value for "reasoningEffort" as many providers are accepting this value (e.g., DeepSeek-V4 and Claude Opus).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->