### PR TITLE
fix(non-interactive-env): respect Windows command shell

### DIFF
--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -13,6 +13,7 @@ describe("non-interactive-env hook", () => {
       SHELL: process.env.SHELL,
       PSModulePath: process.env.PSModulePath,
       MSYSTEM: process.env.MSYSTEM,
+      ComSpec: process.env.ComSpec,
       CI: process.env.CI,
       OPENCODE_NON_INTERACTIVE: process.env.OPENCODE_NON_INTERACTIVE,
     }
@@ -295,6 +296,30 @@ describe("non-interactive-env hook", () => {
       expect(cmd).toStartWith("set ")
       expect(cmd).toContain(" && git status")
       expect(cmd).not.toContain("$env:")
+      expect(cmd).not.toContain("export ")
+    })
+
+    test("#given Windows ComSpec=pwsh.exe without SHELL #when bash tool git command executes #then uses powershell syntax", async () => {
+      delete process.env.SHELL
+      delete process.env.MSYSTEM
+      process.env.ComSpec = "C:\\Program Files\\PowerShell\\7\\pwsh.exe"
+      process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
+      Object.defineProperty(process, "platform", { value: "win32" })
+
+      const hook = createNonInteractiveEnvHook(mockCtx)
+      const output: { args: Record<string, unknown>; message?: string } = {
+        args: { command: "git status" },
+      }
+
+      await hook["tool.execute.before"](
+        { tool: "bash", sessionID: "test", callID: "1" },
+        output
+      )
+
+      const cmd = output.args.command as string
+      expect(cmd).toStartWith("$env:")
+      expect(cmd).toContain("; git status")
+      expect(cmd).not.toContain("set ")
       expect(cmd).not.toContain("export ")
     })
 

--- a/src/hooks/non-interactive-env/index.test.ts
+++ b/src/hooks/non-interactive-env/index.test.ts
@@ -251,8 +251,55 @@ describe("non-interactive-env hook", () => {
       expect(cmd).toContain("; git commit")
     })
 
-    test("#given Windows with PowerShell env #when bash tool git command executes #then uses powershell syntax", async () => {
+    test("#given Windows cmd environment with PSModulePath #when bash tool git command executes #then uses cmd syntax", async () => {
       delete process.env.SHELL
+      delete process.env.MSYSTEM
+      process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
+      Object.defineProperty(process, "platform", { value: "win32" })
+
+      const hook = createNonInteractiveEnvHook(mockCtx)
+      const output: { args: Record<string, unknown>; message?: string } = {
+        args: { command: "git status" },
+      }
+
+      await hook["tool.execute.before"](
+        { tool: "bash", sessionID: "test", callID: "1" },
+        output
+      )
+
+      const cmd = output.args.command as string
+      expect(cmd).toStartWith("set ")
+      expect(cmd).toContain(" && git status")
+      expect(cmd).toContain('GIT_EDITOR=":"')
+      expect(cmd).not.toContain("$env:")
+      expect(cmd).not.toContain("export ")
+    })
+
+    test("#given Windows SHELL=cmd.exe #when bash tool git command executes #then uses cmd syntax", async () => {
+      process.env.SHELL = "C:\\Windows\\System32\\cmd.exe"
+      delete process.env.MSYSTEM
+      process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
+      Object.defineProperty(process, "platform", { value: "win32" })
+
+      const hook = createNonInteractiveEnvHook(mockCtx)
+      const output: { args: Record<string, unknown>; message?: string } = {
+        args: { command: "git status" },
+      }
+
+      await hook["tool.execute.before"](
+        { tool: "bash", sessionID: "test", callID: "1" },
+        output
+      )
+
+      const cmd = output.args.command as string
+      expect(cmd).toStartWith("set ")
+      expect(cmd).toContain(" && git status")
+      expect(cmd).not.toContain("$env:")
+      expect(cmd).not.toContain("export ")
+    })
+
+    test("#given Windows SHELL=pwsh.exe #when bash tool git command executes #then uses powershell syntax", async () => {
+      process.env.SHELL = "C:\\Program Files\\PowerShell\\7\\pwsh.exe"
       delete process.env.MSYSTEM
       process.env.PSModulePath = "C:\\Program Files\\PowerShell\\Modules"
       Object.defineProperty(process, "platform", { value: "win32" })
@@ -270,7 +317,6 @@ describe("non-interactive-env hook", () => {
       const cmd = output.args.command as string
       expect(cmd).toStartWith("$env:")
       expect(cmd).toContain("; git status")
-      expect(cmd).toContain("$env:GIT_EDITOR=':'")
       expect(cmd).not.toContain("set ")
       expect(cmd).not.toContain("export ")
     })

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -20,24 +20,36 @@ function detectBannedCommand(command: string): string | undefined {
   return undefined
 }
 
+function detectWindowsShellType(shellPath: string | undefined): ShellType | undefined {
+  if (!shellPath) {
+    return undefined
+  }
+
+  const shellName = shellPath.replace(/\\/g, "/").split("/").pop()?.toLowerCase()
+  if (shellName === "cmd" || shellName === "cmd.exe") {
+    return "cmd"
+  }
+  if (
+    shellName === "powershell" ||
+    shellName === "powershell.exe" ||
+    shellName === "pwsh" ||
+    shellName === "pwsh.exe"
+  ) {
+    return "powershell"
+  }
+  return undefined
+}
+
 function detectCommandShellType(): ShellType {
   if (process.platform === "win32" && process.env.SHELL) {
-    const shellName = process.env.SHELL.replace(/\\/g, "/").split("/").pop()?.toLowerCase()
-    if (shellName === "cmd" || shellName === "cmd.exe") {
-      return "cmd"
-    }
-    if (
-      shellName === "powershell" ||
-      shellName === "powershell.exe" ||
-      shellName === "pwsh" ||
-      shellName === "pwsh.exe"
-    ) {
-      return "powershell"
+    const shellType = detectWindowsShellType(process.env.SHELL)
+    if (shellType) {
+      return shellType
     }
   }
 
   if (process.platform === "win32" && !process.env.SHELL && !process.env.MSYSTEM) {
-    return "cmd"
+    return detectWindowsShellType(process.env.ComSpec) ?? "cmd"
   }
 
   return detectShellType()

--- a/src/hooks/non-interactive-env/non-interactive-env-hook.ts
+++ b/src/hooks/non-interactive-env/non-interactive-env-hook.ts
@@ -1,7 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { HOOK_NAME, NON_INTERACTIVE_ENV, SHELL_COMMAND_PATTERNS } from "./constants"
 import { log, buildEnvPrefix } from "../../shared"
-import { detectShellType } from "../../shared/shell-env"
+import { detectShellType, type ShellType } from "../../shared/shell-env"
 
 export * from "./constants"
 export * from "./detector"
@@ -18,6 +18,29 @@ function detectBannedCommand(command: string): string | undefined {
     }
   }
   return undefined
+}
+
+function detectCommandShellType(): ShellType {
+  if (process.platform === "win32" && process.env.SHELL) {
+    const shellName = process.env.SHELL.replace(/\\/g, "/").split("/").pop()?.toLowerCase()
+    if (shellName === "cmd" || shellName === "cmd.exe") {
+      return "cmd"
+    }
+    if (
+      shellName === "powershell" ||
+      shellName === "powershell.exe" ||
+      shellName === "pwsh" ||
+      shellName === "pwsh.exe"
+    ) {
+      return "powershell"
+    }
+  }
+
+  if (process.platform === "win32" && !process.env.SHELL && !process.env.MSYSTEM) {
+    return "cmd"
+  }
+
+  return detectShellType()
 }
 
 export function createNonInteractiveEnvHook(_ctx: PluginInput) {
@@ -53,7 +76,7 @@ export function createNonInteractiveEnvHook(_ctx: PluginInput) {
       // The env vars (GIT_EDITOR=:, EDITOR=:, etc.) must ALWAYS be injected
       // for git commands to prevent interactive prompts.
 
-      const shellType = detectShellType()
+      const shellType = detectCommandShellType()
       const envPrefix = buildEnvPrefix(NON_INTERACTIVE_ENV, shellType)
       
       // Check if the command already starts with the prefix to avoid stacking.


### PR DESCRIPTION
## Summary
- Fix non-interactive-env shell selection so Windows command-shell runs with PSModulePath still receive cmd `set ... &&` syntax instead of PowerShell `$env:` assignments.
- Keep explicit Windows `SHELL=cmd.exe` and `SHELL=pwsh.exe` cases covered while preserving Git Bash/MSYSTEM behavior.
- Add regression coverage for the issue #2344 Windows command-shell scenario.

## Verification
- `bun test src/hooks/non-interactive-env/index.test.ts src/shared/shell-env.test.ts`
- `bun --install=fallback /Users/yeongyu/.config/opencode/skills/typescript-programmer/scripts/check-no-excuse-rules.ts src/hooks/non-interactive-env/non-interactive-env-hook.ts src/hooks/non-interactive-env/index.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run test` (CI runner log checked: shared suite 5605 pass, 0 fail; isolated runs all 0 fail)
- Manual hook-driver QA: simulated win32 with PSModulePath and no SHELL/MSYSTEM emitted `set ... && git --version`

Closes #2344

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/code-yeongyu/codesmith/oh-my-openagent/pr/3993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows shell detection for non-interactive commands so cmd shells use `set ... &&` instead of PowerShell `$env:` syntax, even when `PSModulePath` is present, and honors `ComSpec` when `SHELL` is missing. Keeps explicit handling for `SHELL=cmd.exe` and `SHELL=pwsh.exe` and preserves Git Bash/`MSYSTEM` behavior.

- **Bug Fixes**
  - Detects Windows shell from `SHELL` or `ComSpec` (fallback to cmd): `cmd.exe` => cmd, `pwsh`/`powershell` => PowerShell.
  - Env prefix now respects the detected shell: cmd gets `set ... &&`, PowerShell gets `$env:...;`.
  - Added tests for `SHELL=cmd.exe`, `SHELL=pwsh.exe`, `ComSpec=pwsh.exe`, and the `PSModulePath`-only cmd case.

<sup>Written for commit 47d60a74d30f9c562a3e5c4e01b665f0399791bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

