### PR TITLE
docs(readme): rebrand Sisyphus Labs banner to Dori across all languages

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,7 +12,7 @@
 > [!NOTE]
 >
 > [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)
-> > **私たちは、フロンティアエージェントの未来を定義するために、Sisyphus の完全なプロダクト版を構築しています。 <br />[こちら](https://sisyphuslabs.ai) からウェイトリストにご登録ください。**
+> > **OmO は上記の Jobdori によってメンテナンスされています。あなた専用の Jobdori、Dori に会いましょう。 <br />[こちら](https://sisyphuslabs.ai) からウェイトリストにご登録ください。**
 
 > [!TIP]
 > 私たちと一緒に！

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
 > [!NOTE]
 >
 > [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)
-> > **Sisyphus를 완성형 프로덕트로 만들어 프론티어 에이전트의 미래를 정의하고 있습니다. <br />대기 명단은 [여기](https://sisyphuslabs.ai)에서 받습니다.**
+> > **OmO는 위의 Jobdori에 의해 메인테이닝되고 있습니다. 당신의 Jobdori, Dori를 만나세요. <br />대기 명단은 [여기](https://sisyphuslabs.ai)에서 받습니다.**
 
 > [!TIP]
 > 함께해요!

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 > [!NOTE]
 >
 > [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)
-> > **We're building the full product version of Sisyphus to define the future of frontier agents. <br />Join the waitlist [here](https://sisyphuslabs.ai).**
+> > **OmO is maintained by Jobdori, the AI assistant shown above. Meet your own Jobdori — Dori. <br />Join the waitlist [here](https://sisyphuslabs.ai).**
 
 > [!TIP]
 > Be with us!

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@
 >
 > [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)
 >
-> > **Мы создаём полноценную продуктовую версию Sisyphus, чтобы задать стандарты для frontier-агентов. <br />Присоединяйтесь к листу ожидания [здесь](https://sisyphuslabs.ai).**
+> > **OmO поддерживается Jobdori — ИИ-ассистентом, показанным выше. Познакомьтесь со своим Jobdori — Dori. <br />Присоединяйтесь к листу ожидания [здесь](https://sisyphuslabs.ai).**
 
 > [!TIP] Будьте с нами!
 >

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -12,7 +12,7 @@
 > [!NOTE]
 >
 > [![Sisyphus Labs - Sisyphus is the agent that codes like your team.](./.github/assets/sisyphuslabs.png?v=2)](https://sisyphuslabs.ai)
-> > **我们正在构建 Sisyphus 的完全产品化版本，以定义前沿智能体 (Frontier Agents) 的未来。<br />[在此处](https://sisyphuslabs.ai)加入候补名单。**
+> > **OmO 由上述的 Jobdori 进行维护。认识你专属的 Jobdori — Dori。<br />[在此处](https://sisyphuslabs.ai)加入等待名单。**
 
 > [!TIP]
 > 加入我们！


### PR DESCRIPTION
Replaces the old Sisyphus waitlist messaging with the Dori rebrand across all 5 README files (en, ko, ja, ru, zh-cn).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the waitlist note under the README banner to Dori/Jobdori branding across all five languages (en, ko, ja, ru, zh-cn). Aligns docs with the Dori rebrand while keeping the same waitlist link.

<sup>Written for commit 44de4c531bcf9afe36a76e0cb2840c6dc01b9a1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

