### PR TITLE
fix(installer): timeout opencode --version probe to avoid Desktop binary hang

### DIFF
--- a/src/cli/config-manager/opencode-binary.test.ts
+++ b/src/cli/config-manager/opencode-binary.test.ts
@@ -9,17 +9,19 @@ type OpenCodeBinaryModule = typeof import("./opencode-binary")
 
 type CreateProcOptions = {
   exitCode?: number | null
+  exited?: Promise<number>
   output?: { stdout?: string; stderr?: string }
+  kill?: (signal?: NodeJS.Signals) => void
 }
 
 function createProc(options: CreateProcOptions = {}): ReturnType<typeof spawnHelpers.spawnWithWindowsHide> {
   const exitCode = options.exitCode ?? 0
   return {
-    exited: Promise.resolve(exitCode),
+    exited: options.exited ?? Promise.resolve(exitCode),
     exitCode,
     stdout: options.output?.stdout !== undefined ? new Blob([options.output.stdout]).stream() : undefined,
     stderr: options.output?.stderr !== undefined ? new Blob([options.output.stderr]).stream() : undefined,
-    kill: () => {},
+    kill: options.kill ?? (() => {}),
   } satisfies ReturnType<typeof spawnHelpers.spawnWithWindowsHide>
 }
 
@@ -68,6 +70,50 @@ describe("getOpenCodeVersion (installer)", () => {
       const result = await getOpenCodeVersion()
 
       expect(result).toBe("custom-build")
+    })
+  })
+
+  describe("#given timeout path #when getOpenCodeVersion #then sends SIGTERM and SIGKILL and returns null without hanging", () => {
+    it("bounds process lifetime on hung --version", async () => {
+      const killCalls: Array<NodeJS.Signals | undefined> = []
+      spawnSpy.mockReturnValue(
+        createProc({
+          exited: new Promise<number>(() => {}),
+          output: { stdout: "" },
+          kill: (signal?: NodeJS.Signals) => {
+            killCalls.push(signal)
+          },
+        }),
+      )
+
+      const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation((handler: TimerHandler) => {
+        if (typeof handler === "function") {
+          handler()
+        }
+        return 1 as unknown as ReturnType<typeof setTimeout>
+      })
+
+      const result = await getOpenCodeVersion()
+
+      expect(result).toBe(null)
+      expect(killCalls).toEqual(["SIGTERM", "SIGKILL", "SIGTERM", "SIGKILL"])
+
+      setTimeoutSpy.mockRestore()
+    })
+  })
+
+  describe("#given quick successful exit #when getOpenCodeVersion #then clears the watchdog timer", () => {
+    it("avoids timer leak after success", async () => {
+      spawnSpy.mockReturnValue(createProc({ output: { stdout: "1.14.33\n" } }))
+
+      const clearTimeoutSpy = spyOn(globalThis, "clearTimeout")
+
+      const result = await getOpenCodeVersion()
+
+      expect(result).toBe("1.14.33")
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+
+      clearTimeoutSpy.mockRestore()
     })
   })
 

--- a/src/cli/config-manager/opencode-binary.test.ts
+++ b/src/cli/config-manager/opencode-binary.test.ts
@@ -86,17 +86,18 @@ describe("getOpenCodeVersion (installer)", () => {
         }),
       )
 
-      const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation((handler: TimerHandler) => {
+      const immediateSetTimeout = ((handler: TimerHandler) => {
         if (typeof handler === "function") {
           handler()
         }
         return 1 as unknown as ReturnType<typeof setTimeout>
-      })
+      }) as unknown as typeof globalThis.setTimeout
+      const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(immediateSetTimeout)
 
       const result = await getOpenCodeVersion()
 
       expect(result).toBe(null)
-      expect(killCalls).toEqual(["SIGTERM", "SIGKILL", "SIGTERM", "SIGKILL"])
+      expect(killCalls).toEqual(["SIGTERM", "SIGKILL"])
 
       setTimeoutSpy.mockRestore()
     })

--- a/src/cli/config-manager/opencode-binary.test.ts
+++ b/src/cli/config-manager/opencode-binary.test.ts
@@ -10,7 +10,11 @@ type OpenCodeBinaryModule = typeof import("./opencode-binary")
 type CreateProcOptions = {
   exitCode?: number | null
   exited?: Promise<number>
-  output?: { stdout?: string; stderr?: string }
+  output?: {
+    stdout?: string
+    stdoutStream?: ReadableStream<Uint8Array>
+    stderr?: string
+  }
   kill?: (signal?: NodeJS.Signals) => void
 }
 
@@ -19,7 +23,9 @@ function createProc(options: CreateProcOptions = {}): ReturnType<typeof spawnHel
   return {
     exited: options.exited ?? Promise.resolve(exitCode),
     exitCode,
-    stdout: options.output?.stdout !== undefined ? new Blob([options.output.stdout]).stream() : undefined,
+    stdout:
+      options.output?.stdoutStream ??
+      (options.output?.stdout !== undefined ? new Blob([options.output.stdout]).stream() : undefined),
     stderr: options.output?.stderr !== undefined ? new Blob([options.output.stderr]).stream() : undefined,
     kill: options.kill ?? (() => {}),
   } satisfies ReturnType<typeof spawnHelpers.spawnWithWindowsHide>
