### PR TITLE
fix(agents): copy factory mode to agent config for Desktop 1.14.x compat

### DIFF
--- a/src/agents/agent-builder.test.ts
+++ b/src/agents/agent-builder.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "bun:test"
+import { buildAgent } from "./agent-builder"
+import type { AgentFactory } from "./types"
+
+describe("#given an agent factory with mode", () => {
+  const mockFactory = ((model: string) => ({
+    name: "test-agent",
+    description: "Test",
+    instructions: "test",
+    model,
+    temperature: 0.1,
+  })) as AgentFactory
+  mockFactory.mode = "subagent"
+
+  test("#when building agent from factory", () => {
+    const agent = buildAgent(mockFactory, "test-model")
+    expect(agent.mode).toBe("subagent")
+  })
+})
+
+describe("#given an agent factory with mode=primary", () => {
+  const mockFactory = ((model: string) => ({
+    name: "primary-agent",
+    description: "Primary Test",
+    instructions: "test",
+    model,
+    temperature: 0.1,
+  })) as AgentFactory
+  mockFactory.mode = "primary"
+
+  test("#when building agent from factory", () => {
+    const agent = buildAgent(mockFactory, "test-model")
+    expect(agent.mode).toBe("primary")
+  })
+})
+
+describe("#given an agent config object without mode", () => {
+  const mockConfig = {
+    name: "config-agent",
+    description: "Config Test",
+    instructions: "test",
+    model: "test-model",
+    temperature: 0.1,
+  }
+
+  test("#when building agent from config object", () => {
+    const agent = buildAgent(mockConfig, "test-model")
+    expect(agent.mode).toBeUndefined()
+  })
+})
+
+describe("#given an agent factory with mode but config already has mode", () => {
+  const mockFactory = ((model: string) => ({
+    name: "override-agent",
+    description: "Override Test",
+    instructions: "test",
+    model,
+    temperature: 0.1,
+    mode: "all",
+  })) as AgentFactory
+  mockFactory.mode = "subagent"
+
+  test("#when building agent from factory", () => {
+    const agent = buildAgent(mockFactory, "test-model")
+    expect(agent.mode).toBe("all")
+  })
+})

--- a/src/agents/agent-builder.ts
+++ b/src/agents/agent-builder.ts
@@ -33,5 +33,9 @@ export function buildAgent(
     }
   }
 
+  if (isFactory(source) && (base as AgentConfig & { mode?: string }).mode === undefined) {
+    ;(base as AgentConfig & { mode?: string }).mode = source.mode
+  }
+
   return base
 }


### PR DESCRIPTION
## Summary

Fixes agents not appearing in OpenCode Desktop 1.14.x UI.

**Root Cause:** `buildAgent()` never copied the factory's static `mode` property to the generated `AgentConfig` object. OpenCode Desktop filters agents by `mode`, so agents without it were invisible.

## Changes

- `src/agents/agent-builder.ts`: Copy `source.mode` to `base.mode` when building from factory
- `src/agents/agent-builder.test.ts`: 4 new tests covering mode propagation

## Test Plan

```bash
bun test src/agents/agent-builder.test.ts  # 4 pass
```

## Closes

- #3835 (Agents not showing in Desktop GUI)
- Related: #3762, #3812, #3794, #3475, #3474, #3829, #3831, #3824, #3826, #3721, #3806, #3188

cc @code-yeongyu

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agents not showing in OpenCode Desktop 1.14.x by propagating the factory’s `mode` to the built `AgentConfig`. Adds tests to ensure `mode` is copied from factories and not overwritten when already set.

<sup>Written for commit adc6d92a8e7b8738c8fcc7f999ff1ade794981d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

