### PR TITLE
fix(background-agent): retain completed tasks via archive fallback after cleanup

### DIFF
--- a/src/features/background-agent/cancel-task-cleanup.test.ts
+++ b/src/features/background-agent/cancel-task-cleanup.test.ts
@@ -107,7 +107,8 @@ describe("BackgroundManager.cancelTask cleanup", () => {
     expect(cancelled).toBe(true)
     expect(getPendingByParent(manager).get(task.parentSessionId)).toBeUndefined()
     runScheduledCleanup(manager, task.id)
-    expect(manager.getTask(task.id)).toBeUndefined()
+    expect(getTaskMap(manager).has(task.id)).toBe(false)
+    expect(manager.getTask(task.id)?.sessionId).toBe(task.sessionId)
   })
 
   test("#given a running task #when cancelTask called with skipNotification=false #then task is also eventually removed", async () => {
@@ -131,7 +132,8 @@ describe("BackgroundManager.cancelTask cleanup", () => {
     // then
     expect(cancelled).toBe(true)
     runScheduledCleanup(manager, task.id)
-    expect(manager.getTask(task.id)).toBeUndefined()
+    expect(getTaskMap(manager).has(task.id)).toBe(false)
+    expect(manager.getTask(task.id)?.sessionId).toBe(task.sessionId)
   })
 
   test("#given a running task #when cancelTask called with skipNotification=true #then concurrency slot is freed and pending tasks can start", async () => {

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -6014,7 +6014,41 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
 
     //#then
     expect(getTaskMap(manager).has(task.id)).toBe(false)
-    expect(manager.getTask(task.id)?.sessionId).toBe(task.sessionId)
+    const archivedTask = manager.getTask(task.id)
+    expect(archivedTask?.sessionId).toBe(task.sessionId)
+    expect(archivedTask?.prompt).toBe("[redacted]")
+
+    manager.shutdown()
+  })
+
+  test("should cap completed task archive size at 100 entries", () => {
+    //#given
+    const manager = createBackgroundManager()
+
+    //#when
+    for (let index = 0; index < 120; index += 1) {
+      const task: BackgroundTask = {
+        id: `task-archive-${index}`,
+        sessionId: `session-archive-${index}`,
+        parentSessionId: "parent-session",
+        parentMessageId: "msg-1",
+        description: "archive cap regression",
+        prompt: `sensitive-${index}`,
+        agent: "explore",
+        status: "completed",
+        startedAt: new Date(),
+        completedAt: new Date(),
+      }
+      ;(cast<{ removeTask: (task: BackgroundTask) => void }>(manager)).removeTask(task)
+    }
+
+    //#then
+    const archive = cast<Map<string, unknown>>(Reflect.get(manager, "completedTaskArchive"))
+    expect(archive.size).toBe(100)
+    expect(archive.has("task-archive-0")).toBe(false)
+    expect(archive.has("task-archive-19")).toBe(false)
+    expect(archive.has("task-archive-20")).toBe(true)
+    expect(archive.has("task-archive-119")).toBe(true)
 
     manager.shutdown()
   })

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -6017,6 +6017,7 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
     const archivedTask = manager.getTask(task.id)
     expect(archivedTask?.sessionId).toBe(task.sessionId)
     expect(archivedTask?.prompt).toBe("[redacted]")
+    expect(archivedTask?.startedAt).toEqual(task.startedAt)
 
     manager.shutdown()
   })

--- a/src/features/background-agent/manager.test.ts
+++ b/src/features/background-agent/manager.test.ts
@@ -5991,6 +5991,33 @@ describe("BackgroundManager regression fixes - resume and aborted notification",
 
     manager.shutdown()
   })
