### PR TITLE
fix(compaction): exclude compaction agent message.updated from token caches (fixes #3819)

### DIFF
--- a/src/hooks/context-window-monitor.test.ts
+++ b/src/hooks/context-window-monitor.test.ts
@@ -381,4 +381,65 @@ describe("context-window-monitor", () => {
     //#then
     expect(output.output).toBe("original")
   })
+
+  // #given the cache holds low post-compaction token usage
+  // #when the compaction agent emits message.updated with pre-compaction tokens
+  // #then the cache must not be overwritten and stats stay accurate (issue #3819)
+  it("should ignore message.updated from the compaction agent (issue #3819)", async () => {
+    const hook = createContextWindowMonitorHook(ctx as never)
+    const sessionID = "ses_compaction_3819"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            finish: true,
+            tokens: {
+              input: 5000,
+              output: 100,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    // Compaction agent reports pre-compaction tokens that exceed the warning
+    // threshold; without the fix this overwrote tokenCache and made the next
+    // tool.execute.after append a context warning.
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            finish: true,
+            agent: "compaction",
+            tokens: {
+              input: 180000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    const output = { title: "", output: "post-compaction", metadata: null }
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      output
+    )
+
+    // Cache still holds the low post-compaction usage so no reminder is appended
+    expect(output.output).toBe("post-compaction")
+  })
 })

--- a/src/hooks/context-window-monitor.ts
+++ b/src/hooks/context-window-monitor.ts
@@ -4,6 +4,7 @@ import {
   type ContextLimitModelCacheState,
 } from "../shared/context-limit-resolver"
 import { createSystemDirective, SystemDirectiveTypes } from "../shared/system-directive"
+import { isCompactionAgent } from "../shared/compaction-marker"
 
 const CONTEXT_WARNING_THRESHOLD = 0.70
 
@@ -100,10 +101,16 @@ export function createContextWindowMonitorHook(
         modelID?: string
         finish?: boolean
         tokens?: TokenInfo
+        agent?: string
       } | undefined
 
       if (!info || info.role !== "assistant" || !info.finish) return
       if (!info.sessionID || !info.providerID || !info.tokens) return
