### PR TITLE
fix(plugin): guard assistant prefill message tails

### DIFF
--- a/src/plugin/messages-transform.test.ts
+++ b/src/plugin/messages-transform.test.ts
@@ -7,10 +7,13 @@ import type { CreatedHooks } from "../create-hooks"
 type TestPart = {
   type: string
   id?: string
+  sessionID?: string
+  messageID?: string
   callID?: string
   tool_use_id?: string
   content?: string
   text?: string
+  synthetic?: boolean
 }
 
 type TestMessage = {
@@ -38,7 +41,7 @@ function makeHooks(overrides: {
     contextInjectorMessagesTransform: overrides.contextInjector ? makeHook(overrides.contextInjector) : undefined,
     thinkingBlockValidator: overrides.thinkingBlock ? makeHook(overrides.thinkingBlock) : undefined,
     toolPairValidator: overrides.toolPair ? makeHook(overrides.toolPair) : undefined,
-  } as unknown as CreatedHooks
+  } as CreatedHooks
 }
 
 async function runHandler(
@@ -156,6 +159,25 @@ describe("createMessagesTransformHandler", () => {
 
     //#when / #then
     await runHandler(hooks, [])
+  })
+
+  it("appends a synthetic user turn when transformed messages end with assistant prefill", async () => {
+    //#given
+    const messages: TestMessage[] = [
+      { info: { role: "user" }, parts: [{ type: "text", text: "work on this" }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "partial assistant tail" }] },
+    ]
+
+    //#when
+    await runHandler(makeHooks({}), messages)
+
+    //#then
+    expect(messages.at(-1)?.info).toMatchObject({ role: "user" })
+    expect(messages.at(-1)?.parts[0]).toMatchObject({
+      type: "text",
+      text: "[internal] Continue from the previous assistant state.",
+      synthetic: true,
+    })
   })
 })
 

--- a/src/plugin/messages-transform.ts
+++ b/src/plugin/messages-transform.ts
@@ -3,12 +3,75 @@ import type { Message, Part } from "@opencode-ai/sdk"
 import { log } from "../shared/logger"
 import type { CreatedHooks } from "../create-hooks"
 
+const ASSISTANT_PREFILL_RECOVERY_TEXT = "[internal] Continue from the previous assistant state."
+
 type MessageWithParts = {
   info: Message
   parts: Part[]
 }
 
 type MessagesTransformOutput = { messages: MessageWithParts[] }
+type UserMessageInfo = Extract<Message, { role: "user" }>
+
+function getSessionID(message: MessageWithParts): string | undefined {
+  return message.info.sessionID
+}
+
+function findLastUserMessage(messages: MessageWithParts[]): UserMessageInfo | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (message?.info.role === "user") {
+      return message.info
+    }
+  }
+
+  return undefined
+}
+
+function createAssistantPrefillRecoveryMessage(
+  lastAssistantMessage: MessageWithParts,
+  messages: MessageWithParts[],
+): MessageWithParts {
+  const lastUserMessage = findLastUserMessage(messages)
+  const sessionID = getSessionID(lastAssistantMessage) ?? lastUserMessage?.sessionID ?? ""
+  const messageID = `${lastAssistantMessage.info.id}_prefill_recovery`
+  const model = lastUserMessage?.model ?? {
+    providerID: "internal",
+    modelID: "assistant-prefill-guard",
+  }
+
+  return {
+    info: {
+      id: messageID,
+      sessionID,
+      role: "user",
+      time: { created: Date.now() },
+      agent: lastUserMessage?.agent ?? "internal",
+      model,
+      ...(lastUserMessage?.system ? { system: lastUserMessage.system } : {}),
+      ...(lastUserMessage?.tools ? { tools: lastUserMessage.tools } : {}),
+    },
+    parts: [
+      {
+        id: `${messageID}_text`,
+        sessionID,
+        messageID,
+        type: "text",
+        text: ASSISTANT_PREFILL_RECOVERY_TEXT,
+        synthetic: true,
+      },
+    ],
+  }
+}
+
+function ensureUserTurnAfterAssistantTail(output: MessagesTransformOutput): void {
+  const lastMessage = output.messages.at(-1)
+  if (!lastMessage || lastMessage.info.role !== "assistant") {
+    return
+  }
+
+  output.messages.push(createAssistantPrefillRecoveryMessage(lastMessage, output.messages))
+}
 
 async function runMessagesTransformHookSafely<I, O>(
   hookName: string,
@@ -79,5 +142,7 @@ export function createMessagesTransformHandler(args: {
       input,
       output,
     )
+
+    ensureUserTurnAfterAssistantTail(output)
   }
 }


### PR DESCRIPTION
## Summary
- append a synthetic user turn when transformed messages would otherwise end with an assistant message
- preserve the prior user message model/tools metadata on the synthetic continuation turn
- cover the Anthropic assistant prefill regression in messages-transform tests

## Root Cause
The messages transform pipeline could leave the final outgoing message as role=assistant. Providers that do not support assistant prefill then reject the request with the Anthropic-style conversation-must-end-with-user error.

## Validation
- bun test src/plugin/messages-transform.test.ts
- bun test src/plugin
- bun run typecheck
- bun run build
- manual QA: ran the transform handler against a user -> assistant-tail Anthropic payload and confirmed it becomes user -> assistant -> user

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents conversations from ending with an assistant message by appending a synthetic user turn, avoiding Anthropic-style "conversation-must-end-with-user" errors and restoring prefill compatibility.

- **Bug Fixes**
  - Append a synthetic user message when the transformed tail is assistant prefill, using "[internal] Continue from the previous assistant state."
  - Preserve the prior user’s model, tools, agent, and system on the synthetic turn, and link session/message IDs.
  - Add test coverage for the Anthropic prefill regression in the messages-transform suite.

<sup>Written for commit 41629b526284575b28b142696b17d8015f96394e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

