### PR TITLE
fix(atlas): block continuation while delegated tasks are pending

### DIFF
--- a/src/hooks/atlas/boulder-continuation-injector.test.ts
+++ b/src/hooks/atlas/boulder-continuation-injector.test.ts
@@ -91,6 +91,44 @@ describe("injectBoulderContinuation", () => {
     expect(sessionState.lastContinuationInjectedAt).toBe(123)
   })
 
+  test("#given a background task is still pending session creation #when injector checks again #then it still skips continuation", async () => {
+    // given
+    registerAgentName("atlas")
+    const promptAsyncMock = mock(async (_request: unknown) => undefined)
+    const messagesMock = mock(async () => ({ data: [] }))
+    const sessionState = { promptFailureCount: 1, lastContinuationInjectedAt: 456 }
+
+    const ctx = {
+      directory: "/tmp",
+      client: {
+        session: {
+          messages: messagesMock,
+          promptAsync: promptAsyncMock,
+        },
+      },
+    } as unknown as PluginInput
+
+    // when
+    const result = await injectBoulderContinuation({
+      ctx,
+      sessionID: "ses_test_pending",
+      planName: "test-plan",
+      remaining: 1,
+      total: 2,
+      agent: "atlas",
+      backgroundManager: {
+        getTasksByParentSession: () => [{ status: "pending" }],
+      } as unknown as Parameters<typeof injectBoulderContinuation>[0]["backgroundManager"],
+      sessionState,
+    })
+
+    // then
+    expect(result).toBe("skipped_background_tasks")
+    expect(promptAsyncMock).not.toHaveBeenCalled()
+    expect(sessionState.promptFailureCount).toBe(1)
+    expect(sessionState.lastContinuationInjectedAt).toBe(456)
+  })
+
   test("#given the continuation agent is unavailable #when injector runs #then it reports skipped agent unavailable without prompting", async () => {
     // given
     const promptAsyncMock = mock(async (_request: unknown) => undefined)

--- a/src/hooks/atlas/boulder-continuation-injector.ts
+++ b/src/hooks/atlas/boulder-continuation-injector.ts
@@ -13,6 +13,8 @@ import type { SessionState } from "./types"
 
 export type BoulderContinuationResult = "injected" | "skipped_background_tasks" | "skipped_agent_unavailable" | "failed"
 
+const ACTIVE_BACKGROUND_TASK_STATUSES = new Set(["pending", "running"])
+
 export async function injectBoulderContinuation(input: {
   ctx: PluginInput
   sessionID: string
@@ -41,7 +43,7 @@ export async function injectBoulderContinuation(input: {
   } = input
 
   const hasRunningBgTasks = backgroundManager
-    ? backgroundManager.getTasksByParentSession(sessionID).some((t: { status: string }) => t.status === "running")
+    ? backgroundManager.getTasksByParentSession(sessionID).some((t: { status: string }) => ACTIVE_BACKGROUND_TASK_STATUSES.has(t.status))
     : false
 
   if (hasRunningBgTasks) {


### PR DESCRIPTION
## Summary
- treat `pending` background tasks as active when Atlas decides whether to inject a continuation
- prevent Atlas from resuming a plan while a delegated subagent is still in the session-creation window
- add regression coverage for the pending-task continuation race

## Root cause
Atlas continuation only checked for `running` background tasks. When a delegated subagent had already been launched but had not yet acquired its session ID, the task remained in `pending`. That left a race window where Atlas could inject another continuation before the delegated work had actually started, which made the orchestration appear stuck or out of order.

## What changed
- updated `src/hooks/atlas/boulder-continuation-injector.ts` to treat both `pending` and `running` tasks as active background work
- added a regression test covering the pending-session-creation case in `src/hooks/atlas/boulder-continuation-injector.test.ts`

## Tests
- `bun test src/hooks/atlas/boulder-continuation-injector.test.ts src/hooks/atlas/index.test.ts`
- `bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block Atlas continuation while delegated background tasks are still pending session creation, closing a race that could resume plans too early. This keeps orchestration in order and prevents stuck-looking runs.

- **Bug Fixes**
  - Treat both `pending` and `running` background tasks as active in `injectBoulderContinuation` (via `ACTIVE_BACKGROUND_TASK_STATUSES`).
  - Add a regression test to ensure continuation is skipped when a delegated task is still pending.

<sup>Written for commit 56e4044927038f45083cf4a5a8a45904a9087b1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

