### PR TITLE
fix(session-manager): use SQL and vector session search

### DIFF
--- a/src/tools/session-manager/index.ts
+++ b/src/tools/session-manager/index.ts
@@ -1,3 +1,6 @@
 export * from "./tools"
 export * from "./types"
 export * from "./constants"
+export { searchSessions, getDBPath } from "./sql-search"
+export { queryVectorAdapter } from "./vector-adapter"
+export { mergeAndDedupeSearchResults } from "./utils"

--- a/src/tools/session-manager/sql-search.test.ts
+++ b/src/tools/session-manager/sql-search.test.ts
@@ -1,0 +1,313 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Database } from "bun:sqlite"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { unlinkSync, existsSync } from "node:fs"
+import { searchSessionsSQL, getDBPath } from "./sql-search"
+import type { SearchResult } from "./types"
+
+let testDB: Database
+let testDBPath: string
+
+function createTestDB(): { db: Database; path: string } {
+  const path = join(tmpdir(), `omo-test-sql-search-${Date.now()}.db`)
+  const db = new Database(path)
+  db.run("PRAGMA journal_mode=WAL")
+  db.run("PRAGMA foreign_keys=ON")
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      parent_id TEXT,
+      slug TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      title TEXT NOT NULL,
+      version TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL
+    )
+  `)
+  db.run(`
+    CREATE TABLE IF NOT EXISTS message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL,
+      FOREIGN KEY (session_id) REFERENCES session(id)
+    )
+  `)
+  db.run(`
+    CREATE TABLE IF NOT EXISTS part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL,
+      FOREIGN KEY (message_id) REFERENCES message(id)
+    )
+  `)
+
+  return { db, path }
+}
+
+function seedTestData(db: Database) {
+  const now = Date.now()
+
+  // Session 1: "Deploy pipeline discussion"
+  db.run(
+    `INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ["ses_alpha", "proj_1", "alpha-slug", "/workspace/proj", "Deploy pipeline discussion", "1.0", now - 100000, now - 50000]
+  )
+
+  // Session 2: "Bug triage"
+  db.run(
+    `INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ["ses_beta", "proj_2", "beta-slug", "/workspace/bugs", "Bug triage session", "1.0", now - 80000, now - 30000]
+  )
+
+  // Messages for session 1
+  db.run(
+    `INSERT INTO message (id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?)`,
+    ["msg_a1", "ses_alpha", now - 90000, now - 90000, JSON.stringify({ role: "user", model: { providerID: "test", modelID: "gpt-4" } })]
+  )
+  db.run(
+    `INSERT INTO message (id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?)`,
+    ["msg_a2", "ses_alpha", now - 85000, now - 85000, JSON.stringify({ role: "assistant", agent: "build" })]
+  )
+
+  // Messages for session 2
+  db.run(
+    `INSERT INTO message (id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?)`,
+    ["msg_b1", "ses_beta", now - 70000, now - 70000, JSON.stringify({ role: "user", agent: "oracle" })]
+  )
+
+  // Parts for ses_alpha messages
+  db.run(
+    `INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    ["prt_a1", "msg_a1", "ses_alpha", now - 90000, now - 90000, JSON.stringify({ type: "text", text: "Let's discuss the Kubernetes deployment pipeline" })]
+  )
+  db.run(
+    `INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    ["prt_a2", "msg_a2", "ses_alpha", now - 85000, now - 85000, JSON.stringify({ type: "text", text: "I'll configure the CI/CD pipeline now" })]
+  )
+  db.run(
+    `INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    ["prt_a3", "msg_a2", "ses_alpha", now - 84000, now - 84000, JSON.stringify({ type: "thinking", thinking: "Need to check Dockerfile for multistage build" })]
+  )
+
+  // Parts for ses_beta messages
+  db.run(
+    `INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    ["prt_b1", "msg_b1", "ses_beta", now - 70000, now - 70000, JSON.stringify({ type: "text", text: "Found a critical SQL injection bug in the search API" })]
+  )
+  db.run(
+    `INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    ["prt_b2", "msg_b1", "ses_beta", now - 69000, now - 69000, JSON.stringify({ type: "tool_use", tool: "bash", input: { command: "grep -r 'SELECT.*FROM' src/" } })]
+  )
+  db.run(
+    `INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    ["prt_b3", "msg_b1", "ses_beta", now - 68000, now - 68000, JSON.stringify({ type: "text", text: "Cache hit rate is 50% with 4x speedup and 42_days retention" })]
+  )
+}
+
+beforeAll(() => {
+  const created = createTestDB()
+  testDB = created.db
+  testDBPath = created.path
+  seedTestData(testDB)
+})
+
+afterAll(() => {
+  testDB.close()
+  if (existsSync(testDBPath)) {
+    unlinkSync(testDBPath)
+  }
+})
+
+describe("sql-search", () => {
+  describe("getDBPath", () => {
+    test("returns default path from XDG_DATA_HOME", () => {
+      // #when
+      const result = getDBPath()
+
+      // #then
+      expect(result).toContain("opencode.db")
+      expect(result).toContain(".local/share/opencode")
+    })
+  })
+
+  describe("searchSessionsSQL", () => {
+    test("finds exact match in message part text", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "Kubernetes", limit: 10 })
+
+      // #then
+      expect(results.length).toBeGreaterThanOrEqual(1)
+      const kubernetesResult = results.find((r) => r.excerpt.includes("Kubernetes"))
+      expect(kubernetesResult).toBeDefined()
+      expect(kubernetesResult!.session_id).toBe("ses_alpha")
+      expect(kubernetesResult!.source).toBe("sql")
+    })
+
+    test("finds match in thinking parts (not just text)", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "multistage build", limit: 10 })
+
+      // #then
+      expect(results.length).toBeGreaterThanOrEqual(1)
+      const thinkingResult = results.find((r) => r.excerpt.includes("multistage"))
+      expect(thinkingResult).toBeDefined()
+      expect(thinkingResult!.match_type).toContain("text")
+    })
+
+    test("finds match in data column (not part)", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "gpt-4", limit: 10 })
+
+      // #then
+      expect(results.length).toBeGreaterThanOrEqual(1)
+      const dataResult = results.find((r) => r.session_id === "ses_alpha" && r.match_type.includes("data"))
+      expect(dataResult).toBeDefined()
+    })
+
+    test("is case insensitive by default", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "kubernetes", limit: 10 })
+
+      // #then
+      expect(results.length).toBeGreaterThanOrEqual(1)
+      expect(results.some((r) => r.excerpt.includes("Kubernetes"))).toBe(true)
+    })
+
+    test("is case sensitive when requested", () => {
+      // #when
+      const resultsUpper = searchSessionsSQL(testDB, { query: "Kubernetes", caseSensitive: true, limit: 10 })
+      const resultsLower = searchSessionsSQL(testDB, { query: "kubernetes", caseSensitive: true, limit: 10 })
+
+      // #then
+      expect(resultsUpper.length).toBeGreaterThanOrEqual(1)
+      expect(resultsLower.length).toBe(0)
+    })
+
+    test("filters by session_id", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "pipeline", sessionID: "ses_alpha", limit: 10 })
+
+      // #then
+      expect(results.length).toBeGreaterThanOrEqual(1)
+      expect(results.every((r) => r.session_id === "ses_alpha")).toBe(true)
+      expect(results.some((r) => r.session_id === "ses_beta")).toBe(false)
+    })
+
+    test("respects limit parameter", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "the", limit: 1 })
+
+      // #then
+      expect(results.length).toBe(1)
+    })
+
+    test("returns empty array for no matches", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "zzzzz_no_match_xyzzy", limit: 10 })
+
+      // #then
+      expect(results).toEqual([])
+    })
+
+    test("includes title in results", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "Kubernetes", limit: 10 })
+
+      // #then
+      const kubernetesResult = results.find((r) => r.session_id === "ses_alpha")
+      expect(kubernetesResult).toBeDefined()
+      expect(kubernetesResult!.title).toBe("Deploy pipeline discussion")
+    })
+
+    test("includes score field in results", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "Kubernetes", limit: 10 })
+
+      // #then
+      expect(results.every((r) => typeof r.score === "number")).toBe(true)
+    })
+
+    test("has correct SearchResult shape", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "deploy", limit: 10 })
+
+      // #then
+      expect(results.length).toBeGreaterThanOrEqual(1)
+      const r = results[0]
+      expect(typeof r.session_id).toBe("string")
+      expect(typeof r.message_id).toBe("string")
+      expect(typeof r.role).toBe("string")
+      expect(typeof r.excerpt).toBe("string")
+      expect(typeof r.match_count).toBe("number")
+      expect(r.match_count).toBeGreaterThan(0)
+      expect(Array.isArray(r.match_type)).toBe(true)
+      expect(typeof r.source).toBe("string")
+      expect(typeof r.score).toBe("number")
+    })
+
+    test("deduplicates by message_id", () => {
+      // #when - "deploy" appears in one session's title and part
+      const results = searchSessionsSQL(testDB, { query: "deploy", limit: 20 })
+
+      // #then
+      const sesAlphaMessages = results.filter((r) => r.session_id === "ses_alpha")
+      const messageIDs = sesAlphaMessages.map((r) => r.message_id)
+      const uniqueIDs = new Set(messageIDs)
+      expect(messageIDs.length).toBe(uniqueIDs.size)
+    })
+
+    test("handles empty query gracefully", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "", limit: 10 })
+
+      // #then
+      expect(results).toEqual([])
+    })
+
+    test("handles whitespace-only query", () => {
+      // #when
+      const results = searchSessionsSQL(testDB, { query: "   ", limit: 10 })
+
+      // #then
+      expect(results).toEqual([])
+    })
+
+    test("handles literal percent and underscore characters", () => {
+      // #given - test data has "50%" and "42_days" in prt_b3
+
+      // #when
+      const percentResults = searchSessionsSQL(testDB, { query: "50%", limit: 10 })
+
+      // #then
+      expect(percentResults.length).toBeGreaterThanOrEqual(1)
+      expect(percentResults.some((r) => r.excerpt.includes("50%"))).toBe(true)
+
+      // #when
+      const underscoreResults = searchSessionsSQL(testDB, { query: "42_days", limit: 10 })
+
+      // #then
+      expect(underscoreResults.length).toBeGreaterThanOrEqual(1)
+      expect(underscoreResults.some((r) => r.excerpt.includes("42_days"))).toBe(true)
+    })
+  })
+})

--- a/src/tools/session-manager/sql-search.ts
+++ b/src/tools/session-manager/sql-search.ts
@@ -1,0 +1,243 @@
+import { Database } from "bun:sqlite"
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import type { SearchResult } from "./types"
+
+export interface SQLSearchOptions {
+  query: string
+  sessionID?: string
+  caseSensitive?: boolean
+  limit?: number
+}
+
+interface SearchRow {
+  session_id: string
+  session_title: string
+  message_id: string
+  mtime: number
+  data: string
+}
+
+export function getDBPath(): string {
+  if (process.env.OPENCODE_DB) {
+    return process.env.OPENCODE_DB
+  }
+  return join(homedir(), ".local", "share", "opencode", "opencode.db")
+}
+
+function openDB(): Database | null {
+  const dbPath = getDBPath()
+  if (!existsSync(dbPath)) {
+    return null
+  }
+  try {
+    const db = new Database(dbPath, { readonly: true })
+    db.run("PRAGMA query_only = ON")
+    return db
+  } catch {
+    return null
+  }
+}
+
+function termsFor(query: string): string[] {
+  const tokens = query.match(/[\w\u4e00-\u9fff-]+/gu)
+  if (!tokens || tokens.length === 0) return []
+  return Array.from(new Set(tokens.map((t) => t.trim()).filter(Boolean)))
+}
+
+function snippetAround(text: string, query: string, contextSize = 80): string {
+  let idx = -1
+  if (query.length > 0) {
+    idx = text.toLowerCase().indexOf(query.toLowerCase())
+  }
+  if (idx < 0) {
+    idx = 0
+  }
+  const start = Math.max(0, idx - contextSize)
+  const end = Math.min(text.length, idx + query.length + contextSize)
+  let result = text.slice(start, end)
+  if (start > 0) result = "..." + result
+  if (end < text.length) result = result + "..."
+  return result
+}
+
+function executeSQLSearch(
+  db: Database,
+  terms: string[],
+  sessionID: string | undefined,
+  caseSensitive: boolean,
+  limit: number,
+): SearchResult[] {
+  const results: SearchResult[] = []
+  const seen = new Set<string>()
+
+  function searchColumn(table: string, term: string): void {
+    if (results.length >= limit) return
+
+    const whereCol = table === "message" ? "m.data" : "part.data"
+    const joinClause = table === "part" ? "JOIN part ON part.message_id = m.id" : ""
+    const select = table === "part"
+      ? "SELECT DISTINCT s.id as session_id, s.title as session_title, m.id as message_id, m.time_created as mtime, m.data as data"
+      : "SELECT s.id as session_id, s.title as session_title, m.id as message_id, m.time_created as mtime, m.data as data"
+
+    const termParam = caseSensitive ? term : term.toLowerCase()
+    const instrExpr = caseSensitive
+      ? `instr(${whereCol}, ?) > 0`
+      : `instr(lower(${whereCol}), ?) > 0`
+
+    let sql = `${select} FROM message m
+     JOIN session s ON m.session_id = s.id
+     ${joinClause}
+     WHERE ${instrExpr}`
+
+    const params: string[] = [termParam]
+
+    if (sessionID) {
+      sql += " AND m.session_id = ?"
+      params.push(sessionID)
+    }
+
+    sql += " ORDER BY m.time_created DESC LIMIT ?"
+    params.push(String(limit * 3))
+
+    const rows = db.query(sql).all(...params) as SearchRow[]
+
+    for (const row of rows) {
+      if (results.length >= limit) break
+
+      const key = `${row.session_id}:${row.message_id}`
+      if (seen.has(key)) continue
+
+      let parsed: Record<string, unknown> = {}
+      try {
+        parsed = JSON.parse(row.data || "{}") as Record<string, unknown>
+      } catch {
+        parsed = {}
+      }
+      const role = typeof parsed.role === "string" ? parsed.role : "unknown"
+
+      const partRows = db
+        .query("SELECT data FROM part WHERE message_id = ? ORDER BY id LIMIT 5")
+        .all(row.message_id) as { data: string }[]
+
+      const textParts: string[] = []
+      for (const pr of partRows) {
+        try {
+          const pd = JSON.parse(pr.data || "{}") as Record<string, unknown>
+          if (typeof pd.text === "string" && pd.text) {
+            textParts.push(pd.text)
+          } else if (typeof pd.thinking === "string" && pd.thinking) {
+            textParts.push(pd.thinking)
+          }
+        } catch {
+          continue
+        }
+      }
+
+      const combined = textParts.join(" | ")
+      const searchCombined = caseSensitive ? combined : combined.toLowerCase()
+      const searchTerm = caseSensitive ? term : term.toLowerCase()
+      let matchCount = 0
+      const matchTypes: string[] = []
+      let searchPos = 0
+      while ((searchPos = searchCombined.indexOf(searchTerm, searchPos)) !== -1) {
+        matchCount++
+        searchPos += searchTerm.length
+      }
+      if (matchCount > 0) {
+        matchTypes.push("text")
+      }
+
+      if (matchCount === 0) {
+        const dataStr = caseSensitive ? JSON.stringify(parsed) : JSON.stringify(parsed).toLowerCase()
+        let p = 0
+        while ((p = dataStr.indexOf(searchTerm, p)) !== -1) {
+          matchCount++
+          p += searchTerm.length
+        }
+        if (matchCount > 0) {
+          matchTypes.push("data")
+        }
+      }
+
+      if (matchCount === 0) {
+        const dataRaw = caseSensitive ? (row.data || "") : (row.data || "").toLowerCase()
+        let pr = 0
+        while ((pr = dataRaw.indexOf(searchTerm, pr)) !== -1) {
+          matchCount++
+          pr += searchTerm.length
+        }
+        if (matchCount > 0 && !matchTypes.includes("data")) {
+          matchTypes.push("data")
+        }
+      }
+
+      const excerpt = combined
+        ? snippetAround(combined, term)
+        : snippetAround(JSON.stringify(parsed), term, 120)
+
+      seen.add(key)
+      results.push({
+        session_id: row.session_id || "",
+        message_id: row.message_id || "",
+        role,
+        excerpt,
+        match_count: matchCount || 1,
+        timestamp: typeof row.mtime === "number" ? row.mtime : undefined,
+        match_type: matchTypes.length > 0 ? matchTypes : ["text"],
+        source: "sql",
+        title: row.session_title || "",
+        score: Math.min(1.0, (matchCount || 1) * 0.1),
+      })
+    }
+  }
+
+  for (const term of terms.slice(0, 6)) {
+    searchColumn("part", term)
+    if (results.length >= limit) break
+    searchColumn("message", term)
+    if (results.length >= limit) break
+  }
+
+  results.sort((a, b) => {
+    const scoreDiff = b.score - a.score
+    if (Math.abs(scoreDiff) > 0.001) return scoreDiff
+    return (b.timestamp ?? 0) - (a.timestamp ?? 0)
+  })
+
+  return results.slice(0, limit)
+}
+
+export function searchSessionsSQL(
+  db: Database,
+  options: SQLSearchOptions,
+): SearchResult[] {
+  const query = options.query.trim()
+  if (!query) return []
+
+  const searchTerms = termsFor(query)
+  if (searchTerms.length === 0) return []
+
+  const limit = options.limit && options.limit > 0 ? options.limit : 20
+
+  return executeSQLSearch(
+    db,
+    searchTerms,
+    options.sessionID,
+    options.caseSensitive ?? false,
+    limit,
+  )
+}
+
+export function searchSessions(
+  options: SQLSearchOptions,
+): SearchResult[] {
+  const db = openDB()
+  if (!db) return []
+  try {
+    return searchSessionsSQL(db, options)
+  } finally {
+    db.close()
+  }
+}

--- a/src/tools/session-manager/tools.ts
+++ b/src/tools/session-manager/tools.ts
@@ -12,12 +12,15 @@ import {
   formatSessionList,
   formatSessionMessages,
   formatSearchResults,
+  mergeAndDedupeSearchResults,
   searchInSession,
 } from "./utils"
+import { searchSessions } from "./sql-search"
+import { queryVectorAdapter } from "./vector-adapter"
 import type { SessionListArgs, SessionReadArgs, SessionSearchArgs, SessionInfoArgs, SearchResult } from "./types"
 
-const SEARCH_TIMEOUT_MS = 60_000
-const MAX_SESSIONS_TO_SCAN = 50
+const VECTOR_TIMEOUT_MS = 10_000
+const SQL_TIMEOUT_MS = 30_000
 
 function withTimeout<T>(promise: Promise<T>, ms: number, operation: string): Promise<T> {
   return Promise.race([
@@ -96,29 +99,35 @@ export const session_search: ToolDefinition = tool({
     try {
       const resultLimit = args.limit && args.limit > 0 ? args.limit : 20
 
-      const searchOperation = async (): Promise<SearchResult[]> => {
-        if (args.session_id) {
-          return searchInSession(args.session_id, args.query, args.case_sensitive, resultLimit)
-        }
+      const sqlResults: SearchResult[] = await withTimeout(
+        Promise.resolve(
+          searchSessions({
+            query: args.query,
+            sessionID: args.session_id,
+            caseSensitive: args.case_sensitive,
+            limit: resultLimit,
+          }),
+        ),
+        SQL_TIMEOUT_MS,
+        "SQL search",
+      ).catch(() => [])
 
-        const allSessions = await getAllSessions()
-        const sessionsToScan = allSessions.slice(0, MAX_SESSIONS_TO_SCAN)
+      const vectorResults: SearchResult[] = await withTimeout(
+        queryVectorAdapter(args.query, {
+          topK: resultLimit,
+          sessionId: args.session_id,
+        }),
+        VECTOR_TIMEOUT_MS,
+        "Vector search",
+      ).catch(() => [])
 
-        const allResults: SearchResult[] = []
-        for (const sid of sessionsToScan) {
-          if (allResults.length >= resultLimit) break
+      const merged = mergeAndDedupeSearchResults(sqlResults, vectorResults, resultLimit)
 
-          const remaining = resultLimit - allResults.length
-          const sessionResults = await searchInSession(sid, args.query, args.case_sensitive, remaining)
-          allResults.push(...sessionResults)
-        }
-
-        return allResults.slice(0, resultLimit)
+      if (merged.length === 0) {
+        return "No matches found."
       }
 
-      const results = await withTimeout(searchOperation(), SEARCH_TIMEOUT_MS, "Search")
-
-      return formatSearchResults(results)
+      return formatSearchResults(merged)
     } catch (e) {
       return `Error: ${e instanceof Error ? e.message : String(e)}`
     }

--- a/src/tools/session-manager/types.ts
+++ b/src/tools/session-manager/types.ts
@@ -47,6 +47,10 @@ export interface SearchResult {
   excerpt: string
   match_count: number
   timestamp?: number
+  match_type: string[]
+  source: "sql" | "vector"
+  title: string
+  score: number
 }
 
 export interface SessionMetadata {

--- a/src/tools/session-manager/utils.test.ts
+++ b/src/tools/session-manager/utils.test.ts
@@ -120,6 +120,10 @@ describe("session-manager utils", () => {
         excerpt: "...example text...",
         match_count: 3,
         timestamp: Date.now(),
+        match_type: ["text"],
+        source: "sql",
+        title: "Test Session",
+        score: 0.8,
       },
     ]
 

--- a/src/tools/session-manager/utils.ts
+++ b/src/tools/session-manager/utils.ts
@@ -114,12 +114,49 @@ export function formatSearchResults(results: SearchResult[]): string {
 
   for (const result of results) {
     const timestamp = result.timestamp ? new Date(result.timestamp).toISOString() : ""
-    lines.push(`[${result.session_id}] ${result.message_id} (${result.role}) ${timestamp}`)
+    const sourceTag = result.source === "vector" ? " [vector]" : ""
+    const titleInfo = result.title ? ` "${result.title}"` : ""
+    lines.push(
+      `[${result.session_id}]${titleInfo} ${result.message_id} (${result.role})${sourceTag} ${timestamp}`,
+    )
     lines.push(`  ${result.excerpt}`)
-    lines.push(`  Matches: ${result.match_count}\n`)
+    if (result.match_count > 0) {
+      lines.push(`  Matches: ${result.match_count}`)
+    }
+    if (result.match_type.length > 0) {
+      lines.push(`  Type: ${result.match_type.join(", ")}`)
+    }
+    lines.push(`  Score: ${result.score.toFixed(2)}\n`)
   }
 
   return lines.join("\n")
+}
+
+export function mergeAndDedupeSearchResults(
+  sqlResults: SearchResult[],
+  vectorResults: SearchResult[],
+  limit: number,
+): SearchResult[] {
+  const seen = new Set<string>()
+  const merged: SearchResult[] = []
+
+  for (const r of sqlResults) {
+    const key = `${r.session_id}:${r.message_id}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    merged.push(r)
+  }
+
+  for (const r of vectorResults) {
+    const key = `${r.session_id}:${r.message_id}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    merged.push(r)
+  }
+
+  merged.sort((a, b) => b.score - a.score)
+
+  return merged.slice(0, limit)
 }
 
 export async function filterSessionsByDate(
@@ -191,6 +228,10 @@ export async function searchInSession(
         excerpt: excerpts[0] || "",
         match_count: matchCount,
         timestamp: msg.time?.created,
+        match_type: ["text"],
+        source: "sql",
+        title: "",
+        score: Math.min(1.0, matchCount * 0.1),
       })
     }
   }

--- a/src/tools/session-manager/vector-adapter.test.ts
+++ b/src/tools/session-manager/vector-adapter.test.ts
@@ -1,0 +1,440 @@
+import { describe, test, expect, afterEach } from "bun:test"
+import { writeFileSync, unlinkSync, existsSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { queryVectorAdapter } from "./vector-adapter"
+
+let tempAdapterPaths: string[] = []
+
+function createTempAdapter(): string {
+  const path = join(tmpdir(), `test-adapter-${Date.now()}-${Math.random().toString(36).slice(2, 6)}.py`)
+  writeFileSync(path, "#!/usr/bin/env python3\nprint('{}')")
+  tempAdapterPaths.push(path)
+  return path
+}
+
+function cleanupTempAdapters(): void {
+  for (const p of tempAdapterPaths) {
+    if (existsSync(p)) {
+      unlinkSync(p)
+    }
+  }
+  tempAdapterPaths = []
+}
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void
+type MockExecFile = (cmd: string, args: string[], options: Record<string, unknown>, callback: ExecFileCallback) => void
+
+describe("vector-adapter", () => {
+  afterEach(cleanupTempAdapters)
+
+  describe("queryVectorAdapter", () => {
+    test("returns empty array when adapter path does not exist", async () => {
+      const results = await queryVectorAdapter("pipeline", {
+        adapterPath: "/nonexistent/path/to/query_lancedb.py",
+      })
+
+      expect(results).toEqual([])
+    })
+
+    test("returns empty array when subprocess fails", async () => {
+      const results = await queryVectorAdapter("test", {
+        adapterPath: "/usr/bin/false",
+      })
+
+      expect(results).toEqual([])
+    })
+
+    test("parses valid JSON output from subprocess", async () => {
+      const adapterPath = createTempAdapter()
+      const mockStdout = JSON.stringify({
+        results: [
+          {
+            path: "opencode://ses_test",
+            session_id: "ses_test",
+            title: "Test Session",
+            score: 0.85,
+            match_type: ["semantic"],
+            snippet: "found match in session...",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+        ],
+      })
+
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        cb(null, mockStdout, "")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+      })
+
+      expect(results.length).toBe(1)
+      expect(results[0].session_id).toBe("ses_test")
+      expect(results[0].title).toBe("Test Session")
+      expect(results[0].score).toBe(0.85)
+      expect(results[0].source).toBe("vector")
+      expect(results[0].match_type).toContain("semantic")
+    })
+
+    test("returns empty array on malformed JSON", async () => {
+      const adapterPath = createTempAdapter()
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        cb(null, "not valid json {{{", "")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+      })
+
+      expect(results).toEqual([])
+    })
+
+    test("transforms vector result into SearchResult shape", async () => {
+      const adapterPath = createTempAdapter()
+      const mockStdout = JSON.stringify({
+        results: [
+          {
+            path: "opencode://ses_v1",
+            session_id: "ses_v1",
+            title: "Vector Test",
+            score: 0.92,
+            match_type: ["semantic"],
+            snippet: "deployment pipeline configuration...",
+            source_type: "opencode_session",
+            heading_path: "message/assistant",
+          },
+        ],
+      })
+
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        cb(null, mockStdout, "")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("deployment", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+      })
+
+      expect(results.length).toBe(1)
+      const r = results[0]
+      expect(r.session_id).toBe("ses_v1")
+      expect(r.message_id).toBeDefined()
+      expect(r.role).toBe("assistant")
+      expect(r.excerpt).toBe("deployment pipeline configuration...")
+      expect(r.match_count).toBeGreaterThan(0)
+      expect(Array.isArray(r.match_type)).toBe(true)
+      expect(r.source).toBe("vector")
+      expect(typeof r.score).toBe("number")
+      expect(r.timestamp).toBeUndefined()
+    })
+
+    test("gracefully handles stderr from subprocess", async () => {
+      const adapterPath = createTempAdapter()
+      const mockStdout = JSON.stringify({
+        results: [
+          {
+            path: "opencode://ses_err",
+            session_id: "ses_err",
+            title: "Stderr Test",
+            score: 0.5,
+            match_type: ["keyword"],
+            snippet: "test content",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+        ],
+      })
+
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        cb(null, mockStdout, "warning: some deprecation message on stderr")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+      })
+
+      expect(results.length).toBe(1)
+    })
+
+    test("does not throw on subprocess timeout", async () => {
+      const adapterPath = createTempAdapter()
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        const err = new Error("ETIMEDOUT") as Error & { killed?: boolean }
+        err.killed = true
+        cb(err, "", "")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+        timeoutMs: 100,
+      })
+
+      expect(results).toEqual([])
+    })
+
+    test("deduplicates by session_id within vector results", async () => {
+      const adapterPath = createTempAdapter()
+      const mockStdout = JSON.stringify({
+        results: [
+          {
+            path: "opencode://ses_dup",
+            session_id: "ses_dup",
+            title: "Same Session A",
+            score: 0.9,
+            match_type: ["semantic"],
+            snippet: "first chunk",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+          {
+            path: "opencode://ses_dup",
+            session_id: "ses_dup",
+            title: "Same Session B",
+            score: 0.7,
+            match_type: ["semantic"],
+            snippet: "second chunk same session",
+            source_type: "opencode_session",
+            heading_path: "message/assistant",
+          },
+        ],
+      })
+
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        cb(null, mockStdout, "")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+      })
+
+      const sesDup = results.filter((r) => r.session_id === "ses_dup")
+      expect(sesDup.length).toBe(1)
+      expect(sesDup[0].score).toBe(0.9)
+    })
+
+    test("message_id is deterministic for same input", async () => {
+      const adapterPath = createTempAdapter()
+      const mockStdout = JSON.stringify({
+        results: [
+          {
+            path: "opencode://ses_stable",
+            session_id: "ses_stable",
+            title: "Stable",
+            score: 0.88,
+            match_type: ["semantic"],
+            snippet: "stable snippet content",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+        ],
+      })
+
+      const mkSpawn = () =>
+        ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+          cb(null, mockStdout, "")
+        }) as unknown as typeof import("node:child_process").execFile
+
+      const results1 = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mkSpawn(),
+      })
+
+      const results2 = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mkSpawn(),
+      })
+
+      expect(results1.length).toBe(1)
+      expect(results2.length).toBe(1)
+      expect(results1[0].message_id).toBe(results2[0].message_id)
+    })
+
+    test("ignores non-OpenCode results with no session_id", async () => {
+      const adapterPath = createTempAdapter()
+      const mockStdout = JSON.stringify({
+        results: [
+          {
+            path: "opencode://ses_keep",
+            session_id: "ses_keep",
+            title: "Session Result",
+            score: 0.9,
+            match_type: ["semantic"],
+            snippet: "valid session result",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+          {
+            path: "Zettelkasten/some-note.md",
+            title: "A Markdown Note",
+            score: 0.8,
+            match_type: ["keyword"],
+            snippet: "this is markdown content",
+            source_type: "markdown_live_fallback",
+            heading_path: "",
+          },
+          {
+            path: "opencode://ses_only_path",
+            title: "Path Only No Session ID",
+            score: 0.7,
+            match_type: ["keyword"],
+            snippet: "path only item",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+        ],
+      })
+
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        cb(null, mockStdout, "")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+      })
+
+      expect(results.length).toBe(1)
+      expect(results[0].session_id).toBe("ses_keep")
+    })
+
+    test("filters vector results by session_id when sessionId option is set", async () => {
+      const adapterPath = createTempAdapter()
+      const mockStdout = JSON.stringify({
+        results: [
+          {
+            path: "opencode://ses_alpha",
+            session_id: "ses_alpha",
+            title: "Alpha Session",
+            score: 0.95,
+            match_type: ["semantic"],
+            snippet: "alpha content",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+          {
+            path: "opencode://ses_beta",
+            session_id: "ses_beta",
+            title: "Beta Session",
+            score: 0.88,
+            match_type: ["semantic"],
+            snippet: "beta content",
+            source_type: "opencode_session",
+            heading_path: "message/assistant",
+          },
+          {
+            path: "opencode://ses_gamma",
+            session_id: "ses_gamma",
+            title: "Gamma Session",
+            score: 0.72,
+            match_type: ["semantic"],
+            snippet: "gamma content",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+        ],
+      })
+
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        cb(null, mockStdout, "")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+        sessionId: "ses_beta",
+      })
+
+      expect(results.length).toBe(1)
+      expect(results[0].session_id).toBe("ses_beta")
+      expect(results[0].title).toBe("Beta Session")
+    })
+
+    test("returns all results when sessionId option is not set", async () => {
+      const adapterPath = createTempAdapter()
+      const mockStdout = JSON.stringify({
+        results: [
+          {
+            path: "opencode://ses_alpha",
+            session_id: "ses_alpha",
+            title: "Alpha Session",
+            score: 0.95,
+            match_type: ["semantic"],
+            snippet: "alpha content",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+          {
+            path: "opencode://ses_beta",
+            session_id: "ses_beta",
+            title: "Beta Session",
+            score: 0.88,
+            match_type: ["semantic"],
+            snippet: "beta content",
+            source_type: "opencode_session",
+            heading_path: "message/assistant",
+          },
+        ],
+      })
+
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        cb(null, mockStdout, "")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+      })
+
+      expect(results.length).toBe(2)
+      const ids = results.map((r) => r.session_id).sort()
+      expect(ids).toEqual(["ses_alpha", "ses_beta"])
+    })
+
+    test("ignores results with wrong source_type", async () => {
+      const adapterPath = createTempAdapter()
+      const mockStdout = JSON.stringify({
+        results: [
+          {
+            path: "opencode://ses_good",
+            session_id: "ses_good",
+            title: "Good",
+            score: 0.9,
+            match_type: ["semantic"],
+            snippet: "good result",
+            source_type: "opencode_session",
+            heading_path: "message/user",
+          },
+          {
+            path: "Zettelkasten/note.md",
+            session_id: "ses_wrong_source",
+            title: "Wrong Source",
+            score: 0.85,
+            match_type: ["keyword"],
+            snippet: "wrong source type",
+            source_type: "markdown_live_fallback",
+            heading_path: "",
+          },
+        ],
+      })
+
+      const mockSpawn = ((_cmd: string, _args: string[], _opts: Record<string, unknown>, cb: ExecFileCallback) => {
+        cb(null, mockStdout, "")
+      }) as unknown as typeof import("node:child_process").execFile
+
+      const results = await queryVectorAdapter("test", {
+        adapterPath,
+        spawnOverride: mockSpawn,
+      })
+
+      expect(results.length).toBe(1)
+      expect(results[0].session_id).toBe("ses_good")
+    })
+  })
+})

--- a/src/tools/session-manager/vector-adapter.ts
+++ b/src/tools/session-manager/vector-adapter.ts
@@ -1,0 +1,194 @@
+import { execFile } from "node:child_process"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import type { SearchResult } from "./types"
+
+interface VectorAdapterOptions {
+  adapterPath?: string
+  topK?: number
+  sessionId?: string
+  spawnOverride?: typeof import("node:child_process").execFile
+  timeoutMs?: number
+}
+
+interface VectorResultItem {
+  path?: string
+  session_id?: string
+  title?: string
+  score?: number
+  match_type?: string[]
+  snippet?: string
+  source_type?: string
+  heading_path?: string
+  chunk_text?: string
+  mtime?: string
+  absolute_path?: string
+}
+
+function isVectorResultItem(input: unknown): input is VectorResultItem {
+  if (typeof input !== "object" || input === null) return false
+  const obj = input as Record<string, unknown>
+  return typeof obj.session_id === "string" || typeof obj.path === "string"
+}
+
+function isValidSessionItem(item: VectorResultItem): boolean {
+  const sid = item.session_id
+  if (typeof sid !== "string" || sid.length === 0) return false
+  if (typeof item.source_type === "string" && item.source_type !== "opencode_session") return false
+  return true
+}
+
+function isVectorResultArray(input: unknown): input is VectorResultItem[] {
+  return Array.isArray(input) && input.every(isVectorResultItem)
+}
+
+interface VectorOutputShape {
+  results?: unknown
+}
+
+function isVectorOutput(input: unknown): input is VectorOutputShape {
+  return typeof input === "object" && input !== null && "results" in input
+}
+
+function getDefaultAdapterPath(): string {
+  const candidates = [
+    join(
+      process.env.HOME || "",
+      "Library",
+      "Mobile Documents",
+      "iCloud~md~obsidian",
+      "Documents",
+      "Zettelkasten",
+      ".agents",
+      "skills",
+      "search-note",
+      "scripts",
+      "query_lancedb.py",
+    ),
+    join(
+      process.env.HOME || "",
+      "Documents",
+      "Zettelkasten",
+      ".agents",
+      "skills",
+      "search-note",
+      "scripts",
+      "query_lancedb.py",
+    ),
+  ]
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate
+  }
+  return candidates[0]
+}
+
+function deterministicSuffix(input: string): string {
+  let hash = 0
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i)
+    hash = ((hash << 5) - hash) + char
+    hash = hash & hash
+  }
+  const abs = Math.abs(hash)
+  return abs.toString(36).slice(0, 8)
+}
+
+function vectorItemToSearchResult(item: VectorResultItem): SearchResult {
+  const role = (item.heading_path || "").replace("message/", "") || "unknown"
+  const sessionID = item.session_id as string
+  const snippetRaw = item.snippet || item.chunk_text || ""
+
+  const stableSeed = [sessionID, item.path || "", snippetRaw.slice(0, 50), role].join(":")
+  const suffix = deterministicSuffix(stableSeed)
+  const messageID = `${sessionID}_vec_${suffix}`
+
+  return {
+    session_id: sessionID,
+    message_id: messageID,
+    role,
+    excerpt: snippetRaw,
+    match_count: 1,
+    timestamp: undefined,
+    match_type: item.match_type || ["semantic"],
+    source: "vector",
+    title: item.title || "",
+    score: typeof item.score === "number" ? item.score : 0.5,
+  }
+}
+
+export async function queryVectorAdapter(
+  query: string,
+  options: VectorAdapterOptions = {},
+): Promise<SearchResult[]> {
+  const adapterPath = options.adapterPath ?? getDefaultAdapterPath()
+
+  if (!existsSync(adapterPath)) {
+    return []
+  }
+
+  const args = [
+    adapterPath,
+    query,
+    "--source",
+    "opencode",
+    "--mode",
+    "auto",
+    "--top-k",
+    String(options.topK ?? 10),
+  ]
+
+  const cmd = "python3"
+  const timeoutMs = options.timeoutMs ?? 15000
+  const spawnFn = options.spawnOverride ?? execFile
+
+  return new Promise<SearchResult[]>((resolve) => {
+    const timeout = setTimeout(() => {
+      resolve([])
+    }, timeoutMs)
+
+    spawnFn(cmd, args, { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 }, (error, stdout, _stderr) => {
+      clearTimeout(timeout)
+
+      if (error) {
+        resolve([])
+        return
+      }
+
+      if (!stdout || stdout.trim().length === 0) {
+        resolve([])
+        return
+      }
+
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(stdout)
+      } catch {
+        resolve([])
+        return
+      }
+
+      const results: VectorResultItem[] = []
+      if (isVectorOutput(parsed) && isVectorResultArray(parsed.results)) {
+        results.push(...parsed.results)
+      } else if (isVectorResultArray(parsed)) {
+        results.push(...parsed)
+      } else {
+        resolve([])
+        return
+      }
+
+      const seen = new Set<string>()
+      const output: SearchResult[] = []
+      for (const item of results) {
+        if (!isValidSessionItem(item)) continue
+        const sessionID = item.session_id as string
+        if (options.sessionId !== undefined && sessionID !== options.sessionId) continue
+        if (seen.has(sessionID)) continue
+        seen.add(sessionID)
+        output.push(vectorItemToSearchResult(item))
+      }
+
+      resolve(output)
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- Replace the old limited session scan with direct SQLite search over the OpenCode `message` and `part` tables.
- Add a best-effort Search Note vector adapter and merge/dedupe SQL + vector results for `session_search`.
- Enrich search result formatting with source, title, match type, and score metadata, plus focused SQL/vector tests.

## Verification
- `npx bun test --timeout 30000 src/tools/session-manager/` → 65 pass, 0 fail
- `npx tsc --noEmit` → pass
- `npx bun test --timeout 30000` → 1410 pass, 2 skip, 0 fail
- Manual QA: `session_search` returns real hits for `DeepSeek`; scoped `session_id` searches only return the requested session

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `session_search` to a hybrid SQL + vector search to return faster and more relevant session hits. Results now include titles, match types, scores, and clear source tags, with deduping across SQL and vector results.

- **New Features**
  - Direct SQLite search over `message` and `part` tables with optional case sensitivity, `session_id` filtering, and limits.
  - Optional vector search via a best-effort adapter (`query_lancedb.py`) for semantic matches; safe timeouts and error handling.
  - Merges and dedupes SQL and vector results, ranked by score and recency; formatted output shows title, source (`sql`/`vector`), type, and score.
  - New exports: `searchSessions`, `queryVectorAdapter`, `mergeAndDedupeSearchResults`; enriched `SearchResult` shape.
  - Focused tests for SQL search and vector adapter; updated formatting tests.

- **Migration**
  - Uses `OPENCODE_DB` if set; otherwise defaults to `~/.local/share/opencode/opencode.db`.
  - Vector search is optional: place `query_lancedb.py` in the default path or provide `adapterPath`; otherwise only SQL runs.
  - No interface changes to `session_search`; no required actions for existing users.

<sup>Written for commit 8376504b1794bab8021e2b8c1f99d2507a820526. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

