### PR TITLE
fix: resolve simple triaged GitHub bugs

### DIFF
--- a/src/cli/doctor/checks/tools-gh.test.ts
+++ b/src/cli/doctor/checks/tools-gh.test.ts
@@ -1,0 +1,35 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, it, mock } from "bun:test"
+
+const originalWhich = Bun.which
+
+afterEach(() => {
+  Bun.which = originalWhich
+  mock.restore()
+})
+
+describe("getGhCliInfo", () => {
+  it("falls back to gh --version when Bun.which cannot find gh", async () => {
+    // given
+    Bun.which = mock(() => null)
+    mock.module("../spawn-with-timeout", () => ({
+      spawnWithTimeout: mock((command: string[]) => {
+        if (command.join(" ") === "gh --version") {
+          return Promise.resolve({ stdout: "gh version 2.82.1\n", stderr: "", exitCode: 0, timedOut: false })
+        }
+
+        return Promise.resolve({ stdout: "", stderr: "not logged in", exitCode: 1, timedOut: false })
+      }),
+    }))
+    const { getGhCliInfo } = await import("./tools-gh")
+
+    // when
+    const info = await getGhCliInfo()
+
+    // then
+    expect(info.installed).toBe(true)
+    expect(info.version).toBe("2.82.1")
+    expect(info.path).toBe(null)
+  })
+})

--- a/src/cli/doctor/checks/tools-gh.ts
+++ b/src/cli/doctor/checks/tools-gh.ts
@@ -80,6 +80,20 @@ async function getGhAuthStatus(): Promise<{
 export async function getGhCliInfo(): Promise<GhCliInfo> {
   const binaryStatus = await checkBinaryExists("gh")
   if (!binaryStatus.exists) {
+    const version = await getGhVersion()
+    if (version) {
+      const authStatus = await getGhAuthStatus()
+      return {
+        installed: true,
+        version,
+        path: null,
+        authenticated: authStatus.authenticated,
+        username: authStatus.username,
+        scopes: authStatus.scopes,
+        error: authStatus.error,
+      }
+    }
+
     return {
       installed: false,
       version: null,

--- a/src/plugin/normalize-tool-arg-schemas.test.ts
+++ b/src/plugin/normalize-tool-arg-schemas.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { pathToFileURL } from "node:url"
 import { tool } from "@opencode-ai/plugin"
-import { normalizeToolArgSchemas } from "./normalize-tool-arg-schemas"
+import { normalizeToolArgSchemas, sanitizeJsonSchema } from "./normalize-tool-arg-schemas"
 
 const tempDirectories: string[] = []
 
@@ -93,5 +93,38 @@ describe("normalizeToolArgSchemas", () => {
     expect(afterQuery?.description).toBe("Free-text search query")
     expect(afterQuery?.title).toBe("Query")
     expect(afterQuery?.examples).toEqual(["issue 2314"])
+  })
+})
+
+describe("sanitizeJsonSchema", () => {
+  it("rewrites bare $ref values to $defs JSON pointers", () => {
+    // given
+    const schema = {
+      type: "object",
+      properties: {
+        new_encoding: { $ref: "Encoding" },
+        existing_pointer: { $ref: "#/$defs/AlreadyValid" },
+      },
+      $defs: {
+        Encoding: { type: "string" },
+        AlreadyValid: { type: "string" },
+      },
+    }
+
+    // when
+    const sanitized = sanitizeJsonSchema(schema)
+
+    // then
+    expect(sanitized).toEqual({
+      type: "object",
+      properties: {
+        new_encoding: { $ref: "#/$defs/Encoding" },
+        existing_pointer: { $ref: "#/$defs/AlreadyValid" },
+      },
+      $defs: {
+        Encoding: { type: "string" },
+        AlreadyValid: { type: "string" },
+      },
+    })
   })
 })

--- a/src/plugin/normalize-tool-arg-schemas.ts
+++ b/src/plugin/normalize-tool-arg-schemas.ts
@@ -47,6 +47,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
+function normalizeJsonSchemaRef(value: string): string {
+  if (value.startsWith("#") || value.includes(":") || value.startsWith("/")) {
+    return value
+  }
+
+  return `#/$defs/${value}`
+}
+
 export function sanitizeJsonSchema(value: unknown, depth = 0, isPropertyName = false): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeJsonSchema(item, depth + 1, false))
@@ -64,6 +72,11 @@ export function sanitizeJsonSchema(value: unknown, depth = 0, isPropertyName = f
     }
 
     if (depth === 0 && key === "$schema") {
+      continue
+    }
+
+    if (!isPropertyName && key === "$ref" && typeof nestedValue === "string") {
+      sanitized[key] = normalizeJsonSchemaRef(nestedValue)
       continue
     }
 

--- a/src/tools/call-omo-agent/tools.test.ts
+++ b/src/tools/call-omo-agent/tools.test.ts
@@ -136,6 +136,19 @@ describe("createCallOmoAgent", () => {
   })
 
   describe("dynamic custom agent resolution", () => {
+    test("should reject missing subagent_type without throwing", async () => {
+      const mockCtx = createMockCtx(DEFAULT_AGENTS)
+      const toolDef = createCallOmoAgent(mockCtx, mockBackgroundManager, [])
+      const executeFunc = toolDef.execute as Function
+
+      const result = await executeFunc(
+        { description: "Test", prompt: "Fix bug", run_in_background: true },
+        toolCtx
+      )
+
+      expect(result).toContain("subagent_type is required")
+    })
+
     test("should accept a custom agent returned by client.app.agents()", async () => {
       const agents = [...DEFAULT_AGENTS, { name: "bug-fixer", mode: "subagent" }]
       const mockCtx = createMockCtx(agents)

--- a/src/tools/call-omo-agent/tools.ts
+++ b/src/tools/call-omo-agent/tools.ts
@@ -140,6 +140,10 @@ export function createCallOmoAgent(
         `[call_omo_agent] Starting with agent: ${args.subagent_type}, background: ${args.run_in_background}`,
       );
 
+      if (typeof args.subagent_type !== "string" || args.subagent_type.trim() === "") {
+        return "Error: subagent_type is required."
+      }
+
       const callableAgents = await resolveCallableAgents(ctx.client);
 
       // Strip ZWSP and case-insensitive agent validation - allows "Explore", "EXPLORE", "explore" etc.


### PR DESCRIPTION
## Summary
- Return a clear `subagent_type is required` error for malformed `call_omo_agent` calls instead of throwing.
- Normalize bare JSON Schema `$ref` values to `#/$defs/...` pointers.
- Treat `gh` as installed when `Bun.which` misses it but `gh --version` succeeds.

## Verification
- `bun test src/tools/call-omo-agent/tools.test.ts src/plugin/normalize-tool-arg-schemas.test.ts src/cli/doctor/checks/tools-gh.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run script/run-ci-tests.ts`
- Manual Bun driver scripts for all three changed surfaces

## Notes
- Plain `bun test` still fails when run all-at-once because several existing tests require isolated execution; the project CI split runner passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->