### PR TITLE
fix(background-agent): retry deferred parent wake

### DIFF
--- a/src/features/background-agent/manager.ts
+++ b/src/features/background-agent/manager.ts
@@ -106,6 +106,8 @@ const BACKGROUND_PARENT_WAKE_PROMPT = `<system-reminder>
 A background task notification was already added to this session. Continue from that notification.
 </system-reminder>`
 
+const PENDING_PARENT_WAKE_RETRY_MS = 1_000
+
 interface MessagePartInfo {
   id?: string
   sessionID?: string
@@ -228,6 +230,7 @@ export class BackgroundManager {
   private idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
   private notificationQueueByParent: Map<string, Promise<void>> = new Map()
   private pendingParentWakes: Map<string, ParentWakePromptContext> = new Map()
+  private pendingParentWakeTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
   private observedOutputSessions: Set<string> = new Set()
   private observedIncompleteTodosBySession: Map<string, boolean> = new Map()
   private rootDescendantCounts: Map<string, number>
@@ -2233,6 +2236,7 @@ The task was re-queued on a fallback model after a retryable failure.
           })
           if (shouldDeferReply) {
             this.pendingParentWakes.set(task.parentSessionId, parentPromptContext)
+            this.schedulePendingParentWakeFlush(task.parentSessionId)
           }
           log("[background-agent] Sent notification to parent session:", {
             taskId: task.id,
@@ -2296,17 +2300,23 @@ The task was re-queued on a fallback model after a retryable failure.
 
   private async flushPendingParentWake(sessionID: string): Promise<void> {
     const wakeContext = this.pendingParentWakes.get(sessionID)
-    if (!wakeContext) return
+    if (!wakeContext) {
+      this.clearPendingParentWakeTimer(sessionID)
+      return
+    }
 
     if (await this.isSessionActive(sessionID)) {
+      this.schedulePendingParentWakeFlush(sessionID)
       return
     }
 
     this.pendingParentWakes.delete(sessionID)
+    this.clearPendingParentWakeTimer(sessionID)
     await settleAfterSessionIdle()
 
     if (await this.isSessionActive(sessionID)) {
       this.pendingParentWakes.set(sessionID, wakeContext)
+      this.schedulePendingParentWakeFlush(sessionID)
       return
     }
 
@@ -2323,6 +2333,31 @@ The task was re-queued on a fallback model after a retryable failure.
     } catch (error) {
       log("[background-agent] Failed to send deferred parent wake:", { sessionID, error })
     }
+  }
+
+  private schedulePendingParentWakeFlush(sessionID: string): void {
+    if (this.pendingParentWakeTimers.has(sessionID)) {
+      return
+    }
+
+    const timer = setTimeout(() => {
+      this.pendingParentWakeTimers.delete(sessionID)
+      void this.enqueueNotificationForParent(sessionID, () => this.flushPendingParentWake(sessionID)).catch((error) => {
+        log("[background-agent] Failed to retry pending parent wake:", { sessionID, error })
+      })
+    }, PENDING_PARENT_WAKE_RETRY_MS)
+
+    this.pendingParentWakeTimers.set(sessionID, timer)
+  }
+
+  private clearPendingParentWakeTimer(sessionID: string): void {
+    const timer = this.pendingParentWakeTimers.get(sessionID)
+    if (!timer) {
+      return
+    }
+
+    clearTimeout(timer)
+    this.pendingParentWakeTimers.delete(sessionID)
   }
 
   private pruneStaleTasksAndNotifications(allStatuses?: SessionStatusMap): void {
@@ -2637,6 +2672,11 @@ The task was re-queued on a fallback model after a retryable failure.
       clearTimeout(timer)
     }
     this.idleDeferralTimers.clear()
+
+    for (const timer of this.pendingParentWakeTimers.values()) {
+      clearTimeout(timer)
+    }
+    this.pendingParentWakeTimers.clear()
 
     for (const sessionID of trackedSessionIDs) {
       subagentSessions.delete(sessionID)

--- a/src/features/background-agent/task-completion-cleanup.test.ts
+++ b/src/features/background-agent/task-completion-cleanup.test.ts
@@ -155,6 +155,10 @@ function waitForDeferredWake(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 180))
 }
 
