### PR TITLE
fix(model-settings): support DeepSeek reasoning effort

### DIFF
--- a/src/shared/model-capability-heuristics.ts
+++ b/src/shared/model-capability-heuristics.ts
@@ -6,6 +6,7 @@ export type HeuristicModelFamilyDefinition = {
   pattern?: RegExp
   variants?: string[]
   reasoningEfforts?: string[]
+  reasoningEffortAliases?: Record<string, string>
   supportsThinking?: boolean
 }
 

--- a/src/shared/model-capability-heuristics.ts
+++ b/src/shared/model-capability-heuristics.ts
@@ -73,6 +73,12 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
     family: "deepseek",
     includes: ["deepseek"],
     variants: ["low", "medium", "high"],
+    reasoningEfforts: ["high", "max"],
+    reasoningEffortAliases: {
+      low: "high",
+      medium: "high",
+      xhigh: "max",
+    },
   },
   {
     family: "mistral",

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -257,7 +257,7 @@ describe("resolveCompatibleModelSettings", () => {
       { name: "Kimi (k2)", modelID: "k2-v2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "GLM", modelID: "glm-5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Minimax", modelID: "minimax-m2.5", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
-      { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
+      { name: "DeepSeek", modelID: "deepseek-r2", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: true },
       { name: "Mistral", modelID: "mistral-large-next", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Codestral → Mistral", modelID: "codestral-2506", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
       { name: "Llama", modelID: "llama-4-maverick", expectedVariants: ["low", "medium", "high"], hasReasoningEffort: false },
@@ -318,6 +318,45 @@ describe("resolveCompatibleModelSettings", () => {
       reasoningEffort: "xhigh",
       changes: [],
     })
+  })
+
+  test("DeepSeek keeps canonical high and max reasoningEffort values", () => {
+    for (const reasoningEffort of ["high", "max"]) {
+      const result = resolveCompatibleModelSettings({
+        providerID: "openai-compatible",
+        modelID: "deepseek-v4-pro",
+        desired: { reasoningEffort },
+      })
+
+      expect(result.reasoningEffort).toBe(reasoningEffort)
+      expect(result.changes).toEqual([])
+    }
+  })
+
+  test("DeepSeek maps generic reasoningEffort levels to canonical API values", () => {
+    const cases = [
+      { requested: "low", expected: "high" },
+      { requested: "medium", expected: "high" },
+      { requested: "xhigh", expected: "max" },
+    ]
+
+    for (const { requested, expected } of cases) {
+      const result = resolveCompatibleModelSettings({
+        providerID: "openai-compatible",
+        modelID: "deepseek-v4-pro",
+        desired: { reasoningEffort: requested },
+      })
+
+      expect(result.reasoningEffort).toBe(expected)
+      expect(result.changes).toEqual([
+        {
+          field: "reasoningEffort",
+          from: requested,
+          to: expected,
+          reason: "unsupported-by-model-family",
+        },
+      ])
+    }
   })
 
   test("GPT-5 downgrades unsupported max variant to xhigh", () => {

--- a/src/shared/model-settings-compatibility.test.ts
+++ b/src/shared/model-settings-compatibility.test.ts
@@ -359,6 +359,29 @@ describe("resolveCompatibleModelSettings", () => {
     }
   })
 
+  test("DeepSeek maps generic reasoningEffort levels when capabilities come from heuristics", () => {
+    const capabilities = getModelCapabilities({
+      providerID: "openai-compatible",
+      modelID: "deepseek-v4-pro",
+    })
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai-compatible",
+      modelID: "deepseek-v4-pro",
+      desired: { reasoningEffort: "xhigh" },
+      capabilities,
+    })
+
+    expect(result.reasoningEffort).toBe("max")
+    expect(result.changes).toEqual([
+      {
+        field: "reasoningEffort",
+        from: "xhigh",
+        to: "max",
+        reason: "unsupported-by-model-family",
+      },
+    ])
+  })
+
   test("GPT-5 downgrades unsupported max variant to xhigh", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",

--- a/src/shared/model-settings-compatibility.ts
+++ b/src/shared/model-settings-compatibility.ts
@@ -88,6 +88,11 @@ function resolveField(
   metadataOverride?: string[],
   familyAliases?: Record<string, string>,
 ): FieldResolution {
+  const aliased = familyAliases?.[normalized]
+  if (aliased && (metadataOverride?.includes(aliased) || familyCaps?.includes(aliased))) {
+    return { value: aliased, reason: "unsupported-by-model-family" }
+  }
+
   if (metadataOverride) {
     if (metadataOverride.includes(normalized)) return { value: normalized }
     return {
@@ -98,10 +103,6 @@ function resolveField(
 
   if (familyCaps) {
     if (familyCaps.includes(normalized)) return { value: normalized }
-    const aliased = familyAliases?.[normalized]
-    if (aliased && familyCaps.includes(aliased)) {
-      return { value: aliased, reason: "unsupported-by-model-family" }
-    }
     return {
       value: downgradeWithinLadder(normalized, familyCaps, ladder),
       reason: "unsupported-by-model-family",

--- a/src/shared/model-settings-compatibility.ts
+++ b/src/shared/model-settings-compatibility.ts
@@ -86,6 +86,7 @@ function resolveField(
   ladder: string[],
   familyKnown: boolean,
   metadataOverride?: string[],
+  familyAliases?: Record<string, string>,
 ): FieldResolution {
   if (metadataOverride) {
     if (metadataOverride.includes(normalized)) return { value: normalized }
@@ -97,6 +98,10 @@ function resolveField(
 
   if (familyCaps) {
     if (familyCaps.includes(normalized)) return { value: normalized }
+    const aliased = familyAliases?.[normalized]
+    if (aliased && familyCaps.includes(aliased)) {
+      return { value: aliased, reason: "unsupported-by-model-family" }
+    }
     return {
       value: downgradeWithinLadder(normalized, familyCaps, ladder),
       reason: "unsupported-by-model-family",
@@ -132,7 +137,14 @@ export function resolveCompatibleModelSettings(
   let reasoningEffort = input.desired.reasoningEffort
   if (reasoningEffort !== undefined) {
     const normalized = reasoningEffort.toLowerCase()
-    const resolved = resolveField(normalized, family?.reasoningEfforts, REASONING_LADDER, familyKnown, metadataReasoningEfforts)
+    const resolved = resolveField(
+      normalized,
+      family?.reasoningEfforts,
+      REASONING_LADDER,
+      familyKnown,
+      metadataReasoningEfforts,
+      family?.reasoningEffortAliases,
+    )
     if (resolved.value !== normalized && resolved.reason) {
       changes.push({ field: "reasoningEffort", from: reasoningEffort, to: resolved.value, reason: resolved.reason })
     }


### PR DESCRIPTION
## Summary
Adds DeepSeek model-family support for canonical `reasoningEffort` values so `deepseek-v4-pro` no longer has the parameter stripped by compatibility resolution.

## Changes
- Adds model-family reasoning aliases so generic config levels can map to provider-native values.
- Enables DeepSeek `reasoningEfforts: [\"high\", \"max\"]` while preserving existing DeepSeek variant behavior.
- Adds regression coverage for direct resolver use and the production-shaped `getModelCapabilities()` path.

## Testing
- `bun test src/shared/model-settings-compatibility.test.ts` ✅
- `bun test src/plugin/chat-params.test.ts` ✅
- `bun run typecheck` ✅
- `bun run build` ✅
- Manual resolver QA: `deepseek-v4-pro` preserves `high`/`max`, maps `low`/`medium` → `high`, and maps `xhigh` → `max` ✅
- `bun test` full suite: unrelated existing/environment failures observed outside this change area (web Playwright dependency, mocked MCP/HTTP expectations, model-version expectation drift, etc.)

Closes #3922

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables canonical reasoningEffort for DeepSeek by adding family-level aliases and capabilities. `deepseek-v4-pro` now keeps `high`/`max` and maps `low`/`medium`→`high`, `xhigh`→`max`.

- **Bug Fixes**
  - Added `reasoningEfforts` and `reasoningEffortAliases` to the DeepSeek family.
  - Applied alias resolution in the compatibility resolver and when using heuristic capabilities.
  - Updated tests to cover direct resolver usage and the `getModelCapabilities()` path.

<sup>Written for commit 5259bdfd20d69d0176f3744c743b2f455152f7f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

