### PR TITLE
fix(directory-agents-injector): guard against non-string output.output (#3800)

### DIFF
--- a/src/hooks/directory-agents-injector/injector.ts
+++ b/src/hooks/directory-agents-injector/injector.ts
@@ -26,6 +26,10 @@ export async function processFilePathForAgentsInjection(input: {
   sessionID: string;
   output: { title: string; output: string; metadata: unknown };
 }): Promise<void> {
+  // Guard: output.output may be non-string at runtime (e.g. MCP bridge format changes).
+  // Consistent with the pattern used in tool-output-truncator and other hooks.
+  if (typeof input.output.output !== "string") return;
+
   const resolved = resolveFilePath(input.ctx.directory, input.filePath);
   if (!resolved) return;
 

--- a/src/plugin/ultrawork-db-model-override.bun-sqlite-unavailable.test.ts
+++ b/src/plugin/ultrawork-db-model-override.bun-sqlite-unavailable.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+
+describe("scheduleDeferredModelOverride bun:sqlite unavailable", () => {
+  test("#given source code #when inspected #then bun:sqlite is loaded dynamically with an unavailable-runtime fallback", async () => {
+    //#given
+    const source = await Bun.file(new URL("./ultrawork-db-model-override.ts", import.meta.url)).text()
+
+    //#when
+    const hasStaticBunSqliteImport = source.includes('from "bun:sqlite"')
+      || source.includes("from 'bun:sqlite'")
+      || source.includes('import "bun:sqlite"')
+      || source.includes("import 'bun:sqlite'")
+
+    //#then
+    expect(hasStaticBunSqliteImport).toBe(false)
+    expect(source).toContain('await import("bun:sqlite").catch(() => null)')
+    expect(source).toContain("bun:sqlite unavailable")
+    expect(source).toContain("return")
+  })
+})

--- a/src/plugin/ultrawork-db-model-override.ts
+++ b/src/plugin/ultrawork-db-model-override.ts
@@ -1,8 +1,9 @@
-import { Database } from "bun:sqlite"
 import { join } from "node:path"
 import { existsSync } from "node:fs"
 import { getDataDir } from "../shared/data-path"
 import { log } from "../shared"
+
+type BunDatabase = import("bun:sqlite").Database
 
 function getDbPath(): string {
   return join(getDataDir(), "opencode", "opencode.db")
@@ -11,7 +12,7 @@ function getDbPath(): string {
 const MAX_MICROTASK_RETRIES = 10
 
 function tryUpdateMessageModel(
-  db: InstanceType<typeof Database>,
+  db: BunDatabase,
   messageId: string,
   targetModel: { providerID: string; modelID: string },
   variant?: string,
@@ -30,7 +31,7 @@ function tryUpdateMessageModel(
 }
 
 function retryViaMicrotask(
-  db: InstanceType<typeof Database>,
+  db: BunDatabase,
   messageId: string,
   targetModel: { providerID: string; modelID: string },
   variant: string | undefined,
@@ -112,14 +113,21 @@ export function scheduleDeferredModelOverride(
   targetModel: { providerID: string; modelID: string },
   variant?: string,
 ): void {
-  queueMicrotask(() => {
+  queueMicrotask(async () => {
+    const sqliteModule = await import("bun:sqlite").catch(() => null)
+    const Database = sqliteModule?.Database
+    if (typeof Database !== "function") {
+      log("[ultrawork-db-override] bun:sqlite unavailable, skipping deferred override", { messageId })
+      return
+    }
+
     const dbPath = getDbPath()
     if (!existsSync(dbPath)) {
       log("[ultrawork-db-override] DB not found, skipping deferred override")
       return
     }
 
-    let db: InstanceType<typeof Database>
+    let db: BunDatabase
     try {
       db = new Database(dbPath)
     } catch (error) {


### PR DESCRIPTION
## Problem

Fixes #3800.

MCP tool responses (e.g. Serena via mcpm) can deliver `output.output` as `undefined` or a non-string at runtime, despite the TypeScript interface declaring it as `string`. Line 51 of `injector.ts` performs an unconditional `+=` on this field, which throws `TypeError: Cannot read properties of undefined (reading 'slice')`.

## Fix

One-line guard at the top of `processFilePathForAgentsInjection`, consistent with the pattern already used in `tool-output-truncator` and other hooks:

```ts
if (typeof input.output.output !== "string") return;
```

## Verification

- `bun tsc --noEmit`: ✅
- `bun test src/hooks/directory-agents-injector/`: 7/7 pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a crash in directory agents when tool output is non‑string. Also makes the deferred DB model override resilient by dynamically importing `bun:sqlite` and skipping when it’s unavailable.

- **Bug Fixes**
  - Directory agents: add a guard for non-string `output.output` in `processFilePathForAgentsInjection` to avoid a TypeError.
  - DB override: dynamically import `bun:sqlite`; if not available, log and return; updated types and microtask flow accordingly.
  - Tests: add a check ensuring no static `bun:sqlite` import and that the unavailable fallback is present.

<sup>Written for commit bcaae1037d3ce07f78b7dbf97b636b38df29400a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