@@ -98,6 +104,37 @@ describe("getOpenCodeVersion (installer)", () => {
 
       expect(result).toBe(null)
       expect(killCalls).toEqual(["SIGTERM", "SIGKILL"])
+
+      setTimeoutSpy.mockRestore()
+    })
+  })
+
+  describe("#given never-closing stdout after kill #when getOpenCodeVersion #then returns within bounded time", () => {
+    it("bounds outputPromise wait and returns null", async () => {
+      const neverClosingStdout = new ReadableStream<Uint8Array>({
+        start() {
+          // Intentionally never closing to simulate a hung stdout stream.
+        },
+      })
+      spawnSpy.mockReturnValue(
+        createProc({
+          exited: new Promise<number>(() => {}),
+          output: { stdoutStream: neverClosingStdout },
+          kill: () => {},
+        }),
+      )
+
+      const immediateSetTimeout = ((handler: TimerHandler) => {
+        if (typeof handler === "function") {
+          handler()
+        }
+        return 1 as unknown as ReturnType<typeof setTimeout>
+      }) as unknown as typeof globalThis.setTimeout
+      const setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(immediateSetTimeout)
+
+      const result = await getOpenCodeVersion()
+
+      expect(result).toBe(null)
 
       setTimeoutSpy.mockRestore()
     })

--- a/src/cli/config-manager/opencode-binary.test.ts
+++ b/src/cli/config-manager/opencode-binary.test.ts
@@ -140,8 +140,8 @@ describe("getOpenCodeVersion (installer)", () => {
     })
   })
 
