### PR TITLE
chore(workflows): trigger web-deploy on dev push

### DIFF
--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: ""
   push:
-    branches: [master]
+    branches: [master, dev]
     paths:
       - "web/**"
       - ".github/workflows/web-deploy.yml"


### PR DESCRIPTION
## Summary

PRs land on \`dev\` (master is blocked by \`block-master-pr\`), but the deploy workflow only listened to \`master\` pushes — so #3853's web/ dependency bumps merged to dev with no Cloudflare deployment ever running.

## Change

Add \`dev\` to the \`push.branches\` list in \`.github/workflows/web-deploy.yml\`. The existing \`paths\` filter keeps the deploy from firing on non-web changes, and \`workflow_dispatch\` is preserved as the manual fallback.

\`\`\`yaml
push:
  branches: [master, dev]   # was [master]
  paths:
    - "web/**"
    - ".github/workflows/web-deploy.yml"
\`\`\`

## Verification

- Mirrors \`web-ci.yml\`'s branch list (\`[master, dev]\`) for consistency.
- \`paths\` filter unchanged — deploy still fires only on web changes.
- After merge, the next \`web/**\` change merged to dev will trigger the Cloudflare deploy automatically.

## Out of scope

- Cubic / review workflow changes
- Secrets management (\`CLOUDFLARE_API_TOKEN\` + \`CLOUDFLARE_ACCOUNT_ID\` handled separately)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger the `web-deploy` workflow on `dev` pushes (in addition to `master`) so web changes merged to `dev` auto-deploy to Cloudflare. The `paths` filter remains (`web/**`) and `workflow_dispatch` stays as a manual fallback.

<sup>Written for commit 7fe197d8f1efcd3c330c5df0a8d3287c02c77e24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

