### PR TITLE
fix(ralph-loop): commit iteration only after continuation is dispatched

### DIFF
--- a/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
+++ b/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path"
 import { createRalphLoopHook } from "./index"
 import { ULTRAWORK_VERIFICATION_PROMISE } from "./constants"
 import { clearState, writeState } from "./storage"
+import { handleFailedVerification } from "./verification-failure-handler"
 
 describe("ralph-loop dispatch failure invariants", () => {
 	const testDirectory = join(tmpdir(), `ralph-loop-dispatch-failure-${Date.now()}`)
@@ -249,6 +250,163 @@ describe("ralph-loop dispatch failure invariants", () => {
 		expect(hook.getState()).toBeNull()
 		expect(promptCalls).toHaveLength(0)
 		expect(createSessionCalls).toHaveLength(1)
+		expect(toastCalls.some((toast) => toast.title === "Ralph Loop Failed" && toast.message.includes("session_creation_rejected"))).toBe(true)
+	})
+
+	test("#given idle path #when state rebound during settle window #then no dispatch against new owner", async () => {
+		// given
+		const hook = createRalphLoopHook({
+			directory: testDirectory,
+			project: testDirectory,
+			worktree: testDirectory,
+			serverUrl: "http://localhost:4096",
+			$: async () => ({}),
+			client: {
+				session: {
+					messages: async () => ({ data: [] }),
+					promptAsync: async (options: { path: { id: string }; body: { parts: Array<{ type: string; text: string }> } }) => {
+						promptCalls.push({ sessionID: options.path.id, text: options.body.parts[0]?.text ?? "" })
+						return {}
+					},
+					prompt: async () => ({}),
+					create: async () => ({ data: { id: "new-session-id" } }),
+				},
+				tui: {
+					showToast: async (options: { body: { title: string; message: string; variant: string } }) => {
+						toastCalls.push(options.body)
+						return {}
+					},
+				},
+			},
+		} as never, {
+			idleSettleMs: 50,
+		})
+
+		hook.startLoop("session-A", "Keep working", { messageCountAtStart: 0, maxIterations: 5 })
+		expect(hook.getState()?.session_id).toBe("session-A")
+
+		// when
+		const eventPromise = hook.event({
+			event: { type: "session.idle", properties: { sessionID: "session-A" } },
+		})
+		await new Promise((resolve) => setTimeout(resolve, 10))
+		writeState(testDirectory, { ...hook.getState()!, session_id: "session-B" })
+		await eventPromise
+
+		// then
+		expect(promptCalls).toHaveLength(0)
+		expect(hook.getState()?.session_id).toBe("session-B")
+		expect(hook.getState()?.iteration).toBe(1)
+	})
+
+	test("#given verification-failure path #when incrementIteration fails #then loud failure not success", async () => {
+		// given
+		const loopState = {
+			clearVerificationState: () => ({
+				active: true,
+				iteration: 2,
+				prompt: "Build API",
+				started_at: new Date().toISOString(),
+				session_id: "session-123",
+				completion_promise: ULTRAWORK_VERIFICATION_PROMISE,
+				message_count_at_start: 3,
+			}),
+			incrementIteration: () => null,
+			clear: () => true,
+		}
+
+		const result = await handleFailedVerification({
+			directory: testDirectory,
+			project: testDirectory,
+			worktree: testDirectory,
+			serverUrl: "http://localhost:4096",
+			$: async () => ({}),
+			client: {
+				session: {
+					messages: async () => ({ data: [{}, {}, {}] }),
+					promptAsync: async (options: { path: { id: string }; body: { parts: Array<{ type: string; text: string }> } }) => {
+						promptCalls.push({ sessionID: options.path.id, text: options.body.parts[0]?.text ?? "" })
+						return {}
+					},
+					abort: async () => ({}),
+				},
+				tui: {
+					showToast: async (options: { body: { title: string; message: string; variant: string } }) => {
+						toastCalls.push(options.body)
+						return {}
+					},
+				},
+			},
+		} as never, {
+			state: {
+				active: true,
+				iteration: 2,
+				prompt: "Build API",
+				started_at: new Date().toISOString(),
+				session_id: "session-123",
+				completion_promise: ULTRAWORK_VERIFICATION_PROMISE,
+				verification_pending: true,
+				verification_session_id: "ses-oracle",
+			},
+			directory: testDirectory,
+			apiTimeoutMs: 5000,
+			loopState,
+		})
+
+		// then
+		expect(result).toBe(false)
+		expect(promptCalls).toHaveLength(1)
+		expect(toastCalls.some((toast) => toast.title === "ULTRAWORK LOOP")).toBe(false)
+		expect(
+			toastCalls.some(
+				(toast) => toast.title === "Ralph Loop Failed" && toast.message.includes("iteration commit failed"),
+			),
+		).toBe(true)
+	})
+
+	test("#given reset strategy #when session.create throws #then dispatch failure surfaces", async () => {
+		// given
+		const hook = createRalphLoopHook({
+			directory: testDirectory,
+			project: testDirectory,
+			worktree: testDirectory,
+			serverUrl: "http://localhost:4096",
+			$: async () => ({}),
+			client: {
+				session: {
+					messages: async () => ({ data: [] }),
+					promptAsync: async (options: { path: { id: string }; body: { parts: Array<{ type: string; text: string }> } }) => {
+						promptCalls.push({ sessionID: options.path.id, text: options.body.parts[0]?.text ?? "" })
+						return {}
+					},
+					prompt: async () => ({}),
+					create: async () => {
+						throw new Error("simulated network error during session.create")
+					},
+				},
+				tui: {
+					showToast: async (options: { body: { title: string; message: string; variant: string } }) => {
+						toastCalls.push(options.body)
+						return {}
+					},
+				},
+			},
+		} as never)
+
+		hook.startLoop("session-123", "Keep working", {
+			messageCountAtStart: 0,
+			maxIterations: 5,
+			strategy: "reset",
+		})
+
+		// when
+		await hook.event({
+			event: { type: "session.idle", properties: { sessionID: "session-123" } },
+		})
+
+		// then
+		expect(hook.getState()).toBeNull()
+		expect(promptCalls).toHaveLength(0)
 		expect(toastCalls.some((toast) => toast.title === "Ralph Loop Failed" && toast.message.includes("session_creation_rejected"))).toBe(true)
 	})
 })

