### PR TITLE
fix(plugin): allow real session.idle after synthetic idle within dedup window

### DIFF
--- a/src/plugin/event.test.ts
+++ b/src/plugin/event.test.ts
@@ -366,6 +366,72 @@ describe("createEventHandler - idle deduplication", () => {
 		expect((dispatchCalls[1]?.event.properties as { sessionID?: string } | undefined)?.sessionID).toBe(sessionId)
 	})
 
+	it("keeps other session dedup state untouched when bypassing synthetic-idle for current session", async () => {
+		//#given
+		const originalDateNow = Date.now
+		let currentNow = 30_000
+		Date.now = () => currentNow
+		const dispatchedSessionIds: string[] = []
+		const eventHandler = createIdleDedupSpyEventHandler({
+			onEvent: () => {},
+			sessionNotification: async (input: EventInput) => {
+				if (input.event.type !== "session.idle") {
+					return
+				}
+				const props = input.event.properties as { sessionID?: string } | undefined
+				if (props?.sessionID) {
+					dispatchedSessionIds.push(props.sessionID)
+				}
+			},
+		})
+
+		try {
+			//#when
+			await eventHandler(asEventHandlerInput({
+				event: {
+					type: "session.status",
+					properties: {
+						sessionID: "ses_a",
+						status: { type: "idle" },
+					},
+				},
+			}))
+			await eventHandler(asEventHandlerInput({
+				event: {
+					type: "session.idle",
+					properties: {
+						sessionID: "ses_b",
+					},
+				},
+			}))
+
+			currentNow += 100
+			await eventHandler(asEventHandlerInput({
+				event: {
+					type: "session.idle",
+					properties: {
+						sessionID: "ses_a",
+					},
+				},
+			}))
+
+			currentNow += 100
+			await eventHandler(asEventHandlerInput({
+				event: {
+					type: "session.idle",
+					properties: {
+						sessionID: "ses_b",
+					},
+				},
+			}))
+
+			//#then
+			expect(dispatchedSessionIds).toEqual(["ses_a", "ses_b", "ses_a"])
+		} finally {
+			Date.now = originalDateNow
+		}
+	})
+
 	it("dedups back-to-back real session.idle events for the same sessionID within 500ms", async () => {
 		//#given
 		const originalDateNow = Date.now

--- a/src/plugin/event.test.ts
+++ b/src/plugin/event.test.ts
@@ -335,7 +335,7 @@ describe("createEventHandler - idle deduplication", () => {
 		expect(spawnTmuxPane).toHaveBeenCalledTimes(1)
 	})
 
-	it("dedups real-idle-after-synthetic-idle within 500ms", async () => {
+	it("does NOT dedup real-idle-after-synthetic-idle within 500ms", async () => {
 		//#given
 		const dispatchCalls: EventInput[] = []
 		const eventHandler = createIdleTrackingEventHandler(dispatchCalls)
@@ -359,9 +359,11 @@ describe("createEventHandler - idle deduplication", () => {
 		}))
 
 		//#then
-		expect(dispatchCalls).toHaveLength(1)
+		expect(dispatchCalls).toHaveLength(2)
 		expect(dispatchCalls[0]?.event.type).toBe("session.idle")
 		expect((dispatchCalls[0]?.event.properties as { sessionID?: string } | undefined)?.sessionID).toBe(sessionId)
+		expect(dispatchCalls[1]?.event.type).toBe("session.idle")
+		expect((dispatchCalls[1]?.event.properties as { sessionID?: string } | undefined)?.sessionID).toBe(sessionId)
 	})
 
 	it("dedups back-to-back real session.idle events for the same sessionID within 500ms", async () => {

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -415,6 +415,9 @@ export function createEventHandler(args: {
         const emittedAt = recentSyntheticIdles.get(sessionID);
         if (emittedAt !== undefined && now - emittedAt < DEDUP_WINDOW_MS) {
           recentSyntheticIdles.delete(sessionID);
+          // Let real idle events through even when a synthetic idle fired moments earlier.
+          // OpenCode diagnostics expect a concrete session.idle event signal.
+          recentAnyIdles.delete(sessionID);
         }
         recentRealIdles.set(sessionID, now);
         if (!shouldDispatchIdleEvent(sessionID, now)) {

--- a/src/plugin/event.ts
+++ b/src/plugin/event.ts
@@ -417,7 +417,10 @@ export function createEventHandler(args: {
           recentSyntheticIdles.delete(sessionID);
           // Let real idle events through even when a synthetic idle fired moments earlier.
           // OpenCode diagnostics expect a concrete session.idle event signal.
-          recentAnyIdles.delete(sessionID);
+          const lastAnyIdleAt = recentAnyIdles.get(sessionID);
+          if (lastAnyIdleAt === emittedAt) {
+            recentAnyIdles.delete(sessionID);
+          }
         }
         recentRealIdles.set(sessionID, now);
         if (!shouldDispatchIdleEvent(sessionID, now)) {


### PR DESCRIPTION
Fixes #2667

## Summary
Real session.idle event was being deduped by the synthetic-idle path, causing TODO-DIAG red alert "no todossession.idle event".

## Root Cause
- session.status(idle) → synthetic session.idle → recorded in recentAnyIdles
- Real session.idle within 500ms: recentSyntheticIdles cleared, but recentAnyIdles entry persisted
- Result: real idle dropped by dedup logic

## Fix
When real session.idle arrives, also clear recentAnyIdles entry so dedup does not drop it.

## Test Update
Regression test renamed:
- "dedups real-idle-after-synthetic-idle within 500ms"
+ "does NOT dedup real-idle-after-synthetic-idle within 500ms"
Expected dispatchCalls: 1 → 2

## Verification
- LSP diagnostics: clean (event.ts + event.test.ts)
- bun run build: success

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix dedup logic so a real `session.idle` is emitted even if a synthetic idle fired within 500ms. Resolves #2667 and stops the TODO-DIAG red alert for missing `session.idle`.

- **Bug Fixes**
  - On real `session.idle`, clear `recentSyntheticIdles` and only clear `recentAnyIdles` when its marker matches the synthetic timestamp for the same session, ensuring the real event dispatches without clobbering newer markers.
  - Tests: renamed to “does NOT dedup real-idle-after-synthetic-idle within 500ms” (expects two dispatches) and added a cross-session regression test to keep other sessions’ dedup state intact.

<sup>Written for commit 2168040ac68fe812fb784c90dd41f1a5c95ae3dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

