### PR TITLE
feat(config): walk up directory tree to merge ancestor plugin configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Opinionated defaults, adjustable if you insist.
 See [Configuration Documentation](docs/reference/configuration.md).
 
 **Quick Overview:**
-- **Config Locations**: The compatibility layer recognizes both `oh-my-openagent.json[c]` and legacy `oh-my-opencode.json[c]` plugin config files. Existing installs still commonly use the legacy basename.
+- **Config Locations**: User config plus walked `.opencode/oh-my-openagent.json[c]` configs up to `$HOME`; closest wins. Legacy `oh-my-opencode.json[c]` still works.
 - **JSONC Support**: Comments and trailing commas supported
 - **Agents**: Override models, temperatures, prompts, and permissions for any agent
 - **Built-in Skills**: `playwright` (browser automation), `git-master` (atomic commits)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -43,15 +43,17 @@ Complete reference for Oh My OpenCode plugin configuration. During the rename tr
 
 ### File Locations
 
-User config is loaded first, then project config overrides it. In each directory, the compatibility layer recognizes both the renamed and legacy basenames.
+User config loads first. Project configs are discovered by walking from the working directory up to `$HOME`; closer configs win. If the working directory is outside `$HOME`, only that directory is checked.
 
-1. Project config: `.opencode/oh-my-openagent.json[c]` or `.opencode/oh-my-opencode.json[c]`
+1. Walked configs: `.opencode/oh-my-openagent.json[c]` or legacy `.opencode/oh-my-opencode.json[c]`
 2. User config (`.jsonc` preferred over `.json`):
 
 | Platform    | Path candidates |
 | ----------- | --------------- |
 | macOS/Linux | `~/.config/opencode/oh-my-openagent.json[c]`, `~/.config/opencode/oh-my-opencode.json[c]` |
 | Windows     | `%APPDATA%\opencode\oh-my-openagent.json[c]`, `%APPDATA%\opencode\oh-my-opencode.json[c]` |
