### PR TITLE
fix(doctor): extract semver from OpenCode binary stdout (fixes #3765)

### DIFF
--- a/src/cli/doctor/checks/system-binary.test.ts
+++ b/src/cli/doctor/checks/system-binary.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { compareVersions } from "./system-binary"
+
+describe("compareVersions", () => {
+	describe("#given numeric semver inputs", () => {
+		test("#then 1.14.33 is recognized as >= 1.4.0", () => {
+			expect(compareVersions("1.14.33", "1.4.0")).toBe(true)
+		})
+
+		test("#then 1.4.0 satisfies 1.4.0", () => {
+			expect(compareVersions("1.4.0", "1.4.0")).toBe(true)
+		})
+
+		test("#then 1.3.99 fails 1.4.0", () => {
+			expect(compareVersions("1.3.99", "1.4.0")).toBe(false)
+		})
+	})
+
+	describe("#given OpenCode Desktop log-style stdout containing the version", () => {
+		test("#then the embedded 1.14.33 is extracted and compared correctly (fixes #3765)", () => {
+			const desktopOutput = "00:24:25.202 > app starting { version: '1.14.33', packaged: true }"
+			expect(compareVersions(desktopOutput, "1.4.0")).toBe(true)
+		})
+
+		test("#then a multi-line log containing only the version is handled", () => {
+			const multiline = "Some preamble\nopencode 1.14.33\nMore text"
+			expect(compareVersions(multiline, "1.4.0")).toBe(true)
+		})
+	})
+})

--- a/src/cli/doctor/checks/system-binary.ts
+++ b/src/cli/doctor/checks/system-binary.ts
@@ -119,13 +119,18 @@ export async function getOpenCodeVersion(
   }
 }
 
+const SEMVER_PATTERN = /\b(\d+\.\d+\.\d+)\b/
+
+export function extractSemverFromOutput(output: string): string | null {
+  const match = output.match(SEMVER_PATTERN)
+  return match ? match[1] : null
+}
+
 export function compareVersions(current: string, minimum: string): boolean {
-  const parseVersion = (version: string): number[] =>
-    version
-      .replace(/^v/, "")
-      .split("-")[0]
-      .split(".")
-      .map((part) => Number.parseInt(part, 10) || 0)
+  const parseVersion = (version: string): number[] => {
+    const semver = extractSemverFromOutput(version) ?? version.replace(/^v/, "").split("-")[0]
+    return semver.split(".").map((part) => Number.parseInt(part, 10) || 0)
+  }
 
   const currentParts = parseVersion(current)
   const minimumParts = parseVersion(minimum)


### PR DESCRIPTION
## Summary
The `doctor` check incorrectly flagged OpenCode 1.14.x as below the required minimum 1.4.0 because `getOpenCodeVersion` returned the entire stdout (which for OpenCode Desktop is a startup log line, not a clean version string). `compareVersions` then parsed the log line as a version, splitting on `.` and reading parts like `00`, `24`, `25`.

## Root Cause
`src/cli/doctor/checks/system-binary.ts`:
- `getOpenCodeVersion` returns `result.stdout.trim()` directly
- For OpenCode Desktop (Windows in #3765), the binary writes lines like `00:24:25.202 > app starting { version: '1.14.33', packaged: true }` to stdout
- `compareVersions` then runs `parseInt("00", 10)` → 0 → `0 < 1` → returns `false`
- The reporter assumed it was lexicographic comparison, but the underlying numeric compare is correct; the bug is in the parser's input.

## Changes
| File | Change |
|------|--------|
| `src/cli/doctor/checks/system-binary.ts` | Add `extractSemverFromOutput()` that scans stdin for the first `\d+\.\d+\.\d+` token; `parseVersion` now prefers that match before falling back to the legacy v-prefix strip |
| `src/cli/doctor/checks/system-binary.test.ts` | New regression suite: 5 tests covering plain semver inputs, OpenCode Desktop log-style stdout (`00:24:25.202 > app starting { version: '1.14.33', packaged: true }`), and multi-line stdout |

## Reproduction (before fix)
```
(fail) compareVersions > #given OpenCode Desktop log-style stdout containing the version > #then the embedded 1.14.33 is extracted and compared correctly (fixes #3765)
expect(received).toBe(expected)
Expected: true
Received: false
 3 pass
 2 fail
```

## Verification (after fix)
```
bun test src/cli/doctor/checks/system-binary.test.ts
 5 pass
 0 fail
 5 expect() calls

bun test src/cli/doctor/checks/system.test.ts
 6 pass
 0 fail
 8 expect() calls

bun run typecheck
 (clean)
```

## Test
- New regression suite: `src/cli/doctor/checks/system-binary.test.ts` (5 cases)
- Related suite: `bun test src/cli/doctor/checks/system.test.ts` — 6 pass
- Typecheck: `bun run typecheck` — clean

Fixes #3765

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in the doctor check by extracting the first semver from OpenCode binary stdout before comparison, preventing 1.14.x from being flagged as below the 1.4.0 minimum (fixes #3765).

- **Bug Fixes**
  - Added `extractSemverFromOutput` to scan stdout for the first `x.y.z` token and use it for comparisons, with a legacy fallback.
  - Added a small regression suite for plain semver, log-style, and multi-line stdout; all tests pass.

<sup>Written for commit 5a5ce21151df0193b26f5253b073e04f5d79c958. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

