### PR TITLE
fix: prevent non-positive maxOutputTokens from leaking to SDK

### DIFF
--- a/src/plugin/chat-params.test.ts
+++ b/src/plugin/chat-params.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 
 import { createChatParamsHandler, type ChatParamsOutput } from "./chat-params"
 import * as dataPathModule from "../shared/data-path"
-import { writeProviderModelsCache } from "../shared"
+import * as sharedModule from "../shared"
 import {
   clearSessionPromptParams,
   getSessionPromptParams,
@@ -21,13 +21,13 @@ describe("createChatParamsHandler", () => {
     getCacheDirSpy = spyOn(dataPathModule, "getOmoOpenCodeCacheDir").mockReturnValue(
       join(tempCacheRoot, "oh-my-opencode"),
     )
-    writeProviderModelsCache({ connected: [], models: {} })
+    sharedModule.writeProviderModelsCache({ connected: [], models: {} })
   })
 
   afterEach(() => {
     clearSessionPromptParams("ses_chat_params")
     clearSessionPromptParams("ses_chat_params_temperature")
-    writeProviderModelsCache({ connected: [], models: {} })
+    sharedModule.writeProviderModelsCache({ connected: [], models: {} })
     getCacheDirSpy?.mockRestore()
     if (tempCacheRoot) {
       rmSync(tempCacheRoot, { recursive: true, force: true })
@@ -101,7 +101,7 @@ describe("createChatParamsHandler", () => {
 
   test("applies stored prompt params for the session", async () => {
     //#given
-    writeProviderModelsCache({
+    sharedModule.writeProviderModelsCache({
       connected: ["openai"],
       models: {
         openai: [
@@ -256,6 +256,7 @@ describe("createChatParamsHandler", () => {
 
   test("falls back to default maxOutputTokens when stored and compatibility tokens are non-positive", async () => {
     //#given
+    const logSpy = spyOn(sharedModule, "log").mockImplementation(() => undefined)
     setSessionPromptParams("ses_chat_params", {
       maxOutputTokens: 0,
     })
@@ -276,6 +277,43 @@ describe("createChatParamsHandler", () => {
       topP: 1,
       topK: 1,
       maxOutputTokens: 0,
+      options: {},
+    }
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.maxOutputTokens).toBe(4096)
+    expect(logSpy).toHaveBeenCalledWith(
+      "[plugin] maxOutputTokens=0 is non-positive; using safe fallback 4096",
+    )
+
+    logSpy.mockRestore()
+  })
+
+  test("uses safe fallback instead of model max when stored maxOutputTokens is non-positive", async () => {
+    //#given
+    setSessionPromptParams("ses_chat_params", {
+      maxOutputTokens: -1,
+    })
+
+    const handler = createChatParamsHandler({
+      anthropicEffort: null,
+    })
+
+    const input = {
+      sessionID: "ses_chat_params",
+      agent: { name: "oracle" },
+      model: { providerID: "openai", modelID: "gpt-5.4" },
+      provider: { id: "openai" },
+      message: {},
+    }
+
+    const output: ChatParamsOutput = {
+      topP: 1,
+      topK: 1,
+      maxOutputTokens: -1,
       options: {},
     }
 

--- a/src/plugin/chat-params.test.ts
+++ b/src/plugin/chat-params.test.ts
@@ -253,4 +253,36 @@ describe("createChatParamsHandler", () => {
       options: {},
     })
   })
+
+  test("falls back to default maxOutputTokens when stored and compatibility tokens are non-positive", async () => {
+    //#given
+    setSessionPromptParams("ses_chat_params", {
+      maxOutputTokens: 0,
+    })
+
+    const handler = createChatParamsHandler({
+      anthropicEffort: null,
+    })
+
+    const input = {
+      sessionID: "ses_chat_params",
+      agent: { name: "oracle" },
+      model: { providerID: "custom-provider", modelID: "custom-model" },
+      provider: { id: "custom-provider" },
+      message: {},
+    }
+
+    const output: ChatParamsOutput = {
+      topP: 1,
+      topK: 1,
+      maxOutputTokens: 0,
+      options: {},
+    }
+
+    //#when
+    await handler(input, output)
+
+    //#then
+    expect(output.maxOutputTokens).toBe(4096)
+  })
 })

--- a/src/plugin/chat-params.ts
+++ b/src/plugin/chat-params.ts
@@ -1,5 +1,7 @@
 import { getSessionPromptParams } from "../shared/session-prompt-params-state"
-import { getModelCapabilities, resolveCompatibleModelSettings } from "../shared"
+import { getModelCapabilities, log, resolveCompatibleModelSettings } from "../shared"
+
+const SAFE_MAX_OUTPUT_TOKENS_FALLBACK = 4096
 
 export type ChatParamsInput = {
   sessionID: string
@@ -168,9 +170,15 @@ export function createChatParamsHandler(args: {
       if (compatibility.maxTokens !== undefined && compatibility.maxTokens > 0) {
         output.maxOutputTokens = compatibility.maxTokens
       } else {
-        const capabilitiesLimit = capabilities?.maxOutputTokens
-        output.maxOutputTokens =
-          typeof capabilitiesLimit === "number" && capabilitiesLimit > 0 ? capabilitiesLimit : 4096
+        const originalMaxOutputTokens = typeof output.maxOutputTokens === "number"
+          ? output.maxOutputTokens
+          : compatibility.maxTokens
+        output.maxOutputTokens = SAFE_MAX_OUTPUT_TOKENS_FALLBACK
+        if (typeof originalMaxOutputTokens === "number" && originalMaxOutputTokens <= 0) {
+          log(
+            `[plugin] maxOutputTokens=${originalMaxOutputTokens} is non-positive; using safe fallback ${SAFE_MAX_OUTPUT_TOKENS_FALLBACK}`,
+          )
+        }
       }
     }
 

--- a/src/plugin/chat-params.ts
+++ b/src/plugin/chat-params.ts
@@ -96,7 +96,10 @@ export function createChatParamsHandler(args: {
       if (storedPromptParams.topP !== undefined) {
         output.topP = storedPromptParams.topP
       }
-      if (storedPromptParams.maxOutputTokens !== undefined) {
+      if (
+        typeof storedPromptParams.maxOutputTokens === "number" &&
+        storedPromptParams.maxOutputTokens > 0
+      ) {
         (output as Record<string, unknown>).maxOutputTokens = storedPromptParams.maxOutputTokens
       }
       if (storedPromptParams.options) {
@@ -162,10 +165,12 @@ export function createChatParamsHandler(args: {
     }
 
     if ("maxTokens" in compatibility) {
-      if (compatibility.maxTokens !== undefined) {
+      if (compatibility.maxTokens !== undefined && compatibility.maxTokens > 0) {
         output.maxOutputTokens = compatibility.maxTokens
       } else {
-        delete output.maxOutputTokens
+        const capabilitiesLimit = capabilities?.maxOutputTokens
+        output.maxOutputTokens =
+          typeof capabilitiesLimit === "number" && capabilitiesLimit > 0 ? capabilitiesLimit : 4096
       }
     }
 

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -553,6 +553,18 @@ describe("resolveCompatibleModelSettings", () => {
     expect(result.changes).toEqual([])
   })
 
+  test("#given desired.maxTokens is 0 #then maxTokens is dropped", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "gpt-5.4",
+      desired: { maxTokens: 0 },
+      capabilities: { maxOutputTokens: 128_000 },
+    })
+
+    expect(result.maxTokens).toBeUndefined()
+    expect(result.changes).toEqual([])
+  })
+
   // Passthrough: undefined desired values produce no changes
   test("no-op when desired settings are empty", () => {
     const result = resolveCompatibleModelSettings({

--- a/src/shared/model-settings-compatibility.ts
+++ b/src/shared/model-settings-compatibility.ts
@@ -162,6 +162,10 @@ export function resolveCompatibleModelSettings(
   }
 
   let maxTokens = input.desired.maxTokens
+  if (maxTokens !== undefined && maxTokens <= 0) {
+    maxTokens = undefined
+  }
+
   if (
     maxTokens !== undefined &&
     input.capabilities?.maxOutputTokens !== undefined &&


### PR DESCRIPTION
## Summary
- prevent session prompt params from reapplying non-positive `maxOutputTokens` in `chat.params`
- add compatibility fallback so `maxTokens` resolves to a positive value (`capabilities.maxOutputTokens` when valid, otherwise `4096`)
- treat non-positive desired `maxTokens` as invalid in model settings compatibility and cover with regression tests

## Why
OpenCode 1.4.0 validates `maxOutputTokens >= 1`. In custom provider paths, `0`/`undefined` could leak into SDK params and fail request construction.

## Validation
- `bun test src/plugin/chat-params.test.ts src/shared/model-settings-compatibility.test.ts`
- `bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent non-positive `maxOutputTokens` from reaching the SDK and always fall back to a fixed budget of 4096, keeping requests valid with OpenCode 1.4.0.

- **Bug Fixes**
  - Ignore stored `maxOutputTokens` unless it’s a positive number when building chat params.
  - Treat `desired.maxTokens <= 0` as invalid in compatibility and drop it.
  - When limits are invalid or missing, set `output.maxOutputTokens` to `4096` (not capability max) and log a notice.

<sup>Written for commit 2f8ce576dccdc1e1b28ef22da936200652daa8e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

