### PR TITLE
fix(doctor): extract semver from `opencode --version` stdout

### DIFF
--- a/src/cli/config-manager/opencode-binary.test.ts
+++ b/src/cli/config-manager/opencode-binary.test.ts
@@ -1,0 +1,85 @@
+/// <reference types="bun-types" />
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+
+import * as configContext from "./config-context"
+import * as spawnHelpers from "../../shared/spawn-with-windows-hide"
+
+type OpenCodeBinaryModule = typeof import("./opencode-binary")
+
+type CreateProcOptions = {
+  exitCode?: number | null
+  output?: { stdout?: string; stderr?: string }
+}
+
+function createProc(options: CreateProcOptions = {}): ReturnType<typeof spawnHelpers.spawnWithWindowsHide> {
+  const exitCode = options.exitCode ?? 0
+  return {
+    exited: Promise.resolve(exitCode),
+    exitCode,
+    stdout: options.output?.stdout !== undefined ? new Blob([options.output.stdout]).stream() : undefined,
+    stderr: options.output?.stderr !== undefined ? new Blob([options.output.stderr]).stream() : undefined,
+    kill: () => {},
+  } satisfies ReturnType<typeof spawnHelpers.spawnWithWindowsHide>
+}
+
+describe("getOpenCodeVersion (installer)", () => {
+  let spawnSpy: ReturnType<typeof spyOn>
+  let initConfigContextSpy: ReturnType<typeof spyOn>
+  let getOpenCodeVersion: OpenCodeBinaryModule["getOpenCodeVersion"]
+
+  beforeEach(async () => {
+    spawnSpy = spyOn(spawnHelpers, "spawnWithWindowsHide")
+    initConfigContextSpy = spyOn(configContext, "initConfigContext").mockImplementation(() => {})
+    const mod = await import(`./opencode-binary?test=${Date.now()}-${Math.random()}`)
+    getOpenCodeVersion = mod.getOpenCodeVersion
+  })
+
+  afterEach(() => {
+    spawnSpy.mockRestore()
+    initConfigContextSpy.mockRestore()
+  })
+
+  describe("#given clean opencode --version stdout #when getOpenCodeVersion #then returns the semver string", () => {
+    it("plain semver", async () => {
+      spawnSpy.mockReturnValue(createProc({ output: { stdout: "1.14.33\n" } }))
+
+      const result = await getOpenCodeVersion()
+
+      expect(result).toBe("1.14.33")
+    })
+  })
+
+  describe("#given Electron-polluted opencode --version stdout #when getOpenCodeVersion #then returns extracted semver, not the timestamp-prefixed line", () => {
+    it("regression for #3765 installer caller", async () => {
+      const polluted = "00:24:25.202 > app starting { version: '1.14.33', packaged: true }"
+      spawnSpy.mockReturnValue(createProc({ output: { stdout: polluted } }))
+
+      const result = await getOpenCodeVersion()
+
+      expect(result).toBe("1.14.33")
+    })
+  })
+
+  describe("#given non-semver-shaped stdout #when getOpenCodeVersion #then falls back to trimmed output", () => {
+    it("preserves legacy behavior for unrecognized formats", async () => {
+      spawnSpy.mockReturnValue(createProc({ output: { stdout: "  custom-build\n" } }))
+
+      const result = await getOpenCodeVersion()
+
+      expect(result).toBe("custom-build")
+    })
+  })
+
+  describe("#given no opencode binary on PATH #when getOpenCodeVersion #then returns null", () => {
+    it("all candidate spawns throw", async () => {
+      spawnSpy.mockImplementation(() => {
+        throw new Error("ENOENT")
+      })
+
+      const result = await getOpenCodeVersion()
+
+      expect(result).toBe(null)
+    })
+  })
+})

--- a/src/cli/config-manager/opencode-binary.ts
+++ b/src/cli/config-manager/opencode-binary.ts
@@ -1,3 +1,4 @@
+import { extractSemverFromOutput } from "../../shared/extract-semver"
 import type { OpenCodeBinaryType } from "../../shared/opencode-config-dir-types"
 import { spawnWithWindowsHide } from "../../shared/spawn-with-windows-hide"
 import { initConfigContext } from "./config-context"
