### PR TITLE
fix(agents): allow Momus and Metis delegation

### DIFF
--- a/src/agents/metis.ts
+++ b/src/agents/metis.ts
@@ -296,7 +296,6 @@ const metisRestrictions = createAgentToolRestrictions([
   "write",
   "edit",
   "apply_patch",
-  "task",
 ])
 
 export function createMetisAgent(model: string): AgentConfig {

--- a/src/agents/momus.ts
+++ b/src/agents/momus.ts
@@ -286,7 +286,6 @@ export function createMomusAgent(model: string): AgentConfig {
     "write",
     "edit",
     "apply_patch",
-    "task",
   ]);
 
   const base = {

--- a/src/agents/tool-restrictions.test.ts
+++ b/src/agents/tool-restrictions.test.ts
@@ -9,6 +9,7 @@ import { createMetisAgent } from "./metis"
 import { createAtlasAgent } from "./atlas"
 import { createSisyphusAgent } from "./sisyphus"
 import { createHephaestusAgent } from "./hephaestus"
+import { getAgentToolRestrictions } from "../shared/agent-tool-restrictions"
 
 const TEST_MODEL = "anthropic/claude-sonnet-4-5"
 
@@ -85,6 +86,19 @@ describe("read-only agent tool restrictions", () => {
         expect(permission[tool]).toBe("deny")
       }
     })
+
+    test("allows task delegation while remaining ineligible for team membership", () => {
+      // given
+      const agent = createMomusAgent(TEST_MODEL)
+
+      // when
+      const permission = agent.permission as Record<string, string>
+      const sessionRestrictions = getAgentToolRestrictions("momus")
+
+      // then
+      expect(permission["task"]).toBeUndefined()
+      expect(sessionRestrictions["task"]).toBeUndefined()
+    })
   })
 
   describe("Metis", () => {
@@ -99,6 +113,19 @@ describe("read-only agent tool restrictions", () => {
       for (const tool of FILE_WRITE_TOOLS) {
         expect(permission[tool]).toBe("deny")
       }
+    })
+
+    test("allows task delegation while remaining ineligible for team membership", () => {
+      // given
+      const agent = createMetisAgent(TEST_MODEL)
+
+      // when
+      const permission = agent.permission as Record<string, string>
+      const sessionRestrictions = getAgentToolRestrictions("metis")
+
+      // then
+      expect(permission["task"]).toBeUndefined()
+      expect(sessionRestrictions["task"]).toBeUndefined()
     })
   })
 

--- a/src/shared/agent-tool-restrictions.ts
+++ b/src/shared/agent-tool-restrictions.ts
@@ -28,13 +28,11 @@ const AGENT_RESTRICTIONS: Record<string, Record<string, boolean>> = {
   metis: {
     write: false,
     edit: false,
-    task: false,
   },
 
   momus: {
     write: false,
     edit: false,
-    task: false,
   },
 
   "multimodal-looker": {


### PR DESCRIPTION
## Summary
- Allow Momus and Metis to be invoked through task/delegate-task by removing their task deny restriction.
- Keep both agents read-only for file edits and preserve team-mode hard-reject behavior for mailbox-writing team membership.
- Add regression coverage for agent config and session restrictions.

## Verification
- bun test src/agents/tool-restrictions.test.ts src/features/team-mode/types.test.ts src/tools/delegate-task/sync-prompt-sender.test.ts
- bun run typecheck
- bun run build
- bun --install=fallback /Users/yeongyu/.config/opencode/skills/typescript-programmer/scripts/check-no-excuse-rules.ts src/shared/agent-tool-restrictions.ts src/agents/momus.ts src/agents/metis.ts src/agents/tool-restrictions.test.ts
- Manual driver: Momus/Metis task delegation allowed while team membership remains hard-reject

## Notes
- Full split CI test command still has unrelated session-notification/mock failures in the shared suite on this machine.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->