+
+  test("should keep completed task retrievable after scheduled removal", () => {
+    //#given
+    const manager = createBackgroundManager()
+    const task: BackgroundTask = {
+      id: "task-archive-regression",
+      sessionId: "session-archive-regression",
+      parentSessionId: "parent-session",
+      parentMessageId: "msg-1",
+      description: "archive regression",
+      prompt: "test",
+      agent: "explore",
+      status: "completed",
+      startedAt: new Date(),
+      completedAt: new Date(),
+    }
+    getTaskMap(manager).set(task.id, task)
+
+    //#when
+    ;(cast<{ removeTask: (task: BackgroundTask) => void }>(manager)).removeTask(task)
+
+    //#then
+    expect(getTaskMap(manager).has(task.id)).toBe(false)
+    expect(manager.getTask(task.id)?.sessionId).toBe(task.sessionId)
+
+    manager.shutdown()
+  })
 })
 
 describe("BackgroundManager - tool permission spread order", () => {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -188,6 +188,7 @@ export interface SubagentSessionCreatedEvent {
 export type OnSubagentSessionCreated = (event: SubagentSessionCreatedEvent) => Promise<void>
 
 const MAX_TASK_REMOVAL_RESCHEDULES = 6
+const MAX_COMPLETED_TASK_ARCHIVE_SIZE = 500
 
 export interface BackgroundManagerConfig {
   pluginContext: PluginInput
@@ -222,6 +223,7 @@ export class BackgroundManager {
   private queuesByKey: Map<string, QueueItem[]> = new Map()
   private processingKeys: Set<string> = new Set()
   private completionTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+  private completedTaskArchive: Map<string, BackgroundTask> = new Map()
   private completedTaskSummaries: Map<string, BackgroundTaskNotificationTask[]> = new Map()
   private idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
   private notificationQueueByParent: Map<string, Promise<void>> = new Map()
@@ -347,6 +349,7 @@ export class BackgroundManager {
   }
 
   private addTask(task: BackgroundTask): void {
+    this.completedTaskArchive.delete(task.id)
     this.tasks.set(task.id, task)
     if (!task.parentSessionId) {
       return
@@ -358,8 +361,28 @@ export class BackgroundManager {
   }
 
   private removeTask(task: BackgroundTask): void {
+    this.archiveCompletedTask(task)
     this.tasks.delete(task.id)
     this.removeTaskFromParentIndex(task.id, task.parentSessionId)
+  }
+
+  private archiveCompletedTask(task: BackgroundTask): void {
+    if (!task.sessionId) {
+      return
+    }
+    if (task.status === "running" || task.status === "pending") {
+      return
+    }
+
+    this.completedTaskArchive.set(task.id, task)
+    if (this.completedTaskArchive.size <= MAX_COMPLETED_TASK_ARCHIVE_SIZE) {
+      return
+    }
+
+    const oldestTaskID = this.completedTaskArchive.keys().next().value
+    if (typeof oldestTaskID === "string") {
+      this.completedTaskArchive.delete(oldestTaskID)
+    }
   }
 
   private updateTaskParent(task: BackgroundTask, parentSessionID: string): void {
@@ -830,7 +853,7 @@ The fallback retry session is now created and can be inspected directly.
   }
 
   getTask(id: string): BackgroundTask | undefined {
-    return this.tasks.get(id)
+    return this.tasks.get(id) ?? this.completedTaskArchive.get(id)
   }
 
   getTasksByParentSession(sessionID: string): BackgroundTask[] {

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -188,7 +188,7 @@ export interface SubagentSessionCreatedEvent {
 export type OnSubagentSessionCreated = (event: SubagentSessionCreatedEvent) => Promise<void>
 
 const MAX_TASK_REMOVAL_RESCHEDULES = 6
-const MAX_COMPLETED_TASK_ARCHIVE_SIZE = 500
+const MAX_COMPLETED_TASK_ARCHIVE_SIZE = 100
 
 export interface BackgroundManagerConfig {
   pluginContext: PluginInput
@@ -374,7 +374,22 @@ export class BackgroundManager {
       return
     }
 
-    this.completedTaskArchive.set(task.id, task)
+    const archivedTask: BackgroundTask = {
+      id: task.id,
+      parentSessionId: task.parentSessionId,
+      parentMessageId: task.parentMessageId,
+      description: task.description,
+      prompt: "[redacted]",
+      agent: task.agent,
+      sessionId: task.sessionId,
+      status: task.status,
+      completedAt: task.completedAt,
+      model: task.model,
+      error: task.error,
+      category: task.category,
+    }
+
+    this.completedTaskArchive.set(task.id, archivedTask)
     if (this.completedTaskArchive.size <= MAX_COMPLETED_TASK_ARCHIVE_SIZE) {
       return
     }

--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -383,6 +383,8 @@ export class BackgroundManager {
       agent: task.agent,
       sessionId: task.sessionId,
       status: task.status,
+      queuedAt: task.queuedAt,
+      startedAt: task.startedAt,
       completedAt: task.completedAt,
       model: task.model,
       error: task.error,


### PR DESCRIPTION
Fixes #3895

## Summary
After MessageAbortedError or worker shutdown, scheduled cleanup could race with background_output, causing manager.getTask to return "Task not found" for tasks that had actually completed.

## Root Cause
removeTask deletes from active map immediately. background_output relying on getTask had no fallback once cleanup hit.

## Fix
- Added completedTaskArchive (Map, max 500, FIFO eviction)
- removeTask: archives non-running/pending tasks with sessionId
- getTask: falls back to archive on active-map miss
- addTask: clears stale archive entry on re-registration with same id

## Verification
- LSP diagnostics: clean (manager.ts + manager.test.ts)
- bun test src/features/background-agent/manager.test.ts: 153 pass (incl. new regression "should keep completed task retrievable after scheduled removal")
- bun run build: success
- No overlap with fixer-poller (#2702): they only touch delegate-task/sync-session-poller

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents completed background tasks from returning “Task not found” after cleanup by adding a sanitized archive fallback in `BackgroundManager`, preserving non-sensitive timing for accurate durations. Fixes #3895.

- **Bug Fixes**
  - Added `completedTaskArchive` (max 100, FIFO eviction).
  - On `removeTask`, archive non-running/pending tasks with `sessionId`; redacts `prompt`; preserves `queuedAt`, `startedAt`, and `completedAt`.
  - `getTask` falls back to the archive; `addTask` clears stale entries.
  - Updated tests: cancel-cleanup assertions; retrieval with redacted prompt and preserved timing; archive size capped at 100.

<sup>Written for commit eb6605a87f7fd69a8d7975b993901cf4335f1c76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

