### PR TITLE
fix(runtime-fallback): match Volcano Engine quota exceeded errors

### DIFF
--- a/src/hooks/runtime-fallback/auto-retry-signal.test.ts
+++ b/src/hooks/runtime-fallback/auto-retry-signal.test.ts
@@ -15,6 +15,7 @@ describe("extractAutoRetrySignal", () => {
     //#then
     expect(signal).toBeDefined()
     expect(signal?.signal).toContain("exceeded")
+    expect(signal?.signal).toContain("usage quota")
   })
 
   test("detects standard 'quota exceeded' signal", () => {

--- a/src/hooks/runtime-fallback/auto-retry-signal.test.ts
+++ b/src/hooks/runtime-fallback/auto-retry-signal.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+
+import { extractAutoRetrySignal } from "./auto-retry-signal"
+
+describe("extractAutoRetrySignal", () => {
+  test("detects Volcano Engine 'exceeded the usage quota' signal", () => {
+    //#given
+    const info = {
+      status: "You have exceeded the 5-hour usage quota. It will reset at 2026-05-11 01:20:12 +0800 CST.",
+    }
+
+    //#when
+    const signal = extractAutoRetrySignal(info)
+
+    //#then
+    expect(signal).toBeDefined()
+    expect(signal?.signal).toContain("exceeded")
+  })
+
+  test("detects standard 'quota exceeded' signal", () => {
+    //#given
+    const info = { message: "Quota exceeded for model gpt-4" }
+
+    //#when
+    const signal = extractAutoRetrySignal(info)
+
+    //#then
+    expect(signal).toBeDefined()
+  })
+
+  test("returns undefined for non-retryable info", () => {
+    //#given
+    const info = { message: "Something went wrong" }
+
+    //#when
+    const signal = extractAutoRetrySignal(info)
+
+    //#then
+    expect(signal).toBeUndefined()
+  })
+})

--- a/src/hooks/runtime-fallback/auto-retry-signal.ts
+++ b/src/hooks/runtime-fallback/auto-retry-signal.ts
@@ -5,7 +5,7 @@ export interface AutoRetrySignal {
 const AUTO_RETRY_PATTERNS: Array<(combined: string) => boolean> = [
   (combined) => /retrying\s+in/i.test(combined),
   (combined) =>
-    /(?:too\s+many\s+requests|quota\s+will\s+reset\s+after|quota\s*exceeded|usage\s+limit|rate\s+limit|limit\s+reached|all\s+credentials\s+for\s+model|cool(?:ing)?\s*down|exhausted\s+your\s+capacity)/i.test(combined),
+    /(?:too\s+many\s+requests|quota\s+will\s+reset\s+after|quota\s*exceeded|exceeded.*quota|usage\s+limit|usage\s*quota|rate\s+limit|limit\s+reached|all\s+credentials\s+for\s+model|cool(?:ing)?\s*down|exhausted\s+your\s+capacity)/i.test(combined),
 ]
 
 export function extractAutoRetrySignal(info: Record<string, unknown> | undefined): AutoRetrySignal | undefined {

--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -28,7 +28,7 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /quota\s+will\s+reset\s+after/i,
   /quota.?exceeded/i,
   /exceeded.*quota/i,
-  /usage.?quota/i,
+  /usage\s*quota/i,
   /exhausted\s+your\s+capacity/i,
   /all\s+credentials\s+for\s+model/i,
   /cool(?:ing)?\s+down/i,

--- a/src/hooks/runtime-fallback/constants.ts
+++ b/src/hooks/runtime-fallback/constants.ts
@@ -27,6 +27,8 @@ export const RETRYABLE_ERROR_PATTERNS = [
   /too.?many.?requests/i,
   /quota\s+will\s+reset\s+after/i,
   /quota.?exceeded/i,
+  /exceeded.*quota/i,
+  /usage.?quota/i,
   /exhausted\s+your\s+capacity/i,
   /all\s+credentials\s+for\s+model/i,
   /cool(?:ing)?\s+down/i,

--- a/src/hooks/runtime-fallback/error-classifier.ts
+++ b/src/hooks/runtime-fallback/error-classifier.ts
@@ -126,6 +126,8 @@ export function classifyErrorType(error: unknown): string | undefined {
     errorName?.includes("insufficientquota") ||
     errorName?.includes("billingerror") ||
     /quota.?exceeded/i.test(message) ||
+    /exceeded.*quota/i.test(message) ||
+    /usage\s*quota/i.test(message) ||
     /subscription.*quota/i.test(message) ||
     /insufficient.?(?:quota|balance|funds?)/i.test(message) ||
     /billing.?(?:hard.?)?limit/i.test(message) ||

--- a/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
+++ b/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
@@ -56,4 +56,19 @@ describe("runtime-fallback quota error regressions", () => {
     // quota errors trigger fallback to next configured model
     expect(retryable).toBe(true)
   })
+
+  test("classifies Volcano Engine 'exceeded the usage quota' as retryable", () => {
+    //#given
+    const error = {
+      name: "SessionRetry",
+      message: "You have exceeded the 5-hour usage quota. It will reset at 2026-05-11 01:20:12 +0800 CST. We recommend using a different model.",
+    }
+
+    //#when
+    const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
+
+    //#then
+    // Volcano Engine quota errors trigger fallback to the next model
+    expect(retryable).toBe(true)
+  })
 })

--- a/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
+++ b/src/hooks/runtime-fallback/quota-error-classifier.regression.test.ts
@@ -57,7 +57,7 @@ describe("runtime-fallback quota error regressions", () => {
     expect(retryable).toBe(true)
   })
 
-  test("classifies Volcano Engine 'exceeded the usage quota' as retryable", () => {
+  test("classifies Volcano Engine 'exceeded the usage quota' as quota_exceeded and retryable", () => {
     //#given
     const error = {
       name: "SessionRetry",
@@ -65,9 +65,11 @@ describe("runtime-fallback quota error regressions", () => {
     }
 
     //#when
+    const errorType = classifyErrorType(error)
     const retryable = isRetryableError(error, [429, 500, 502, 503, 504])
 
     //#then
+    expect(errorType).toBe("quota_exceeded")
     // Volcano Engine quota errors trigger fallback to the next model
     expect(retryable).toBe(true)
   })


### PR DESCRIPTION
## Summary

Volcano Engine sends quota exceeded errors with the words in reverse order: 'You have exceeded the 5-hour usage quota'. The existing regex patterns required 'quota' to precede 'exceeded', so runtime-fallback never matched these errors and did not auto-switch to fallback models.

## Changes

- Add `/exceeded.*quota/i` and `/usage.?quota/i` to `RETRYABLE_ERROR_PATTERNS` (`constants.ts`)
- Add `exceeded.*quota` and `usage\s*quota` to `AUTO_RETRY_PATTERNS` (`auto-retry-signal.ts`)
- Add regression tests for both detection paths

## Testing

- `bun test src/hooks/runtime-fallback/` — 132 pass, 1 pre-existing flaky failure unrelated to this change
- Typecheck could not run locally due to corrupted worktree node_modules (CI will validate)

## Related

Fixes runtime-fallback not triggering on Volcano Engine '5-hour usage quota' errors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runtime fallback not triggering for Volcano Engine quota errors by matching “exceeded the usage quota” and classifying them as `quota_exceeded`. These errors are now detected as retryable and we auto-switch to fallback models.

- **Bug Fixes**
  - Added `/exceeded.*quota/i` and `/usage\s*quota/i` to `RETRYABLE_ERROR_PATTERNS`, auto-retry detection, and the error classifier.
  - Aligned pattern to `/usage\s*quota/i` across code for consistency.
  - Added a new `auto-retry-signal` test and strengthened regression tests to cover detection and classification.

<sup>Written for commit f3f72fc96f2b0a1f789eff12187b4b50cdeb9116. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