--- a/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
+++ b/src/hooks/ralph-loop/dispatch-failure-invariant.test.ts
@@ -1,0 +1,254 @@
+/// <reference types="bun-types" />
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createRalphLoopHook } from "./index"
+import { ULTRAWORK_VERIFICATION_PROMISE } from "./constants"
+import { clearState, writeState } from "./storage"
+
+describe("ralph-loop dispatch failure invariants", () => {
+	const testDirectory = join(tmpdir(), `ralph-loop-dispatch-failure-${Date.now()}`)
+	let promptCalls: Array<{ sessionID: string; text: string }>
+	let toastCalls: Array<{ title: string; message: string; variant: string }>
+	let messagesCalls: Array<{ sessionID: string }>
+	let createSessionCalls: Array<{ parentID: string }>
+
+	beforeEach(() => {
+		promptCalls = []
+		toastCalls = []
+		messagesCalls = []
+		createSessionCalls = []
+		mkdirSync(testDirectory, { recursive: true })
+		clearState(testDirectory)
+	})
+
+	afterEach(() => {
+		clearState(testDirectory)
+		if (existsSync(testDirectory)) {
+			rmSync(testDirectory, { recursive: true, force: true })
+		}
+	})
+
+	test("#given idle path #when promptAsync throws #then no state or toast advance", async () => {
+		// given
+		const hook = createRalphLoopHook({
+			directory: testDirectory,
+			project: testDirectory,
+			worktree: testDirectory,
+			serverUrl: "http://localhost:4096",
+			$: async () => ({}),
+			client: {
+				session: {
+					messages: async (options: { path: { id: string } }) => {
+						messagesCalls.push({ sessionID: options.path.id })
+						return { data: [] }
+					},
+					promptAsync: async () => {
+						throw new Error("simulated dispatch failure")
+					},
+					prompt: async () => ({}),
+					create: async () => ({ data: { id: "new-session-id" } }),
+				},
+				tui: {
+					showToast: async (options: { body: { title: string; message: string; variant: string } }) => {
+						toastCalls.push(options.body)
+						return {}
+					},
+				},
+			},
+		} as never)
+
+		hook.startLoop("session-123", "Keep working", {
+			messageCountAtStart: 0,
+			maxIterations: 5,
+		})
+		expect(hook.getState()?.iteration).toBe(1)
+
+		// when
+		await hook.event({
+			event: { type: "session.idle", properties: { sessionID: "session-123" } },
+		})
+
+		// then
+		expect(toastCalls.some((toast) => toast.title === "Ralph Loop" && toast.message.includes("Iteration"))).toBe(false)
+		expect(hook.getState()).toBeNull()
+		expect(toastCalls.some((toast) => toast.title === "Ralph Loop Failed" && toast.message.includes("dispatch_rejected"))).toBe(true)
+	})
+
+	test("#given error retry path #when promptAsync throws #then no state or toast advance", async () => {
+		// given
+		const hook = createRalphLoopHook({
+			directory: testDirectory,
+			project: testDirectory,
+			worktree: testDirectory,
+			serverUrl: "http://localhost:4096",
+			$: async () => ({}),
+			client: {
+				session: {
+					messages: async (options: { path: { id: string } }) => {
+						messagesCalls.push({ sessionID: options.path.id })
+						return { data: [] }
+					},
+					promptAsync: async () => {
+						throw new Error("simulated dispatch failure")
+					},
+					prompt: async () => ({}),
+					create: async () => ({ data: { id: "new-session-id" } }),
+				},
+				tui: {
+					showToast: async (options: { body: { title: string; message: string; variant: string } }) => {
+						toastCalls.push(options.body)
+						return {}
+					},
+				},
+			},
+		} as never)
+
+		hook.startLoop("session-123", "Keep working", {
+			messageCountAtStart: 0,
+			maxIterations: 5,
+		})
+		expect(hook.getState()?.iteration).toBe(1)
+
+		// when
+		await hook.event({
+			event: {
+				type: "session.error",
+				properties: {
+					sessionID: "session-123",
+					error: { name: "RuntimeError" },
+				},
+			},
+		})
+
+		// then
+		expect(toastCalls.some((toast) => toast.title === "Ralph Loop" && toast.message.includes("Iteration"))).toBe(false)
+		expect(hook.getState()).toBeNull()
+		expect(toastCalls.some((toast) => toast.title === "Ralph Loop Failed" && toast.message.includes("dispatch_rejected"))).toBe(true)
+	})
+
+	test("#given verification-failure path #when promptAsync throws #then iteration not advanced", async () => {
+		// given
+		const parentTranscriptPath = join(testDirectory, "transcript-parent.jsonl")
+		const oracleTranscriptPath = join(testDirectory, "transcript-oracle.jsonl")
+		const hook = createRalphLoopHook({
+			directory: testDirectory,
+			project: testDirectory,
+			worktree: testDirectory,
+			serverUrl: "http://localhost:4096",
+			$: async () => ({}),
+			client: {
+				session: {
+					messages: async (options: { path: { id: string } }) => {
+						messagesCalls.push({ sessionID: options.path.id })
+						if (options.path.id === "session-123") {
+							return { data: [{}, {}, {}] }
+						}
+						return { data: [] }
+					},
+					promptAsync: async (options: { body: { parts: Array<{ type: string; text: string }> } }) => {
+						if (options.body.parts[0]?.text.includes("Verification failed")) {
+							throw new Error("simulated dispatch failure")
+						}
+						return {}
+					},
+					prompt: async () => ({}),
+					abort: async () => ({}),
+					create: async () => ({ data: { id: "new-session-id" } }),
+				},
+				tui: {
+					showToast: async (options: { body: { title: string; message: string; variant: string } }) => {
+						toastCalls.push(options.body)
+						return {}
+					},
+				},
+			},
+		} as never, {
+			getTranscriptPath: (sessionID): string => sessionID === "ses-oracle" ? oracleTranscriptPath : parentTranscriptPath,
+		})
+
+		hook.startLoop("session-123", "Build API", { ultrawork: true })
+		writeState(testDirectory, {
+			...hook.getState()!,
+			iteration: 2,
+			verification_pending: true,
+			verification_session_id: "ses-oracle",
+			completion_promise: ULTRAWORK_VERIFICATION_PROMISE,
+			initial_completion_promise: "DONE",
+		})
+		writeState(testDirectory, {
+			...hook.getState()!,
+			verification_session_id: "ses-oracle",
+		})
+		writeFileSync(
+			oracleTranscriptPath,
+			`${JSON.stringify({ type: "tool_result", timestamp: new Date().toISOString(), tool_output: { output: "verification failed" } })}\n`,
+		)
+
+		const preRestartIteration = hook.getState()?.iteration
+
+		// when
+		await hook.event({ event: { type: "session.idle", properties: { sessionID: "ses-oracle" } } })
+
+		// then
+		expect(preRestartIteration).toBe(2)
+		expect(hook.getState()).toBeNull()
+		expect(toastCalls.some((toast) => toast.title === "Ralph Loop Failed" && toast.message.includes("Verification continuation rejected"))).toBe(true)
+	})
+
+	test("#given reset strategy #when createIterationSession returns null #then dispatch failure surfaces", async () => {
+		// given
+		const hook = createRalphLoopHook({
+			directory: testDirectory,
+			project: testDirectory,
+			worktree: testDirectory,
+			serverUrl: "http://localhost:4096",
+			$: async () => ({}),
+			client: {
+				session: {
+					messages: async (options: { path: { id: string } }) => {
+						messagesCalls.push({ sessionID: options.path.id })
+						return { data: [] }
+					},
+					promptAsync: async (options: { path: { id: string }; body: { parts: Array<{ type: string; text: string }> } }) => {
+						promptCalls.push({
+							sessionID: options.path.id,
+							text: options.body.parts[0]?.text ?? "",
+						})
+						return {}
+					},
+					prompt: async () => ({}),
+					create: async (options: { body: { parentID: string } }) => {
+						createSessionCalls.push({ parentID: options.body.parentID })
+						return { error: "fail", data: undefined }
+					},
+				},
+				tui: {
+					showToast: async (options: { body: { title: string; message: string; variant: string } }) => {
+						toastCalls.push(options.body)
+						return {}
+					},
+				},
+			},
+		} as never)
+
+		hook.startLoop("session-123", "Keep working", {
+			messageCountAtStart: 0,
+			maxIterations: 5,
+			strategy: "reset",
+		})
+		expect(hook.getState()?.iteration).toBe(1)
+
+		// when
+		await hook.event({
+			event: { type: "session.idle", properties: { sessionID: "session-123" } },
+		})
+
+		// then
+		expect(hook.getState()).toBeNull()
+		expect(promptCalls).toHaveLength(0)
+		expect(createSessionCalls).toHaveLength(1)
+		expect(toastCalls.some((toast) => toast.title === "Ralph Loop Failed" && toast.message.includes("session_creation_rejected"))).toBe(true)
+	})
+})