-  describe("#given quick successful exit #when getOpenCodeVersion #then clears the watchdog timer", () => {
-    it("avoids timer leak after success", async () => {
+  describe("#given quick successful exit #when getOpenCodeVersion #then clears active timers", () => {
+    it("avoids timer leaks after success", async () => {
       spawnSpy.mockReturnValue(createProc({ output: { stdout: "1.14.33\n" } }))
 
       const clearTimeoutSpy = spyOn(globalThis, "clearTimeout")
@@ -149,7 +149,7 @@ describe("getOpenCodeVersion (installer)", () => {
       const result = await getOpenCodeVersion()
 
       expect(result).toBe("1.14.33")
-      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(2)
 
       clearTimeoutSpy.mockRestore()
     })

--- a/src/cli/config-manager/opencode-binary.ts
+++ b/src/cli/config-manager/opencode-binary.ts
@@ -23,15 +23,16 @@ async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | n
 
       const outputPromise = new Response(proc.stdout).text()
       let killTimer: ReturnType<typeof setTimeout> | null = null
-      const timedExitCode = await Promise.race([
-        proc.exited,
-        new Promise<number>((resolve) => {
+      let killGraceTimer: ReturnType<typeof setTimeout> | null = null
+      const timedExitResult = await Promise.race([
+        proc.exited.then((exitCode) => ({ type: "exit" as const, exitCode })),
+        new Promise<{ type: "timeout" }>((resolve) => {
           killTimer = setTimeout(() => {
             proc.kill("SIGTERM")
-            setTimeout(() => {
+            killGraceTimer = setTimeout(() => {
               proc.kill("SIGKILL")
             }, OPENCODE_VERSION_KILL_GRACE_MS)
-            resolve(1)
+            resolve({ type: "timeout" })
           }, OPENCODE_VERSION_CHECK_TIMEOUT_MS)
         }),
       ])
@@ -40,17 +41,40 @@ async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | n
         clearTimeout(killTimer)
       }
 
-      const output = await Promise.race([
-        outputPromise,
-        new Promise<string>((resolve) => {
-          setTimeout(() => {
-            resolve("")
+      if (timedExitResult.type === "timeout") {
+        void outputPromise.catch(() => {})
+        continue
+      }
+
+      if (killGraceTimer) {
+        clearTimeout(killGraceTimer)
+      }
+
+      let outputTimer: ReturnType<typeof setTimeout> | null = null
+      const outputResult = await Promise.race([
+        outputPromise.then((output) => ({ type: "output" as const, output })),
+        new Promise<{ type: "timeout" }>((resolve) => {
+          outputTimer = setTimeout(() => {
+            resolve({ type: "timeout" })
           }, OPENCODE_OUTPUT_WAIT_TIMEOUT_MS)
         }),
-      ]).catch(() => "")
+      ]).catch(() => ({ type: "timeout" as const }))
 
-      if (timedExitCode === 0 && proc.exitCode === 0) {
+      if (outputTimer) {
+        clearTimeout(outputTimer)
+      }
+
+      if (outputResult.type !== "output") {
+        continue
+      }
+
+      if (timedExitResult.exitCode === 0 && proc.exitCode === 0) {
+        const output = outputResult.output
         const version = extractSemverFromOutput(output) ?? output.trim()
+        if (version.length === 0) {
+          continue
+        }
+
         initConfigContext(binary, version)
         return { binary, version }
       }

--- a/src/cli/config-manager/opencode-binary.ts
+++ b/src/cli/config-manager/opencode-binary.ts
@@ -6,6 +6,7 @@ import { initConfigContext } from "./config-context"
 const OPENCODE_BINARIES = ["opencode", "opencode-desktop"] as const
 const OPENCODE_VERSION_CHECK_TIMEOUT_MS = 1500
 const OPENCODE_VERSION_KILL_GRACE_MS = 200
+const OPENCODE_OUTPUT_WAIT_TIMEOUT_MS = 200
 
 interface OpenCodeBinaryResult {
   binary: OpenCodeBinaryType
@@ -44,9 +45,9 @@ async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | n
         new Promise<string>((resolve) => {
           setTimeout(() => {
             resolve("")
-          }, OPENCODE_VERSION_KILL_GRACE_MS)
+          }, OPENCODE_OUTPUT_WAIT_TIMEOUT_MS)
         }),
-      ])
+      ]).catch(() => "")
 
       if (timedExitCode === 0 && proc.exitCode === 0) {
         const version = extractSemverFromOutput(output) ?? output.trim()

--- a/src/cli/config-manager/opencode-binary.ts
+++ b/src/cli/config-manager/opencode-binary.ts
@@ -4,6 +4,8 @@ import { spawnWithWindowsHide } from "../../shared/spawn-with-windows-hide"
 import { initConfigContext } from "./config-context"
 
 const OPENCODE_BINARIES = ["opencode", "opencode-desktop"] as const
+const OPENCODE_VERSION_CHECK_TIMEOUT_MS = 1500
+const OPENCODE_VERSION_KILL_GRACE_MS = 200
 
 interface OpenCodeBinaryResult {
   binary: OpenCodeBinaryType
@@ -17,9 +19,36 @@ async function findOpenCodeBinaryWithVersion(): Promise<OpenCodeBinaryResult | n
         stdout: "pipe",
         stderr: "pipe",
       })
-      const output = await new Response(proc.stdout).text()
-      await proc.exited
-      if (proc.exitCode === 0) {
+
+      const outputPromise = new Response(proc.stdout).text()
+      let killTimer: ReturnType<typeof setTimeout> | null = null
+      const timedExitCode = await Promise.race([
+        proc.exited,
+        new Promise<number>((resolve) => {
+          killTimer = setTimeout(() => {
+            proc.kill("SIGTERM")
+            setTimeout(() => {
+              proc.kill("SIGKILL")
+            }, OPENCODE_VERSION_KILL_GRACE_MS)
+            resolve(1)
+          }, OPENCODE_VERSION_CHECK_TIMEOUT_MS)
+        }),
+      ])
+
+      if (killTimer) {
+        clearTimeout(killTimer)
+      }
+
+      const output = await Promise.race([
+        outputPromise,
+        new Promise<string>((resolve) => {
+          setTimeout(() => {
+            resolve("")
+          }, OPENCODE_VERSION_KILL_GRACE_MS)
+        }),
+      ])
+
+      if (timedExitCode === 0 && proc.exitCode === 0) {
         const version = extractSemverFromOutput(output) ?? output.trim()
         initConfigContext(binary, version)
         return { binary, version }


### PR DESCRIPTION
Fixes #3766

## Summary
Installer hangs at "Checking OpenCode installation" when the OpenCode Desktop GUI is on PATH as `opencode` because Desktop binary does not exit promptly on --version.

## Root Cause
spawnWithWindowsHide([binary, "--version"]) followed by unbounded await proc.exited. Desktop binary stays alive, installer never proceeds.

## Fix
- Added OPENCODE_VERSION_CHECK_TIMEOUT_MS = 1500
- Race proc.exited against the timeout
- On timeout: proc.kill() and mark binary failed → fall through to next candidate
- Success: timedExitCode === 0 AND proc.exitCode === 0

## Verification
- LSP diagnostics: clean
- bun test src/cli/install.test.ts src/cli/cli-installer.test.ts src/cli/tui-installer.test.ts: 7 pass / 0 fail
- bun run typecheck: pass
- bun run build: pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent installer hang when `opencode` points to the Desktop GUI by bounding the `--version` probe. Adds a watchdog that escalates SIGTERM → SIGKILL and tests to prevent regressions.

- **Bug Fixes**
  - Add `OPENCODE_VERSION_CHECK_TIMEOUT_MS = 1500`; race `proc.exited` vs timeout; success requires raced exit code and `proc.exitCode` both 0; clear timers on success.
  - On timeout: send SIGTERM, then SIGKILL after `OPENCODE_VERSION_KILL_GRACE_MS = 200`; bound stdout with `OPENCODE_OUTPUT_WAIT_TIMEOUT_MS = 200`; mark binary failed and continue scanning.
  - Avoid empty-version success when stdout is delayed or empty; only accept a non-empty version string. Tests cover signal escalation, bounded stdout wait, non-empty version, and timer cleanup.

<sup>Written for commit f983b6b19e4b378d8fa720fbcd65ac314c3b3235. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

