### PR TITLE
fix(installer): add opencode-go fallback entries for deep and artistry categories

### DIFF
--- a/src/cli/__snapshots__/model-fallback.test.ts.snap
+++ b/src/cli/__snapshots__/model-fallback.test.ts.snap
@@ -4379,6 +4379,12 @@ exports[`generateModelConfig Vercel AI Gateway provider uses vercel/ model strin
         {
           "model": "vercel/openai/gpt-5.5",
         },
+        {
+          "model": "vercel/moonshotai/kimi-k2.6",
+        },
+        {
+          "model": "vercel/zai/glm-5.1",
+        },
       ],
       "model": "vercel/google/gemini-3.1-pro-preview",
       "variant": "high",
@@ -4392,6 +4398,12 @@ exports[`generateModelConfig Vercel AI Gateway provider uses vercel/ model strin
         {
           "model": "vercel/google/gemini-3.1-pro-preview",
           "variant": "high",
+        },
+        {
+          "model": "vercel/moonshotai/kimi-k2.6",
+        },
+        {
+          "model": "vercel/zai/glm-5.1",
         },
       ],
       "model": "vercel/openai/gpt-5.5",
@@ -4678,6 +4690,12 @@ exports[`generateModelConfig Vercel AI Gateway provider uses vercel/ model strin
         {
           "model": "vercel/openai/gpt-5.5",
         },
+        {
+          "model": "vercel/moonshotai/kimi-k2.6",
+        },
+        {
+          "model": "vercel/zai/glm-5.1",
+        },
       ],
       "model": "vercel/google/gemini-3.1-pro-preview",
       "variant": "high",
@@ -4691,6 +4709,12 @@ exports[`generateModelConfig Vercel AI Gateway provider uses vercel/ model strin
         {
           "model": "vercel/google/gemini-3.1-pro-preview",
           "variant": "high",
+        },
+        {
+          "model": "vercel/moonshotai/kimi-k2.6",
+        },
+        {
+          "model": "vercel/zai/glm-5.1",
         },
       ],
       "model": "vercel/openai/gpt-5.5",

--- a/src/shared/model-requirements.ts
+++ b/src/shared/model-requirements.ts
@@ -244,6 +244,8 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         model: "gemini-3.1-pro",
         variant: "high",
       },
+      { providers: ["opencode-go", "vercel"], model: "kimi-k2.6" },
+      { providers: ["opencode-go", "vercel"], model: "glm-5.1" },
     ],
   },
   artistry: {
@@ -259,6 +261,8 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
         variant: "max",
       },
       { providers: ["openai", "github-copilot", "opencode", "vercel"], model: "gpt-5.5" },
+      { providers: ["opencode-go", "vercel"], model: "kimi-k2.6" },
+      { providers: ["opencode-go", "vercel"], model: "glm-5.1" },
     ],
   },
   quick: {


### PR DESCRIPTION
## Summary

Fixes #3924

The `deep` and `artistry` category fallback chains in `model-requirements.ts` had no `opencode-go` provider entries. When only the opencode Go plan is available, `resolveModelFromChain()` returned `null` for these categories, causing them to fall through to `ULTIMATE_FALLBACK = "opencode/gpt-5-nano"` — a model not available to opencode-go users.

### Changes

Added `opencode-go` entries to the two affected category fallback chains:

- **`deep`**: `deepseek-v4-pro` → `kimi-k2.6` → `glm-5.1`
- **`artistry`**: `kimi-k2.6` → `glm-5.1`

### Before (opencode-go only)

```json
"deep": { "model": "opencode/gpt-5-nano" },
"artistry": { "model": "opencode/gpt-5-nano" }
```

### After (opencode-go only)

```json
"deep": {
  "model": "opencode-go/deepseek-v4-pro",
  "fallback_models": [
    { "model": "opencode-go/kimi-k2.6" },
    { "model": "opencode-go/glm-5.1" }
  ]
},
"artistry": {
  "model": "opencode-go/kimi-k2.6",
  "fallback_models": [
    { "model": "opencode-go/glm-5.1" }
  ]
}
```

### Testing

- All 52 `model-fallback.test.ts` tests pass (snapshots updated)
- All 31 `model-requirements.test.ts` tests pass
- Manual QA verified: zero `opencode/gpt-5-nano` in generated config for opencode-go-only users

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken fallbacks for the `deep` and `artistry` categories when only the `opencode-go` plan is available. The installer now uses supported `opencode-go` models instead of falling back to `opencode/gpt-5-nano`.

- **Bug Fixes**
  - Added `opencode-go` fallbacks: deep = deepseek-v4-pro → kimi-k2.6 → glm-5.1; artistry = kimi-k2.6 → glm-5.1. Mirrored in `vercel` gateway as `vercel/moonshotai/kimi-k2.6` and `vercel/zai/glm-5.1`.
  - Updated snapshots; all model-fallback and model-requirements tests pass; configs for `opencode-go`-only users no longer include `opencode/gpt-5-nano`.

<sup>Written for commit cfab5caea353db96dbc2cba05b89c44752fe96c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