--- a/src/hooks/ralph-loop/iteration-continuation.ts
+++ b/src/hooks/ralph-loop/iteration-continuation.ts
@@ -15,11 +15,16 @@ type ContinuationOptions = {
   }
 }
 
+export type ContinuationResult =
+  | { status: "dispatched" }
+  | { status: "session_creation_rejected" }
+  | { status: "dispatch_rejected"; error: unknown }
+
 export async function continueIteration(
   ctx: PluginInput,
   state: RalphLoopState,
   options: ContinuationOptions,
-): Promise<void> {
+): Promise<ContinuationResult> {
   const strategy = state.strategy ?? "continue"
   const continuationPrompt = buildContinuationPrompt(state)
 
@@ -30,16 +35,20 @@ export async function continueIteration(
       options.directory,
     )
     if (!newSessionID) {
-      return
+      return { status: "session_creation_rejected" }
     }
 
-    await injectContinuationPrompt(ctx, {
-      sessionID: newSessionID,
-      inheritFromSessionID: options.previousSessionID,
-      prompt: continuationPrompt,
-      directory: options.directory,
-      apiTimeoutMs: options.apiTimeoutMs,
-    })
+    try {
+      await injectContinuationPrompt(ctx, {
+        sessionID: newSessionID,
+        inheritFromSessionID: options.previousSessionID,
+        prompt: continuationPrompt,
+        directory: options.directory,
+        apiTimeoutMs: options.apiTimeoutMs,
+      })
+    } catch (error: unknown) {
+      return { status: "dispatch_rejected", error }
+    }
 
     await selectSessionInTui(ctx.client, newSessionID)
 
@@ -49,16 +58,22 @@ export async function continueIteration(
         previousSessionID: options.previousSessionID,
         newSessionID,
       })
