### PR TITLE
feat(hooks): /btw context-shielded side-question command

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -67,7 +67,8 @@
           "refactor",
           "start-work",
           "stop-continuation",
-          "remove-ai-slops"
+          "remove-ai-slops",
+          "btw"
         ]
       }
     },

--- a/src/config/schema/commands.ts
+++ b/src/config/schema/commands.ts
@@ -9,6 +9,7 @@ export const BuiltinCommandNameSchema = z.enum([
   "start-work",
   "stop-continuation",
   "remove-ai-slops",
+  "btw",
 ])
 
 export type BuiltinCommandName = z.infer<typeof BuiltinCommandNameSchema>

--- a/src/features/builtin-commands/commands.test.ts
+++ b/src/features/builtin-commands/commands.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, test, expect } from "bun:test"
 import { loadBuiltinCommands } from "./commands"
 import { HANDOFF_TEMPLATE } from "./templates/handoff"
 import { REMOVE_AI_SLOPS_TEMPLATE } from "./templates/remove-ai-slops"
+import { BTW_TEMPLATE } from "./templates/btw"
 import type { BuiltinCommandName } from "./types"
 import { _resetForTesting, registerAgentName } from "../claude-code-session-state"
 
@@ -257,5 +258,62 @@ describe("HANDOFF_TEMPLATE", () => {
     //#when / #then
     const emojiRegex = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2702}-\u{27B0}\u{24C2}-\u{1F251}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/u
     expect(emojiRegex.test(HANDOFF_TEMPLATE)).toBe(false)
+  })
+})
+
+describe("loadBuiltinCommands - btw", () => {
+  test("should include btw command in loaded commands", () => {
+    //#given
+    const disabledCommands: BuiltinCommandName[] = []
+
+    //#when
+    const commands = loadBuiltinCommands(disabledCommands)
+
+    //#then
+    expect(commands.btw).toBeDefined()
+    expect(commands.btw.name).toBe("btw")
+  })
+
+  test("should exclude btw when disabled", () => {
+    //#given
+    const disabledCommands: BuiltinCommandName[] = ["btw"]
+
+    //#when
+    const commands = loadBuiltinCommands(disabledCommands)
+
+    //#then
+    expect(commands.btw).toBeUndefined()
+  })
+
+  test("should embed BTW_TEMPLATE inside btw command template", () => {
+    //#given - no disabled commands
+
+    //#when
+    const commands = loadBuiltinCommands()
+
+    //#then
+    expect(commands.btw.template).toContain(BTW_TEMPLATE)
+  })
+
+  test("should pass user arguments through a side-question slot", () => {
+    //#given - no disabled commands
+
+    //#when
+    const commands = loadBuiltinCommands()
+
+    //#then
+    expect(commands.btw.template).toContain("<side-question>")
+    expect(commands.btw.template).toContain("$ARGUMENTS")
+  })
+
+  test("should describe btw as a side-question command that does not pollute main flow", () => {
+    //#given - no disabled commands
+
+    //#when
+    const commands = loadBuiltinCommands()
+
+    //#then
+    expect(commands.btw.description).toContain("side question")
+    expect(commands.btw.description).toContain("does not pollute")
   })
 })

--- a/src/features/builtin-commands/commands.ts
+++ b/src/features/builtin-commands/commands.ts
@@ -8,6 +8,7 @@ import { REFACTOR_TEMPLATE } from "./templates/refactor"
 import { START_WORK_TEMPLATE } from "./templates/start-work"
 import { HANDOFF_TEMPLATE } from "./templates/handoff"
 import { REMOVE_AI_SLOPS_TEMPLATE } from "./templates/remove-ai-slops"