@@ -19,7 +20,7 @@ async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | n
       const output = await new Response(proc.stdout).text()
       await proc.exited
       if (proc.exitCode === 0) {
-        const version = output.trim()
+        const version = extractSemverFromOutput(output) ?? output.trim()
         initConfigContext(binary, version)
         return { binary, version }
       }

--- a/src/cli/doctor/checks/system-binary.test.ts
+++ b/src/cli/doctor/checks/system-binary.test.ts
@@ -1,0 +1,62 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, it } from "bun:test"
+import { extractSemverFromOutput } from "./system-binary"
+
+describe("extractSemverFromOutput", () => {
+  describe("#given clean version output #when extractSemverFromOutput #then returns the semver token", () => {
+    it("plain semver", () => {
+      expect(extractSemverFromOutput("1.14.33")).toBe("1.14.33")
+    })
+
+    it("v-prefixed semver strips the prefix", () => {
+      expect(extractSemverFromOutput("v1.14.33")).toBe("1.14.33")
+    })
+
+    it("trailing whitespace and newlines are tolerated", () => {
+      expect(extractSemverFromOutput("  1.14.33\n")).toBe("1.14.33")
+    })
+
+    it("pre-release suffix is preserved", () => {
+      expect(extractSemverFromOutput("1.0.0-beta.1")).toBe("1.0.0-beta.1")
+    })
+
+    it("build metadata is preserved", () => {
+      expect(extractSemverFromOutput("1.0.0+build.42")).toBe("1.0.0+build.42")
+    })
+  })
+
+  describe("#given Electron log-polluted stdout #when extractSemverFromOutput #then ignores the timestamp and finds the version", () => {
+    it("regression for #3765: Electron desktop dumps log lines into stdout", () => {
+      const polluted = "00:24:25.202 > app starting { version: '1.14.33', packaged: true }"
+      expect(extractSemverFromOutput(polluted)).toBe("1.14.33")
+    })
+
+    it("multi-line stdout with log prefix and trailing version", () => {
+      const polluted = "12:00:00.001 [info] starting opencode\n1.14.33\n"
+      expect(extractSemverFromOutput(polluted)).toBe("1.14.33")
+    })
+
+    it("timestamp-only stdout returns null", () => {
+      expect(extractSemverFromOutput("00:24:25.202 some log line")).toBe(null)
+    })
+  })
+
+  describe("#given empty or invalid output #when extractSemverFromOutput #then returns null", () => {
+    it("empty string", () => {
+      expect(extractSemverFromOutput("")).toBe(null)
+    })
+
+    it("only whitespace", () => {
+      expect(extractSemverFromOutput("   \n  ")).toBe(null)
+    })
+
+    it("text without any semver-shaped token", () => {
+      expect(extractSemverFromOutput("hello world")).toBe(null)
+    })
+
+    it("incomplete semver (only major.minor) is rejected", () => {
+      expect(extractSemverFromOutput("1.14")).toBe(null)
+    })
+  })
+})