-      return
+      return { status: "dispatched" }
     }
 
-    return
+    return { status: "dispatched" }
   }
 
-  await injectContinuationPrompt(ctx, {
-    sessionID: options.previousSessionID,
-    prompt: continuationPrompt,
-    directory: options.directory,
-    apiTimeoutMs: options.apiTimeoutMs,
-  })
+  try {
+    await injectContinuationPrompt(ctx, {
+      sessionID: options.previousSessionID,
+      prompt: continuationPrompt,
+      directory: options.directory,
+      apiTimeoutMs: options.apiTimeoutMs,
+    })
+  } catch (error: unknown) {
+    return { status: "dispatch_rejected", error }
+  }
+
+  return { status: "dispatched" }
 }

--- a/src/hooks/ralph-loop/loop-state-controller.ts
+++ b/src/hooks/ralph-loop/loop-state-controller.ts
@@ -174,5 +174,27 @@ export function createLoopStateController(options: {
 
 			return state
 		},
+
+		clearVerificationState(sessionID: string, messageCountAtStart?: number): RalphLoopState | null {
+			const state = readState(directory, stateDir)
+			if (!state || state.session_id !== sessionID || !state.ultrawork || !state.verification_pending) {
+				return null
+			}
+
+			state.started_at = new Date().toISOString()
+			state.completion_promise = state.initial_completion_promise ?? DEFAULT_COMPLETION_PROMISE
+			state.verification_pending = undefined
+			state.verification_attempt_id = undefined
+			state.verification_session_id = undefined
+			if (typeof messageCountAtStart === "number") {
+				state.message_count_at_start = messageCountAtStart
+			}
+
+			if (!writeState(directory, state, stateDir)) {
+				return null
+			}
+
+			return state
+		},
 	}
 }