+import { BTW_TEMPLATE } from "./templates/btw"
 
 interface LoadBuiltinCommandsOptions {
   useRegisteredAgents?: boolean
@@ -120,6 +121,17 @@ Timestamp: $TIMESTAMP
 $ARGUMENTS
 </user-request>`,
       argumentHint: "[goal]",
+    },
+    btw: {
+      description: "(builtin) Ask a side question that does not pollute the main conversation or todo list",
+      template: `<command-instruction>
+${BTW_TEMPLATE}
+</command-instruction>
+
+<side-question>
+$ARGUMENTS
+</side-question>`,
+      argumentHint: "<question>",
     },
   }
 }

--- a/src/features/builtin-commands/templates/btw.test.ts
+++ b/src/features/builtin-commands/templates/btw.test.ts
@@ -1,0 +1,78 @@
+/// <reference path="../../../../bun-test.d.ts" />
+
+import { describe, test, expect } from "bun:test"
+import { BTW_TEMPLATE } from "./btw"
+
+describe("BTW_TEMPLATE", () => {
+  test("should declare its purpose as a side-question command", () => {
+    //#given - the template string
+
+    //#when / #then
+    expect(BTW_TEMPLATE).toContain("BTW Command")
+    expect(BTW_TEMPLATE).toContain("side question")
+  })
+
+  test("should forbid mutating the main todo list and task flow", () => {
+    //#given - the template string
+
+    //#when / #then
+    expect(BTW_TEMPLATE).toContain("MUST NOT be added to the active todo list")
+    expect(BTW_TEMPLATE).toContain("Do NOT add it to the existing todo list")
+    expect(BTW_TEMPLATE).toContain("DO NOT modify files, branches, or commits because of /btw")
+  })
+
+  test("should provide a usage hint for empty invocation", () => {
+    //#given - the template string
+
+    //#when / #then
+    expect(BTW_TEMPLATE).toContain("Usage: /btw <question>")
+  })
+
+  test("should instruct delegation to a fresh subagent session via task tool", () => {
+    //#given - the template string
+
+    //#when / #then
+    expect(BTW_TEMPLATE).toContain("DELEGATE TO A SEPARATE SESSION")
+    expect(BTW_TEMPLATE).toContain("task tool")
+    expect(BTW_TEMPLATE).toContain("run_in_background: false")
+  })
+
+  test("should recommend lightweight categories by default", () => {
+    //#given - the template string
+
+    //#when / #then
+    expect(BTW_TEMPLATE).toContain('"quick"')
+    expect(BTW_TEMPLATE).toContain('"unspecified-low"')
+  })
+
+  test("should require concise relayed output and a resume marker", () => {
+    //#given - the template string
+
+    //#when / #then
+    expect(BTW_TEMPLATE).toContain("Side answer (not added to main task):")
+    expect(BTW_TEMPLATE).toContain("Resuming main task.")
+  })
+
+  test("should allow direct answer for trivial questions without delegation", () => {
+    //#given - the template string
+
+    //#when / #then
+    expect(BTW_TEMPLATE).toContain("answer directly without delegation")
+  })
+
+  test("should not contain emojis", () => {
+    //#given - the template string
+
+    //#when / #then
+    const emojiRegex = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2702}-\u{27B0}\u{24C2}-\u{1F251}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/u
+    expect(emojiRegex.test(BTW_TEMPLATE)).toBe(false)
+  })
+
+  test("should not use em or en dashes", () => {
+    //#given - the template string
+
+    //#when / #then
+    expect(BTW_TEMPLATE).not.toContain("\u2014")
+    expect(BTW_TEMPLATE).not.toContain("\u2013")
+  })
+})

--- a/src/features/builtin-commands/templates/btw.ts
+++ b/src/features/builtin-commands/templates/btw.ts
@@ -1,0 +1,117 @@
+export const BTW_TEMPLATE = `# BTW Command
+
+## Purpose
+
+Use /btw when:
+- The user has a quick side question that should not pollute the main conversation
+- The user wants a fast answer without derailing the current task or todo list
+- The user wants the answer to be reasoned out in a separate context, then summarized back
+
+The side question MUST NOT be added to the active todo list, plan, or main task tracking. After answering, the main task flow continues unchanged.
+
+---
+
+# PHASE 0: VALIDATE REQUEST
+
+Before proceeding, confirm:
+- [ ] The user provided a non-empty question after /btw
+- [ ] The question is a side question, not a redefinition of the main task
+
+If the arguments are empty or only whitespace, respond with a short usage hint and stop:
+
+\`\`\`
+Usage: /btw <question>
+Example: /btw what does this regex match?
+\`\`\`
+
+Do NOT create todos, do NOT modify plans, do NOT touch the working tree for an empty /btw invocation.
+
+---
+
+# PHASE 1: ISOLATE THE SIDE QUESTION
+
+The side question is the verbatim user input below. Treat it as an isolated request:
+
+- Do NOT add it to the existing todo list
+- Do NOT mark any current todo as in_progress, completed, or cancelled because of it
+- Do NOT change branch, files, or build state because of it
+- Do NOT use it to revise the main task interpretation
+
+Capture the side question exactly as written.
+
+---
+
+# PHASE 2: DELEGATE TO A SEPARATE SESSION
+
+Delegate the side question to a fresh subagent session so the main session context stays clean.
+
+Use the task tool with these parameters:
+- category: "quick" for short factual or local code questions; "unspecified-low" for slightly broader questions; "deep" only when the user explicitly asks for thorough investigation
+- run_in_background: false (the user is waiting for a synchronous answer)
+- load_skills: [] unless a skill clearly matches the question domain
+- description: short label like "Side question: <topic>"
+- prompt: a self-contained prompt that includes:
+  - The verbatim side question
+  - A directive that this is an isolated side question with no side effects
+  - Required output format (concise direct answer, no preamble, no flattery)
+  - Forbidden actions: do not commit, do not edit files, do not create todos
+
+Suggested prompt skeleton:
+
+\`\`\`
+This is an isolated side question. Do not modify files, do not commit,
+do not create todos, do not run long-running tasks. Read-only investigation
+is allowed. Answer concisely.
+
+Side question (verbatim):
+<verbatim user question>
+
+Output format:
+- One short answer first (1-3 sentences when possible)
+- Then up to 5 bullet points of supporting detail if useful
+- No preamble, no apologies, no follow-up offers
+\`\`\`
+
+If the question is trivially answerable from existing knowledge with no exploration needed, you MAY answer directly without delegation. In that case, still keep the answer short and skip todo updates.
+
+---
+
+# PHASE 3: RELAY THE ANSWER
+
+When the subagent returns:
+
+- Forward the answer to the user as-is, lightly trimmed of any duplicated preamble
+- Prefix the answer with a single line: \`Side answer (not added to main task):\`
+- Do not summarize the delegation process itself
+- Do not add a "let me know if you want me to" closer
+
+---
+
+# PHASE 4: RETURN TO MAIN TASK
+
+After the answer is delivered, on a new line append exactly:
+
+\`\`\`
+Resuming main task.
+\`\`\`
+
+Do not restart, replan, or summarize the main task unless the user explicitly asks. The main todo list and plan remain untouched.
+
+---
+
+# IMPORTANT CONSTRAINTS
+
+- DO NOT add the side question to the todo list
+- DO NOT modify files, branches, or commits because of /btw
+- DO NOT run long background tasks for /btw
+- DO NOT echo the original side question back unless quoting briefly is necessary
+- DO keep the answer focused and short by default
+- DO use task delegation when the question requires any non-trivial investigation
+- DO answer directly without delegation only when the question is trivial
+
+---
+
+# EXECUTE NOW
+
+Read the user request below as the side question. Validate, delegate when needed, relay the answer, then resume the main task.
+`

--- a/src/features/builtin-commands/types.ts
+++ b/src/features/builtin-commands/types.ts
@@ -1,6 +1,6 @@
 import type { CommandDefinition } from "../claude-code-command-loader"
 
-export type BuiltinCommandName = "init-deep" | "ralph-loop" | "cancel-ralph" | "ulw-loop" | "refactor" | "start-work" | "stop-continuation" | "handoff" | "remove-ai-slops"
+export type BuiltinCommandName = "init-deep" | "ralph-loop" | "cancel-ralph" | "ulw-loop" | "refactor" | "start-work" | "stop-continuation" | "handoff" | "remove-ai-slops" | "btw"
 
 export interface BuiltinCommandConfig {
   disabled_commands?: BuiltinCommandName[]


### PR DESCRIPTION
## Summary

Add a builtin slash command `/btw <question>` for asking a quick side question without dragging the question text, the assistant chain-of-thought, or any tool calls into the main session context. Implemented as a `chat.message` hook (`btw-isolation`) that runs the question in a fresh child session under the parent and rewrites the parent's outgoing user message to a single short answer line.

## What this PR does NOT promise

OpenCode core does not currently expose a way to send a chat turn that leaves zero footprint on the parent session (closed `anomalyco/opencode#25615`, open issue `#4489` track this). So this PR cannot make `/btw` truly invisible. What it does:

- The user's verbatim `/btw` question text and the full BTW template body do **not** reach the parent transcript and do **not** reach the parent's model context.
- All reasoning, tool calls, and intermediate assistant turns happen in a child session that is referenced from the parent only via `parentID` (no metadata link is published into parent tool output).
- The parent transcript still contains a single short user message of the form `Side answer (not added to main task):\n<answer>` so the user can read the result. That short line is the smallest footprint achievable at the plugin layer today.

A follow-up `anomalyco/opencode` PR could remove even that line by adding ephemeral message support to OpenCode core. This PR is the plugin-side half of that story.

## Behavior

**Layer 1: Builtin command** (`src/features/builtin-commands/templates/btw.ts`)

- Registers `/btw <question>` with `argumentHint: "<question>"` and a `<side-question>$ARGUMENTS</side-question>` arg slot.
- Template starts with the marker `<!-- omo:btw-isolation v1 -->` so the hook can detect it. Body is a slim fallback instruction set so the command still works in advisory mode when the hook is disabled via `disabled_hooks`.

**Layer 2: chat.message hook** (`src/hooks/btw-isolation/`)

When the hook fires for the parent session:

1. **Re-entrance guard**: skip if the current `sessionID` is in `subagentSessions` (so child-session prompts triggered by the hook itself never recurse).
2. **Detect**: scan `output.parts` for the marker and extract the verbatim `<side-question>` content. Bail if not present.
3. **Spawn**: call `createSyncSession` to allocate a fresh child session under the parent. Mark `subagentSessions.add(childID)` BEFORE issuing the prompt so any chat.message handlers that fire for the child early-return via subagent gating.
4. **Inherit model**: forward `input.model` (or `getSessionModel(parentSessionID)` as a fallback) into the child prompt body, so the child runs on the same provider/model as the parent rather than the workspace default.
5. **Run**: call `client.session.prompt` on the child with an isolation system prompt that forbids file/commit/todo edits and asks for a concise answer. Poll until `isSessionComplete` is true (or 120s timeout).
6. **Fetch**: read only the final assistant text via `fetchSyncResult`.
7. **Rewrite parent**: mutate `output.parts[i].text` in place (preserving any opaque OpenCode metadata such as `id` / `sessionID` / `messageID`) so the parent message becomes `Side answer (not added to main task):\n<answer>`. On any failure, replace with a short failure note so the raw template body never reaches the model or the transcript.
8. **Clean up**: remove `childID` from `subagentSessions` and fire-and-forget delete the child session.

**Layer 3: Wiring**

- Hook registered in `create-transform-hooks.ts` alongside `keywordDetector`.
- Invoked in `plugin/chat-message.ts` BEFORE `claudeCodeHooks`, so the on-disk JSONL transcript written by `claude-code-hooks` captures the sanitized text rather than the original `/btw` payload.
- `btw-isolation` added to `HookNameSchema` so users can disable the hook via `disabled_hooks: [\"btw-isolation\"]`. With the hook off, `/btw` falls back to the prompt-only template (advisory mode).

## What this fixes vs the prompt-only design

| Concern | Prompt-only template | This PR (hook) |
|---|---|---|
| Verbatim user question in parent transcript | yes (full /btw text) | no (replaced with short answer) |
| Assistant chain-of-thought in parent context | yes (LLM reasons in main session) | no (reasoning lives in child session) |
| Tool calls / probes recorded in parent | yes | no (only in child session) |
| Parent token cost for reasoning | full | only the short answer |
| Delegation enforcement | advisory (LLM may inline) | enforced by plugin code |
| Final short answer line in parent | yes | yes (single line, see 'What this PR does NOT promise') |

## Files

**New** (5):

- `src/hooks/btw-isolation/detect.ts` — marker detection + side-question extraction
- `src/hooks/btw-isolation/detect.test.ts`
- `src/hooks/btw-isolation/child-session.ts` — spawn / prompt / poll / fetch / cleanup, with parent-model forwarding
- `src/hooks/btw-isolation/index.ts` — `createBtwIsolationHook` factory + parent-message rewrite logic (in-place mutation)
- `src/hooks/btw-isolation/index.test.ts` — covers success / failure / no-marker passthrough / re-entrance guard / multi-line preservation / model inheritance / metadata preservation

**Modified** (8):

- `src/features/builtin-commands/templates/btw.ts` — prepend `BTW_HOOK_MARKER`, slim down the template to fallback instructions
- `src/features/builtin-commands/templates/btw.test.ts`
- `src/features/builtin-commands/types.ts` — extend `BuiltinCommandName` with `\"btw\"`
- `src/features/builtin-commands/commands.ts` — register `btw` definition
- `src/features/builtin-commands/commands.test.ts`
- `src/config/schema/commands.ts` — add `\"btw\"` to `BuiltinCommandNameSchema`
- `src/config/schema/hooks.ts` — add `\"btw-isolation\"` to `HookNameSchema`
- `src/hooks/index.ts` — barrel export
- `src/plugin/chat-message.ts` — invoke hook before keyword-detector / claude-code-hooks
- `src/plugin/hooks/create-transform-hooks.ts` — register hook in `TransformHooks`
- `assets/oh-my-opencode.schema.json` — regenerated via `bun run build:schema`

## Verification

- `bun run typecheck` clean
- `bun run build` succeeds (ESM + CLI + schema)
- `bun test` — 5953 pass / 0 fail at the time of the initial hook commit
- Manual end-to-end test: `/btw` invocation triggers child session creation under the parent, child session runs on the inherited model, parent transcript receives only the short side-answer line

## PR Checklist

- [x] Code follows project conventions (kebab-case files, factory pattern, barrel exports, no `as any` / `@ts-ignore`)
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] No version changes in `package.json`
- [x] No `bun publish` invoked
- [x] No emojis added
- [x] No em / en dashes used in generated content
- [x] Tested locally