### PR TITLE
prevent infinite loop when fallback model equals current model

### DIFF
--- a/src/hooks/runtime-fallback/fallback-state.ts
+++ b/src/hooks/runtime-fallback/fallback-state.ts
@@ -28,6 +28,10 @@ export function findNextAvailableFallback(
 ): string | undefined {
   for (let i = state.fallbackIndex + 1; i < fallbackModels.length; i++) {
     const candidate = fallbackModels[i]
+    if (candidate === state.currentModel) {
+      log(`[${HOOK_NAME}] Skipping fallback model (same as current)`, { model: candidate, index: i })
+      continue
+    }
     if (!isModelInCooldown(candidate, state, cooldownSeconds)) {
       return candidate
     }


### PR DESCRIPTION
## Summary
- Prevents an infinite retry loop when a primary model encounters a quota limit or failure.
- Ensures the fallback mechanism explicitly skips the currently failing model when iterating through the `fallback_models` list.
- Hardens fallback stability when a model hasn't been fully registered in the cooldown map yet.
- 
## Changes
- Modified `findNextAvailableFallback` in `src/hooks/runtime-fallback/fallback-state.ts`.
- Added a strict equality check (`candidate === state.currentModel`) to immediately bypass the failing model before evaluating cooldown status.
- Added diagnostic logging when a model is skipped due to being the current model.

## Why this is necessary (The State Management Bug)
While duplicate entries in a user's `fallback_models` config can trigger this loop, the loop can also occur with a perfectly clean configuration due to manual model switching mid-session:
1. A user starts a session with Agent A (Primary Model: `Claude`).
2. Agent A's fallback list is `[GPT, Gemini]`.
3. The user manually switches the active model to `GPT` via the UI. The plugin updates `state.currentModel` to `GPT`.
4. `GPT` runs out of tokens/encounters an error.
5. The fallback system triggers and loads the original fallback list: `[GPT, Gemini]`.
6. Because the failed model (`GPT`) hasn't been fully registered in the `failedModels` cooldown map at the exact moment `findNextAvailableFallback` is evaluated, the function sees `GPT` (index 0) as available and selects it.
7. The system enters an infinite loop, repeatedly trying to fall back to the exact same exhausted model.
This patch guarantees that regardless of config quirks or manual state changes, the fallback mechanism will never attempt to use the model that just failed.

## Testing
```bash
bun run typecheck
bun test
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents an infinite fallback loop by skipping the current model if it appears in `fallback_models`, improving stability after manual model switches or cooldown race conditions.

- **Bug Fixes**
  - Updated `findNextAvailableFallback` to bypass `state.currentModel` before cooldown checks.
  - Added diagnostic log when a candidate equals the current model.

<sup>Written for commit d800fec6b1369e77d096be996a5437afddebdfbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

