### PR TITLE
feat(continuation): make timing constants configurable via plugin config

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -5722,6 +5722,39 @@
       },
       "additionalProperties": false
     },
+    "continuation": {
+      "type": "object",
+      "properties": {
+        "cooldownMs": {
+          "type": "number",
+          "minimum": 1000
+        },
+        "abortWindowMs": {
+          "type": "number",
+          "minimum": 500
+        },
+        "maxStagnationCount": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
+        },
+        "maxConsecutiveFailures": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
+        },
+        "failureResetWindowMs": {
+          "type": "number",
+          "minimum": 30000
+        },
+        "countdownSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991
+        }
+      },
+      "additionalProperties": false
+    },
     "notification": {
       "type": "object",
       "properties": {

--- a/src/config/schema/continuation.test.ts
+++ b/src/config/schema/continuation.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test"
+import { ZodError } from "zod"
+import { ContinuationConfigSchema } from "./continuation"
+
+describe("ContinuationConfigSchema", () => {
+  describe("cooldownMs", () => {
+    describe("#given valid cooldownMs (5000)", () => {
+      test("#when parsed #then returns correct value", () => {
+        const result = ContinuationConfigSchema.parse({ cooldownMs: 5000 })
+        expect(result.cooldownMs).toBe(5000)
+      })
+    })
+
+    describe("#given cooldownMs below minimum (999)", () => {
+      test("#when parsed #then throws ZodError", () => {
+        let thrownError: unknown
+        try {
+          ContinuationConfigSchema.parse({ cooldownMs: 999 })
+        } catch (error) {
+          thrownError = error
+        }
+        expect(thrownError).toBeInstanceOf(ZodError)
+      })
+    })
+
+    describe("#given cooldownMs not provided", () => {
+      test("#when parsed #then field is undefined", () => {
+        const result = ContinuationConfigSchema.parse({})
+        expect(result.cooldownMs).toBeUndefined()
+      })
+    })
+  })
+
+  describe("abortWindowMs", () => {
+    describe("#given valid abortWindowMs (3000)", () => {
+      test("#when parsed #then returns correct value", () => {
+        const result = ContinuationConfigSchema.parse({ abortWindowMs: 3000 })
+        expect(result.abortWindowMs).toBe(3000)
+      })
+    })
+
+    describe("#given abortWindowMs below minimum (499)", () => {
+      test("#when parsed #then throws ZodError", () => {
+        let thrownError: unknown
+        try {
+          ContinuationConfigSchema.parse({ abortWindowMs: 499 })
+        } catch (error) {
+          thrownError = error
+        }
+        expect(thrownError).toBeInstanceOf(ZodError)
+      })
+    })
+
+    describe("#given abortWindowMs not provided", () => {
+      test("#when parsed #then field is undefined", () => {
+        const result = ContinuationConfigSchema.parse({})
+        expect(result.abortWindowMs).toBeUndefined()
+      })
+    })
+  })
+
+  describe("maxStagnationCount", () => {
+    describe("#given valid maxStagnationCount (3)", () => {
+      test("#when parsed #then returns correct value", () => {
+        const result = ContinuationConfigSchema.parse({ maxStagnationCount: 3 })
+        expect(result.maxStagnationCount).toBe(3)
+      })
+    })
+
+    describe("#given maxStagnationCount below minimum (0)", () => {
+      test("#when parsed #then throws ZodError", () => {
+        let thrownError: unknown
+        try {
+          ContinuationConfigSchema.parse({ maxStagnationCount: 0 })
+        } catch (error) {
+          thrownError = error
+        }
+        expect(thrownError).toBeInstanceOf(ZodError)
+      })
+    })
+
+    describe("#given maxStagnationCount not provided", () => {
+      test("#when parsed #then field is undefined", () => {
+        const result = ContinuationConfigSchema.parse({})
+        expect(result.maxStagnationCount).toBeUndefined()
+      })
+    })
+  })
+
+  describe("maxConsecutiveFailures", () => {
+    describe("#given valid maxConsecutiveFailures (5)", () => {
+      test("#when parsed #then returns correct value", () => {
+        const result = ContinuationConfigSchema.parse({ maxConsecutiveFailures: 5 })
+        expect(result.maxConsecutiveFailures).toBe(5)
+      })
+    })
+
+    describe("#given maxConsecutiveFailures below minimum (0)", () => {
+      test("#when parsed #then throws ZodError", () => {
+        let thrownError: unknown
+        try {
+          ContinuationConfigSchema.parse({ maxConsecutiveFailures: 0 })
+        } catch (error) {
+          thrownError = error
+        }
+        expect(thrownError).toBeInstanceOf(ZodError)
+      })
+    })
+
+    describe("#given maxConsecutiveFailures not provided", () => {
+      test("#when parsed #then field is undefined", () => {
+        const result = ContinuationConfigSchema.parse({})
+        expect(result.maxConsecutiveFailures).toBeUndefined()
+      })
+    })
+  })
+
+  describe("failureResetWindowMs", () => {
+    describe("#given valid failureResetWindowMs (300000)", () => {
+      test("#when parsed #then returns correct value", () => {
+        const result = ContinuationConfigSchema.parse({ failureResetWindowMs: 300000 })
+        expect(result.failureResetWindowMs).toBe(300000)
+      })
+    })
+
+    describe("#given failureResetWindowMs below minimum (29999)", () => {
+      test("#when parsed #then throws ZodError", () => {
+        let thrownError: unknown
+        try {
+          ContinuationConfigSchema.parse({ failureResetWindowMs: 29999 })
+        } catch (error) {
+          thrownError = error
+        }
+        expect(thrownError).toBeInstanceOf(ZodError)
+      })
+    })
+
+    describe("#given failureResetWindowMs not provided", () => {
+      test("#when parsed #then field is undefined", () => {
+        const result = ContinuationConfigSchema.parse({})
+        expect(result.failureResetWindowMs).toBeUndefined()
+      })
+    })
+  })
+
+  describe("countdownSeconds", () => {
+    describe("#given valid countdownSeconds (2)", () => {
+      test("#when parsed #then returns correct value", () => {
+        const result = ContinuationConfigSchema.parse({ countdownSeconds: 2 })
+        expect(result.countdownSeconds).toBe(2)
+      })
+    })
+
+    describe("#given countdownSeconds below minimum (0)", () => {
+      test("#when parsed #then throws ZodError", () => {
+        let thrownError: unknown
+        try {
+          ContinuationConfigSchema.parse({ countdownSeconds: 0 })
+        } catch (error) {
+          thrownError = error
+        }
+        expect(thrownError).toBeInstanceOf(ZodError)
+      })
+    })
+
+    describe("#given countdownSeconds not provided", () => {
+      test("#when parsed #then field is undefined", () => {
+        const result = ContinuationConfigSchema.parse({})
+        expect(result.countdownSeconds).toBeUndefined()
+      })
+    })
+  })
+})

--- a/src/config/schema/continuation.ts
+++ b/src/config/schema/continuation.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const ContinuationConfigSchema = z.object({
+  /** Base cooldown between continuation injections in ms (default: 5000, minimum: 1000) */
+  cooldownMs: z.number().min(1000).optional(),
+  /** Grace period after abort detection in ms (default: 3000, minimum: 500) */
+  abortWindowMs: z.number().min(500).optional(),
+  /** Max consecutive injections without todo progress before stopping (default: 3, minimum: 1) */
+  maxStagnationCount: z.number().int().min(1).optional(),
+  /** Max injection failures before entering pause period (default: 5, minimum: 1) */
+  maxConsecutiveFailures: z.number().int().min(1).optional(),
+  /** Window in ms before consecutive failure count resets (default: 300000, minimum: 30000) */
+  failureResetWindowMs: z.number().min(30000).optional(),
+  /** Countdown toast duration in seconds (default: 2, minimum: 1) */
+  countdownSeconds: z.number().int().min(1).optional(),
+})
+
+export type ContinuationConfig = z.infer<typeof ContinuationConfigSchema>

--- a/src/config/schema/oh-my-opencode-config.ts
+++ b/src/config/schema/oh-my-opencode-config.ts
@@ -5,6 +5,7 @@ import { AgentDefinitionsConfigSchema } from "./agent-definitions"
 import { AgentOverridesSchema } from "./agent-overrides"
 import { BabysittingConfigSchema } from "./babysitting"
 import { BackgroundTaskConfigSchema } from "./background-task"
+import { ContinuationConfigSchema } from "./continuation"
 import { BrowserAutomationConfigSchema } from "./browser-automation"
 import { CategoriesConfigSchema } from "./categories"
 import { ClaudeCodeConfigSchema } from "./claude-code"
@@ -62,6 +63,7 @@ export const OhMyOpenCodeConfigSchema = z.object({
    */
   runtime_fallback: z.union([z.boolean(), RuntimeFallbackConfigSchema]).optional(),
   background_task: BackgroundTaskConfigSchema.optional(),
+  continuation: ContinuationConfigSchema.optional(),
   notification: NotificationConfigSchema.optional(),
   model_capabilities: ModelCapabilitiesConfigSchema.optional(),
   openclaw: OpenClawConfigSchema.optional(),

--- a/src/hooks/todo-continuation-enforcer/countdown.ts
+++ b/src/hooks/todo-continuation-enforcer/countdown.ts
@@ -39,6 +39,7 @@ export function startCountdown(args: {
   skipAgents: string[]
   sessionStateStore: SessionStateStore
   isContinuationStopped?: (sessionID: string) => boolean
+  countdownSeconds?: number
 }): void {
   const {
     ctx,
@@ -49,12 +50,14 @@ export function startCountdown(args: {
     skipAgents,
     sessionStateStore,
     isContinuationStopped,
+    countdownSeconds,
   } = args
+  const effectiveSeconds = countdownSeconds ?? COUNTDOWN_SECONDS
 
   const state = sessionStateStore.getState(sessionID)
   sessionStateStore.cancelCountdown(sessionID)
 
-  let secondsRemaining = COUNTDOWN_SECONDS
+  let secondsRemaining = effectiveSeconds
   showCountdownToast(ctx, secondsRemaining, incompleteCount)
   state.countdownStartedAt = Date.now()
 
@@ -76,11 +79,11 @@ export function startCountdown(args: {
       sessionStateStore,
       isContinuationStopped,
     })
-  }, COUNTDOWN_SECONDS * 1000)
+  }, effectiveSeconds * 1000)
 
   log(`[${HOOK_NAME}] Countdown started`, {
     sessionID,
-    seconds: COUNTDOWN_SECONDS,
+    seconds: effectiveSeconds,
     incompleteCount,
   })
 }

--- a/src/hooks/todo-continuation-enforcer/handler.ts
+++ b/src/hooks/todo-continuation-enforcer/handler.ts
@@ -12,6 +12,7 @@ import type { SessionStateStore } from "./session-state"
 import { handleSessionIdle } from "./idle-event"
 import { handleNonIdleEvent } from "./non-idle-events"
 import { isTokenLimitError } from "./token-limit-detection"
+import type { ContinuationTimingConfig } from "./types"
 
 export function createTodoContinuationHandler(args: {
   ctx: PluginInput
@@ -19,6 +20,7 @@ export function createTodoContinuationHandler(args: {
   backgroundManager?: BackgroundManager
   skipAgents?: string[]
   isContinuationStopped?: (sessionID: string) => boolean
+  continuationConfig?: ContinuationTimingConfig
 }): (input: { event: { type: string; properties?: unknown } }) => Promise<void> {
   const {
     ctx,
@@ -26,6 +28,7 @@ export function createTodoContinuationHandler(args: {
     backgroundManager,
     skipAgents = DEFAULT_SKIP_AGENTS,
     isContinuationStopped,
+    continuationConfig,
   } = args
 
   return async ({ event }: { event: { type: string; properties?: unknown } }): Promise<void> => {
@@ -69,6 +72,7 @@ export function createTodoContinuationHandler(args: {
         backgroundManager,
         skipAgents,
         isContinuationStopped,
+        continuationConfig,
       })
       return
     }

--- a/src/hooks/todo-continuation-enforcer/idle-event.test.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.test.ts
@@ -66,6 +66,126 @@ describe("handleSessionIdle", () => {
     // then
     expect(resetCalls).toEqual([sessionID])
   })
+  
+  function createStateStoreWithState(initialState: Partial<SessionState>): {
+    store: SessionStateStore
+    resetCalls: string[]
+  } {
+    const state: SessionState = {
+      stagnationCount: 0,
+      consecutiveFailures: 0,
+      ...initialState,
+    } as SessionState
+    const resetCalls: string[] = []
+    const progressUpdate: ContinuationProgressUpdate = {
+      previousStagnationCount: 0,
+      stagnationCount: 0,
+      hasProgressed: false,
+      progressSource: "none",
+    }
+
+    return {
+      resetCalls,
+      store: {
+        getState: () => state,
+        getExistingState: () => state,
+        startPruneInterval: () => {},
+        recordActivity: () => {},
+        trackContinuationProgress: () => progressUpdate,
+        resetContinuationProgress: (sessionID: string) => {
+          resetCalls.push(sessionID)
+        },
+        cancelCountdown: () => {},
+        cleanup: () => {},
+        cancelAllCountdowns: () => {},
+        shutdown: () => {},
+      },
+    }
+  }
+
+  describe("continuationConfig", () => {
+    it("proceeds past abort check when custom abortWindowMs is smaller than elapsed", async () => {
+      // given
+      const sessionID = "ses_custom_abort_small"
+      const abortDetectedAt = Date.now() - 2000
+      const { store, resetCalls } = createStateStoreWithState({ abortDetectedAt })
+      const ctx = {
+        client: {
+          session: {
+            messages: async () => ({ data: [] }),
+            todo: async () => ({ data: [] }),
+          },
+        },
+        directory: "/tmp/test",
+      }
+
+      // when
+      await handleSessionIdle({
+        ctx: ctx as never,
+        sessionID,
+        sessionStateStore: store,
+        continuationConfig: { abortWindowMs: 500 },
+      })
+
+      // then
+      expect(resetCalls).toEqual([sessionID])
+    })
+
+    it("returns early when custom abortWindowMs is larger than elapsed", async () => {
+      // given
+      const sessionID = "ses_custom_abort_large"
+      const abortDetectedAt = Date.now() - 4000
+      const { store, resetCalls } = createStateStoreWithState({ abortDetectedAt })
+      const ctx = {
+        client: {
+          session: {
+            messages: async () => ({ data: [] }),
+            todo: async () => ({ data: [] }),
+          },
+        },
+        directory: "/tmp/test",
+      }
+
+      // when
+      await handleSessionIdle({
+        ctx: ctx as never,
+        sessionID,
+        sessionStateStore: store,
+        continuationConfig: { abortWindowMs: 10000 },
+      })
+
+      // then
+      expect(resetCalls).toEqual([])
+    })
+
+    it("returns early when consecutiveFailures is at custom maxConsecutiveFailures", async () => {
+      // given
+      const sessionID = "ses_failure_limit"
+      const { store, resetCalls } = createStateStoreWithState({ consecutiveFailures: 3 })
+      const ctx = {
+        client: {
+          session: {
+            messages: async () => ({ data: [] }),
+            todo: async () => ({
+              data: [{ id: "todo-1", content: "Do something", status: "in_progress", priority: "high" }],
+            }),
+          },
+        },
+        directory: "/tmp/test",
+      }
+
+      // when
+      await handleSessionIdle({
+        ctx: ctx as never,
+        sessionID,
+        sessionStateStore: store,
+        continuationConfig: { maxConsecutiveFailures: 3 },
+      })
+
+      // then
+      expect(resetCalls).toEqual([])
+    })
+  })
 
   it("resets continuation progress once when every todo is complete", async () => {
     // given

--- a/src/hooks/todo-continuation-enforcer/idle-event.ts
+++ b/src/hooks/todo-continuation-enforcer/idle-event.ts
@@ -10,7 +10,7 @@ import { isLastAssistantMessageAborted } from "./abort-detection"
 import { hasUnansweredQuestion } from "./pending-question-detection"
 import { shouldStopForStagnation } from "./stagnation-detection"
 import { getIncompleteCount } from "./todo"
-import type { MessageInfo, MessageWithInfo, ResolvedMessageInfo, Todo } from "./types"
+import type { ContinuationTimingConfig, MessageInfo, MessageWithInfo, ResolvedMessageInfo, Todo } from "./types"
 import { resolveLatestMessageInfo } from "./resolve-message-info"
 import { acknowledgeCompactionGuard, isCompactionGuardActive } from "./compaction-guard"
 import type { SessionStateStore } from "./session-state"
@@ -31,6 +31,7 @@ export async function handleSessionIdle(args: {
   backgroundManager?: BackgroundManager
   skipAgents?: string[]
   isContinuationStopped?: (sessionID: string) => boolean
+  continuationConfig?: ContinuationTimingConfig
 }): Promise<void> {
   const {
     ctx,
@@ -39,6 +40,7 @@ export async function handleSessionIdle(args: {
     backgroundManager,
     skipAgents = DEFAULT_SKIP_AGENTS,
     isContinuationStopped,
+    continuationConfig,
   } = args
 
   log(`[${HOOK_NAME}] session.idle`, { sessionID })
@@ -62,7 +64,7 @@ export async function handleSessionIdle(args: {
 
   if (state.abortDetectedAt) {
     const timeSinceAbort = Date.now() - state.abortDetectedAt
-    if (timeSinceAbort < ABORT_WINDOW_MS) {
+    if (timeSinceAbort < (continuationConfig?.abortWindowMs ?? ABORT_WINDOW_MS)) {
       log(`[${HOOK_NAME}] Skipped: abort detected via event ${timeSinceAbort}ms ago`, { sessionID })
       state.abortDetectedAt = undefined
       return
@@ -126,21 +128,21 @@ export async function handleSessionIdle(args: {
   }
 
   if (
-    state.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES
+    state.consecutiveFailures >= (continuationConfig?.maxConsecutiveFailures ?? MAX_CONSECUTIVE_FAILURES)
     && state.lastInjectedAt
-    && Date.now() - state.lastInjectedAt >= FAILURE_RESET_WINDOW_MS
+    && Date.now() - state.lastInjectedAt >= (continuationConfig?.failureResetWindowMs ?? FAILURE_RESET_WINDOW_MS)
   ) {
     state.consecutiveFailures = 0
-    log(`[${HOOK_NAME}] Reset consecutive failures after recovery window`, { sessionID, failureResetWindowMs: FAILURE_RESET_WINDOW_MS })
+    log(`[${HOOK_NAME}] Reset consecutive failures after recovery window`, { sessionID, failureResetWindowMs: continuationConfig?.failureResetWindowMs ?? FAILURE_RESET_WINDOW_MS })
   }
 
-  if (state.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+  if (state.consecutiveFailures >= (continuationConfig?.maxConsecutiveFailures ?? MAX_CONSECUTIVE_FAILURES)) {
     log(`[${HOOK_NAME}] Skipped: max consecutive failures reached`, { sessionID, consecutiveFailures: state.consecutiveFailures })
     return
   }
 
   const effectiveCooldown =
-    CONTINUATION_COOLDOWN_MS * Math.pow(2, Math.min(state.consecutiveFailures, 5))
+    (continuationConfig?.cooldownMs ?? CONTINUATION_COOLDOWN_MS) * Math.pow(2, Math.min(state.consecutiveFailures, 5))
   if (state.lastInjectedAt && Date.now() - state.lastInjectedAt < effectiveCooldown) {
     log(`[${HOOK_NAME}] Skipped: cooldown active`, { sessionID, effectiveCooldown, consecutiveFailures: state.consecutiveFailures })
     return
@@ -206,7 +208,7 @@ export async function handleSessionIdle(args: {
     todos,
     { allowActivityProgress: shouldAllowActivityProgress(resolvedInfo?.model?.modelID) },
   )
-  if (shouldStopForStagnation({ sessionID, incompleteCount, progressUpdate })) {
+  if (shouldStopForStagnation({ sessionID, incompleteCount, progressUpdate, maxStagnationCount: continuationConfig?.maxStagnationCount })) {
     return
   }
   startCountdown({
@@ -219,5 +221,6 @@ export async function handleSessionIdle(args: {
     skipAgents,
     sessionStateStore,
     isContinuationStopped,
+    countdownSeconds: continuationConfig?.countdownSeconds,
   })
 }

--- a/src/hooks/todo-continuation-enforcer/index.ts
+++ b/src/hooks/todo-continuation-enforcer/index.ts
@@ -17,6 +17,7 @@ export function createTodoContinuationEnforcer(
     backgroundManager,
     skipAgents = DEFAULT_SKIP_AGENTS,
     isContinuationStopped,
+    continuationConfig,
   } = options
 
   const sessionStateStore = createSessionStateStore()
@@ -42,6 +43,7 @@ export function createTodoContinuationEnforcer(
     backgroundManager,
     skipAgents,
     isContinuationStopped,
+    continuationConfig,
   })
 
   const cancelAllCountdowns = (): void => {

--- a/src/hooks/todo-continuation-enforcer/stagnation-detection.ts
+++ b/src/hooks/todo-continuation-enforcer/stagnation-detection.ts
@@ -7,8 +7,10 @@ export function shouldStopForStagnation(args: {
   sessionID: string
   incompleteCount: number
   progressUpdate: ContinuationProgressUpdate
+  maxStagnationCount?: number
 }): boolean {
-  const { sessionID, incompleteCount, progressUpdate } = args
+  const { sessionID, incompleteCount, progressUpdate, maxStagnationCount: configMaxStagnationCount } = args
+  const effectiveMax = configMaxStagnationCount ?? MAX_STAGNATION_COUNT
 
   if (progressUpdate.hasProgressed) {
     log(`[${HOOK_NAME}] Progress detected: reset stagnation count`, {
@@ -17,11 +19,11 @@ export function shouldStopForStagnation(args: {
       previousStagnationCount: progressUpdate.previousStagnationCount,
       incompleteCount,
       progressSource: progressUpdate.progressSource,
-      recoveredFromStagnationStop: progressUpdate.previousStagnationCount >= MAX_STAGNATION_COUNT,
+      recoveredFromStagnationStop: progressUpdate.previousStagnationCount >= effectiveMax,
     })
   }
 
-  if (progressUpdate.stagnationCount < MAX_STAGNATION_COUNT) {
+  if (progressUpdate.stagnationCount < effectiveMax) {
     return false
   }
 
@@ -30,7 +32,7 @@ export function shouldStopForStagnation(args: {
     incompleteCount,
     previousIncompleteCount: progressUpdate.previousIncompleteCount,
     stagnationCount: progressUpdate.stagnationCount,
-    maxStagnationCount: MAX_STAGNATION_COUNT,
+    maxStagnationCount: effectiveMax,
   })
   return true
 }

--- a/src/hooks/todo-continuation-enforcer/types.ts
+++ b/src/hooks/todo-continuation-enforcer/types.ts
@@ -1,10 +1,26 @@
 import type { BackgroundManager } from "../../features/background-agent"
 import type { ToolPermission } from "../../features/hook-message-injector"
 
+export interface ContinuationTimingConfig {
+  /** Base cooldown between continuation injections in ms (default: 5000) */
+  cooldownMs?: number
+  /** Grace period after abort detection in ms (default: 3000) */
+  abortWindowMs?: number
+  /** Max consecutive injections without todo progress before stopping (default: 3) */
+  maxStagnationCount?: number
+  /** Max injection failures before entering pause period (default: 5) */
+  maxConsecutiveFailures?: number
+  /** Window in ms before consecutive failure count resets (default: 300000) */
+  failureResetWindowMs?: number
+  /** Countdown toast duration in seconds (default: 2) */
+  countdownSeconds?: number
+}
+
 export interface TodoContinuationEnforcerOptions {
   backgroundManager?: BackgroundManager
   skipAgents?: string[]
   isContinuationStopped?: (sessionID: string) => boolean
+  continuationConfig?: ContinuationTimingConfig
 }
 
 export interface TodoContinuationEnforcer {

--- a/src/plugin/hooks/create-continuation-hooks.ts
+++ b/src/plugin/hooks/create-continuation-hooks.ts
@@ -69,6 +69,7 @@ export function createContinuationHooks(args: {
       createTodoContinuationEnforcer(ctx, {
           backgroundManager,
           isContinuationStopped: stopContinuationGuard?.isStopped,
+          continuationConfig: pluginConfig.continuation,
         }))
     : null
 


### PR DESCRIPTION
## Summary

- Adds a `continuation` config section to `oh-my-opencode.jsonc` with 6 optional fields: `cooldownMs`, `abortWindowMs`, `maxStagnationCount`, `maxConsecutiveFailures`, `failureResetWindowMs`, `countdownSeconds`
- Threads the config through the entire `todo-continuation-enforcer` factory chain — zero behavior change when config is omitted (all defaults preserved)
- Adds schema validation tests and behavior tests for the new config parameter

## Motivation

Claude Code sessions were stopping mid-conversation when the `todo-continuation-enforcer`'s hardcoded timing constants were too aggressive for slower models. This change allows per-installation tuning without code changes.

## Changes

- `src/config/schema/continuation.ts` — new `ContinuationConfigSchema` (6 optional fields, min bounds)
- `src/config/schema/oh-my-opencode-config.ts` — `continuation` field added to root config
- `src/hooks/todo-continuation-enforcer/types.ts` — `ContinuationTimingConfig` interface + field on options
- `src/plugin/hooks/create-continuation-hooks.ts` — passes `pluginConfig.continuation` to enforcer
- `src/hooks/todo-continuation-enforcer/index.ts`, `handler.ts` — threads `continuationConfig` through factory chain
- `src/hooks/todo-continuation-enforcer/idle-event.ts` — 4 usages of constants → `config ?? CONSTANT`
- `src/hooks/todo-continuation-enforcer/stagnation-detection.ts` — `maxStagnationCount` configurable
- `src/hooks/todo-continuation-enforcer/countdown.ts` — `countdownSeconds` configurable
- `src/config/schema/continuation.test.ts` — 18 schema tests (valid/below-min/omitted for each field)
- `src/hooks/todo-continuation-enforcer/idle-event.test.ts` — 3 behavior tests for `continuationConfig`
- `assets/oh-my-opencode.schema.json` — auto-updated by build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make continuation timing configurable to reduce premature session stops and let teams tune behavior per install. Adds a `continuation` section to `oh-my-opencode.jsonc` with safe defaults when omitted.

- **New Features**
  - Added `continuation` config with six optional fields: `cooldownMs`, `abortWindowMs`, `maxStagnationCount`, `maxConsecutiveFailures`, `failureResetWindowMs`, `countdownSeconds`.
  - Threaded config through `create-continuation-hooks` → enforcer → handler → idle-event; cooldown/backoff, abort window, failure limit + reset window, stagnation stop, and countdown now respect config (defaults preserved).
  - Added Zod schema and tests; extended behavior tests for custom values; updated JSON schema.

<sup>Written for commit 3f72a736116fc31c39608ae59824047f594c7dbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