--- a/src/cli/doctor/checks/system-binary.test.ts
+++ b/src/cli/doctor/checks/system-binary.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, it } from "bun:test"
-import { extractSemverFromOutput } from "./system-binary"
+import { extractSemverFromOutput } from "../../../shared/extract-semver"
 
 describe("extractSemverFromOutput", () => {
   describe("#given clean version output #when extractSemverFromOutput #then returns the semver token", () => {

--- a/src/cli/doctor/checks/system-binary.ts
+++ b/src/cli/doctor/checks/system-binary.ts
@@ -1,9 +1,12 @@
 import { existsSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
+import { extractSemverFromOutput } from "../../../shared/extract-semver"
 import { spawnWithTimeout } from "../spawn-with-timeout"
 
 import { OPENCODE_BINARIES } from "../constants"
+
+export { extractSemverFromOutput }
 
 const WINDOWS_EXECUTABLE_EXTS = [".exe", ".cmd", ".bat", ".ps1"]
 
@@ -103,17 +106,6 @@ export async function findOpenCodeBinary(): Promise<OpenCodeBinaryInfo | null> {
   }
 
   return findDesktopBinary()
-}
-
-export function extractSemverFromOutput(output: string): string | null {
-  const trimmed = output.trim()
-  if (!trimmed) return null
-  // Match a semver-shaped token, allowing optional `v` prefix and `-prerelease+build` suffix.
-  // The negative lookbehind `(?<![\d:])` prevents matching the milliseconds segment of timestamps
-  // like `00:24:25.202` that the Electron-based OpenCode binary leaks into stdout.
-  const semverPattern = /(?<![\d:])v?(\d+\.\d+\.\d+(?:[-+][\w.]+)*)/
-  const match = trimmed.match(semverPattern)
-  return match?.[1] ?? null
 }
 
 export async function getOpenCodeVersion(

--- a/src/cli/doctor/checks/system-binary.ts
+++ b/src/cli/doctor/checks/system-binary.ts
@@ -105,6 +105,17 @@ export async function findOpenCodeBinary(): Promise<OpenCodeBinaryInfo | null> {
   return findDesktopBinary()
 }
 
+export function extractSemverFromOutput(output: string): string | null {
+  const trimmed = output.trim()
+  if (!trimmed) return null
+  // Match a semver-shaped token, allowing optional `v` prefix and `-prerelease+build` suffix.
+  // The negative lookbehind `(?<![\d:])` prevents matching the milliseconds segment of timestamps
+  // like `00:24:25.202` that the Electron-based OpenCode binary leaks into stdout.
+  const semverPattern = /(?<![\d:])v?(\d+\.\d+\.\d+(?:[-+][\w.]+)*)/
+  const match = trimmed.match(semverPattern)
+  return match?.[1] ?? null
+}
+
 export async function getOpenCodeVersion(
   binaryPath: string,
   platform: NodeJS.Platform = process.platform
@@ -113,7 +124,7 @@ export async function getOpenCodeVersion(
     const command = buildVersionCommand(binaryPath, platform)
     const result = await spawnWithTimeout(command, { stdout: "pipe", stderr: "pipe" })
     if (result.timedOut || result.exitCode !== 0) return null
-    return result.stdout.trim() || null
+    return extractSemverFromOutput(result.stdout)
   } catch {
     return null
   }

--- a/src/shared/extract-semver.ts
+++ b/src/shared/extract-semver.ts
@@ -1,0 +1,9 @@
+export function extractSemverFromOutput(output: string): string | null {
+  const trimmed = output.trim()
+  if (!trimmed) return null
+  // The negative lookbehind `(?<![\d:])` prevents matching the milliseconds segment of timestamps
+  // like `00:24:25.202` that the Electron-based OpenCode binary leaks into stdout.
+  const semverPattern = /(?<![\d:])v?(\d+\.\d+\.\d+(?:[-+][\w.]+)*)/
+  const match = trimmed.match(semverPattern)
+  return match?.[1] ?? null
+}


### PR DESCRIPTION
Fixes #3765

## Summary
- Original doctor fix: extract semver from polluted `opencode --version` stdout
- Extended scope: apply the same fix to the installer's version probe in `opencode-binary.ts`
- Helper extracted to `src/shared/extract-semver.ts` so doctor and installer share one source of truth

## Root Cause
OpenCode desktop/Electron binaries may print runtime log lines to stdout before or alongside the semantic version output. The previous `output.trim()` logic in doctor could treat these polluted strings as version text and produce false positives like "OpenCode is outdated". The same parsing assumption also existed in the installer caller, where polluted output could be persisted into config as the OpenCode version.

## Files Changed
- NEW: `src/shared/extract-semver.ts`
- MODIFIED: `src/cli/doctor/checks/system-binary.ts` (imports from shared, re-exports for compatibility)
- MODIFIED: `src/cli/doctor/checks/system-binary.test.ts` (import path update)
- MODIFIED: `src/cli/config-manager/opencode-binary.ts` (uses shared helper with `?? output.trim()` fallback)
- NEW: `src/cli/config-manager/opencode-binary.test.ts` (4 installer regression tests)

## Verification
- `bun test src/cli/doctor/checks/system-binary.test.ts src/cli/config-manager/opencode-binary.test.ts` → 16 pass / 0 fail
- `bun test src/cli/doctor src/cli/config-manager src/cli/install.test.ts` → 129 pass / 0 fail
- `bun run typecheck` → clean
- `bun run build` → success

## Note on PR #3817
PR #3817 by @MoerAI proposed a similar doctor-only fix. Closing in favor of this more complete PR, which covers both doctor and installer callers with a shared helper and broader regression coverage.
