### PR TITLE
test: remove redundant local env restoration

### DIFF
--- a/src/features/claude-code-agent-loader/loader.test.ts
+++ b/src/features/claude-code-agent-loader/loader.test.ts
@@ -191,31 +191,18 @@ describe("claude-code-agent-loader", () => {
   describe("loadUserAgents", () => {
     test("returns empty object when pointed at dir without agents/", () => {
       const root = trackDir(mkdtempSync(join(tmpdir(), "agent-loader-test-")))
-      // Temporarily set env var — best-effort in parallel test runner
-      const prev = process.env.CLAUDE_CONFIG_DIR
-      try {
-        process.env.CLAUDE_CONFIG_DIR = root
-        const result = loadUserAgents()
-        expect(result).toEqual({})
-      } finally {
-        if (prev !== undefined) process.env.CLAUDE_CONFIG_DIR = prev
-        else delete process.env.CLAUDE_CONFIG_DIR
-      }
+      process.env.CLAUDE_CONFIG_DIR = root
+      const result = loadUserAgents()
+      expect(result).toEqual({})
     })
   })
 
   describe("loadOpencodeGlobalAgents", () => {
     test("returns empty object when pointed at dir without agents/", () => {
       const root = trackDir(mkdtempSync(join(tmpdir(), "agent-loader-test-")))
-      const prev = process.env.OPENCODE_CONFIG_DIR
-      try {
-        process.env.OPENCODE_CONFIG_DIR = root
-        const result = loadOpencodeGlobalAgents()
-        expect(result).toEqual({})
-      } finally {
-        if (prev !== undefined) process.env.OPENCODE_CONFIG_DIR = prev
-        else delete process.env.OPENCODE_CONFIG_DIR
-      }
+      process.env.OPENCODE_CONFIG_DIR = root
+      const result = loadOpencodeGlobalAgents()
+      expect(result).toEqual({})
     })
   })
 

--- a/src/features/skill-mcp-manager/connection-env-vars.test.ts
+++ b/src/features/skill-mcp-manager/connection-env-vars.test.ts
@@ -126,8 +126,6 @@ function createClientKey(info: SkillMcpClientInfo): string {
   return `${info.sessionID}:${info.skillName}:${info.serverName}`
 }
 
-const ORIGINAL_ENV = { ...process.env }
-
 beforeEach(() => {
   createdStdioTransports.length = 0
   createdHttpTransports.length = 0
@@ -146,15 +144,6 @@ afterEach(async () => {
     await disconnectAll(state)
   }
   trackedStates.length = 0
-
-  for (const key of Object.keys(process.env)) {
-    if (!(key in ORIGINAL_ENV)) {
-      delete process.env[key]
-    }
-  }
-  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
-    process.env[key] = value
-  }
 
   setStdioClientDependenciesForTesting()
   setHttpClientDependenciesForTesting()

--- a/src/shared/claude-config-dir.test.ts
+++ b/src/shared/claude-config-dir.test.ts
@@ -1,23 +1,9 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { describe, test, expect } from "bun:test"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { getClaudeConfigDir } from "./claude-config-dir"
 
 describe("getClaudeConfigDir", () => {
-  let originalEnv: string | undefined
-
-  beforeEach(() => {
-    originalEnv = process.env.CLAUDE_CONFIG_DIR
-  })
-
-  afterEach(() => {
-    if (originalEnv !== undefined) {
-      process.env.CLAUDE_CONFIG_DIR = originalEnv
-    } else {
-      delete process.env.CLAUDE_CONFIG_DIR
-    }
-  })
-
   test("returns CLAUDE_CONFIG_DIR when env var is set", () => {
     process.env.CLAUDE_CONFIG_DIR = "/custom/claude/path"
     

--- a/src/shared/plugin-command-discovery.test.ts
+++ b/src/shared/plugin-command-discovery.test.ts
@@ -4,16 +4,6 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { discoverPluginCommandDefinitions } from "./plugin-command-discovery"
 
-const ENV_KEYS = [
-  "CLAUDE_CONFIG_DIR",
-  "CLAUDE_PLUGINS_HOME",
-  "CLAUDE_SETTINGS_PATH",
-  "OPENCODE_CONFIG_DIR",
-] as const
-
-type EnvKey = (typeof ENV_KEYS)[number]
-type EnvSnapshot = Record<EnvKey, string | undefined>
-
 function writePluginFixture(baseDir: string): void {
   const claudeConfigDir = join(baseDir, "claude-config")
   const pluginsHome = join(claudeConfigDir, "plugins")
@@ -94,28 +84,13 @@ Build a plan from plugin skill context.
 
 describe("plugin command discovery utility", () => {
   let tempDir = ""
-  let envSnapshot: EnvSnapshot
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), "omo-shared-plugin-discovery-test-"))
-    envSnapshot = {
-      CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
-      CLAUDE_PLUGINS_HOME: process.env.CLAUDE_PLUGINS_HOME,
-      CLAUDE_SETTINGS_PATH: process.env.CLAUDE_SETTINGS_PATH,
-      OPENCODE_CONFIG_DIR: process.env.OPENCODE_CONFIG_DIR,
-    }
     writePluginFixture(tempDir)
   })
 
   afterEach(() => {
-    for (const key of ENV_KEYS) {
-      const previousValue = envSnapshot[key]
-      if (previousValue === undefined) {
-        delete process.env[key]
-      } else {
-        process.env[key] = previousValue
-      }
-    }
     rmSync(tempDir, { recursive: true, force: true })
   })
 


### PR DESCRIPTION
Four test files maintain their own `process.env` snapshot/restore logic that is already handled globally by `test-setup.ts` (preloaded via `bunfig.toml`). The codebase had accumulated four different patterns for the same problem.

| File | Pattern removed |
|---|---|
| `src/shared/claude-config-dir.test.ts` | `let originalEnv` + beforeEach + afterEach pair |
| `src/shared/plugin-command-discovery.test.ts` | `ENV_KEYS` + `envSnapshot` + restore loop |
| `src/features/claude-code-agent-loader/loader.test.ts` | per-test `try`/`finally` env restore |
| `src/features/skill-mcp-manager/connection-env-vars.test.ts` | module-load `ORIGINAL_ENV` + restore loops |

The global `afterEach` deletes keys added during the test, restores originals (handling `undefined` correctly), and restores `process.cwd()`. Bun runs file-level `afterEach` before the global one, so removing the local restore lets the global one handle cleanup as designed.

`connection-env-vars.test.ts` keeps its `setStdioClientDependenciesForTesting()`/`setHttpClientDependenciesForTesting()` calls; only the env-restore portion is removed (those setters don't read env).

All 4 files pass (27/27).