+function waitForDeferredWakeRetry(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 1_180))
+}
+
 function getRequiredTimer(manager: BackgroundManager, taskID: string): ReturnType<typeof setTimeout> {
   const timer = getCompletionTimers(manager).get(taskID)
   expect(timer).toBeDefined()
@@ -208,7 +212,7 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
     })
   })
 
-  describe("#given 2 tasks for same parent and both completed", () => {
+  describe("#given background tasks for same parent", () => {
     test("#when the second completion notification is sent #then ALL BACKGROUND TASKS COMPLETE notification still works correctly", async () => {
       // given
       const { manager, promptAsyncCalls } = createManager(true)
@@ -281,6 +285,31 @@ describe("BackgroundManager.notifyParentSession cleanup scheduling", () => {
       sessionStatuses["parent-1"] = { type: "idle" }
       manager.handleEvent({ type: "session.idle", properties: { sessionID: "parent-1" } })
       await waitForDeferredWake()
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(promptAsyncCalls[1]?.body.noReply).toBe(false)
+      const wakePayload = JSON.stringify(promptAsyncCalls[1]?.body.parts)
+      expect(wakePayload).toContain("BACKGROUND TASK NOTIFICATION READY")
+      expect(wakePayload).not.toContain("ALL BACKGROUND TASKS COMPLETE")
+    })
+
+    test("#when a single background task finishes during a stale busy parent status #then wake prompt is sent after the parent becomes idle", async () => {
+      // given
+      const sessionStatuses: Record<string, { type: string }> = {
+        "parent-1": { type: "busy" },
+      }
+      const { manager, promptAsyncCalls } = createManager(true, sessionStatuses)
+      managerUnderTest = manager
+      const task = createTask({ id: "task-a", parentSessionId: "parent-1", description: "task A", status: "completed", completedAt: new Date("2026-03-11T00:01:00.000Z") })
+      getTasks(manager).set(task.id, task)
+      getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+
+      // when
+      await notifyParentSessionForTest(manager, task)
+      sessionStatuses["parent-1"] = { type: "idle" }
+      await waitForDeferredWakeRetry()
 
       // then
       expect(promptAsyncCalls).toHaveLength(2)


### PR DESCRIPTION
## Summary
- retry deferred parent wake prompts when a completion notification was inserted with `noReply: true` while the parent session still looked busy
- clear retry timers on wake delivery and shutdown
- add a single-task regression for the stale busy-status race that left delegate-task background completion notifications silent

## Root Cause
A singleton background delegate can finish while the parent session status API still reports `busy` after the real idle event has already passed. The manager inserted the all-complete notification with `noReply: true` and waited for a future `session.idle` event to wake the parent, but no future idle event was guaranteed, so the done message stayed silent.

## Validation
- bun test src/features/background-agent/task-completion-cleanup.test.ts src/features/background-agent/background-task-notification-template.test.ts --bail
- bun run typecheck
- bun run build
- bun run script/run-ci-tests.ts
- manual QA: reproduced the singleton stale-busy deferred wake path in `task-completion-cleanup.test.ts`; it failed red with one prompt call before the fix and now sends the wake prompt as the second call

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent background task completion notifications caused by a stale busy parent session. Adds a retry to wake the parent and cleans up timers to prevent leaks.

- **Bug Fixes**
  - Retry deferred parent wake every 1s when the completion was sent with `noReply: true` and the parent still looks busy.
  - Clear retry timers on successful wake and on shutdown.
  - Reschedule wake if the session becomes active during flush to avoid races.
  - Add a regression test to confirm the wake prompt is sent once the parent turns idle.

<sup>Written for commit a5cc4984335e2763e8f9acd18c940dc3bd7e6c60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

