### PR TITLE
fix(delegate-task): clarify sync inactivity timeout

### DIFF
--- a/src/tools/delegate-task/sync-poll-timeout.test.ts
+++ b/src/tools/delegate-task/sync-poll-timeout.test.ts
@@ -75,7 +75,7 @@ describe("syncPollTimeoutMs threading", () => {
             taskId: undefined,
           }, 120_000)
 
-          expect(result).toBe("Poll timeout reached after 120000ms for session ses_custom")
+          expect(result).toBe("Poll inactivity timeout reached after 120000ms without active OpenCode status for session ses_custom")
           expect(abortCount).toBe(1)
         })
       })
@@ -141,7 +141,7 @@ describe("syncPollTimeoutMs threading", () => {
             taskId: undefined,
           })
 
-          expect(result).toBe(`Poll timeout reached after ${MAX_POLL_TIME_MS}ms for session ses_default`)
+          expect(result).toBe(`Poll inactivity timeout reached after ${MAX_POLL_TIME_MS}ms without active OpenCode status for session ses_default`)
         })
       })
 
@@ -159,7 +159,7 @@ describe("syncPollTimeoutMs threading", () => {
             taskId: undefined,
           })
 
-          expect(result).toBe("Poll timeout reached after 120000ms for session ses_legacy")
+          expect(result).toBe("Poll inactivity timeout reached after 120000ms without active OpenCode status for session ses_legacy")
         })
       })
     })
@@ -177,7 +177,7 @@ describe("syncPollTimeoutMs threading", () => {
             taskId: undefined,
           }, 10)
 
-          expect(result).toBe("Poll timeout reached after 50ms for session ses_guard")
+          expect(result).toBe("Poll inactivity timeout reached after 50ms without active OpenCode status for session ses_guard")
         })
       })
     })

--- a/src/tools/delegate-task/sync-session-poller.test.ts
+++ b/src/tools/delegate-task/sync-session-poller.test.ts
@@ -100,7 +100,7 @@ describe("pollSyncSession", () => {
       }, 50)
 
       // then: times out (ignores stale error)
-      expect(result).toContain("Poll timeout reached")
+      expect(result).toContain("Poll inactivity timeout reached")
     })
 
     test("detects completion when assistant message has terminal finish reason", async () => {
@@ -459,7 +459,7 @@ describe("pollSyncSession", () => {
       }, 0)
 
       // then: returns timeout error
-      expect(result).toBe("Poll timeout reached after 50ms for session ses_timeout")
+      expect(result).toBe("Poll inactivity timeout reached after 50ms without active OpenCode status for session ses_timeout")
       expect(abortCount).toBe(1)
     })
   })

--- a/src/tools/delegate-task/sync-session-poller.ts
+++ b/src/tools/delegate-task/sync-session-poller.ts
@@ -214,9 +214,11 @@ export async function pollSyncSession(
   }
 
   if (timedOut) {
-    log("[task] Poll timeout reached", { sessionID: input.sessionID, pollCount })
+    log("[task] Poll inactivity timeout reached", { sessionID: input.sessionID, pollCount })
     abortSyncSession(client, input.sessionID, "poll_timeout")
   }
 
-  return timedOut ? `Poll timeout reached after ${maxPollTimeMs}ms for session ${input.sessionID}` : null
+  return timedOut
+    ? `Poll inactivity timeout reached after ${maxPollTimeMs}ms without active OpenCode status for session ${input.sessionID}`
+    : null
 }

--- a/src/tools/delegate-task/timing.test.ts
+++ b/src/tools/delegate-task/timing.test.ts
@@ -3,7 +3,7 @@ const { describe, expect, test } = require("bun:test")
 import { __resetTimingConfig, __setTimingConfig, getDefaultSyncPollTimeoutMs, getTimingConfig } from "./timing"
 
 describe("timing sync poll timeout defaults", () => {
-  test("default sync timeout is 30 minutes", () => {
+  test("default sync inactivity timeout is 30 minutes", () => {
     // #given
     __resetTimingConfig()
 
@@ -14,7 +14,7 @@ describe("timing sync poll timeout defaults", () => {
     expect(timeout).toBe(30 * 60 * 1000)
   })
 
-  test("default sync timeout accessor follows MAX_POLL_TIME_MS config", () => {
+  test("default sync inactivity timeout accessor follows MAX_POLL_TIME_MS config", () => {
     // #given
     __resetTimingConfig()
 

--- a/src/tools/delegate-task/tool-description.test.ts
+++ b/src/tools/delegate-task/tool-description.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+
+import { createDelegateTaskPresentation } from "./tool-description"
+
+describe("createDelegateTaskPresentation", () => {
+  test("#given sync task usage #when description is rendered #then timeout is described as inactivity based", () => {
+    //#given
+    const presentation = createDelegateTaskPresentation({})
+
+    //#when
+    const description = presentation.description
+
+    //#then
+    expect(description).toContain("30-minute inactivity window")
+    expect(description).toContain("busy/retry/running")
+    expect(description).toContain("not a total wall-clock limit")
+  })
+})

--- a/src/tools/delegate-task/tool-description.ts
+++ b/src/tools/delegate-task/tool-description.ts
@@ -67,6 +67,7 @@ export function createDelegateTaskPresentation(options: DelegateTaskToolOptions)
   ${categoryList}
   - subagent_type: Use specific agent directly (explore, librarian, oracle, metis, momus)
   - run_in_background: REQUIRED. true=async (returns task_id), false=sync (waits). Use background=true ONLY for parallel exploration with 5+ independent queries.
+    Sync waits use a 30-minute inactivity window: OpenCode busy/retry/running status resets the window, so this is not a total wall-clock limit.
   - task_id: Existing task to continue (from previous task output). Continues the same subagent session with FULL CONTEXT PRESERVED.
   - command: The command that triggered this task (optional, for slash command tracking).
   


### PR DESCRIPTION
## Summary
- clarify task tool sync waits as a 30-minute inactivity window, not total wall-clock time
- make poll timeout output name the inactive OpenCode-status condition
- add description coverage for the tool contract

## Validation
- bun test src/tools/delegate-task/tool-description.test.ts src/tools/delegate-task/sync-poll-timeout.test.ts src/tools/delegate-task/sync-session-poller.test.ts src/tools/delegate-task/timing.test.ts
- bun test src/tools/delegate-task
- bun run typecheck
- bun run build
- manual QA: rendered the tool description and confirmed it says busy/retry/running resets the 30-minute inactivity window

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the sync timeout for delegate-task: it’s a 30‑minute inactivity window that resets on busy/retry/running, not total wall‑clock time. Updates poll/log messages to “Poll inactivity timeout,” refreshes the tool description to explain the rule, and adds tests to verify the contract.

<sup>Written for commit eef62cc4f28f6152641e04d57d6a796ac672e3c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

