### PR TITLE
fix(cli): require semver in opencode --version stdout (fixes #3766)

### DIFF
--- a/src/cli/config-manager/opencode-binary.test.ts
+++ b/src/cli/config-manager/opencode-binary.test.ts
@@ -1,0 +1,105 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+
+import * as spawnHelpers from "../../shared/spawn-with-windows-hide"
+import * as configContext from "./config-context"
+
+type OpenCodeBinaryModule = typeof import("./opencode-binary")
+
+type CreateProcOptions = {
+	exitCode?: number | null
+	exited?: Promise<number>
+	stdout?: string
+	stderr?: string
+}
+
+function createProc(options: CreateProcOptions = {}): ReturnType<typeof spawnHelpers.spawnWithWindowsHide> {
+	const exitCode = options.exitCode ?? 0
+
+	return {
+		exited: options.exited ?? Promise.resolve(exitCode),
+		exitCode,
+		stdout: options.stdout !== undefined ? new Blob([options.stdout]).stream() : undefined,
+		stderr: options.stderr !== undefined ? new Blob([options.stderr]).stream() : undefined,
+		kill: () => {},
+	} satisfies ReturnType<typeof spawnHelpers.spawnWithWindowsHide>
+}
+
+describe("getOpenCodeVersion", () => {
+	let spawnSpy: ReturnType<typeof spyOn>
+	let initConfigContextSpy: ReturnType<typeof spyOn>
+	let getOpenCodeVersion: OpenCodeBinaryModule["getOpenCodeVersion"]
+	let isOpenCodeInstalled: OpenCodeBinaryModule["isOpenCodeInstalled"]
+
+	beforeEach(async () => {
+		initConfigContextSpy = spyOn(configContext, "initConfigContext").mockImplementation(() => {})
+		const mod = await import(`./opencode-binary?test=${Date.now()}-${Math.random()}`)
+		getOpenCodeVersion = mod.getOpenCodeVersion
+		isOpenCodeInstalled = mod.isOpenCodeInstalled
+	})
+
+	afterEach(() => {
+		spawnSpy?.mockRestore()
+		initConfigContextSpy?.mockRestore()
+	})
+
+	describe("#given the CLI binary returns a real version on stdout", () => {
+		it("#then returns that version", async () => {
+			spawnSpy = spyOn(spawnHelpers, "spawnWithWindowsHide").mockReturnValue(
+				createProc({ exitCode: 0, stdout: "1.14.39\n" }),
+			)
+
+			const version = await getOpenCodeVersion()
+
+			expect(version).toBe("1.14.39")
+		})
+	})
+
+	describe("#given the OpenCode Desktop GUI launches and exits cleanly with no version output (fixes #3766)", () => {
+		it("#then treats the binary as not-installed instead of returning empty version", async () => {
+			spawnSpy = spyOn(spawnHelpers, "spawnWithWindowsHide").mockReturnValue(
+				createProc({ exitCode: 0, stdout: "" }),
+			)
+
+			const installed = await isOpenCodeInstalled()
+			const version = await getOpenCodeVersion()
+
+			expect(installed).toBe(false)
+			expect(version).toBe(null)
+			expect(initConfigContextSpy).not.toHaveBeenCalled()
+		})
+
+		it("#then a whitespace-only stdout is also rejected", async () => {
+			spawnSpy = spyOn(spawnHelpers, "spawnWithWindowsHide").mockReturnValue(
+				createProc({ exitCode: 0, stdout: "   \n  \t  " }),
+			)
+
+			const version = await getOpenCodeVersion()
+
+			expect(version).toBe(null)
+		})
+
+		it("#then non-version stdout (e.g. a Tauri startup banner) is rejected", async () => {
+			spawnSpy = spyOn(spawnHelpers, "spawnWithWindowsHide").mockReturnValue(
+				createProc({ exitCode: 0, stdout: "OpenCode Desktop\nLoading window...\n" }),
+			)
+
+			const version = await getOpenCodeVersion()
+
+			expect(version).toBe(null)
+		})
+	})
+
+	describe("#given the binary exits non-zero", () => {
+		it("#then returns null (not installed)", async () => {
+			spawnSpy = spyOn(spawnHelpers, "spawnWithWindowsHide").mockReturnValue(
+				createProc({ exitCode: 1, stdout: "" }),
+			)
+
+			const version = await getOpenCodeVersion()
+
+			expect(version).toBe(null)
+		})
+	})
+})

--- a/src/cli/config-manager/opencode-binary.ts
+++ b/src/cli/config-manager/opencode-binary.ts
@@ -3,10 +3,16 @@ import { spawnWithWindowsHide } from "../../shared/spawn-with-windows-hide"
 import { initConfigContext } from "./config-context"
 
 const OPENCODE_BINARIES = ["opencode", "opencode-desktop"] as const
+const SEMVER_PATTERN = /\b\d+\.\d+\.\d+\b/
 
 interface OpenCodeBinaryResult {
   binary: OpenCodeBinaryType
   version: string
+}
+
+function extractSemver(output: string): string | null {
+  const match = output.match(SEMVER_PATTERN)
+  return match ? match[0] : null
 }
 
 async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | null> {
@@ -18,11 +24,11 @@ async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | n
       })
       const output = await new Response(proc.stdout).text()
       await proc.exited