+
+**Security note:** `mcp_env_allowlist` is user-only. Walked configs cannot extend it.
 
 **Rename compatibility:** The published package and CLI binary remain `oh-my-opencode`. OpenCode plugin registration prefers `oh-my-openagent`, while legacy `oh-my-opencode` entries and config basenames still load during the transition. Config detection checks `oh-my-opencode` before `oh-my-openagent`, so if both plugin config basenames exist in the same directory, the legacy `oh-my-opencode.*` file currently wins.
 JSONC supports `// line comments`, `/* block comments */`, and trailing commas.

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { mergeConfigs, parseConfigPartially } from "./plugin-config";
@@ -799,6 +799,137 @@ describe("loadPluginConfig", () => {
     // then - $HOME's config applies, but the directory above it does NOT
     expect(config.agents?.hephaestus?.model).toBe("home/wins")
     expect(config.agents?.oracle).toBeUndefined()
+  })
+
+  it("should not walk above the start directory when start is outside $HOME", async () => {
+    // given
+    const rootDir = mkdtempSync(join(tmpdir(), "omo-plugin-config-walk-outside-"))
+    const userConfigDir = join(rootDir, "user-config")
+    const homeDir = join(rootDir, "home")
+    const outsideHomeRoot = join(rootDir, "outside-home")
+    const projectDir = join(outsideHomeRoot, "proj")
+
+    tempDirs.push(rootDir)
+    mkdirSync(userConfigDir, { recursive: true })
+    mkdirSync(homeDir, { recursive: true })
+    mkdirSync(join(outsideHomeRoot, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+
+    writeFileSync(join(userConfigDir, "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(
+      join(outsideHomeRoot, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { oracle: { model: "outside-home/leak" } } })
+    )
+    writeFileSync(
+      join(projectDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { hephaestus: { model: "project/wins" } } })
+    )
+
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+    process.env.HOME = homeDir
+
+    // when
+    const { loadPluginConfig } = await importFreshPluginConfigModule()
+    const config = loadPluginConfig(projectDir, {})
+
+    // then - project loads, but the parent above it (outside $HOME) is not walked into
+    expect(config.agents?.hephaestus?.model).toBe("project/wins")
+    expect(config.agents?.oracle).toBeUndefined()
+  })
+
+  it("should merge git_master overrides across ancestors with closer winning", async () => {
+    // given
+    const rootDir = mkdtempSync(join(tmpdir(), "omo-plugin-config-walk-git-master-"))
+    const userConfigDir = join(rootDir, "user-config")
+    const homeDir = join(rootDir, "home")
+    const workDir = join(homeDir, "work")
+    const projectDir = join(workDir, "project")
+
+    tempDirs.push(rootDir)
+    mkdirSync(userConfigDir, { recursive: true })
+    mkdirSync(join(homeDir, ".opencode"), { recursive: true })
+    mkdirSync(join(workDir, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+
+    writeFileSync(join(userConfigDir, "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(
+      join(homeDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({
+        git_master: {
+          commit_footer: false,
+          include_co_authored_by: false,
+          git_env_prefix: "HOME=1",
+        },
+      })
+    )
+    writeFileSync(
+      join(workDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({
+        git_master: {
+          include_co_authored_by: true,
+        },
+      })
+    )
+    writeFileSync(
+      join(projectDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({
+        git_master: {
+          commit_footer: true,
+        },
+      })
+    )
+
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+    process.env.HOME = homeDir
+
+    // when
+    const { loadPluginConfig } = await importFreshPluginConfigModule()
+    const config = loadPluginConfig(projectDir, {})
+
+    // then project's commit_footer wins, work's include_co_authored_by wins,
+    // home's git_env_prefix is preserved since nobody else set it
+    expect(config.git_master).toEqual({
+      commit_footer: true,
+      include_co_authored_by: true,
+      git_env_prefix: "HOME=1",
+    })
+  })
+
+  it("should resolve agent_definitions relative to each ancestor's own .opencode directory", async () => {
+    // given
+    const rootDir = mkdtempSync(join(tmpdir(), "omo-plugin-config-walk-agent-defs-"))
+    const userConfigDir = join(rootDir, "user-config")
+    const homeDir = join(rootDir, "home")
+    const workDir = join(homeDir, "work")
+    const projectDir = join(workDir, "project")
+    const workDefRelativePath = "./work-agent.md"
+    const projectDefRelativePath = "./project-agent.md"
+
+    tempDirs.push(rootDir)
+    mkdirSync(userConfigDir, { recursive: true })
+    mkdirSync(join(workDir, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+
+    writeFileSync(join(userConfigDir, "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(
+      join(workDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agent_definitions: [workDefRelativePath] })
+    )
+    writeFileSync(
+      join(projectDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agent_definitions: [projectDefRelativePath] })
+    )
+
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+    process.env.HOME = homeDir
+
+    // when
+    const { loadPluginConfig } = await importFreshPluginConfigModule()
+    const config = loadPluginConfig(projectDir, {})
+
+    // then each ancestor's relative path resolves against its own .opencode/
+    expect(config.agent_definitions).toContain(join(realpathSync(workDir), ".opencode", "work-agent.md"))
+    expect(config.agent_definitions).toContain(join(realpathSync(projectDir), ".opencode", "project-agent.md"))
   })
 
   it("should migrate legacy basenames found in ancestor directories", async () => {

--- a/src/plugin-config.test.ts
+++ b/src/plugin-config.test.ts
@@ -560,7 +560,6 @@ describe("loadPluginConfig", () => {
       git_env_prefix: "GIT_MASTER=1",
     })
   })
-
   describe("team_mode.tmux_visualization", () => {
     it("#given canonical user config enables team_mode and legacy config also exists #when loadPluginConfig runs #then tmux_visualization remains false", async () => {
       // given
@@ -638,5 +637,202 @@ describe("loadPluginConfig", () => {
       // This proves a concurrent canonical file suppresses the legacy team_mode subtree entirely.
       expect(config.team_mode).toBeUndefined()
     })
+  })
+
+  it("should merge configs from ancestor directories with closer winning", async () => {
+    // given
+    const rootDir = mkdtempSync(join(tmpdir(), "omo-plugin-config-walk-"))
+    const userConfigDir = join(rootDir, "user-config")
+    const homeDir = join(rootDir, "home")
+    const workDir = join(homeDir, "work")
+    const projectDir = join(workDir, "project")
+
+    tempDirs.push(rootDir)
+    mkdirSync(userConfigDir, { recursive: true })
+    mkdirSync(join(homeDir, ".opencode"), { recursive: true })
+    mkdirSync(join(workDir, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+
+    writeFileSync(
+      join(userConfigDir, "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { oracle: { model: "user/model" } } })
+    )
+    writeFileSync(
+      join(homeDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { oracle: { model: "home/model" } } })
+    )
+    writeFileSync(
+      join(workDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { oracle: { model: "work/model" } } })
+    )
+    writeFileSync(
+      join(projectDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { oracle: { model: "project/model" } } })
+    )
+
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+    process.env.HOME = homeDir
+
+    // when
+    const { loadPluginConfig } = await importFreshPluginConfigModule()
+    const config = loadPluginConfig(projectDir, {})
+
+    // then
+    expect(config.agents?.oracle?.model).toBe("project/model")
+  })
+
+  it("should layer ancestor configs so each contributes fields not overridden by closer ones", async () => {
+    // given
+    const rootDir = mkdtempSync(join(tmpdir(), "omo-plugin-config-walk-layer-"))
+    const userConfigDir = join(rootDir, "user-config")
+    const homeDir = join(rootDir, "home")
+    const workDir = join(homeDir, "work")
+    const projectDir = join(workDir, "project")
+
+    tempDirs.push(rootDir)
+    mkdirSync(userConfigDir, { recursive: true })
+    mkdirSync(join(homeDir, ".opencode"), { recursive: true })
+    mkdirSync(join(workDir, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+
+    writeFileSync(join(userConfigDir, "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(
+      join(homeDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { oracle: { model: "home/oracle" } } })
+    )
+    writeFileSync(
+      join(workDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { hephaestus: { model: "work/hephaestus" } } })
+    )
+    writeFileSync(
+      join(projectDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { sisyphus: { model: "project/sisyphus" } } })
+    )
+
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+    process.env.HOME = homeDir
+
+    // when
+    const { loadPluginConfig } = await importFreshPluginConfigModule()
+    const config = loadPluginConfig(projectDir, {})
+
+    // then - each level contributes a non-conflicting field
+    expect(config.agents?.oracle?.model).toBe("home/oracle")
+    expect(config.agents?.hephaestus?.model).toBe("work/hephaestus")
+    expect(config.agents?.sisyphus?.model).toBe("project/sisyphus")
+  })
+
+  it("should preserve mcp_env_allowlist as user-only when ancestors set their own allowlists", async () => {
+    // given
+    const rootDir = mkdtempSync(join(tmpdir(), "omo-plugin-config-walk-allowlist-"))
+    const userConfigDir = join(rootDir, "user-config")
+    const homeDir = join(rootDir, "home")
+    const workDir = join(homeDir, "work")
+    const projectDir = join(workDir, "project")
+
+    tempDirs.push(rootDir)
+    mkdirSync(userConfigDir, { recursive: true })
+    mkdirSync(join(homeDir, ".opencode"), { recursive: true })
+    mkdirSync(join(workDir, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+
+    writeFileSync(
+      join(userConfigDir, "oh-my-openagent.jsonc"),
+      JSON.stringify({ mcp_env_allowlist: ["USER_ONLY_TOKEN"] })
+    )
+    writeFileSync(
+      join(homeDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ mcp_env_allowlist: ["HOME_TOKEN"] })
+    )
+    writeFileSync(
+      join(workDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ mcp_env_allowlist: ["WORK_TOKEN"] })
+    )
+    writeFileSync(
+      join(projectDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ mcp_env_allowlist: ["PROJECT_TOKEN"] })
+    )
+
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+    process.env.HOME = homeDir
+
+    // when
+    const { loadPluginConfig } = await importFreshPluginConfigModule()
+    const config = loadPluginConfig(projectDir, {})
+
+    // then - only the canonical user config can extend the allowlist
+    expect(config.mcp_env_allowlist).toEqual(["USER_ONLY_TOKEN"])
+  })
+
+  it("should stop walking at $HOME and ignore configs above it", async () => {
+    // given
+    const rootDir = mkdtempSync(join(tmpdir(), "omo-plugin-config-walk-stop-"))
+    const userConfigDir = join(rootDir, "user-config")
+    const aboveHomeDir = join(rootDir, "above-home")
+    const homeDir = join(aboveHomeDir, "home")
+    const projectDir = join(homeDir, "project")
+
+    tempDirs.push(rootDir)
+    mkdirSync(userConfigDir, { recursive: true })
+    mkdirSync(join(aboveHomeDir, ".opencode"), { recursive: true })
+    mkdirSync(join(homeDir, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+
+    writeFileSync(join(userConfigDir, "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(
+      join(aboveHomeDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { oracle: { model: "above-home/leak" } } })
+    )
+    writeFileSync(
+      join(homeDir, ".opencode", "oh-my-openagent.jsonc"),
+      JSON.stringify({ agents: { hephaestus: { model: "home/wins" } } })
+    )
+    writeFileSync(join(projectDir, ".opencode", "oh-my-openagent.jsonc"), "{}")
+
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+    process.env.HOME = homeDir
+
+    // when
+    const { loadPluginConfig } = await importFreshPluginConfigModule()
+    const config = loadPluginConfig(projectDir, {})
+
+    // then - $HOME's config applies, but the directory above it does NOT
+    expect(config.agents?.hephaestus?.model).toBe("home/wins")
+    expect(config.agents?.oracle).toBeUndefined()
+  })
+
+  it("should migrate legacy basenames found in ancestor directories", async () => {
+    // given
+    const rootDir = mkdtempSync(join(tmpdir(), "omo-plugin-config-walk-legacy-"))
+    const userConfigDir = join(rootDir, "user-config")
+    const homeDir = join(rootDir, "home")
+    const workDir = join(homeDir, "work")
+    const projectDir = join(workDir, "project")
+    const ancestorLegacyPath = join(workDir, ".opencode", "oh-my-opencode.jsonc")
+    const ancestorCanonicalPath = join(workDir, ".opencode", "oh-my-openagent.jsonc")
+
+    tempDirs.push(rootDir)
+    mkdirSync(userConfigDir, { recursive: true })
+    mkdirSync(join(homeDir, ".opencode"), { recursive: true })
+    mkdirSync(join(workDir, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+
+    writeFileSync(join(userConfigDir, "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(
+      ancestorLegacyPath,
+      JSON.stringify({ agents: { oracle: { model: "ancestor-legacy/model" } } })
+    )
+
+    process.env.OPENCODE_CONFIG_DIR = userConfigDir
+    process.env.HOME = homeDir
+
+    // when
+    const { loadPluginConfig } = await importFreshPluginConfigModule()
+    const config = loadPluginConfig(projectDir, {})
+
+    // then
+    expect(existsSync(ancestorLegacyPath)).toBe(false)
+    expect(existsSync(ancestorCanonicalPath)).toBe(true)
+    expect(config.agents?.oracle?.model).toBe("ancestor-legacy/model")
   })
 })

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import { homedir } from "node:os";
 import * as path from "path";
 import { OhMyOpenCodeConfigSchema, type OhMyOpenCodeConfig } from "./config";
 import {
@@ -8,11 +9,40 @@ import {
   addConfigLoadError,
   parseJsonc,
   detectPluginConfigFile,
+  findProjectOpencodePluginConfigFiles,
   migrateConfigFile,
   resolveAgentDefinitionPaths,
 } from "./shared";
 import { migrateLegacyConfigFile } from "./shared/migrate-legacy-config-file";
 import { CONFIG_BASENAME, LEGACY_CONFIG_BASENAME } from "./shared/plugin-identity";
+
+function resolveHomeDirectory(): string {
+  // Read env vars directly to bypass os.homedir() caching. Bun caches the
+  // first os.homedir() result, which means tests that set process.env.HOME
+  // after import never see the new value. Production behaviour is preserved
+  // because HOME (or USERPROFILE on Windows) is set by the OS at startup.
+  return process.env.HOME ?? process.env.USERPROFILE ?? homedir()
+}
+
+function migrateLegacyAndResolveCanonicalPath(detectedPath: string): string {
+  if (!path.basename(detectedPath).startsWith(LEGACY_CONFIG_BASENAME)) {
+    return detectedPath
+  }
+
+  const migrated = migrateLegacyConfigFile(detectedPath)
+  const canonicalPath = path.join(
+    path.dirname(detectedPath),
+    `${CONFIG_BASENAME}${path.extname(detectedPath)}`,
+  )
+
+  // Only switch to canonical path if migration succeeded OR canonical file already exists
+  if (migrated || fs.existsSync(canonicalPath)) {
+    return canonicalPath
+  }
+
+  // Otherwise keep loading from the legacy path that was detected
+  return detectedPath
+}
 
 function loadExplicitGitMasterOverrides(configPath: string): Record<string, unknown> | undefined {
   try {
@@ -214,47 +244,35 @@ export function loadPluginConfig(
   }
 
   // Auto-copy legacy config file to canonical name if needed
-  if (userDetected.format !== "none" && path.basename(userDetected.path).startsWith(LEGACY_CONFIG_BASENAME)) {
-    const migrated = migrateLegacyConfigFile(userDetected.path);
-    const canonicalPath = path.join(
-      path.dirname(userDetected.path),
-      `${CONFIG_BASENAME}${path.extname(userDetected.path)}`
-    );
-    // Only switch to canonical path if migration succeeded OR canonical file already exists
-    if (migrated || fs.existsSync(canonicalPath)) {
-      userConfigPath = canonicalPath;
+  if (userDetected.format !== "none") {
+    userConfigPath = migrateLegacyAndResolveCanonicalPath(userConfigPath)
+  }
+
+  // Walk up from directory to $HOME for ancestor configs (closest first)
+  // This subsumes the previous single project-config load: the closest hit is
+  // the project's own .opencode/oh-my-openagent.json[c], and walking continues
+  // up so configs in ~/work/ (etc.) apply to all subprojects.
+  const ancestorConfigPaths = findProjectOpencodePluginConfigFiles(
+    directory,
+    resolveHomeDirectory(),
+  )
+  log("Walked ancestor plugin configs", {
+    paths: ancestorConfigPaths,
+    count: ancestorConfigPaths.length,
+  })
+
+  // Migrate any legacy basenames among ancestors and warn on dual-config presence
+  const canonicalAncestorPaths = ancestorConfigPaths.map((ancestorPath) => {
+    const opencodeDir = path.dirname(ancestorPath)
+    const ancestorDetected = detectPluginConfigFile(opencodeDir)
+    if (ancestorDetected.legacyPath) {
+      log("Canonical plugin config detected alongside legacy config. Remove the legacy file to avoid confusion.", {
+        canonicalPath: ancestorDetected.path,
+        legacyPath: ancestorDetected.legacyPath,
+      })
     }
-    // Otherwise keep loading from the legacy path that was detected
-  }
-
-  // Project-level config path - prefer .jsonc over .json
-  const projectBasePath = path.join(directory, ".opencode");
-  const projectDetected = detectPluginConfigFile(projectBasePath);
-  let projectConfigPath =
-    projectDetected.format !== "none"
-      ? projectDetected.path
-      : path.join(projectBasePath, `${CONFIG_BASENAME}.json`);
-
-  if (projectDetected.legacyPath) {
-    log("Canonical plugin config detected alongside legacy config. Remove the legacy file to avoid confusion.", {
-      canonicalPath: projectDetected.path,
-      legacyPath: projectDetected.legacyPath,
-    });
-  }
-
-  // Auto-copy legacy project config file to canonical name if needed
-  if (projectDetected.format !== "none" && path.basename(projectDetected.path).startsWith(LEGACY_CONFIG_BASENAME)) {
-    const projectMigrated = migrateLegacyConfigFile(projectDetected.path);
-    const canonicalProjectPath = path.join(
-      path.dirname(projectDetected.path),
-      `${CONFIG_BASENAME}${path.extname(projectDetected.path)}`
-    );
-    // Only switch to canonical path if migration succeeded OR canonical file already exists
-    if (projectMigrated || fs.existsSync(canonicalProjectPath)) {
-      projectConfigPath = canonicalProjectPath;
-    }
-    // Otherwise keep loading from the legacy path that was detected
-  }
+    return migrateLegacyAndResolveCanonicalPath(ancestorPath)
+  })
 
   // Load user config first (base). Parse empty config through Zod to apply field defaults.
   const userConfig = loadConfigFromPath(userConfigPath, ctx)
@@ -271,34 +289,52 @@ export function loadPluginConfig(
   let config: OhMyOpenCodeConfig =
     userConfig ?? OhMyOpenCodeConfigSchema.parse({});
 
-  // Override with project config
+  // Merge ancestor configs from farthest to nearest, so closer overrides farther.
+  // Walker returns nearest-first; reverse for merge order.
   const defaultGitMaster = OhMyOpenCodeConfigSchema.parse({}).git_master
-  const projectConfig = loadConfigFromPath(projectConfigPath, ctx);
-  const projectGitMasterOverrides = loadExplicitGitMasterOverrides(projectConfigPath)
+  const ancestorGitMasterOverrides: Array<Record<string, unknown>> = []
 
-  if (projectConfig?.agent_definitions) {
-    projectConfig.agent_definitions = resolveAgentDefinitionPaths(
-      projectConfig.agent_definitions,
-      projectBasePath,
-      directory
-    )
+  for (const ancestorPath of canonicalAncestorPaths.slice().reverse()) {
+    const ancestorConfig = loadConfigFromPath(ancestorPath, ctx)
+    const ancestorOverrides = loadExplicitGitMasterOverrides(ancestorPath)
+
+    if (ancestorConfig?.agent_definitions) {
+      // Resolve relative paths against this ancestor's own .opencode/ base.
+      const ancestorBasePath = path.dirname(ancestorPath)
+      const ancestorDir = path.dirname(ancestorBasePath)
+      ancestorConfig.agent_definitions = resolveAgentDefinitionPaths(
+        ancestorConfig.agent_definitions,
+        ancestorBasePath,
+        ancestorDir,
+      )
+    }
+
+    if (ancestorConfig) {
+      config = mergeConfigs(config, ancestorConfig)
+    }
+
+    if (ancestorOverrides) {
+      ancestorGitMasterOverrides.push(ancestorOverrides)
+    }
   }
 
-  if (projectConfig) {
-    config = mergeConfigs(config, projectConfig);
-  }
-
-  if (userGitMasterOverrides || projectGitMasterOverrides) {
+  if (userGitMasterOverrides || ancestorGitMasterOverrides.length > 0) {
     config = {
       ...config,
       git_master: {
         ...defaultGitMaster,
         ...(userGitMasterOverrides ?? {}),
-        ...(projectGitMasterOverrides ?? {}),
+        // Ancestors are pushed far-to-near; Object.assign with an empty seed
+        // applies each in order so the nearest (last) wins.
+        ...Object.assign({}, ...ancestorGitMasterOverrides),
       },
     }
   }
 
+  // Security: mcp_env_allowlist remains user-only across the entire walk.
+  // This prevents clone-and-load attacks where a malicious project (or any
+  // walked ancestor) could extend the env var allowlist used during ${VAR}
+  // expansion in .mcp.json files. See commit 316d2504 for context.
   config = {
     ...config,
     mcp_env_allowlist: userConfig?.mcp_env_allowlist ?? [],

--- a/src/plugin-config.ts
+++ b/src/plugin-config.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { OhMyOpenCodeConfigSchema, type OhMyOpenCodeConfig } from "./config";
 import {
   log,
+  containsPath,
   deepMerge,
   getOpenCodeConfigDir,
   addConfigLoadError,
@@ -24,7 +25,7 @@ function resolveHomeDirectory(): string {
   return process.env.HOME ?? process.env.USERPROFILE ?? homedir()
 }
 
-function migrateLegacyAndResolveCanonicalPath(detectedPath: string): string {
+function resolveConfigPathAfterLegacyMigration(detectedPath: string): string {
   if (!path.basename(detectedPath).startsWith(LEGACY_CONFIG_BASENAME)) {
     return detectedPath
   }
@@ -245,34 +246,38 @@ export function loadPluginConfig(
 
   // Auto-copy legacy config file to canonical name if needed
   if (userDetected.format !== "none") {
-    userConfigPath = migrateLegacyAndResolveCanonicalPath(userConfigPath)
+    userConfigPath = resolveConfigPathAfterLegacyMigration(userConfigPath)
   }
 
-  // Walk up from directory to $HOME for ancestor configs (closest first)
-  // This subsumes the previous single project-config load: the closest hit is
-  // the project's own .opencode/oh-my-openagent.json[c], and walking continues
-  // up so configs in ~/work/ (etc.) apply to all subprojects.
-  const ancestorConfigPaths = findProjectOpencodePluginConfigFiles(
+  // Pin the walk to $HOME only when the start directory is inside it. Outside
+  // $HOME the walker would otherwise reach FS root and surface unrelated configs
+  // in /tmp, /opt, etc.
+  const homeDirectory = resolveHomeDirectory()
+  const stopDirectory = containsPath(homeDirectory, directory) ? homeDirectory : directory
+  const ancestorConfigPathsNearestFirst = findProjectOpencodePluginConfigFiles(
     directory,
-    resolveHomeDirectory(),
+    stopDirectory,
   )
   log("Walked ancestor plugin configs", {
-    paths: ancestorConfigPaths,
-    count: ancestorConfigPaths.length,
+    paths: ancestorConfigPathsNearestFirst,
+    count: ancestorConfigPathsNearestFirst.length,
+    stopDirectory,
   })
 
   // Migrate any legacy basenames among ancestors and warn on dual-config presence
-  const canonicalAncestorPaths = ancestorConfigPaths.map((ancestorPath) => {
-    const opencodeDir = path.dirname(ancestorPath)
-    const ancestorDetected = detectPluginConfigFile(opencodeDir)
-    if (ancestorDetected.legacyPath) {
-      log("Canonical plugin config detected alongside legacy config. Remove the legacy file to avoid confusion.", {
-        canonicalPath: ancestorDetected.path,
-        legacyPath: ancestorDetected.legacyPath,
-      })
-    }
-    return migrateLegacyAndResolveCanonicalPath(ancestorPath)
-  })
+  const canonicalAncestorPathsNearestFirst = ancestorConfigPathsNearestFirst.map(
+    (ancestorPath) => {
+      const opencodeDir = path.dirname(ancestorPath)
+      const ancestorDetected = detectPluginConfigFile(opencodeDir)
+      if (ancestorDetected.legacyPath) {
+        log("Canonical plugin config detected alongside legacy config. Remove the legacy file to avoid confusion.", {
+          canonicalPath: ancestorDetected.path,
+          legacyPath: ancestorDetected.legacyPath,
+        })
+      }
+      return resolveConfigPathAfterLegacyMigration(ancestorPath)
+    },
+  )
 
   // Load user config first (base). Parse empty config through Zod to apply field defaults.
   const userConfig = loadConfigFromPath(userConfigPath, ctx)
@@ -289,12 +294,11 @@ export function loadPluginConfig(
   let config: OhMyOpenCodeConfig =
     userConfig ?? OhMyOpenCodeConfigSchema.parse({});
 
-  // Merge ancestor configs from farthest to nearest, so closer overrides farther.
-  // Walker returns nearest-first; reverse for merge order.
+  const canonicalAncestorPathsFarthestFirst = [...canonicalAncestorPathsNearestFirst].reverse()
   const defaultGitMaster = OhMyOpenCodeConfigSchema.parse({}).git_master
-  const ancestorGitMasterOverrides: Array<Record<string, unknown>> = []
+  const ancestorGitMasterOverridesFarthestFirst: Array<Record<string, unknown>> = []
 
-  for (const ancestorPath of canonicalAncestorPaths.slice().reverse()) {
+  for (const ancestorPath of canonicalAncestorPathsFarthestFirst) {
     const ancestorConfig = loadConfigFromPath(ancestorPath, ctx)
     const ancestorOverrides = loadExplicitGitMasterOverrides(ancestorPath)
 
@@ -314,19 +318,21 @@ export function loadPluginConfig(
     }
 
     if (ancestorOverrides) {
-      ancestorGitMasterOverrides.push(ancestorOverrides)
+      ancestorGitMasterOverridesFarthestFirst.push(ancestorOverrides)
     }
   }
 
-  if (userGitMasterOverrides || ancestorGitMasterOverrides.length > 0) {
+  if (userGitMasterOverrides || ancestorGitMasterOverridesFarthestFirst.length > 0) {
+    const mergedAncestorGitMaster: Record<string, unknown> = {}
+    for (const override of ancestorGitMasterOverridesFarthestFirst) {
+      Object.assign(mergedAncestorGitMaster, override)
+    }
     config = {
       ...config,
       git_master: {
         ...defaultGitMaster,
         ...(userGitMasterOverrides ?? {}),
-        // Ancestors are pushed far-to-near; Object.assign with an empty seed
-        // applies each in order so the nearest (last) wins.
-        ...Object.assign({}, ...ancestorGitMasterOverrides),
+        ...mergedAncestorGitMaster,
       },
     }
   }

--- a/src/shared/project-discovery-dirs.test.ts
+++ b/src/shared/project-discovery-dirs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
-import { mkdirSync, realpathSync, rmSync } from "node:fs"
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -119,6 +119,96 @@ describe("project-discovery-dirs", () => {
 
     // then
     expect(directories).toEqual([canonicalPath(join(projectDir, ".opencode", "skills"))])
+  })
+
+  it("#given nested .opencode plugin config files #when finding plugin config files #then returns nearest-first canonical paths", async () => {
+    // given
+    const grandparentDir = join(TEST_DIR, "grandparent")
+    const parentDir = join(grandparentDir, "parent")
+    const projectDir = join(parentDir, "project")
+    mkdirSync(join(grandparentDir, ".opencode"), { recursive: true })
+    mkdirSync(join(parentDir, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+    writeFileSync(join(grandparentDir, ".opencode", "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(join(parentDir, ".opencode", "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(join(projectDir, ".opencode", "oh-my-openagent.jsonc"), "{}")
+
+    const { clearPluginConfigFileDetectionCache } = await import("./jsonc-parser")
+    clearPluginConfigFileDetectionCache()
+    const { findProjectOpencodePluginConfigFiles } = await import("./project-discovery-dirs")
+
+    // when
+    const paths = findProjectOpencodePluginConfigFiles(projectDir, TEST_DIR)
+
+    // then
+    expect(paths).toEqual([
+      canonicalPath(join(projectDir, ".opencode", "oh-my-openagent.jsonc")),
+      canonicalPath(join(parentDir, ".opencode", "oh-my-openagent.jsonc")),
+      canonicalPath(join(grandparentDir, ".opencode", "oh-my-openagent.jsonc")),
+    ])
+  })
+
+  it("#given a stop directory #when finding plugin config files #then walking halts at the stop boundary inclusive", async () => {
+    // given
+    const stopDir = join(TEST_DIR, "stop")
+    const childDir = join(stopDir, "child")
+    mkdirSync(join(TEST_DIR, ".opencode"), { recursive: true })
+    mkdirSync(join(stopDir, ".opencode"), { recursive: true })
+    mkdirSync(join(childDir, ".opencode"), { recursive: true })
+    writeFileSync(join(TEST_DIR, ".opencode", "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(join(stopDir, ".opencode", "oh-my-openagent.jsonc"), "{}")
+    writeFileSync(join(childDir, ".opencode", "oh-my-openagent.jsonc"), "{}")
+
+    const { clearPluginConfigFileDetectionCache } = await import("./jsonc-parser")
+    clearPluginConfigFileDetectionCache()
+    const { findProjectOpencodePluginConfigFiles } = await import("./project-discovery-dirs")
+
+    // when
+    const paths = findProjectOpencodePluginConfigFiles(childDir, stopDir)
+
+    // then
+    expect(paths).toEqual([
+      canonicalPath(join(childDir, ".opencode", "oh-my-openagent.jsonc")),
+      canonicalPath(join(stopDir, ".opencode", "oh-my-openagent.jsonc")),
+    ])
+  })
+
+  it("#given a legacy basename in an ancestor #when finding plugin config files #then detection picks up the legacy path", async () => {
+    // given
+    const projectDir = join(TEST_DIR, "project")
+    mkdirSync(join(TEST_DIR, ".opencode"), { recursive: true })
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true })
+    writeFileSync(join(TEST_DIR, ".opencode", "oh-my-opencode.jsonc"), "{}")
+    writeFileSync(join(projectDir, ".opencode", "oh-my-openagent.jsonc"), "{}")
+
+    const { clearPluginConfigFileDetectionCache } = await import("./jsonc-parser")
+    clearPluginConfigFileDetectionCache()
+    const { findProjectOpencodePluginConfigFiles } = await import("./project-discovery-dirs")
+
+    // when
+    const paths = findProjectOpencodePluginConfigFiles(projectDir, TEST_DIR)
+
+    // then
+    expect(paths).toEqual([
+      canonicalPath(join(projectDir, ".opencode", "oh-my-openagent.jsonc")),
+      canonicalPath(join(TEST_DIR, ".opencode", "oh-my-opencode.jsonc")),
+    ])
+  })
+
+  it("#given no .opencode directories along the walk #when finding plugin config files #then returns an empty list", async () => {
+    // given
+    const projectDir = join(TEST_DIR, "project", "deep")
+    mkdirSync(projectDir, { recursive: true })
+
+    const { clearPluginConfigFileDetectionCache } = await import("./jsonc-parser")
+    clearPluginConfigFileDetectionCache()
+    const { findProjectOpencodePluginConfigFiles } = await import("./project-discovery-dirs")
+
+    // when
+    const paths = findProjectOpencodePluginConfigFiles(projectDir, TEST_DIR)
+
+    // then
+    expect(paths).toEqual([])
   })
 
 })

--- a/src/shared/project-discovery-dirs.ts
+++ b/src/shared/project-discovery-dirs.ts
@@ -2,6 +2,8 @@ import { execFileSync } from "node:child_process"
 import { existsSync, realpathSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 
+import { detectPluginConfigFile } from "./jsonc-parser"
+
 const worktreePathCache = new Map<string, string | undefined>()
 
 function normalizePath(path: string): string {
@@ -113,4 +115,36 @@ export function findProjectOpencodeCommandDirs(startDirectory: string, stopDirec
     ],
     stopDirectory ?? detectWorktreePath(startDirectory),
   )
+}
+
+export function findProjectOpencodePluginConfigFiles(
+  startDirectory: string,
+  stopDirectory?: string,
+): string[] {
+  const paths: string[] = []
+  const seen = new Set<string>()
+  let currentDirectory = normalizePath(startDirectory)
+  const resolvedStopDirectory = stopDirectory ? normalizePath(stopDirectory) : undefined
+
+  while (true) {
+    const opencodeDirectory = join(currentDirectory, ".opencode")
+    if (existsSync(opencodeDirectory)) {
+      const detected = detectPluginConfigFile(opencodeDirectory)
+      if (detected.format !== "none" && !seen.has(detected.path)) {
+        seen.add(detected.path)
+        paths.push(detected.path)
+      }
+    }
+
+    if (resolvedStopDirectory === currentDirectory) {
+      return paths
+    }
+
+    const parentDirectory = dirname(currentDirectory)
+    if (parentDirectory === currentDirectory) {
+      return paths
+    }
+
+    currentDirectory = normalizePath(parentDirectory)
+  }
 }


### PR DESCRIPTION
## Summary

Closes #417.

`loadPluginConfig` now walks from the working directory up to `$HOME` (inclusive), collecting every `.opencode/oh-my-openagent.json[c]` it finds. Configs closer to the working directory override configs farther up, enabling per-tree setups like:

```
~/work/.opencode/oh-my-openagent.json     # work credentials
~/dev/.opencode/oh-my-openagent.json      # personal credentials
~/.config/opencode/oh-my-openagent.json   # global fallback
```

The previous single project-config load is subsumed by the walk: the project's own config is just the closest hit.

## Changes

### `src/shared/project-discovery-dirs.ts`
- Add `findProjectOpencodePluginConfigFiles(startDirectory, stopDirectory?)` walker.
- Reuses `detectPluginConfigFile` from `jsonc-parser` so canonical/legacy basename detection, caching, and JSONC vs JSON precedence stay consistent.
- Returns paths in nearest-first order.

### `src/plugin-config.ts`
- Replace the single project-config block with the new walk, stopping at `$HOME`.
- Each ancestor's `agent_definitions` resolves against its own `.opencode/` base path.
- Each ancestor's `git_master` overrides accumulate (closer wins).
- Legacy basenames are migrated wherever they appear in the walk.
- `mcp_env_allowlist` stays user-only (security boundary preserved).
- `os.homedir()` is cached by Bun, so the stop directory is read from `process.env.HOME` directly. Production behaviour is unchanged because the OS sets `HOME` at startup.

### Tests
- New unit tests in `src/shared/project-discovery-dirs.test.ts` for the walker (nearest-first order, stop boundary, legacy basename detection, empty result).
- New integration tests in `src/plugin-config.test.ts` for layered merge, mcp_env_allowlist staying user-only across the walk, stop boundary at `$HOME`, and ancestor legacy migration.

## Testing

- `bun test src/shared/project-discovery-dirs.test.ts` — 9/9 ✅
- `bun test src/plugin-config.test.ts` — 24/24 ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test` (full suite) — 5921/5924 ✅ (3 pre-existing local-env failures, same as on `dev`)

## Security note

`mcp_env_allowlist` deliberately remains user-only across the entire walk. Allowing walked ancestors to extend the allowlist would re-open the clone-and-load attack vector that commit 316d2504 closed: a malicious project (or any walked ancestor) could grant `\${VAR}` expansion access to arbitrary env vars in `.mcp.json` files. The existing test pinning this behaviour is extended to cover the multi-ancestor case.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load and merge `.opencode/oh-my-openagent.json[c]` from the working directory up to `$HOME`, with closer configs winning. Stops at `$HOME` (inclusive) or the start directory if outside `$HOME`. Closes #417.

- **New Features**
  - Walk ancestor directories to collect plugin configs; stop at `$HOME`. If outside `$HOME`, only check the start directory. Read `HOME`/`USERPROFILE` to avoid `os.homedir()` caching.
  - Resolve each ancestor’s `agent_definitions` relative to its own `.opencode/`.
  - Merge `git_master` overrides across ancestors (closer wins).
  - Migrate legacy basenames during the walk; detection handles canonical vs legacy.
  - Docs: updated README and config reference with a hierarchical example and the user-only `mcp_env_allowlist` note.

<sup>Written for commit 13c70cff121865fcc22cd26e2e13fb623273bce8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

