### PR TITLE
fix(docs): schema URL is oh-my-opencode.schema.json (file never renamed)

### DIFF
--- a/docs/examples/coding-focused.jsonc
+++ b/docs/examples/coding-focused.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   // Optimized for intensive coding sessions.
   // Prioritizes deep implementation agents and fast feedback loops.

--- a/docs/examples/default.jsonc
+++ b/docs/examples/default.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   // Balanced defaults for general development.
   // Tuned for reliability across diverse tasks without overspending.

--- a/docs/examples/planning-focused.jsonc
+++ b/docs/examples/planning-focused.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   // Optimized for strategic planning, architecture, and complex project design.
   // Prioritizes deep thinking agents and thorough analysis before execution.

--- a/docs/guide/agent-model-matching.md
+++ b/docs/guide/agent-model-matching.md
@@ -337,7 +337,7 @@ See the [Orchestration System Guide](./orchestration.md) for how agents dispatch
 
 ```jsonc
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   "agents": {
     // Sisyphus: Kimi K2.6 is the top alternative to Claude for orchestration

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -38,7 +38,7 @@ Core CLI subcommands are: `install`, `run`, `doctor`, `mcp-oauth`, `refresh-mode
 Config schema URL:
 
 ```json
-"$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json"
+"$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json"
 ```
 
 Operational notes:

--- a/docs/guide/overview.md
+++ b/docs/guide/overview.md
@@ -167,7 +167,7 @@ You can override specific agents or categories in your config:
 
 ```jsonc
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   "agents": {
     // Main orchestrator: Claude Opus or Kimi K2.5 work best

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,7 +62,7 @@ Enable schema autocomplete:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json"
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json"
 }
 ```
 
@@ -74,7 +74,7 @@ Here's a practical starting configuration:
 
 ```jsonc
 {
-  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json",
+  "$schema": "https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json",
 
   "agents": {
     // Main orchestrator: Claude Opus or Kimi K2.5 work best


### PR DESCRIPTION
## Summary

User caught that the schema URLs I bulk-changed in #3859 actually return HTTP 404. The schema file basename never followed the package rename — it's still \`oh-my-opencode.schema.json\` on disk and in the repo URL.

## Evidence

\`\`\`
$ ls assets/
oh-my-opencode.schema.json    # only file

$ grep -A1 schema.json package.json | head -3
"./schema.json": "./dist/oh-my-opencode.schema.json"

$ curl -sI https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-openagent.schema.json
HTTP/2 404

$ curl -sI https://raw.githubusercontent.com/code-yeongyu/oh-my-openagent/dev/assets/oh-my-opencode.schema.json
HTTP/2 200
\`\`\`

Root \`AGENTS.md\` (line 135) also documents the legacy URL. The file rename never happened; the package rename did.

## Change

Bulk \`oh-my-openagent.schema.json\` -> \`oh-my-opencode.schema.json\` across the 7 docs files I broke:

- \`docs/examples/{coding,default,planning}-focused.jsonc\`
- \`docs/guide/{overview,installation,agent-model-matching}.md\`
- \`docs/reference/configuration.md\` (2 occurrences)

## Effect

Anyone copying a \`\$schema\` example out of the docs lands on a real, fetchable schema again. Schema-aware editors stop reporting "file not found".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix docs by reverting the schema URL from `oh-my-openagent.schema.json` to `oh-my-opencode.schema.json`. Examples and guides now point to a valid file, so `$schema` resolves correctly and schema-aware editors stop showing errors.

<sup>Written for commit 268ee57c041f1b0c7f7156e0cda9cbcc31e9910b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