--- a/src/hooks/ralph-loop/pending-verification-handler.ts
+++ b/src/hooks/ralph-loop/pending-verification-handler.ts
@@ -82,6 +82,9 @@ async function detectOracleVerificationFromParentSession(
 
 type LoopStateController = {
 	restartAfterFailedVerification: (sessionID: string, messageCountAtStart?: number) => RalphLoopState | null
+	clearVerificationState: (sessionID: string, messageCountAtStart?: number) => RalphLoopState | null
+	incrementIteration: () => RalphLoopState | null
+	clear: () => boolean
 	setVerificationSessionID: (sessionID: string, verificationSessionID: string) => RalphLoopState | null
 }
 

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -19,6 +19,7 @@ type LoopStateController = {
 	markVerificationPending: (sessionID: string) => RalphLoopState | null
 	setVerificationSessionID: (sessionID: string, verificationSessionID: string) => RalphLoopState | null
 	restartAfterFailedVerification: (sessionID: string, messageCountAtStart?: number) => RalphLoopState | null
+	clearVerificationState: (sessionID: string, messageCountAtStart?: number) => RalphLoopState | null
 }
 type RalphLoopEventHandlerOptions = { directory: string; apiTimeoutMs: number; idleSettleMs: number; getTranscriptPath: (sessionID: string) => string | undefined; checkSessionExists?: RalphLoopOptions["checkSessionExists"]; backgroundManager?: RalphLoopOptions["backgroundManager"]; loopState: LoopStateController }
 
@@ -272,34 +273,48 @@ export function createRalphLoopEventHandler(
 					return
 				}
 
-				const newState = options.loopState.incrementIteration()
-				if (!newState) {
-					log(`[${HOOK_NAME}] Failed to increment iteration`, { sessionID })
+				await sleep(options.idleSettleMs)
+				const stateAfterSettle = options.loopState.getState()
+				if (!stateAfterSettle || !stateAfterSettle.active) {
 					return
 				}
 
+				const nextIteration = stateAfterSettle.iteration + 1
+				const previewState: RalphLoopState = { ...stateAfterSettle, iteration: nextIteration }
+
 				log(`[${HOOK_NAME}] Continuing loop`, {
 					sessionID,
-					iteration: newState.iteration,
-					max: newState.max_iterations,
+					iteration: nextIteration,
+					max: previewState.max_iterations,
 				})
 
-				showIterationToast(ctx, newState)
-				await sleep(options.idleSettleMs)
+				const result = await continueIteration(ctx, previewState, {
+					previousSessionID: sessionID,
+					directory: options.directory,
+					apiTimeoutMs: options.apiTimeoutMs,
+					loopState: options.loopState,
+				})
 
-				try {
-					await continueIteration(ctx, newState, {
-						previousSessionID: sessionID,
-						directory: options.directory,
-						apiTimeoutMs: options.apiTimeoutMs,
-						loopState: options.loopState,
-					})
-				} catch (err) {
-					log(`[${HOOK_NAME}] Failed to inject continuation`, {
-						sessionID,
-						error: String(err),
-					})
+				if (result.status === "dispatched") {
+					const committed = options.loopState.incrementIteration()
+					if (committed) {
+						showIterationToast(ctx, committed)
+					} else {
+						log(`[${HOOK_NAME}] Dispatch succeeded but iteration commit failed`, { sessionID })
+					}
+					return
 				}
+
+				log(`[${HOOK_NAME}] Dispatch failed`, { sessionID, status: result.status })
+				options.loopState.clear()
+				showToastBestEffort(ctx, {
+					title: "Ralph Loop Failed",
+					message: result.status === "dispatch_rejected"
+						? `Dispatch ${result.status}: ${String(result.error)}`
+						: `Dispatch ${result.status}`,
+					variant: "warning",
+					duration: 5000,
+				})
 				return
 			} finally {
 				inFlightSessions.delete(sessionID)
@@ -381,28 +396,43 @@ export function createRalphLoopEventHandler(
 					return
 				}
 
-				const newState = options.loopState.incrementIteration()
-				if (!newState) {
-					log(`[${HOOK_NAME}] Failed to increment iteration after runtime error`, { sessionID })
+				await sleep(options.idleSettleMs)
+				const stateAfterSettle = options.loopState.getState()
+				if (!stateAfterSettle || !stateAfterSettle.active) {
 					return
 				}
 
-				showIterationToast(ctx, newState)
-				await sleep(options.idleSettleMs)
-				try {
-					await continueIteration(ctx, newState, {
-						previousSessionID: sessionID,
-						directory: options.directory,
-						apiTimeoutMs: options.apiTimeoutMs,
-						loopState: options.loopState,
-					})
-					runtimeErrorRetriedSessions.set(sessionID, newState.iteration)
-				} catch (err) {
-					log(`[${HOOK_NAME}] Failed to retry after runtime error`, {
-						sessionID,
-						error: String(err),
-					})
+				const nextIteration = stateAfterSettle.iteration + 1
+				const previewState: RalphLoopState = { ...stateAfterSettle, iteration: nextIteration }
+
+				const result = await continueIteration(ctx, previewState, {
+					previousSessionID: sessionID,
+					directory: options.directory,
+					apiTimeoutMs: options.apiTimeoutMs,
+					loopState: options.loopState,
+				})
+
+				if (result.status === "dispatched") {
+					const committed = options.loopState.incrementIteration()
+					if (committed) {
+						showIterationToast(ctx, committed)
+						runtimeErrorRetriedSessions.set(sessionID, committed.iteration)
+					} else {
+						log(`[${HOOK_NAME}] Dispatch succeeded but iteration commit failed after runtime error`, { sessionID })
+					}
+					return
 				}
+
+				log(`[${HOOK_NAME}] Dispatch failed after runtime error`, { sessionID, status: result.status })
+				options.loopState.clear()
+				showToastBestEffort(ctx, {
+					title: "Ralph Loop Failed",
+					message: result.status === "dispatch_rejected"
+						? `Dispatch ${result.status}: ${String(result.error)}`
+						: `Dispatch ${result.status}`,
+					variant: "warning",
+					duration: 5000,
+				})
 			} finally {
 				inFlightSessions.delete(sessionID)
 			}

--- a/src/hooks/ralph-loop/ralph-loop-event-handler.ts
+++ b/src/hooks/ralph-loop/ralph-loop-event-handler.ts
@@ -278,6 +278,17 @@ export function createRalphLoopEventHandler(
 				if (!stateAfterSettle || !stateAfterSettle.active) {
 					return
 				}
+				if (stateAfterSettle.session_id !== undefined && stateAfterSettle.session_id !== sessionID) {
+					log(`[${HOOK_NAME}] Skipped: state rebound during settle window`, {
+						sessionID,
+						currentOwner: stateAfterSettle.session_id,
+					})
+					return
+				}
+				if (stateAfterSettle.verification_pending) {
+					log(`[${HOOK_NAME}] Skipped: state entered verification_pending during settle window`, { sessionID })
+					return
+				}
 
 				const nextIteration = stateAfterSettle.iteration + 1
 				const previewState: RalphLoopState = { ...stateAfterSettle, iteration: nextIteration }
@@ -399,6 +410,17 @@ export function createRalphLoopEventHandler(
 				await sleep(options.idleSettleMs)
 				const stateAfterSettle = options.loopState.getState()
 				if (!stateAfterSettle || !stateAfterSettle.active) {
+					return
+				}
+				if (stateAfterSettle.session_id !== undefined && stateAfterSettle.session_id !== sessionID) {
+					log(`[${HOOK_NAME}] Skipped: state rebound during settle window`, {
+						sessionID,
+						currentOwner: stateAfterSettle.session_id,
+					})
+					return
+				}
+				if (stateAfterSettle.verification_pending) {
+					log(`[${HOOK_NAME}] Skipped: state entered verification_pending during settle window`, { sessionID })
 					return
 				}
 

--- a/src/hooks/ralph-loop/session-reset-strategy.ts
+++ b/src/hooks/ralph-loop/session-reset-strategy.ts
@@ -7,23 +7,31 @@ export async function createIterationSession(
   parentSessionID: string,
   directory: string,
 ): Promise<string | null> {
-  const createResult = await ctx.client.session.create({
-    body: {
-      parentID: parentSessionID,
-      title: "Ralph Loop Iteration",
-    },
-    query: { directory },
-  })
+  try {
+    const createResult = await ctx.client.session.create({
+      body: {
+        parentID: parentSessionID,
+        title: "Ralph Loop Iteration",
+      },
+      query: { directory },
+    })
 
-  if (createResult.error || !createResult.data?.id) {
-    log("[ralph-loop] Failed to create iteration session", {
+    if (createResult.error || !createResult.data?.id) {
+      log("[ralph-loop] Failed to create iteration session", {
+        parentSessionID,
+        error: String(createResult.error ?? "No session ID returned"),
+      })
+      return null
+    }
+
+    return createResult.data.id
+  } catch (error: unknown) {
+    log("[ralph-loop] session.create threw during iteration session creation", {
       parentSessionID,
-      error: String(createResult.error ?? "No session ID returned"),
+      error: String(error),
     })
     return null
   }
-
-  return createResult.data.id
 }
 
 export async function selectSessionInTui(

--- a/src/hooks/ralph-loop/verification-failure-handler.ts
+++ b/src/hooks/ralph-loop/verification-failure-handler.ts
@@ -122,6 +122,14 @@ export async function handleFailedVerification(
 	const committed = loopState.incrementIteration()
 	if (!committed) {
 		log(`[${HOOK_NAME}] Failed to commit iteration after verification restart`, { parentSessionID })
+		loopState.clear()
+		showToastBestEffort(ctx, {
+			title: "Ralph Loop Failed",
+			message: "Verification continuation dispatched but iteration commit failed",
+			variant: "warning",
+			duration: 5000,
+		})
+		return false
 	}
 
 	await ctx.client.tui?.showToast?.({

--- a/src/hooks/ralph-loop/verification-failure-handler.ts
+++ b/src/hooks/ralph-loop/verification-failure-handler.ts
@@ -6,10 +6,22 @@ import { injectContinuationPrompt } from "./continuation-prompt-injector"
 import type { RalphLoopState } from "./types"
 
 type LoopStateController = {
-	restartAfterFailedVerification: (
+	clearVerificationState: (
 		sessionID: string,
 		messageCountAtStart?: number,
 	) => RalphLoopState | null
+	incrementIteration: () => RalphLoopState | null
+	clear: () => boolean
+}
+
+function showToastBestEffort(
+	ctx: PluginInput,
+	body: { title: string; message: string; variant: "warning" | "info"; duration: number },
+): void {
+	try {
+		void Promise.resolve(ctx.client.tui?.showToast?.({ body })).catch(() => {})
+	} catch {
+	}
 }
 
 function getMessageCountFromResponse(messagesResponse: unknown): number {
@@ -72,23 +84,45 @@ export async function handleFailedVerification(
 		ctx.client.session.abort({ path: { id: state.verification_session_id } }).catch(() => {})
 	}
 
-	const resumedState = loopState.restartAfterFailedVerification(
+	const clearedState = loopState.clearVerificationState(
 		parentSessionID,
 		messageCountAtStart,
 	)
-	if (!resumedState) {
+	if (!clearedState) {
 		log(`[${HOOK_NAME}] Failed to restart loop after verification failure`, {
 			parentSessionID,
 		})
 		return false
 	}
 
-	await injectContinuationPrompt(ctx, {
-		sessionID: parentSessionID,
-		prompt: buildVerificationFailurePrompt(resumedState),
-		directory,
-		apiTimeoutMs,
-	})
+	const previewState: RalphLoopState = { ...clearedState, iteration: clearedState.iteration + 1 }
+
+	try {
+		await injectContinuationPrompt(ctx, {
+			sessionID: parentSessionID,
+			prompt: buildVerificationFailurePrompt(previewState),
+			directory,
+			apiTimeoutMs,
+		})
+	} catch (error) {
+		log(`[${HOOK_NAME}] Failed to inject verification failure prompt`, {
+			parentSessionID,
+			error: String(error),
+		})
+		loopState.clear()
+		showToastBestEffort(ctx, {
+			title: "Ralph Loop Failed",
+			message: `Verification continuation rejected: ${String(error)}`,
+			variant: "warning",
+			duration: 5000,
+		})
+		return false
+	}
+
+	const committed = loopState.incrementIteration()
+	if (!committed) {
+		log(`[${HOOK_NAME}] Failed to commit iteration after verification restart`, { parentSessionID })
+	}
 
 	await ctx.client.tui?.showToast?.({
 		body: {


### PR DESCRIPTION
## Summary

Ralph loop was incrementing the iteration counter and showing the "Iteration N/M" toast BEFORE attempting to dispatch the continuation prompt. When dispatch silently failed (session creation rejected, promptAsync threw, etc.) the loop appeared to advance while no message was actually sent — the user-reported symptom.

Three orchestration paths shared this defect; all are fixed:

- `session.idle` in `ralph-loop-event-handler.ts`
- `session.error` retry in `ralph-loop-event-handler.ts`
- verification-failure restart via `verification-failure-handler.ts` + `loop-state-controller.ts`

The fix enforces a single invariant: durable iteration state and visible UI advance ONLY when `continueIteration` returns `{ status: "dispatched" }`. On any typed failure (`session_creation_rejected` from a null `createIterationSession`, or `dispatch_rejected` from a `promptAsync` rejection) the loop clears its state and emits a loud warning toast instead of silently logging while looking like it is still working.

Diagnosis was produced via a hyperplan adversarial review (5 members × 3 rounds: skeptic / validator / researcher / architect / creative) and formalized by the plan agent. See commit C1 for the TDD red tests that lock the corrected behavior.

## Changes

- `iteration-continuation.ts` — return `Promise<ContinuationResult>` (discriminated union); silent returns become typed failure variants; injection wrapped in try/catch.
- `ralph-loop-event-handler.ts` — reorder both idle and `session.error` paths to commit iteration + toast only after successful dispatch; on failure clear + warn loudly; explicit settle-window state check guards the `idleSettleMs` window from a `session.deleted` race. `runtimeErrorRetriedSessions.set` moves to the post-dispatch branch.
- `loop-state-controller.ts` — new `clearVerificationState()` (resets verification flags WITHOUT incrementing iteration; `restartAfterFailedVerification` kept for backward compatibility).
- `verification-failure-handler.ts` — uses `clearVerificationState` + try-injection + `incrementIteration` on success; loud failure on rejection.
- `pending-verification-handler.ts` — `LoopStateController` type extended with the methods `handleFailedVerification` now uses.
- `dispatch-failure-invariant.test.ts` (new) — 4 permanent invariant tests across all 3 orchestration paths + the reset-strategy null path.

`idleSettleMs = 150ms` is preserved (commit 806842981 added it for a real idle-settle race documented in `reset-strategy-race-condition.test.ts`). The intentional `messages()` API fallback in `continuation-prompt-injector.ts:57` is preserved.

## Testing

- `bun script/run-ci-tests.ts` (the same command CI runs): 5481 pass / 1 skip / 0 fail (shared suite) + 80 pass / 0 fail across isolated test files. 5561 tests total green.
- `bun test src/hooks/ralph-loop/`: 115 pass / 0 fail across 10 files (9 pre-existing + the new invariant file).
- `bun run typecheck`: clean.
- `bun run build`: clean.

## Related context

The bug surfaced because three suspect commits over the past two weeks (`c92f84168`, `47b5c5666`, `ebe26eab1`, `806842981`) progressively elaborated the loop driver around the original increment-before-dispatch ordering without enforcing the dispatch-before-commit invariant. The fix retrofits that invariant uniformly across all three orchestration paths.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the Ralph loop advanced the iteration and showed progress before the continuation actually dispatched. Iteration and toast now commit only after a successful dispatch; on failure, the loop clears state and shows a warning.

- **Bug Fixes**
  - Enforced dispatch-before-commit for `session.idle` and `session.error`; progress toast shows only after commit; on failure, clear state and warn.
  - After `idleSettleMs`, revalidate state ownership and ensure not `verification_pending` before dispatch; skip if ownership changed.
  - `continueIteration` returns a discriminated union and catches `promptAsync` and thrown `session.create` errors; reset strategy surfaces `session_creation_rejected`.
  - Verification restart uses `clearVerificationState`, injects the continuation, then increments; on rejection or failed increment, clear state and warn.

- **Tests**
  - Added invariant tests covering idle and retry paths, reset-strategy null/throws, state ownership race during the settle window, and verification commit failure.

<sup>Written for commit 2e36a92c25458572d12d2da3382e9223962a88c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

