### PR TITLE
fix(posthog): disable feature flags, remove plugin_loaded for billing optimization

### DIFF
--- a/src/cli/cli-installer.telemetry.test.ts
+++ b/src/cli/cli-installer.telemetry.test.ts
@@ -39,8 +39,6 @@ describe("runCliInstaller telemetry isolation", () => {
     mock.module("../shared/posthog", () => ({
       createCliPostHog: mock(() => ({
         trackActive: mock(() => {}),
-        capture: mock(() => {}),
-        captureException: mock(() => {}),
         shutdown: mock(async () => {
           throw new Error("shutdown failed")
         }),

--- a/src/index.telemetry.test.ts
+++ b/src/index.telemetry.test.ts
@@ -30,14 +30,6 @@ const mockCreateHooks = mock(() => ({
   claudeCodeHooks: undefined,
 }))
 const mockCreatePluginInterface = mock(() => ({}))
-const mockCreatePluginPostHog = mock(() => ({
-  trackActive: () => {
-    throw new Error("telemetry failed")
-  },
-  shutdown: mock(async () => {}),
-}))
-const mockGetPostHogDistinctId = mock(() => "plugin-distinct-id")
-
 function installModuleMocks(): void {
   mock.module("./cli/config-manager/config-context", () => ({
     initConfigContext: mockInitConfigContext,
@@ -97,10 +89,6 @@ function installModuleMocks(): void {
       releaseClient: mock(() => {}),
       cleanupTempDirectoryClients: mock(async () => {}),
     },
-  }))
-  mock.module("./shared/posthog", () => ({
-    createPluginPostHog: mockCreatePluginPostHog,
-    getPostHogDistinctId: mockGetPostHogDistinctId,
   }))
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import { injectServerAuthIntoClient, log, logLegacyPluginStartupWarning } from "
 import { installAgentSortShim } from "./shared/agent-sort-shim"
 import { detectExternalSkillPlugin, getSkillPluginConflictWarning } from "./shared/external-plugin-detector"
 import { startBackgroundCheck as startTmuxCheck } from "./tools/interactive-bash"
-import { createPluginPostHog, getPostHogDistinctId } from "./shared/posthog"
 
 const serverPlugin: Plugin = async (input, _options): Promise<Hooks> => {
   installAgentSortShim()
@@ -36,13 +35,6 @@ const serverPlugin: Plugin = async (input, _options): Promise<Hooks> => {
 
   const pluginConfig = loadPluginConfig(input.directory, input)
 
-  const posthog = createPluginPostHog()
-  const distinctId = getPostHogDistinctId()
-  try {
-    posthog.trackActive(distinctId, "plugin_loaded")
-  } catch {
-    // telemetry failure is non-fatal, silently ignore
-  }
   if (pluginConfig.openclaw) {
     await initializeOpenClaw(pluginConfig.openclaw)
   }

--- a/src/shared/posthog.test.ts
+++ b/src/shared/posthog.test.ts
@@ -67,7 +67,7 @@ describe("posthog client creation", () => {
     expect(() => cliPostHog.trackActive("cli", "run_started")).not.toThrow()
     await expect(cliPostHog.shutdown()).resolves.toBeUndefined()
 
-    expect(() => pluginPostHog.trackActive("plugin", "plugin_loaded")).not.toThrow()
+    expect(() => pluginPostHog.trackActive("plugin", "run_started")).not.toThrow()
     await expect(pluginPostHog.shutdown()).resolves.toBeUndefined()
   })
 
@@ -104,8 +104,43 @@ describe("posthog client creation", () => {
     const pluginPostHog = createPluginPostHog()
 
     // then
-    expect(() => pluginPostHog.trackActive("plugin", "plugin_loaded")).not.toThrow()
+    expect(() => pluginPostHog.trackActive("plugin", "run_started")).not.toThrow()
     await expect(pluginPostHog.shutdown()).resolves.toBeUndefined()
+  })
+
+  it("passes the strict PostHog constructor options for both clients", async () => {
+    // given
+    enableTelemetryEnv()
+    const capturedOptions: Array<Record<string, unknown>> = []
+
+    mock.module("posthog-node", () => ({
+      PostHog: class {
+        constructor(_apiKey: string, options: Record<string, unknown>) {
+          capturedOptions.push(options)
+        }
+        capture() {}
+        async shutdown() {}
+      },
+    }))
+
+    const { createCliPostHog, createPluginPostHog } = await importPostHogModule()
+
+    // when
+    createCliPostHog()
+    createPluginPostHog()
+
+    // then
+    expect(capturedOptions).toHaveLength(2)
+    for (const options of capturedOptions) {
+      expect(options).toMatchObject({
+        enableExceptionAutocapture: false,
+        enableLocalEvaluation: false,
+        strictLocalEvaluation: true,
+        disableRemoteConfig: true,
+        flushAt: 1,
+        flushInterval: 0,
+      })
+    }
   })
 })
 
@@ -170,7 +205,7 @@ describe("posthog trackActive emission contract", () => {
     const client = posthogModule.createPluginPostHog()
 
     // when
-    client.trackActive("distinct-plugin", "plugin_loaded")
+    client.trackActive("distinct-plugin", "run_started")
 
     // then
     expect(captured).toHaveLength(0)

--- a/src/shared/posthog.ts
+++ b/src/shared/posthog.ts
@@ -29,7 +29,7 @@ const DEFAULT_POSTHOG_API_KEY = "phc_CFJhj5HyvA62QPhvyaUCtaq23aUfznnijg5VaaGkNk7
 
 type PostHogCaptureEvent = Parameters<PostHog["capture"]>[0]
 type PostHogSource = "cli" | "plugin"
-type PostHogActivityReason = "run_started" | "plugin_loaded"
+type PostHogActivityReason = "run_started"
 
 type PostHogClient = {
   trackActive: (distinctId: string, reason: PostHogActivityReason) => void
@@ -151,6 +151,9 @@ export function getPostHogDistinctId(): string {
 export function createCliPostHog(): PostHogClient {
   return createPostHogClient("cli", {
     enableExceptionAutocapture: false,
+    enableLocalEvaluation: false,
+    strictLocalEvaluation: true,
+    disableRemoteConfig: true,
     flushAt: 1,
     flushInterval: 0,
   })
@@ -159,6 +162,9 @@ export function createCliPostHog(): PostHogClient {
 export function createPluginPostHog(): PostHogClient {
   return createPostHogClient("plugin", {
     enableExceptionAutocapture: false,
+    enableLocalEvaluation: false,
+    strictLocalEvaluation: true,
+    disableRemoteConfig: true,
     flushAt: 1,
     flushInterval: 0,
   })


### PR DESCRIPTION
## Problem

PostHog first bill estimate: **$1,200.50/month** — unsustainable for an OSS side project.

### Root causes (30-day analysis via PostHog HogQL):
- `plugin_loaded`: **2,831,211 events (46.5%)** — fired every plugin init
- Feature flag `/decide` API calls: **~$960+** estimated (not visible in event DB)
- `$exception`: **232,097 events** — despite `enableExceptionAutocapture: false`

## Changes

### 1. Remove `plugin_loaded` telemetry entirely
- Removed `createPluginPostHog()` + `trackActive(distinctId, "plugin_loaded")` from `src/index.ts`
- Removed `"plugin_loaded"` from `PostHogActivityReason` type
- **Impact: -2.83M events/month**

### 2. Disable feature flag requests
- Added `enableLocalEvaluation: false` — prevents feature flag poller from starting
- Added `strictLocalEvaluation: true` — prevents server fallback for flags
- Added `disableRemoteConfig: true` — prevents remote config network calls
- **Impact: eliminates all `/decide` API billing**

### 3. Exception autocapture
- `enableExceptionAutocapture: false` already present (kept explicit)

### Preserved events
- `omo_daily_active` (MAU/DAU tracking)
- `run_started` (CLI usage tracking)
- `install_completed`, `install_failed` (if added later)

## Tests
- 14 tests pass, 0 fail
- New test: verifies SDK constructor options include all billing-safe flags
- Updated stale mocks (`captureException`, `plugin_loaded` references)
- `bun run typecheck` + `bun run build` pass

## Estimated savings
- Events: **-3M+/month** (~50% reduction)
- Cost: **-$960+/month** from feature flag requests alone

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable PostHog feature flag/remote config requests and remove the noisy `plugin_loaded` event to cut telemetry cost while keeping essential tracking.

- **Refactors**
  - Removed `plugin_loaded` emission and its type; deleted usage in `src/index.ts`.
  - Disabled all flag/remote config traffic via PostHog options: `enableLocalEvaluation: false`, `strictLocalEvaluation: true`, `disableRemoteConfig: true` (kept `enableExceptionAutocapture: false`).
  - Tests: cleaned stale mocks and added a test that asserts the strict constructor options.
  - Impact: ~2.83M fewer events/month and elimination of `/decide` calls (~$960+/month).

<sup>Written for commit 8586cb89657812b1950734f76d4e6e13195c8089. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

