### PR TITLE
fix(desktop): hide bun:sqlite import from Node.js/Electron ESM loader

### DIFF
--- a/src/plugin/ultrawork-db-model-override.bun-sqlite-unavailable.test.ts
+++ b/src/plugin/ultrawork-db-model-override.bun-sqlite-unavailable.test.ts
@@ -13,7 +13,9 @@ describe("scheduleDeferredModelOverride bun:sqlite unavailable", () => {
 
     //#then
     expect(hasStaticBunSqliteImport).toBe(false)
-    expect(source).toContain('await import("bun:sqlite").catch(() => null)')
+    // new Function() hides the bun: import from Node.js/Electron static ESM loader
+    expect(source).toContain("new Function(\"return import('bun:sqlite')\")")
+    expect(source).toContain("typeof globalThis.Bun === \"undefined\"")
     expect(source).toContain("bun:sqlite unavailable")
     expect(source).toContain("return")
   })

--- a/src/plugin/ultrawork-db-model-override.ts
+++ b/src/plugin/ultrawork-db-model-override.ts
@@ -5,6 +5,24 @@ import { log } from "../shared"
 
 type BunDatabase = import("bun:sqlite").Database
 
+/**
+ * Safely import bun:sqlite only when running in Bun runtime.
+ * Uses new Function() to hide the import from Node.js/Electron's static parser,
+ * which would fail on bun: protocol resolution before .catch() could run.
+ */
+async function importBunSqlite(): Promise<typeof import("bun:sqlite") | null> {
+  if (typeof globalThis.Bun === "undefined") {
+    return null
+  }
+  try {
+    // new Function() prevents Node.js ESM loader from seeing the bun: import at parse time
+    const dynamicImport = new Function("return import('bun:sqlite')") as () => Promise<typeof import("bun:sqlite")>
+    return await dynamicImport()
+  } catch {
+    return null
+  }
+}
+
 function getDbPath(): string {
   return join(getDataDir(), "opencode", "opencode.db")
 }
@@ -114,7 +132,7 @@ export function scheduleDeferredModelOverride(
   variant?: string,
 ): void {
   queueMicrotask(async () => {
-    const sqliteModule = await import("bun:sqlite").catch(() => null)
+    const sqliteModule = await importBunSqlite()
     const Database = sqliteModule?.Database
     if (typeof Database !== "function") {
       log("[ultrawork-db-override] bun:sqlite unavailable, skipping deferred override", { messageId })


### PR DESCRIPTION
## Problem

OpenCode Desktop (Electron/Node.js runtime) fails to load the plugin because `bun:sqlite` is imported with a static protocol that Node.js' ESM loader cannot resolve.

Error from Electron logs:
```
Only URLs with a scheme in: file, data, node, and electron are supported by the default ESM loader. Received protocol 'bun:'
```

## Root Cause

`await import('bun:sqlite').catch(() => null)` looks safe, but **Node.js's static ESM loader fails during module resolution** before the `.catch()` can run. The Bun protocol is unknown to Node.js.

OpenCode CLI ✅ (Bun runtime)
OpenCode Desktop ❌ (Electron/Node.js runtime)

## Solution

Wrap the import in `new Function("return import('bun:sqlite')")` which:
1. **Hides the import specifier from the static ESM parser** at parse/load time
2. **Only evaluates at runtime** when called inside a Bun environment
3. **Returns `null` gracefully** when `globalThis.Bun` is undefined (Node.js/Electron)
4. **Fully backward-compatible** with existing Bun CLI behavior

## Changes

- `src/plugin/ultrawork-db-model-override.ts`: Replaced `await import('bun:sqlite')` with `importBunSqlite()` helper using `new Function()` pattern
- `src/plugin/ultrawork-db-model-override.bun-sqlite-unavailable.test.ts`: Updated test expectations to verify the new pattern

## Verification

- Build passes: `bun run build` ✅
- Test passes: `bun test src/plugin/ultrawork-db-model-override.bun-sqlite-unavailable.test.ts` ✅ (5 assertions)
- Bundle inspection: `grep -c 'bun:' dist/index.js` = 2 occurrences, both inside `new Function("return import('bun:sqlite')")` string ✅

## Fixes

- Fixes #3829 (Desktop Electron incompatibility)
- Likely fixes #3762 (Plugin not loading in OpenCode 1.14.32)

## Related Issues

- #3475 (bun:sqlite import incompatible with OpenCode embedded JS runtime)
- #3794 (After updating OMO, the OpenCode agent list does not display OMO agents)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin load failures in Desktop by hiding the `bun:sqlite` import from Node/Electron’s static ESM loader. Desktop now skips the DB override when Bun isn’t available, avoiding runtime errors.

- **Bug Fixes**
  - Replaced direct `await import('bun:sqlite')` with an `importBunSqlite()` helper that uses `new Function("return import('bun:sqlite')")` and a `globalThis.Bun` guard.
  - Updated test to assert no static `bun:` import and to verify the runtime guard behavior.

<sup>Written for commit 3a93a40e683bf772556c9fcf4edcd454d18ab115. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