-      if (proc.exitCode === 0) {
-        const version = output.trim()
-        initConfigContext(binary, version)
-        return { binary, version }
-      }
+      if (proc.exitCode !== 0) continue
+      const version = extractSemver(output)
+      if (!version) continue
+      initConfigContext(binary, version)
+      return { binary, version }
     } catch {
       continue
     }


### PR DESCRIPTION
## Summary
On Windows, when OpenCode Desktop GUI (`OpenCode.exe`) is on PATH ahead of `opencode-cli.exe`, the installer's binary detector launches the GUI window via `--version`. The GUI exits with code 0 but produces no stdout, and the detector treats this as "installed", caching an empty version. The installer keeps re-running the same check and spawns more GUI windows, never completing.

## Root Cause
`src/cli/config-manager/opencode-binary.ts` (`findOpenCodeBinaryWithVersion`) accepts `proc.exitCode === 0` as proof of a working CLI, regardless of stdout. OpenCode Desktop satisfies that check while writing nothing useful, so the installer's `isOpenCodeInstalled()` returns `true` with `version === ""`.

## Changes
| File | Change |
|------|--------|
| `src/cli/config-manager/opencode-binary.ts` | Require `--version` stdout to contain a `\d+\.\d+\.\d+` semver token before treating the binary as installed; fall through to the next candidate otherwise |
| `src/cli/config-manager/opencode-binary.test.ts` | New regression suite covering valid CLI output, empty/whitespace-only stdout (Desktop scenario), banner-only stdout, and non-zero exit code |

## Reproduction (before fix)
~~~
(fail) getOpenCodeVersion > #given the OpenCode Desktop GUI launches and exits cleanly with no version output (fixes #3766) > #then treats the binary as not-installed instead of returning empty version
expect(received).toBe(expected)
Expected: false
Received: true
 2 pass
 3 fail
~~~

## Verification (after fix)
~~~
bun test src/cli/config-manager/opencode-binary.test.ts
 5 pass
 0 fail
 7 expect() calls
~~~

## Test
- New regression suite: `src/cli/config-manager/opencode-binary.test.ts` (5 cases: valid CLI output, empty stdout, whitespace stdout, Tauri/Electron banner stdout, non-zero exit)
- Related installer suites: `bun test src/cli/cli-installer.test.ts src/cli/install.test.ts src/cli/tui-installer.test.ts` — 7 pass
- Typecheck: `bun run typecheck` — clean
- Note: `src/cli/config-manager/write-omo-config.test.ts` shows pre-existing failures on `upstream/dev` unrelated to this PR (basename normalization mismatch)

Fixes #3766

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a real semver in `opencode --version` stdout to validate the CLI, preventing the Windows installer from caching an empty version and looping on GUI launches. Fixes #3766.

- **Bug Fixes**
  - Accept the binary only if stdout contains a `x.y.z` token; otherwise skip to the next candidate.
  - Added regression tests for valid version, empty/whitespace/banner stdout, and non-zero exit.

<sup>Written for commit cfc3f37e8249973a4115f32ac5efdb8fb824de64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

