### PR TITLE
[codex] preserve native delegate task metadata

### DIFF
--- a/src/plugin/tool-execute-after.test.ts
+++ b/src/plugin/tool-execute-after.test.ts
@@ -92,4 +92,34 @@ describe("createToolExecuteAfterHandler", () => {
     expect(output.title).toBe("stored title")
     expect(output.metadata).toEqual({ sessionId: "ses_native", agent: "hephaestus" })
   })
+
+  it("#given native session linkage without model #when stored metadata exists #then required task metadata is preserved", async () => {
+    // given
+    const model = { providerID: "openai", modelID: "gpt-5.5" }
+    storeToolMetadata("ses_parent", "call_model", {
+      title: "stored title",
+      metadata: { sessionId: "ses_stored", agent: "oracle", model },
+    })
+
+    const handler = createToolExecuteAfterHandler({
+      ctx: {} as never,
+      hooks: {} as never,
+    })
+
+    const output = {
+      title: "result",
+      output: "original output",
+      metadata: { sessionId: "ses_native", agent: "hephaestus" },
+    }
+
+    // when
+    await handler(
+      { tool: "task", sessionID: "ses_parent", callID: "call_model" },
+      output
+    )
+
+    // then
+    expect(output.title).toBe("stored title")
+    expect(output.metadata).toEqual({ sessionId: "ses_native", agent: "hephaestus", model })
+  })
 })

--- a/src/plugin/tool-execute-after.ts
+++ b/src/plugin/tool-execute-after.ts
@@ -59,12 +59,13 @@ export function createToolExecuteAfterHandler(args: {
       }
       if (stored.metadata) {
         if (nativeSessionId) {
-          log("[tool-execute-after] Native output metadata already includes session linkage; skipping stored metadata overwrite", {
+          log("[tool-execute-after] Native output metadata already includes session linkage; preserving native metadata precedence", {
             tool: input.tool,
             sessionID: input.sessionID,
             callID: input.callID ?? input.callId ?? input.call_id,
             nativeSessionId,
           })
+          output.metadata = { ...stored.metadata, ...output.metadata }
         } else {
           output.metadata = { ...output.metadata, ...stored.metadata }
         }


### PR DESCRIPTION
## Summary

- Preserve stored delegate-task metadata when OpenCode native task output already includes `sessionId` linkage.
- Keep native `sessionId` and `agent` precedence, while restoring missing required fields such as `model`.
- Add a regression test for the native-linkage path where stored metadata must fill absent fields.

## Root Cause

OpenCode's native Task tool records metadata with `sessionId` and `model`. Its TUI uses `metadata.sessionId` for child-session linkage and navigation. This plugin already persisted the richer delegate-task metadata, but `tool.execute.after` skipped all stored metadata whenever native output already contained a `sessionId`, which dropped fields like `model` in that recovery path.

## Validation

- `bun test src/plugin/tool-execute-after.test.ts` initially failed for the new regression, then passed after the fix.
- `bun test src/plugin/tool-execute-after.test.ts src/tools/delegate-task/metadata-model-unification.test.ts src/tools/delegate-task/metadata-task-id-consistency.test.ts src/tools/delegate-task/background-task.test.ts src/tools/delegate-task/metadata-await.test.ts src/tools/delegate-task/oracle-gap-closure.test.ts` passed: 55 pass, 0 fail.
- `bun --install=fallback /Users/yeongyu/.config/opencode/skills/typescript-programmer/scripts/check-no-excuse-rules.ts src/plugin/tool-execute-after.ts src/plugin/tool-execute-after.test.ts` passed.
- `bun run typecheck` passed.
- `bun run build` passed.
- Post-rebase: `bun --install=fallback test src/plugin/tool-execute-after.test.ts` passed: 4 pass, 0 fail.

## Known Validation Blocker

- `bun run test` currently fails outside this change in `src/plugin/chat-params.test.ts`: `createChatParamsHandler > falls back to default maxOutputTokens when stored and compatibility tokens are non-positive` expects a log call that is not emitted. The official run reported 6609 pass, 1 skip, 1 fail. Because this PR touches only `src/plugin/tool-execute-after.*`, I left that existing failure out of scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves delegate-task metadata when native task output already includes session linkage. Prevents dropping required fields like `model` by merging stored metadata while keeping native `sessionId`/`agent`.

- **Bug Fixes**
  - If native output has `sessionId`, merge stored metadata into it to restore missing fields while keeping native values.
  - Added a regression test to ensure `model` is preserved in the native-linkage path.

<sup>Written for commit 0fd918ea80d2fbd9bb59d4c774decd41e8eb1890. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

