### PR TITLE
fix(compaction-todo-preserver): restore snapshot when post-compaction todos are only the Atlas bootstrap pair (fixes #3833)

### DIFF
--- a/src/hooks/compaction-todo-preserver/hook.ts
+++ b/src/hooks/compaction-todo-preserver/hook.ts
@@ -12,6 +12,20 @@ type TodoWriter = (input: { sessionID: string; todos: TodoSnapshot[] }) => Promi
 
 const HOOK_NAME = "compaction-todo-preserver"
 
+// Atlas's hard-coded bootstrap todo list (mirrors the templates in
+// src/agents/atlas/{default,gpt,gemini}-prompt-sections.ts). When Atlas runs
+// after compaction it writes these two todos before the preserver gets a
+// chance to restore the captured snapshot — so the previous "current todos
+// non-empty -> skip restore" guard discarded the richer pre-compaction state.
+// (issue #3833)
+const ATLAS_BOOTSTRAP_TODO_IDS: readonly string[] = ["orchestrate-plan", "pass-final-wave"] as const
+
+function isAtlasBootstrapTodoList(todos: readonly TodoSnapshot[]): boolean {
+  if (todos.length !== ATLAS_BOOTSTRAP_TODO_IDS.length) return false
+  const ids = new Set(todos.map((todo) => todo.id))
+  return ATLAS_BOOTSTRAP_TODO_IDS.every((expectedId) => ids.has(expectedId))
+}
+
 function extractTodos(response: unknown): TodoSnapshot[] {
   const payload = response as { data?: unknown }
   if (Array.isArray(payload?.data)) {
@@ -81,7 +95,15 @@ export function createCompactionTodoPreserverHook(
       log(`[${HOOK_NAME}] Failed to fetch todos post-compaction`, { sessionID, error: String(err) })
     }
 
-    if (hasCurrent && currentTodos.length > 0) {
+    // Atlas writes its 2-item bootstrap todo list at the start of every post-
+    // compaction run. Treating that list as authoritative drops the richer
+    // pre-compaction snapshot. Restore the snapshot instead, but only when the
+    // captured snapshot is itself richer than the bootstrap list (issue #3833).
+    const currentIsAtlasBootstrap =
+      hasCurrent && currentTodos.length > 0 && isAtlasBootstrapTodoList(currentTodos)
+    const snapshotIsAtlasBootstrap = isAtlasBootstrapTodoList(snapshot)
+
+    if (hasCurrent && currentTodos.length > 0 && !(currentIsAtlasBootstrap && !snapshotIsAtlasBootstrap)) {
       snapshots.delete(sessionID)
       log(`[${HOOK_NAME}] Skipped restore (todos already present)`, { sessionID, count: currentTodos.length })
       return

--- a/src/hooks/compaction-todo-preserver/index.test.ts
+++ b/src/hooks/compaction-todo-preserver/index.test.ts
@@ -84,4 +84,55 @@ describe("compaction-todo-preserver", () => {
     //#then
     expect(updateMock).not.toHaveBeenCalled()
   })
+
+  // #given a richer pre-compact snapshot
+  // #when post-compaction todos are only the Atlas bootstrap pair
+  // #then the snapshot should be restored, not the bootstrap stub (issue #3833)
+  it("restores richer snapshot when post-compaction todos are only Atlas bootstrap items (issue #3833)", async () => {
+    //#given
+    updateMock.mockClear()
+    const sessionID = "session-compaction-atlas-bootstrap"
+    const richSnapshot: Todo[] = [
+      { id: "task-1", content: "Implement feature A", status: "in_progress", priority: "high" },
+      { id: "task-2", content: "Write tests for feature A", status: "pending", priority: "high" },
+      { id: "task-3", content: "Update documentation", status: "pending", priority: "medium" },
+    ]
+    const atlasBootstrap: Todo[] = [
+      { id: "orchestrate-plan", content: "Complete ALL implementation tasks", status: "in_progress", priority: "high" },
+      { id: "pass-final-wave", content: "Pass Final Verification Wave - ALL reviewers APPROVE", status: "pending", priority: "high" },
+    ]
+    // First todo() call returns the rich snapshot during capture; second returns the Atlas bootstrap during restore
+    const ctx = createMockContext([richSnapshot, atlasBootstrap])
+    const hook = createCompactionTodoPreserverHook(ctx)
+
+    //#when
+    await hook.capture(sessionID)
+    await hook.event({ event: { type: "session.compacted", properties: { sessionID } } })
+
+    //#then: rich snapshot wins, the bootstrap pair does not
+    expect(updateMock).toHaveBeenCalledTimes(1)
+    expect(updateMock).toHaveBeenCalledWith({ sessionID, todos: richSnapshot })
+  })
+
+  // #given a captured snapshot that itself is the Atlas bootstrap
+  // #when post-compaction shows the same Atlas bootstrap
+  // #then restore must NOT thrash the list (no Todo.update call) (issue #3833)
+  it("does not overwrite when both snapshot and current todos are the Atlas bootstrap pair (issue #3833)", async () => {
+    //#given
+    updateMock.mockClear()
+    const sessionID = "session-compaction-atlas-bootstrap-only"
+    const atlasBootstrap: Todo[] = [
+      { id: "orchestrate-plan", content: "Complete ALL implementation tasks", status: "in_progress", priority: "high" },
+      { id: "pass-final-wave", content: "Pass Final Verification Wave - ALL reviewers APPROVE", status: "pending", priority: "high" },
+    ]
+    const ctx = createMockContext([atlasBootstrap, atlasBootstrap])
+    const hook = createCompactionTodoPreserverHook(ctx)
+
+    //#when
+    await hook.capture(sessionID)
+    await hook.event({ event: { type: "session.compacted", properties: { sessionID } } })
+
+    //#then: nothing to restore beyond what is already present
+    expect(updateMock).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
After compaction in an Atlas-driven session, Atlas writes its two hard-coded bootstrap todos (\`orchestrate-plan\` + \`pass-final-wave\`) at the start of the next turn. The preserver then sees a non-empty post-compaction todo list and skips restoration, so the richer pre-compaction todo list is lost.

## Root Cause
\`createCompactionTodoPreserverHook\` captures todos before compaction and tries to restore them on \`session.compacted\`. The restore guard at \`src/hooks/compaction-todo-preserver/hook.ts\` was too coarse:

\`\`\`typescript
if (hasCurrent && currentTodos.length > 0) {
  // skip restore — treat current todos as authoritative
}
\`\`\`

Atlas's prompt templates (\`default-prompt-sections.ts\`, \`gpt-prompt-sections.ts\`, \`gemini-prompt-sections.ts\`) all push exactly:

\`\`\`typescript
{ id: \"orchestrate-plan\", content: \"Complete ALL implementation tasks\", status: \"in_progress\", priority: \"high\" },
{ id: \"pass-final-wave\", content: \"Pass Final Verification Wave - ALL reviewers APPROVE\", status: \"pending\", priority: \"high\" }
\`\`\`

When those two todos are the entire post-compact list, they should not block restoration of a richer pre-compact snapshot.

## Changes
| File | Change |
|------|--------|
| \`src/hooks/compaction-todo-preserver/hook.ts\` | Add \`isAtlasBootstrapTodoList\` helper. Override the \"skip when non-empty\" guard only when current is the Atlas bootstrap pair AND the captured snapshot is richer (i.e. not itself the bootstrap pair). |
| \`src/hooks/compaction-todo-preserver/index.test.ts\` | Two regression tests: (1) rich snapshot wins over Atlas bootstrap, (2) bootstrap-only snapshot does NOT thrash a bootstrap-only current list. |

Net diff: +74 LOC, -1 LOC across 2 files.

## Behavior Matrix
| Pre-compact snapshot | Post-compact current | Action |
|--|--|--|
| empty | anything | skip (no snapshot to restore) |
| any | empty | restore snapshot (existing behavior) |
| any | non-bootstrap, non-empty | skip (existing behavior — current is authoritative) |
| **richer than bootstrap** | **= Atlas bootstrap pair** | **restore richer snapshot (NEW)** |
| Atlas bootstrap pair | Atlas bootstrap pair | skip (no thrash, NEW guard) |

## Verification
~~~
$ bun test src/hooks/compaction-todo-preserver/
 4 pass
 0 fail
 6 expect() calls
Ran 4 tests across 1 file. [98.00ms]
~~~

- All 2 existing tests still pass (\`restores when missing\`, \`skips when present\`)
- 2 new regression tests pass
- Typecheck: \`bun run typecheck\` clean

## Notes
- The bootstrap detection is by \`id\` only (\`orchestrate-plan\` + \`pass-final-wave\`), which matches the prompt template authoritatively. If a future Atlas variant renames either id, this helper just stops detecting the bootstrap and the existing skip-when-non-empty branch takes over — safe degradation.
- The change is intentionally narrow per the issue suggestion (\"exact bootstrap detection is the minimal safe fix\"). A broader \"compare list richness\" rule was considered but discarded as too easy to misclassify a partially-progressed user list.

Fixes #3833

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the richer pre-compaction todo snapshot when post-compaction todos are only Atlas’s bootstrap pair, preventing loss of user todos in Atlas sessions. Real non-bootstrap post-compaction lists remain authoritative.

- **Bug Fixes**
  - Detects the exact Atlas bootstrap pair (`orchestrate-plan`, `pass-final-wave`) and restores the snapshot only when the snapshot is richer and current is the bootstrap pair (fixes #3833).
  - Adds regression tests for restoring over the bootstrap stub and for no-ops when both snapshot and current are the bootstrap pair.

<sup>Written for commit 5c8f035a850205e94f84015d0cd6501c1950c200. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