+
+      // The compaction agent reports pre-compaction token counts in its summary
+      // message. Caching those would make the displayed context-window stats
+      // jump back up after a successful compaction (issue #3819).
+      if (isCompactionAgent(info.agent)) return
 
       tokenCache.set(info.sessionID, {
         providerID: info.providerID,

--- a/src/hooks/preemptive-compaction.test.ts
+++ b/src/hooks/preemptive-compaction.test.ts
@@ -761,4 +761,77 @@ describe("preemptive-compaction", () => {
 
     expect(ctx.client.session.summarize).toHaveBeenCalled()
   })
+
+  // #given a session was already compacted (compactedSessions guard set, low post-compaction tokens cached)
+  // #when the compaction agent emits message.updated carrying pre-compaction tokens
+  // #then the cache must NOT be overwritten and the compactedSessions guard must NOT be cleared,
+  //       otherwise the very next tool.execute.after would re-trigger compaction (issue #3819)
+  it("should ignore message.updated from compaction agent so it does not retrigger compaction (issue #3819)", async () => {
+    const hook = createPreemptiveCompactionHook(ctx as never, {} as never)
+    const sessionID = "ses_compaction_3819"
+
+    // Seed real assistant message with low post-compaction tokens
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            finish: true,
+            tokens: {
+              input: 5000,
+              output: 100,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    // Mark session as just-compacted so compactedSessions guard would block re-compaction
+    await hook.event({
+      event: {
+        type: "session.compacted",
+        properties: { sessionID },
+      },
+    })
+
+    // Compaction agent now reports stale pre-compaction token counts; without the
+    // fix this overwrites tokenCache AND clears compactedSessions, immediately
+    // re-triggering compaction.
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            finish: true,
+            agent: "compaction",
+            tokens: {
+              input: 180000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      { title: "", output: "test", metadata: null }
+    )
+
+    // No retrigger: summarize must not be called because both the guard and the
+    // low cached tokens are still in place.
+    expect(ctx.client.session.summarize).not.toHaveBeenCalled()
+  })
 })

--- a/src/hooks/preemptive-compaction.ts
+++ b/src/hooks/preemptive-compaction.ts
@@ -8,6 +8,7 @@ import type {
   PreemptiveCompactionContext,
   TokenInfo,
 } from "./preemptive-compaction-types"
+import { isCompactionAgent } from "../shared/compaction-marker"
 
 export function createPreemptiveCompactionHook(
   ctx: PreemptiveCompactionContext,
@@ -77,9 +78,16 @@ export function createPreemptiveCompactionHook(
         finish?: boolean
         tokens?: TokenInfo
         parts?: unknown
+        agent?: string
       } | undefined
 
       if (!info || info.role !== "assistant" || !info.finish || !info.sessionID) return
+
+      // The compaction agent emits an assistant message that carries pre-compaction
+      // token counts. Treating it as a regular response would overwrite the cache
+      // with stale values and clear the compactedSessions guard, which immediately
+      // re-triggers preemptive compaction (issue #3819).
+      if (isCompactionAgent(info.agent)) return
 
       if (info.providerID && info.tokens) {
         tokenCache.set(info.sessionID, {


### PR DESCRIPTION
## Summary
After preemptive compaction, the next user turn briefly showed pre-compaction context stats and immediately re-triggered another auto-compaction cycle. The compaction agent's own \`message.updated\` event was being treated as a regular assistant response.

## Root Cause
Both \`src/hooks/preemptive-compaction.ts\` and \`src/hooks/context-window-monitor.ts\` cache token info on every \`message.updated\` event whose \`info.role === \"assistant\"\` and \`info.finish === true\`. When the compaction agent finishes, OpenCode emits exactly that shape, but \`info.tokens\` still reflects the **pre-compaction** size of the original context.

In \`preemptive-compaction.ts\` this also clears \`compactedSessions.delete(info.sessionID)\`, removing the guard that prevented immediate re-compaction. The next \`tool.execute.after\` saw high cached usage + an unguarded session and called \`session.summarize\` again.

The shared \`isCompactionAgent\` helper in \`src/shared/compaction-marker.ts\` is already used by \`compaction-context-injector\` and \`prometheus-md-only\` for exactly this kind of filter — these two hooks were simply missed.

## Changes
| File | Change |
|------|--------|
| \`src/hooks/preemptive-compaction.ts\` | Skip \`message.updated\` when \`info.agent === \"compaction\"\` so tokenCache and compactedSessions stay correct |
| \`src/hooks/context-window-monitor.ts\` | Same filter so the displayed context stats do not jump back to pre-compaction values |
| \`src/hooks/preemptive-compaction.test.ts\` | Regression test asserting the compaction summary does NOT retrigger \`session.summarize\` |
| \`src/hooks/context-window-monitor.test.ts\` | Regression test asserting cached low post-compaction stats survive a compaction-agent message |

Net diff: +149 LOC across 4 files (8 prod LOC + 134 test LOC + 7 import lines).

## Reproduction (issue body)
1. Start a session, let context grow past 78% so preemptive compaction fires.
2. After compaction completes, send a new message.
3. Before fix: stats jump back to pre-compaction values, second auto-compaction triggers shortly after.

## Verification (after fix)
~~~
$ bun test src/hooks/preemptive-compaction.test.ts src/hooks/context-window-monitor.test.ts
 26 pass
 0 fail
 43 expect() calls
Ran 26 tests across 2 files. [137.00ms]
~~~

- Both new regression tests pass (issue #3819 specifically)
- Typecheck: \`bun run typecheck\` clean

## Test
- New: \`should ignore message.updated from compaction agent so it does not retrigger compaction (issue #3819)\` in \`preemptive-compaction.test.ts\`
- New: \`should ignore message.updated from the compaction agent (issue #3819)\` in \`context-window-monitor.test.ts\`
- All 24 existing tests in those two suites still pass

Fixes #3819

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents token caches from using compaction agent message.updated events that carry pre-compaction token counts. This stops context stats from jumping and avoids unintended re-compaction on the next turn. Fixes #3819.

- **Bug Fixes**
  - Ignore `message.updated` from the compaction agent in `src/hooks/preemptive-compaction.ts` and `src/hooks/context-window-monitor.ts` via `isCompactionAgent`.
  - Preserve accurate post-compaction token cache and keep `compactedSessions` intact to prevent re-triggering compaction.
  - Add regression tests covering both hooks.

<sup>Written for commit 89d18fa85031c392ed4910e1f794f2a6b1dcadea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

