### PR TITLE
docs(manifesto): canonical domain is ohmyopenagent.com (no dashes)

### DIFF
--- a/docs/manifesto.md
+++ b/docs/manifesto.md
@@ -1,6 +1,14 @@
 # Manifesto
 
-The principles and philosophy behind Oh My OpenAgent.
+The principles and philosophy behind oh-my-openagent (OmO).
+
+Project reality check:
+
+- Name: oh-my-openagent (renamed from oh-my-opencode; both npm packages still publish in tandem during the transition)
+- Domain: https://ohmyopenagent.com (legacy https://ohmyopencode.org redirects 308)
+- Building in Public: https://discord.gg/PUwSMR9XNk
+- Maintained by Jobdori, an AI assistant running on a heavily customized OpenClaw fork
+- Sisyphus Labs: https://sisyphuslabs.ai
 
 ---
 


### PR DESCRIPTION
## Summary

User caught: the manifesto's project-context block was using `oh-my-openagent.com` (dashes). The canonical domain has **no dashes** — `ohmyopenagent.com`. Same with the legacy alias `ohmyopencode.org`.

## Evidence

```
$ dig +short ohmyopenagent.com    # 104.21.94.59, 172.67.220.78  -> Cloudflare
$ dig +short oh-my-openagent.com  # (empty)                      -> does not resolve
```

The codebase was already correct everywhere that matters (`web/wrangler.toml` routes, `web/middleware.ts` redirect, `web/app/{layout.tsx,sitemap.ts,robots.ts}`, `.github/workflows/web-deploy.yml` environment URL). Only the manifesto prose carried the dashed typo.

Repo-wide sweep after this commit returns 0 hits for `oh-my-openagent.com` or `oh-my-openagent.org`.

## Change

`docs/manifesto.md` project-context block:
- `oh-my-openagent.com` -> `ohmyopenagent.com`
- explicit note that the legacy alias `ohmyopencode.org` 308-redirects to the canonical host

That same project-context block had been sitting in a stale local working tree from earlier audit work and never landed on dev — promoting it as a clean commit at the same time.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the manifesto's project-context block to use the correct canonical domain `ohmyopenagent.com` instead of the non-resolving `oh-my-openagent.com`. Also added a note that the legacy alias `ohmyopencode.org` redirects to the canonical domain.

<sup>Written for commit 4181993324ed3d44437f27be9fef63736ff997b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

