### PR TITLE
fix(plugin): preserve background output results

### DIFF
--- a/src/plugin/tool-execute-after.test.ts
+++ b/src/plugin/tool-execute-after.test.ts
@@ -92,4 +92,54 @@ describe("createToolExecuteAfterHandler", () => {
     expect(output.title).toBe("stored title")
     expect(output.metadata).toEqual({ sessionId: "ses_native", agent: "hephaestus" })
   })
+
+  it("#given long background_output #when tool.execute.after runs #then output is preserved for agent consumption", async () => {
+    // given
+    const handler = createToolExecuteAfterHandler({
+      ctx: { directory: "/repo" } as never,
+      hooks: {} as never,
+    })
+    const longOutput = [
+      "Task Result",
+      "",
+      "Task ID: bg_test",
+      "Description: Investigate regression",
+      "---",
+      "A".repeat(3500),
+    ].join("\n")
+    const output = { title: "background result", output: longOutput, metadata: {} }
+
+    // when
+    await handler(
+      { tool: "background_output", sessionID: "ses_parent", callID: "call_background" },
+      output
+    )
+
+    // then
+    expect(output.output).toBe(longOutput)
+    expect(output.output).not.toContain("output truncated for display")
+  })
+
+  it("#given long error output #when tool.execute.after runs #then display flood guard still caps it", async () => {
+    // given
+    const handler = createToolExecuteAfterHandler({
+      ctx: { directory: "/repo" } as never,
+      hooks: {} as never,
+    })
+    const output = {
+      title: "look_at error",
+      output: `Error: Failed to analyze missing.pdf: ${"A".repeat(3500)}`,
+      metadata: {},
+    }
+
+    // when
+    await handler(
+      { tool: "look_at", sessionID: "ses_parent", callID: "call_look_at" },
+      output
+    )
+
+    // then
+    expect(output.output.length).toBeLessThan(3500)
+    expect(output.output).toContain("output truncated for display")
+  })
 })

--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -5,6 +5,13 @@ import { stripInvisibleAgentCharacters } from "../shared/agent-display-names"
 import type { PluginContext } from "./types"
 
 const VERIFICATION_ATTEMPT_PATTERN = /<ulw_verification_attempt_id>(.*?)<\/ulw_verification_attempt_id>/i
+const MAX_ERROR_OUTPUT_CHARS = 3000
+const FAILURE_OUTPUT_PREFIX_PATTERN =
+  /^(?:Error|TypeError|ReferenceError|SyntaxError|RangeError|ENOENT|EACCES|EPERM|Traceback\b|Exception\b|Session error:)/i
+
+function shouldCapErrorOutput(output: string): boolean {
+  return output.length > MAX_ERROR_OUTPUT_CHARS && FAILURE_OUTPUT_PREFIX_PATTERN.test(output.trimStart())
+}
 
 function getMetadataString(metadata: Record<string, unknown> | undefined, keys: string[]): string | undefined {
   for (const key of keys) {
@@ -187,8 +194,7 @@ export function createToolExecuteAfterHandler(args: {
     // stack traces or framework internals. Normal outputs are handled by the
     // tool-output-truncator hook for specific tools; this catch-all only fires
     // for outputs that still exceed a safe display length after all hooks.
-    const MAX_ERROR_OUTPUT_CHARS = 3000
-    if (typeof output.output === "string" && output.output.length > MAX_ERROR_OUTPUT_CHARS) {
+    if (typeof output.output === "string" && shouldCapErrorOutput(output.output)) {
       output.output = output.output.slice(0, MAX_ERROR_OUTPUT_CHARS) + "\n\n...(output truncated for display)"
     }
   }


### PR DESCRIPTION
## Summary

- preserve long successful `background_output` tool results so parent agents can consume complete subagent reports
- keep the display flood guard for long outputs that look like failures
- add regression coverage for both paths

## Problem

Oh My OpenAgent uses background agents for investigation work. The parent session later calls `background_output` to read the completed task result. Since [commit `2c78cc68dab4326f1a53919ee949fd4be5269f12`](https://github.com/code-yeongyu/oh-my-openagent/commit/2c78cc68dab4326f1a53919ee949fd4be5269f12), the global cap in [`src/plugin/tool-execute-after.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/plugin/tool-execute-after.ts) trims every string output above 3000 chars and appends `...(output truncated for display)`

That guard was added for [`code-yeongyu/oh-my-openagent#3586`](https://github.com/code-yeongyu/oh-my-openagent/issues/3586) to stop noisy failure output from flooding the UI, but it also truncates successful subagent reports. In practice the parent model receives only the beginning of the report, loses the rest of the findings, and may continue from incomplete evidence. This wastes context and tokens because the parent agent has to recover from an incomplete result

## Regression Window

- introduced by [commit `2c78cc68dab4326f1a53919ee949fd4be5269f12`](https://github.com/code-yeongyu/oh-my-openagent/commit/2c78cc68dab4326f1a53919ee949fd4be5269f12) on 2026-04-24
- merged through [pull request `code-yeongyu/oh-my-openagent#3622`](https://github.com/code-yeongyu/oh-my-openagent/pull/3622) on 2026-05-06
- first released in [`v4.0.0`](https://github.com/code-yeongyu/oh-my-openagent/releases/tag/v4.0.0) on 2026-05-07

## Fix

- move the 3000-char guard behind `shouldCapErrorOutput`
- cap only outputs with failure-shaped prefixes such as `Error:`, `TypeError`, `Traceback`, and `Session error:`
- leave normal long outputs unchanged, including `background_output`

## Verification

- `bun test src/plugin/tool-execute-after.test.ts --bail` - pass
- `bun run typecheck` - pass
- `bun run build` - pass
- `git diff --check` - pass
- `bun test bin script src` - 6570 pass, 1 skip, 5 fail; failures are outside this change:
  - [`src/shared/tmux/tmux-utils/pane-replace.test.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/shared/tmux/tmux-utils/pane-replace.test.ts) fails because `runTmuxCommandMock.mock.calls[...]` is undefined
  - [`src/hooks/auto-update-checker/checker/plugin-entry.test.ts`](https://github.com/code-yeongyu/oh-my-openagent/blob/dev/src/hooks/auto-update-checker/checker/plugin-entry.test.ts) reads local config and finds `oh-my-openagent@4.0.0` in `/Users/kain/.config/opencode/opencode.jsonc`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop truncating successful `background_output` results so parent agents receive complete subagent reports. Keep the display flood guard by only capping long outputs that look like errors.

- **Bug Fixes**
  - Apply the 3000-char cap only when `shouldCapErrorOutput` matches failure-like prefixes (e.g., Error, TypeError, Traceback, Exception, Session error, ENOENT/EACCES/EPERM).
  - Preserve long non-error outputs, including `background_output`.
  - Add tests for preserved background output and capped error output.

<sup>Written for commit 867ea40b84c3176894a9f60b5851bc1cf2b81825. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

