### PR TITLE
Revert "fix(tool-execute-after): cap excessively long tool output to prevent TUI flooding (fixes #3586)"

### DIFF
--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -182,14 +182,5 @@ export function createToolExecuteAfterHandler(args: {
     }
 
     await runToolExecuteAfterHooks()
-
-    // Cap excessively long error outputs that would flood the TUI with raw
-    // stack traces or framework internals. Normal outputs are handled by the
-    // tool-output-truncator hook for specific tools; this catch-all only fires
-    // for outputs that still exceed a safe display length after all hooks.
-    const MAX_ERROR_OUTPUT_CHARS = 3000
-    if (typeof output.output === "string" && output.output.length > MAX_ERROR_OUTPUT_CHARS) {
-      output.output = output.output.slice(0, MAX_ERROR_OUTPUT_CHARS) + "\n\n...(output truncated for display)"
-    }
   }
 }


### PR DESCRIPTION
Reverts code-yeongyu/oh-my-openagent#3622

No idea how this was even merged; it caused a severe regression caught by two agents in review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the global error-output truncation in `tool-execute-after`, restoring previous behavior. Tool-specific truncation via existing hooks remains, and full error details are visible again to avoid missing critical context.

<sup>Written for commit 299275094f50a0759651538173c3a835ddae23ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

