### PR TITLE
fix(background-agent): fix parentSessionID -> parentSessionId typo causing TS build failure

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -451,7 +451,7 @@ export class BackgroundManager {
       this.markPreStartDescendantReservation(task)
 
       // Signal CLI run mode that background tasks are active
-      this.updateBackgroundTaskMarker(input.parentSessionID)
+      this.updateBackgroundTaskMarker(input.parentSessionId)
 
       // Trigger processing (fire-and-forget)
       void this.processKey(key)
@@ -517,7 +517,7 @@ export class BackgroundManager {
           }
 
           // Update continuation marker for CLI run mode
-          this.updateBackgroundTaskMarker(item.task.parentSessionID)
+          this.updateBackgroundTaskMarker(item.task.parentSessionId)
 
           this.markForNotification(item.task)
           this.enqueueNotificationForParent(item.task.parentSessionId, () => this.notifyParentSession(item.task)).catch(err => {
@@ -1548,8 +1548,8 @@ The fallback retry session is now created and can be inspected directly.
     }
 
     // Update continuation marker for CLI run mode
-    if (task.parentSessionID) {
-      this.updateBackgroundTaskMarker(task.parentSessionID)
+    if (task.parentSessionId) {
+      this.updateBackgroundTaskMarker(task.parentSessionId)
     }
 
     this.markForNotification(task)
@@ -1852,8 +1852,8 @@ The task was re-queued on a fallback model after a retryable failure.
     removeTaskToastTracking(task.id)
 
     // Update continuation marker for CLI run mode
-    if (task.parentSessionID) {
-      this.updateBackgroundTaskMarker(task.parentSessionID)
+    if (task.parentSessionId) {
+      this.updateBackgroundTaskMarker(task.parentSessionId)
     }
 
     if (options?.skipNotification) {
@@ -1975,8 +1975,8 @@ The task was re-queued on a fallback model after a retryable failure.
     }
 
     // Update continuation marker for CLI run mode
-    if (task.parentSessionID) {
-      this.updateBackgroundTaskMarker(task.parentSessionID)
+    if (task.parentSessionId) {
+      this.updateBackgroundTaskMarker(task.parentSessionId)
     }
 
     try {
@@ -2216,8 +2216,8 @@ The task was re-queued on a fallback model after a retryable failure.
         }
         this.cleanupPendingByParent(task)
         // Update continuation marker for CLI run mode
-        if (task.parentSessionID) {
-          this.updateBackgroundTaskMarker(task.parentSessionID)
+        if (task.parentSessionId) {
+          this.updateBackgroundTaskMarker(task.parentSessionId)
         }
         this.markForNotification(task)
         this.enqueueNotificationForParent(task.parentSessionId, () => this.notifyParentSession(task)).catch(err => {
@@ -2282,8 +2282,8 @@ The task was re-queued on a fallback model after a retryable failure.
     }
 
     // Update continuation marker for CLI run mode
-    if (task.parentSessionID) {
-      this.updateBackgroundTaskMarker(task.parentSessionID)
+    if (task.parentSessionId) {
+      this.updateBackgroundTaskMarker(task.parentSessionId)
     }
 
     this.markForNotification(task)


### PR DESCRIPTION
## Problem
CI build was failing on `dev` branch with TypeScript errors:

```
src/features/background-agent/manager.ts(454,45): error TS2551: Property 'parentSessionID' does not exist on type 'LaunchInput'. Did you mean 'parentSessionId'?
```

12 occurrences of `.parentSessionID` were using the wrong casing (uppercase `D`).

## Fix
Replace all `.parentSessionID` → `.parentSessionId` (camelCase, lowercase `d`) in `manager.ts`.

## Verification
- `bun run build` passes ✓
- `bun test` passes (5915/5916, 1 pre-existing flaky timing test) ✓

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TypeScript build failure by renaming `.parentSessionID` to `.parentSessionId` in the background agent manager. Restores CI builds and ensures background task markers use the correct field.

- **Bug Fixes**
  - Replaced 12 references to `.parentSessionID` with `.parentSessionId` in `src/features/background-agent/manager.ts`.
  - `bun run build` and `bun test` pass (1 known flaky test remains).

<sup>Written for commit 6323fa8ef9380217cde240fb323fd991bb1c4fb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

