### PR TITLE
docs(readme): add Vercel to adopters list

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -390,6 +390,7 @@ OpenCode が Debian/Arch だとすれば、oh-my-openagent は Ubuntu/[Omarchy](
   - インフルエンサーマーケティングソリューション Spray、クロスボーダーコマースプラットフォーム vovushop、AI コマースレビューマーケティングソリューション vreview の開発元。
 - [Google](https://google.com)
 - [Microsoft](https://microsoft.com)
+- [Vercel](https://vercel.com)
 - [ELESTYLE](https://elestyle.jp)
   - マルチモバイル決済ゲートウェイ elepay、キャッシュレスソリューション向けモバイルアプリケーション SaaS OneQR の開発元。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -391,6 +391,7 @@ OpenCode가 Debian/Arch라면, oh-my-openagent는 Ubuntu/[Omarchy](https://omarc
   - Spray(인플루언서 마케팅 솔루션), vovushop(크로스보더 커머스 플랫폼), vreview(AI 커머스 리뷰 마케팅 솔루션) 개발사.
 - [Google](https://google.com)
 - [Microsoft](https://microsoft.com)
+- [Vercel](https://vercel.com)
 - [ELESTYLE](https://elestyle.jp)
   - elepay(멀티 모바일 결제 게이트웨이), OneQR(캐시리스 솔루션용 모바일 앱 SaaS) 개발사.
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ No affiliation with any project or model mentioned. Just personal experimentatio
   - Makers of Spray (influencer marketing solution), vovushop (cross-border commerce platform), and vreview (AI commerce review marketing solution).
 - [Google](https://google.com)
 - [Microsoft](https://microsoft.com)
+- [Vercel](https://vercel.com)
 - [ELESTYLE](https://elestyle.jp)
   - Makers of elepay (multi-mobile payment gateway) and OneQR (mobile application SaaS for cashless solutions).
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -393,6 +393,7 @@ project/
   - Создатели Spray (решение для influencer-маркетинга), vovushop (платформа трансграничной торговли) и vreview (AI-решение для маркетинга отзывов в commerce).
 - [Google](https://google.com)
 - [Microsoft](https://microsoft.com)
+- [Vercel](https://vercel.com)
 - [ELESTYLE](https://elestyle.jp)
   - Создатели elepay (мультимобильный платёжный шлюз) и OneQR (мобильное SaaS-приложение для безналичных расчётов).
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -390,6 +390,7 @@ Agent 会自动顺藤摸瓜加载对应的 Context，免去了你所有的手动
   - 开发了 Spray（意见领袖营销系统）、vovushop（跨境电商独立站）、vreview（AI 赋能的电商买家秀营销解决方案）。
 - [Google](https://google.com)
 - [Microsoft](https://microsoft.com)
+- [Vercel](https://vercel.com)
 - [ELESTYLE](https://elestyle.jp)
   - 开发了 elepay（全渠道移动支付网关）、OneQR（专为无现金社会打造的移动 SaaS 生态系统）。
 


### PR DESCRIPTION
Adds Vercel to the adopters section across all 5 README files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Vercel to the adopters list across all five README translations (EN, JA, KO, RU, ZH) to keep the list consistent and up to date.

<sup>Written for commit 35426eb2ff99952cd38574632f98c75f0efe2d03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

